### PR TITLE
`<mdspan>`: Improve debug checks

### DIFF
--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -265,7 +265,7 @@ public:
         } else {
             index_type _Result{1};
 #pragma warning(push)
-#pragma warning(disable : 6287) // TRANSITION, DevCom-???
+#pragma warning(disable : 6287) // TRANSITION, DevCom-10398426
             const bool _Overflow = (_Mul_overflow(static_cast<index_type>(_Extents), _Result, _Result) || ...);
 #pragma warning(pop)
             return !_Overflow;

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -41,6 +41,7 @@ public:
 
     static constexpr rank_type _Rank         = sizeof...(_Extents);
     static constexpr rank_type _Rank_dynamic = (static_cast<rank_type>(_Extents == dynamic_extent) + ... + 0);
+    static constexpr bool _Multidim_index_space_size_is_always_zero = ((_Extents == 0) || ...);
 
 private:
     static constexpr array<rank_type, _Rank> _Static_extents = {_Extents...};
@@ -1052,12 +1053,17 @@ public:
     }
 
     _NODISCARD constexpr bool empty() const noexcept {
-        for (rank_type _Idx = 0; _Idx < extents_type::_Rank; ++_Idx) {
-            if (_Map.extents().extent(_Idx) == 0) {
-                return true;
+        if constexpr (extents_type::_Multidim_index_space_size_is_always_zero) {
+            return true;
+        } else {
+            const extents_type& _Exts = _Map.extents();
+            for (rank_type _Idx = 0; _Idx < extents_type::_Rank; ++_Idx) {
+                if (_Exts.extent(_Idx) == 0) {
+                    return true;
+                }
             }
+            return false;
         }
-        return false;
     }
 
     friend constexpr void swap(mdspan& _Left, mdspan& _Right) noexcept {

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1136,14 +1136,7 @@ public:
               && (is_nothrow_constructible_v<index_type, _OtherIndexTypes> && ...)
               && (sizeof...(_OtherIndexTypes) == rank())
     _NODISCARD constexpr reference operator[](_OtherIndexTypes... _Indices) const {
-#if _CONTAINER_DEBUG_LEVEL > 0
-        if constexpr ((integral<_OtherIndexTypes> && ...)) {
-            _STL_VERIFY(_Map.extents()._Contains_multidimensional_index(
-                            make_index_sequence<rank()>{}, static_cast<index_type>(_Indices)...),
-                "I must be a multidimensional index in extents() (N4950 [mdspan.mdspan.members]/3).");
-        }
-#endif // _CONTAINER_DEBUG_LEVEL > 0
-        return _Acc.access(_Ptr, static_cast<size_t>(_Map(static_cast<index_type>(_STD move(_Indices))...)));
+        return _Access_impl(static_cast<index_type>(_STD move(_Indices))...);
     }
 #endif // __cpp_multidimensional_subscript
 
@@ -1151,14 +1144,26 @@ public:
         requires is_convertible_v<const _OtherIndexType&, index_type>
               && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
     _NODISCARD constexpr reference operator[](span<_OtherIndexType, rank()> _Indices) const {
-        return _Index_impl(_Indices, make_index_sequence<rank()>{});
+        return [&]<size_t... _Seq>(index_sequence<_Seq...>) -> reference {
+#ifdef __cpp_multidimensional_subscript // TRANSITION, P2128R6
+            return operator[](_STD as_const(_Indices[_Seq])...);
+#else // ^^^ defined(__cpp_multidimensional_subscript) / !defined(__cpp_multidimensional_subscript) vvv
+            return _Multidimensional_access(_STD as_const(_Indices[_Seq])...);
+#endif // ^^^ !defined(__cpp_multidimensional_subscript) ^^^
+        }(make_index_sequence<rank()>{});
     }
 
     template <class _OtherIndexType>
         requires is_convertible_v<const _OtherIndexType&, index_type>
               && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
     _NODISCARD constexpr reference operator[](const array<_OtherIndexType, rank()>& _Indices) const {
-        return _Index_impl(span{_Indices}, make_index_sequence<rank()>{});
+        return [&]<size_t... _Seq>(index_sequence<_Seq...>) -> reference {
+#ifdef __cpp_multidimensional_subscript // TRANSITION, P2128R6
+            return operator[](_Indices[_Seq]...);
+#else // ^^^ defined(__cpp_multidimensional_subscript) / !defined(__cpp_multidimensional_subscript) vvv
+            return _Multidimensional_access(_Indices[_Seq]...);
+#endif // ^^^ !defined(__cpp_multidimensional_subscript) ^^^
+        }(make_index_sequence<rank()>{});
     }
 
     _NODISCARD constexpr size_type size() const noexcept {
@@ -1242,21 +1247,23 @@ public:
     }
 
 private:
-    template <class _OtherIndexType, size_t... _Seq>
-    _NODISCARD constexpr reference _Index_impl(span<_OtherIndexType, rank()> _Indices, index_sequence<_Seq...>) const {
-#ifdef __cpp_multidimensional_subscript // TRANSITION, P2128R6
-        return operator[](_STD as_const(_Indices[_Seq])...);
-#else // ^^^ defined(__cpp_multidimensional_subscript) / !defined(__cpp_multidimensional_subscript) vvv
-        return _Multidimensional_access(_STD as_const(_Indices[_Seq])...);
-#endif // ^^^ !defined(__cpp_multidimensional_subscript) ^^^
-    }
-
 #ifndef __cpp_multidimensional_subscript // TRANSITION, P2128R6
     template <class... _OtherIndexTypes>
     _NODISCARD constexpr reference _Multidimensional_access(_OtherIndexTypes... _Indices) const {
-        return _Acc.access(_Ptr, static_cast<size_t>(_Map(static_cast<index_type>(_STD move(_Indices))...)));
+        return _Access_impl(static_cast<index_type>(_STD move(_Indices))...);
     }
-#endif // __cpp_multidimensional_subscript
+#endif // ^^^ !defined(__cpp_multidimensional_subscript) ^^^
+
+    template <class... _OtherIndexTypes>
+    _NODISCARD constexpr reference _Access_impl(_OtherIndexTypes... _Indices) const {
+        _STL_INTERNAL_STATIC_ASSERT((same_as<_OtherIndexTypes, index_type> && ...));
+#if _CONTAINER_DEBUG_LEVEL > 0
+        _STL_VERIFY(_Map.extents()._Contains_multidimensional_index(make_index_sequence<rank()>{}, _Indices...),
+            "I must be a multidimensional index in extents() (N4950 [mdspan.mdspan.members]/3).");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
+
+        return _Acc.access(_Ptr, static_cast<size_t>(_Map(_Indices...)));
+    }
 
     data_handle_type _Ptr{};
     mapping_type _Map{};

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -270,6 +270,28 @@ public:
         }
     }
 
+    _NODISCARD constexpr bool _Is_dynamic_multidim_index_space_size_representable() const noexcept {
+        // Pre: rank_dynamic() != 0
+        if constexpr (_Multidim_index_space_size_is_always_zero) {
+            return true;
+        } else {
+            index_type _Result{1};
+            bool _Overflow = false;
+            for (rank_type _Idx = 0; _Idx < _Rank; ++_Idx) {
+                const index_type _Ext = extent(_Idx);
+                if (_Ext == 0) {
+                    return true;
+                }
+
+                if (!_Overflow) {
+                    _Overflow = _Mul_overflow(extent(_Idx), _Result, _Result);
+                }
+            }
+
+            return !_Overflow;
+        }
+    }
+
     template <class... _IndexTypes, size_t... _Seq>
     _NODISCARD constexpr bool _Contains_multidimensional_index(
         index_sequence<_Seq...>, _IndexTypes... _Indices) const noexcept {
@@ -425,7 +447,13 @@ public:
     constexpr mapping(const mapping&) noexcept = default;
 
     constexpr mapping(const extents_type& _Exts_) noexcept : _Exts(_Exts_) {
-        // TRANSITION, CHECK [mdspan.layout.left.cons]/1 (REQUIRES '_Multiply_with_overflow_check' FROM #3561)
+#if _CONTAINER_DEBUG_LEVEL > 0
+        if constexpr (extents_type::rank_dynamic() != 0) {
+            _STL_VERIFY(_Exts_._Is_dynamic_multidim_index_space_size_representable(),
+                "The size of the multidimensional index space e must be representable as a value of type index_type "
+                "(N4950 [mdspan.layout.left.cons]/1).");
+        }
+#endif // _CONTAINER_DEBUG_LEVEL > 0
     }
 
     template <class _OtherExtents>

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -756,8 +756,17 @@ public:
         if constexpr (extents_type::rank() != 0) {
             _Strides.back() = 1;
             for (rank_type _Idx = extents_type::_Rank - 1; _Idx-- > 0;) {
-                // TRANSITION USE `_Multiply_with_overflow_check` IN DEBUG MODE
+#if _CONTAINER_DEBUG_LEVEL > 0
+                const bool _Overflow = _Mul_overflow(_Strides[_Idx + 1], _Exts.extent(_Idx + 1), _Strides[_Idx]);
+                // NB: N4950 requires value of 'layout_right​::​mapping<extents_type>().required_span_size()' to be
+                // representable as value of type 'index_type', but this is not enough. We need to require every single
+                // stride to be representable as value of type 'index_type', so we can get desired effects.
+                _STL_VERIFY(!_Overflow,
+                    "Value of layout_right::mapping<extents_type>().required_span_size() must be "
+                    "representable as a value of type index_type (N4950 [mdspan.layout.stride.cons]/1).");
+#else // ^^^ _CONTAINER_DEBUG_LEVEL > 0 / _CONTAINER_DEBUG_LEVEL == 0 vvv
                 _Strides[_Idx] = static_cast<index_type>(_Strides[_Idx + 1] * _Exts.extent(_Idx + 1));
+#endif // _CONTAINER_DEBUG_LEVEL > 0
             }
         }
     }

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -599,7 +599,13 @@ public:
     constexpr mapping(const mapping&) noexcept = default;
 
     constexpr mapping(const extents_type& _Exts_) noexcept : _Exts(_Exts_) {
-        // TRANSITION, CHECK [mdspan.layout.right.cons]/1 (REQUIRES '_Multiply_with_overflow_check' FROM #3561)
+#if _CONTAINER_DEBUG_LEVEL > 0
+        if constexpr (extents_type::rank_dynamic() != 0) {
+            _STL_VERIFY(_Exts_._Is_dynamic_multidim_index_space_size_representable(),
+                "The size of the multidimensional index space e must be representable as a value of type index_type "
+                "(N4950 [mdspan.layout.right.cons]/1).");
+        }
+#endif // _CONTAINER_DEBUG_LEVEL > 0
     }
 
     template <class _OtherExtents>

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -636,21 +636,17 @@ public:
         : _Exts(_Other.extents()) {
 #if _CONTAINER_DEBUG_LEVEL > 0
         if constexpr (extents_type::rank() > 0) {
-            const bool _Verify = [&]<size_t... _Indices>(index_sequence<_Indices...>) {
-                index_type _Prod = stride(0);
-                return (
-                    (_Other.stride(_Indices)
-                        == (_Indices == extents_type::_Rank - 1
-                                ? _Prod
-                                : _STD exchange(_Prod, static_cast<index_type>(_Prod / _Exts.extent(_Indices + 1)))))
-                    && ...);
-            }(make_index_sequence<extents_type::rank()>{});
-            _STL_VERIFY(_Verify, "For all r in the range [0, extents_type::rank()), other.stride(r) must be equal to "
-                                 "extents().rev-prod-of-extents(r) (N4950 [mdspan.layout.right.cons]/10.1).");
+            index_type _Prod = 1;
+            for (size_t _Idx = extents_type::_Rank; _Idx-- > 0;) {
+                _STL_VERIFY(_Prod == _Other.stride(_Idx),
+                    "For all r in the range [0, extents_type::rank()), other.stride(r) must be equal to "
+                    "extents().rev-prod-of-extents(r) (N4950 [mdspan.layout.right.cons]/10.1).");
+                _Prod = static_cast<index_type>(_Prod * _Exts.extent(_Idx));
+            }
+            _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
+                "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
+                "[mdspan.layout.right.cons]/10.2).");
         }
-        _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
-            "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
-            "[mdspan.layout.right.cons]/10.2).");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
     }
 

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1164,7 +1164,7 @@ public:
     _NODISCARD constexpr size_type size() const noexcept {
 #if _CONTAINER_DEBUG_LEVEL > 0
         if constexpr (rank_dynamic() != 0) {
-            _STL_VERIFY(_Map.extents()._Is_dynamic_multidim_index_space_size_representable<size_type>(),
+            _STL_VERIFY(_Map.extents().template _Is_dynamic_multidim_index_space_size_representable<size_type>(),
                 "The size of the multidimensional index space extents() must be representable as a value of type "
                 "size_type (N4950 [mdspan.mdspan.members]/7).");
         }

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -272,21 +272,22 @@ public:
         }
     }
 
