### PR TITLE
`<functional>`: Deleted `operator()` overloads for return types of `bind`, `bind_front`, and `bind_back`

### DIFF
--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -653,38 +653,6 @@ public:
 
 extern "C++" [[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xbad_function_call();
 
-struct _Unforced { // tag to distinguish bind() from bind<R>()
-    explicit _Unforced() = default;
-};
-
-// helper to give INVOKE an explicit return type; avoids undesirable Expression SFINAE
-template <class _Rx>
-struct _Invoker_ret { // selected for all _Rx other than _Unforced
-    template <class _Fx, class... _Valtys,
-        enable_if_t<_Select_invoke_traits<_Fx, _Valtys...>::template _Is_invocable_r<_Rx>::value, int> = 0>
-    static _CONSTEXPR20 _Rx _Call(_Fx&& _Func, _Valtys&&... _Vals) noexcept(_Select_invoke_traits<_Fx,
-        _Valtys...>::template _Is_nothrow_invocable_r<_Rx>::value) { // INVOKE, implicitly converted
-        if constexpr (is_void_v<_Rx>) {
-            _STL_INTERNAL_STATIC_ASSERT(
-                _Select_invoke_traits<_Fx, _Valtys...>::_Is_nothrow_invocable::value
-                == _Select_invoke_traits<_Fx, _Valtys...>::template _Is_nothrow_invocable_r<_Rx>::value);
-            _STD invoke(static_cast<_Fx&&>(_Func), static_cast<_Valtys&&>(_Vals)...);
-        } else {
-            return _STD invoke(static_cast<_Fx&&>(_Func), static_cast<_Valtys&&>(_Vals)...);
-        }
-    }
-};
-
-template <>
-struct _Invoker_ret<_Unforced> { // selected for _Rx being _Unforced
-    template <class _Fx, class... _Valtys>
-    static _CONSTEXPR20 auto _Call(_Fx&& _Func, _Valtys&&... _Vals) noexcept(
-        _Select_invoke_traits<_Fx, _Valtys...>::_Is_nothrow_invocable::value)
-        -> decltype(_STD invoke(static_cast<_Fx&&>(_Func), static_cast<_Valtys&&>(_Vals)...)) { // INVOKE, unchanged
-        return _STD invoke(static_cast<_Fx&&>(_Func), static_cast<_Valtys&&>(_Vals)...);
-    }
-};
-
 _EXPORT_STD template <class _Fty>
 class function;
 
@@ -1984,6 +1952,38 @@ constexpr auto _Fix_arg(_Cv_TiD& _Tid, _Untuple&& _Ut) noexcept(
     return _Select_fixer<_Cv_TiD>::_Fix(_Tid, _STD move(_Ut));
 }
 
+struct _Unforced { // tag to distinguish bind() from bind<R>()
+    explicit _Unforced() = default;
+};
+
+// helper to give INVOKE an explicit return type; avoids undesirable Expression SFINAE
+template <class _Rx>
+struct _Invoker_ret { // selected for all _Rx other than _Unforced
+    template <class _Fx, class... _Valtys,
+        enable_if_t<_Select_invoke_traits<_Fx, _Valtys...>::template _Is_invocable_r<_Rx>::value, int> = 0>
+    static _CONSTEXPR20 _Rx _Call(_Fx&& _Func, _Valtys&&... _Vals) noexcept(_Select_invoke_traits<_Fx,
+        _Valtys...>::template _Is_nothrow_invocable_r<_Rx>::value) { // INVOKE, implicitly converted
+        if constexpr (is_void_v<_Rx>) {
+            _STL_INTERNAL_STATIC_ASSERT(
+                _Select_invoke_traits<_Fx, _Valtys...>::_Is_nothrow_invocable::value
+                == _Select_invoke_traits<_Fx, _Valtys...>::template _Is_nothrow_invocable_r<_Rx>::value);
+            _STD invoke(static_cast<_Fx&&>(_Func), static_cast<_Valtys&&>(_Vals)...);
+        } else {
+            return _STD invoke(static_cast<_Fx&&>(_Func), static_cast<_Valtys&&>(_Vals)...);
+        }
+    }
+};
+
+template <>
+struct _Invoker_ret<_Unforced> { // selected for _Rx being _Unforced
+    template <class _Fx, class... _Valtys>
+    static _CONSTEXPR20 auto _Call(_Fx&& _Func, _Valtys&&... _Vals) noexcept(
+        _Select_invoke_traits<_Fx, _Valtys...>::_Is_nothrow_invocable::value)
+        -> decltype(_STD invoke(static_cast<_Fx&&>(_Func), static_cast<_Valtys&&>(_Vals)...)) { // INVOKE, unchanged
+        return _STD invoke(static_cast<_Fx&&>(_Func), static_cast<_Valtys&&>(_Vals)...);
+    }
+};
+
 template <class _Ret, size_t... _Ix, class _Cv_FD, class _Cv_tuple_TiD, class _Untuple>
 _CONSTEXPR20 auto _Call_binder(_Invoker_ret<_Ret>, index_sequence<_Ix...>, _Cv_FD& _Obj, _Cv_tuple_TiD& _Tpl,
     _Untuple&& _Ut) noexcept(noexcept(_Invoker_ret<_Ret>::_Call(_Obj,
@@ -1992,6 +1992,14 @@ _CONSTEXPR20 auto _Call_binder(_Invoker_ret<_Ret>, index_sequence<_Ix...>, _Cv_F
     // bind() and bind<R>() invocation
     return _Invoker_ret<_Ret>::_Call(_Obj, _STD _Fix_arg(_STD get<_Ix>(_Tpl), _STD move(_Ut))...);
 }
+
+template <class _Ret, class _CvFD, class _IntSeq, class _CvBoundTuple, class _UnboundTuple, class = void>
+_INLINE_VAR constexpr bool _Can_call_binder = false;
+
+template <class _Ret, class _CvFD, class _IntSeq, class _CvBoundTuple, class _UnboundTuple>
+_INLINE_VAR constexpr bool _Can_call_binder<_Ret, _CvFD, _IntSeq, _CvBoundTuple, _UnboundTuple,
+    void_t<decltype(_STD _Call_binder(_Invoker_ret<_Ret>{}, _IntSeq{}, _STD declval<_CvFD&>(),
+        _STD declval<_CvBoundTuple&>(), _STD declval<_UnboundTuple>()))>> = true;
 
 template <class _Ret>
 struct _Forced_result_type { // used by bind<R>()
@@ -2011,30 +2019,39 @@ struct _Binder_result_type { // provide result_type (sometimes)
 template <class _Ret, class _Fx, class... _Types>
 class _Binder : public _Binder_result_type<_Ret, _Fx>::type { // wrap bound callable object and arguments
 private:
-    using _Seq    = index_sequence_for<_Types...>;
-    using _First  = decay_t<_Fx>;
-    using _Second = tuple<decay_t<_Types>...>;
+    using _Seq         = index_sequence_for<_Types...>;
+    using _Fd          = decay_t<_Fx>;
+    using _Bound_tuple = tuple<decay_t<_Types>...>;
 
-    _Compressed_pair<_First, _Second> _Mypair;
+    _Compressed_pair<_Fd, _Bound_tuple> _Mypair;
 
 public:
     constexpr explicit _Binder(_Fx&& _Func, _Types&&... _Args)
         : _Mypair(_One_then_variadic_args_t{}, _STD forward<_Fx>(_Func), _STD forward<_Types>(_Args)...) {}
 
-#define _CALL_BINDER                                                                  \
-    _Call_binder(_Invoker_ret<_Ret>{}, _Seq{}, _Mypair._Get_first(), _Mypair._Myval2, \
+#define _CALL_BINDER                                                                       \
+    _STD _Call_binder(_Invoker_ret<_Ret>{}, _Seq{}, _Mypair._Get_first(), _Mypair._Myval2, \
         _STD forward_as_tuple(_STD forward<_Unbound>(_Unbargs)...))
 
-    template <class... _Unbound>
-    _CONSTEXPR20 auto operator()(_Unbound&&... _Unbargs) noexcept(noexcept(_CALL_BINDER)) -> decltype(_CALL_BINDER) {
+    template <class... _Unbound,
+        enable_if_t<_Can_call_binder<_Ret, _Fd, _Seq, _Bound_tuple, tuple<_Unbound&&...>>, int> = 0>
+    _CONSTEXPR20 decltype(auto) operator()(_Unbound&&... _Unbargs) noexcept(noexcept(_CALL_BINDER)) {
         return _CALL_BINDER;
     }
 
-    template <class... _Unbound>
-    _CONSTEXPR20 auto operator()(_Unbound&&... _Unbargs) const noexcept(noexcept(_CALL_BINDER))
-        -> decltype(_CALL_BINDER) {
+    template <class... _Unbound,
+        enable_if_t<!_Can_call_binder<_Ret, _Fd, _Seq, _Bound_tuple, tuple<_Unbound&&...>>, int> = 0>
+    void operator()(_Unbound&&...) = delete;
+
+    template <class... _Unbound,
+        enable_if_t<_Can_call_binder<_Ret, const _Fd, _Seq, const _Bound_tuple, tuple<_Unbound&&...>>, int> = 0>
+    _CONSTEXPR20 decltype(auto) operator()(_Unbound&&... _Unbargs) const noexcept(noexcept(_CALL_BINDER)) {
         return _CALL_BINDER;
     }
+
+    template <class... _Unbound,
+        enable_if_t<!_Can_call_binder<_Ret, const _Fd, _Seq, const _Bound_tuple, tuple<_Unbound&&...>>, int> = 0>
+    void operator()(_Unbound&&...) const = delete;
 
 #undef _CALL_BINDER
 };
@@ -2083,6 +2100,19 @@ constexpr auto _Call_front_binder(index_sequence<_Ix...>, _Cv_FD&& _Obj, _Cv_tup
         _STD forward<_Unbound>(_Unbargs)...);
 }
 
+template <class, class _IntSeq, class _CvFD, class _CvBoundTuple, class... _Unbound>
+inline constexpr bool _Can_call_front_binder_impl = false;
+
+template <class _IntSeq, class _CvFD, class _CvBoundTuple, class... _Unbound>
+inline constexpr bool
+    _Can_call_front_binder_impl<void_t<decltype(_STD _Call_front_binder(_IntSeq{}, _STD declval<_CvFD>(),
+                                    _STD declval<_CvBoundTuple>(), _STD declval<_Unbound>()...))>,
+        _IntSeq, _CvFD, _CvBoundTuple, _Unbound...> = true;
+
+template <class _IntSeq, class _CvFD, class _CvBoundTuple, class... _Unbound>
+inline constexpr bool _Can_call_front_binder =
+    _Can_call_front_binder_impl<void, _IntSeq, _CvFD, _CvBoundTuple, _Unbound...>;
+
 template <class _Fx, class... _Types>
 class _Front_binder { // wrap bound callable object and arguments
 private:
@@ -2099,39 +2129,53 @@ public:
     constexpr explicit _Front_binder(_FxInit&& _Func, _TypesInit&&... _Args)
         : _Mypair(_One_then_variadic_args_t{}, _STD forward<_FxInit>(_Func), _STD forward<_TypesInit>(_Args)...) {}
 
-    template <class... _Unbound>
-    constexpr auto operator()(_Unbound&&... _Unbargs) & noexcept(noexcept(
-        _Call_front_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...)))
-        -> decltype(_Call_front_binder(
-            _Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...)) {
-        return _Call_front_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...);
+    template <class... _Unbound,
+        enable_if_t<_Can_call_front_binder<_Seq, _Fx&, tuple<_Types...>&, _Unbound&&...>, int> = 0>
+    constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) & noexcept(noexcept(
+        _STD _Call_front_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...))) {
+        return _STD _Call_front_binder(
+            _Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...);
     }
 
-    template <class... _Unbound>
-    constexpr auto operator()(_Unbound&&... _Unbargs) const& noexcept(noexcept(
-        _Call_front_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...)))
-        -> decltype(_Call_front_binder(
-            _Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...)) {
-        return _Call_front_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...);
+    template <class... _Unbound,
+        enable_if_t<!_Can_call_front_binder<_Seq, _Fx&, tuple<_Types...>&, _Unbound&&...>, int> = 0>
+    void operator()(_Unbound&&...) & = delete;
+
+    template <class... _Unbound,
+        enable_if_t<_Can_call_front_binder<_Seq, const _Fx&, const tuple<_Types...>&, _Unbound&&...>, int> = 0>
+    constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) const& noexcept(noexcept(
+        _STD _Call_front_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...))) {
+        return _STD _Call_front_binder(
+            _Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...);
     }
 
-    template <class... _Unbound>
-    constexpr auto operator()(_Unbound&&... _Unbargs) && noexcept(noexcept(_Call_front_binder(
-        _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...)))
-        -> decltype(_Call_front_binder(
-            _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...)) {
-        return _Call_front_binder(
+    template <class... _Unbound,
+        enable_if_t<!_Can_call_front_binder<_Seq, const _Fx&, const tuple<_Types...>&, _Unbound&&...>, int> = 0>
+    void operator()(_Unbound&&...) const& = delete;
+
+    template <class... _Unbound,
+        enable_if_t<_Can_call_front_binder<_Seq, _Fx, tuple<_Types...>, _Unbound&&...>, int> = 0>
+    constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) && noexcept(noexcept(_STD _Call_front_binder(
+        _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...))) {
+        return _STD _Call_front_binder(
             _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...);
     }
 
-    template <class... _Unbound>
-    constexpr auto operator()(_Unbound&&... _Unbargs) const&& noexcept(noexcept(_Call_front_binder(
-        _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...)))
-        -> decltype(_Call_front_binder(
-            _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...)) {
-        return _Call_front_binder(
+    template <class... _Unbound,
+        enable_if_t<!_Can_call_front_binder<_Seq, _Fx, tuple<_Types...>, _Unbound&&...>, int> = 0>
+    void operator()(_Unbound&&...) && = delete;
+
+    template <class... _Unbound,
+        enable_if_t<_Can_call_front_binder<_Seq, const _Fx, const tuple<_Types...>, _Unbound&&...>, int> = 0>
+    constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) const&& noexcept(noexcept(_STD _Call_front_binder(
+        _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...))) {
+        return _STD _Call_front_binder(
             _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...);
     }
+
+    template <class... _Unbound,
+        enable_if_t<!_Can_call_front_binder<_Seq, const _Fx, const tuple<_Types...>, _Unbound&&...>, int> = 0>
+    void operator()(_Unbound&&...) const&& = delete;
 };
 
 _EXPORT_STD template <class _Fx, class... _Types>
@@ -2160,6 +2204,19 @@ constexpr auto _Call_back_binder(index_sequence<_Ix...>, _Cv_FD&& _Obj, _Cv_tupl
         _STD get<_Ix>(_STD forward<_Cv_tuple_TiD>(_Tpl))...);
 }
 
+template <class, class _IntSeq, class _CvFD, class _CvBoundTuple, class... _Unbound>
+inline constexpr bool _Can_call_back_binder_impl = false;
+
+template <class _IntSeq, class _CvFD, class _CvBoundTuple, class... _Unbound>
+inline constexpr bool
+    _Can_call_back_binder_impl<void_t<decltype(_STD _Call_back_binder(_IntSeq{}, _STD declval<_CvFD>(),
+                                   _STD declval<_CvBoundTuple>(), _STD declval<_Unbound>()...))>,
+        _IntSeq, _CvFD, _CvBoundTuple, _Unbound...> = true;
+
+template <class _IntSeq, class _CvFD, class _CvBoundTuple, class... _Unbound>
+inline constexpr bool _Can_call_back_binder =
+    _Can_call_back_binder_impl<void, _IntSeq, _CvFD, _CvBoundTuple, _Unbound...>;
+
 template <class _Fx, class... _Types>
 class _Back_binder { // wrap bound callable object and arguments
 private:
@@ -2176,39 +2233,52 @@ public:
     constexpr explicit _Back_binder(_FxInit&& _Func, _TypesInit&&... _Args)
         : _Mypair(_One_then_variadic_args_t{}, _STD forward<_FxInit>(_Func), _STD forward<_TypesInit>(_Args)...) {}
 
-    template <class... _Unbound>
-    constexpr auto operator()(_Unbound&&... _Unbargs) & noexcept(
-        noexcept(_Call_back_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...)))
-        -> decltype(_Call_back_binder(
-            _Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...)) {
-        return _Call_back_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...);
+    template <class... _Unbound,
+        enable_if_t<_Can_call_back_binder<_Seq, _Fx&, tuple<_Types...>&, _Unbound...>, int> = 0>
+    constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) & noexcept(noexcept(
+        _STD _Call_back_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...))) {
+        return _STD _Call_back_binder(
+            _Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...);
     }
 
-    template <class... _Unbound>
-    constexpr auto operator()(_Unbound&&... _Unbargs) const& noexcept(
-        noexcept(_Call_back_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...)))
-        -> decltype(_Call_back_binder(
-            _Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...)) {
-        return _Call_back_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...);
+    template <class... _Unbound,
+        enable_if_t<!_Can_call_back_binder<_Seq, _Fx&, tuple<_Types...>&, _Unbound&&...>, int> = 0>
+    void operator()(_Unbound&&...) & = delete;
+
+    template <class... _Unbound,
+        enable_if_t<_Can_call_back_binder<_Seq, const _Fx&, const tuple<_Types...>&, _Unbound&&...>, int> = 0>
+    constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) const& noexcept(noexcept(
+        _STD _Call_back_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...))) {
+        return _STD _Call_back_binder(
+            _Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...);
     }
 
