### PR TITLE
`<charconv>`: Optimize `to_chars(...(u)short)`

### DIFF
--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -176,7 +176,7 @@ _EXPORT_STD _CONSTEXPR23 to_chars_result to_chars(
 }
 _EXPORT_STD _CONSTEXPR23 to_chars_result to_chars(char* const _First, char* const _Last, const unsigned short _Value,
     const int _Base = 10) noexcept /* strengthened */ {
-    return _Integer_to_chars(_First, _Last, static_cast<unsigned>(_Value), _Base);
+    return _Integer_to_chars(_First, _Last, static_cast<unsigned int>(_Value), _Base);
 }
 _EXPORT_STD _CONSTEXPR23 to_chars_result to_chars(
     char* const _First, char* const _Last, const int _Value, const int _Base = 10) noexcept /* strengthened */ {

--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -172,11 +172,11 @@ _EXPORT_STD _CONSTEXPR23 to_chars_result to_chars(char* const _First, char* cons
 }
 _EXPORT_STD _CONSTEXPR23 to_chars_result to_chars(
     char* const _First, char* const _Last, const short _Value, const int _Base = 10) noexcept /* strengthened */ {
-    return _Integer_to_chars(_First, _Last, _Value, _Base);
+    return _Integer_to_chars(_First, _Last, static_cast<int>(_Value), _Base);
 }
 _EXPORT_STD _CONSTEXPR23 to_chars_result to_chars(char* const _First, char* const _Last, const unsigned short _Value,
     const int _Base = 10) noexcept /* strengthened */ {
-    return _Integer_to_chars(_First, _Last, _Value, _Base);
+    return _Integer_to_chars(_First, _Last, static_cast<unsigned>(_Value), _Base);
 }
 _EXPORT_STD _CONSTEXPR23 to_chars_result to_chars(
     char* const _First, char* const _Last, const int _Value, const int _Base = 10) noexcept /* strengthened */ {


### PR DESCRIPTION
For (u)short types, we can have a performance gain simply by adding a `static_cast<(u)int>` before calling `_Integer_to_chars`. By applying the change, I get the following result in `Maximum Optimization (Favor Speed) (/O2)` mode. The modified version works much better in base 10 case.
<details>
<summary>Benchmark</summary>

```cpp
#include<charconv>
#include<cstdio>
#include<ctime>

namespace updated {
	_CONSTEXPR23 std::to_chars_result to_chars(
		char* const _First, char* const _Last, const char _Value, const int _Base = 10) noexcept /* strengthened */ {
		using _Prom = std::conditional_t<std::is_signed_v<char>, int, unsigned>;
		return std::_Integer_to_chars(_First, _Last, static_cast<_Prom>(_Value), _Base);
	}
	_CONSTEXPR23 std::to_chars_result to_chars(
		char* const _First, char* const _Last, const signed char _Value, const int _Base = 10) noexcept /* strengthened */ {
		return std::_Integer_to_chars(_First, _Last, static_cast<int>(_Value), _Base);
	}
	_CONSTEXPR23 std::to_chars_result to_chars(char* const _First, char* const _Last, const unsigned char _Value,
		const int _Base = 10) noexcept /* strengthened */ {
		return std::_Integer_to_chars(_First, _Last, static_cast<unsigned>(_Value), _Base);
	}
	_CONSTEXPR23 std::to_chars_result to_chars(
		char* const _First, char* const _Last, const short _Value, const int _Base = 10) noexcept /* strengthened */ {
		return std::_Integer_to_chars(_First, _Last, static_cast<int>(_Value), _Base);
	}
	_CONSTEXPR23 std::to_chars_result to_chars(char* const _First, char* const _Last, const unsigned short _Value,
		const int _Base = 10) noexcept /* strengthened */ {
		return std::_Integer_to_chars(_First, _Last, static_cast<unsigned>(_Value), _Base);
	}
}

template<bool STD, class T>
void test_base(int rep, int base) {
	constexpr T _Min = std::numeric_limits<T>::min();
	constexpr T _Max = std::numeric_limits<T>::max();
	char buffer[100];
	volatile char sink{};
	for (int i = 0; i < rep; i++) {
		for (T val = _Min; val != _Max; val++) {
			if constexpr (STD) {
				std::to_chars(buffer, std::end(buffer), val, base);
			}
			else {
				updated::to_chars(buffer, std::end(buffer), val, base);
			}
			sink = buffer[0];
		}
	}
}

long benchmark(auto what, int session = 10) {
	long mincost = LONG_MAX;
	for (int i = 0; i < session; i++) {
		long now = clock();
		what();
		long diff = clock() - now;
		if (diff < mincost) {
			mincost = diff;
		}
	}
	return mincost;
}

template<class T>
void compare(const char* msg, int rep) {
	puts(msg);
	auto compare_base = [rep](int base) {
		printf("base %d: ", base);
		long before = benchmark([&] {test_base<true, T>(rep, base); });
		long now = benchmark([&] {test_base<false, T>(rep, base); });
		printf("%ld -> %ld\n", before, now);
	};
	puts("--");
	for (int base : {2, 4, 8, 16, 32}) {
		compare_base(base);
	}
	puts("--");
	compare_base(10);
	puts("--");
	for (int base : {3, 5, 6, 7, 9}) {
		compare_base(base);
	}
	puts("--");
	for (int base : {11, 13, 18, 19, 22, 26, 33, 34, 36}) { //sampled
		compare_base(base);
	}
}

int main() {
	//puts("--------------------------------");
	//compare<signed char>("(s)char", 50 * 256);
	//puts("--------------------------------");
	//compare<unsigned char>("(u)char", 50 * 256);
	//puts("--------------------------------");
	compare<signed short>("(s)short", 50);
	puts("--------------------------------");
	compare<unsigned short>("(u)short", 50);
}
```
</details>

<details>
<summary>Result</summary>

![image](https://github.com/microsoft/STL/assets/60953653/c7a82c0d-36e8-4b1e-bc3d-bb418fbb2dbc)
</details>

For bases other than 10, the change will also make a efficiency gain **if given the opportunity to be inlined(so that division can become multiplication).**

<details>
<summary>Benchmark for base 19</summary>

```cpp
#include<charconv>
#include<cstdio>
#include<ctime>

namespace updated {
	_CONSTEXPR23 std::to_chars_result to_chars(
		char* const _First, char* const _Last, const char _Value, const int _Base = 10) noexcept /* strengthened */ {
		using _Prom = std::conditional_t<std::is_signed_v<char>, int, unsigned>;
		return std::_Integer_to_chars(_First, _Last, static_cast<_Prom>(_Value), _Base);
	}
	_CONSTEXPR23 std::to_chars_result to_chars(
		char* const _First, char* const _Last, const signed char _Value, const int _Base = 10) noexcept /* strengthened */ {
		return std::_Integer_to_chars(_First, _Last, static_cast<int>(_Value), _Base);
	}
	_CONSTEXPR23 std::to_chars_result to_chars(char* const _First, char* const _Last, const unsigned char _Value,
		const int _Base = 10) noexcept /* strengthened */ {
		return std::_Integer_to_chars(_First, _Last, static_cast<unsigned>(_Value), _Base);
	}
	_CONSTEXPR23 std::to_chars_result to_chars(
		char* const _First, char* const _Last, const short _Value, const int _Base = 10) noexcept /* strengthened */ {
		return std::_Integer_to_chars(_First, _Last, static_cast<int>(_Value), _Base);
	}
	_CONSTEXPR23 std::to_chars_result to_chars(char* const _First, char* const _Last, const unsigned short _Value,
		const int _Base = 10) noexcept /* strengthened */ {
		return std::_Integer_to_chars(_First, _Last, static_cast<unsigned>(_Value), _Base);
	}
}

template<bool STD, class T>
void test_base(int rep, int base) {
	constexpr T _Min = std::numeric_limits<T>::min();
	constexpr T _Max = std::numeric_limits<T>::max();
	char buffer[100];
	volatile char sink{};
	for (int i = 0; i < rep; i++) {
		for (T val = _Min; val != _Max; val++) {
			if constexpr (STD) {
				std::to_chars(buffer, std::end(buffer), val, base);
			}
			else {
				updated::to_chars(buffer, std::end(buffer), val, base);
			}
			sink = buffer[0];
		}
	}
}

long benchmark(auto what, int session = 10) {
	long mincost = LONG_MAX;
	for (int i = 0; i < session; i++) {
		long now = clock();
		what();
		long diff = clock() - now;
		if (diff < mincost) {
			mincost = diff;
		}
	}
	return mincost;
}

template<class T>
void compare(const char* msg, int rep) {
	puts(msg);
	
	puts("--");

	printf("base %d: ", 19);
	long before = benchmark([&] {test_base<true, T>(rep, 19); });
	long now = benchmark([&] {test_base<false, T>(rep, 19); });
	printf("%ld -> %ld\n", before, now);
}

int main() {
	//puts("--------------------------------");
	//compare<signed char>("(s)char", 50 * 256);
	//puts("--------------------------------");
	//compare<unsigned char>("(u)char", 50 * 256);
	//puts("--------------------------------");
	compare<signed short>("(s)short", 50);
	puts("--------------------------------");
	compare<unsigned short>("(u)short", 50);
}
```
</details>
<details>
<summary>Result</summary>

![image](https://github.com/microsoft/STL/assets/60953653/14d27c7b-104d-440d-8b2a-367226f4d10b)
</details>

For (u/s)char types, the efficiency gain is not observable. Perhaps we can provide some specialized optimizations for char types finally.