### PR TITLE
C++26 freestanding feature-test macros

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -72,6 +72,12 @@
 // P1164R1 Making create_directory() Intuitive
 // P1165R1 Consistently Propagating Stateful Allocators In basic_string's operator+()
 // P1902R1 Missing Feature-Test Macros 2017-2019
+// P2013R5 Freestanding Language: Optional ::operator new
+//     (no change is needed for our hosted implementation)
+// P2198R7 Freestanding Feature-Test Macros And Implementation-Defined Extensions
+//     (except for __cpp_lib_freestanding_ranges)
+// P2338R4 Freestanding Library: Character Primitives And The C Library
+//     (except for __cpp_lib_freestanding_charconv)
 // P2401R0 Conditional noexcept For exchange()
 
 // _HAS_CXX17 directly controls:
@@ -127,6 +133,8 @@
 // P2162R2 Inheriting From variant
 // P2251R1 Require span And basic_string_view To Be Trivially Copyable
 //     (basic_string_view always provides this behavior)
+// P2338R4 Freestanding Library: Character Primitives And The C Library
+//     (including __cpp_lib_freestanding_charconv)
 // P2517R1 Conditional noexcept For apply()
 
 // _HAS_CXX17 indirectly controls:
@@ -266,6 +274,8 @@
 // P2106R0 Range Algorithm Result Types
 // P2116R0 Removing tuple-Like Protocol Support From Fixed-Extent span
 // P2167R3 Improving boolean-testable Usage
+// P2198R7 Freestanding Feature-Test Macros And Implementation-Defined Extensions
+//     (including __cpp_lib_freestanding_ranges)
 // P2210R2 Superior String Splitting
 // P2216R3 std::format Improvements
 // P2231R1 Completing constexpr In optional And variant
@@ -1522,20 +1532,33 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #endif // _HAS_GARBAGE_COLLECTION_SUPPORT_DELETED_IN_CXX23
 
 // C++14
-#define __cpp_lib_chrono_udls                 201304L
-#define __cpp_lib_complex_udls                201309L
-#define __cpp_lib_exchange_function           201304L
-#define __cpp_lib_generic_associative_lookup  201304L
-#define __cpp_lib_integer_sequence            201304L
-#define __cpp_lib_integral_constant_callable  201304L
-#define __cpp_lib_is_final                    201402L
-#define __cpp_lib_is_null_pointer             201309L
-#define __cpp_lib_make_reverse_iterator       201402L
-#define __cpp_lib_make_unique                 201304L
-#define __cpp_lib_null_iterators              201304L
-#define __cpp_lib_quoted_string_io            201304L
-#define __cpp_lib_result_of_sfinae            201210L
-#define __cpp_lib_robust_nonmodifying_seq_ops 201304L
+#define __cpp_lib_chrono_udls                      201304L
+#define __cpp_lib_complex_udls                     201309L
+#define __cpp_lib_exchange_function                201304L
+#define __cpp_lib_freestanding_char_traits         202306L
+#define __cpp_lib_freestanding_cstdlib             202306L
+#define __cpp_lib_freestanding_cstring             202306L
+#define __cpp_lib_freestanding_cwchar              202306L
+#define __cpp_lib_freestanding_errc                202306L
+#define __cpp_lib_freestanding_feature_test_macros 202306L
+#define __cpp_lib_freestanding_functional          202306L
+#define __cpp_lib_freestanding_iterator            202306L
+#define __cpp_lib_freestanding_memory              202306L
+#define __cpp_lib_freestanding_operator_new        202306L
+#define __cpp_lib_freestanding_ratio               202306L
+#define __cpp_lib_freestanding_tuple               202306L
+#define __cpp_lib_freestanding_utility             202306L
+#define __cpp_lib_generic_associative_lookup       201304L
+#define __cpp_lib_integer_sequence                 201304L
+#define __cpp_lib_integral_constant_callable       201304L
+#define __cpp_lib_is_final                         201402L
+#define __cpp_lib_is_null_pointer                  201309L
+#define __cpp_lib_make_reverse_iterator            201402L
+#define __cpp_lib_make_unique                      201304L
+#define __cpp_lib_null_iterators                   201304L
+#define __cpp_lib_quoted_string_io                 201304L
+#define __cpp_lib_result_of_sfinae                 201210L
+#define __cpp_lib_robust_nonmodifying_seq_ops      201304L
 #ifndef _M_CEE_PURE
 #define __cpp_lib_shared_timed_mutex 201402L
 #endif // _M_CEE_PURE