-    template <class... _Unbound>
-    constexpr auto operator()(_Unbound&&... _Unbargs) && noexcept(noexcept(_Call_back_binder(
-        _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...)))
-        -> decltype(_Call_back_binder(
-            _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...)) {
-        return _Call_back_binder(
+    template <class... _Unbound,
+        enable_if_t<!_Can_call_back_binder<_Seq, const _Fx&, const tuple<_Types...>&, _Unbound&&...>, int> = 0>
+    void operator()(_Unbound&&...) const& = delete;
+
+    template <class... _Unbound, enable_if_t<_Can_call_back_binder<_Seq, _Fx, tuple<_Types...>, _Unbound...>, int> = 0>
+    constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) && noexcept(noexcept(_STD _Call_back_binder(
+        _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...))) {
+        return _STD _Call_back_binder(
             _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...);
     }
 
-    template <class... _Unbound>
-    constexpr auto operator()(_Unbound&&... _Unbargs) const&& noexcept(noexcept(_Call_back_binder(
-        _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...)))
-        -> decltype(_Call_back_binder(
-            _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...)) {
-        return _Call_back_binder(
+    template <class... _Unbound,
+        enable_if_t<!_Can_call_back_binder<_Seq, _Fx, tuple<_Types...>, _Unbound&&...>, int> = 0>
+    void operator()(_Unbound&&...) && = delete;
+
+    template <class... _Unbound,
+        enable_if_t<_Can_call_back_binder<_Seq, const _Fx, const tuple<_Types...>, _Unbound...>, int> = 0>
+    constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) const&& noexcept(noexcept(_STD _Call_back_binder(
+        _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...))) {
+        return _STD _Call_back_binder(
             _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...);
     }
+
+    template <class... _Unbound,
+        enable_if_t<!_Can_call_back_binder<_Seq, const _Fx, const tuple<_Types...>, _Unbound&&...>, int> = 0>
+    void operator()(_Unbound&&...) const&& = delete;
 };
 
 _EXPORT_STD template <class _Fx, class... _Types>

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1993,6 +1993,12 @@ _CONSTEXPR20 auto _Call_binder(_Invoker_ret<_Ret>, index_sequence<_Ix...>, _Cv_F
     return _Invoker_ret<_Ret>::_Call(_Obj, _STD _Fix_arg(_STD get<_Ix>(_Tpl), _STD move(_Ut))...);
 }
 
+#if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+template <class _Ret, class _CvFD, class _IntSeq, class _CvBoundTuple, class _UnboundTuple>
+concept _Can_call_binder = requires(_CvFD& _Fx, _CvBoundTuple& _Bound_tuple, _UnboundTuple&& _Unbound_tuple) {
+    _STD _Call_binder(_Invoker_ret<_Ret>{}, _IntSeq{}, _Fx, _Bound_tuple, _STD move(_Unbound_tuple));
+};
+#else // ^^^ concept available / concept unavailable vvv
 template <class _Ret, class _CvFD, class _IntSeq, class _CvBoundTuple, class _UnboundTuple, class = void>
 _INLINE_VAR constexpr bool _Can_call_binder = false;
 
@@ -2000,6 +2006,7 @@ template <class _Ret, class _CvFD, class _IntSeq, class _CvBoundTuple, class _Un
 _INLINE_VAR constexpr bool _Can_call_binder<_Ret, _CvFD, _IntSeq, _CvBoundTuple, _UnboundTuple,
     void_t<decltype(_STD _Call_binder(_Invoker_ret<_Ret>{}, _IntSeq{}, _STD declval<_CvFD&>(),
         _STD declval<_CvBoundTuple&>(), _STD declval<_UnboundTuple>()))>> = true;
+#endif // ^^^ concept unavailable ^^^
 
 template <class _Ret>
 struct _Forced_result_type { // used by bind<R>()
@@ -2033,6 +2040,25 @@ public:
     _STD _Call_binder(_Invoker_ret<_Ret>{}, _Seq{}, _Mypair._Get_first(), _Mypair._Myval2, \
         _STD forward_as_tuple(_STD forward<_Unbound>(_Unbargs)...))
 
+#if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+    template <class... _Unbound>
+        requires _Can_call_binder<_Ret, _Fd, _Seq, _Bound_tuple, tuple<_Unbound&&...>>
+    _CONSTEXPR20 decltype(auto) operator()(_Unbound&&... _Unbargs) noexcept(noexcept(_CALL_BINDER)) {
+        return _CALL_BINDER;
+    }
+
+    template <class... _Unbound>
+    void operator()(_Unbound&&...) = delete;
+
+    template <class... _Unbound>
+        requires _Can_call_binder<_Ret, const _Fd, _Seq, const _Bound_tuple, tuple<_Unbound&&...>>
+    _CONSTEXPR20 decltype(auto) operator()(_Unbound&&... _Unbargs) const noexcept(noexcept(_CALL_BINDER)) {
+        return _CALL_BINDER;
+    }
+
+    template <class... _Unbound>
+    void operator()(_Unbound&&...) const = delete;
+#else // ^^^ requires available / requires unavailable vvv
     template <class... _Unbound,
         enable_if_t<_Can_call_binder<_Ret, _Fd, _Seq, _Bound_tuple, tuple<_Unbound&&...>>, int> = 0>
     _CONSTEXPR20 decltype(auto) operator()(_Unbound&&... _Unbargs) noexcept(noexcept(_CALL_BINDER)) {
@@ -2052,7 +2078,7 @@ public:
     template <class... _Unbound,
         enable_if_t<!_Can_call_binder<_Ret, const _Fd, _Seq, const _Bound_tuple, tuple<_Unbound&&...>>, int> = 0>
     void operator()(_Unbound&&...) const = delete;
-
+#endif // ^^^ requires unavailable ^^^
 #undef _CALL_BINDER
 };
 
@@ -2100,6 +2126,13 @@ constexpr auto _Call_front_binder(index_sequence<_Ix...>, _Cv_FD&& _Obj, _Cv_tup
         _STD forward<_Unbound>(_Unbargs)...);
 }
 
+#ifdef __cpp_lib_concepts // TRANSITION, GH-395
+template <class _IntSeq, class _CvFD, class _CvBoundTuple, class... _Unbound>
+concept _Can_call_front_binder = requires(_CvFD&& _Fx, _CvBoundTuple&& _Bound_tuple, _Unbound&&... _Unbound_args) {
+    _STD _Call_front_binder(_IntSeq{}, _STD forward<_CvFD>(_Fx), _STD forward<_CvBoundTuple>(_Bound_tuple),
+        _STD forward<_Unbound>(_Unbound_args)...);
+};
+#else // ^^^ concept available / concept unavailable vvv
 template <class, class _IntSeq, class _CvFD, class _CvBoundTuple, class... _Unbound>
 inline constexpr bool _Can_call_front_binder_impl = false;
 
@@ -2112,6 +2145,7 @@ inline constexpr bool
 template <class _IntSeq, class _CvFD, class _CvBoundTuple, class... _Unbound>
 inline constexpr bool _Can_call_front_binder =
     _Can_call_front_binder_impl<void, _IntSeq, _CvFD, _CvBoundTuple, _Unbound...>;
+#endif // ^^^ concept unavailable ^^^
 
 template <class _Fx, class... _Types>
 class _Front_binder { // wrap bound callable object and arguments
@@ -2129,6 +2163,51 @@ public:
     constexpr explicit _Front_binder(_FxInit&& _Func, _TypesInit&&... _Args)
         : _Mypair(_One_then_variadic_args_t{}, _STD forward<_FxInit>(_Func), _STD forward<_TypesInit>(_Args)...) {}
 
+#ifdef __cpp_lib_concepts // TRANSITON, GH-395
+    template <class... _Unbound>
+        requires _Can_call_front_binder<_Seq, _Fx&, tuple<_Types...>&, _Unbound...>
+    constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) & noexcept(noexcept(
+        _STD _Call_front_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...))) {
+        return _STD _Call_front_binder(
+            _Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...);
+    }
+
+    template <class... _Unbound>
+    void operator()(_Unbound&&...) & = delete;
+
+    template <class... _Unbound>
+        requires _Can_call_front_binder<_Seq, const _Fx&, const tuple<_Types...>&, _Unbound...>
+    constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) const& noexcept(noexcept(
+        _STD _Call_front_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...))) {
+        return _STD _Call_front_binder(
+            _Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...);
+    }
+
+    template <class... _Unbound>
+    void operator()(_Unbound&&...) const& = delete;
+
+    template <class... _Unbound>
+        requires _Can_call_front_binder<_Seq, _Fx&&, tuple<_Types...>&&, _Unbound...>
+    constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) && noexcept(noexcept(_STD _Call_front_binder(
+        _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...))) {
+        return _STD _Call_front_binder(
+            _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...);
+    }
+
+    template <class... _Unbound>
+    void operator()(_Unbound&&...) && = delete;
+
+    template <class... _Unbound>
+        requires _Can_call_front_binder<_Seq, const _Fx&&, const tuple<_Types...>&&, _Unbound...>
+    constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) const&& noexcept(noexcept(_STD _Call_front_binder(
+        _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...))) {
+        return _STD _Call_front_binder(
+            _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...);
+    }
+
+    template <class... _Unbound>
+    void operator()(_Unbound&&...) const&& = delete;
+#else // ^^^ requires available / requires unavailable vvv
     template <class... _Unbound,
         enable_if_t<_Can_call_front_binder<_Seq, _Fx&, tuple<_Types...>&, _Unbound&&...>, int> = 0>
     constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) & noexcept(noexcept(
@@ -2176,6 +2255,7 @@ public:
     template <class... _Unbound,
         enable_if_t<!_Can_call_front_binder<_Seq, const _Fx, const tuple<_Types...>, _Unbound&&...>, int> = 0>
     void operator()(_Unbound&&...) const&& = delete;
+#endif // ^^^ requires unavailable ^^^
 };
 
 _EXPORT_STD template <class _Fx, class... _Types>
@@ -2204,6 +2284,13 @@ constexpr auto _Call_back_binder(index_sequence<_Ix...>, _Cv_FD&& _Obj, _Cv_tupl
         _STD get<_Ix>(_STD forward<_Cv_tuple_TiD>(_Tpl))...);
 }
 
