### PR TITLE
Avoid evil macros

### DIFF
--- a/stl/inc/__msvc_bit_utils.hpp
+++ b/stl/inc/__msvc_bit_utils.hpp
@@ -49,19 +49,19 @@ _INLINE_VAR constexpr int _Unsigned_integer_digits = sizeof(_UInt) * CHAR_BIT;
 // see "Hacker's Delight" section 5-3
 template <class _Ty>
 _NODISCARD constexpr int _Countl_zero_fallback(_Ty _Val) noexcept {
-    _Ty _Yy = 0;
+    _Ty _Yx = 0;
 
-    unsigned int _Nn = _Unsigned_integer_digits<_Ty>;
-    unsigned int _Cc = _Unsigned_integer_digits<_Ty> / 2;
+    unsigned int _Nx = _Unsigned_integer_digits<_Ty>;
+    unsigned int _Cx = _Unsigned_integer_digits<_Ty> / 2;
     do {
-        _Yy = static_cast<_Ty>(_Val >> _Cc);
-        if (_Yy != 0) {
-            _Nn -= _Cc;
-            _Val = _Yy;
+        _Yx = static_cast<_Ty>(_Val >> _Cx);
+        if (_Yx != 0) {
+            _Nx -= _Cx;
+            _Val = _Yx;
         }
-        _Cc >>= 1;
-    } while (_Cc != 0);
-    return static_cast<int>(_Nn) - static_cast<int>(_Val);
+        _Cx >>= 1;
+    } while (_Cx != 0);
+    return static_cast<int>(_Nx) - static_cast<int>(_Val);
 }
 
 #if !defined(_M_CEE_PURE) && !defined(__CUDACC__) && !defined(__INTEL_COMPILER)