@@ -1574,6 +1597,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #endif // _HAS_STD_BYTE
 #define __cpp_lib_clamp                             201603L
 #define __cpp_lib_filesystem                        201703L
+#define __cpp_lib_freestanding_charconv             202306L
 #define __cpp_lib_gcd_lcm                           201606L
 #define __cpp_lib_hardware_interference_size        201703L
 #define __cpp_lib_has_unique_object_representations 201606L
@@ -1656,7 +1680,8 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_erase_if                202002L
 
 #ifdef __cpp_lib_concepts
-#define __cpp_lib_format 202207L
+#define __cpp_lib_format              202207L
+#define __cpp_lib_freestanding_ranges 202306L
 #endif // __cpp_lib_concepts
 
 #define __cpp_lib_generic_unordered_lookup     201811L

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -1013,9 +1013,9 @@ STATIC_ASSERT(__cpp_lib_freestanding_ranges == 202306L);
 #endif
 
 #ifndef __cpp_lib_freestanding_ratio
-#error __cpp_lib_freestanding_operator_new is not defined
+#error __cpp_lib_freestanding_ratio is not defined
 #elif __cpp_lib_freestanding_ratio != 202306L
-#error __cpp_lib_freestanding_operator_new is not 202306L
+#error __cpp_lib_freestanding_ratio is not 202306L
 #else
 STATIC_ASSERT(__cpp_lib_freestanding_ratio == 202306L);
 #endif

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -904,6 +904,138 @@ STATIC_ASSERT(__cpp_lib_forward_like == 202207L);
 #endif
 #endif
 
