### PR TITLE
`<mdspan>`: Final cleanups

### DIFF
--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -79,7 +79,7 @@ private:
         rank_type _Counter = 0;
         for (rank_type _Idx = 0; _Idx < _Rank; ++_Idx) {
             if (_Static_extents[_Idx] == dynamic_extent) {
-                __assume(_Counter < _Rank_dynamic); // TRANSITION, DevCom-923103
+                _Analysis_assume_(_Counter < _Rank_dynamic); // TRANSITION, DevCom-923103
                 _Result[_Counter] = _Idx;
                 ++_Counter;
             }

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -532,7 +532,8 @@ public:
 
     template <class _OtherExtents>
         requires is_constructible_v<extents_type, _OtherExtents>
-    constexpr explicit(extents_type::rank() > 0) mapping(const layout_stride::template mapping<_OtherExtents>& _Other)
+    constexpr explicit(extents_type::rank() > 0)
+        mapping(const layout_stride::template mapping<_OtherExtents>& _Other) noexcept // strengthened
         : _Base(_Other.extents()) {
 #if _CONTAINER_DEBUG_LEVEL > 0
         if constexpr (extents_type::rank() > 0) {

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1205,7 +1205,9 @@ public:
                   && (is_nothrow_constructible_v<index_type, _OtherIndexTypes> && ...)
                   && (sizeof...(_OtherIndexTypes) == rank() || sizeof...(_OtherIndexTypes) == rank_dynamic())
                   && is_constructible_v<mapping_type, extents_type> && is_default_constructible_v<accessor_type>
-    constexpr explicit mdspan(data_handle_type _Ptr_, _OtherIndexTypes... _Exts)
+    constexpr explicit mdspan(data_handle_type _Ptr_, _OtherIndexTypes... _Exts) noexcept(
+        is_nothrow_move_constructible_v<data_handle_type>&& is_nothrow_constructible_v<mapping_type, extents_type>&&
+            is_nothrow_default_constructible_v<accessor_type>) // strengthened
         : _Mapping_base(extents_type{static_cast<index_type>(_STD move(_Exts))...}), _Accessor_base(),
           _Ptr(_STD move(_Ptr_)) {}
 

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1216,7 +1216,10 @@ public:
                   && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
                   && (_Size == rank() || _Size == rank_dynamic())
                   && is_constructible_v<mapping_type, extents_type> && is_default_constructible_v<accessor_type>
-    constexpr explicit(_Size != rank_dynamic()) mdspan(data_handle_type _Ptr_, span<_OtherIndexType, _Size> _Exts)
+    constexpr explicit(_Size != rank_dynamic())
+        mdspan(data_handle_type _Ptr_, span<_OtherIndexType, _Size> _Exts) noexcept(
+            is_nothrow_move_constructible_v<data_handle_type>&& is_nothrow_constructible_v<mapping_type, extents_type>&&
+                is_nothrow_default_constructible_v<accessor_type>) // strengthened
         : _Mapping_base(extents_type{_Exts}), _Accessor_base(), _Ptr(_STD move(_Ptr_)) {}
 
     template <class _OtherIndexType, size_t _Size>
@@ -1225,8 +1228,10 @@ public:
                   && (_Size == rank() || _Size == rank_dynamic())
                   && is_constructible_v<mapping_type, extents_type> && is_default_constructible_v<accessor_type>
     constexpr explicit(_Size != rank_dynamic())
-        mdspan(data_handle_type _Ptr_, const array<_OtherIndexType, _Size>& _Exts)
-        : _Mapping_base(extents_type{_Exts}), _Accessor_base(), _Ptr(_STD move(_Ptr_)) {}
+        mdspan(data_handle_type _Ptr_, const array<_OtherIndexType, _Size>& _Exts) noexcept(
+            is_nothrow_move_constructible_v<data_handle_type>&& is_nothrow_constructible_v<mapping_type, extents_type>&&
+                is_nothrow_default_constructible_v<accessor_type>) // strengthened
+        : _Mapping_base(extents_type{_Exts}), _Accessor_base(), _Ptr(_STD move(_Ptr_)) {}a_handle, array/span)` constructor)
 
     constexpr mdspan(data_handle_type _Ptr_, const extents_type& _Exts)
         requires is_constructible_v<mapping_type, const extents_type&> && is_default_constructible_v<accessor_type>

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -342,9 +342,10 @@ template <class _IndexType, size_t... _Args>
 inline constexpr bool _Is_extents<extents<_IndexType, _Args...>> = true;
 
 template <class _Extents>
-    requires _Is_extents<_Extents>
 class _Fwd_prod_of_extents {
 public:
+    _STL_INTERNAL_STATIC_ASSERT(_Is_extents<_Extents>);
+
     _NODISCARD static constexpr _Extents::index_type _Calculate(const _Extents& _Exts, const size_t _Idx) noexcept {
         _STL_INTERNAL_CHECK(_Idx <= _Extents::_Rank);
         if constexpr (_Extents::rank() == 0) {
@@ -359,34 +360,36 @@ public:
     }
 };
 
-template <class _IndexType, size_t... _Extents>
-    requires (sizeof...(_Extents) > 0) && ((_Extents != dynamic_extent) && ...)
-class _Fwd_prod_of_extents<extents<_IndexType, _Extents...>> {
+template <class _Extents>
+    requires (_Extents::rank() > 0) && (_Extents::rank_dynamic() == 0)
+class _Fwd_prod_of_extents<_Extents> {
 private:
-    using _Ty = extents<_IndexType, _Extents...>;
+    _STL_INTERNAL_STATIC_ASSERT(_Is_extents<_Extents>);
 
     _NODISCARD static consteval auto _Make_prods() noexcept {
-        array<typename _Ty::index_type, _Ty::rank() + 1> _Result;
+        array<typename _Extents::index_type, _Extents::rank() + 1> _Result;
         _Result.front() = 1;
-        for (size_t _Idx = 1; _Idx < _Ty::_Rank + 1; ++_Idx) {
-            _Result[_Idx] = static_cast<_Ty::index_type>(_Result[_Idx - 1] * _Ty::_Static_extents[_Idx - 1]);
+        for (size_t _Idx = 1; _Idx < _Extents::_Rank + 1; ++_Idx) {
+            _Result[_Idx] = static_cast<_Extents::index_type>(_Result[_Idx - 1] * _Extents::_Static_extents[_Idx - 1]);
         }
         return _Result;
     }
 
-    static constexpr array<typename _Ty::index_type, _Ty::rank() + 1> _Cache = _Make_prods();
+    static constexpr array<typename _Extents::index_type, _Extents::rank() + 1> _Cache = _Make_prods();
 
 public:
-    _NODISCARD static constexpr _Ty::index_type _Calculate(const _Ty&, const size_t _Idx) noexcept {
-        _STL_INTERNAL_CHECK(_Idx <= _Ty::_Rank);
+    _NODISCARD static constexpr _Extents::index_type _Calculate(const _Extents&, const size_t _Idx) noexcept {
+        _STL_INTERNAL_CHECK(_Idx <= _Extents::_Rank);
         return _Cache[_Idx];
     }
 };
 
 template <class _Extents>
-    requires _Is_extents<_Extents> && (_Extents::rank() > 0)
 class _Rev_prod_of_extents {
 public:
+    _STL_INTERNAL_STATIC_ASSERT(_Is_extents<_Extents>);
+    _STL_INTERNAL_STATIC_ASSERT(_Extents::rank() > 0);
+
     _NODISCARD static constexpr _Extents::index_type _Calculate(const _Extents& _Exts, const size_t _Idx) noexcept {
         _STL_INTERNAL_CHECK(_Idx < _Extents::_Rank);
         typename _Extents::index_type _Result = 1;
@@ -397,26 +400,27 @@ public:
     }
 };
 
-template <class _IndexType, size_t... _Extents>
-    requires ((_Extents != dynamic_extent) && ...)
-class _Rev_prod_of_extents<extents<_IndexType, _Extents...>> {
+template <class _Extents>
+    requires (_Extents::rank_dynamic() == 0)
+class _Rev_prod_of_extents<_Extents> {
 private:
-    using _Ty = extents<_IndexType, _Extents...>;
+    _STL_INTERNAL_STATIC_ASSERT(_Is_extents<_Extents>);
+    _STL_INTERNAL_STATIC_ASSERT(_Extents::rank() > 0);
 
     _NODISCARD static consteval auto _Make_prods() noexcept {
-        array<typename _Ty::index_type, _Ty::rank()> _Result;
+        array<typename _Extents::index_type, _Extents::rank()> _Result;
         _Result.back() = 1;
-        for (size_t _Idx = _Ty::_Rank; _Idx-- > 1;) {
-            _Result[_Idx - 1] = static_cast<_Ty::index_type>(_Result[_Idx] * _Ty::_Static_extents[_Idx]);
+        for (size_t _Idx = _Extents::_Rank; _Idx-- > 1;) {
+            _Result[_Idx - 1] = static_cast<_Extents::index_type>(_Result[_Idx] * _Extents::_Static_extents[_Idx]);
         }
         return _Result;
     }
 
-    static constexpr array<typename _Ty::index_type, _Ty::rank()> _Cache = _Make_prods();
+    static constexpr array<typename _Extents::index_type, _Extents::rank()> _Cache = _Make_prods();
 
 public:
-    _NODISCARD static constexpr _Ty::index_type _Calculate(const _Ty&, const size_t _Idx) noexcept {
-        _STL_INTERNAL_CHECK(_Idx < _Ty::_Rank);
+    _NODISCARD static constexpr _Extents::index_type _Calculate(const _Extents&, const size_t _Idx) noexcept {
+        _STL_INTERNAL_CHECK(_Idx < _Extents::_Rank);
         return _Cache[_Idx];
     }
 };

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -75,19 +75,19 @@ private:
     static constexpr array<rank_type, _Rank + 1> _Dynamic_indices = _Make_dynamic_indices();
 
     _NODISCARD static consteval auto _Make_dynamic_indices_inv() noexcept {
-        array<rank_type, _Rank> _Result{};
+        array<rank_type, _Rank_dynamic> _Result{};
+        rank_type _Counter = 0;
         for (rank_type _Idx = 0; _Idx < _Rank; ++_Idx) {
-            for (rank_type _Idx_inv = 0; _Idx_inv < _Rank; ++_Idx_inv) {
-                if (_Dynamic_indices[_Idx_inv + 1] == _Idx + 1) {
-                    _Result[_Idx] = _Idx_inv;
-                    break;
-                }
+            if (_Static_extents[_Idx] == dynamic_extent) {
+                __assume(_Counter < _Rank_dynamic); // TRANSITION, DevCom-923103
+                _Result[_Counter] = _Idx;
+                ++_Counter;
             }
         }
         return _Result;
     }
 
-    static constexpr array<rank_type, _Rank> _Dynamic_indices_inv = _Make_dynamic_indices_inv();
+    static constexpr array<rank_type, _Rank_dynamic> _Dynamic_indices_inv = _Make_dynamic_indices_inv();
 
     using _Base = _Maybe_empty_array<_IndexType, _Rank_dynamic>;
 

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1413,7 +1413,7 @@ private:
 
     template <class... _OtherIndexTypes>
     _NODISCARD constexpr reference _Access_impl(_OtherIndexTypes... _Indices) const
-        noexcept(noexcept(_Acc.access(_Ptr, static_cast<size_t>(_Map(_Indices...))))) /* strengthened */ {
+        noexcept(noexcept(this->_Acc.access(_Ptr, static_cast<size_t>(this->_Map(_Indices...))))) /* strengthened */ {
         _STL_INTERNAL_STATIC_ASSERT((same_as<_OtherIndexTypes, index_type> && ...));
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(this->_Map.extents()._Contains_multidimensional_index(make_index_sequence<rank()>{}, _Indices...),

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1245,7 +1245,9 @@ public:
         requires is_default_constructible_v<accessor_type>
         : _Mapping_base(_Map_), _Accessor_base(), _Ptr(_STD move(_Ptr_)) {}
 
-    constexpr mdspan(data_handle_type _Ptr_, const mapping_type& _Map_, const accessor_type& _Acc_)
+    constexpr mdspan(data_handle_type _Ptr_, const mapping_type& _Map_, const accessor_type& _Acc_) noexcept(
+        is_nothrow_move_constructible_v<data_handle_type>&& is_nothrow_copy_constructible_v<mapping_type>&&
+            is_nothrow_copy_constructible_v<accessor_type>) // strengthened
         : _Mapping_base(_Map_), _Accessor_base(_Acc_), _Ptr(_STD move(_Ptr_)) {}
 
     template <class _OtherElementType, class _OtherExtents, class _OtherLayoutPolicy, class _OtherAccessor>

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1231,9 +1231,11 @@ public:
         mdspan(data_handle_type _Ptr_, const array<_OtherIndexType, _Size>& _Exts) noexcept(
             is_nothrow_move_constructible_v<data_handle_type>&& is_nothrow_constructible_v<mapping_type, extents_type>&&
                 is_nothrow_default_constructible_v<accessor_type>) // strengthened
-        : _Mapping_base(extents_type{_Exts}), _Accessor_base(), _Ptr(_STD move(_Ptr_)) {}a_handle, array/span)` constructor)
+        : _Mapping_base(extents_type{_Exts}), _Accessor_base(), _Ptr(_STD move(_Ptr_)) {}
 
-    constexpr mdspan(data_handle_type _Ptr_, const extents_type& _Exts)
+    constexpr mdspan(data_handle_type _Ptr_, const extents_type& _Exts) noexcept(
+        is_nothrow_move_constructible_v<data_handle_type>&& is_nothrow_constructible_v<mapping_type,
+            const extents_type&>&& is_nothrow_default_constructible_v<accessor_type>) // strengthened
         requires is_constructible_v<mapping_type, const extents_type&> && is_default_constructible_v<accessor_type>
         : _Mapping_base(_Exts), _Accessor_base(), _Ptr(_STD move(_Ptr_)) {}
 

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1190,7 +1190,9 @@ public:
         return this->_Map.extents().extent(_Idx);
     }
 
