### PR TITLE
`<mdspan>`: More EBO

### DIFF
--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -456,7 +456,7 @@ struct _Maybe_fully_static_extents<_Extents> {
     template <class _OtherExtents>
     constexpr explicit _Maybe_fully_static_extents([[maybe_unused]] const _OtherExtents& _Exts_) {
 #if _CONTAINER_DEBUG_LEVEL > 0
-        (void) _Extents(_Exts_); // NB: temporary created for preconditions check
+        (void) _Extents{_Exts_}; // NB: temporary created for preconditions check
 #endif // _CONTAINER_DEBUG_LEVEL > 0
     }
 };

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -437,13 +437,41 @@ _EXPORT_STD struct layout_stride {
 };
 
 template <class _Extents>
-class layout_left::mapping {
+struct _Maybe_fully_static_extents {
+    _Extents _Exts{};
+
+    constexpr _Maybe_fully_static_extents() noexcept = default;
+
+    template <class _OtherExtents>
+    constexpr explicit _Maybe_fully_static_extents(const _OtherExtents& _Exts_) : _Exts(_Exts_) {}
+};
+
+template <class _Extents>
+    requires (_Extents::rank_dynamic() == 0)
+struct _Maybe_fully_static_extents<_Extents> {
+    static constexpr _Extents _Exts{};
+
+    constexpr _Maybe_fully_static_extents() noexcept = default;
+
+    template <class _OtherExtents>
+    constexpr explicit _Maybe_fully_static_extents([[maybe_unused]] const _OtherExtents& _Exts_) {
+#if _CONTAINER_DEBUG_LEVEL > 0
+        (void) _Extents(_Exts_); // NB: temporary created for preconditions check
+#endif // _CONTAINER_DEBUG_LEVEL > 0
+    }
+};
+
+template <class _Extents>
+class layout_left::mapping : private _Maybe_fully_static_extents<_Extents> {
 public:
     using extents_type = _Extents;
     using index_type   = extents_type::index_type;
     using size_type    = extents_type::size_type;
     using rank_type    = extents_type::rank_type;
     using layout_type  = layout_left;
+
+private:
+    using _Base = _Maybe_fully_static_extents<_Extents>;
 
     static_assert(_Is_extents<extents_type>,
         "Extents must be a specialization of std::extents (N4950 [mdspan.layout.left.overview]/2).");
@@ -452,10 +480,11 @@ public:
         "If Extents::rank_dynamic() == 0 is true, then the size of the multidimensional index space Extents() must be "
         "representable as a value of type typename Extents::index_type (N4950 [mdspan.layout.left.overview]/4).");
 
+public:
     constexpr mapping() noexcept               = default;
     constexpr mapping(const mapping&) noexcept = default;
 
-    constexpr mapping(const extents_type& _Exts_) noexcept : _Exts(_Exts_) {
+    constexpr mapping(const extents_type& _Exts_) noexcept : _Base(_Exts_) {
 #if _CONTAINER_DEBUG_LEVEL > 0
         if constexpr (extents_type::rank_dynamic() != 0) {
             _STL_VERIFY(_Exts_._Is_dynamic_multidim_index_space_size_representable(),
@@ -469,7 +498,7 @@ public:
         requires is_constructible_v<extents_type, _OtherExtents>
     constexpr explicit(!is_convertible_v<_OtherExtents, extents_type>)
         mapping(const mapping<_OtherExtents>& _Other) noexcept
-        : _Exts(_Other.extents()) {
+        : _Base(_Other.extents()) {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
             "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
@@ -481,7 +510,7 @@ public:
         requires (extents_type::rank() <= 1) && is_constructible_v<extents_type, _OtherExtents>
     constexpr explicit(!is_convertible_v<_OtherExtents, extents_type>)
         mapping(const layout_right::mapping<_OtherExtents>& _Other) noexcept
-        : _Exts(_Other.extents()) {
+        : _Base(_Other.extents()) {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
             "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
@@ -492,7 +521,7 @@ public:
     template <class _OtherExtents>
         requires is_constructible_v<extents_type, _OtherExtents>
     constexpr explicit(extents_type::rank() > 0) mapping(const layout_stride::template mapping<_OtherExtents>& _Other)
-        : _Exts(_Other.extents()) {
+        : _Base(_Other.extents()) {
 #if _CONTAINER_DEBUG_LEVEL > 0
         if constexpr (extents_type::rank() > 0) {
             index_type _Prod = 1;
@@ -500,7 +529,7 @@ public:
                 _STL_VERIFY(_Other.stride(_Idx) == _Prod,
                     "For all r in the range [0, extents_type::rank()), other.stride(r) must be equal to "
                     "extents().fwd-prod-of-extents(r) (N4950 [mdspan.layout.left.cons]/10.1).");
-                _Prod = static_cast<index_type>(_Prod * _Exts.extent(_Idx));
+                _Prod = static_cast<index_type>(_Prod * this->_Exts.extent(_Idx));
             }
             _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
                 "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
@@ -512,11 +541,11 @@ public:
     constexpr mapping& operator=(const mapping&) noexcept = default;
 
     _NODISCARD constexpr const extents_type& extents() const noexcept {
-        return _Exts;
+        return this->_Exts;
     }
 
     _NODISCARD constexpr index_type required_span_size() const noexcept {
-        return _Fwd_prod_of_extents<extents_type>::_Calculate(_Exts, extents_type::_Rank);
+        return _Fwd_prod_of_extents<extents_type>::_Calculate(this->_Exts, extents_type::_Rank);
     }
 
     template <class... _IndexTypes>
@@ -557,7 +586,7 @@ public:
         _STL_VERIFY(_Idx < extents_type::_Rank,
             "Value of i must be less than extents_type::rank() (N4950 [mdspan.layout.left.obs]/6).");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-        return _Fwd_prod_of_extents<extents_type>::_Calculate(_Exts, _Idx);
+        return _Fwd_prod_of_extents<extents_type>::_Calculate(this->_Exts, _Idx);
     }
 
     template <class _OtherExtents>
@@ -567,21 +596,19 @@ public:
     }
 
 private:
-    extents_type _Exts{};
-
     template <class... _IndexTypes, size_t... _Seq>
     _NODISCARD constexpr index_type _Index_impl(
         [[maybe_unused]] index_sequence<_Seq...> _Index_seq, _IndexTypes... _Indices) const noexcept {
         _STL_INTERNAL_STATIC_ASSERT((same_as<_IndexTypes, index_type> && ...));
 #if _CONTAINER_DEBUG_LEVEL > 0
-        _STL_VERIFY(_Exts._Contains_multidimensional_index(_Index_seq, _Indices...),
+        _STL_VERIFY(this->_Exts._Contains_multidimensional_index(_Index_seq, _Indices...),
             "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
             "[mdspan.layout.left.obs]/3).");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
 
         index_type _Stride = 1;
         index_type _Result = 0;
-        (((_Result += _Indices * _Stride), (_Stride *= _Exts.extent(_Seq))), ...);
+        (((_Result += _Indices * _Stride), (_Stride *= this->_Exts.extent(_Seq))), ...);
         return _Result;
     }
 };

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -456,7 +456,7 @@ struct _Maybe_fully_static_extents<_Extents> {
     template <class _OtherExtents>
     constexpr explicit _Maybe_fully_static_extents([[maybe_unused]] const _OtherExtents& _Exts_) {
 #if _CONTAINER_DEBUG_LEVEL > 0
-        (void) _Extents{_Exts_}; // NB: temporary created for preconditions check
+        (void) _Extents(_Exts_); // NB: temporary created for preconditions check
 #endif // _CONTAINER_DEBUG_LEVEL > 0
     }
 };
@@ -471,7 +471,7 @@ public:
     using layout_type  = layout_left;
 
 private:
-    using _Base = _Maybe_fully_static_extents<extents_type>;
+    using _Base = _Maybe_fully_static_extents<_Extents>;
 
     static_assert(_Is_extents<extents_type>,
         "Extents must be a specialization of std::extents (N4950 [mdspan.layout.left.overview]/2).");
@@ -623,7 +623,7 @@ public:
     using layout_type  = layout_right;
 
 private:
-    using _Base = _Maybe_fully_static_extents<extents_type>;
+    using _Base = _Maybe_fully_static_extents<_Extents>;
 
     static_assert(_Is_extents<extents_type>,
         "Extents must be a specialization of std::extents (N4950 [mdspan.layout.right.overview]/2).");
@@ -777,18 +777,13 @@ concept _Layout_mapping_alike = requires {
 };
 
 template <class _Extents>
-class layout_stride::mapping : private _Maybe_fully_static_extents<_Extents>,
-                               private _Maybe_empty_array<typename _Extents::index_type, _Extents::rank()> {
+class layout_stride::mapping {
 public:
     using extents_type = _Extents;
     using index_type   = extents_type::index_type;
     using size_type    = extents_type::size_type;
     using rank_type    = extents_type::rank_type;
     using layout_type  = layout_stride;
-
-private:
-    using _Extents_base = _Maybe_fully_static_extents<extents_type>;
-    using _Strides_base = _Maybe_empty_array<index_type, _Extents::rank()>;
 
     static_assert(_Is_extents<extents_type>,
         "Extents must be a specialization of std::extents (N4950 [mdspan.layout.stride.overview]/2).");
@@ -797,14 +792,12 @@ private:
         "If Extents::rank_dynamic() == 0 is true, then the size of the multidimensional index space Extents() must be "
         "representable as a value of type typename Extents::index_type (N4950 [mdspan.layout.stride.overview]/4).");
 
-public:
-    constexpr mapping() noexcept : _Extents_base(extents_type{}) {
+    constexpr mapping() noexcept : _Exts(extents_type{}) {
         if constexpr (extents_type::rank() != 0) {
-            this->_Array.back() = 1;
+            _Strides.back() = 1;
             for (rank_type _Idx = extents_type::_Rank - 1; _Idx-- > 0;) {
 #if _CONTAINER_DEBUG_LEVEL > 0
-                const bool _Overflow =
-                    _Mul_overflow(this->_Array[_Idx + 1], this->_Exts.extent(_Idx + 1), this->_Array[_Idx]);
+                const bool _Overflow = _Mul_overflow(_Strides[_Idx + 1], _Exts.extent(_Idx + 1), _Strides[_Idx]);
                 // NB: N4950 requires value of 'layout_right::mapping<extents_type>().required_span_size()' to be
                 // representable as value of type 'index_type', but this is not enough. We need to require every single
                 // stride to be representable as value of type 'index_type', so we can get desired effects.
@@ -812,7 +805,7 @@ public:
                     "Value of layout_right::mapping<extents_type>().required_span_size() must be "
                     "representable as a value of type index_type (N4950 [mdspan.layout.stride.cons]/1).");
 #else // ^^^ _CONTAINER_DEBUG_LEVEL > 0 / _CONTAINER_DEBUG_LEVEL == 0 vvv
-                this->_Array[_Idx] = static_cast<index_type>(this->_Array[_Idx + 1] * this->_Exts.extent(_Idx + 1));
+                _Strides[_Idx] = static_cast<index_type>(_Strides[_Idx + 1] * _Exts.extent(_Idx + 1));
 #endif // _CONTAINER_DEBUG_LEVEL > 0
             }
         }
@@ -825,17 +818,17 @@ public:
                   && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
     constexpr mapping(const extents_type& _Exts_, span<_OtherIndexType, extents_type::rank()> _Strides_,
         index_sequence<_Indices...>) noexcept
-        : _Extents_base(_Exts_), _Strides_base{static_cast<index_type>(_STD as_const(_Strides_[_Indices]))...} {
+        : _Exts(_Exts_), _Strides{static_cast<index_type>(_STD as_const(_Strides_[_Indices]))...} {
 #if _CONTAINER_DEBUG_LEVEL > 0
         if constexpr (extents_type::rank() != 0) {
             bool _Found_zero          = false;
             bool _Overflow            = false;
             index_type _Req_span_size = 0;
             for (rank_type _Idx = 0; _Idx < extents_type::_Rank; ++_Idx) {
-                const index_type _Stride = this->_Array[_Idx];
+                const index_type _Stride = _Strides[_Idx];
                 _STL_VERIFY(_Stride > 0, "Value of s[i] must be greater than 0 for all i in the range [0, rank_) "
                                          "(N4950 [mdspan.layout.stride.cons]/4.1).");
-                const index_type _Ext = this->_Exts.extent(_Idx);
+                const index_type _Ext = _Exts.extent(_Idx);
                 if (_Ext == 0) {
                     _Found_zero = true;
                 }
@@ -888,7 +881,7 @@ public:
         && (_Is_mapping_of<layout_left, _StridedLayoutMapping> || _Is_mapping_of<layout_right, _StridedLayoutMapping>
             || _Is_mapping_of<layout_stride, _StridedLayoutMapping>) ))
         mapping(const _StridedLayoutMapping& _Other) noexcept
-        : _Extents_base(_Other.extents()) {
+        : _Exts(_Other.extents()) {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
             "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
@@ -902,18 +895,18 @@ public:
             _STL_VERIFY(_Stride > 0, "Value of other.stride(r) must be greater than 0 for every rank index r of "
                                      "extents() (N4950 [mdspan.layout.stride.cons]/7.2).");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-            this->_Array[_Idx] = static_cast<index_type>(_Stride);
+            _Strides[_Idx] = static_cast<index_type>(_Stride);
         }
     }
 
     constexpr mapping& operator=(const mapping&) noexcept = default;
 
     _NODISCARD constexpr const extents_type& extents() const noexcept {
-        return this->_Exts;
+        return _Exts;
     }
 
     _NODISCARD constexpr array<index_type, extents_type::rank()> strides() const noexcept {
-        return this->_Array;
+        return _Strides;
     }
 
     _NODISCARD constexpr index_type required_span_size() const noexcept {
@@ -922,12 +915,12 @@ public:
         } else {
             index_type _Result = 1;
             for (rank_type _Idx = 0; _Idx < extents_type::_Rank; ++_Idx) {
-                const index_type _Ext = this->_Exts.extent(_Idx);
+                const index_type _Ext = _Exts.extent(_Idx);
                 if (_Ext == 0) {
                     return 0;
                 }
 
-                _Result += (_Ext - 1) * this->_Array[_Idx];
+                _Result += (_Ext - 1) * _Strides[_Idx];
             }
 
             return _Result;
@@ -961,8 +954,7 @@ public:
         if constexpr (extents_type::rank() == 0) {
             return true;
         } else {
-            return required_span_size()
-                == _Fwd_prod_of_extents<extents_type>::_Calculate(this->_Exts, extents_type::_Rank);
+            return required_span_size() == _Fwd_prod_of_extents<extents_type>::_Calculate(_Exts, extents_type::_Rank);
         }
     }
 
@@ -971,7 +963,7 @@ public:
     }
 
     _NODISCARD constexpr index_type stride(const rank_type _Idx) const noexcept {
-        return this->_Array[_Idx];
+        return _Strides[_Idx];
     }
 
     template <class _OtherMapping>
@@ -994,6 +986,9 @@ public:
     }
 
 private:
+    extents_type _Exts{};
+    array<index_type, extents_type::rank()> _Strides{};
+
     template <class _OtherMapping>
     _NODISCARD static constexpr _OtherMapping::index_type _Offset(_OtherMapping& _Mapping) noexcept {
         if constexpr (extents_type::rank() == 0) {
@@ -1015,12 +1010,12 @@ private:
         [[maybe_unused]] index_sequence<_Seq...> _Index_seq, _IndexTypes... _Indices) const noexcept {
         _STL_INTERNAL_STATIC_ASSERT((same_as<_IndexTypes, index_type> && ...));
 #if _CONTAINER_DEBUG_LEVEL > 0
-        _STL_VERIFY(this->_Exts._Contains_multidimensional_index(_Index_seq, _Indices...),
+        _STL_VERIFY(_Exts._Contains_multidimensional_index(_Index_seq, _Indices...),
             "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
             "[mdspan.layout.stride.obs]/3).");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
 
-        return static_cast<index_type>(((_Indices * this->_Array[_Seq]) + ... + 0));
+        return static_cast<index_type>(((_Indices * _Strides[_Seq]) + ... + 0));
     }
 };
 

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -442,18 +442,20 @@ _EXPORT_STD struct layout_stride {
 
 template <class _Extents>
 struct _Maybe_fully_static_extents {
-    _Extents _Exts{};
+    _STL_INTERNAL_STATIC_ASSERT(_Is_extents<_Extents>);
 
     constexpr _Maybe_fully_static_extents() noexcept = default;
 
     template <class _OtherExtents>
     constexpr explicit _Maybe_fully_static_extents(const _OtherExtents& _Exts_) : _Exts(_Exts_) {}
+
+    _Extents _Exts{};
 };
 
 template <class _Extents>
     requires (_Extents::rank_dynamic() == 0)
 struct _Maybe_fully_static_extents<_Extents> {
-    static constexpr _Extents _Exts{};
+    _STL_INTERNAL_STATIC_ASSERT(_Is_extents<_Extents>);
 
     constexpr _Maybe_fully_static_extents() noexcept = default;
 
@@ -463,6 +465,8 @@ struct _Maybe_fully_static_extents<_Extents> {
         (void) _Extents{_Exts_}; // NB: temporary created for preconditions check
 #endif // _CONTAINER_DEBUG_LEVEL > 0
     }
+
+    static constexpr _Extents _Exts{};
 };
 
 template <class _Extents>
@@ -1064,6 +1068,8 @@ concept _Elidable_layout_mapping =
 
 template <class _Extents, class _LayoutPolicy>
 struct _Mdspan_mapping_base {
+    _STL_INTERNAL_STATIC_ASSERT(_Is_extents<_Extents>);
+
     using _Mapping = _LayoutPolicy::template mapping<_Extents>;
 
     constexpr _Mdspan_mapping_base() noexcept = default;
@@ -1078,6 +1084,8 @@ struct _Mdspan_mapping_base {
 
 template <class _Extents, _Elidable_layout_mapping<_Extents> _LayoutPolicy>
 struct _Mdspan_mapping_base<_Extents, _LayoutPolicy> {
+    _STL_INTERNAL_STATIC_ASSERT(_Is_extents<_Extents>);
+
     using _Mapping = _LayoutPolicy::template mapping<_Extents>;
 
     constexpr _Mdspan_mapping_base() noexcept = default;

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -614,13 +614,16 @@ private:
 };
 
 template <class _Extents>
-class layout_right::mapping {
+class layout_right::mapping : private _Maybe_fully_static_extents<_Extents> {
 public:
     using extents_type = _Extents;
     using index_type   = extents_type::index_type;
     using size_type    = extents_type::size_type;
     using rank_type    = extents_type::rank_type;
     using layout_type  = layout_right;
+
+private:
+    using _Base = _Maybe_fully_static_extents<_Extents>;
 
     static_assert(_Is_extents<extents_type>,
         "Extents must be a specialization of std::extents (N4950 [mdspan.layout.right.overview]/2).");
@@ -629,10 +632,11 @@ public:
         "If Extents::rank_dynamic() == 0 is true, then the size of the multidimensional index space Extents() must be "
         "representable as a value of type typename Extents::index_type (N4950 [mdspan.layout.right.overview]/4).");
 
+public:
     constexpr mapping() noexcept               = default;
     constexpr mapping(const mapping&) noexcept = default;
 
-    constexpr mapping(const extents_type& _Exts_) noexcept : _Exts(_Exts_) {
+    constexpr mapping(const extents_type& _Exts_) noexcept : _Base(_Exts_) {
 #if _CONTAINER_DEBUG_LEVEL > 0
         if constexpr (extents_type::rank_dynamic() != 0) {
             _STL_VERIFY(_Exts_._Is_dynamic_multidim_index_space_size_representable(),
@@ -646,7 +650,7 @@ public:
         requires is_constructible_v<extents_type, _OtherExtents>
     constexpr explicit(!is_convertible_v<_OtherExtents, extents_type>)
         mapping(const mapping<_OtherExtents>& _Other) noexcept
-        : _Exts(_Other.extents()) {
+        : _Base(_Other.extents()) {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
             "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
@@ -658,7 +662,7 @@ public:
         requires (extents_type::rank() <= 1) && is_constructible_v<extents_type, _OtherExtents>
     constexpr explicit(!is_convertible_v<_OtherExtents, extents_type>)
         mapping(const layout_left::mapping<_OtherExtents>& _Other) noexcept
-        : _Exts(_Other.extents()) {
+        : _Base(_Other.extents()) {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
             "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
@@ -670,7 +674,7 @@ public:
         requires is_constructible_v<extents_type, _OtherExtents>
     constexpr explicit(extents_type::rank() > 0)
         mapping(const layout_stride::template mapping<_OtherExtents>& _Other) noexcept
-        : _Exts(_Other.extents()) {
+        : _Base(_Other.extents()) {
 #if _CONTAINER_DEBUG_LEVEL > 0
         if constexpr (extents_type::rank() > 0) {
             index_type _Prod = 1;
@@ -678,7 +682,7 @@ public:
                 _STL_VERIFY(_Prod == _Other.stride(_Idx),
                     "For all r in the range [0, extents_type::rank()), other.stride(r) must be equal to "
                     "extents().rev-prod-of-extents(r) (N4950 [mdspan.layout.right.cons]/10.1).");
-                _Prod = static_cast<index_type>(_Prod * _Exts.extent(_Idx));
+                _Prod = static_cast<index_type>(_Prod * this->_Exts.extent(_Idx));
             }
             _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
                 "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
@@ -690,11 +694,11 @@ public:
     constexpr mapping& operator=(const mapping&) noexcept = default;
 
     _NODISCARD constexpr const extents_type& extents() const noexcept {
-        return _Exts;
+        return this->_Exts;
     }
 
     _NODISCARD constexpr index_type required_span_size() const noexcept {
-        return _Fwd_prod_of_extents<extents_type>::_Calculate(_Exts, extents_type::_Rank);
+        return _Fwd_prod_of_extents<extents_type>::_Calculate(this->_Exts, extents_type::_Rank);
     }
 
     template <class... _IndexTypes>
@@ -735,30 +739,28 @@ public:
         _STL_VERIFY(_Idx < extents_type::_Rank,
             "Value of i must be less than extents_type::rank() (N4950 [mdspan.layout.right.obs]/6).");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-        return _Rev_prod_of_extents<extents_type>::_Calculate(_Exts, _Idx);
+        return _Rev_prod_of_extents<extents_type>::_Calculate(this->_Exts, _Idx);
     }
 
     template <class _OtherExtents>
         requires (extents_type::rank() == _OtherExtents::rank())
     _NODISCARD_FRIEND constexpr bool operator==(const mapping& _Left, const mapping<_OtherExtents>& _Right) noexcept {
-        return _Left.extents() == _Right.extents();
+        return _Left._Exts == _Right.extents();
     }
 
 private:
-    extents_type _Exts{};
-
     template <class... _IndexTypes, size_t... _Seq>
     _NODISCARD constexpr index_type _Index_impl(
         [[maybe_unused]] index_sequence<_Seq...> _Index_seq, _IndexTypes... _Indices) const noexcept {
         _STL_INTERNAL_STATIC_ASSERT((same_as<_IndexTypes, index_type> && ...));
 #if _CONTAINER_DEBUG_LEVEL > 0
-        _STL_VERIFY(_Exts._Contains_multidimensional_index(_Index_seq, _Indices...),
+        _STL_VERIFY(this->_Exts._Contains_multidimensional_index(_Index_seq, _Indices...),
             "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
             "[mdspan.layout.right.obs]/3).");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
 
         index_type _Result = 0;
-        ((_Result = static_cast<index_type>(_Indices + _Exts.extent(_Seq) * _Result)), ...);
+        ((_Result = static_cast<index_type>(_Indices + this->_Exts.extent(_Seq) * _Result)), ...);
         return _Result;
     }
 };

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -471,7 +471,7 @@ public:
     using layout_type  = layout_left;
 
 private:
-    using _Base = _Maybe_fully_static_extents<_Extents>;
+    using _Base = _Maybe_fully_static_extents<extents_type>;
 
     static_assert(_Is_extents<extents_type>,
         "Extents must be a specialization of std::extents (N4950 [mdspan.layout.left.overview]/2).");
@@ -623,7 +623,7 @@ public:
     using layout_type  = layout_right;
 
 private:
-    using _Base = _Maybe_fully_static_extents<_Extents>;
+    using _Base = _Maybe_fully_static_extents<extents_type>;
 
     static_assert(_Is_extents<extents_type>,
         "Extents must be a specialization of std::extents (N4950 [mdspan.layout.right.overview]/2).");

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1059,7 +1059,8 @@ struct default_accessor {
 
 template <class _LayoutPolicy, class _Extents>
 concept _Elidable_layout_mapping =
-    _Is_any_of_v<_LayoutPolicy, layout_left, layout_right> && (_Extents::rank_dynamic() == 0);
+    (_Is_any_of_v<_LayoutPolicy, layout_left, layout_right> && _Extents::rank_dynamic() == 0)
+    || (same_as<_LayoutPolicy, layout_stride> && _Extents::rank() == 0);
 
 template <class _Extents, class _LayoutPolicy>
 struct _Mdspan_mapping_base {

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -34,7 +34,7 @@ template <class _IndexType>
 struct _Maybe_empty_array<_IndexType, 0> {};
 
 template <size_t... _Extents>
-inline constexpr size_t _Calculate_rank_dynamic = ((_Extents == dynamic_extent) + ... + 0);
+inline constexpr size_t _Calculate_rank_dynamic = (static_cast<size_t>(_Extents == dynamic_extent) + ... + 0);
 
 _EXPORT_STD template <class _IndexType, size_t... _Extents>
 class extents : private _Maybe_empty_array<_IndexType, _Calculate_rank_dynamic<_Extents...>> {

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1114,7 +1114,7 @@ struct _Mdspan_accessor_base<_AccessorPolicy> {
 
     template <class _OtherAccessorPolicy>
     constexpr explicit _Mdspan_accessor_base(const _OtherAccessorPolicy& _Acc_) {
-        // NB: Constructing _AccessorPolicy from _OtherAccessorPolicy may have side effects - we should create  a
+        // NB: Constructing _AccessorPolicy from _OtherAccessorPolicy may have side effects - we should create a
         // temporary.
         if constexpr (!_Elidable_accessor_policy<_OtherAccessorPolicy>) {
             (void) _AccessorPolicy{_Acc_};

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -986,8 +986,8 @@ public:
     }
 
 private:
-    extents_type _Exts{};
-    array<index_type, extents_type::rank()> _Strides{};
+    /* [[no_unique_address]] */ extents_type _Exts{};
+    /* [[no_unique_address]] */ array<index_type, extents_type::rank()> _Strides{};
 
     template <class _OtherMapping>
     _NODISCARD static constexpr _OtherMapping::index_type _Offset(_OtherMapping& _Mapping) noexcept {

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1064,8 +1064,6 @@ struct _Mdspan_mapping_base {
 
     constexpr explicit _Mdspan_mapping_base(const _Extents& _Exts) : _Map(_Exts) {}
 
-    constexpr explicit _Mdspan_mapping_base(const _Mapping& _Map_) : _Map(_Map_) {}
-
     template <class _OtherMapping>
     constexpr explicit _Mdspan_mapping_base(const _OtherMapping& _Map_) : _Map(_Map_) {}
 
@@ -1079,8 +1077,6 @@ struct _Mdspan_mapping_base<_Extents, _LayoutPolicy> {
     constexpr _Mdspan_mapping_base() noexcept = default;
 
     constexpr explicit _Mdspan_mapping_base(const _Extents&) noexcept {}
-
-    constexpr explicit _Mdspan_mapping_base(const _Mapping&) noexcept {}
 
     template <class _OtherMapping>
     constexpr explicit _Mdspan_mapping_base(const _OtherMapping& _Map_) {

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -781,13 +781,18 @@ concept _Layout_mapping_alike = requires {
 };
 
 template <class _Extents>
-class layout_stride::mapping {
+class layout_stride::mapping : private _Maybe_fully_static_extents<_Extents>,
+                               private _Maybe_empty_array<typename _Extents::index_type, _Extents::rank()> {
 public:
     using extents_type = _Extents;
     using index_type   = extents_type::index_type;
     using size_type    = extents_type::size_type;
     using rank_type    = extents_type::rank_type;
     using layout_type  = layout_stride;
+
+private:
+    using _Extents_base = _Maybe_fully_static_extents<extents_type>;
+    using _Strides_base = _Maybe_empty_array<index_type, _Extents::rank()>;
 
     static_assert(_Is_extents<extents_type>,
         "Extents must be a specialization of std::extents (N4950 [mdspan.layout.stride.overview]/2).");
@@ -796,12 +801,14 @@ public:
         "If Extents::rank_dynamic() == 0 is true, then the size of the multidimensional index space Extents() must be "
         "representable as a value of type typename Extents::index_type (N4950 [mdspan.layout.stride.overview]/4).");
 
-    constexpr mapping() noexcept : _Exts(extents_type{}) {
+public:
+    constexpr mapping() noexcept : _Extents_base(extents_type{}) {
         if constexpr (extents_type::rank() != 0) {
-            _Strides.back() = 1;
+            this->_Array.back() = 1;
             for (rank_type _Idx = extents_type::_Rank - 1; _Idx-- > 0;) {
 #if _CONTAINER_DEBUG_LEVEL > 0
-                const bool _Overflow = _Mul_overflow(_Strides[_Idx + 1], _Exts.extent(_Idx + 1), _Strides[_Idx]);
+                const bool _Overflow =
+                    _Mul_overflow(this->_Array[_Idx + 1], this->_Exts.extent(_Idx + 1), this->_Array[_Idx]);
                 // NB: N4950 requires value of 'layout_right::mapping<extents_type>().required_span_size()' to be
                 // representable as value of type 'index_type', but this is not enough. We need to require every single
                 // stride to be representable as value of type 'index_type', so we can get desired effects.
@@ -809,7 +816,7 @@ public:
                     "Value of layout_right::mapping<extents_type>().required_span_size() must be "
                     "representable as a value of type index_type (N4950 [mdspan.layout.stride.cons]/1).");
 #else // ^^^ _CONTAINER_DEBUG_LEVEL > 0 / _CONTAINER_DEBUG_LEVEL == 0 vvv
-                _Strides[_Idx] = static_cast<index_type>(_Strides[_Idx + 1] * _Exts.extent(_Idx + 1));
+                this->_Array[_Idx] = static_cast<index_type>(this->_Array[_Idx + 1] * this->_Exts.extent(_Idx + 1));
 #endif // _CONTAINER_DEBUG_LEVEL > 0
             }
         }
@@ -822,17 +829,17 @@ public:
                   && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
     constexpr mapping(const extents_type& _Exts_, span<_OtherIndexType, extents_type::rank()> _Strides_,
         index_sequence<_Indices...>) noexcept
-        : _Exts(_Exts_), _Strides{static_cast<index_type>(_STD as_const(_Strides_[_Indices]))...} {
+        : _Extents_base(_Exts_), _Strides_base{static_cast<index_type>(_STD as_const(_Strides_[_Indices]))...} {
 #if _CONTAINER_DEBUG_LEVEL > 0
         if constexpr (extents_type::rank() != 0) {
             bool _Found_zero          = false;
             bool _Overflow            = false;
             index_type _Req_span_size = 0;
             for (rank_type _Idx = 0; _Idx < extents_type::_Rank; ++_Idx) {
-                const index_type _Stride = _Strides[_Idx];
+                const index_type _Stride = this->_Array[_Idx];
                 _STL_VERIFY(_Stride > 0, "Value of s[i] must be greater than 0 for all i in the range [0, rank_) "
                                          "(N4950 [mdspan.layout.stride.cons]/4.1).");
-                const index_type _Ext = _Exts.extent(_Idx);
+                const index_type _Ext = this->_Exts.extent(_Idx);
                 if (_Ext == 0) {
                     _Found_zero = true;
                 }
@@ -885,7 +892,7 @@ public:
         && (_Is_mapping_of<layout_left, _StridedLayoutMapping> || _Is_mapping_of<layout_right, _StridedLayoutMapping>
             || _Is_mapping_of<layout_stride, _StridedLayoutMapping>) ))
         mapping(const _StridedLayoutMapping& _Other) noexcept
-        : _Exts(_Other.extents()) {
+        : _Extents_base(_Other.extents()) {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
             "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
@@ -899,18 +906,18 @@ public:
             _STL_VERIFY(_Stride > 0, "Value of other.stride(r) must be greater than 0 for every rank index r of "
                                      "extents() (N4950 [mdspan.layout.stride.cons]/7.2).");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-            _Strides[_Idx] = static_cast<index_type>(_Stride);
+            this->_Array[_Idx] = static_cast<index_type>(_Stride);
         }
     }
 
     constexpr mapping& operator=(const mapping&) noexcept = default;
 
     _NODISCARD constexpr const extents_type& extents() const noexcept {
-        return _Exts;
+        return this->_Exts;
     }
 
     _NODISCARD constexpr array<index_type, extents_type::rank()> strides() const noexcept {
-        return _Strides;
+        return this->_Array;
     }
 
     _NODISCARD constexpr index_type required_span_size() const noexcept {
@@ -919,12 +926,12 @@ public:
         } else {
             index_type _Result = 1;
             for (rank_type _Idx = 0; _Idx < extents_type::_Rank; ++_Idx) {
-                const index_type _Ext = _Exts.extent(_Idx);
+                const index_type _Ext = this->_Exts.extent(_Idx);
                 if (_Ext == 0) {
                     return 0;
                 }
 
-                _Result += (_Ext - 1) * _Strides[_Idx];
+                _Result += (_Ext - 1) * this->_Array[_Idx];
             }
 
             return _Result;
@@ -958,7 +965,8 @@ public:
         if constexpr (extents_type::rank() == 0) {
             return true;
         } else {
-            return required_span_size() == _Fwd_prod_of_extents<extents_type>::_Calculate(_Exts, extents_type::_Rank);
+            return required_span_size()
+                == _Fwd_prod_of_extents<extents_type>::_Calculate(this->_Exts, extents_type::_Rank);
         }
     }
 
@@ -967,7 +975,7 @@ public:
     }
 
     _NODISCARD constexpr index_type stride(const rank_type _Idx) const noexcept {
-        return _Strides[_Idx];
+        return this->_Array[_Idx];
     }
 
     template <class _OtherMapping>
@@ -990,9 +998,6 @@ public:
     }
 
 private:
-    /* [[no_unique_address]] */ extents_type _Exts{};
-    /* [[no_unique_address]] */ array<index_type, extents_type::rank()> _Strides{};
-
     template <class _OtherMapping>
     _NODISCARD static constexpr _OtherMapping::index_type _Offset(_OtherMapping& _Mapping) noexcept {
         if constexpr (extents_type::rank() == 0) {
@@ -1014,12 +1019,12 @@ private:
         [[maybe_unused]] index_sequence<_Seq...> _Index_seq, _IndexTypes... _Indices) const noexcept {
         _STL_INTERNAL_STATIC_ASSERT((same_as<_IndexTypes, index_type> && ...));
 #if _CONTAINER_DEBUG_LEVEL > 0
-        _STL_VERIFY(_Exts._Contains_multidimensional_index(_Index_seq, _Indices...),
+        _STL_VERIFY(this->_Exts._Contains_multidimensional_index(_Index_seq, _Indices...),
             "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
             "[mdspan.layout.stride.obs]/3).");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
 
-        return static_cast<index_type>(((_Indices * _Strides[_Seq]) + ... + 0));
+        return static_cast<index_type>(((_Indices * this->_Array[_Seq]) + ... + 0));
     }
 };
 

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -456,7 +456,7 @@ struct _Maybe_fully_static_extents<_Extents> {
     template <class _OtherExtents>
     constexpr explicit _Maybe_fully_static_extents([[maybe_unused]] const _OtherExtents& _Exts_) {
 #if _CONTAINER_DEBUG_LEVEL > 0
-        (void) _Extents(_Exts_); // NB: temporary created for preconditions check
+        (void) _Extents{_Exts_}; // NB: temporary created for preconditions check
 #endif // _CONTAINER_DEBUG_LEVEL > 0
     }
 };
@@ -471,7 +471,7 @@ public:
     using layout_type  = layout_left;
 
 private:
-    using _Base = _Maybe_fully_static_extents<_Extents>;
+    using _Base = _Maybe_fully_static_extents<extents_type>;
 
     static_assert(_Is_extents<extents_type>,
         "Extents must be a specialization of std::extents (N4950 [mdspan.layout.left.overview]/2).");
@@ -623,7 +623,7 @@ public:
     using layout_type  = layout_right;
 
 private:
-    using _Base = _Maybe_fully_static_extents<_Extents>;
+    using _Base = _Maybe_fully_static_extents<extents_type>;
 
     static_assert(_Is_extents<extents_type>,
         "Extents must be a specialization of std::extents (N4950 [mdspan.layout.right.overview]/2).");
@@ -777,13 +777,18 @@ concept _Layout_mapping_alike = requires {
 };
 
 template <class _Extents>
-class layout_stride::mapping {
+class layout_stride::mapping : private _Maybe_fully_static_extents<_Extents>,
+                               private _Maybe_empty_array<typename _Extents::index_type, _Extents::rank()> {
 public:
     using extents_type = _Extents;
     using index_type   = extents_type::index_type;
     using size_type    = extents_type::size_type;
     using rank_type    = extents_type::rank_type;
     using layout_type  = layout_stride;
+
+private:
+    using _Extents_base = _Maybe_fully_static_extents<extents_type>;
+    using _Strides_base = _Maybe_empty_array<index_type, _Extents::rank()>;
 
     static_assert(_Is_extents<extents_type>,
         "Extents must be a specialization of std::extents (N4950 [mdspan.layout.stride.overview]/2).");
@@ -792,12 +797,14 @@ public:
         "If Extents::rank_dynamic() == 0 is true, then the size of the multidimensional index space Extents() must be "
         "representable as a value of type typename Extents::index_type (N4950 [mdspan.layout.stride.overview]/4).");
 
-    constexpr mapping() noexcept : _Exts(extents_type{}) {
+public:
+    constexpr mapping() noexcept : _Extents_base(extents_type{}) {
         if constexpr (extents_type::rank() != 0) {
-            _Strides.back() = 1;
+            this->_Array.back() = 1;
             for (rank_type _Idx = extents_type::_Rank - 1; _Idx-- > 0;) {
 #if _CONTAINER_DEBUG_LEVEL > 0
-                const bool _Overflow = _Mul_overflow(_Strides[_Idx + 1], _Exts.extent(_Idx + 1), _Strides[_Idx]);
+                const bool _Overflow =
+                    _Mul_overflow(this->_Array[_Idx + 1], this->_Exts.extent(_Idx + 1), this->_Array[_Idx]);
                 // NB: N4950 requires value of 'layout_right::mapping<extents_type>().required_span_size()' to be
                 // representable as value of type 'index_type', but this is not enough. We need to require every single
                 // stride to be representable as value of type 'index_type', so we can get desired effects.
@@ -805,7 +812,7 @@ public:
                     "Value of layout_right::mapping<extents_type>().required_span_size() must be "
                     "representable as a value of type index_type (N4950 [mdspan.layout.stride.cons]/1).");
 #else // ^^^ _CONTAINER_DEBUG_LEVEL > 0 / _CONTAINER_DEBUG_LEVEL == 0 vvv
-                _Strides[_Idx] = static_cast<index_type>(_Strides[_Idx + 1] * _Exts.extent(_Idx + 1));
+                this->_Array[_Idx] = static_cast<index_type>(this->_Array[_Idx + 1] * this->_Exts.extent(_Idx + 1));
 #endif // _CONTAINER_DEBUG_LEVEL > 0
             }
         }
@@ -818,17 +825,17 @@ public:
                   && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
     constexpr mapping(const extents_type& _Exts_, span<_OtherIndexType, extents_type::rank()> _Strides_,
         index_sequence<_Indices...>) noexcept
-        : _Exts(_Exts_), _Strides{static_cast<index_type>(_STD as_const(_Strides_[_Indices]))...} {
+        : _Extents_base(_Exts_), _Strides_base{static_cast<index_type>(_STD as_const(_Strides_[_Indices]))...} {
 #if _CONTAINER_DEBUG_LEVEL > 0
         if constexpr (extents_type::rank() != 0) {
             bool _Found_zero          = false;
             bool _Overflow            = false;
             index_type _Req_span_size = 0;
             for (rank_type _Idx = 0; _Idx < extents_type::_Rank; ++_Idx) {
-                const index_type _Stride = _Strides[_Idx];
+                const index_type _Stride = this->_Array[_Idx];
                 _STL_VERIFY(_Stride > 0, "Value of s[i] must be greater than 0 for all i in the range [0, rank_) "
                                          "(N4950 [mdspan.layout.stride.cons]/4.1).");
-                const index_type _Ext = _Exts.extent(_Idx);
+                const index_type _Ext = this->_Exts.extent(_Idx);
                 if (_Ext == 0) {
                     _Found_zero = true;
                 }
@@ -881,7 +888,7 @@ public:
         && (_Is_mapping_of<layout_left, _StridedLayoutMapping> || _Is_mapping_of<layout_right, _StridedLayoutMapping>
             || _Is_mapping_of<layout_stride, _StridedLayoutMapping>) ))
         mapping(const _StridedLayoutMapping& _Other) noexcept
-        : _Exts(_Other.extents()) {
+        : _Extents_base(_Other.extents()) {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
             "Value of other.required_span_size() must be representable as a value of type index_type (N4950 "
@@ -895,18 +902,18 @@ public:
             _STL_VERIFY(_Stride > 0, "Value of other.stride(r) must be greater than 0 for every rank index r of "
                                      "extents() (N4950 [mdspan.layout.stride.cons]/7.2).");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-            _Strides[_Idx] = static_cast<index_type>(_Stride);
+            this->_Array[_Idx] = static_cast<index_type>(_Stride);
         }
     }
 
     constexpr mapping& operator=(const mapping&) noexcept = default;
 
     _NODISCARD constexpr const extents_type& extents() const noexcept {
-        return _Exts;
+        return this->_Exts;
     }
 
     _NODISCARD constexpr array<index_type, extents_type::rank()> strides() const noexcept {
-        return _Strides;
+        return this->_Array;
     }
 
     _NODISCARD constexpr index_type required_span_size() const noexcept {
@@ -915,12 +922,12 @@ public:
         } else {
             index_type _Result = 1;
             for (rank_type _Idx = 0; _Idx < extents_type::_Rank; ++_Idx) {
-                const index_type _Ext = _Exts.extent(_Idx);
+                const index_type _Ext = this->_Exts.extent(_Idx);
                 if (_Ext == 0) {
                     return 0;
                 }
 
-                _Result += (_Ext - 1) * _Strides[_Idx];
+                _Result += (_Ext - 1) * this->_Array[_Idx];
             }
 
             return _Result;
@@ -954,7 +961,8 @@ public:
         if constexpr (extents_type::rank() == 0) {
             return true;
         } else {
-            return required_span_size() == _Fwd_prod_of_extents<extents_type>::_Calculate(_Exts, extents_type::_Rank);
+            return required_span_size()
+                == _Fwd_prod_of_extents<extents_type>::_Calculate(this->_Exts, extents_type::_Rank);
         }
     }
 
@@ -963,7 +971,7 @@ public:
     }
 
     _NODISCARD constexpr index_type stride(const rank_type _Idx) const noexcept {
-        return _Strides[_Idx];
+        return this->_Array[_Idx];
     }
 
     template <class _OtherMapping>
@@ -986,9 +994,6 @@ public:
     }
 
 private:
-    extents_type _Exts{};
-    array<index_type, extents_type::rank()> _Strides{};
-
     template <class _OtherMapping>
     _NODISCARD static constexpr _OtherMapping::index_type _Offset(_OtherMapping& _Mapping) noexcept {
         if constexpr (extents_type::rank() == 0) {
@@ -1010,12 +1015,12 @@ private:
         [[maybe_unused]] index_sequence<_Seq...> _Index_seq, _IndexTypes... _Indices) const noexcept {
         _STL_INTERNAL_STATIC_ASSERT((same_as<_IndexTypes, index_type> && ...));
 #if _CONTAINER_DEBUG_LEVEL > 0
-        _STL_VERIFY(_Exts._Contains_multidimensional_index(_Index_seq, _Indices...),
+        _STL_VERIFY(this->_Exts._Contains_multidimensional_index(_Index_seq, _Indices...),
             "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
             "[mdspan.layout.stride.obs]/3).");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
 
-        return static_cast<index_type>(((_Indices * _Strides[_Seq]) + ... + 0));
+        return static_cast<index_type>(((_Indices * this->_Array[_Seq]) + ... + 0));
     }
 };
 

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -24,6 +24,10 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+// TRANSITION, non-_Ugly attribute tokens
+#pragma push_macro("empty_bases")
+#undef empty_bases
+
 _STD_BEGIN
 template <class _IndexType, size_t _Size>
 struct _Maybe_empty_array {
@@ -1048,9 +1052,80 @@ struct default_accessor {
     }
 };
 
+template <class _LayoutPolicy, class _Extents>
+concept _Elidable_layout_mapping =
+    _Is_any_of_v<_LayoutPolicy, layout_left, layout_right> && (_Extents::rank_dynamic() == 0);
+
+template <class _Extents, class _LayoutPolicy>
+struct _Mdspan_mapping_base {
+    using _Mapping = _LayoutPolicy::template mapping<_Extents>;
+
+    constexpr _Mdspan_mapping_base() noexcept = default;
+
+    constexpr explicit _Mdspan_mapping_base(const _Extents& _Exts) : _Map(_Exts) {}
+
+    constexpr explicit _Mdspan_mapping_base(const _Mapping& _Map_) : _Map(_Map_) {}
+
+    template <class _OtherMapping>
+    constexpr explicit _Mdspan_mapping_base(const _OtherMapping& _Map_) : _Map(_Map_) {}
+
+    _Mapping _Map{};
+};
+
+template <class _Extents, _Elidable_layout_mapping<_Extents> _LayoutPolicy>
+struct _Mdspan_mapping_base<_Extents, _LayoutPolicy> {
+    using _Mapping = _LayoutPolicy::template mapping<_Extents>;
+
+    constexpr _Mdspan_mapping_base() noexcept = default;
+
+    constexpr explicit _Mdspan_mapping_base(const _Extents&) noexcept {}
+
+    constexpr explicit _Mdspan_mapping_base(const _Mapping&) noexcept {}
+
+    template <class _OtherMapping>
+    constexpr explicit _Mdspan_mapping_base(const _OtherMapping& _Map_) {
+        // NB: Constructing _Mapping from _OtherMapping may have side effects - we should create a temporary.
+        if constexpr (!_Elidable_layout_mapping<typename _OtherMapping::layout_type, _Extents>) {
+            (void) _Mapping{_Map_};
+        }
+    }
+
+    static constexpr _Mapping _Map{};
+};
+
+template <class _AccessorPolicy>
+concept _Elidable_accessor_policy = _Is_specialization_v<_AccessorPolicy, default_accessor>;
+
+template <class _AccessorPolicy>
+struct _Mdspan_accessor_base {
+    constexpr _Mdspan_accessor_base() noexcept = default;
+
+    template <class _OtherAccessorPolicy>
+    constexpr explicit _Mdspan_accessor_base(const _OtherAccessorPolicy& _Acc_) : _Acc(_Acc_) {}
+
+    _AccessorPolicy _Acc{};
+};
+
+template <_Elidable_accessor_policy _AccessorPolicy>
+struct _Mdspan_accessor_base<_AccessorPolicy> {
+    constexpr _Mdspan_accessor_base() noexcept = default;
+
+    template <class _OtherAccessorPolicy>
+    constexpr explicit _Mdspan_accessor_base(const _OtherAccessorPolicy& _Acc_) {
+        // NB: Constructing _AccessorPolicy from _OtherAccessorPolicy may have side effects - we should create  a
+        // temporary.
+        if constexpr (!_Elidable_accessor_policy<_OtherAccessorPolicy>) {
+            (void) _AccessorPolicy{_Acc_};
+        }
+    }
+
+    static constexpr _AccessorPolicy _Acc{};
+};
+
 _EXPORT_STD template <class _ElementType, class _Extents, class _LayoutPolicy = layout_right,
     class _AccessorPolicy = default_accessor<_ElementType>>
-class mdspan {
+class __declspec(empty_bases) mdspan : private _Mdspan_mapping_base<_Extents, _LayoutPolicy>,
+                                       private _Mdspan_accessor_base<_AccessorPolicy> {
 public:
     using extents_type     = _Extents;
     using layout_type      = _LayoutPolicy;
@@ -1064,6 +1139,10 @@ public:
     using data_handle_type = accessor_type::data_handle_type;
     using reference        = accessor_type::reference;
 
+private:
+    using _Mapping_base  = _Mdspan_mapping_base<extents_type, layout_type>;
+    using _Accessor_base = _Mdspan_accessor_base<accessor_type>;
+
     static_assert(
         sizeof(element_type) > 0, "ElementType must be a complete type (N4950 [mdspan.mdspan.overview]/2.1).");
     static_assert(
@@ -1076,6 +1155,7 @@ public:
         "ElementType and typename AccessorPolicy::element_type must be the same type (N4950 "
         "[mdspan.mdspan.overview]/2.3).");
 
+public:
     _NODISCARD static constexpr rank_type rank() noexcept {
         return extents_type::_Rank;
     }
@@ -1092,7 +1172,7 @@ public:
     }
 
     _NODISCARD constexpr index_type extent(const rank_type _Idx) const noexcept {
-        return _Map.extents().extent(_Idx);
+        return this->_Map.extents().extent(_Idx);
     }
 
     constexpr mdspan()
@@ -1109,7 +1189,8 @@ public:
                   && (sizeof...(_OtherIndexTypes) == rank() || sizeof...(_OtherIndexTypes) == rank_dynamic())
                   && is_constructible_v<mapping_type, extents_type> && is_default_constructible_v<accessor_type>
     constexpr explicit mdspan(data_handle_type _Ptr_, _OtherIndexTypes... _Exts)
-        : _Ptr(_STD move(_Ptr_)), _Map(extents_type{static_cast<index_type>(_STD move(_Exts))...}), _Acc() {}
+        : _Mapping_base(extents_type{static_cast<index_type>(_STD move(_Exts))...}), _Accessor_base(),
+          _Ptr(_STD move(_Ptr_)) {}
 
     template <class _OtherIndexType, size_t _Size>
         requires is_convertible_v<_OtherIndexType, index_type>
@@ -1117,7 +1198,7 @@ public:
                   && (_Size == rank() || _Size == rank_dynamic())
                   && is_constructible_v<mapping_type, extents_type> && is_default_constructible_v<accessor_type>
     constexpr explicit(_Size != rank_dynamic()) mdspan(data_handle_type _Ptr_, span<_OtherIndexType, _Size> _Exts)
-        : _Ptr(_STD move(_Ptr_)), _Map(extents_type{_Exts}), _Acc() {}
+        : _Mapping_base(extents_type{_Exts}), _Accessor_base(), _Ptr(_STD move(_Ptr_)) {}
 
     template <class _OtherIndexType, size_t _Size>
         requires is_convertible_v<const _OtherIndexType&, index_type>
@@ -1126,18 +1207,18 @@ public:
                   && is_constructible_v<mapping_type, extents_type> && is_default_constructible_v<accessor_type>
     constexpr explicit(_Size != rank_dynamic())
         mdspan(data_handle_type _Ptr_, const array<_OtherIndexType, _Size>& _Exts)
-        : _Ptr(_STD move(_Ptr_)), _Map(extents_type{_Exts}), _Acc() {}
+        : _Mapping_base(extents_type{_Exts}), _Accessor_base(), _Ptr(_STD move(_Ptr_)) {}
 
-    constexpr mdspan(data_handle_type _Ptr_, const extents_type& _Ext)
+    constexpr mdspan(data_handle_type _Ptr_, const extents_type& _Exts)
         requires is_constructible_v<mapping_type, const extents_type&> && is_default_constructible_v<accessor_type>
-        : _Ptr(_STD move(_Ptr_)), _Map(_Ext), _Acc() {}
+        : _Mapping_base(_Exts), _Accessor_base(), _Ptr(_STD move(_Ptr_)) {}
 
     constexpr mdspan(data_handle_type _Ptr_, const mapping_type& _Map_)
         requires is_default_constructible_v<accessor_type>
-        : _Ptr(_STD move(_Ptr_)), _Map(_Map_), _Acc() {}
+        : _Mapping_base(_Map_), _Accessor_base(), _Ptr(_STD move(_Ptr_)) {}
 
     constexpr mdspan(data_handle_type _Ptr_, const mapping_type& _Map_, const accessor_type& _Acc_)
-        : _Ptr(_STD move(_Ptr_)), _Map(_Map_), _Acc(_Acc_) {}
+        : _Mapping_base(_Map_), _Accessor_base(_Acc_), _Ptr(_STD move(_Ptr_)) {}
 
     template <class _OtherElementType, class _OtherExtents, class _OtherLayoutPolicy, class _OtherAccessor>
         requires is_constructible_v<mapping_type, const typename _OtherLayoutPolicy::template mapping<_OtherExtents>&>
@@ -1146,7 +1227,7 @@ public:
         !is_convertible_v<const typename _OtherLayoutPolicy::template mapping<_OtherExtents>&, mapping_type>
         || !is_convertible_v<const _OtherAccessor&, accessor_type>)
         mdspan(const mdspan<_OtherElementType, _OtherExtents, _OtherLayoutPolicy, _OtherAccessor>& _Other)
-        : _Ptr(_Other.data_handle()), _Map(_Other.mapping()), _Acc(_Other.accessor()) {
+        : _Mapping_base(_Other.mapping()), _Accessor_base(_Other.accessor()), _Ptr(_Other.data_handle()) {
         static_assert(is_constructible_v<data_handle_type, const typename _OtherAccessor::data_handle_type&>,
             "The data_handle_type must be constructible from const typename OtherAccessor::data_handle_type& (N4950 "
             "[mdspan.mdspan.cons]/20.1).");
@@ -1204,20 +1285,20 @@ public:
     _NODISCARD constexpr size_type size() const noexcept {
 #if _CONTAINER_DEBUG_LEVEL > 0
         if constexpr (rank_dynamic() != 0) {
-            _STL_VERIFY(_Map.extents().template _Is_dynamic_multidim_index_space_size_representable<size_type>(),
+            _STL_VERIFY(this->_Map.extents().template _Is_dynamic_multidim_index_space_size_representable<size_type>(),
                 "The size of the multidimensional index space extents() must be representable as a value of type "
                 "size_type (N4950 [mdspan.mdspan.members]/7).");
         }
 #endif // _CONTAINER_DEBUG_LEVEL > 0
         return static_cast<size_type>(
-            _Fwd_prod_of_extents<extents_type>::_Calculate(_Map.extents(), extents_type::_Rank));
+            _Fwd_prod_of_extents<extents_type>::_Calculate(this->_Map.extents(), extents_type::_Rank));
     }
 
     _NODISCARD constexpr bool empty() const noexcept {
         if constexpr (extents_type::_Multidim_index_space_size_is_always_zero) {
             return true;
         } else {
-            const extents_type& _Exts = _Map.extents();
+            const extents_type& _Exts = this->_Map.extents();
             for (rank_type _Idx = 0; _Idx < extents_type::_Rank; ++_Idx) {
                 if (_Exts.extent(_Idx) == 0) {
                     return true;
@@ -1229,12 +1310,18 @@ public:
 
     friend constexpr void swap(mdspan& _Left, mdspan& _Right) noexcept {
         swap(_Left._Ptr, _Right._Ptr); // intentional ADL
-        swap(_Left._Map, _Right._Map); // intentional ADL
-        swap(_Left._Acc, _Right._Acc); // intentional ADL
+
+        if constexpr (!_Elidable_layout_mapping<layout_type, extents_type>) {
+            swap(_Left._Map, _Right._Map); // intentional ADL
+        }
+
+        if constexpr (!_Elidable_accessor_policy<accessor_type>) {
+            swap(_Left._Acc, _Right._Acc); // intentional ADL
+        }
     }
 
     _NODISCARD constexpr const extents_type& extents() const noexcept {
-        return _Map.extents();
+        return this->_Map.extents();
     }
 
     _NODISCARD constexpr const data_handle_type& data_handle() const noexcept {
@@ -1242,11 +1329,11 @@ public:
     }
 
     _NODISCARD constexpr const mapping_type& mapping() const noexcept {
-        return _Map;
+        return this->_Map;
     }
 
     _NODISCARD constexpr const accessor_type& accessor() const noexcept {
-        return _Acc;
+        return this->_Acc;
     }
 
     _NODISCARD static constexpr bool is_always_unique() noexcept(
@@ -1264,21 +1351,21 @@ public:
         return mapping_type::is_always_strided();
     }
 
-    _NODISCARD constexpr bool is_unique() const noexcept(noexcept(_Map.is_unique())) /* strengthened */ {
-        return _Map.is_unique();
+    _NODISCARD constexpr bool is_unique() const noexcept(noexcept(this->_Map.is_unique())) /* strengthened */ {
+        return this->_Map.is_unique();
     }
 
-    _NODISCARD constexpr bool is_exhaustive() const noexcept(noexcept(_Map.is_exhaustive())) /* strengthened */ {
-        return _Map.is_exhaustive();
+    _NODISCARD constexpr bool is_exhaustive() const noexcept(noexcept(this->_Map.is_exhaustive())) /* strengthened */ {
+        return this->_Map.is_exhaustive();
     }
 
-    _NODISCARD constexpr bool is_strided() const noexcept(noexcept(_Map.is_strided())) /* strengthened */ {
-        return _Map.is_strided();
+    _NODISCARD constexpr bool is_strided() const noexcept(noexcept(this->_Map.is_strided())) /* strengthened */ {
+        return this->_Map.is_strided();
     }
 
     _NODISCARD constexpr index_type stride(const rank_type _Idx) const
-        noexcept(noexcept(_Map.stride(_Idx))) /* strengthened */ {
-        return _Map.stride(_Idx);
+        noexcept(noexcept(this->_Map.stride(_Idx))) /* strengthened */ {
+        return this->_Map.stride(_Idx);
     }
 
 private:
@@ -1293,16 +1380,14 @@ private:
     _NODISCARD constexpr reference _Access_impl(_OtherIndexTypes... _Indices) const {
         _STL_INTERNAL_STATIC_ASSERT((same_as<_OtherIndexTypes, index_type> && ...));
 #if _CONTAINER_DEBUG_LEVEL > 0
-        _STL_VERIFY(_Map.extents()._Contains_multidimensional_index(make_index_sequence<rank()>{}, _Indices...),
+        _STL_VERIFY(this->_Map.extents()._Contains_multidimensional_index(make_index_sequence<rank()>{}, _Indices...),
             "I must be a multidimensional index in extents() (N4950 [mdspan.mdspan.members]/3).");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
 
-        return _Acc.access(_Ptr, static_cast<size_t>(_Map(_Indices...)));
+        return this->_Acc.access(_Ptr, static_cast<size_t>(this->_Map(_Indices...)));
     }
 
-    data_handle_type _Ptr{};
-    mapping_type _Map{};
-    accessor_type _Acc{};
+    /* [[no_unique_address]] */ data_handle_type _Ptr{};
 };
 
 template <class _CArray>
@@ -1337,6 +1422,9 @@ mdspan(const typename _AccessorType::data_handle_type&, const _MappingType&, con
         typename _MappingType::layout_type, _AccessorType>;
 
 _STD_END
+
+// TRANSITION, non-_Ugly attribute tokens
+#pragma pop_macro("empty_bases")
 
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
@@ -13,6 +13,7 @@
 #define intrinsic       3
 #define lifetimebound   4
 #define noop_dtor       5
+#define empty_bases     6
 
 #include <__msvc_all_public_headers.hpp>
 
@@ -35,3 +36,7 @@
 #if noop_dtor != 5
 #error bad macro expansion
 #endif // noop_dtor != 5
+
+#if empty_bases != 6
+#error bad macro expansion
+#endif // noop_dtor != 6

--- a/tests/std/tests/P0009R18_mdspan_default_accessor/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_default_accessor/test.cpp
@@ -27,6 +27,9 @@ constexpr void test_one(array<ElementType, 3> elems) {
     static_assert(is_trivially_copyable_v<Accessor>);
     static_assert(semiregular<Accessor>);
 
+    // Check if default_accessor is emtpy
+    static_assert(std::is_empty_v<Accessor>);
+
     // Check nested types
     static_assert(same_as<typename Accessor::offset_policy, Accessor>);
     static_assert(same_as<typename Accessor::element_type, ElementType>);

--- a/tests/std/tests/P0009R18_mdspan_default_accessor/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_default_accessor/test.cpp
@@ -27,7 +27,7 @@ constexpr void test_one(array<ElementType, 3> elems) {
     static_assert(is_trivially_copyable_v<Accessor>);
     static_assert(semiregular<Accessor>);
 
-    // Check if default_accessor is emtpy
+    // Check if default_accessor is empty
     static_assert(std::is_empty_v<Accessor>);
 
     // Check nested types

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -423,6 +423,10 @@ constexpr void check_correctness() {
 #endif // ^^^ !defined(__cpp_multidimensional_subscript) ^^^
     }
 
+
+#ifdef __clang__
+    if (!is_constant_evaluated()) // FIXME clang hits constexpr limit here
+#endif
     { // 3x2 matrix with column-major order
         const array values{0, 1, 2, 3, 4, 5};
         mdspan<const int, extents<int, 3, 2>, layout_left> matrix{values.data()};
@@ -444,6 +448,9 @@ constexpr void check_correctness() {
 #endif // ^^^ !defined(__cpp_multidimensional_subscript) ^^^
     }
 
+#ifdef __clang__
+    if (!is_constant_evaluated()) // FIXME clang hits constexpr limit here
+#endif
     { // 3x2x4 tensor
         const array values{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
         mdspan<const int, dextents<size_t, 3>, layout_left> tensor{values.data(), 3, 2, 4};
@@ -492,6 +499,12 @@ constexpr void check_correctness() {
 #endif // ^^^ !defined(__cpp_multidimensional_subscript) ^^^
     }
 }
+
+// When 'M::extents_type::rank_dynamic()' is equal to 0 then 'is_empty_v<M>' should be true (MSVC STL specific behavior)
+static_assert(!is_empty_v<layout_left::mapping<dextents<long long, 2>>>);
+static_assert(!is_empty_v<layout_left::mapping<extents<long long, 3, dynamic_extent>>>);
+static_assert(is_empty_v<layout_left::mapping<extents<long long, 3, 3>>>);
+static_assert(is_empty_v<layout_left::mapping<extents<long long>>>);
 
 constexpr bool test() {
     check_members_with_various_extents([]<class E>(const E& e) { check_members(e, make_index_sequence<E::rank()>{}); });

--- a/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
@@ -516,6 +516,12 @@ constexpr void check_correctness() {
     }
 }
 
+// When 'M::extents_type::rank_dynamic()' is equal to 0 then 'is_empty_v<M>' should be true (MSVC STL specific behavior)
+static_assert(!is_empty_v<layout_right::mapping<dextents<long, 2>>>);
+static_assert(!is_empty_v<layout_right::mapping<extents<long, 3, dynamic_extent>>>);
+static_assert(is_empty_v<layout_right::mapping<extents<long, 3, 3>>>);
+static_assert(is_empty_v<layout_right::mapping<extents<long>>>);
+
 constexpr bool test() {
     check_members_with_various_extents([]<class E>(const E& e) { check_members(e, make_index_sequence<E::rank()>{}); });
     if (!is_constant_evaluated()) { // too heavy for compile time

--- a/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
@@ -821,12 +821,6 @@ constexpr void check_correctness() {
     }
 }
 
-// When 'M::extents_type::rank()' is equal to 0 then 'is_empty_v<M>' should be true (MSVC STL specific behavior)
-static_assert(!is_empty_v<layout_stride::mapping<dextents<long long, 2>>>);
-static_assert(!is_empty_v<layout_stride::mapping<extents<long long, 3, dynamic_extent>>>);
-static_assert(!is_empty_v<layout_stride::mapping<extents<long long, 3, 3>>>);
-static_assert(is_empty_v<layout_stride::mapping<extents<long long>>>);
-
 constexpr bool test() {
     // Check signed integers
     check_members(extents<signed char, 5>{5}, array{1});

--- a/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
@@ -821,6 +821,12 @@ constexpr void check_correctness() {
     }
 }
 
+// When 'M::extents_type::rank()' is equal to 0 then 'is_empty_v<M>' should be true (MSVC STL specific behavior)
+static_assert(!is_empty_v<layout_stride::mapping<dextents<long long, 2>>>);
+static_assert(!is_empty_v<layout_stride::mapping<extents<long long, 3, dynamic_extent>>>);
+static_assert(!is_empty_v<layout_stride::mapping<extents<long long, 3, 3>>>);
+static_assert(is_empty_v<layout_stride::mapping<extents<long long>>>);
+
 constexpr bool test() {
     // Check signed integers
     check_members(extents<signed char, 5>{5}, array{1});

--- a/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
@@ -1335,7 +1335,9 @@ constexpr void check_deduction_guides() {
 
 // When
 // * 'Mds::accessor_type' is specialization of 'default_accesor', and
-// * 'Mds::layout_type' is layout_left or layout_right and 'Mds::extents_type::rank_dynamic() == 0',
+// * 'Mds::layout_type' is
+//   * 'layout_left' or 'layout_right' and 'Mds::extents_type::rank_dynamic() == 0', or
+//   * 'layout_stride' and 'Mds::extents_type::rank() == 0'
 // then 'sizeof(Mds) == sizeof(void*)' (MSVC STL specific behavior).
 static_assert(sizeof(mdspan<int, extents<int, 3, 3, 3>, layout_left>) == sizeof(void*));
 static_assert(sizeof(mdspan<int, dextents<int, 3>, layout_left>) > sizeof(void*));
@@ -1345,11 +1347,19 @@ static_assert(sizeof(mdspan<long, extents<long, 2, 2, 2>, layout_right>) == size
 static_assert(sizeof(mdspan<long, dextents<long, 2>, layout_right>) > sizeof(void*));
 static_assert(sizeof(mdspan<long, extents<long, 2, 2, 2>, layout_right, TrivialAccessor<long>>) > sizeof(void*));
 
+static_assert(sizeof(mdspan<short, extents<short>, layout_stride>) == sizeof(void*));
+static_assert(sizeof(mdspan<short, extents<short, 4, 4, 4>, layout_stride>) > sizeof(void*));
+static_assert(sizeof(mdspan<short, dextents<short, 4>, layout_stride>) > sizeof(void*));
+static_assert(sizeof(mdspan<short, extents<short, 4, 4, 4>, layout_stride, TrivialAccessor<short>>) > sizeof(void*));
+
 constexpr bool test() {
+    check_modeled_concepts_and_member_types<dextents<unsigned long long, 3>, layout_left, default_accessor>();
+    check_modeled_concepts_and_member_types<dextents<unsigned long long, 3>, layout_right, default_accessor>();
+    check_modeled_concepts_and_member_types<dextents<unsigned long long, 3>, layout_stride, default_accessor>();
+    check_modeled_concepts_and_member_types<dextents<unsigned long long, 3>, layout_left, TrackingAccessor>();
     check_modeled_concepts_and_member_types<extents<signed char, 2, 3, 5>, layout_stride, TrivialAccessor>();
     check_modeled_concepts_and_member_types<extents<unsigned short, 2, 4, dynamic_extent>, TrackingLayout<>,
         AccessorWithTrackingDataHandle>();
-    check_modeled_concepts_and_member_types<dextents<unsigned long long, 3>, layout_left, TrackingAccessor>();
     check_observers();
     check_default_constructor();
     check_defaulted_copy_and_move_constructors();


### PR DESCRIPTION
* Add new base classes required for EBO implementation:
  * `_Maybe_fully_static_extents` - EBO for `layout_left::mapping`,`layout_right::mapping` and `layout_stride::mapping`,
  * `_Mdspan_mapping_base` - EBO for `mdspan` (`_Map` member only),
  * `_Mdspan_accessor_base` - EBO for `mdspan` (`_Acc` member only),
* Add `/* [[no_unique_address]] */` comments when EBO cannot be applied.
  * Ideally we would get rid of those base classes and just use this attribute (see #1364).
* Drive-by: address comment from #3825 (`static_cast<size_t>` in `_Calculate_rank_dynamic`).
* Add tests.
