### PR TITLE
Status Chart: Fix error TS2590

### DIFF
--- a/.github/workflows/compile-typescript.yml
+++ b/.github/workflows/compile-typescript.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ">=20.0.0"
+          node-version: ">=20.4.0"
       - name: Install Packages
         run: |
           npm ci

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This branch generates the STL's [Status Chart][].
 
 ## Repo
 
-1. Install [Node.js][] 20.0.0 or newer.
+1. Install [Node.js][] 20.4.0 or newer.
     + You can accept all of the installer's default options.
 2. Open a new Command Prompt.
     + You can run `node --version` to verify that Node.js was successfully installed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@octokit/graphql": "^7.0.0",
         "@types/cli-progress": "^3.11.0",
         "@types/luxon": "^3.3.0",
-        "@types/node": "^20.4.0",
+        "@types/node": "^20.4.1",
         "@types/yargs": "^17.0.24",
         "chart.js": "^4.3.0",
         "chartjs-adapter-luxon": "^1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -361,24 +361,16 @@
       "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
     "node_modules/@octokit/endpoint": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-8.0.1.tgz",
-      "integrity": "sha512-tVviBdPuf3kcCiIvXYDJg7NAJrkTh8QEnc+UCybknKdEBCjIi7uQbFX3liQrpk1m5PjwC7fUJg08DYZ4F+l1RQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.0.tgz",
+      "integrity": "sha512-szrQhiqJ88gghWY2Htt8MqUDO6++E/EIXqJ2ZEp5ma3uGS46o7LZAzSLt49myB7rT+Hfw5Y6gO3LmOxGzHijAQ==",
       "dependencies": {
-        "@octokit/types": "^10.0.0",
+        "@octokit/types": "^11.0.0",
         "is-plain-object": "^5.0.0",
         "universal-user-agent": "^6.0.0"
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
-      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@octokit/graphql": {
@@ -400,12 +392,12 @@
       "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
     },
     "node_modules/@octokit/request": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.0.0.tgz",
-      "integrity": "sha512-q8u2rQokfN2xv6Qeg4Y8euvtkSLW9vA0mkcBUL/WdFoKPH/xg6EGGGt80FWmmrpge0pBnvEYgre1QYQubQT5Dg==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.0.4.tgz",
+      "integrity": "sha512-YZ1XeDRil4ejHKoBP8BgROgP4auOH5A9lLZH96l39GKKEmsKOccQxKP5M7m+Punblg1bFw8LrdeKIDwIzQ8afA==",
       "dependencies": {
-        "@octokit/endpoint": "^8.0.1",
-        "@octokit/request-error": "^4.0.1",
+        "@octokit/endpoint": "^9.0.0",
+        "@octokit/request-error": "^5.0.0",
         "@octokit/types": "^11.0.0",
         "is-plain-object": "^5.0.0",
         "universal-user-agent": "^6.0.0"
@@ -415,24 +407,16 @@
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-4.0.2.tgz",
-      "integrity": "sha512-uqwUEmZw3x4I9DGYq9fODVAAvcLsPQv97NRycP6syEFu5916M189VnNBW2zANNwqg3OiligNcAey7P0SET843w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.0.tgz",
+      "integrity": "sha512-1ue0DH0Lif5iEqT52+Rf/hf0RmGO9NWFjrzmrkArpG9trFfDM/efx00BJHdLGuro4BR/gECxCU2Twf5OKrRFsQ==",
       "dependencies": {
-        "@octokit/types": "^10.0.0",
+        "@octokit/types": "^11.0.0",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
-      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@octokit/types": {
@@ -457,9 +441,9 @@
       "integrity": "sha512-uKRI5QORDnrGFYgcdAVnHvEIvEZ8noTpP/Bg+HeUzZghwinDlIS87DEenV5r1YoOF9G4x600YsUXLWZ19rmTmg=="
     },
     "node_modules/@types/node": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.0.tgz",
-      "integrity": "sha512-jfT7iTf/4kOQ9S7CHV9BIyRaQqHu67mOjsIQBC3BKZvzvUB6zLxEwJ6sBE3ozcvP8kF6Uk5PXN0Q+c0dfhGX0g=="
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@octokit/graphql": "^7.0.0",
     "@types/cli-progress": "^3.11.0",
     "@types/luxon": "^3.3.0",
-    "@types/node": "^20.4.0",
+    "@types/node": "^20.4.1",
     "@types/yargs": "^17.0.24",
     "chart.js": "^4.3.0",
     "chartjs-adapter-luxon": "^1.3.1",

--- a/src_gather/gather_stats.ts
+++ b/src_gather/gather_stats.ts
@@ -570,7 +570,7 @@ export const daily_table: DailyRow[] = [
 
         str += `avg_age: ${row.avg_age.toFixed(2)}, `;
         str += `sum_age: ${row.sum_age.toFixed(2)}, `;
-        str += '},\n';
+        str += '} as DailyRow,\n';
     }
 
     str += '];\n';


### PR DESCRIPTION
The Status Chart's automated daily update started failing with "error TS2590: Expression produces a union type that is too complex to represent." This is because we've accumulated so many days of history that TypeScript's advanced type inference is reaching internal limits.

The fix is very simple. When generating our `DailyRow[]` table, add `as DailyRow` type assertions to each element. This avoids making TypeScript deduce what each element could be, because we already know what type we ultimately want.

This PR also contains unrelated housekeeping - minor dependency updates, and increasing the mentioned Node.js version to 20.4.0 (I've gone back and forth on this; I think we should be a bit more diligent about keeping this updated).

Finally, this contains a "DROP BEFORE MERGING" commit to make the live preview work, which will accumulate merge conflicts.

:chart_with_upwards_trend: Live preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)
===