### PR TITLE
`<functional>`: Make `function::target` return null function pointers without cast

### DIFF
--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1134,12 +1134,20 @@ public:
 
     template <class _Fx>
     _NODISCARD _Fx* target() noexcept {
-        return reinterpret_cast<_Fx*>(const_cast<void*>(this->_Target(typeid(_Fx))));
+        if constexpr (is_function_v<_Fx>) {
+            return nullptr;
+        } else {
+            return reinterpret_cast<_Fx*>(const_cast<void*>(this->_Target(typeid(_Fx))));
+        }
     }
 
     template <class _Fx>
     _NODISCARD const _Fx* target() const noexcept {
-        return reinterpret_cast<const _Fx*>(this->_Target(typeid(_Fx)));
+        if constexpr (is_function_v<_Fx>) {
+            return nullptr;
+        } else {
+            return reinterpret_cast<const _Fx*>(this->_Target(typeid(_Fx)));
+        }
     }
 #else // _HAS_STATIC_RTTI
     const type_info& target_type() const noexcept = delete; // requires static RTTI

--- a/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
+++ b/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
@@ -1615,6 +1615,11 @@ void test_function() {
         assert(f.target<short (*)(long)>() == nullptr);
         assert(c.target<short (*)(long)>() == nullptr);
 
+        assert(f.target<int(int)>() == nullptr);
+        assert(c.target<int(int)>() == nullptr);
+        assert(f.target<short(long)>() == nullptr);
+        assert(c.target<short(long)>() == nullptr);
+
         f = triple;
         assert(f(1000) == 3000);
         assert(f.target_type() == typeid(int (*)(int)));
@@ -1623,6 +1628,11 @@ void test_function() {
         assert(f.target<short (*)(long)>() == nullptr);
         assert(c.target<short (*)(long)>() == nullptr);
 
+        assert(f.target<int(int)>() == nullptr);
+        assert(c.target<int(int)>() == nullptr);
+        assert(f.target<short(long)>() == nullptr);
+        assert(c.target<short(long)>() == nullptr);
+
         f = short_long;
         assert(f(1000) == 29);
         assert(f.target_type() == typeid(short (*)(long)));
@@ -1630,6 +1640,11 @@ void test_function() {
         assert(c.target<int (*)(int)>() == nullptr);
         assert(*f.target<short (*)(long)>() == &short_long);
         assert(*c.target<short (*)(long)>() == &short_long);
+
+        assert(f.target<int(int)>() == nullptr);
+        assert(c.target<int(int)>() == nullptr);
+        assert(f.target<short(long)>() == nullptr);
+        assert(c.target<short(long)>() == nullptr);
     }
 
 


### PR DESCRIPTION
Fixes #3843.