+    template <integral _Ty = index_type>
     _NODISCARD constexpr bool _Is_dynamic_multidim_index_space_size_representable() const noexcept {
         // Pre: rank_dynamic() != 0
         if constexpr (_Multidim_index_space_size_is_always_zero) {
             return true;
         } else {
-            index_type _Result{1};
             bool _Overflow = false;
+            _Ty _Result    = 1;
             for (rank_type _Idx = 0; _Idx < _Rank; ++_Idx) {
-                const index_type _Ext = extent(_Idx);
+                const auto _Ext = static_cast<_Ty>(extent(_Idx));
                 if (_Ext == 0) {
                     return true;
                 }
 
                 if (!_Overflow) {
-                    _Overflow = _Mul_overflow(extent(_Idx), _Result, _Result);
+                    _Overflow = _Mul_overflow(_Ext, _Result, _Result);
                 }
             }
 
@@ -1155,6 +1156,13 @@ public:
     }
 
     _NODISCARD constexpr size_type size() const noexcept {
+#if _CONTAINER_DEBUG_LEVEL > 0
+        if constexpr (rank_dynamic() != 0) {
+            _STL_VERIFY(_Map.extents()._Is_dynamic_multidim_index_space_size_representable<size_type>(),
+                "The size of the multidimensional index space extents() must be representable as a value of type "
+                "size_type (N4950 [mdspan.mdspan.members]/7).");
+        }
+#endif // _CONTAINER_DEBUG_LEVEL > 0
         return static_cast<size_type>(
             _Fwd_prod_of_extents<extents_type>::_Calculate(_Map.extents(), extents_type::_Rank));
     }

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1120,7 +1120,7 @@ public:
 #if _CONTAINER_DEBUG_LEVEL > 0
         for (rank_type _Idx = 0; _Idx < extents_type::_Rank; ++_Idx) {
             const auto _Static_ext = extents_type::_Static_extents[_Idx];
-            _STL_VERIFY(_Static_ext == dynamic_extent || _Static_ext == _Other.extent(_Idx),
+            _STL_VERIFY(_STD cmp_equal(_Static_ext, dynamic_extent) || _STD cmp_equal(_Static_ext, _Other.extent(_Idx)),
                 "For each rank index r of extents_type, static_extent(r) == dynamic_extent || static_extent(r) == "
                 "other.extent(r) must be true (N4950 [mdspan.mdspan.cons]/21.1).");
         }

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -565,10 +565,10 @@ private:
 
     template <class... _IndexTypes, size_t... _Seq>
     _NODISCARD constexpr index_type _Index_impl(
-        [[maybe_unused]] index_sequence<_Seq...> _IndexSeq, _IndexTypes... _Indices) const noexcept {
+        [[maybe_unused]] index_sequence<_Seq...> _Index_seq, _IndexTypes... _Indices) const noexcept {
         _STL_INTERNAL_STATIC_ASSERT((same_as<_IndexTypes, index_type> && ...));
 #if _CONTAINER_DEBUG_LEVEL > 0
-        _STL_VERIFY(_Exts._Contains_multidimensional_index(_IndexSeq, _Indices...),
+        _STL_VERIFY(_Exts._Contains_multidimensional_index(_Index_seq, _Indices...),
             "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
             "[mdspan.layout.left.obs]/3).");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
@@ -716,10 +716,10 @@ private:
 
     template <class... _IndexTypes, size_t... _Seq>
     _NODISCARD constexpr index_type _Index_impl(
-        [[maybe_unused]] index_sequence<_Seq...> _IndexSeq, _IndexTypes... _Indices) const noexcept {
+        [[maybe_unused]] index_sequence<_Seq...> _Index_seq, _IndexTypes... _Indices) const noexcept {
         _STL_INTERNAL_STATIC_ASSERT((same_as<_IndexTypes, index_type> && ...));
 #if _CONTAINER_DEBUG_LEVEL > 0
-        _STL_VERIFY(_Exts._Contains_multidimensional_index(_IndexSeq, _Indices...),
+        _STL_VERIFY(_Exts._Contains_multidimensional_index(_Index_seq, _Indices...),
             "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
             "[mdspan.layout.right.obs]/3).");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
@@ -972,10 +972,10 @@ private:
 
     template <class... _IndexTypes, size_t... _Seq>
     _NODISCARD constexpr index_type _Index_impl(
-        [[maybe_unused]] index_sequence<_Seq...> _IndexSeq, _IndexTypes... _Indices) const noexcept {
+        [[maybe_unused]] index_sequence<_Seq...> _Index_seq, _IndexTypes... _Indices) const noexcept {
         _STL_INTERNAL_STATIC_ASSERT((same_as<_IndexTypes, index_type> && ...));
 #if _CONTAINER_DEBUG_LEVEL > 0
-        _STL_VERIFY(_Exts._Contains_multidimensional_index(_IndexSeq, _Indices...),
+        _STL_VERIFY(_Exts._Contains_multidimensional_index(_Index_seq, _Indices...),
             "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
             "[mdspan.layout.stride.obs]/3).");
 #endif // _CONTAINER_DEBUG_LEVEL > 0

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1050,7 +1050,10 @@ public:
     }
 
     _NODISCARD static constexpr size_t static_extent(const rank_type _Idx) noexcept {
-        return extents_type::static_extent(_Idx);
+#if _CONTAINER_DEBUG_LEVEL > 0
+        _STL_VERIFY(_Idx < extents_type::_Rank, "Index must be less than rank() (N4950 [mdspan.extents.obs]/1)");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
+        return extents_type::_Static_extents[_Idx];
     }
 
     _NODISCARD constexpr index_type extent(const rank_type _Idx) const noexcept {

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1129,6 +1129,13 @@ public:
               && (is_nothrow_constructible_v<index_type, _OtherIndexTypes> && ...)
               && (sizeof...(_OtherIndexTypes) == rank())
     _NODISCARD constexpr reference operator[](_OtherIndexTypes... _Indices) const {
+#if _CONTAINER_DEBUG_LEVEL > 0
+        if constexpr ((integral<_OtherIndexTypes> && ...)) {
+            _STL_VERIFY(_Map.extents()._Contains_multidimensional_index(
+                            make_index_sequence<rank()>{}, static_cast<index_type>(_Indices)...),
+                "I must be a multidimensional index in extents() (N4950 [mdspan.mdspan.members]/3).");
+        }
+#endif // _CONTAINER_DEBUG_LEVEL > 0
         return _Acc.access(_Ptr, static_cast<size_t>(_Map(static_cast<index_type>(_STD move(_Indices))...)));
     }
 #endif // __cpp_multidimensional_subscript

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -780,10 +780,27 @@ public:
         index_sequence<_Indices...>) noexcept
         : _Exts(_Exts_), _Strides{static_cast<index_type>(_STD as_const(_Strides_[_Indices]))...} {
 #if _CONTAINER_DEBUG_LEVEL > 0
-        for (rank_type _Idx = 0; _Idx < extents_type::_Rank; ++_Idx) {
-            // TRANSITION CHECK [mdspan.layout.stride.cons]/4.2 (REQUIRES `_Multiply_with_overflow_check`)
-            _STL_VERIFY(_Strides[_Idx] > 0, "Value of s[i] must be greater than 0 for all i in the range [0, rank_) "
-                                            "(N4950 [mdspan.layout.stride.cons]/4.1).");
+        if constexpr (extents_type::rank() != 0) {
+            bool _Found_zero          = false;
+            bool _Overflow            = false;
+            index_type _Req_span_size = 0;
+            for (rank_type _Idx = 0; _Idx < extents_type::_Rank; ++_Idx) {
+                const index_type _Stride = _Strides[_Idx];
+                _STL_VERIFY(_Stride > 0, "Value of s[i] must be greater than 0 for all i in the range [0, rank_) "
+                                         "(N4950 [mdspan.layout.stride.cons]/4.1).");
+                const index_type _Ext = _Exts.extent(_Idx);
+                if (_Ext == 0) {
+                    _Found_zero = true;
+                }
+
+                if (!_Found_zero && !_Overflow) {
+                    index_type _Prod;
+                    _Overflow = _Mul_overflow(static_cast<index_type>(_Ext - 1), _Stride, _Prod)
+                             || _Add_overflow(_Req_span_size, _Prod, _Req_span_size);
+                }
+            }
+            _STL_VERIFY(_Found_zero || !_Overflow, "REQUIRED-SPAN-SIZE(e, s) must be representable as a value of type "
+                                                   "index_type (N4950 [mdspan.layout.stride.cons]/4.2).");
         }
 #endif // _CONTAINER_DEBUG_LEVEL > 0
     }

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -486,20 +486,17 @@ public:
         : _Exts(_Other.extents()) {
 #if _CONTAINER_DEBUG_LEVEL > 0
         if constexpr (extents_type::rank() > 0) {
-            const bool _Verify = [&]<size_t... _Indices>(index_sequence<_Indices...>) {
-                index_type _Prod = 1;
-                return ((_Other.stride(_Indices)
-                            == (_Indices == extents_type::_Rank - 1
-                                    ? _Prod
-                                    : _STD exchange(_Prod, static_cast<index_type>(_Prod * _Exts.extent(_Indices)))))
-                        && ...);
-            }(make_index_sequence<extents_type::rank()>{});
-            _STL_VERIFY(_Verify, "For all r in the range [0, extents_type::rank()), other.stride(r) must be equal to "
-                                 "extents().fwd-prod-of-extents(r) (N4950 [mdspan.layout.left.cons]/10.1).");
+            index_type _Prod = 1;
+            for (size_t _Idx = 0; _Idx < extents_type::_Rank; ++_Idx) {
+                _STL_VERIFY(_Other.stride(_Idx) == _Prod,
+                    "For all r in the range [0, extents_type::rank()), other.stride(r) must be equal to "
+                    "extents().fwd-prod-of-extents(r) (N4950 [mdspan.layout.left.cons]/10.1).");
+                _Prod = static_cast<index_type>(_Prod * _Exts.extent(_Idx));
+            }
+            _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
+                "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
+                "[mdspan.layout.left.cons]/10.2).");
         }
-        _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
-            "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
-            "[mdspan.layout.left.cons]/10.2).");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
     }
 

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -433,9 +433,11 @@ public:
     constexpr explicit(!is_convertible_v<_OtherExtents, extents_type>)
         mapping(const mapping<_OtherExtents>& _Other) noexcept
         : _Exts(_Other.extents()) {
+#if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
             "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
             "[mdspan.layout.left.cons]/4).");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
     }
 
     template <class _OtherExtents>
@@ -443,15 +445,18 @@ public:
     constexpr explicit(!is_convertible_v<_OtherExtents, extents_type>)
         mapping(const layout_right::mapping<_OtherExtents>& _Other) noexcept
         : _Exts(_Other.extents()) {
+#if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
             "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
             "[mdspan.layout.left.cons]/7).");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
     }
 
     template <class _OtherExtents>
         requires is_constructible_v<extents_type, _OtherExtents>
     constexpr explicit(extents_type::rank() > 0) mapping(const layout_stride::template mapping<_OtherExtents>& _Other)
         : _Exts(_Other.extents()) {
+#if _CONTAINER_DEBUG_LEVEL > 0
         if constexpr (extents_type::rank() > 0) {
             const bool _Verify = [&]<size_t... _Indices>(index_sequence<_Indices...>) {
                 index_type _Prod = 1;
@@ -467,6 +472,7 @@ public:
         _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
             "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
             "[mdspan.layout.left.cons]/10.2).");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
     }
 
     constexpr mapping& operator=(const mapping&) noexcept = default;
@@ -483,10 +489,12 @@ public:
         requires (sizeof...(_IndexTypes) == extents_type::rank()) && (is_convertible_v<_IndexTypes, index_type> && ...)
               && (is_nothrow_constructible_v<index_type, _IndexTypes> && ...)
     _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
+#if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Exts._Contains_multidimensional_index(
                         make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...),
             "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
             "[mdspan.layout.left.obs]/3).");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
         return _Index_impl(make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...);
     }
 
@@ -517,8 +525,10 @@ public:
     _NODISCARD constexpr index_type stride(const rank_type _Idx) const noexcept
         requires (extents_type::rank() > 0)
     {
+#if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Idx < extents_type::_Rank,
             "Value of i must be less than extents_type::rank() (N4950 [mdspan.layout.left.obs]/6).");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
         return _Fwd_prod_of_extents<extents_type>::_Calculate(_Exts, _Idx);
     }
 

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -256,11 +256,17 @@ public:
         }
     }
 