+#ifdef __cpp_lib_concepts // TRANSITION, GH-395
+template <class _IntSeq, class _CvFD, class _CvBoundTuple, class... _Unbound>
+concept _Can_call_back_binder = requires(_CvFD&& _Fx, _CvBoundTuple&& _Bound_tuple, _Unbound&&... _Unbound_args) {
+    _STD _Call_back_binder(_IntSeq{}, _STD forward<_CvFD>(_Fx), _STD forward<_CvBoundTuple>(_Bound_tuple),
+        _STD forward<_Unbound>(_Unbound_args)...);
+};
+#else // ^^^ concept available / concept unavailable vvv
 template <class, class _IntSeq, class _CvFD, class _CvBoundTuple, class... _Unbound>
 inline constexpr bool _Can_call_back_binder_impl = false;
 
@@ -2216,6 +2303,7 @@ inline constexpr bool
 template <class _IntSeq, class _CvFD, class _CvBoundTuple, class... _Unbound>
 inline constexpr bool _Can_call_back_binder =
     _Can_call_back_binder_impl<void, _IntSeq, _CvFD, _CvBoundTuple, _Unbound...>;
+#endif // ^^^ concept unavailable ^^^
 
 template <class _Fx, class... _Types>
 class _Back_binder { // wrap bound callable object and arguments
@@ -2233,6 +2321,51 @@ public:
     constexpr explicit _Back_binder(_FxInit&& _Func, _TypesInit&&... _Args)
         : _Mypair(_One_then_variadic_args_t{}, _STD forward<_FxInit>(_Func), _STD forward<_TypesInit>(_Args)...) {}
 
+#ifdef __cpp_lib_concepts // TRANSITON, GH-395
+    template <class... _Unbound>
+        requires _Can_call_back_binder<_Seq, _Fx&, tuple<_Types...>&, _Unbound...>
+    constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) & noexcept(noexcept(
+        _STD _Call_back_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...))) {
+        return _STD _Call_back_binder(
+            _Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...);
+    }
+
+    template <class... _Unbound>
+    void operator()(_Unbound&&...) & = delete;
+
+    template <class... _Unbound>
+        requires _Can_call_back_binder<_Seq, const _Fx&, const tuple<_Types...>&, _Unbound...>
+    constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) const& noexcept(noexcept(
+        _STD _Call_back_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...))) {
+        return _STD _Call_back_binder(
+            _Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...);
+    }
+
+    template <class... _Unbound>
+    void operator()(_Unbound&&...) const& = delete;
+
+    template <class... _Unbound>
+        requires _Can_call_back_binder<_Seq, _Fx&&, tuple<_Types...>&&, _Unbound...>
+    constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) && noexcept(noexcept(_STD _Call_back_binder(
+        _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...))) {
+        return _STD _Call_back_binder(
+            _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...);
+    }
+
+    template <class... _Unbound>
+    void operator()(_Unbound&&...) && = delete;
+
+    template <class... _Unbound>
+        requires _Can_call_back_binder<_Seq, const _Fx&&, const tuple<_Types...>&&, _Unbound...>
+    constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) const&& noexcept(noexcept(_STD _Call_back_binder(
+        _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...))) {
+        return _STD _Call_back_binder(
+            _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...);
+    }
+
+    template <class... _Unbound>
+    void operator()(_Unbound&&...) const&& = delete;
+#else // ^^^ requires available / requires unavailable vvv
     template <class... _Unbound,
         enable_if_t<_Can_call_back_binder<_Seq, _Fx&, tuple<_Types...>&, _Unbound...>, int> = 0>
     constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) & noexcept(noexcept(
@@ -2279,6 +2412,7 @@ public:
     template <class... _Unbound,
         enable_if_t<!_Can_call_back_binder<_Seq, const _Fx, const tuple<_Types...>, _Unbound&&...>, int> = 0>
     void operator()(_Unbound&&...) const&& = delete;
+#endif // ^^^ requires unavailable ^^^
 };
 
 _EXPORT_STD template <class _Fx, class... _Types>

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -2043,7 +2043,7 @@ public:
 #if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <class... _Unbound>
         requires _Can_call_binder<_Ret, _Fd, _Seq, _Bound_tuple, tuple<_Unbound&&...>>
-    _CONSTEXPR20 decltype(auto) operator()(_Unbound&&... _Unbargs) noexcept(noexcept(_CALL_BINDER)) {
+    constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) noexcept(noexcept(_CALL_BINDER)) {
         return _CALL_BINDER;
     }
 
@@ -2052,7 +2052,7 @@ public:
 
     template <class... _Unbound>
         requires _Can_call_binder<_Ret, const _Fd, _Seq, const _Bound_tuple, tuple<_Unbound&&...>>
-    _CONSTEXPR20 decltype(auto) operator()(_Unbound&&... _Unbargs) const noexcept(noexcept(_CALL_BINDER)) {
+    constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) const noexcept(noexcept(_CALL_BINDER)) {
         return _CALL_BINDER;
     }
 
@@ -2163,7 +2163,7 @@ public:
     constexpr explicit _Front_binder(_FxInit&& _Func, _TypesInit&&... _Args)
         : _Mypair(_One_then_variadic_args_t{}, _STD forward<_FxInit>(_Func), _STD forward<_TypesInit>(_Args)...) {}
 
-#ifdef __cpp_lib_concepts // TRANSITON, GH-395
+#ifdef __cpp_lib_concepts // TRANSITION, GH-395
     template <class... _Unbound>
         requires _Can_call_front_binder<_Seq, _Fx&, tuple<_Types...>&, _Unbound...>
     constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) & noexcept(noexcept(
@@ -2187,7 +2187,7 @@ public:
     void operator()(_Unbound&&...) const& = delete;
 
     template <class... _Unbound>
-        requires _Can_call_front_binder<_Seq, _Fx&&, tuple<_Types...>&&, _Unbound...>
+        requires _Can_call_front_binder<_Seq, _Fx, tuple<_Types...>, _Unbound...>
     constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) && noexcept(noexcept(_STD _Call_front_binder(
         _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...))) {
         return _STD _Call_front_binder(
@@ -2198,7 +2198,7 @@ public:
     void operator()(_Unbound&&...) && = delete;
 
     template <class... _Unbound>
-        requires _Can_call_front_binder<_Seq, const _Fx&&, const tuple<_Types...>&&, _Unbound...>
+        requires _Can_call_front_binder<_Seq, const _Fx, const tuple<_Types...>, _Unbound...>
     constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) const&& noexcept(noexcept(_STD _Call_front_binder(
         _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...))) {
         return _STD _Call_front_binder(
@@ -2209,7 +2209,7 @@ public:
     void operator()(_Unbound&&...) const&& = delete;
 #else // ^^^ requires available / requires unavailable vvv
     template <class... _Unbound,
-        enable_if_t<_Can_call_front_binder<_Seq, _Fx&, tuple<_Types...>&, _Unbound&&...>, int> = 0>
+        enable_if_t<_Can_call_front_binder<_Seq, _Fx&, tuple<_Types...>&, _Unbound...>, int> = 0>
     constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) & noexcept(noexcept(
         _STD _Call_front_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...))) {
         return _STD _Call_front_binder(
@@ -2217,11 +2217,11 @@ public:
     }
 
     template <class... _Unbound,
-        enable_if_t<!_Can_call_front_binder<_Seq, _Fx&, tuple<_Types...>&, _Unbound&&...>, int> = 0>
+        enable_if_t<!_Can_call_front_binder<_Seq, _Fx&, tuple<_Types...>&, _Unbound...>, int> = 0>
     void operator()(_Unbound&&...) & = delete;
 
     template <class... _Unbound,
-        enable_if_t<_Can_call_front_binder<_Seq, const _Fx&, const tuple<_Types...>&, _Unbound&&...>, int> = 0>
+        enable_if_t<_Can_call_front_binder<_Seq, const _Fx&, const tuple<_Types...>&, _Unbound...>, int> = 0>
     constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) const& noexcept(noexcept(
         _STD _Call_front_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...))) {
         return _STD _Call_front_binder(
@@ -2229,11 +2229,10 @@ public:
     }
 
     template <class... _Unbound,
-        enable_if_t<!_Can_call_front_binder<_Seq, const _Fx&, const tuple<_Types...>&, _Unbound&&...>, int> = 0>
+        enable_if_t<!_Can_call_front_binder<_Seq, const _Fx&, const tuple<_Types...>&, _Unbound...>, int> = 0>
     void operator()(_Unbound&&...) const& = delete;
 
-    template <class... _Unbound,
-        enable_if_t<_Can_call_front_binder<_Seq, _Fx, tuple<_Types...>, _Unbound&&...>, int> = 0>
+    template <class... _Unbound, enable_if_t<_Can_call_front_binder<_Seq, _Fx, tuple<_Types...>, _Unbound...>, int> = 0>
     constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) && noexcept(noexcept(_STD _Call_front_binder(
         _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...))) {
         return _STD _Call_front_binder(
@@ -2241,11 +2240,11 @@ public:
     }
 
     template <class... _Unbound,
-        enable_if_t<!_Can_call_front_binder<_Seq, _Fx, tuple<_Types...>, _Unbound&&...>, int> = 0>
+        enable_if_t<!_Can_call_front_binder<_Seq, _Fx, tuple<_Types...>, _Unbound...>, int> = 0>
     void operator()(_Unbound&&...) && = delete;
 
     template <class... _Unbound,
-        enable_if_t<_Can_call_front_binder<_Seq, const _Fx, const tuple<_Types...>, _Unbound&&...>, int> = 0>
+        enable_if_t<_Can_call_front_binder<_Seq, const _Fx, const tuple<_Types...>, _Unbound...>, int> = 0>
     constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) const&& noexcept(noexcept(_STD _Call_front_binder(
         _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...))) {
         return _STD _Call_front_binder(
@@ -2253,7 +2252,7 @@ public:
     }
 
     template <class... _Unbound,
-        enable_if_t<!_Can_call_front_binder<_Seq, const _Fx, const tuple<_Types...>, _Unbound&&...>, int> = 0>
+        enable_if_t<!_Can_call_front_binder<_Seq, const _Fx, const tuple<_Types...>, _Unbound...>, int> = 0>
     void operator()(_Unbound&&...) const&& = delete;
 #endif // ^^^ requires unavailable ^^^
 };
@@ -2321,7 +2320,7 @@ public:
     constexpr explicit _Back_binder(_FxInit&& _Func, _TypesInit&&... _Args)
         : _Mypair(_One_then_variadic_args_t{}, _STD forward<_FxInit>(_Func), _STD forward<_TypesInit>(_Args)...) {}
 
-#ifdef __cpp_lib_concepts // TRANSITON, GH-395
+#ifdef __cpp_lib_concepts // TRANSITION, GH-395
     template <class... _Unbound>
         requires _Can_call_back_binder<_Seq, _Fx&, tuple<_Types...>&, _Unbound...>
     constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) & noexcept(noexcept(
@@ -2345,7 +2344,7 @@ public:
     void operator()(_Unbound&&...) const& = delete;
 
     template <class... _Unbound>
-        requires _Can_call_back_binder<_Seq, _Fx&&, tuple<_Types...>&&, _Unbound...>
+        requires _Can_call_back_binder<_Seq, _Fx, tuple<_Types...>, _Unbound...>
     constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) && noexcept(noexcept(_STD _Call_back_binder(
         _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...))) {
         return _STD _Call_back_binder(
@@ -2356,7 +2355,7 @@ public:
     void operator()(_Unbound&&...) && = delete;
 
     template <class... _Unbound>
-        requires _Can_call_back_binder<_Seq, const _Fx&&, const tuple<_Types...>&&, _Unbound...>
+        requires _Can_call_back_binder<_Seq, const _Fx, const tuple<_Types...>, _Unbound...>
     constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) const&& noexcept(noexcept(_STD _Call_back_binder(
         _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...))) {
         return _STD _Call_back_binder(
@@ -2375,11 +2374,11 @@ public:
     }
 
     template <class... _Unbound,
-        enable_if_t<!_Can_call_back_binder<_Seq, _Fx&, tuple<_Types...>&, _Unbound&&...>, int> = 0>
+        enable_if_t<!_Can_call_back_binder<_Seq, _Fx&, tuple<_Types...>&, _Unbound...>, int> = 0>
     void operator()(_Unbound&&...) & = delete;
 
     template <class... _Unbound,
-        enable_if_t<_Can_call_back_binder<_Seq, const _Fx&, const tuple<_Types...>&, _Unbound&&...>, int> = 0>
+        enable_if_t<_Can_call_back_binder<_Seq, const _Fx&, const tuple<_Types...>&, _Unbound...>, int> = 0>
     constexpr decltype(auto) operator()(_Unbound&&... _Unbargs) const& noexcept(noexcept(
         _STD _Call_back_binder(_Seq{}, _Mypair._Get_first(), _Mypair._Myval2, _STD forward<_Unbound>(_Unbargs)...))) {
         return _STD _Call_back_binder(
@@ -2387,7 +2386,7 @@ public:
     }
 
     template <class... _Unbound,
-        enable_if_t<!_Can_call_back_binder<_Seq, const _Fx&, const tuple<_Types...>&, _Unbound&&...>, int> = 0>
+        enable_if_t<!_Can_call_back_binder<_Seq, const _Fx&, const tuple<_Types...>&, _Unbound...>, int> = 0>
     void operator()(_Unbound&&...) const& = delete;
 
     template <class... _Unbound, enable_if_t<_Can_call_back_binder<_Seq, _Fx, tuple<_Types...>, _Unbound...>, int> = 0>
@@ -2397,8 +2396,7 @@ public:
             _Seq{}, _STD move(_Mypair._Get_first()), _STD move(_Mypair._Myval2), _STD forward<_Unbound>(_Unbargs)...);
     }
 
-    template <class... _Unbound,
-        enable_if_t<!_Can_call_back_binder<_Seq, _Fx, tuple<_Types...>, _Unbound&&...>, int> = 0>
+    template <class... _Unbound, enable_if_t<!_Can_call_back_binder<_Seq, _Fx, tuple<_Types...>, _Unbound...>, int> = 0>
     void operator()(_Unbound&&...) && = delete;
 
     template <class... _Unbound,
@@ -2410,7 +2408,7 @@ public:
     }
 
     template <class... _Unbound,
-        enable_if_t<!_Can_call_back_binder<_Seq, const _Fx, const tuple<_Types...>, _Unbound&&...>, int> = 0>
+        enable_if_t<!_Can_call_back_binder<_Seq, const _Fx, const tuple<_Types...>, _Unbound...>, int> = 0>
     void operator()(_Unbound&&...) const&& = delete;
 #endif // ^^^ requires unavailable ^^^
 };

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -819,9 +819,6 @@ std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.
 std/utilities/format/format.formatter/format.parse.ctx/next_arg_id.pass.cpp FAIL
 std/time/time.syn/formatter.month_day_last.pass.cpp FAIL
 