-    constexpr mdspan()
+    constexpr mdspan() noexcept(
+        is_nothrow_default_constructible_v<data_handle_type>&& is_nothrow_default_constructible_v<mapping_type>&&
+            is_nothrow_default_constructible_v<accessor_type>) // strengthened
         requires (rank_dynamic() > 0) && is_default_constructible_v<data_handle_type>
               && is_default_constructible_v<mapping_type> && is_default_constructible_v<accessor_type>
     {}

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1285,7 +1285,8 @@ public:
         requires (is_convertible_v<_OtherIndexTypes, index_type> && ...)
               && (is_nothrow_constructible_v<index_type, _OtherIndexTypes> && ...)
               && (sizeof...(_OtherIndexTypes) == rank())
-    _NODISCARD constexpr reference operator[](_OtherIndexTypes... _Indices) const {
+    _NODISCARD constexpr reference operator[](_OtherIndexTypes... _Indices) const
+        noexcept(noexcept(_Access_impl(static_cast<index_type>(_STD move(_Indices))...))) /* strengthened */ {
         return _Access_impl(static_cast<index_type>(_STD move(_Indices))...);
     }
 #endif // __cpp_multidimensional_subscript
@@ -1411,7 +1412,8 @@ private:
 #endif // ^^^ !defined(__cpp_multidimensional_subscript) ^^^
 
     template <class... _OtherIndexTypes>
-    _NODISCARD constexpr reference _Access_impl(_OtherIndexTypes... _Indices) const {
+    _NODISCARD constexpr reference _Access_impl(_OtherIndexTypes... _Indices) const
+        noexcept(noexcept(_Acc.access(_Ptr, static_cast<size_t>(_Map(_Indices...))))) /* strengthened */ {
         _STL_INTERNAL_STATIC_ASSERT((same_as<_OtherIndexTypes, index_type> && ...));
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(this->_Map.extents()._Contains_multidimensional_index(make_index_sequence<rank()>{}, _Indices...),

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -819,8 +819,8 @@ public:
                 const bool _Overflow =
                     _Mul_overflow(this->_Array[_Idx + 1], this->_Exts.extent(_Idx + 1), this->_Array[_Idx]);
                 // NB: N4950 requires value of 'layout_right::mapping<extents_type>().required_span_size()' to be
-                // representable as value of type 'index_type', but this is not enough. We need to require every single
-                // stride to be representable as value of type 'index_type', so we can get desired effects.
+                // representable as a value of type 'index_type', but this is not enough. We need to require every
+                // single stride to be representable as a value of type 'index_type', so we can get desired effects.
                 _STL_VERIFY(!_Overflow,
                     "Value of layout_right::mapping<extents_type>().required_span_size() must be "
                     "representable as a value of type index_type (N4950 [mdspan.layout.stride.cons]/1).");

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -89,11 +89,89 @@ private:
 
     static constexpr array<rank_type, _Rank> _Dynamic_indices_inv = _Make_dynamic_indices_inv();
 
+    using _Base = _Maybe_empty_array<_IndexType, _Rank_dynamic>;
+
+    template <class _OtherIndexType, size_t... _OtherExtents, size_t... _Indices>
+        requires (sizeof...(_OtherExtents) == _Rank)
+              && ((_OtherExtents == dynamic_extent || _Extents == dynamic_extent || _OtherExtents == _Extents) && ...)
+    constexpr explicit extents(
+        const extents<_OtherIndexType, _OtherExtents...>& _Other, index_sequence<_Indices...>) noexcept
+        : _Base{static_cast<index_type>(_Other.extent(_Dynamic_indices_inv[_Indices]))...} {
+#if _CONTAINER_DEBUG_LEVEL > 0
+        if constexpr (rank() > 0) {
+            for (rank_type _Idx = 0; _Idx < _Rank; ++_Idx) {
+                if constexpr (rank() != rank_dynamic()) {
+                    _STL_VERIFY(_Static_extents[_Idx] == dynamic_extent
+                                    || _STD cmp_equal(_Static_extents[_Idx], _Other.extent(_Idx)),
+                        "Value of other.extent(r) must be equal to extent(r) for each r for which extent(r) is a "
+                        "static extent (N4950 [mdspan.extents.cons]/2.1)");
+                }
+                _STL_VERIFY(_STD in_range<index_type>(_Other.extent(_Idx)),
+                    "Value of other.extent(r) must be representable as a value of type index_type for every rank index "
+                    "r (N4950 [mdspan.extents.cons]/2.2)");
+            }
+        }
+#endif // _CONTAINER_DEBUG_LEVEL > 0
+    }
+
     struct _Construct_from_tuple {
         explicit _Construct_from_tuple() = default;
     };
 
-    using _Base = _Maybe_empty_array<_IndexType, _Rank_dynamic>;
+    template <class _ExtsTuple, size_t... _Indices>
+        requires (tuple_size_v<_ExtsTuple> == _Rank_dynamic)
+    constexpr explicit extents(_Construct_from_tuple, _ExtsTuple _Tpl, index_sequence<_Indices...>) noexcept
+        : _Base{static_cast<index_type>(_STD move(_STD get<_Indices>(_Tpl)))...} {}
+
+    template <class _ExtsTuple, size_t... _DynIndices>
+        requires (tuple_size_v<_ExtsTuple> != _Rank_dynamic)
+    constexpr explicit extents(_Construct_from_tuple, _ExtsTuple _Tpl, index_sequence<_DynIndices...>) noexcept
+        : _Base{static_cast<index_type>(_STD move(_STD get<_Dynamic_indices_inv[_DynIndices]>(_Tpl)))...} {
+#if _CONTAINER_DEBUG_LEVEL > 0
+        [&]<size_t... _MixedIndices>(index_sequence<_MixedIndices...>) {
+            _STL_VERIFY(((_Static_extents[_MixedIndices] == dynamic_extent
+                             || _STD cmp_equal(_Static_extents[_MixedIndices],
+                                 static_cast<index_type>(_STD move(_STD get<_MixedIndices>(_Tpl)))))
+                            && ...),
+                "Value of exts_arr[r] must be equal to extent(r) for each r for which extent(r) is a static extent "
+                "(N4950 [mdspan.extents.cons]/7.1)");
+        }(make_index_sequence<rank()>{});
+#endif // _CONTAINER_DEBUG_LEVEL > 0
+    }
+
+    template <class _OtherIndexType, size_t _Size, size_t... _Indices>
+        requires is_convertible_v<const _OtherIndexType&, index_type>
+              && is_nothrow_constructible_v<index_type, const _OtherIndexType&> && (_Size == _Rank_dynamic)
+    constexpr explicit extents(span<_OtherIndexType, _Size> _Dynamic_exts, index_sequence<_Indices...>) noexcept
+        : _Base{static_cast<index_type>(_STD as_const(_Dynamic_exts[_Indices]))...} {
+#if _CONTAINER_DEBUG_LEVEL > 0
+        if constexpr (_Is_standard_integer<_OtherIndexType> && _Size != 0) {
+            _STL_VERIFY(((_Dynamic_exts[_Indices] >= 0 && _STD in_range<index_type>(_Dynamic_exts[_Indices])) && ...),
+                "Either N must be zero or exts[r] must be nonnegative and must be representable as value of type "
+                "index_type for every rank index r (N4950 [mdspan.extents.cons]/10.2)");
+        }
+#endif // _CONTAINER_DEBUG_LEVEL > 0
+    }
+
+    template <class _OtherIndexType, size_t _Size, size_t... _Indices>
+        requires is_convertible_v<const _OtherIndexType&, index_type>
+              && is_nothrow_constructible_v<index_type, const _OtherIndexType&> && (_Size != _Rank_dynamic)
+    constexpr explicit extents(span<_OtherIndexType, _Size> _Mixed_exts, index_sequence<_Indices...>) noexcept
+        : _Base{static_cast<index_type>(_STD as_const(_Mixed_exts[_Dynamic_indices_inv[_Indices]]))...} {
+#if _CONTAINER_DEBUG_LEVEL > 0
+        if constexpr (_Is_standard_integer<_OtherIndexType>) {
+            for (rank_type _Idx = 0; _Idx < _Rank; ++_Idx) {
+                _STL_VERIFY(
+                    _Static_extents[_Idx] == dynamic_extent || _STD cmp_equal(_Static_extents[_Idx], _Mixed_exts[_Idx]),
+                    "Value of exts[r] must be equal to extent(r) for each r for which extent(r) is a static extent "
+                    "(N4950 [mdspan.extents.cons]/10.1)");
+                _STL_VERIFY(_Mixed_exts[_Idx] >= 0 && _STD in_range<index_type>(_Mixed_exts[_Idx]),
+                    "Either N must be zero or exts[r] must be nonnegative and must be representable as value of type "
+                    "index_type for every rank index r (N4950 [mdspan.extents.cons]/10.2)");
+            }
+        }
+#endif // _CONTAINER_DEBUG_LEVEL > 0
+    }
 
 public:
     _NODISCARD static constexpr rank_type rank() noexcept {
@@ -130,29 +208,6 @@ public:
 
     constexpr extents() noexcept = default;
 
-    template <class _OtherIndexType, size_t... _OtherExtents, size_t... _Indices>
-        requires (sizeof...(_OtherExtents) == rank())
-              && ((_OtherExtents == dynamic_extent || _Extents == dynamic_extent || _OtherExtents == _Extents) && ...)
-    constexpr explicit extents(
-        const extents<_OtherIndexType, _OtherExtents...>& _Other, index_sequence<_Indices...>) noexcept
-        : _Base{static_cast<index_type>(_Other.extent(_Dynamic_indices_inv[_Indices]))...} {
-#if _CONTAINER_DEBUG_LEVEL > 0
-        if constexpr (rank() > 0) {
-            for (rank_type _Idx = 0; _Idx < _Rank; ++_Idx) {
-                if constexpr (rank() != rank_dynamic()) {
-                    _STL_VERIFY(_Static_extents[_Idx] == dynamic_extent
-                                    || _STD cmp_equal(_Static_extents[_Idx], _Other.extent(_Idx)),
-                        "Value of other.extent(r) must be equal to extent(r) for each r for which extent(r) is a "
-                        "static extent (N4950 [mdspan.extents.cons]/2.1)");
-                }
-                _STL_VERIFY(_STD in_range<index_type>(_Other.extent(_Idx)),
-                    "Value of other.extent(r) must be representable as a value of type index_type for every rank index "
-                    "r (N4950 [mdspan.extents.cons]/2.2)");
-            }
-        }
-#endif // _CONTAINER_DEBUG_LEVEL > 0
-    }
-
     template <class _OtherIndexType, size_t... _OtherExtents>
         requires (sizeof...(_OtherExtents) == rank())
               && ((_OtherExtents == dynamic_extent || _Extents == dynamic_extent || _OtherExtents == _Extents) && ...)
@@ -160,27 +215,6 @@ public:
                        || (numeric_limits<index_type>::max)() < (numeric_limits<_OtherIndexType>::max)())
         extents(const extents<_OtherIndexType, _OtherExtents...>& _Other) noexcept
         : extents(_Other, make_index_sequence<rank_dynamic()>{}) {}
-
-    template <class _ExtsTuple, size_t... _Indices>
-        requires (tuple_size_v<_ExtsTuple> == rank_dynamic())
-    constexpr explicit extents(_Construct_from_tuple, _ExtsTuple _Tpl, index_sequence<_Indices...>) noexcept
-        : _Base{static_cast<index_type>(_STD move(_STD get<_Indices>(_Tpl)))...} {}
-
-    template <class _ExtsTuple, size_t... _DynIndices>
-        requires (tuple_size_v<_ExtsTuple> != rank_dynamic())
-    constexpr explicit extents(_Construct_from_tuple, _ExtsTuple _Tpl, index_sequence<_DynIndices...>) noexcept
-        : _Base{static_cast<index_type>(_STD move(_STD get<_Dynamic_indices_inv[_DynIndices]>(_Tpl)))...} {
-#if _CONTAINER_DEBUG_LEVEL > 0
-        [&]<size_t... _MixedIndices>(index_sequence<_MixedIndices...>) {
-            _STL_VERIFY(((_Static_extents[_MixedIndices] == dynamic_extent
-                             || _STD cmp_equal(_Static_extents[_MixedIndices],
-                                 static_cast<index_type>(_STD move(_STD get<_MixedIndices>(_Tpl)))))
-                            && ...),
-                "Value of exts_arr[r] must be equal to extent(r) for each r for which extent(r) is a static extent "
-                "(N4950 [mdspan.extents.cons]/7.1)");
-        }(make_index_sequence<rank()>{});
-#endif // _CONTAINER_DEBUG_LEVEL > 0
-    }
 
     template <class... _OtherIndexTypes>
         requires (is_convertible_v<_OtherIndexTypes, index_type> && ...)
@@ -202,40 +236,6 @@ public:
         _STL_VERIFY((_Check_extent(_Exts) && ...),
             "Either sizeof...(exts) must be equal to 0 or each element of exts must be nonnegative and must be "
             "representable as value of type index_type (N4950 [mdspan.extents.cons]/7.2)");
-#endif // _CONTAINER_DEBUG_LEVEL > 0
-    }
-
-    template <class _OtherIndexType, size_t _Size, size_t... _Indices>
-        requires is_convertible_v<const _OtherIndexType&, index_type>
-              && is_nothrow_constructible_v<index_type, const _OtherIndexType&> && (_Size == rank_dynamic())
-    constexpr explicit extents(span<_OtherIndexType, _Size> _Dynamic_exts, index_sequence<_Indices...>) noexcept
-        : _Base{static_cast<index_type>(_STD as_const(_Dynamic_exts[_Indices]))...} {
-#if _CONTAINER_DEBUG_LEVEL > 0
-        if constexpr (_Is_standard_integer<_OtherIndexType> && _Size != 0) {
-            _STL_VERIFY(((_Dynamic_exts[_Indices] >= 0 && _STD in_range<index_type>(_Dynamic_exts[_Indices])) && ...),
-                "Either N must be zero or exts[r] must be nonnegative and must be representable as value of type "
-                "index_type for every rank index r (N4950 [mdspan.extents.cons]/10.2)");
-        }
-#endif // _CONTAINER_DEBUG_LEVEL > 0
-    }
-
-    template <class _OtherIndexType, size_t _Size, size_t... _Indices>
-        requires is_convertible_v<const _OtherIndexType&, index_type>
-              && is_nothrow_constructible_v<index_type, const _OtherIndexType&> && (_Size != rank_dynamic())
-    constexpr explicit extents(span<_OtherIndexType, _Size> _Mixed_exts, index_sequence<_Indices...>) noexcept
-        : _Base{static_cast<index_type>(_STD as_const(_Mixed_exts[_Dynamic_indices_inv[_Indices]]))...} {
-#if _CONTAINER_DEBUG_LEVEL > 0
-        if constexpr (_Is_standard_integer<_OtherIndexType>) {
-            for (rank_type _Idx = 0; _Idx < _Rank; ++_Idx) {
-                _STL_VERIFY(
-                    _Static_extents[_Idx] == dynamic_extent || _STD cmp_equal(_Static_extents[_Idx], _Mixed_exts[_Idx]),
-                    "Value of exts[r] must be equal to extent(r) for each r for which extent(r) is a static extent "
-                    "(N4950 [mdspan.extents.cons]/10.1)");
-                _STL_VERIFY(_Mixed_exts[_Idx] >= 0 && _STD in_range<index_type>(_Mixed_exts[_Idx]),
-                    "Either N must be zero or exts[r] must be nonnegative and must be representable as value of type "
-                    "index_type for every rank index r (N4950 [mdspan.extents.cons]/10.2)");
-            }
-        }
 #endif // _CONTAINER_DEBUG_LEVEL > 0
     }
 

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1239,7 +1239,9 @@ public:
         requires is_constructible_v<mapping_type, const extents_type&> && is_default_constructible_v<accessor_type>
         : _Mapping_base(_Exts), _Accessor_base(), _Ptr(_STD move(_Ptr_)) {}
 
-    constexpr mdspan(data_handle_type _Ptr_, const mapping_type& _Map_)
+    constexpr mdspan(data_handle_type _Ptr_, const mapping_type& _Map_) noexcept(
+        is_nothrow_move_constructible_v<data_handle_type>&& is_nothrow_copy_constructible_v<mapping_type>&&
+            is_nothrow_default_constructible_v<accessor_type>) // strengthened
         requires is_default_constructible_v<accessor_type>
         : _Mapping_base(_Map_), _Accessor_base(), _Ptr(_STD move(_Ptr_)) {}
 

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1256,7 +1256,11 @@ public:
     constexpr explicit(
         !is_convertible_v<const typename _OtherLayoutPolicy::template mapping<_OtherExtents>&, mapping_type>
         || !is_convertible_v<const _OtherAccessor&, accessor_type>)
-        mdspan(const mdspan<_OtherElementType, _OtherExtents, _OtherLayoutPolicy, _OtherAccessor>& _Other)
+        mdspan(const mdspan<_OtherElementType, _OtherExtents, _OtherLayoutPolicy, _OtherAccessor>& _Other) noexcept(
+            is_nothrow_constructible_v<data_handle_type, const typename _OtherAccessor::data_handle_type&>&&
+                is_nothrow_constructible_v<mapping_type,
+                    const typename _OtherLayoutPolicy::template mapping<_OtherExtents>&>&&
+                    is_nothrow_constructible_v<accessor_type, const _OtherAccessor&>) // strengthened
         : _Mapping_base(_Other.mapping()), _Accessor_base(_Other.accessor()), _Ptr(_Other.data_handle()) {
         static_assert(is_constructible_v<data_handle_type, const typename _OtherAccessor::data_handle_type&>,
             "The data_handle_type must be constructible from const typename OtherAccessor::data_handle_type& (N4950 "

--- a/tests/std/include/test_mdspan_support.hpp
+++ b/tests/std/include/test_mdspan_support.hpp
@@ -229,9 +229,9 @@ constexpr void check_members_with_various_extents(Fn&& fn) {
     details::check_members_with_various_extents_impl(std::forward<Fn>(fn), std::make_index_sequence<2>{});
     details::check_members_with_various_extents_impl(std::forward<Fn>(fn), std::make_index_sequence<4>{});
     details::check_members_with_various_extents_impl(std::forward<Fn>(fn), std::make_index_sequence<8>{});
-#ifndef _PREFAST_
-    details::check_members_with_various_extents_impl(std::forward<Fn>(fn), std::make_index_sequence<16>{});
-#endif // _PREFAST_
+    if (!std::is_constant_evaluated()) {
+        details::check_members_with_various_extents_impl(std::forward<Fn>(fn), std::make_index_sequence<16>{});
+    }
 }
 
 namespace details {

--- a/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
@@ -39,4 +39,4 @@
 
 #if empty_bases != 6
 #error bad macro expansion
-#endif // noop_dtor != 6
+#endif // empty_bases != 6

--- a/tests/std/tests/P0009R18_mdspan_extents_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_extents_death/test.cpp
@@ -55,7 +55,7 @@ void test_construction_from_pack_with_unrepresentable_as_index_type_values_2() {
 }
 
 void test_construction_from_pack_with_unrepresentable_as_index_type_values_3() {
-    static_assert(signed_integral<char>, "char is not signed integral");
+    static_assert(signed_integral<char>, "This test assumes that it isn't being compiled with /J");
     // Either sizeof...(exts) must be equal to 0 or each element of exts must be nonnegative and must be representable
     // as value of type index_type
     [[maybe_unused]] extents<signed char, 1, dynamic_extent> e{static_cast<char>(-1)};

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -84,9 +84,6 @@ constexpr void check_members(const extents<IndexType, Extents...>& ext, index_se
         // Other tests are defined in 'check_construction_from_other_right_mapping' function
     }
 
-#ifdef __clang__
-    if (!is_constant_evaluated()) // FIXME clang hits constexpr limit here
-#endif
     { // Check construction from layout_stride::mapping
         array<IndexType, Ext::rank()> strides{};
         if constexpr (Ext::rank() > 0) {
@@ -423,10 +420,6 @@ constexpr void check_correctness() {
 #endif // ^^^ !defined(__cpp_multidimensional_subscript) ^^^
     }
 
-
-#ifdef __clang__
-    if (!is_constant_evaluated()) // FIXME clang hits constexpr limit here
-#endif
     { // 3x2 matrix with column-major order
         const array values{0, 1, 2, 3, 4, 5};
         mdspan<const int, extents<int, 3, 2>, layout_left> matrix{values.data()};
@@ -448,9 +441,6 @@ constexpr void check_correctness() {
 #endif // ^^^ !defined(__cpp_multidimensional_subscript) ^^^
     }
 
-#ifdef __clang__
-    if (!is_constant_evaluated()) // FIXME clang hits constexpr limit here
-#endif
     { // 3x2x4 tensor
         const array values{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
         mdspan<const int, dextents<size_t, 3>, layout_left> tensor{values.data(), 3, 2, 4};
@@ -472,9 +462,6 @@ constexpr void check_correctness() {
 #endif // ^^^ !defined(__cpp_multidimensional_subscript) ^^^
     }
 
-#ifdef __clang__
-    if (!is_constant_evaluated()) // FIXME clang hits constexpr limit here
-#endif
     { // 2x3x2x3 tensor
         const array values{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
             26, 27, 28, 29, 30, 31, 32, 33, 34, 35};

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -261,14 +261,14 @@ constexpr void check_construction_from_other_right_mapping() {
 
 constexpr void check_construction_from_other_stride_mapping() {
     { // Check construction from layout_stride::mapping<E> with various values of E::rank()
-        static_assert(
-            is_constructible_v<layout_left::mapping<dextents<int, 0>>, layout_stride::mapping<dextents<int, 0>>>);
-        static_assert(
-            is_constructible_v<layout_left::mapping<dextents<int, 1>>, layout_stride::mapping<dextents<int, 1>>>);
-        static_assert(
-            is_constructible_v<layout_left::mapping<dextents<int, 2>>, layout_stride::mapping<dextents<int, 2>>>);
-        static_assert(
-            is_constructible_v<layout_left::mapping<dextents<int, 3>>, layout_stride::mapping<dextents<int, 3>>>);
+        static_assert(is_nothrow_constructible_v<layout_left::mapping<dextents<int, 0>>,
+            layout_stride::mapping<dextents<int, 0>>>); // strengthened
+        static_assert(is_nothrow_constructible_v<layout_left::mapping<dextents<int, 1>>,
+            layout_stride::mapping<dextents<int, 1>>>); // strengthened
+        static_assert(is_nothrow_constructible_v<layout_left::mapping<dextents<int, 2>>,
+            layout_stride::mapping<dextents<int, 2>>>); // strengthened
+        static_assert(is_nothrow_constructible_v<layout_left::mapping<dextents<int, 3>>,
+            layout_stride::mapping<dextents<int, 3>>>); // strengthened
     }
 
     { // Check construction from layout_stride::mapping<E> when E is invalid

--- a/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
@@ -33,9 +33,6 @@ constexpr void check_members(const extents<IndexType, Extents...>& ext, index_se
     static_assert(same_as<typename Mapping::rank_type, typename Ext::rank_type>);
     static_assert(same_as<typename Mapping::layout_type, layout_right>);
 
-#ifdef __clang__
-    if (!is_constant_evaluated()) // FIXME clang hits constexpr limit here
-#endif
     { // Check default and copy constructor
         const Mapping m;
         Mapping cpy = m;
@@ -63,9 +60,6 @@ constexpr void check_members(const extents<IndexType, Extents...>& ext, index_se
     using Ext2           = extents<OtherIndexType, Extents...>;
     using Mapping2       = layout_right::mapping<Ext2>;
 
-#ifdef __clang__
-    if (!is_constant_evaluated()) // FIXME clang hits constexpr limit here
-#endif
     { // Check construction from other layout_right::mapping
         Mapping m1{ext};
         Mapping2 m2{m1};

--- a/tests/std/tests/P0009R18_mdspan_layout_stride_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride_death/test.cpp
@@ -15,7 +15,7 @@ using namespace std;
 
 void test_default_construction() {
     using Ext = extents<signed char, dynamic_extent, 4, 5, 7>;
-    // Value of layout_right::mapping<extents_type>().required_span_size() must be
+    // Value of layout_stride::mapping<extents_type>().required_span_size() must be
     // representable as a value of type index_type
     [[maybe_unused]] layout_stride::mapping<Ext> m{}; // NB: strides are [140, 35, 7, 1]
 }

--- a/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
@@ -907,6 +907,11 @@ constexpr void check_multidimensional_subscript_operator() {
         assert(r1);
         same_as<vector<bool>::reference> decltype(auto) r2 = as_const(mds)[0, 1];
         assert(!r2);
+
+#ifndef __clang__ // TRANSITION, Clang 17
+        static_assert(noexcept(mds[1, 1])); // strengthened
+        static_assert(noexcept(as_const(mds)[0, 1])); // strengthened
+#endif // __clang__
     }
 
     { // Check that indices are moved and then casted to 'index_type'

--- a/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
@@ -787,8 +787,8 @@ constexpr void check_data_handle_and_mapping_and_accessor_constructor() {
 constexpr void check_construction_from_other_mdspan() {
     { // Check constraint: 'is_constructible_v<mapping_type, const OtherLayoutPolicy::template
       // mapping<OtherExtents>&>'
-        static_assert(is_constructible_v<mdspan<int, extents<int, 4, 4, 4>, layout_stride>,
-            mdspan<int, dextents<long, 3>, layout_right>>);
+        static_assert(is_nothrow_constructible_v<mdspan<int, extents<int, 4, 4, 4>, layout_stride>,
+            mdspan<int, dextents<long, 3>, layout_right>>); // strengthened
         static_assert(!is_constructible_v<mdspan<float, dextents<long long, 2>, layout_left>,
                       mdspan<float, extents<signed char, 3, 3>, layout_right>>);
         static_assert(!is_constructible_v<mdspan<double, dextents<unsigned int, 2>, layout_left>,
@@ -797,8 +797,9 @@ constexpr void check_construction_from_other_mdspan() {
 
     { // Check constraint: 'is_constructible_v<accessor_type, const OtherAccessor&>'
         using Ext = extents<long, 8, 8, 8>;
-        static_assert(is_constructible_v<mdspan<const double, Ext, layout_right, default_accessor<const double>>,
-            mdspan<double, Ext, layout_right, default_accessor<double>>>);
+        static_assert(
+            is_nothrow_constructible_v<mdspan<const double, Ext, layout_right, default_accessor<const double>>,
+                mdspan<double, Ext, layout_right, default_accessor<double>>>); // strengthened
         static_assert(!is_constructible_v<mdspan<const double, Ext, layout_right, TrivialAccessor<const double>>,
                       mdspan<double, Ext, layout_right, TrivialAccessor<double>>>);
     }

--- a/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
@@ -456,36 +456,40 @@ constexpr void check_defaulted_copy_and_move_constructors() {
 constexpr void check_data_handle_and_indices_pack_constructor() {
     { // Check constraint: '(is_convertible_v<OtherIndexTypes, index_type> && ...)'
         using Mds = mdspan<const int, dextents<long long, 3>>;
-        static_assert(is_constructible_v<Mds, int*, signed char, short, int>);
-        static_assert(is_constructible_v<Mds, int*, long, long long, unsigned char>);
-        static_assert(is_constructible_v<Mds, const int*, unsigned short, unsigned int, unsigned long>);
-        static_assert(is_constructible_v<Mds, const int*, unsigned long long, int, ConvertibleToInt<int>>);
+        static_assert(is_nothrow_constructible_v<Mds, int*, signed char, short, int>); // strengthened
+        static_assert(is_nothrow_constructible_v<Mds, int*, long, long long, unsigned char>); // strengthened
+        static_assert(
+            is_nothrow_constructible_v<Mds, const int*, unsigned short, unsigned int, unsigned long>); // strengthened
+        static_assert(is_nothrow_constructible_v<Mds, const int*, unsigned long long, int,
+            ConvertibleToInt<int>>); // strengthened
         static_assert(!is_constructible_v<Mds, const int*, unsigned long long, int, NonConvertibleToAnything>);
     }
 
     { // Check constraint: '(is_nothrow_constructible<index_type, OtherIndexTypes> && ...)'
         using Mds = mdspan<double, dextents<int, 2>>;
-        static_assert(is_constructible_v<Mds, double*, size_t, ConvertibleToInt<ptrdiff_t, IsNothrow::yes>>);
+        static_assert(is_nothrow_constructible_v<Mds, double*, size_t,
+            ConvertibleToInt<ptrdiff_t, IsNothrow::yes>>); // strengthened
         static_assert(!is_constructible_v<Mds, double*, size_t, ConvertibleToInt<ptrdiff_t, IsNothrow::no>>);
     }
 
     { // Check constraint: 'N == rank() || N == rank_dynamic()'
         using Mds = mdspan<int*, extents<short, 2, 3, dynamic_extent, dynamic_extent>>;
         static_assert(!is_constructible_v<Mds, int**, int>);
-        static_assert(is_constructible_v<Mds, int**, int, int>);
+        static_assert(is_nothrow_constructible_v<Mds, int**, int, int>); // strengthened
         static_assert(!is_constructible_v<Mds, int** const, int, int, int>);
-        static_assert(is_constructible_v<Mds, int** const, int, int, int, int>);
+        static_assert(is_nothrow_constructible_v<Mds, int** const, int, int, int, int>); // strengthened
     }
 
     { // Check constraint: 'is_constructible_v<mapping_type, extents_type>'
-        static_assert(is_constructible_v<mdspan<const int, dextents<int, 2>, layout_left>, int* const, int, int>);
+        static_assert(is_nothrow_constructible_v<mdspan<const int, dextents<int, 2>, layout_left>, int* const, int,
+            int>); // strengthened
         static_assert(!is_constructible_v<mdspan<int, dextents<int, 2>, layout_stride>, int*, int, int>);
         static_assert(!is_constructible_v<mdspan<int, extents<int, 4, 4>, TrackingLayout<>>, int*, int, int>);
     }
 
     { // Check constraint: 'is_default_constructible_v<accessor_type>'
-        static_assert(is_constructible_v<mdspan<bool, dextents<int, 2>, layout_right, VectorBoolAccessor>,
-            vector<bool>::iterator, int, int>);
+        static_assert(is_nothrow_constructible_v<mdspan<bool, dextents<int, 2>, layout_right, VectorBoolAccessor>,
+            vector<bool>::iterator, int, int>); // strengthened
         static_assert(
             !is_constructible_v<mdspan<int, dextents<int, 2>, layout_right, TrackingAccessor<int>>, int*, int, int>);
     }

--- a/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
@@ -542,18 +542,20 @@ constexpr void check_data_handle_and_indices_pack_constructor() {
 constexpr void check_data_handle_and_span_array_constructors() {
     { // Check constraint: 'is_convertible_v<const OtherIndexType&, index_type>'
         using Mds = mdspan<const int, dextents<long long, 3>>;
-        static_assert(is_constructible_v<Mds, int*, span<int, 3>>);
-        static_assert(is_constructible_v<Mds, int*, array<int, 3>>);
-        static_assert(is_constructible_v<Mds, const int*, span<ConvertibleToInt<short>, 3>>);
-        static_assert(is_constructible_v<Mds, const int*, array<ConvertibleToInt<short>, 3>>);
+        static_assert(is_nothrow_constructible_v<Mds, int*, span<int, 3>>); // strengthened
+        static_assert(is_nothrow_constructible_v<Mds, int*, array<int, 3>>); // strengthened
+        static_assert(is_nothrow_constructible_v<Mds, const int*, span<ConvertibleToInt<short>, 3>>); // strengthened
+        static_assert(is_nothrow_constructible_v<Mds, const int*, array<ConvertibleToInt<short>, 3>>); // strengthened
         static_assert(!is_constructible_v<Mds, const int*, span<NonConvertibleToAnything, 3>>);
         static_assert(!is_constructible_v<Mds, const int*, array<NonConvertibleToAnything, 3>>);
     }
 
     { // Check constraint: 'is_nothrow_constructible<index_type, OtherIndexTypes>'
         using Mds = mdspan<double, dextents<int, 2>>;
-        static_assert(is_constructible_v<Mds, double*, span<ConvertibleToInt<ptrdiff_t, IsNothrow::yes>, 2>>);
-        static_assert(is_constructible_v<Mds, double*, array<ConvertibleToInt<ptrdiff_t, IsNothrow::yes>, 2>>);
+        static_assert(is_nothrow_constructible_v<Mds, double*,
+            span<ConvertibleToInt<ptrdiff_t, IsNothrow::yes>, 2>>); // strengthened
+        static_assert(is_nothrow_constructible_v<Mds, double*,
+            array<ConvertibleToInt<ptrdiff_t, IsNothrow::yes>, 2>>); // strengthened
         static_assert(!is_constructible_v<Mds, double*, span<ConvertibleToInt<ptrdiff_t, IsNothrow::no>, 2>>);
         static_assert(!is_constructible_v<Mds, double*, array<ConvertibleToInt<ptrdiff_t, IsNothrow::no>, 2>>);
     }
@@ -562,23 +564,31 @@ constexpr void check_data_handle_and_span_array_constructors() {
         using Mds = mdspan<int*, extents<short, 2, 3, dynamic_extent, dynamic_extent>>;
         static_assert(!is_constructible_v<Mds, int**, span<int, 1>>);
         static_assert(!is_constructible_v<Mds, int**, array<int, 1>>);
-        static_assert(is_constructible_v<Mds, int**, span<int, 2>>);
-        static_assert(is_constructible_v<Mds, int**, array<int, 2>>);
+        static_assert(is_nothrow_constructible_v<Mds, int**, span<int, 2>>); // strengthened
+        static_assert(is_nothrow_constructible_v<Mds, int**, array<int, 2>>); // strengthened
         static_assert(!is_constructible_v<Mds, int**, span<int, 3>>);
         static_assert(!is_constructible_v<Mds, int**, array<int, 3>>);
-        static_assert(is_constructible_v<Mds, int**, span<int, 4>>);
-        static_assert(is_constructible_v<Mds, int**, array<int, 4>>);
+        static_assert(is_nothrow_constructible_v<Mds, int**, span<int, 4>>); // strengthened
+        static_assert(is_nothrow_constructible_v<Mds, int**, array<int, 4>>); // strengthened
     }
 
     { // Check constraint: 'is_constructible_v<mapping_type, extents_type>'
-        static_assert(is_constructible_v<mdspan<const int, dextents<int, 2>, layout_left>, int* const, span<int, 2>>);
-        static_assert(is_constructible_v<mdspan<const int, dextents<int, 2>, layout_left>, int* const, array<int, 2>>);
+        static_assert(is_nothrow_constructible_v<mdspan<const int, dextents<int, 2>, layout_left>, int* const,
+            span<int, 2>>); // strengthened
+        static_assert(is_nothrow_constructible_v<mdspan<const int, dextents<int, 2>, layout_left>, int* const,
+            array<int, 2>>); // strengthened
         static_assert(
             is_constructible_v<mdspan<const int, dextents<int, 2>, TrackingLayout<layout_left, RequireId::no>>,
                 int* const, span<int, 2>>);
         static_assert(
+            !is_nothrow_constructible_v<mdspan<const int, dextents<int, 2>, TrackingLayout<layout_left, RequireId::no>>,
+                int* const, span<int, 2>>); // strengthened
+        static_assert(
             is_constructible_v<mdspan<const int, dextents<int, 2>, TrackingLayout<layout_left, RequireId::no>>,
                 int* const, array<int, 2>>);
+        static_assert(
+            !is_nothrow_constructible_v<mdspan<const int, dextents<int, 2>, TrackingLayout<layout_left, RequireId::no>>,
+                int* const, array<int, 2>>); // strengthened
         static_assert(!is_constructible_v<mdspan<int, dextents<int, 2>, layout_stride>, int*, span<int, 2>>);
         static_assert(!is_constructible_v<mdspan<int, dextents<int, 2>, layout_stride>, int*, array<int, 2>>);
         static_assert(!is_constructible_v<mdspan<int, dextents<int, 2>, TrackingLayout<>>, int*, span<int, 2>>);
@@ -586,10 +596,10 @@ constexpr void check_data_handle_and_span_array_constructors() {
     }
 
     { // Check constraint: 'is_default_constructible_v<accessor_type>'
-        static_assert(is_constructible_v<mdspan<bool, dextents<int, 2>, layout_right, VectorBoolAccessor>,
-            vector<bool>::iterator, span<short, 2>>);
-        static_assert(is_constructible_v<mdspan<bool, dextents<int, 2>, layout_right, VectorBoolAccessor>,
-            vector<bool>::iterator, array<short, 2>>);
+        static_assert(is_nothrow_constructible_v<mdspan<bool, dextents<int, 2>, layout_right, VectorBoolAccessor>,
+            vector<bool>::iterator, span<short, 2>>); // strengthened
+        static_assert(is_nothrow_constructible_v<mdspan<bool, dextents<int, 2>, layout_right, VectorBoolAccessor>,
+            vector<bool>::iterator, array<short, 2>>); // strengthened
         static_assert(!is_constructible_v<mdspan<int, dextents<int, 2>, layout_right, TrackingAccessor<int>>, int*,
                       span<int, 2>>);
         static_assert(!is_constructible_v<mdspan<int, dextents<int, 2>, layout_right, TrackingAccessor<int>>, int*,

--- a/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
@@ -1369,7 +1369,7 @@ constexpr void check_deduction_guides() {
 }
 
 // When
-// * 'Mds::accessor_type' is specialization of 'default_accesor', and
+// * 'Mds::accessor_type' is a specialization of 'default_accessor', and
 // * 'Mds::layout_type' is
 //   * 'layout_left' or 'layout_right' and 'Mds::extents_type::rank_dynamic() == 0', or
 //   * 'layout_stride' and 'Mds::extents_type::rank() == 0'

--- a/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
@@ -673,18 +673,20 @@ constexpr void check_data_handle_and_span_array_constructors() {
 
 constexpr void check_data_handle_and_extents_constructor() {
     { // Check constraint: 'is_constructible_v<mapping_type, const extents_type&>'
-        static_assert(is_constructible_v<mdspan<int, dextents<int, 3>>, int*, dextents<int, 3>>);
-        static_assert(is_constructible_v<mdspan<int, dextents<int, 3>>, int*, dextents<long, 3>>);
+        static_assert(
+            is_nothrow_constructible_v<mdspan<int, dextents<int, 3>>, int*, dextents<int, 3>>); // strengthened
+        static_assert(
+            is_nothrow_constructible_v<mdspan<int, dextents<int, 3>>, int*, dextents<long, 3>>); // strengthened
         static_assert(!is_constructible_v<mdspan<int, dextents<int, 3>, layout_stride>, int*, dextents<int, 3>>);
         static_assert(!is_constructible_v<mdspan<int, dextents<int, 3>>, int*, dextents<int, 2>>);
         static_assert(!is_constructible_v<mdspan<int, extents<int, 3, 3>>, int*, extents<long, 3, 2>>);
     }
 
     { // Check constraint: is_default_constructible_v<accessor_type>
-        static_assert(is_constructible_v<mdspan<bool, dextents<int, 2>, layout_right, VectorBoolAccessor>,
-            vector<bool>::iterator, dextents<short, 2>>);
-        static_assert(is_constructible_v<mdspan<bool, dextents<int, 2>, layout_right, VectorBoolAccessor>,
-            vector<bool>::iterator, extents<long, 3, 3>>);
+        static_assert(is_nothrow_constructible_v<mdspan<bool, dextents<int, 2>, layout_right, VectorBoolAccessor>,
+            vector<bool>::iterator, dextents<short, 2>>); // strengthened
+        static_assert(is_nothrow_constructible_v<mdspan<bool, dextents<int, 2>, layout_right, VectorBoolAccessor>,
+            vector<bool>::iterator, extents<long, 3, 3>>); // strengthened
         static_assert(!is_constructible_v<mdspan<int, dextents<int, 2>, layout_right, TrackingAccessor<int>>, int*,
                       dextents<signed char, 2>>);
         static_assert(!is_constructible_v<mdspan<int, dextents<int, 2>, layout_right, TrackingAccessor<int>>, int*,

--- a/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
@@ -397,13 +397,14 @@ constexpr void check_observers() {
 
 constexpr void check_default_constructor() {
     { // Check constraint: 'rank_dynamic() > 0'
-        static_assert(is_default_constructible_v<mdspan<const int, dextents<int, 1>>>);
+        static_assert(is_nothrow_default_constructible_v<mdspan<const int, dextents<int, 1>>>); // strengthened
         static_assert(!is_default_constructible_v<mdspan<const int, extents<int, 3>>>);
         static_assert(!is_default_constructible_v<mdspan<const int, extents<int>>>);
     }
 
     { // Check constraints: 'is_default_constructible_v<data_handle_type>'
-        static_assert(is_default_constructible_v<mdspan<bool, dextents<int, 2>, layout_right, VectorBoolAccessor>>);
+        static_assert(is_nothrow_default_constructible_v<
+            mdspan<bool, dextents<int, 2>, layout_right, VectorBoolAccessor>>); // strengthened
         static_assert(
             !is_default_constructible_v<mdspan<bool, dextents<int, 2>, layout_right, TrackingAccessor<bool>>>);
     }
@@ -414,8 +415,8 @@ constexpr void check_default_constructor() {
     }
 
     { // Check constraint: 'is_default_constructible_v<accessor_type>'
-        static_assert(is_default_constructible_v<
-            mdspan<float, dextents<int, 2>, layout_right, AccessorWithCustomOffsetPolicy<float>>>);
+        static_assert(is_nothrow_default_constructible_v<
+            mdspan<float, dextents<int, 2>, layout_right, AccessorWithCustomOffsetPolicy<float>>>); // strengthened
         static_assert(
             !is_default_constructible_v<mdspan<float, dextents<int, 2>, layout_right, TrackingAccessor<float>>>);
     }

--- a/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
@@ -716,10 +716,10 @@ constexpr void check_data_handle_and_extents_constructor() {
 
 constexpr void check_data_handle_and_mapping_constructor() {
     { // Check constraint: 'is_default_constructible_v<accessor_type>'
-        static_assert(is_constructible_v<mdspan<bool, dextents<int, 4>, layout_left, VectorBoolAccessor>,
-            vector<bool>::iterator, layout_left::mapping<dextents<short, 4>>>);
-        static_assert(is_constructible_v<mdspan<int, extents<short, 2, 2>, layout_left>, int* const,
-            layout_left::mapping<extents<short, 2, 2>>>);
+        static_assert(is_nothrow_constructible_v<mdspan<bool, dextents<int, 4>, layout_left, VectorBoolAccessor>,
+            vector<bool>::iterator, layout_left::mapping<dextents<short, 4>>>); // strengthened
+        static_assert(is_nothrow_constructible_v<mdspan<int, extents<short, 2, 2>, layout_left>, int* const,
+            layout_left::mapping<extents<short, 2, 2>>>); // strengthened
         static_assert(!is_constructible_v<
                       mdspan<vector<int>, extents<long, 5, 5>, TrackingLayout<>, TrackingAccessor<vector<int>>>,
                       vector<int>*, TrackingLayout<>::mapping<extents<long, 5, 5>>>);

--- a/tests/std/tests/P0009R18_mdspan_mdspan_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan_death/test.cpp
@@ -13,7 +13,7 @@ using namespace std;
 constexpr array<int, 256> some_ints{};
 
 void test_construction_from_other_mdspan() {
-    auto mds1 = mdspan{some_ints.data(), 8, 2, 8};
+    mdspan mds1{some_ints.data(), 8, 2, 8};
     // For each rank index r of extents_type, static_extent(r) == dynamic_extent || static_extent(r) == other.extent(r)
     // must be true
     [[maybe_unused]] mdspan<const int, extents<int, 8, 8, 2>> mds2{mds1};
@@ -21,26 +21,26 @@ void test_construction_from_other_mdspan() {
 
 #ifdef __cpp_multidimensional_subscript // TRANSITION, P2128R6
 void test_access_with_invalid_multidimensional_index_1() {
-    auto mds = mdspan{some_ints.data(), 4, 4};
+    mdspan mds{some_ints.data(), 4, 4};
     // I must be a multidimensional index in extents()
     (void) mds[3, 4];
 }
 #endif // __cpp_multidimensional_subscript
 
 void test_access_with_invalid_multidimensional_index_2() {
-    auto mds = mdspan{some_ints.data(), 5, 5};
+    mdspan mds{some_ints.data(), 5, 5};
     // I must be a multidimensional index in extents()
     (void) mds[array{4, 5}];
 }
 
 void test_size_when_index_type_is_signed() {
-    auto mds = mdspan{some_ints.data(), dextents<signed char, 3>{8, 8, 4}};
+    mdspan mds{some_ints.data(), dextents<signed char, 3>{8, 8, 4}};
     // The size of the multidimensional index space extents() must be representable as a value of type size_type
     (void) mds.size();
 }
 
 void test_size_when_index_type_is_unsigned() {
-    auto mds = mdspan{some_ints.data(), dextents<unsigned char, 3>{8, 8, 4}};
+    mdspan mds{some_ints.data(), dextents<unsigned char, 3>{8, 8, 4}};
     // The size of the multidimensional index space extents() must be representable as a value of type size_type
     (void) mds.size();
 }


### PR DESCRIPTION
* Privatize implementation-defined constructors,
* Strengthen various functions,
* Address comments from previous PRs:
  * https://github.com/microsoft/STL/pull/3829,
  * https://github.com/microsoft/STL/pull/3847,
* Add extra `_STL_INTERNAL_STATIC_ASSERT` in various places,
* Simplify `_Make_dynamic_indices_inv` and fix size of `_Dynamic_indices_inv` array,
* Make `check_members_with_various_extents` test less heavy.

After this PR `<mdspan>` will be ready for final review 😸