### PR TITLE
Enhancements for `<bitset>`

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -105,6 +105,7 @@ function(add_benchmark name)
     target_compile_definitions(benchmark-${name} PRIVATE BENCHMARK_STATIC_DEFINE)
 endfunction()
 
+add_benchmark(bitset_to_string src/bitset_to_string.cpp)
 add_benchmark(locale_classic src/locale_classic.cpp)
 add_benchmark(random_integer_generation src/random_integer_generation.cpp)
 add_benchmark(std_copy src/std_copy.cpp)

--- a/benchmarks/src/bitset_to_string.cpp
+++ b/benchmarks/src/bitset_to_string.cpp
@@ -3,80 +3,46 @@
 
 #include <array>
 #include <benchmark/benchmark.h>
+#include <bit>
 #include <bitset>
 #include <random>
 
 using namespace std;
 
 namespace {
-    auto random_bits = [] {
-        mt19937_64 rnd(12345);
-        array<uint64_t, 100> data;
+    const auto random_bits = [] {
+        mt19937_64 rnd{};
+        array<uint64_t, 32> data;
         for (auto& d : data) {
             d = rnd();
         }
         return data;
     }();
 
-    auto large_bitset = [] {
-        constexpr size_t len = 2000;
-        bitset<len> bs;
-        mt19937_64 rnd(12345);
-        for (int i = 0; i < len; i++) {
-            bs[i] = rnd() & 1;
+    template <size_t N, class charT>
+    void BM_bitset_to_string(benchmark::State& state) {
+        for (auto _ : state) {
+            for (auto bits : random_bits) {
+                bitset<N> bs{bits};
+                benchmark::DoNotOptimize(bs.to_string<charT>());
+            }
         }
-        return bs;
-    }();
+    }
 
-    void BM_to_string_small(benchmark::State& state) {
+    template <class charT>
+    void BM_bitset_to_string_large_single(benchmark::State& state) {
+        const auto large_bitset = bit_cast<bitset<CHAR_BIT * sizeof random_bits>>(random_bits);
         for (auto _ : state) {
-            for (auto bits : random_bits) {
-                std::bitset<15> bs{bits};
-                benchmark::DoNotOptimize(bs.to_string());
-            }
-        }
-    }
-    void BM_to_string_medium(benchmark::State& state) {
-        for (auto _ : state) {
-            for (auto bits : random_bits) {
-                std::bitset<64> bs{bits};
-                benchmark::DoNotOptimize(bs.to_string());
-            }
-        }
-    }
-    void BM_to_string_large(benchmark::State& state) {
-        for (auto _ : state) {
-            benchmark::DoNotOptimize(large_bitset.to_string());
-        }
-    }
-    void BM_to_wstring_small(benchmark::State& state) {
-        for (auto _ : state) {
-            for (auto bits : random_bits) {
-                std::bitset<7> bs{bits};
-                benchmark::DoNotOptimize(bs.to_string<wchar_t>());
-            }
-        }
-    }
-    void BM_to_wstring_medium(benchmark::State& state) {
-        for (auto _ : state) {
-            for (auto bits : random_bits) {
-                std::bitset<64> bs{bits};
-                benchmark::DoNotOptimize(bs.to_string<wchar_t>());
-            }
-        }
-    }
-    void BM_to_wstring_large(benchmark::State& state) {
-        for (auto _ : state) {
-            benchmark::DoNotOptimize(large_bitset.to_string<wchar_t>());
+            benchmark::DoNotOptimize(large_bitset.to_string<charT>());
         }
     }
 } // namespace
 
-BENCHMARK(BM_to_string_small);
-BENCHMARK(BM_to_string_medium);
-BENCHMARK(BM_to_string_large);
-BENCHMARK(BM_to_wstring_small);
-BENCHMARK(BM_to_wstring_medium);
-BENCHMARK(BM_to_wstring_large);
+BENCHMARK(BM_bitset_to_string<15, char>);
+BENCHMARK(BM_bitset_to_string<64, char>);
+BENCHMARK(BM_bitset_to_string_large_single<char>);
+BENCHMARK(BM_bitset_to_string<7, wchar_t>);
+BENCHMARK(BM_bitset_to_string<64, wchar_t>);
+BENCHMARK(BM_bitset_to_string_large_single<wchar_t>);
 
 BENCHMARK_MAIN();

--- a/benchmarks/src/bitset_to_string.cpp
+++ b/benchmarks/src/bitset_to_string.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <array>
+#include <benchmark/benchmark.h>
+#include <bitset>
+#include <random>
+
+using namespace std;
+
+namespace {
+    auto random_bits = [] {
+        mt19937_64 rnd(12345);
+        array<uint64_t, 100> data;
+        for (auto& d : data) {
+            d = rnd();
+        }
+        return data;
+    }();
+
+    auto large_bitset = [] {
+        constexpr size_t len = 2000;
+        bitset<len> bs;
+        mt19937_64 rnd(12345);
+        for (int i = 0; i < len; i++) {
+            bs[i] = rnd() & 1;
+        }
+        return bs;
+    }();
+
+    void BM_to_string_small(benchmark::State& state) {
+        for (auto _ : state) {
+            for (auto bits : random_bits) {
+                std::bitset<15> bs{bits};
+                benchmark::DoNotOptimize(bs.to_string());
+            }
+        }
+    }
+    void BM_to_string_medium(benchmark::State& state) {
+        for (auto _ : state) {
+            for (auto bits : random_bits) {
+                std::bitset<64> bs{bits};
+                benchmark::DoNotOptimize(bs.to_string());
+            }
+        }
+    }
+    void BM_to_string_large(benchmark::State& state) {
+        for (auto _ : state) {
+            benchmark::DoNotOptimize(large_bitset.to_string());
+        }
+    }
+    void BM_to_wstring_small(benchmark::State& state) {
+        for (auto _ : state) {
+            for (auto bits : random_bits) {
+                std::bitset<7> bs{bits};
+                benchmark::DoNotOptimize(bs.to_string<wchar_t>());
+            }
+        }
+    }
+    void BM_to_wstring_medium(benchmark::State& state) {
+        for (auto _ : state) {
+            for (auto bits : random_bits) {
+                std::bitset<64> bs{bits};
+                benchmark::DoNotOptimize(bs.to_string<wchar_t>());
+            }
+        }
+    }
+    void BM_to_wstring_large(benchmark::State& state) {
+        for (auto _ : state) {
+            benchmark::DoNotOptimize(large_bitset.to_string<wchar_t>());
+        }
+    }
+} // namespace
+
+BENCHMARK(BM_to_string_small);
+BENCHMARK(BM_to_string_medium);
+BENCHMARK(BM_to_string_large);
+BENCHMARK(BM_to_wstring_small);
+BENCHMARK(BM_to_wstring_medium);
+BENCHMARK(BM_to_wstring_large);
+
+BENCHMARK_MAIN();

--- a/benchmarks/src/bitset_to_string.cpp
+++ b/benchmarks/src/bitset_to_string.cpp
@@ -5,6 +5,9 @@
 #include <benchmark/benchmark.h>
 #include <bit>
 #include <bitset>
+#include <climits>
+#include <cstddef>
+#include <cstdint>
 #include <random>
 
 using namespace std;
@@ -12,17 +15,17 @@ using namespace std;
 namespace {
     const auto random_bits = [] {
         mt19937_64 rnd{};
-        array<uint64_t, 32> data;
-        for (auto& d : data) {
+        array<uint64_t, 32> arr;
+        for (auto& d : arr) {
             d = rnd();
         }
-        return data;
+        return arr;
     }();
 
     template <size_t N, class charT>
     void BM_bitset_to_string(benchmark::State& state) {
         for (auto _ : state) {
-            for (auto bits : random_bits) {
+            for (const auto& bits : random_bits) {
                 bitset<N> bs{bits};
                 benchmark::DoNotOptimize(bs.to_string<charT>());
             }
@@ -31,7 +34,7 @@ namespace {
 
     template <class charT>
     void BM_bitset_to_string_large_single(benchmark::State& state) {
-        const auto large_bitset = bit_cast<bitset<CHAR_BIT * sizeof random_bits>>(random_bits);
+        const auto large_bitset = bit_cast<bitset<CHAR_BIT * sizeof(random_bits)>>(random_bits);
         for (auto _ : state) {
             benchmark::DoNotOptimize(large_bitset.to_string<charT>());
         }

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -343,11 +343,11 @@ public:
     _NODISCARD _CONSTEXPR23 basic_string<_Elem, _Tr, _Alloc> to_string(
         const _Elem _Elem0 = static_cast<_Elem>('0'), const _Elem _Elem1 = static_cast<_Elem>('1')) const {
         // convert bitset to string
-        basic_string<_Elem, _Tr, _Alloc> _Str;
-        _Str.reserve(_Bits);
-
-        for (auto _Pos = _Bits; 0 < _Pos;) {
-            _Str.push_back(_Subscript(--_Pos) ? _Elem1 : _Elem0);
+        basic_string<_Elem, _Tr, _Alloc> _Str(_Bits, _Elem0);
+        for (size_t _Pos = 0; _Pos < _Bits; ++_Pos) {
+            if (_Subscript(_Bits - 1 - _Pos)) {
+                _Str[_Pos] = _Elem1;
+            }
         }
 
         return _Str;

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -76,17 +76,13 @@ public:
 #endif // _ITERATOR_DEBUG_LEVEL == 0
     }
 
-    constexpr bool _Subscript(size_t _Pos) const {
+    constexpr bool _Subscript(size_t _Pos) const noexcept {
         return (_Array[_Pos / _Bitsperword] & (_Ty{1} << _Pos % _Bitsperword)) != 0;
     }
 
-    _NODISCARD constexpr bool operator[](size_t _Pos) const {
-#if _ITERATOR_DEBUG_LEVEL == 0
+    _NODISCARD constexpr bool operator[](size_t _Pos) const noexcept /* strengthened */ {
+        _Validate(_Pos);
         return _Subscript(_Pos);
-
-#else // _ITERATOR_DEBUG_LEVEL == 0
-        return _Bits <= _Pos ? (_Validate(_Pos), false) : _Subscript(_Pos);
-#endif // _ITERATOR_DEBUG_LEVEL == 0
     }
 
     _NODISCARD _CONSTEXPR23 reference operator[](const size_t _Pos) noexcept /* strengthened */ {

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -22,12 +22,13 @@ _STL_DISABLE_CLANG_WARNINGS
 _STD_BEGIN
 _EXPORT_STD template <size_t _Bits>
 class bitset { // store fixed-length sequence of Boolean elements
-public:
+private:
 #pragma warning(push)
 #pragma warning(disable : 4296) // expression is always true (/Wall)
     using _Ty = conditional_t<_Bits <= sizeof(unsigned long) * CHAR_BIT, unsigned long, unsigned long long>;
 #pragma warning(pop)
 
+public:
     class reference { // proxy for an element
         friend bitset;
 

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -68,6 +68,7 @@ public:
         size_t _Mypos; // position of element in bitset
     };
 
+private:
     static _CONSTEXPR23 void _Validate(const size_t _Pos) noexcept { // verify that _Pos is within bounds
 #if _ITERATOR_DEBUG_LEVEL == 0
         (void) _Pos;
@@ -80,6 +81,10 @@ public:
         return (_Array[_Pos / _Bitsperword] & (_Ty{1} << _Pos % _Bitsperword)) != 0;
     }
 
+    static constexpr bool _Need_mask          = _Bits < CHAR_BIT * sizeof(unsigned long long);
+    static constexpr unsigned long long _Mask = (1ULL << (_Need_mask ? _Bits : 0)) - 1ULL;
+
+public:
     _NODISCARD constexpr bool operator[](size_t _Pos) const noexcept /* strengthened */ {
         _Validate(_Pos);
         return _Subscript(_Pos);
@@ -92,12 +97,9 @@ public:
 
     constexpr bitset() noexcept : _Array() {} // construct with all false values
 
-    static constexpr bool _Need_mask = _Bits < CHAR_BIT * sizeof(unsigned long long);
-
-    static constexpr unsigned long long _Mask = (1ULL << (_Need_mask ? _Bits : 0)) - 1ULL;
-
     constexpr bitset(unsigned long long _Val) noexcept : _Array{static_cast<_Ty>(_Need_mask ? _Val & _Mask : _Val)} {}
 
+private:
     template <class _Traits, class _Elem>
     _CONSTEXPR23 void _Construct(const _Elem* const _Ptr, size_t _Count, const _Elem _Elem0, const _Elem _Elem1) {
         if (_Count > _Bits) {
@@ -143,6 +145,7 @@ public:
         }
     }
 
+public:
     template <class _Elem, class _Traits, class _Alloc>
     _CONSTEXPR23 explicit bitset(const basic_string<_Elem, _Traits, _Alloc>& _Str,
         typename basic_string<_Elem, _Traits, _Alloc>::size_type _Pos   = 0,


### PR DESCRIPTION
- simplifies `bool operator[](size_t) const`.
- makes some public `_Members` private.
- optimizes `to_string`.
<details>
<summary>Benchmark</summary>

```cpp
#include <bitset>

#include "benchmark/benchmark.h"

template <class _Char = char, size_t _N>
auto _to_string_bef(const std::bitset<_N>& _Bset, const _Char _Elem0 = '0',
                       const _Char _Elem1 = '1') {
  return _Bset.to_string(_Elem0, _Elem1);
}

template <class _Char = char, size_t _N>
auto _to_string_now(const std::bitset<_N>& _Bset, const _Char _Elem0 = '0',
                    const _Char _Elem1 = '1') {
  std::basic_string<_Char> _Str(_N, _Elem0);
  for (size_t _Idx = 0; _Idx < _N; ++_Idx) {
    if (_Bset[_N - 1 - _Idx]) {
      _Str[_Idx] = _Elem1;
    }
  }
  return _Str;
}

template <class _Char, size_t N>
void BM_bef(benchmark::State& state) {
  std::bitset<N> bs{static_cast<uint64_t>(state.range(0))};
  for (auto _ : state) {
    benchmark::DoNotOptimize(_to_string_bef(bs));
  }
}

template <class _Char, size_t N>
void BM_now(benchmark::State& state) {
  std::bitset<N> bs{static_cast<uint64_t>(state.range(0))};
  for (auto _ : state) {
    benchmark::DoNotOptimize(_to_string_now(bs));
  }
}

BENCHMARK(BM_bef<char, 15>)->Arg(0x3333333333333333);
BENCHMARK(BM_now<char, 15>)->Arg(0x3333333333333333);
BENCHMARK(BM_bef<char, 64>)->Arg(0x3333333333333333);
BENCHMARK(BM_now<char, 64>)->Arg(0x3333333333333333);

BENCHMARK(BM_bef<char, 15>)->Arg(0xffffffffffffffff);
BENCHMARK(BM_now<char, 15>)->Arg(0xffffffffffffffff);
BENCHMARK(BM_bef<char, 64>)->Arg(0xffffffffffffffff);
BENCHMARK(BM_now<char, 64>)->Arg(0xffffffffffffffff);

BENCHMARK(BM_bef<wchar_t, 7>)->Arg(0x3333333333333333);
BENCHMARK(BM_now<wchar_t, 7>)->Arg(0x3333333333333333);
BENCHMARK(BM_bef<wchar_t, 64>)->Arg(0x3333333333333333);
BENCHMARK(BM_now<wchar_t, 64>)->Arg(0x3333333333333333);

BENCHMARK(BM_bef<wchar_t, 7>)->Arg(0xffffffffffffffff);
BENCHMARK(BM_now<wchar_t, 7>)->Arg(0xffffffffffffffff);
BENCHMARK(BM_bef<wchar_t, 64>)->Arg(0xffffffffffffffff);
BENCHMARK(BM_now<wchar_t, 64>)->Arg(0xffffffffffffffff);

BENCHMARK_MAIN();
```
</details>

<details>
<summary>Result(release mode)</summary>

![image](https://github.com/microsoft/STL/assets/60953653/bb8f5f99-c8f5-4628-8bb8-1e531b61a039)
</details>

↓(Updated benchmark)
<details>
<summary>Benchmark</summary>

```cpp
#include <bitset>
#include <random>
#include <array>
#include "benchmark/benchmark.h"

auto random_bits = [] {
  std::mt19937_64 rnd(12345);
  std::array<uint64_t, 100> data;
  for (auto& d : data) {
  d = rnd();
  }
  return data;
}();

template <class _Char = char, size_t _N>
auto _to_string_bef(const std::bitset<_N>& _Bset, const _Char _Elem0 = '0',
                       const _Char _Elem1 = '1') {
  return _Bset.to_string(_Elem0, _Elem1);
}

template <class _Char = char, size_t _N>
auto _to_string_now(const std::bitset<_N>& _Bset, const _Char _Elem0 = '0',
                    const _Char _Elem1 = '1') {
  std::basic_string<_Char> _Str(_N, _Elem0);
  for (size_t _Idx = 0; _Idx < _N; ++_Idx) {
    if (_Bset[_N - 1 - _Idx]) {
      _Str[_Idx] = _Elem1;
    }
  }
  return _Str;
}

template <class _Char, size_t N>
void BM_bef(benchmark::State& state) {
  for (auto _ : state) {
    for (auto bits:random_bits) {
      std::bitset<N> bs{bits};
      benchmark::DoNotOptimize(_to_string_bef(bs));
    }
  }
}

template <class _Char, size_t N>
void BM_now(benchmark::State& state) {
  for (auto _ : state) {
    for (auto bits : random_bits) {
      std::bitset<N> bs{bits};
      benchmark::DoNotOptimize(_to_string_now(bs));
    }
  }
}

BENCHMARK(BM_bef<char, 15>);
BENCHMARK(BM_now<char, 15>);
BENCHMARK(BM_bef<char, 64>);
BENCHMARK(BM_now<char, 64>);

BENCHMARK(BM_bef<wchar_t, 7>);
BENCHMARK(BM_now<wchar_t, 7>);
BENCHMARK(BM_bef<wchar_t, 64>);
BENCHMARK(BM_now<wchar_t, 64>);

BENCHMARK_MAIN();
```
</details>

<details>
<summary>Result(release mode)</summary>

![image](https://github.com/microsoft/STL/assets/60953653/7e8acd8d-79e9-42fc-a9e0-91fe6b6953de)
</details>