--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -1531,8 +1531,8 @@ _NODISCARD _Ty abs(const complex<_Ty>& _Left) {
 
 _EXPORT_STD template <class _Ty>
 _NODISCARD complex<_Ty> acos(const complex<_Ty>& _Left) {
-    const _Ty _Arcbig = static_cast<_Ty>(0.25) * _Ctraits<_Ty>::sqrt(_Ctraits<_Ty>::_Flt_max());
-    constexpr _Ty _Pi = static_cast<_Ty>(3.1415926535897932384626433832795029L);
+    const _Ty _Arcbig     = static_cast<_Ty>(0.25) * _Ctraits<_Ty>::sqrt(_Ctraits<_Ty>::_Flt_max());
+    constexpr _Ty _Pi_val = static_cast<_Ty>(3.1415926535897932384626433832795029L);
 
     const _Ty _Re = real(_Left);
     const _Ty _Im = imag(_Left);
@@ -1545,18 +1545,18 @@ _NODISCARD complex<_Ty> acos(const complex<_Ty>& _Left) {
     } else if (_Ctraits<_Ty>::_Isinf(_Re)) { // (+/-Inf, not NaN)
         if (_Ctraits<_Ty>::_Isinf(_Im)) {
             if (_Re < 0) {
-                _Ux = static_cast<_Ty>(0.75) * _Pi; // (-Inf, +/-Inf)
+                _Ux = static_cast<_Ty>(0.75) * _Pi_val; // (-Inf, +/-Inf)
             } else {
-                _Ux = static_cast<_Ty>(0.25) * _Pi; // (+Inf, +/-Inf)
+                _Ux = static_cast<_Ty>(0.25) * _Pi_val; // (+Inf, +/-Inf)
             }
         } else if (_Re < 0) {
-            _Ux = _Pi; // (-Inf, finite)
+            _Ux = _Pi_val; // (-Inf, finite)
         } else {
             _Ux = 0; // (+Inf, finite)
         }
         _Vx = -_Ctraits<_Ty>::_Copysign(_Ctraits<_Ty>::_Infv(), _Im);
     } else if (_Ctraits<_Ty>::_Isinf(_Im)) { // (finite, finite)
-        _Ux = static_cast<_Ty>(0.50) * _Pi; // (finite, +/-Inf)
+        _Ux = static_cast<_Ty>(0.50) * _Pi_val; // (finite, +/-Inf)
         _Vx = -_Im;
     } else { // (finite, finite)
         const complex<_Ty> _Wx = sqrt(complex<_Ty>(1 + _Re, -_Im));
@@ -1598,8 +1598,8 @@ _NODISCARD complex<_Ty> acos(const complex<_Ty>& _Left) {
 
 _EXPORT_STD template <class _Ty>
 _NODISCARD complex<_Ty> acosh(const complex<_Ty>& _Left) {
-    const _Ty _Arcbig = static_cast<_Ty>(0.25) * _Ctraits<_Ty>::sqrt(_Ctraits<_Ty>::_Flt_max());
-    constexpr _Ty _Pi = static_cast<_Ty>(3.1415926535897932384626433832795029L);
+    const _Ty _Arcbig     = static_cast<_Ty>(0.25) * _Ctraits<_Ty>::sqrt(_Ctraits<_Ty>::_Flt_max());
+    constexpr _Ty _Pi_val = static_cast<_Ty>(3.1415926535897932384626433832795029L);
 
     const _Ty _Re = real(_Left);
     _Ty _Im       = imag(_Left);
@@ -1614,12 +1614,12 @@ _NODISCARD complex<_Ty> acosh(const complex<_Ty>& _Left) {
 
         if (_Ctraits<_Ty>::_Isinf(_Im)) {
             if (_Re < 0) {
-                _Vx = static_cast<_Ty>(0.75) * _Pi; // (-Inf, +/-Inf)
+                _Vx = static_cast<_Ty>(0.75) * _Pi_val; // (-Inf, +/-Inf)
             } else {
-                _Vx = static_cast<_Ty>(0.25) * _Pi; // (+Inf, +/-Inf)
+                _Vx = static_cast<_Ty>(0.25) * _Pi_val; // (+Inf, +/-Inf)
             }
         } else if (_Re < 0) {
-            _Vx = _Pi; // (-Inf, finite)
+            _Vx = _Pi_val; // (-Inf, finite)
         } else {
             _Vx = 0; // (+Inf, finite)
         }
@@ -1627,7 +1627,7 @@ _NODISCARD complex<_Ty> acosh(const complex<_Ty>& _Left) {
         _Vx = _Ctraits<_Ty>::_Copysign(_Vx, _Im);
     } else if (_Ctraits<_Ty>::_Isinf(_Im)) { // (finite, +/-Inf)
         _Ux = _Ctraits<_Ty>::_Infv();
-        _Vx = _Ctraits<_Ty>::_Copysign(static_cast<_Ty>(0.50) * _Pi, _Im);
+        _Vx = _Ctraits<_Ty>::_Copysign(static_cast<_Ty>(0.50) * _Pi_val, _Im);
     } else { // (finite, finite)
         const complex<_Ty> _Wx = sqrt(complex<_Ty>(_Re - 1, -_Im));
         const complex<_Ty> _Zx = sqrt(complex<_Ty>(_Re + 1, _Im));
@@ -1668,8 +1668,8 @@ _NODISCARD complex<_Ty> acosh(const complex<_Ty>& _Left) {
 
 _EXPORT_STD template <class _Ty>
 _NODISCARD complex<_Ty> asinh(const complex<_Ty>& _Left) {
-    const _Ty _Arcbig = static_cast<_Ty>(0.25) * _Ctraits<_Ty>::sqrt(_Ctraits<_Ty>::_Flt_max());
-    constexpr _Ty _Pi = static_cast<_Ty>(3.1415926535897932384626433832795029L);
+    const _Ty _Arcbig     = static_cast<_Ty>(0.25) * _Ctraits<_Ty>::sqrt(_Ctraits<_Ty>::_Flt_max());
+    constexpr _Ty _Pi_val = static_cast<_Ty>(3.1415926535897932384626433832795029L);
 
     const _Ty _Re = real(_Left);
     _Ty _Im       = imag(_Left);
@@ -1684,14 +1684,14 @@ _NODISCARD complex<_Ty> asinh(const complex<_Ty>& _Left) {
 
         if (_Ctraits<_Ty>::_Isinf(_Im)) { // (+/-Inf, +/-Inf)
             _Ux = _Re;
-            _Vx = _Ctraits<_Ty>::_Copysign(static_cast<_Ty>(0.25) * _Pi, _Im);
+            _Vx = _Ctraits<_Ty>::_Copysign(static_cast<_Ty>(0.25) * _Pi_val, _Im);
         } else { // (+/-Inf, finite)
             _Ux = _Re;
             _Vx = _Ctraits<_Ty>::_Copysign(_Ty{0}, _Im);
         }
     } else if (_Ctraits<_Ty>::_Isinf(_Im)) { // (finite, +/-Inf)
         _Ux = _Ctraits<_Ty>::_Copysign(_Ctraits<_Ty>::_Infv(), _Re);
-        _Vx = _Ctraits<_Ty>::_Copysign(static_cast<_Ty>(0.50) * _Pi, _Im);
+        _Vx = _Ctraits<_Ty>::_Copysign(static_cast<_Ty>(0.50) * _Pi_val, _Im);
     } else { // (finite, finite)
         const complex<_Ty> _Wx = sqrt(complex<_Ty>(1 - _Im, _Re));
         const complex<_Ty> _Zx = sqrt(complex<_Ty>(1 + _Im, -_Re));

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1316,7 +1316,7 @@ private:
         }
     };
 
-    enum class _Is_bidi : bool { _No, _Yes };
+    enum class _Is_bidi : bool { _Nope, _Yes };
 
     template <_Is_bidi _Bidi, class _Iter, class _Sent>
     iterator _Insert_range(const size_type _Off, _Iter _First, _Sent _Last) {
@@ -1352,7 +1352,7 @@ private:
             const auto _Num     = static_cast<difference_type>(_Mysize() - _Oldsize);
             const auto _Myfirst = _Unchecked_begin();
             const auto _Mymid   = _Myfirst + _Num;
-            if constexpr (_Bidi == _Is_bidi::_No) {
+            if constexpr (_Bidi == _Is_bidi::_Nope) {
                 _STD reverse(_Myfirst, _Mymid); // flip new stuff in place
             }
             _STD rotate(_Myfirst, _Mymid, _Mymid + static_cast<difference_type>(_Off));
@@ -1392,7 +1392,7 @@ public:
             return _Insert_range<_Is_bidi::_Yes>(
                 _Off, _RANGES _Ubegin(_Range), _RANGES _Get_final_iterator_unwrapped(_Range));
         } else {
-            return _Insert_range<_Is_bidi::_No>(_Off, _RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
+            return _Insert_range<_Is_bidi::_Nope>(_Off, _RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
         }
     }
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -49,7 +49,7 @@ struct _Mtx_internal_imp_mirror {
     static constexpr size_t _Critical_section_align = alignof(void*);
 
     int _Type;
-    _Aligned_storage_t<_Critical_section_size, _Critical_section_align> _Cs;
+    _Aligned_storage_t<_Critical_section_size, _Critical_section_align> _Cs_storage;
     long _Thread_id;
     int _Count;
 };

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -61,10 +61,10 @@ using _Enable_if_seed_seq_t =
                     && !is_same_v<remove_cv_t<_Seed_seq>, _Self> && !is_same_v<remove_cv_t<_Seed_seq>, _Engine>,
         int>;
 
-_INLINE_VAR constexpr long double _Pi    = 3.14159265358979323846264338327950288L;
-_INLINE_VAR constexpr long double _Exp1  = 2.71828182845904523536028747135266250L;
-_INLINE_VAR constexpr long double _Two32 = 4294967296.0L;
-_INLINE_VAR constexpr long double _Two31 = 2147483648.0L;
+_INLINE_VAR constexpr long double _Pi_val = 3.14159265358979323846264338327950288L;
+_INLINE_VAR constexpr long double _Exp1   = 2.71828182845904523536028747135266250L;
+_INLINE_VAR constexpr long double _Two32  = 4294967296.0L;
+_INLINE_VAR constexpr long double _Two31  = 2147483648.0L;
 
 extern "C++" _CRTIMP2_PURE float __CLRCALL_PURE_OR_CDECL _XLgamma(float);
 extern "C++" _CRTIMP2_PURE double __CLRCALL_PURE_OR_CDECL _XLgamma(double);
@@ -2466,7 +2466,7 @@ private:
             _Ty _Res;
             _Ty1 _Yx;
             for (;;) { // generate a tentative value
-                _Yx = static_cast<_Ty1>(_CSTD tan(_Pi * _NRAND(_Eng, _Ty1)));
+                _Yx = static_cast<_Ty1>(_CSTD tan(_Pi_val * _NRAND(_Eng, _Ty1)));
                 const _Ty1 _Mx{_Par0._Sqrt * _Yx + _Par0._Mean};
                 if (0.0 <= _Mx && _Mx < _Ty1_max) {
                     _Res = static_cast<_Ty>(_Mx);
@@ -2661,7 +2661,7 @@ private:
             for (;;) { // generate and reject
                 _Ty1 _Yx;
                 for (;;) { // generate a tentative value
-                    _Yx = static_cast<_Ty1>(_CSTD tan(_Pi * _NRAND(_Eng, _Ty1)));
+                    _Yx = static_cast<_Ty1>(_CSTD tan(_Pi_val * _NRAND(_Eng, _Ty1)));
                     const _Ty1 _Mx{_Par0._Sqrt * _Yx + _Par0._Mean};
                     if (0.0 <= _Mx && _Mx < _Ty1_Tx) {
                         _Res = static_cast<_Ty>(_Mx);
@@ -3317,7 +3317,7 @@ private:
 
         // no shortcuts
         for (;;) { // generate and reject
-            _Yx = static_cast<_Ty>(_CSTD tan(_Pi * _NRAND(_Eng, _Ty)));
+            _Yx = static_cast<_Ty>(_CSTD tan(_Pi_val * _NRAND(_Eng, _Ty)));
             _Xx = _Par0._Sqrt * _Yx + _Par0._Alpha - 1;
             if (0 < _Xx
                 && _NRAND(_Eng, _Ty) <= (1 + _Yx * _Yx)
@@ -3949,7 +3949,7 @@ private:
     template <class _Engine>
     result_type _Eval(_Engine& _Eng, const param_type& _Par0) const { // generate pseudo-random value
         _Ty Px = _NRAND(_Eng, _Ty);
-        return static_cast<_Ty>(_Par0._Ax + _Par0._Bx * _CSTD tan(_Pi * (Px - static_cast<_Ty>(0.5))));
+        return static_cast<_Ty>(_Par0._Ax + _Par0._Bx * _CSTD tan(_Pi_val * (Px - static_cast<_Ty>(0.5))));
     }
 
     param_type _Par;

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1486,8 +1486,8 @@ struct _Loop_vals_t { // storage for loop administration
 
 class _Node_rep : public _Node_base { // node that marks the beginning of a repetition
 public:
-    _Node_rep(bool _Greedy, int _Mn, int _Mx, _Node_end_rep* _End, unsigned int _Number)
-        : _Node_base(_N_rep, _Greedy ? _Fl_greedy : _Fl_none), _Min(_Mn), _Max(_Mx), _End_rep(_End),
+    _Node_rep(bool _Greedy, int _Min_, int _Max_, _Node_end_rep* _End, unsigned int _Number)
+        : _Node_base(_N_rep, _Greedy ? _Fl_greedy : _Fl_none), _Min(_Min_), _Max(_Max_), _End_rep(_End),
           _Loop_number(_Number), _Simple_loop(-1) {}
 
     const int _Min;


### PR DESCRIPTION
ICU previously macroized these reserved names. This was fixed by https://github.com/unicode-org/icu/pull/1555 on 2021-02-01, but old versions of ICU are still being used by various projects. Let's avoid these names for now. I haven't added test coverage because the UCRT uses some of these reserved names (which it's getting away with, due to the specific order in which headers are being included).

Fixes VSO-1837381 "\[RWC\]\[prod/fe\]\[Regression\] PDFium failed with error C2209: `'std::_Aligned_storage_t<64,8>'`: aliases cannot be used in constructor declarations".

* `_Cs` => `_Cs_storage`
  + This introduces a slight but acceptable asymmetry with `mutex.cpp`.
  + This is the actual fix for the regression introduced by #3763. We were getting away with the others.
* `_No` => `_Nope`
  + This makes `<deque>` `_Is_bidi` consistent with `<format>` `_Add_newline`, `<xlocale>` `_Case_sensitive`, etc.
* `_Mn` => `_Min_`, also `_Mx` => `_Max_` for consistency
  + This is our conventional pattern for avoiding parameters shadowing data members.
* `_Cc` => `_Cx`, also `_Yy` => `_Yx` and `_Nn` => `_Nx` for consistency
  + This is our common pattern for "single letter" variable names.
* `_Pi` => `_Pi_val`