-# Likely STL bug in `bind_front`: we don't respect deletion of the target call operator
-std/utilities/function.objects/func.bind_front/bind_front.pass.cpp FAIL
-
 # Likely STL bug in `join_view::_Iterator`: constexpr weirdness
 std/ranges/range.adaptors/range.join.view/end.pass.cpp:1 FAIL
 std/ranges/range.adaptors/range.join.view/iterator/decrement.pass.cpp:0 FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -667,6 +667,9 @@ std/utilities/format/format.formatter/format.formatter.spec/formatter.unsigned_i
 std/utilities/format/format.formatter/format.formatter.spec/formatter.char.pass.cpp FAIL
 std/utilities/format/format.formatter/format.formatter.spec/formatter.floating_point.pass.cpp FAIL
 
+# libc++ requires bind_front to be SFINAE-friendly, although the Standard uses "Mandates:" for constructibility.
+std/utilities/function.objects/func.bind_front/bind_front.pass.cpp FAIL
+
 # libc++ chose option A for [time.clock.file.members], and we chose option B.
 std/time/time.clock/time.clock.file/to_from_sys.pass.cpp FAIL
 
@@ -818,9 +821,6 @@ std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.
 # Likely STL bugs in <format>
 std/utilities/format/format.formatter/format.parse.ctx/next_arg_id.pass.cpp FAIL
 std/time/time.syn/formatter.month_day_last.pass.cpp FAIL
