### PR TITLE
Toolset update: VS 2022 17.7 Preview 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.7 Preview 1 or later.
+1. Install Visual Studio 2022 17.7 Preview 2 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
@@ -157,7 +157,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.7 Preview 1 or later.
+1. Install Visual Studio 2022 17.7 Preview 2 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.

--- a/azure-devops/cmake-configure-build.yml
+++ b/azure-devops/cmake-configure-build.yml
@@ -46,7 +46,7 @@ steps:
     -host_arch=${{ parameters.hostArch }} -arch=${{ parameters.targetArch }} -no_logo
     cmake --build $(${{ parameters.buildOutputLocationVar }})
   displayName: 'Build the STL'
-  timeoutInMinutes: 10
+  timeoutInMinutes: 5
   env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
 - script: |
     if exist "$(${{ parameters.benchmarkBuildOutputLocationVar }})" (
@@ -68,6 +68,6 @@ steps:
     -host_arch=${{ parameters.hostArch }} -arch=${{ parameters.targetArch }} -no_logo
     cmake --build $(${{ parameters.benchmarkBuildOutputLocationVar }})
   displayName: 'Build the benchmarks'
-  timeoutInMinutes: 10
+  timeoutInMinutes: 2
   env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
   condition: ne('${{ parameters.benchmarkBuildOutputLocationVar }}', '')

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -14,7 +14,7 @@ $ErrorActionPreference = 'Stop'
 $CurrentDate = Get-Date
 
 $Location = 'eastus'
-$VMSize = 'Standard_D32ds_v5'
+$VMSize = 'Standard_D32ads_v5'
 $ProtoVMName = 'PROTOTYPE'
 $ImagePublisher = 'MicrosoftWindowsServer'
 $ImageOffer = 'WindowsServer'

--- a/azure-devops/cross-build.yml
+++ b/azure-devops/cross-build.yml
@@ -28,7 +28,7 @@ jobs:
     litFlags: '$(fixedFlags);$(parallelismFlag);$(xmlOutputFlag);$(shardFlags)'
   strategy:
     parallel: ${{ parameters.numShards }}
-  timeoutInMinutes: 360
+  timeoutInMinutes: 25
   steps:
   - script: |
       if exist "$(tmpDir)" (rmdir /S /Q $(tmpDir))

--- a/azure-devops/native-build-test.yml
+++ b/azure-devops/native-build-test.yml
@@ -25,7 +25,7 @@ jobs:
     litFlags: '$(fixedFlags);$(parallelismFlag);$(xmlOutputFlag);$(shardFlags)'
   strategy:
     parallel: ${{ parameters.numShards }}
-  timeoutInMinutes: 360
+  timeoutInMinutes: 25
   steps:
   - script: |
       if exist "$(tmpDir)" (rmdir /S /Q $(tmpDir))

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -136,7 +136,7 @@ $Workloads = @(
 )
 
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/17/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.11.3/python-3.11.3-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.11.4/python-3.11.4-amd64.exe'
 
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_511.23_windows.exe'
 

--- a/azure-devops/run-tests.yml
+++ b/azure-devops/run-tests.yml
@@ -17,7 +17,7 @@ parameters:
 steps:
 - task: CmdLine@2
   displayName: ${{ parameters.displayName }}
-  timeoutInMinutes: 120
+  timeoutInMinutes: 20
   condition: succeeded()
   inputs:
     workingDirectory: $(${{ parameters.buildOutputLocationVar }})
@@ -28,7 +28,7 @@ steps:
   env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
 - task: PublishTestResults@2
   displayName: 'Publish Tests'
-  timeoutInMinutes: 10
+  timeoutInMinutes: 5
   condition: succeededOrFailed()
   inputs:
     searchFolder: $(${{ parameters.buildOutputLocationVar }})

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ variables:
   benchmarkBuildOutputLocation: 'D:\benchmark'
 
 pool:
-  name: 'StlBuild-2023-06-13T1427-Pool'
+  name: 'StlBuild-2023-06-13T1913-Pool'
   demands: EnableSpotVM -equals true
 
 pr:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ variables:
   benchmarkBuildOutputLocation: 'D:\benchmark'
 
 pool:
-  name: 'StlBuild-2023-05-16T1204-Pool'
+  name: 'StlBuild-2023-06-13T1427-Pool'
   demands: EnableSpotVM -equals true
 
 pr:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ stages:
     displayName: 'Code Format'
     jobs:
       - job: Code_Format_Validation
-        timeoutInMinutes: 20
+        timeoutInMinutes: 5
         displayName: 'Validation'
         steps:
           - script: |

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1218,11 +1218,7 @@ public:
     _Ref_count_resource(_Resource _Px, _Dx _Dt)
         : _Ref_count_base(), _Mypair(_One_then_variadic_args_t{}, _STD move(_Dt), _Px) {}
 
-#ifdef __EDG__ // TRANSITION, VSO-1292293
-    ~_Ref_count_resource() noexcept override {} // TRANSITION, should be non-virtual
-#else // ^^^ workaround / no workaround vvv
     ~_Ref_count_resource() noexcept override = default; // TRANSITION, should be non-virtual
-#endif // ^^^ no workaround ^^^
 
     void* _Get_deleter(const type_info& _Typeid) const noexcept override {
 #if _HAS_STATIC_RTTI
@@ -1256,11 +1252,7 @@ public:
         : _Ref_count_base(),
           _Mypair(_One_then_variadic_args_t{}, _STD move(_Dt), _One_then_variadic_args_t{}, _Ax, _Px) {}
 
-#ifdef __EDG__ // TRANSITION, VSO-1292293
-    ~_Ref_count_resource_alloc() noexcept override {} // TRANSITION, should be non-virtual
-#else // ^^^ workaround / no workaround vvv
     ~_Ref_count_resource_alloc() noexcept override = default; // TRANSITION, should be non-virtual
-#endif // ^^^ no workaround ^^^
 
     void* _Get_deleter(const type_info& _Typeid) const noexcept override {
 #if _HAS_STATIC_RTTI

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -8762,11 +8762,7 @@ namespace ranges {
 
     template <class _Fn, class _Ty, size_t... _Indices>
     struct _Invoke_result_with_repeated_type_impl<_Fn, _Ty, index_sequence<_Indices...>> {
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1761088
         using type = invoke_result_t<_Fn, _Repeat_type<_Ty, _Indices>...>;
-#else // ^^^ no workaround / workaround vvv
-        using type = decltype(_STD invoke(_STD declval<_Fn>(), _STD declval<_Repeat_type<_Ty, _Indices>>()...));
-#endif // ^^^ workaround ^^^
     };
 
     template <class _Fn, class _Ty, size_t _Nx>

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -8762,7 +8762,11 @@ namespace ranges {
 
     template <class _Fn, class _Ty, size_t... _Indices>
     struct _Invoke_result_with_repeated_type_impl<_Fn, _Ty, index_sequence<_Indices...>> {
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1761088
         using type = invoke_result_t<_Fn, _Repeat_type<_Ty, _Indices>...>;
+#else // ^^^ no workaround / workaround vvv
+        using type = decltype(_STD invoke(_STD declval<_Fn>(), _STD declval<_Repeat_type<_Ty, _Indices>>()...));
+#endif // ^^^ workaround ^^^
     };
 
     template <class _Fn, class _Ty, size_t _Nx>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4170,24 +4170,14 @@ public:
         return _Left._Current - _Right._Get_last();
     }
 
-    _NODISCARD_FRIEND constexpr reference iter_move(const move_iterator& _It)
-#ifdef __EDG__ // TRANSITION, VSO-1222776
-        noexcept(noexcept(_RANGES iter_move(_STD declval<const _Iter&>())))
-#else // ^^^ workaround / no workaround vvv
-        noexcept(noexcept(_RANGES iter_move(_It._Current)))
-#endif // TRANSITION, VSO-1222776
-    {
+    _NODISCARD_FRIEND constexpr reference iter_move(const move_iterator& _It) noexcept(
+        noexcept(_RANGES iter_move(_It._Current))) {
         return _RANGES iter_move(_It._Current);
     }
 
     template <indirectly_swappable<_Iter> _Iter2>
-    friend constexpr void iter_swap(const move_iterator& _Left, const move_iterator<_Iter2>& _Right)
-#ifdef __EDG__ // TRANSITION, VSO-1222776
-        noexcept(noexcept(_RANGES iter_swap(_STD declval<const _Iter&>(), _STD declval<const _Iter2&>())))
-#else // ^^^ workaround / no workaround vvv
-        noexcept(noexcept(_RANGES iter_swap(_Left._Current, _Right.base())))
-#endif // TRANSITION, VSO-1222776
-    {
+    friend constexpr void iter_swap(const move_iterator& _Left, const move_iterator<_Iter2>& _Right) noexcept(
+        noexcept(_RANGES iter_swap(_Left._Current, _Right.base()))) {
         _RANGES iter_swap(_Left._Current, _Right.base());
     }
 #endif // __cpp_lib_concepts


### PR DESCRIPTION
* Updated build compiler to VS 2022 17.7 Preview 2.
* Updated Python to 3.11.4.
* Switched our VM SKU to Standard_D32ads_v5, which 1ES has already been doing for us behind the scenes.
* Updated our VM pool, also containing June's Patch Tuesday.
* Removed compiler bug workarounds:
  + VSO-1292293 "EDG incorrectly rejects defaulted `noexcept` dtor when a data member has a throwing dtor".
  + VSO-1222776 "EDG doesn't know that `noexcept`-specifiers of hidden friend functions are complete-class contexts".
* Reduce timeouts. It looks like the new pool doesn't avoid the timeouts we've been suffering recently, but this will waste less time.
  + `azure-pipelines.yml`:
    - Reduce the timeout for Code Format Validation from 20 min to 5 min. This is still a ~5x safety margin as it takes ~56 seconds total.
  + `azure-devops/cmake-configure-build.yml`:
    - Reduce the timeout for building the STL from 10 min to 5 min. This is still a ~3x safety margin as it takes ~1m 43s to build.
    - Reduce the timeout for building the benchmarks from 10 min to 2 min. This is a massive safety margin as it takes ~5s to build.
  + `azure-devops/run-tests.yml`:
    - Reduce the timeout for actually running the tests from 120 min to 20 min. This is still a ~2x safety margin as the tests currently take ~8.5 min to run for the slowest slice.
    - Reduce the timeout for publishing the tests for 10 min to 5 min. This is a massive safety margin as it takes ~11s to publish, although it may be network-dependent, hence the caution.
  + `azure-devops/cross-build.yml`:
  + `azure-devops/native-build-test.yml`:
    - Reduce the overall timeouts from 360 minutes to 25 minutes. This gives us a ~2x safety margin, as the tests typically finish in ~12 min, and are virtually guaranteed to be doomed if they've run for over 15 minutes.
