### PR TITLE
Test coverage and precondition checking for LWG-2295 Locale name when the provided `Facet` is a `nullptr`

### DIFF
--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -280,6 +280,7 @@ public:
     locale(const locale& _Loc, const locale& _Other, category _Cat) : _Ptr(_Locimp::_New_Locimp(*_Loc._Ptr)) {
         // construct a locale by copying named facets
         if (_Cat != none) { // worth adding, do it
+            _STL_ASSERT((_Cat & all) == _Cat, "the bitmask value specifying category must be valid");
             _Facet_guard _Guard{_Ptr};
             _BEGIN_LOCINFO(_Lobj)
             _Locimp::_Makeloc(_Lobj, _Cat, _Ptr, &_Other);
@@ -294,6 +295,7 @@ public:
 
 private:
     void _Construct(const string& _Str, category _Cat) {
+        _STL_ASSERT((_Cat & all) == _Cat, "the bitmask value specifying category must be valid");
         // construct a locale with named facets
         bool _Bad = false;
         _Init();

--- a/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
+++ b/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
@@ -52,7 +52,7 @@ void test_exe_part2() {
     assert(!isspace(L'Z', locale()));
 }
 
-
+#ifndef _M_CEE_PURE
 locale make_unnamed_locale() {
     locale result{locale{"C"}, &use_facet<numpunct<char>>(locale{"C"})};
     assert(result.name() == "*");
@@ -167,13 +167,16 @@ void test_locale_name_with_another_locale_and_cats() {
         }
     }
 }
+#endif // _M_CEE_PURE
 
 int main() {
     test_exe_part1();
     test_dll();
     test_exe_part2();
 
+#ifndef _M_CEE_PURE
     // test coverage for LWG-2295
     test_locale_name_with_facet_pointer_all();
     test_locale_name_with_another_locale_and_cats();
+#endif // _M_CEE_PURE
 }

--- a/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
+++ b/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#define _SILENCE_CXX20_CODECVT_FACETS_DEPRECATION_WARNING
+
 #include <cassert>
 #include <cstdio>
 #include <locale>
@@ -11,8 +13,8 @@ using namespace std;
 
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
 
-STATIC_ASSERT(noexcept(locale{} == locale{}));
-STATIC_ASSERT(noexcept(locale{} != locale{}));
+STATIC_ASSERT(noexcept(locale{} == locale{})); // strengthened
+STATIC_ASSERT(noexcept(locale{} != locale{})); // strengthened
 
 void test_dll() {
     puts("Calling dll");
@@ -50,8 +52,128 @@ void test_exe_part2() {
     assert(!isspace(L'Z', locale()));
 }
 
+
+locale make_unnamed_locale() {
+    locale result{locale{"C"}, &use_facet<numpunct<char>>(locale{"C"})};
+    assert(result.name() == "*");
+    return result;
+}
+
+template <class Facet>
+void test_locale_name_with_facet_pointer_one() {
+    {
+        locale result{locale{"C"}, static_cast<Facet*>(nullptr)};
+        assert(result.name() == "C");
+    }
+    {
+        locale result{make_unnamed_locale(), static_cast<Facet*>(nullptr)};
+        assert(result.name() == "*");
+    }
+    {
+        locale le{"C"};
+        locale result{le, &use_facet<Facet>(le)};
+        assert(result.name() == "*");
+    }
+    {
+        locale lunnamed{make_unnamed_locale()};
+        locale result{lunnamed, &use_facet<Facet>(lunnamed)};
+        assert(result.name() == "*");
+    }
+}
+
+void test_locale_name_with_facet_pointer_all() {
+    test_locale_name_with_facet_pointer_one<collate<char>>();
+    test_locale_name_with_facet_pointer_one<collate<wchar_t>>();
+
+    test_locale_name_with_facet_pointer_one<ctype<char>>();
+    test_locale_name_with_facet_pointer_one<ctype<wchar_t>>();
+    test_locale_name_with_facet_pointer_one<codecvt<char, char, mbstate_t>>();
+    test_locale_name_with_facet_pointer_one<codecvt<char16_t, char, mbstate_t>>();
+    test_locale_name_with_facet_pointer_one<codecvt<char32_t, char, mbstate_t>>();
+#ifdef __cpp_char8_t
+    test_locale_name_with_facet_pointer_one<codecvt<char16_t, char8_t, mbstate_t>>();
+    test_locale_name_with_facet_pointer_one<codecvt<char32_t, char8_t, mbstate_t>>();
+#endif // __cpp_char8_t
+    test_locale_name_with_facet_pointer_one<codecvt<wchar_t, char, mbstate_t>>();
+
+    test_locale_name_with_facet_pointer_one<moneypunct<char>>();
+    test_locale_name_with_facet_pointer_one<moneypunct<wchar_t>>();
+    test_locale_name_with_facet_pointer_one<moneypunct<char, true>>();
+    test_locale_name_with_facet_pointer_one<moneypunct<wchar_t, true>>();
+    test_locale_name_with_facet_pointer_one<money_get<char>>();
+    test_locale_name_with_facet_pointer_one<money_get<wchar_t>>();
+    test_locale_name_with_facet_pointer_one<money_put<char>>();
+    test_locale_name_with_facet_pointer_one<money_put<wchar_t>>();
+
+    test_locale_name_with_facet_pointer_one<numpunct<char>>();
+    test_locale_name_with_facet_pointer_one<numpunct<wchar_t>>();
+    test_locale_name_with_facet_pointer_one<num_get<char>>();
+    test_locale_name_with_facet_pointer_one<num_get<wchar_t>>();
+    test_locale_name_with_facet_pointer_one<num_put<char>>();
+    test_locale_name_with_facet_pointer_one<num_put<wchar_t>>();
+
+    test_locale_name_with_facet_pointer_one<time_get<char>>();
+    test_locale_name_with_facet_pointer_one<time_get<wchar_t>>();
+    test_locale_name_with_facet_pointer_one<time_put<char>>();
+    test_locale_name_with_facet_pointer_one<time_put<wchar_t>>();
+
+    test_locale_name_with_facet_pointer_one<messages<char>>();
+    test_locale_name_with_facet_pointer_one<messages<wchar_t>>();
+}
+
+void test_locale_name_with_another_locale_and_cats() {
+    locale lc{"C"};
+    locale lunnamed{make_unnamed_locale()};
+    {
+        std::locale result{lc, lc, std::locale::none};
+        assert(result.name() != "*");
+    }
+    {
+        std::locale result{lc, lunnamed, std::locale::none};
+        assert(result.name() != "*");
+    }
+    {
+        std::locale result{lunnamed, lc, std::locale::none};
+        assert(result.name() == "*");
+    }
+    {
+        std::locale result{lunnamed, lunnamed, std::locale::none};
+        assert(result.name() == "*");
+    }
+
+    constexpr int cats_masks_count = 6; // collate | ctype | monetary | numeric | time | messages
+    for (int precats = 1; precats < (1 << cats_masks_count); ++precats) {
+        const locale::category cats = ((precats & (1 << 0)) != 0 ? locale::collate : locale::none)
+                                    | ((precats & (1 << 1)) != 0 ? locale::ctype : locale::none)
+                                    | ((precats & (1 << 2)) != 0 ? locale::monetary : locale::none)
+                                    | ((precats & (1 << 3)) != 0 ? locale::numeric : locale::none)
+                                    | ((precats & (1 << 4)) != 0 ? locale::time : locale::none)
+                                    | ((precats & (1 << 5)) != 0 ? locale::messages : locale::none);
+        {
+            std::locale result{lc, lc, cats};
+            assert(result.name() != "*");
+        }
+        {
+            std::locale result{lc, lunnamed, cats};
+            assert(result.name() == "*");
+        }
+        {
+            std::locale result{lunnamed, lc, cats};
+            assert(result.name() == "*");
+        }
+        {
+            std::locale result{lunnamed, lunnamed, cats};
+            assert(result.name() == "*");
+        }
+    }
+}
+
 int main() {
     test_exe_part1();
     test_dll();
     test_exe_part2();
+
+    // test coverage for LWG-2295
+    test_locale_name_with_facet_pointer_all();
+    test_locale_name_with_another_locale_and_cats();
 }

--- a/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
+++ b/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
@@ -125,19 +125,19 @@ void test_locale_name_with_another_locale_and_cats() {
     locale lc{"C"};
     locale lunnamed{make_unnamed_locale()};
     {
-        std::locale result{lc, lc, std::locale::none};
+        locale result{lc, lc, locale::none};
         assert(result.name() != "*");
     }
     {
-        std::locale result{lc, lunnamed, std::locale::none};
+        locale result{lc, lunnamed, locale::none};
         assert(result.name() != "*");
     }
     {
-        std::locale result{lunnamed, lc, std::locale::none};
+        locale result{lunnamed, lc, locale::none};
         assert(result.name() == "*");
     }
     {
-        std::locale result{lunnamed, lunnamed, std::locale::none};
+        locale result{lunnamed, lunnamed, locale::none};
         assert(result.name() == "*");
     }
 
@@ -150,19 +150,19 @@ void test_locale_name_with_another_locale_and_cats() {
                                     | ((precats & (1 << 4)) != 0 ? locale::time : locale::none)
                                     | ((precats & (1 << 5)) != 0 ? locale::messages : locale::none);
         {
-            std::locale result{lc, lc, cats};
+            locale result{lc, lc, cats};
             assert(result.name() != "*");
         }
         {
-            std::locale result{lc, lunnamed, cats};
+            locale result{lc, lunnamed, cats};
             assert(result.name() == "*");
         }
         {
-            std::locale result{lunnamed, lc, cats};
+            locale result{lunnamed, lc, cats};
             assert(result.name() == "*");
         }
         {
-            std::locale result{lunnamed, lunnamed, cats};
+            locale result{lunnamed, lunnamed, cats};
             assert(result.name() == "*");
         }
     }


### PR DESCRIPTION
I think that LWG issue is actually already implemented, and thus just add test coverage and precondition checking.

Driven-by change: mark the `noexcept` checking (added in #3250) as `// strengthened`.

Fixes #3463.