-
-# Likely STL bug in `bind_front`: we don't respect deletion of the target call operator
-std/utilities/function.objects/func.bind_front/bind_front.pass.cpp FAIL
 
 # Likely STL bug in `join_view::_Iterator`: constexpr weirdness
 std/ranges/range.adaptors/range.join.view/end.pass.cpp:1 FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -819,6 +819,9 @@ std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.
 std/utilities/format/format.formatter/format.parse.ctx/next_arg_id.pass.cpp FAIL
 std/time/time.syn/formatter.month_day_last.pass.cpp FAIL
 
+# Likely STL bug in `bind_front`: we don't respect deletion of the target call operator
+std/utilities/function.objects/func.bind_front/bind_front.pass.cpp FAIL
+
 # Likely STL bug in `join_view::_Iterator`: constexpr weirdness
 std/ranges/range.adaptors/range.join.view/end.pass.cpp:1 FAIL
 std/ranges/range.adaptors/range.join.view/iterator/decrement.pass.cpp:0 FAIL

--- a/tests/std/tests/GH_000952_bind_constraints/test.compile.pass.cpp
+++ b/tests/std/tests/GH_000952_bind_constraints/test.compile.pass.cpp
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// some portions of this file is derived from libc++'s test files:
+// some portions of this file are derived from libc++'s test files:
 // * std/utilities/function.objects/func.bind_front/bind_front.pass.cpp
 
 #include <functional>