-    _NODISCARD static consteval bool _Is_index_space_size_representable() {
-        if constexpr (rank_dynamic() == 0 && rank() > 0) {
-            return _STD in_range<index_type>((_Extents * ...));
-        } else {
+    _NODISCARD static consteval bool _Is_static_multidim_index_space_size_representable() noexcept {
+        // Pre: rank_dynamic() == 0
+        if constexpr (_Multidim_index_space_size_is_always_zero) {
             return true;
+        } else {
+            index_type _Result{1};
+#pragma warning(push)
+#pragma warning(disable : 6287) // TRANSITION, DevCom-???
+            const bool _Overflow = (_Mul_overflow(static_cast<index_type>(_Extents), _Result, _Result) || ...);
+#pragma warning(pop)
+            return !_Overflow;
         }
     }
 
@@ -410,7 +416,8 @@ public:
 
     static_assert(_Is_extents<extents_type>,
         "Extents must be a specialization of std::extents (N4950 [mdspan.layout.left.overview]/2).");
-    static_assert(extents_type::_Is_index_space_size_representable(),
+    static_assert(
+        extents_type::rank_dynamic() != 0 || extents_type::_Is_static_multidim_index_space_size_representable(),
         "If Extents::rank_dynamic() == 0 is true, then the size of the multidimensional index space Extents() must be "
         "representable as a value of type typename Extents::index_type (N4950 [mdspan.layout.left.overview]/4).");
 
@@ -545,7 +552,8 @@ public:
 
     static_assert(_Is_extents<extents_type>,
         "Extents must be a specialization of std::extents (N4950 [mdspan.layout.right.overview]/2).");
-    static_assert(extents_type::_Is_index_space_size_representable(),
+    static_assert(
+        extents_type::rank_dynamic() != 0 || extents_type::_Is_static_multidim_index_space_size_representable(),
         "If Extents::rank_dynamic() == 0 is true, then the size of the multidimensional index space Extents() must be "
         "representable as a value of type typename Extents::index_type (N4950 [mdspan.layout.right.overview]/4).");
 
@@ -692,7 +700,8 @@ public:
 
     static_assert(_Is_extents<extents_type>,
         "Extents must be a specialization of std::extents (N4950 [mdspan.layout.stride.overview]/2).");
-    static_assert(extents_type::_Is_index_space_size_representable(),
+    static_assert(
+        extents_type::rank_dynamic() != 0 || extents_type::_Is_static_multidim_index_space_size_representable(),
         "If Extents::rank_dynamic() == 0 is true, then the size of the multidimensional index space Extents() must be "
         "representable as a value of type typename Extents::index_type (N4950 [mdspan.layout.stride.overview]/4).");
 

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -765,7 +765,7 @@ public:
             for (rank_type _Idx = extents_type::_Rank - 1; _Idx-- > 0;) {
 #if _CONTAINER_DEBUG_LEVEL > 0
                 const bool _Overflow = _Mul_overflow(_Strides[_Idx + 1], _Exts.extent(_Idx + 1), _Strides[_Idx]);
-                // NB: N4950 requires value of 'layout_right​::​mapping<extents_type>().required_span_size()' to be
+                // NB: N4950 requires value of 'layout_right::mapping<extents_type>().required_span_size()' to be
                 // representable as value of type 'index_type', but this is not enough. We need to require every single
                 // stride to be representable as value of type 'index_type', so we can get desired effects.
                 _STL_VERIFY(!_Overflow,

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1111,6 +1111,14 @@ public:
             "[mdspan.mdspan.cons]/20.1).");
         static_assert(is_constructible_v<extents_type, _OtherExtents>,
             "The extents_type must be constructible from OtherExtents (N4950 [mdspan.mdspan.cons]/20.2).");
+#if _CONTAINER_DEBUG_LEVEL > 0
+        for (rank_type _Idx = 0; _Idx < extents_type::_Rank; ++_Idx) {
+            const auto _Static_ext = static_extent(_Idx);
+            _STL_VERIFY(_Static_ext == dynamic_extent || _Static_ext == _Other.extent(_Idx),
+                "For each rank index r of extents_type, static_extent(r) == dynamic_extent || static_extent(r) == "
+                "other.extent(r) must be true (N4950 [mdspan.mdspan.cons]/21.1).");
+        }
+#endif // _CONTAINER_DEBUG_LEVEL > 0
     }
 
     constexpr mdspan& operator=(const mdspan&) = default;

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -183,6 +183,9 @@ public:
         auto _Check_extent = []<class _Ty>(const _Ty& _Ext) {
             if constexpr (_Is_standard_integer<_Ty>) {
                 return _Ext >= 0 && _STD in_range<index_type>(_Ext);
+            } else if constexpr (integral<_Ty> && !same_as<_Ty, bool>) { // NB: character types
+                const auto _Integer_ext = static_cast<long long>(_Ext);
+                return _Integer_ext >= 0 && _STD in_range<index_type>(_Integer_ext);
             } else {
                 return true; // NB: We cannot check preconditions
             }

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -41,11 +41,10 @@ public:
 
     static constexpr rank_type _Rank         = sizeof...(_Extents);
     static constexpr rank_type _Rank_dynamic = (static_cast<rank_type>(_Extents == dynamic_extent) + ... + 0);
+    static constexpr array<rank_type, _Rank> _Static_extents        = {_Extents...};
     static constexpr bool _Multidim_index_space_size_is_always_zero = ((_Extents == 0) || ...);
 
 private:
-    static constexpr array<rank_type, _Rank> _Static_extents = {_Extents...};
-
     _NODISCARD static consteval auto _Make_dynamic_indices() noexcept {
         array<rank_type, _Rank + 1> _Result{};
         rank_type _Counter = 0;
@@ -359,7 +358,7 @@ private:
         array<typename _Ty::index_type, _Ty::rank() + 1> _Result;
         _Result.front() = 1;
         for (size_t _Idx = 1; _Idx < _Ty::_Rank + 1; ++_Idx) {
-            _Result[_Idx] = static_cast<_Ty::index_type>(_Result[_Idx - 1] * _Ty::static_extent(_Idx - 1));
+            _Result[_Idx] = static_cast<_Ty::index_type>(_Result[_Idx - 1] * _Ty::_Static_extents[_Idx - 1]);
         }
         return _Result;
     }
@@ -397,7 +396,7 @@ private:
         array<typename _Ty::index_type, _Ty::rank()> _Result;
         _Result.back() = 1;
         for (size_t _Idx = _Ty::_Rank; _Idx-- > 1;) {
-            _Result[_Idx - 1] = static_cast<_Ty::index_type>(_Result[_Idx] * _Ty::static_extent(_Idx));
+            _Result[_Idx - 1] = static_cast<_Ty::index_type>(_Result[_Idx] * _Ty::_Static_extents[_Idx]);
         }
         return _Result;
     }
@@ -1113,7 +1112,7 @@ public:
             "The extents_type must be constructible from OtherExtents (N4950 [mdspan.mdspan.cons]/20.2).");
 #if _CONTAINER_DEBUG_LEVEL > 0
         for (rank_type _Idx = 0; _Idx < extents_type::_Rank; ++_Idx) {
-            const auto _Static_ext = static_extent(_Idx);
+            const auto _Static_ext = extents_type::_Static_extents[_Idx];
             _STL_VERIFY(_Static_ext == dynamic_extent || _Static_ext == _Other.extent(_Idx),
                 "For each rank index r of extents_type, static_extent(r) == dynamic_extent || static_extent(r) == "
                 "other.extent(r) must be true (N4950 [mdspan.mdspan.cons]/21.1).");

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -607,9 +607,11 @@ public:
     constexpr explicit(!is_convertible_v<_OtherExtents, extents_type>)
         mapping(const mapping<_OtherExtents>& _Other) noexcept
         : _Exts(_Other.extents()) {
+#if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
             "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
             "[mdspan.layout.right.cons]/4).");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
     }
 
     template <class _OtherExtents>
@@ -617,9 +619,11 @@ public:
     constexpr explicit(!is_convertible_v<_OtherExtents, extents_type>)
         mapping(const layout_left::mapping<_OtherExtents>& _Other) noexcept
         : _Exts(_Other.extents()) {
+#if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
             "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
             "[mdspan.layout.right.cons]/7).");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
     }
 
     template <class _OtherExtents>
@@ -627,6 +631,7 @@ public:
     constexpr explicit(extents_type::rank() > 0)
         mapping(const layout_stride::template mapping<_OtherExtents>& _Other) noexcept
         : _Exts(_Other.extents()) {
+#if _CONTAINER_DEBUG_LEVEL > 0
         if constexpr (extents_type::rank() > 0) {
             const bool _Verify = [&]<size_t... _Indices>(index_sequence<_Indices...>) {
                 index_type _Prod = stride(0);
@@ -643,6 +648,7 @@ public:
         _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
             "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
             "[mdspan.layout.right.cons]/10.2).");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
     }
 
     constexpr mapping& operator=(const mapping&) noexcept = default;
@@ -659,10 +665,12 @@ public:
         requires (sizeof...(_IndexTypes) == extents_type::rank()) && (is_convertible_v<_IndexTypes, index_type> && ...)
               && (is_nothrow_constructible_v<index_type, _IndexTypes> && ...)
     _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
+#if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Exts._Contains_multidimensional_index(
                         make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...),
             "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
             "[mdspan.layout.right.obs]/3).");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
         return _Index_impl(make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...);
     }
 
@@ -693,8 +701,10 @@ public:
     _NODISCARD constexpr index_type stride(const rank_type _Idx) const noexcept
         requires (extents_type::rank() > 0)
     {
+#if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Idx < extents_type::_Rank,
             "Value of i must be less than extents_type::rank() (N4950 [mdspan.layout.right.obs]/6).");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
         return _Rev_prod_of_extents<extents_type>::_Calculate(_Exts, _Idx);
     }
 

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -518,10 +518,12 @@ public:
               && (is_nothrow_constructible_v<index_type, _IndexTypes> && ...)
     _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
 #if _CONTAINER_DEBUG_LEVEL > 0
