### PR TITLE
Add `[[noreturn]]` for some functions

### DIFF
--- a/stl/src/cthread.cpp
+++ b/stl/src/cthread.cpp
@@ -42,7 +42,7 @@ namespace {
 _EXTERN_C
 
 // TRANSITION, ABI: _Thrd_exit() is preserved for binary compatibility
-_CRTIMP2_PURE void _Thrd_exit(int res) { // terminate execution of calling thread
+[[noreturn]] _CRTIMP2_PURE void _Thrd_exit(int res) { // terminate execution of calling thread
     _endthreadex(res);
 }
 

--- a/stl/src/mutex.cpp
+++ b/stl/src/mutex.cpp
@@ -13,7 +13,7 @@
 
 #include "primitives.hpp"
 
-[[noreturn]] extern "C" _CRTIMP2_PURE void _Thrd_abort(const char* msg) { // abort on precondition failure
+extern "C" [[noreturn]] _CRTIMP2_PURE void _Thrd_abort(const char* msg) { // abort on precondition failure
     fputs(msg, stderr);
     fputc('\n', stderr);
     abort();

--- a/stl/src/mutex.cpp
+++ b/stl/src/mutex.cpp
@@ -13,7 +13,7 @@
 
 #include "primitives.hpp"
 
-extern "C" _CRTIMP2_PURE void _Thrd_abort(const char* msg) { // abort on precondition failure
+[[noreturn]] extern "C" _CRTIMP2_PURE void _Thrd_abort(const char* msg) { // abort on precondition failure
     fputs(msg, stderr);
     fputc('\n', stderr);
     abort();

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -35,7 +35,7 @@ extern "C" NTSYSAPI _Success_(return != 0) WORD NTAPI
 namespace Concurrency {
 
     namespace details {
-        _CRTIMP2 void __cdecl _ReportUnobservedException() {
+        [[noreturn]] _CRTIMP2 void __cdecl _ReportUnobservedException() {
 
 #if (defined(_M_IX86) || defined(_M_X64)) && !defined(_CRT_APP)
             if (IsProcessorFeaturePresent(PF_FASTFAIL_AVAILABLE))


### PR DESCRIPTION
They are: `_Thrd_abort`, `_Thrd_exit` and `_ReportUnobservedException`.