@@ -75,7 +75,7 @@ static_assert(
 static_assert(is_invocable_v<const WeirdIdentity&, int>
               == is_invocable_v<const decltype(bind(WeirdIdentity{}, placeholders::_1))&, int>);
 static_assert(is_invocable_v<const WeirdIdentity&, int>
-              == is_invocable_v<const decltype(bind(WeirdIdentity{}, placeholders::_1))&, int>);
+              == is_invocable_v<const decltype(bind(WeirdIdentity{}, placeholders::_1)), int>);
 
 static_assert(is_invocable_r_v<void, WeirdIdentity&, int>
               == is_invocable_v<decltype(bind<void>(WeirdIdentity{}, placeholders::_1))&, int>);
@@ -84,7 +84,7 @@ static_assert(is_invocable_r_v<void, WeirdIdentity&, int>
 static_assert(is_invocable_r_v<void, const WeirdIdentity&, int>
               == is_invocable_v<const decltype(bind<void>(WeirdIdentity{}, placeholders::_1))&, int>);
 static_assert(is_invocable_r_v<void, const WeirdIdentity&, int>
-              == is_invocable_v<const decltype(bind<void>(WeirdIdentity{}, placeholders::_1))&, int>);
+              == is_invocable_v<const decltype(bind<void>(WeirdIdentity{}, placeholders::_1)), int>);
 
 static_assert(is_invocable_r_v<int, WeirdIdentity&, int>
               == is_invocable_v<decltype(bind<int>(WeirdIdentity{}, placeholders::_1))&, int>);