-        _STL_VERIFY(_Exts._Contains_multidimensional_index(
-                        make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...),
-            "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
-            "[mdspan.layout.left.obs]/3).");
+        if constexpr ((integral<_IndexTypes> && ...)) {
+            _STL_VERIFY(_Exts._Contains_multidimensional_index(
+                            make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...),
+                "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
+                "[mdspan.layout.left.obs]/3).");
+        }
 #endif // _CONTAINER_DEBUG_LEVEL > 0
         return _Index_impl(make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...);
     }
@@ -668,10 +670,12 @@ public:
               && (is_nothrow_constructible_v<index_type, _IndexTypes> && ...)
     _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
 #if _CONTAINER_DEBUG_LEVEL > 0
-        _STL_VERIFY(_Exts._Contains_multidimensional_index(
-                        make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...),
-            "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
-            "[mdspan.layout.right.obs]/3).");
+        if constexpr ((integral<_IndexTypes> && ...)) {
+            _STL_VERIFY(_Exts._Contains_multidimensional_index(
+                            make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...),
+                "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
+                "[mdspan.layout.right.obs]/3).");
+        }
 #endif // _CONTAINER_DEBUG_LEVEL > 0
         return _Index_impl(make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...);
     }
@@ -895,10 +899,12 @@ public:
               && (is_nothrow_constructible_v<index_type, _IndexTypes> && ...)
     _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
 #if _CONTAINER_DEBUG_LEVEL > 0
