### PR TITLE
`<format>`: Move the major part of `visit_format_arg` into a member function of `basic_format_arg`

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -745,10 +745,45 @@ public:
         }
     }
 
-private:
-    template <class _Visitor, class _Ctx>
-    friend decltype(auto) visit_format_arg(_Visitor&&, basic_format_arg<_Ctx>);
+    template <class _Visitor>
+    decltype(auto) _Visit(_Visitor&& _Vis) {
+        switch (_Active_state) {
+        case _Basic_format_arg_type::_None:
+            return _STD forward<_Visitor>(_Vis)(_No_state);
+        case _Basic_format_arg_type::_Int_type:
+            return _STD forward<_Visitor>(_Vis)(_Int_state);
+        case _Basic_format_arg_type::_UInt_type:
+            return _STD forward<_Visitor>(_Vis)(_UInt_state);
+        case _Basic_format_arg_type::_Long_long_type:
+            return _STD forward<_Visitor>(_Vis)(_Long_long_state);
+        case _Basic_format_arg_type::_ULong_long_type:
+            return _STD forward<_Visitor>(_Vis)(_ULong_long_state);
+        case _Basic_format_arg_type::_Bool_type:
+            return _STD forward<_Visitor>(_Vis)(_Bool_state);
+        case _Basic_format_arg_type::_Char_type:
+            return _STD forward<_Visitor>(_Vis)(_Char_state);
+        case _Basic_format_arg_type::_Float_type:
+            return _STD forward<_Visitor>(_Vis)(_Float_state);
+        case _Basic_format_arg_type::_Double_type:
+            return _STD forward<_Visitor>(_Vis)(_Double_state);
+        case _Basic_format_arg_type::_Long_double_type:
+            return _STD forward<_Visitor>(_Vis)(_Long_double_state);
+        case _Basic_format_arg_type::_Pointer_type:
+            return _STD forward<_Visitor>(_Vis)(_Pointer_state);
+        case _Basic_format_arg_type::_CString_type:
+            return _STD forward<_Visitor>(_Vis)(_CString_state);
+        case _Basic_format_arg_type::_String_type:
+            return _STD forward<_Visitor>(_Vis)(_String_state);
+        case _Basic_format_arg_type::_Custom_type:
+            return _STD forward<_Visitor>(_Vis)(_Custom_state);
+        default:
+            _STL_VERIFY(false, "basic_format_arg is in impossible state");
+            int _Dummy{};
+            return _STD forward<_Visitor>(_Vis)(_Dummy);
+        }
+    }
 
+private:
     friend basic_format_args<_Context>;
     friend _Format_handler<_CharType>;
     friend _Format_arg_traits<_Context>;
@@ -838,39 +873,7 @@ auto _Format_arg_traits<_Context>::_Type_eraser() {
 
 _EXPORT_STD template <class _Visitor, class _Context>
 decltype(auto) visit_format_arg(_Visitor&& _Vis, basic_format_arg<_Context> _Arg) {
-    switch (_Arg._Active_state) {
-    case _Basic_format_arg_type::_None:
-        return _STD forward<_Visitor>(_Vis)(_Arg._No_state);
-    case _Basic_format_arg_type::_Int_type:
-        return _STD forward<_Visitor>(_Vis)(_Arg._Int_state);
-    case _Basic_format_arg_type::_UInt_type:
-        return _STD forward<_Visitor>(_Vis)(_Arg._UInt_state);
-    case _Basic_format_arg_type::_Long_long_type:
-        return _STD forward<_Visitor>(_Vis)(_Arg._Long_long_state);
-    case _Basic_format_arg_type::_ULong_long_type:
-        return _STD forward<_Visitor>(_Vis)(_Arg._ULong_long_state);
-    case _Basic_format_arg_type::_Bool_type:
-        return _STD forward<_Visitor>(_Vis)(_Arg._Bool_state);
-    case _Basic_format_arg_type::_Char_type:
-        return _STD forward<_Visitor>(_Vis)(_Arg._Char_state);
-    case _Basic_format_arg_type::_Float_type:
-        return _STD forward<_Visitor>(_Vis)(_Arg._Float_state);
-    case _Basic_format_arg_type::_Double_type:
-        return _STD forward<_Visitor>(_Vis)(_Arg._Double_state);
-    case _Basic_format_arg_type::_Long_double_type:
-        return _STD forward<_Visitor>(_Vis)(_Arg._Long_double_state);
-    case _Basic_format_arg_type::_Pointer_type:
-        return _STD forward<_Visitor>(_Vis)(_Arg._Pointer_state);
-    case _Basic_format_arg_type::_CString_type:
-        return _STD forward<_Visitor>(_Vis)(_Arg._CString_state);
-    case _Basic_format_arg_type::_String_type:
-        return _STD forward<_Visitor>(_Vis)(_Arg._String_state);
-    case _Basic_format_arg_type::_Custom_type:
-        return _STD forward<_Visitor>(_Vis)(_Arg._Custom_state);
-    default:
-        _STL_VERIFY(false, "basic_format_arg is in impossible state");
-        return _STD forward<_Visitor>(_Vis)(0);
-    }
+    return _Arg._Visit(_STD forward<_Visitor>(_Vis));
 }
 
 // we need to implement this ourselves because from_chars does not work with wide characters and isn't constexpr

--- a/tests/std/tests/P0645R10_text_formatting_args/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_args/test.cpp
@@ -252,6 +252,18 @@ void test_lwg3810() {
     static_assert(same_as<decltype(basic_format_args{args_store}), basic_format_args<Context>>);
 }
 
+struct lvalue_only_visitor {
+    template <class T>
+    void operator()(T&&) const = delete;
+    template <class T>
+    void operator()(T&) const noexcept {}
+};
+
+template <class Context>
+void test_lvalue_only_visitation() {
+    visit_format_arg(lvalue_only_visitor{}, basic_format_arg<Context>{});
+}
+
 int main() {
     test_basic_format_arg<format_context>();
     test_basic_format_arg<wformat_context>();
@@ -259,6 +271,10 @@ int main() {
     test_format_arg_store<wformat_context>();
     test_visit_monostate<format_context>();
     test_visit_monostate<wformat_context>();
+
     test_lwg3810<format_context>();
     test_lwg3810<wformat_context>();
+
+    test_lvalue_only_visitation<format_context>();
+    test_lvalue_only_visitation<wformat_context>();
 }


### PR DESCRIPTION
Also fix a small bug on visiting `0`. As the visitor always visits a cv-unqualified `basic_format_arg` lvalue, it's incorrect to use `_STD forward<_Visitor>(_Vis)(0)` which takes an `int` prvalue and can result in non-conforming ill-formedness.

IMO this PR will make it simpler to implement WG21-P2637R3. Unfortunately, we're perhaps unable to implement that paper at this moment.