@@ -93,7 +93,7 @@ static_assert(is_invocable_r_v<int, WeirdIdentity&, int>
 static_assert(is_invocable_r_v<int, const WeirdIdentity&, int>
               == is_invocable_v<const decltype(bind<int>(WeirdIdentity{}, placeholders::_1))&, int>);
 static_assert(is_invocable_r_v<int, const WeirdIdentity&, int>
-              == is_invocable_v<const decltype(bind<int>(WeirdIdentity{}, placeholders::_1))&, int>);
+              == is_invocable_v<const decltype(bind<int>(WeirdIdentity{}, placeholders::_1)), int>);
 #endif // _HAS_CXX17
 
 #if _HAS_CXX20
@@ -194,6 +194,7 @@ void test_bind_front_deletion() {
         static_assert(!is_invocable_v<X>);
     }
 }
+#endif // _HAS_CXX20
 
 #if _HAS_CXX23
 static_assert(is_invocable_v<WeirdDual&, int, long> == is_invocable_v<decltype(bind_back(WeirdDual{}, 0L))&, int>);
@@ -280,4 +281,3 @@ void test_bind_back_deletion() {
     }
 }
 #endif // _HAS_CXX23
-#endif // _HAS_CXX20

--- a/tests/std/tests/GH_000952_bind_constraints/test.compile.pass.cpp
+++ b/tests/std/tests/GH_000952_bind_constraints/test.compile.pass.cpp
@@ -108,11 +108,11 @@ static_assert(
     is_invocable_v<const WeirdDual, int, long> == is_invocable_v<const decltype(bind_front(WeirdDual{}, 0)), long>);
 
 #if _HAS_CXX23