-        _STL_VERIFY(_Exts._Contains_multidimensional_index(
-                        make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...),
-            "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
-            "[mdspan.layout.stride.obs]/3).");
+        if constexpr ((integral<_IndexTypes> && ...)) {
+            _STL_VERIFY(_Exts._Contains_multidimensional_index(
+                            make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...),
+                "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
+                "[mdspan.layout.stride.obs]/3).");
+        }
 #endif // _CONTAINER_DEBUG_LEVEL > 0
         return _Index_impl(make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...);
     }

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -517,14 +517,6 @@ public:
         requires (sizeof...(_IndexTypes) == extents_type::rank()) && (is_convertible_v<_IndexTypes, index_type> && ...)
               && (is_nothrow_constructible_v<index_type, _IndexTypes> && ...)
     _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
-#if _CONTAINER_DEBUG_LEVEL > 0
-        if constexpr ((integral<_IndexTypes> && ...)) {
-            _STL_VERIFY(_Exts._Contains_multidimensional_index(
-                            make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...),
-                "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
-                "[mdspan.layout.left.obs]/3).");
-        }
-#endif // _CONTAINER_DEBUG_LEVEL > 0
         return _Index_impl(make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...);
     }
 
@@ -572,8 +564,15 @@ private:
     extents_type _Exts{};
 
     template <class... _IndexTypes, size_t... _Seq>
