### PR TITLE
Implement LWG-3904 `lazy_split_view::outer-iterator`'s `const`-converting constructor isn't setting `trailing_empty_`

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -4596,7 +4596,7 @@ namespace ranges {
 
             constexpr _Outer_iter(_Outer_iter<!_Const> _It)
                 requires _Const && convertible_to<iterator_t<_Vw>, iterator_t<_BaseTy>>
-                : _Mybase{_STD move(_It._Current)}, _Parent{_It._Parent} {}
+                : _Mybase{_STD move(_It._Current)}, _Parent{_It._Parent}, _Trailing_empty{_It._Trailing_empty} {}
 
             _NODISCARD constexpr auto operator*() const noexcept(noexcept(value_type{*this})) /* strengthened */ {
                 return value_type{*this};

--- a/tests/std/tests/P0896R4_views_lazy_split/test.cpp
+++ b/tests/std/tests/P0896R4_views_lazy_split/test.cpp
@@ -337,7 +337,18 @@ constexpr bool instantiation_test() {
     return true;
 }
 
+constexpr bool test_lwg_3904() {
+    auto r = views::single(0) | views::lazy_split(0);
+    auto i = r.begin();
+    ++i;
+    decltype(as_const(r).begin()) j = i;
+    return j != r.end();
+}
+
 int main() {
     STATIC_ASSERT(instantiation_test());
     instantiation_test();
+
+    STATIC_ASSERT(test_lwg_3904());
+    assert(test_lwg_3904());
 }


### PR DESCRIPTION
Towards #3778.