-static_assert(is_invocable_v<WeirdDual&, int, long> == is_invocable_v<decltype(bind_back(WeirdDual{}, 0L))&, long>);
+static_assert(is_invocable_v<WeirdDual&, int, long> == is_invocable_v<decltype(bind_back(WeirdDual{}, 0L))&, int>);
 static_assert(
-    is_invocable_v<const WeirdDual&, int, long> == is_invocable_v<const decltype(bind_front(WeirdDual{}, 0L))&, long>);
-static_assert(is_invocable_v<WeirdDual, int, long> == is_invocable_v<decltype(bind_front(WeirdDual{}, 0L)), long>);
+    is_invocable_v<const WeirdDual&, int, long> == is_invocable_v<const decltype(bind_back(WeirdDual{}, 0L))&, int>);
+static_assert(is_invocable_v<WeirdDual, int, long> == is_invocable_v<decltype(bind_back(WeirdDual{}, 0L)), int>);
 static_assert(
-    is_invocable_v<const WeirdDual, int, long> == is_invocable_v<const decltype(bind_front(WeirdDual{}, 0L)), long>);
+    is_invocable_v<const WeirdDual, int, long> == is_invocable_v<const decltype(bind_back(WeirdDual{}, 0L)), int>);
 #endif // _HAS_CXX23
 #endif // _HAS_CXX20


### PR DESCRIPTION
The deleted overloads prevent overload resolution flowing into another unintended overload when the invocation should be (SFINAE-friendlily) ill-formed.

Since the `operator()` overloads are constrained in default template arguments now, I think it would be better to use `decltype(auto)` to specify the return types.

There seems to be something wrong with modules when using traditional SFINAE, so I'm changing to use `requires` when possible.

~Unblock one libc++ test:~
- ~`std/utilities/function.objects/func.bind_front/bind_front.pass.cpp`~

The test seemly requires `bind_front` to be SFINAE-friendly, while the Standard uses "_Mandates_:"... As a result, I decided to copy some parts of that file into MSVC STL's test file.

Driven-by: `_STD`-qualify the internal calling helpers.