### PR TITLE
`<mdspan>`: Finish `layout_stride`'s tests

### DIFF
--- a/tests/std/include/test_mdspan_support.hpp
+++ b/tests/std/include/test_mdspan_support.hpp
@@ -304,7 +304,8 @@ MappingProperties<Mapping> get_mapping_properties(const Mapping& mapping) {
             std::optional<IndexType> sr;
             for (auto i : multidim_indices) {
                 const auto i_plus_dr = [&]<size_t... Indices>(std::index_sequence<Indices...>) {
-                    return std::array{static_cast<IndexType>(std::get<Indices>(i) + (Indices == r ? 1 : 0))...};
+                    return std::array<IndexType, rank>{
+                        static_cast<IndexType>(std::get<Indices>(i) + (Indices == r ? 1 : 0))...};
                 }(rank_indices);
 
                 if (i_plus_dr[r] < get_extent(r)) {

--- a/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
@@ -22,9 +22,6 @@ struct CmpEqual {
     }
 };
 
-enum class AlwaysUnique { no, yes };
-enum class AlwaysStrided { no, yes };
-
 struct NotLayoutMappingAlikeAtAll {
     template <class Extents>
     class mapping : public layout_right::mapping<Extents> {
@@ -37,6 +34,9 @@ struct NotLayoutMappingAlikeAtAll {
 };
 
 static_assert(!_Layout_mapping_alike<NotLayoutMappingAlikeAtAll::mapping<extents<int, 4, 4>>>);
+
+enum class AlwaysUnique { no, yes };
+enum class AlwaysStrided { no, yes };
 
 template <AlwaysUnique Unique, AlwaysStrided Strided>
 struct LyingLayout {


### PR DESCRIPTION
Drive-by: fix `get_mapping_properties` when `Mapping::extents_type::rank() == 0`.