-    _NODISCARD constexpr index_type _Index_impl(index_sequence<_Seq...>, _IndexTypes... _Indices) const noexcept {
+    _NODISCARD constexpr index_type _Index_impl(
+        [[maybe_unused]] index_sequence<_Seq...> _IndexSeq, _IndexTypes... _Indices) const noexcept {
         _STL_INTERNAL_STATIC_ASSERT((same_as<_IndexTypes, index_type> && ...));
+#if _CONTAINER_DEBUG_LEVEL > 0
+        _STL_VERIFY(_Exts._Contains_multidimensional_index(_IndexSeq, _Indices...),
+            "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
+            "[mdspan.layout.left.obs]/3).");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
+
         index_type _Stride = 1;
         index_type _Result = 0;
         (((_Result += _Indices * _Stride), (_Stride *= _Exts.extent(_Seq))), ...);
@@ -669,14 +668,6 @@ public:
         requires (sizeof...(_IndexTypes) == extents_type::rank()) && (is_convertible_v<_IndexTypes, index_type> && ...)
               && (is_nothrow_constructible_v<index_type, _IndexTypes> && ...)
     _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
-#if _CONTAINER_DEBUG_LEVEL > 0
-        if constexpr ((integral<_IndexTypes> && ...)) {
-            _STL_VERIFY(_Exts._Contains_multidimensional_index(
-                            make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...),
-                "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
-                "[mdspan.layout.right.obs]/3).");
-        }
-#endif // _CONTAINER_DEBUG_LEVEL > 0
         return _Index_impl(make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...);
     }
 
@@ -724,8 +715,15 @@ private:
     extents_type _Exts{};
 
     template <class... _IndexTypes, size_t... _Seq>
-    _NODISCARD constexpr index_type _Index_impl(index_sequence<_Seq...>, _IndexTypes... _Indices) const noexcept {
+    _NODISCARD constexpr index_type _Index_impl(
+        [[maybe_unused]] index_sequence<_Seq...> _IndexSeq, _IndexTypes... _Indices) const noexcept {
         _STL_INTERNAL_STATIC_ASSERT((same_as<_IndexTypes, index_type> && ...));
+#if _CONTAINER_DEBUG_LEVEL > 0
+        _STL_VERIFY(_Exts._Contains_multidimensional_index(_IndexSeq, _Indices...),
+            "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
+            "[mdspan.layout.right.obs]/3).");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
+
         index_type _Result = 0;
         ((_Result = static_cast<index_type>(_Indices + _Exts.extent(_Seq) * _Result)), ...);
         return _Result;
@@ -898,14 +896,6 @@ public:
         requires (sizeof...(_IndexTypes) == extents_type::rank()) && (is_convertible_v<_IndexTypes, index_type> && ...)
               && (is_nothrow_constructible_v<index_type, _IndexTypes> && ...)
     _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
-#if _CONTAINER_DEBUG_LEVEL > 0
-        if constexpr ((integral<_IndexTypes> && ...)) {
-            _STL_VERIFY(_Exts._Contains_multidimensional_index(
-                            make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...),
-                "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
-                "[mdspan.layout.stride.obs]/3).");
-        }
-#endif // _CONTAINER_DEBUG_LEVEL > 0
         return _Index_impl(make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...);
     }
 
@@ -981,8 +971,15 @@ private:
     }
 
     template <class... _IndexTypes, size_t... _Seq>
-    _NODISCARD constexpr index_type _Index_impl(index_sequence<_Seq...>, _IndexTypes... _Indices) const noexcept {
+    _NODISCARD constexpr index_type _Index_impl(
+        [[maybe_unused]] index_sequence<_Seq...> _IndexSeq, _IndexTypes... _Indices) const noexcept {
         _STL_INTERNAL_STATIC_ASSERT((same_as<_IndexTypes, index_type> && ...));
+#if _CONTAINER_DEBUG_LEVEL > 0
+        _STL_VERIFY(_Exts._Contains_multidimensional_index(_IndexSeq, _Indices...),
+            "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
+            "[mdspan.layout.stride.obs]/3).");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
+
         return static_cast<index_type>(((_Indices * _Strides[_Seq]) + ... + 0));
     }
 };

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -777,11 +777,13 @@ public:
     constexpr mapping(const extents_type& _Exts_, span<_OtherIndexType, extents_type::rank()> _Strides_,
         index_sequence<_Indices...>) noexcept
         : _Exts(_Exts_), _Strides{static_cast<index_type>(_STD as_const(_Strides_[_Indices]))...} {
+#if _CONTAINER_DEBUG_LEVEL > 0
         for (rank_type _Idx = 0; _Idx < extents_type::_Rank; ++_Idx) {
             // TRANSITION CHECK [mdspan.layout.stride.cons]/4.2 (REQUIRES `_Multiply_with_overflow_check`)
             _STL_VERIFY(_Strides[_Idx] > 0, "Value of s[i] must be greater than 0 for all i in the range [0, rank_) "
                                             "(N4950 [mdspan.layout.stride.cons]/4.1).");
         }
+#endif // _CONTAINER_DEBUG_LEVEL > 0
     }
 
 #ifndef __clang__ // TRANSITION, DevCom-10360833
@@ -821,15 +823,19 @@ public:
             || _Is_mapping_of<layout_stride, _StridedLayoutMapping>) ))
         mapping(const _StridedLayoutMapping& _Other) noexcept
         : _Exts(_Other.extents()) {
+#if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
             "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
             "[mdspan.layout.stride.cons]/7.3).");
         _STL_VERIFY(
             _Offset(_Other) == 0, "Value of OFFSET(other) must be equal to 0 (N4950 [mdspan.layout.stride.cons]/7.4).");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
         for (rank_type _Idx = 0; _Idx < extents_type::_Rank; ++_Idx) {
             const auto _Stride = _Other.stride(_Idx);
+#if _CONTAINER_DEBUG_LEVEL > 0
             _STL_VERIFY(_Stride > 0, "Value of other.stride(r) must be greater than 0 for every rank index r of "
                                      "extents() (N4950 [mdspan.layout.stride.cons]/7.2).");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
             _Strides[_Idx] = static_cast<index_type>(_Stride);
         }
     }
@@ -866,10 +872,12 @@ public:
         requires (sizeof...(_IndexTypes) == extents_type::rank()) && (is_convertible_v<_IndexTypes, index_type> && ...)
               && (is_nothrow_constructible_v<index_type, _IndexTypes> && ...)
     _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
+#if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Exts._Contains_multidimensional_index(
                         make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...),
             "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
             "[mdspan.layout.stride.obs]/3).");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
         return _Index_impl(make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...);
     }
 