+#ifndef __cpp_lib_freestanding_char_traits
+#error __cpp_lib_freestanding_char_traits is not defined
+#elif __cpp_lib_freestanding_char_traits != 202306L
+#error __cpp_lib_freestanding_char_traits is not 202306L
+#else
+STATIC_ASSERT(__cpp_lib_freestanding_char_traits == 202306L);
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_freestanding_charconv
+#error __cpp_lib_freestanding_charconv is not defined
+#elif __cpp_lib_freestanding_charconv != 202306L
+#error __cpp_lib_freestanding_charconv is not 202306L
+#else
+STATIC_ASSERT(__cpp_lib_freestanding_charconv == 202306L);
+#endif
+#else
+#ifdef __cpp_lib_freestanding_charconv
+#error __cpp_lib_freestanding_charconv is defined
+#endif
+#endif
+
+#ifndef __cpp_lib_freestanding_cstdlib
+#error __cpp_lib_freestanding_cstdlib is not defined
+#elif __cpp_lib_freestanding_cstdlib != 202306L
+#error __cpp_lib_freestanding_cstdlib is not 202306L
+#else
+STATIC_ASSERT(__cpp_lib_freestanding_cstdlib == 202306L);
+#endif
+
+#ifndef __cpp_lib_freestanding_cstring
+#error __cpp_lib_freestanding_cstring is not defined
+#elif __cpp_lib_freestanding_cstring != 202306L
+#error __cpp_lib_freestanding_cstring is not 202306L
+#else
+STATIC_ASSERT(__cpp_lib_freestanding_cstring == 202306L);
+#endif
+
+#ifndef __cpp_lib_freestanding_cwchar
+#error __cpp_lib_freestanding_cwchar is not defined
+#elif __cpp_lib_freestanding_cwchar != 202306L
+#error __cpp_lib_freestanding_cwchar is not 202306L
+#else
+STATIC_ASSERT(__cpp_lib_freestanding_cwchar == 202306L);
+#endif
+
+#ifndef __cpp_lib_freestanding_errc
+#error __cpp_lib_freestanding_errc is not defined
+#elif __cpp_lib_freestanding_errc != 202306L
+#error __cpp_lib_freestanding_errc is not 202306L
+#else
+STATIC_ASSERT(__cpp_lib_freestanding_errc == 202306L);
+#endif
+
+#ifndef __cpp_lib_freestanding_feature_test_macros
+#error __cpp_lib_freestanding_feature_test_macros is not defined
+#elif __cpp_lib_freestanding_feature_test_macros != 202306L
+#error __cpp_lib_freestanding_feature_test_macros is not 202306L
+#else
+STATIC_ASSERT(__cpp_lib_freestanding_feature_test_macros == 202306L);
+#endif
+
+#ifndef __cpp_lib_freestanding_functional
+#error __cpp_lib_freestanding_functional is not defined
+#elif __cpp_lib_freestanding_functional != 202306L
+#error __cpp_lib_freestanding_functional is not 202306L
+#else
+STATIC_ASSERT(__cpp_lib_freestanding_functional == 202306L);
+#endif
+
+#ifndef __cpp_lib_freestanding_iterator
+#error __cpp_lib_freestanding_iterator is not defined
+#elif __cpp_lib_freestanding_iterator != 202306L
+#error __cpp_lib_freestanding_iterator is not 202306L
+#else
+STATIC_ASSERT(__cpp_lib_freestanding_iterator == 202306L);
+#endif
+
+#ifndef __cpp_lib_freestanding_memory
+#error __cpp_lib_freestanding_memory is not defined
+#elif __cpp_lib_freestanding_memory != 202306L
+#error __cpp_lib_freestanding_memory is not 202306L
+#else
+STATIC_ASSERT(__cpp_lib_freestanding_memory == 202306L);
+#endif
+
+#ifndef __cpp_lib_freestanding_operator_new
+#error __cpp_lib_freestanding_operator_new is not defined
+#elif __cpp_lib_freestanding_operator_new != 202306L
+#error __cpp_lib_freestanding_operator_new is not 202306L
+#else
+STATIC_ASSERT(__cpp_lib_freestanding_operator_new == 202306L);
+#endif
+
+#ifdef __cpp_lib_concepts
+#ifndef __cpp_lib_freestanding_ranges
+#error __cpp_lib_freestanding_ranges is not defined
+#elif __cpp_lib_freestanding_ranges != 202306L
+#error __cpp_lib_freestanding_ranges is not 202306L
+#else
+STATIC_ASSERT(__cpp_lib_freestanding_ranges == 202306L);
+#endif
+#else
+#ifdef __cpp_lib_freestanding_ranges
+#error __cpp_lib_freestanding_ranges is defined
+#endif
+#endif
+
+#ifndef __cpp_lib_freestanding_ratio
+#error __cpp_lib_freestanding_operator_new is not defined
+#elif __cpp_lib_freestanding_ratio != 202306L
+#error __cpp_lib_freestanding_operator_new is not 202306L
+#else
+STATIC_ASSERT(__cpp_lib_freestanding_ratio == 202306L);
+#endif
+
+#ifndef __cpp_lib_freestanding_tuple
+#error __cpp_lib_freestanding_tuple is not defined
+#elif __cpp_lib_freestanding_tuple != 202306L
+#error __cpp_lib_freestanding_tuple is not 202306L
+#else
+STATIC_ASSERT(__cpp_lib_freestanding_tuple == 202306L);
+#endif
+
+#ifndef __cpp_lib_freestanding_utility
+#error __cpp_lib_freestanding_utility is not defined
+#elif __cpp_lib_freestanding_utility != 202306L
+#error __cpp_lib_freestanding_utility is not 202306L
+#else
+STATIC_ASSERT(__cpp_lib_freestanding_utility == 202306L);
+#endif
+
 #if _HAS_CXX17
 #ifndef __cpp_lib_gcd_lcm
 #error __cpp_lib_gcd_lcm is not defined


### PR DESCRIPTION
Fixes #3793. Fixes #3794. Fixes #3795.

(But we may need to reopen these issues and #2914 in future once freestanding mode is added. See #1289.)

It seems to me that hosted implementations are required to provide all of these macros (see "Rejected alternatives" in WG21-P2198R7). I think it makes more sense to define them in older modes when the corresponding feature/header is available.

Possibly related question: should we leave feature-test macros for non-core components not defined when `_ENFORCE_ONLY_CORE_HEADERS` is defined?