### PR TITLE
Initialize array<T, 0>'s single element

### DIFF
--- a/stl/inc/array
+++ b/stl/inc/array
@@ -761,7 +761,7 @@ public:
 
     conditional_t<disjunction_v<is_default_constructible<_Ty>, _Is_implicitly_default_constructible<_Ty>>, _Ty,
         _Empty_array_element>
-        _Elems[1];
+        _Elems[1]{};
 
 private:
     [[noreturn]] static void _Xran() {

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -680,8 +680,9 @@ std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get
 std/containers/sequences/vector/vector.cons/assign_copy.pass.cpp FAIL
 
 # LIT's ADDITIONAL_COMPILE_FLAGS is problematic
-std/utilities/meta/meta.unary/dependent_return_type.compile.pass.cpp SKIPPED
+std/concepts/concepts.lang/concept.default.init/default_initializable.compile.pass.cpp:0 FAIL
 std/utilities/format/format.functions/escaped_output.ascii.pass.cpp SKIPPED
+std/utilities/meta/meta.unary/dependent_return_type.compile.pass.cpp SKIPPED
 std/utilities/variant/variant.variant/implicit_ctad.pass.cpp SKIPPED
 
 # libc++ speculatively implements LWG-3645
@@ -712,6 +713,9 @@ std/time/time.syn/formatter.year_month_weekday.pass.cpp:0 FAIL
 # unused-variable warning
 std/thread/thread.mutex/thread.lock/thread.lock.scoped/mutex.pass.cpp FAIL
 std/thread/thread.mutex/thread.mutex.requirements/thread.shared_mutex.requirements/thread.shared_mutex.class/default.pass.cpp:1 FAIL
+
+# This test assumes that array<int, 0> is not const-default-constructible.
+std/concepts/concepts.lang/concept.default.init/default_initializable.compile.pass.cpp:1 FAIL
 
 
 # *** LIKELY STL BUGS ***
@@ -978,7 +982,6 @@ std/algorithms/algorithms.results/in_found_result.pass.cpp:0 FAIL
 std/algorithms/algorithms.results/min_max_result.pass.cpp:0 FAIL
 std/algorithms/ranges_robust_against_dangling.pass.cpp FAIL
 std/algorithms/robust_against_proxy_iterators_lifetime_bugs.pass.cpp FAIL
-std/concepts/concepts.lang/concept.default.init/default_initializable.compile.pass.cpp:0 FAIL
 std/containers/sequences/deque/abi.compile.pass.cpp FAIL
 std/containers/sequences/vector.bool/construct_iter_iter.pass.cpp:0 FAIL
 std/containers/sequences/vector.bool/construct_iter_iter_alloc.pass.cpp:0 FAIL

--- a/tests/std/tests/Dev11_1074023_constexpr/test.cpp
+++ b/tests/std/tests/Dev11_1074023_constexpr/test.cpp
@@ -625,6 +625,11 @@ STATIC_ASSERT(arr0.size() == 0);
 STATIC_ASSERT(arr0.max_size() != 5);
 STATIC_ASSERT(arr0.empty() == true);
 
+// Also test DevCom-10299275, in which array<int, 0> was not a valid constant expression
+// since we didn't initialize the single element.
+constexpr array<int, 0> empty_array;
+STATIC_ASSERT(empty_array.size() == 0);
+
 constexpr istream_iterator<int> istream_it{};
 
 constexpr istreambuf_iterator<char> istreambuf_it{};

--- a/tests/tr1/tests/array/test.cpp
+++ b/tests/tr1/tests/array/test.cpp
@@ -8,13 +8,6 @@
 #include <array>
 #include <stdexcept>
 
-#define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
-
-// Also test DevCom-10299275, in which array<int, 0> was not a valid constant expression
-// since we didn't initialize the single element.
-constexpr STD array<int, 0> empty_array;
-STATIC_ASSERT(empty_array.size() == 0);
-
 void test_main() { // test header <array>
     STD array<int, 0> a0 = {};
 

--- a/tests/tr1/tests/array/test.cpp
+++ b/tests/tr1/tests/array/test.cpp
@@ -8,6 +8,13 @@
 #include <array>
 #include <stdexcept>
 
+#define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
+
+// Also test DevCom-10299275, in which array<int, 0> was not a valid constant expression
+// since we didn't initialize the single element.
+constexpr STD array<int, 0> empty_array;
+STATIC_ASSERT(empty_array.size() == 0);
+
 void test_main() { // test header <array>
     STD array<int, 0> a0 = {};
 


### PR DESCRIPTION
... which shouldn't even be there, but can't be removed because ABI.

Fixes DevCom-10299275 / VSO-1759562 / AB#1759562.

Notably this will fail with `T`'s that cannot be `{}`-initialized, e.g., types with explicit default constructors. We could work around that in C++17-and-later by initializing the array with `{T()}`, but I didn't want to obfuscate the code and I feel these two corner cases are incredibly unlikely to occur together.