--- a/tests/std/include/test_mdspan_support.hpp
+++ b/tests/std/include/test_mdspan_support.hpp
@@ -294,7 +294,7 @@ MappingProperties<Mapping> get_mapping_properties(const Mapping& mapping) {
 
     // Is mapping exhaustive? (N4950 [mdspan.layout.reqmts]/16)
     props.exhaustiveness =
-        std::ranges::adjacent_find(mapped_indices, [](auto x, auto y) { return y - x != 1; }) == mapped_indices.end();
+        std::ranges::adjacent_find(mapped_indices, [](auto x, auto y) { return y - x > 1; }) == mapped_indices.end();
 
     { // Is mapping strided? (N4950 [mdspan.layout.reqmts]/18)
         props.strideness = true; // assumption

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -246,6 +246,7 @@ tests\P0009R18_mdspan_layout_right_death
 tests\P0009R18_mdspan_layout_stride
 tests\P0009R18_mdspan_layout_stride_death
 tests\P0009R18_mdspan_mdspan
+tests\P0009R18_mdspan_mdspan_death
 tests\P0019R8_atomic_ref
 tests\P0024R2_parallel_algorithms_adjacent_difference
 tests\P0024R2_parallel_algorithms_adjacent_find

--- a/tests/std/tests/P0009R18_mdspan_extents_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_extents_death/test.cpp
@@ -54,6 +54,13 @@ void test_construction_from_pack_with_unrepresentable_as_index_type_values_2() {
     [[maybe_unused]] extents<unsigned char, 1, dynamic_extent> e{ConvertibleToInt<unsigned char>{.val = 1}, 256};
 }
 
+void test_construction_from_pack_with_unrepresentable_as_index_type_values_3() {
+    static_assert(signed_integral<char>, "char is not signed integral");
+    // Either sizeof...(exts) must be equal to 0 or each element of exts must be nonnegative and must be representable
+    // as value of type index_type
+    [[maybe_unused]] extents<signed char, 1, dynamic_extent> e{static_cast<char>(-1)};
+}
+
 void test_construction_from_span_with_invalid_values() {
     int vals[] = {1, 2};
     span s{vals};
@@ -93,6 +100,7 @@ int main(int argc, char* argv[]) {
         test_construction_from_pack_with_invalid_values,
         test_construction_from_pack_with_unrepresentable_as_index_type_values_1,
         test_construction_from_pack_with_unrepresentable_as_index_type_values_2,
+        test_construction_from_pack_with_unrepresentable_as_index_type_values_3,
         test_construction_from_span_with_invalid_values,
         test_construction_from_span_with_unrepresentable_as_index_type_values,
         test_construction_from_array_with_invalid_values,

--- a/tests/std/tests/P0009R18_mdspan_layout_left_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left_death/test.cpp
@@ -38,7 +38,7 @@ void test_construction_from_other_right_mapping() {
 
 void test_construction_from_other_stride_mapping_1() {
     using Ext = extents<int, 2, 4>;
-    layout_stride::mapping<Ext> m1{Ext{}, array{1, 1}};
+    layout_stride::mapping<Ext> m1{Ext{}, array{4, 1}};
     // For all r in the range [0, extents_type::rank()), other.stride(r) must be equal to
     // extents().fwd-prod-of-extents(r)
     layout_left::mapping<Ext> m2{m1};

--- a/tests/std/tests/P0009R18_mdspan_layout_left_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left_death/test.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#define _CONTAINER_DEBUG_LEVEL 1
+
 #include <array>
 #include <cstddef>
 #include <mdspan>

--- a/tests/std/tests/P0009R18_mdspan_layout_left_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left_death/test.cpp
@@ -12,7 +12,17 @@
 
 using namespace std;
 
-// TRANSITION, Test Construction From extents_type
+void test_construction_from_extents_type_with_signed_index_type() {
+    using Ext = dextents<signed char, 3>;
+    // The size of the multidimensional index space e must be representable as a value of type index_type
+    [[maybe_unused]] layout_left::mapping<Ext> m{Ext{5, 4, 7}};
+}
+
+void test_construction_from_extents_type_with_unsigned_index_type() {
+    using Ext = dextents<unsigned char, 3>;
+    // The size of the multidimensional index space e must be representable as a value of type index_type
+    [[maybe_unused]] layout_left::mapping<Ext> m{Ext{5, 10, 6}};
+}
 
 void test_construction_from_other_left_mapping() {
     layout_left::mapping<dextents<int, 1>> m1{dextents<int, 1>{256}};
@@ -55,7 +65,8 @@ void test_stride_function() {
 int main(int argc, char* argv[]) {
     std_testing::death_test_executive exec;
     exec.add_death_tests({
-        // TRANSITION Construction From extents_type
+        test_construction_from_extents_type_with_signed_index_type,
+        test_construction_from_extents_type_with_unsigned_index_type,
         test_construction_from_other_left_mapping,
         test_construction_from_other_right_mapping,
         test_construction_from_other_stride_mapping_1,

--- a/tests/std/tests/P0009R18_mdspan_layout_right_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_right_death/test.cpp
@@ -38,7 +38,7 @@ void test_construction_from_other_left_mapping() {
 
 void test_construction_from_other_stride_mapping_1() {
     using Ext = extents<int, 2, 4>;
-    layout_stride::mapping<Ext> m1{Ext{}, array{3, 1}};
+    layout_stride::mapping<Ext> m1{Ext{}, array{1, 2}};
     // For all r in the range [0, extents_type::rank()), other.stride(r) must be equal to
     // extents().rev-prod-of-extents(r)
     layout_right::mapping<Ext> m2{m1};

--- a/tests/std/tests/P0009R18_mdspan_layout_right_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_right_death/test.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#define _CONTAINER_DEBUG_LEVEL 1
+
 #include <array>
 #include <cstddef>
 #include <mdspan>

--- a/tests/std/tests/P0009R18_mdspan_layout_right_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_right_death/test.cpp
@@ -12,7 +12,17 @@
 
 using namespace std;
 
-// TRANSITION, Test Construction From extents_type
+void test_construction_from_extents_type_with_signed_index_type() {
+    using Ext = dextents<signed char, 3>;
+    // The size of the multidimensional index space e must be representable as a value of type index_type
+    [[maybe_unused]] layout_right::mapping<Ext> m{Ext{5, 4, 7}};
+}
+
+void test_construction_from_extents_type_with_unsigned_index_type() {
+    using Ext = dextents<unsigned char, 3>;
+    // The size of the multidimensional index space e must be representable as a value of type index_type
+    [[maybe_unused]] layout_right::mapping<Ext> m{Ext{5, 10, 6}};
+}
 
 void test_construction_from_other_right_mapping() {
     layout_right::mapping<dextents<int, 1>> m1{dextents<int, 1>{256}};
@@ -55,7 +65,8 @@ void test_stride_function() {
 int main(int argc, char* argv[]) {
     std_testing::death_test_executive exec;
     exec.add_death_tests({
-        // TRANSITION Construction From extents_type
+        test_construction_from_extents_type_with_signed_index_type,
+        test_construction_from_extents_type_with_unsigned_index_type,
         test_construction_from_other_right_mapping,
         test_construction_from_other_left_mapping,
         test_construction_from_other_stride_mapping_1,

--- a/tests/std/tests/P0009R18_mdspan_layout_stride_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride_death/test.cpp
@@ -12,6 +12,13 @@
 
 using namespace std;
 
+void test_default_construction() {
+    using Ext = extents<signed char, dynamic_extent, 4, 5, 7>;
+    // Value of layout_right::mapping<extents_type>().required_span_size() must be
+    // representable as a value of type index_type
+    [[maybe_unused]] layout_stride::mapping<Ext> m{}; // NB: strides are [140, 35, 7, 1]
+}
+
 void test_construction_from_extents_and_array() {
     // Value of s[i] must be greater than 0 for all i in the range [0, rank_)
     [[maybe_unused]] layout_stride::mapping<dextents<int, 1>> m1{extents<int, 1>{}, array<int, 1>{-1}};
@@ -38,7 +45,7 @@ void test_call_operator() {
 int main(int argc, char* argv[]) {
     std_testing::death_test_executive exec;
     exec.add_death_tests({
-        // TRANSITION more tests
+        test_default_construction,
         test_construction_from_extents_and_array,
         test_construction_from_extents_and_span,
         test_construction_from_strided_layout_mapping,

--- a/tests/std/tests/P0009R18_mdspan_layout_stride_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride_death/test.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#define _CONTAINER_DEBUG_LEVEL 1
+
 #include <array>
 #include <cstddef>
 #include <mdspan>

--- a/tests/std/tests/P0009R18_mdspan_layout_stride_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride_death/test.cpp
@@ -39,7 +39,7 @@ void test_construction_from_extents_and_span_1() {
 }
 
 void test_construction_from_extents_and_span_2() {
-    using Ext = extents<unsigned char, 126>;
+    using Ext = extents<unsigned char, 130>;
     array<ConvertibleToInt<int>, 1> a{{{.val = 2}}};
     const span s{a};
     // REQUIRED-SPAN-SIZE(e, s) must be representable as a value of type index_type

--- a/tests/std/tests/P0009R18_mdspan_layout_stride_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride_death/test.cpp
@@ -9,6 +9,7 @@
 #include <span>
 
 #include <test_death.hpp>
+#include <test_mdspan_support.hpp>
 
 using namespace std;
 
@@ -19,15 +20,30 @@ void test_default_construction() {
     [[maybe_unused]] layout_stride::mapping<Ext> m{}; // NB: strides are [140, 35, 7, 1]
 }
 
-void test_construction_from_extents_and_array() {
+void test_construction_from_extents_and_array_1() {
     // Value of s[i] must be greater than 0 for all i in the range [0, rank_)
     [[maybe_unused]] layout_stride::mapping<dextents<int, 1>> m1{extents<int, 1>{}, array<int, 1>{-1}};
 }
 
-void test_construction_from_extents_and_span() {
+void test_construction_from_extents_and_array_2() {
+    using Ext = extents<signed char, 120>;
+    // REQUIRED-SPAN-SIZE(e, s) must be representable as a value of type index_type
+    [[maybe_unused]] layout_stride::mapping<Ext> m{Ext{}, array<int, 1>{2}};
+}
+
+
+void test_construction_from_extents_and_span_1() {
     array<int, 1> s{-1};
     // Value of s[i] must be greater than 0 for all i in the range [0, rank_)
-    [[maybe_unused]] layout_stride::mapping<dextents<int, 1>> m1{extents<int, 1>{}, span{s}};
+    [[maybe_unused]] layout_stride::mapping<dextents<int, 1>> m{extents<int, 1>{}, span{s}};
+}
+
+void test_construction_from_extents_and_span_2() {
+    using Ext = extents<unsigned char, 126>;
+    array<ConvertibleToInt<int>, 1> a{{{.val = 2}}};
+    const span s{a};
+    // REQUIRED-SPAN-SIZE(e, s) must be representable as a value of type index_type
+    [[maybe_unused]] layout_stride::mapping<Ext> m{Ext{}, s};
 }
 
 void test_construction_from_strided_layout_mapping() {
@@ -46,8 +62,10 @@ int main(int argc, char* argv[]) {
     std_testing::death_test_executive exec;
     exec.add_death_tests({
         test_default_construction,
-        test_construction_from_extents_and_array,
-        test_construction_from_extents_and_span,
+        test_construction_from_extents_and_array_1,
+        test_construction_from_extents_and_array_2,
+        test_construction_from_extents_and_span_1,
+        test_construction_from_extents_and_span_2,
         test_construction_from_strided_layout_mapping,
         test_call_operator,
     });

--- a/tests/std/tests/P0009R18_mdspan_mdspan_death/env.lst
+++ b/tests/std/tests/P0009R18_mdspan_mdspan_death/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P0009R18_mdspan_mdspan_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan_death/test.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#define _CONTAINER_DEBUG_LEVEL 1
+
+#include <array>
+#include <mdspan>
+
+#include <test_death.hpp>
+
+using namespace std;
+
+constexpr array<int, 128> some_ints{};
+
+void test_construction_from_other_mdspan() {
+    auto mds1 = mdspan{some_ints.data(), 8, 2, 8};
+    // For each rank index r of extents_type, static_extent(r) == dynamic_extent || static_extent(r) == other.extent(r)
+    // must be true
+    [[maybe_unused]] mdspan<const int, extents<int, 8, 8, 2>> mds2{mds1};
+}
+
+int main(int argc, char* argv[]) {
+    std_testing::death_test_executive exec;
+    exec.add_death_tests({
+        test_construction_from_other_mdspan,
+    });
+    return exec.run(argc, argv);
+}

--- a/tests/std/tests/P0009R18_mdspan_mdspan_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan_death/test.cpp
@@ -10,7 +10,7 @@
 
 using namespace std;
 
-constexpr array<int, 128> some_ints{};
+constexpr array<int, 256> some_ints{};
 
 void test_construction_from_other_mdspan() {
     auto mds1 = mdspan{some_ints.data(), 8, 2, 8};
@@ -33,6 +33,18 @@ void test_access_with_invalid_multidimensional_index_2() {
     (void) mds[array{4, 5}];
 }
 
+void test_size_when_index_type_is_signed() {
+    auto mds = mdspan{some_ints.data(), dextents<signed char, 3>{8, 8, 4}};
+    // The size of the multidimensional index space extents() must be representable as a value of type size_type
+    (void) mds.size();
+}
+
+void test_size_when_index_type_is_unsigned() {
+    auto mds = mdspan{some_ints.data(), dextents<unsigned char, 3>{8, 8, 4}};
+    // The size of the multidimensional index space extents() must be representable as a value of type size_type
+    (void) mds.size();
+}
+
 int main(int argc, char* argv[]) {
     std_testing::death_test_executive exec;
     exec.add_death_tests({
@@ -41,6 +53,8 @@ int main(int argc, char* argv[]) {
         test_access_with_invalid_multidimensional_index_1,
 #endif // __cpp_multidimensional_subscript
         test_access_with_invalid_multidimensional_index_2,
+        test_size_when_index_type_is_signed,
+        test_size_when_index_type_is_unsigned,
     });
     return exec.run(argc, argv);
 }

--- a/tests/std/tests/P0009R18_mdspan_mdspan_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan_death/test.cpp
@@ -19,10 +19,28 @@ void test_construction_from_other_mdspan() {
     [[maybe_unused]] mdspan<const int, extents<int, 8, 8, 2>> mds2{mds1};
 }
 
+#ifdef __cpp_multidimensional_subscript // TRANSITION, P2128R6
+void test_access_with_invalid_multidimensional_index_1() {
+    auto mds = mdspan{some_ints.data(), 4, 4};
+    // I must be a multidimensional index in extents()
+    (void) mds[3, 4];
+}
+#endif // __cpp_multidimensional_subscript
+
+void test_access_with_invalid_multidimensional_index_2() {
+    auto mds = mdspan{some_ints.data(), 5, 5};
+    // I must be a multidimensional index in extents()
+    (void) mds[array{4, 5}];
+}
+
 int main(int argc, char* argv[]) {
     std_testing::death_test_executive exec;
     exec.add_death_tests({
         test_construction_from_other_mdspan,
+#ifdef __cpp_multidimensional_subscript // TRANSITION, P2128R6
+        test_access_with_invalid_multidimensional_index_1,
+#endif // __cpp_multidimensional_subscript
+        test_access_with_invalid_multidimensional_index_2,
     });
     return exec.run(argc, argv);
 }


### PR DESCRIPTION
* Guard all existing debug checks with `#if _CONTAINER_DEBUG_LEVEL > 0` (addresses https://github.com/microsoft/STL/pull/3586#discussion_r1148075895),
* `extents`:
  * Make `_Static_extents` array public and use it when possible,
  * Add new `_Multidim_index_space_size_is_always_zero` static member variable,
  * Split `_Is_index_space_size_representable` into two functions: `_Is_static_multidim_index_space_size_representable` and `_Is_dynamic_multidim_index_space_size_representable`,
  * Report DevCom-10398426 and silence it,
  * Improve debug check in `extents(_OtherIndexTypes... _Exts)` constructor,
* `layout_(left|right|stride)`
  * Implement missing debug checks,
  * Replace scary looking immediately invoked lambda expressions with simple `for` loops (`layout_(left|right)`'s constructors from `layout_stride`),
  * Move precondition checks from `operator()` to corresponding `_Index_impl` functions (to avoid casting `_Indices` to `index_type` twice),
  * Drive-by: Remove unnecessary `[[maybe_unused]]` attributes in tests,
  * Drive-by: Simplify calls to `check_members_with_various_extents` in tests,
  * Drive-by: use `ranges::adjacent_find` instead of `views::pairwise_transform` in `get_mapping_properties` function,
  * Drive-by: fix exhaustiveness check in `get_mapping_properties` - previously, non-unique exhaustive mappings were recognized as non-exhaustive,
* `mdspan`:
  * Implement missing debug checks,
  * Manually inline call to `extents_type::static_extent` in `mdspan::static_extent` and add precondition check,
  * Drive-by: improve performance of `mdspan::empty`,
  * Implement new death tests.