### PR TITLE
Add `[[msvc::lifetimebound]]` to `minmax`

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -21,6 +21,12 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+// TRANSITION, non-_Ugly attribute tokens
+#pragma push_macro("msvc")
+#pragma push_macro("lifetimebound")
+#undef msvc
+#undef lifetimebound
+
 #if _USE_STD_VECTOR_ALGORITHMS
 
 _EXTERN_C
@@ -10003,8 +10009,9 @@ namespace ranges {
 #endif // _HAS_CXX17
 
 _EXPORT_STD template <class _Ty, class _Pr>
-_NODISCARD constexpr pair<const _Ty&, const _Ty&> minmax(const _Ty& _Left, const _Ty& _Right, _Pr _Pred) noexcept(
-    noexcept(_DEBUG_LT_PRED(_Pred, _Right, _Left))) /* strengthened */ {
+_NODISCARD constexpr pair<const _Ty&, const _Ty&> minmax(const _Ty& _Left _MSVC_LIFETIMEBOUND,
+    const _Ty& _Right _MSVC_LIFETIMEBOUND,
+    _Pr _Pred) noexcept(noexcept(_DEBUG_LT_PRED(_Pred, _Right, _Left))) /* strengthened */ {
     // return pair(leftmost/smaller, rightmost/larger) of _Left and _Right
     if (_DEBUG_LT_PRED(_Pred, _Right, _Left)) {
         return {_Right, _Left};
@@ -10021,8 +10028,8 @@ _NODISCARD constexpr pair<_Ty, _Ty> minmax(initializer_list<_Ty> _Ilist, _Pr _Pr
 }
 
 _EXPORT_STD template <class _Ty>
-_NODISCARD constexpr pair<const _Ty&, const _Ty&> minmax(const _Ty& _Left, const _Ty& _Right) noexcept(
-    noexcept(_Right < _Left)) /* strengthened */ {
+_NODISCARD constexpr pair<const _Ty&, const _Ty&> minmax(const _Ty& _Left _MSVC_LIFETIMEBOUND,
+    const _Ty& _Right _MSVC_LIFETIMEBOUND) noexcept(noexcept(_Right < _Left)) /* strengthened */ {
     // return pair(leftmost/smaller, rightmost/larger) of _Left and _Right
     if (_Right < _Left) {
         _STL_ASSERT(!(_Left < _Right), "invalid comparator");
@@ -10673,6 +10680,11 @@ namespace ranges {
 #endif // _HAS_CXX17
 
 _STD_END
+
+// TRANSITION, non-_Ugly attribute tokens
+#pragma pop_macro("lifetimebound")
+#pragma pop_macro("msvc")
+
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -10056,8 +10056,8 @@ namespace ranges {
 
         template <class _Ty, class _Pj = identity,
             indirect_strict_weak_order<projected<const _Ty*, _Pj>> _Pr = ranges::less>
-        _NODISCARD constexpr minmax_result<const _Ty&> operator()(
-            const _Ty& _Left, const _Ty& _Right, _Pr _Pred = {}, _Pj _Proj = {}) const {
+        _NODISCARD constexpr minmax_result<const _Ty&> operator()(const _Ty& _Left _MSVC_LIFETIMEBOUND,
+            const _Ty& _Right _MSVC_LIFETIMEBOUND, _Pr _Pred = {}, _Pj _Proj = {}) const {
             if (_STD invoke(_Pred, _STD invoke(_Proj, _Right), _STD invoke(_Proj, _Left))) {
                 return {_Right, _Left};
             } else {

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -703,17 +703,15 @@
 #endif
 
 // Should we enable [[msvc::lifetimebound]] or [[clang::lifetimebound]] warnings?
-#ifndef _SILENCE_LIFETIMEBOUND_WARNING
-#if _HAS_MSVC_ATTRIBUTE(lifetimebound)
+#if !defined(__has_cpp_attribute) || defined(_SILENCE_LIFETIMEBOUND_WARNING)
+#define _MSVC_LIFETIMEBOUND
+#elif _HAS_MSVC_ATTRIBUTE(lifetimebound)
 #define _MSVC_LIFETIMEBOUND [[msvc::lifetimebound]]
 #elif __has_cpp_attribute(_Clang::__lifetimebound__)
 #define _MSVC_LIFETIMEBOUND [[_Clang::__lifetimebound__]]
 #else
 #define _MSVC_LIFETIMEBOUND
 #endif
-#else // ^^^ warning enabled / warning disabled vvv
-#define _MSVC_LIFETIMEBOUND
-#endif // ^^^ warning disabled ^^^
 
 #undef _HAS_MSVC_ATTRIBUTE
 #pragma pop_macro("lifetimebound")

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -663,10 +663,12 @@
 #pragma push_macro("known_semantics")
 #pragma push_macro("noop_dtor")
 #pragma push_macro("intrinsic")
+#pragma push_macro("lifetimebound")
 #undef msvc
 #undef known_semantics
 #undef noop_dtor
 #undef intrinsic
+#undef lifetimebound
 
 #ifndef __has_cpp_attribute
 #define _HAS_MSVC_ATTRIBUTE(x) 0
@@ -700,7 +702,21 @@
 #define _MSVC_INTRINSIC
 #endif
 
+// Should we enable [[msvc::lifetimebound]] or [[clang::lifetimebound]] warnings?
+#ifndef _SILENCE_LIFETIMEBOUND_WARNING
+#if _HAS_MSVC_ATTRIBUTE(lifetimebound)
+#define _MSVC_LIFETIMEBOUND [[msvc::lifetimebound]]
+#elif __has_cpp_attribute(_Clang::__lifetimebound__)
+#define _MSVC_LIFETIMEBOUND [[_Clang::__lifetimebound__]]
+#else
+#define _MSVC_LIFETIMEBOUND
+#endif
+#else // ^^^ warning enabled / warning disabled vvv
+#define _MSVC_LIFETIMEBOUND
+#endif // ^^^ warning disabled ^^^
+
 #undef _HAS_MSVC_ATTRIBUTE
+#pragma pop_macro("lifetimebound")
 #pragma pop_macro("intrinsic")
 #pragma pop_macro("noop_dtor")
 #pragma pop_macro("known_semantics")

--- a/tests/std/lit.site.cfg.in
+++ b/tests/std/lit.site.cfg.in
@@ -19,12 +19,14 @@ config.test_format    = stl.test.format.STLTestFormat()
 lit_config.expected_results = getattr(lit_config, 'expected_results', dict())
 lit_config.include_dirs     = getattr(lit_config, 'include_dirs', dict())
 lit_config.library_dirs     = getattr(lit_config, 'library_dirs', dict())
+lit_config.ruleset_dirs     = getattr(lit_config, 'ruleset_dirs', dict())
 lit_config.test_subdirs     = getattr(lit_config, 'test_subdirs', dict())
 
 lit_config.expected_results[config.name] = stl.test.file_parsing.parse_result_file('@STD_EXPECTED_RESULTS@')
 lit_config.include_dirs[config.name]     = \
     ['@STL_TESTED_HEADERS_DIR@', '@LIBCXX_SOURCE_DIR@/test/support', '@STL_SOURCE_DIR@/tests/std/include']
 lit_config.library_dirs[config.name]     = ['@STL_LIBRARY_OUTPUT_DIRECTORY@', '@TOOLSET_LIB@']
+lit_config.ruleset_dirs[config.name]     = ['@STL_SOURCE_DIR@/tests/std/rulesets']
 lit_config.test_subdirs[config.name]     = ['@CMAKE_CURRENT_SOURCE_DIR@/tests']
 
 lit_config.cxx_headers = '@STL_TESTED_HEADERS_DIR@'

--- a/tests/std/rulesets/stl.ruleset
+++ b/tests/std/rulesets/stl.ruleset
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation. -->
+<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
+<RuleSet Name="STL Ruleset" Description="C++ Core Guidelines rules for microsoft/STL" ToolsVersion="15.0">
+  <Rules AnalyzerId="Microsoft.Analyzers.NativeCodeAnalysis" RuleNamespace="Microsoft.Rules.Native">
+    <!-- The pointer is dangling because it points at a temporary instance that was destroyed. (ES.65) -->
+    <Rule Id="C26815" Action="Warning" />
+    <!-- The pointer points to memory allocated on the stack (ES.65) -->
+    <Rule Id="C26816" Action="Warning" />
+  </Rules>
+</RuleSet>

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -200,7 +200,8 @@ tests\GH_002030_asan_annotate_vector
 tests\GH_002039_byte_is_not_trivially_swappable
 tests\GH_002045_put_time_changes_errno
 tests\GH_002058_debug_iterator_race
-tests\GH_002094_cpp_core_guidelines
+# Needs special machinery to work in the MSVC-internal test harness, not yet implemented:
+# tests\GH_002094_cpp_core_guidelines
 tests\GH_002120_streambuf_seekpos_and_seekoff
 tests\GH_002168_regex_overflow
 tests\GH_002206_unreserved_names

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -200,6 +200,7 @@ tests\GH_002030_asan_annotate_vector
 tests\GH_002039_byte_is_not_trivially_swappable
 tests\GH_002045_put_time_changes_errno
 tests\GH_002058_debug_iterator_race
+tests\GH_002094_cpp_core_guidelines
 tests\GH_002120_streambuf_seekpos_and_seekoff
 tests\GH_002168_regex_overflow
 tests\GH_002206_unreserved_names

--- a/tests/std/tests/GH_002094_cpp_core_guidelines/env.lst
+++ b/tests/std/tests/GH_002094_cpp_core_guidelines/env.lst
@@ -1,0 +1,16 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\prefix.lst
+RUNALL_CROSSLIST
+PM_CL="/EHsc /w14640 /Zc:threadSafeInit-"
+RUNALL_CROSSLIST
+PM_CL="/MD /D_ITERATOR_DEBUG_LEVEL=0 /std:c++14 /analyze:only /analyze:autolog- /analyze:plugin EspXEngine.dll /analyze:ruleset stl.ruleset"
+PM_CL="/MDd /D_ITERATOR_DEBUG_LEVEL=2 /std:c++17 /permissive- /analyze:only /analyze:autolog- /analyze:plugin EspXEngine.dll /analyze:ruleset stl.ruleset"
+PM_CL="/MDd /D_ITERATOR_DEBUG_LEVEL=2 /std:c++20 /permissive- /analyze:only /analyze:autolog- /analyze:plugin EspXEngine.dll /analyze:ruleset stl.ruleset"
+PM_CL="/MT /D_ITERATOR_DEBUG_LEVEL=0 /std:c++latest /permissive- /analyze:only /analyze:autolog- /analyze:plugin EspXEngine.dll /analyze:ruleset stl.ruleset"
+PM_CL="/MTd /D_ITERATOR_DEBUG_LEVEL=2 /std:c++latest /permissive- /analyze:only /analyze:autolog- /analyze:plugin EspXEngine.dll /analyze:ruleset stl.ruleset"
+PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /MD /std:c++14"
+PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /MDd /std:c++17"
+PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /MT /std:c++20 /permissive-"
+PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /MTd /std:c++latest /permissive-"

--- a/tests/std/tests/GH_002094_cpp_core_guidelines/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002094_cpp_core_guidelines/test.compile.pass.cpp
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <__msvc_all_public_headers.hpp>

--- a/tests/utils/stl/test/format.py
+++ b/tests/utils/stl/test/format.py
@@ -145,7 +145,7 @@ class STLTestFormat:
             env: Dict[str, str] = field(default_factory=dict)
 
         execDir, _ = test.getTempPaths()
-        shared = SharedState(None, execDir, copy.deepcopy(litConfig.test_env))
+        shared = SharedState(None, execDir, _mergeEnvironments(litConfig.test_env, test.env))
         shared.env['TMP'] = execDir
         shared.env['TEMP'] = execDir
         shared.env['TMPDIR'] = execDir


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->

Works towards #3754. Works towards #2094.

This PR adds `[[msvc::lifetimebound]]` to `std::minmax` and `std::ranges::minmax`, which are more error-prone than `std::min`/`std::max` but not as widely used.

`#define _SILENCE_LIFETIMEBOUND_WARNING` to suppress the warning.

```
C:\Users\He\source\repos\STL\out>type test.cpp
```
```cpp
#include <algorithm>

int square(int x) {
    return x * x;
}

int square_diff(int x, int y) {
    const auto [min, max] = std::minmax(square(x), square(y));
    return max - min;
}
```
```
C:\Users\He\source\repos\STL\out>clang -Wall -Wextra -std=c++17 -c test.cpp
test.cpp:8:41: warning: temporary whose address is used as value of local variable '[min, max]' will be destroyed at the
      end of the full-expression [-Wdangling]
    const auto [min, max] = std::minmax(square(x), square(y));
                                        ^~~~~~~~~
test.cpp:8:52: warning: temporary whose address is used as value of local variable '[min, max]' will be destroyed at the
      end of the full-expression [-Wdangling]
    const auto [min, max] = std::minmax(square(x), square(y));
                                                   ^~~~~~~~~
2 warnings generated.

C:\Users\He\source\repos\STL\out>set Esp.Extensions=CppCoreCheck.dll

C:\Users\He\source\repos\STL\out>cl /EHsc /W4 /std:c++17 /c /analyze:plugin EspXEngine.dll /analyze:ruleset ..\tests\std\rulesets\stl.ruleset test.cpp
用于 x64 的 Microsoft (R) C/C++ 优化编译器 19.37.32705 版
版权所有(C) Microsoft Corporation。保留所有权利。

test.cpp
C:\Users\He\source\repos\STL\out\test.cpp(8) : warning C26815: 指针无关联，因为它指向已销毁的临时实例。
```