### PR TITLE
`<filesystem>`: fix dangerous `noexcept` specification of `_Current_path`

### DIFF
--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -4056,11 +4056,9 @@ namespace filesystem {
             _Result._Text.resize(_Temp_result._Size);
             if (_Temp_result._Size < _Requested_size) {
                 _Ec = _Make_ec(_Temp_result._Error);
-                break;
+                return _Result;
             }
         }
-
-        return _Result;
     }
 
     _EXPORT_STD _NODISCARD inline path current_path() {

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -619,7 +619,7 @@ namespace filesystem {
         friend inline __std_win_error _Absolute(path& _Result, const wstring& _Text);
         friend inline __std_win_error _Canonical(path& _Result, const wstring& _Text);
         friend inline path temp_directory_path(error_code& _Ec);
-        friend inline __std_win_error _Current_path(path& _Result) noexcept;
+        friend inline path current_path(error_code& _Ec);
         friend inline void current_path(const path& _To);
         friend inline void current_path(const path& _To, error_code& _Ec) noexcept;
         friend inline __std_win_error _Read_symlink(const path& _Symlink_path, path& _Result) noexcept;
@@ -1816,6 +1816,10 @@ namespace filesystem {
     [[noreturn]] inline void _Throw_fs_error(
         const char* _Op, __std_win_error _Error, const path& _Path1, const path& _Path2) {
         _THROW(filesystem_error(_Op, _Path1, _Path2, _Make_ec(_Error)));
+    }
+
+    [[noreturn]] inline void _Throw_fs_error(const char* _Op, const error_code& _Error) {
+        _THROW(filesystem_error(_Op, _Error));
     }
 
     [[noreturn]] inline void _Throw_fs_error(const char* _Op, const error_code& _Error, const path& _Path1) {
@@ -4042,30 +4046,28 @@ namespace filesystem {
         return _Result;
     }
 
-    _NODISCARD inline __std_win_error _Current_path(path& _Result) noexcept {
+    _EXPORT_STD _NODISCARD inline path current_path(error_code& _Ec) {
+        _Ec.clear();
+        path _Result;
         _Result._Text.resize(__std_fs_max_path);
         for (;;) {
             const auto _Requested_size = static_cast<unsigned long>(_Result._Text.size());
             const auto _Temp_result    = __std_fs_get_current_path(_Requested_size, _Result._Text.data());
             _Result._Text.resize(_Temp_result._Size);
             if (_Temp_result._Size < _Requested_size) {
-                return _Temp_result._Error;
+                _Ec = _Make_ec(_Temp_result._Error);
+                break;
             }
         }
-    }
 
-    _EXPORT_STD _NODISCARD inline path current_path(error_code& _Ec) {
-        _Ec.clear();
-        path _Result;
-        _Ec = _Make_ec(_Current_path(_Result));
         return _Result;
     }
 
     _EXPORT_STD _NODISCARD inline path current_path() {
-        path _Result;
-        const auto _Err = _Current_path(_Result);
-        if (_Err != __std_win_error::_Success) {
-            _Throw_fs_error("current_path()", _Err);
+        error_code _Ec;
+        path _Result(_STD filesystem::current_path(_Ec));
+        if (_Ec) {
+            _Throw_fs_error("current_path()", _Ec);
         }
         return _Result;
     }


### PR DESCRIPTION
`_Current_path` is wrongly marked as `noexcept`, which will cause the program to terminate if `resize` throws.
https://github.com/microsoft/STL/blob/2261f7edb760eb3fe0726187c818b796dc7ea798/stl/inc/filesystem#L4045-L4046

This pr fixes it by merging the function into throwable `path current_path(error_code&)`.