### PR TITLE
`<stacktrace>`: avoid zero-initialization of large vector for `basic_stacktrace::current`

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -107,4 +107,5 @@ endfunction()
 
 add_benchmark(locale_classic src/locale_classic.cpp)
 add_benchmark(random_integer_generation src/random_integer_generation.cpp)
+add_benchmark(stacktrace_current src/stacktrace_current.cpp)
 add_benchmark(std_copy src/std_copy.cpp)

--- a/benchmarks/src/stacktrace_current.cpp
+++ b/benchmarks/src/stacktrace_current.cpp
@@ -11,7 +11,7 @@ namespace {
         if (extra_depth > 0) {
             return get_current(extra_depth - 1);
         } else {
-            return std::stacktrace::current();
+            return std::stacktrace::current(1);
         }
     }
 #pragma optimize("", on) // end inhibit tail call optimization

--- a/benchmarks/src/stacktrace_current.cpp
+++ b/benchmarks/src/stacktrace_current.cpp
@@ -6,6 +6,7 @@
 
 namespace {
 
+#pragma optimize("", off) // inhibit tail call optimization
     std::stacktrace get_current(int extra_depth) {
         if (extra_depth > 0) {
             return get_current(extra_depth - 1);
@@ -13,6 +14,7 @@ namespace {
             return std::stacktrace::current();
         }
     }
+#pragma optimize("", on) // end inhibit tail call optimization
 
     void BM_stacktrace_current(benchmark::State& state) {
         int extra_depth = state.range(0);
@@ -24,5 +26,5 @@ namespace {
 } // namespace
 
 // <NOTICE> this is subject to the final decision of _Try_frames. Currently: 100 < _Try_frames < 150
-BENCHMARK(BM_stacktrace_current)->Arg(0)->Arg(50)->Arg(100)->Arg(150)->Arg(300);
+BENCHMARK(BM_stacktrace_current)->Arg(0)->Arg(50)->Arg(100)->Arg(150)->Arg(200);
 BENCHMARK_MAIN();

--- a/benchmarks/src/stacktrace_current.cpp
+++ b/benchmarks/src/stacktrace_current.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <benchmark/benchmark.h>
+#include <stacktrace>
+
+namespace {
+
+    std::stacktrace get_current(int extra_depth) {
+        if (extra_depth > 0) {
+            return get_current(extra_depth - 1);
+        } else {
+            return std::stacktrace::current();
+        }
+    }
+
+    void BM_stacktrace_current(benchmark::State& state) {
+        int extra_depth = state.range(0);
+        for (auto _ : state) {
+            benchmark::DoNotOptimize(get_current(extra_depth));
+        }
+    }
+
+} // namespace
+
+BENCHMARK(BM_stacktrace_current)->Arg(0)->Arg(32)->Arg(128)->Arg(256)->Arg(512);
+BENCHMARK_MAIN();

--- a/benchmarks/src/stacktrace_current.cpp
+++ b/benchmarks/src/stacktrace_current.cpp
@@ -17,7 +17,7 @@ namespace {
 #pragma optimize("", on) // end inhibit tail call optimization
 
     void BM_stacktrace_current(benchmark::State& state) {
-        int extra_depth = state.range(0);
+        const int extra_depth = state.range(0);
         for (auto _ : state) {
             benchmark::DoNotOptimize(get_current(extra_depth));
         }

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -295,7 +295,7 @@ private:
         unsigned short _Caught =
             __std_stacktrace_capture(_Skip, static_cast<unsigned long>((_STD min)(_Max_depth, _Small_frame_limit)),
                 reinterpret_cast<void**>(_Buffer), &_Result._Hash);
-        if (_Caught != _Small_frame_limit) { // actual size
+        if (_Max_depth <= _Small_frame_limit || _Caught != _Small_frame_limit) { // actual size
             _Result._Frames.assign(_Buffer, _Buffer + _Caught);
             return _Result;
         }

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -313,11 +313,17 @@ private:
     }
 
     void _Prepare_space(size_type _Size) {
-        // <NOTICE> resize _Vec without value initialization, discarding previously allocated buffer if there is.
-        // <NOTICE> currently I cannot think of a better name, and the comment rely on the final decision of _Current.
+        // <NOTICE> need better name and a comment on its effect(clear old data; do resize without value initialization)
 
-        // static_assert(is_implicit_lifetime_v<stacktrace_entry>); TRANSITION, not implemented
+        // To make this trick well-defined, `stacktrace_entry` must be an implicit-lifetime type
+        // TRANSITION, should use `is_implicit_lifetime_v` when it is available
+        static_assert(
+            is_trivially_destructible_v<stacktrace_entry> && is_trivially_copy_constructible_v<stacktrace_entry>);
+
         const auto _Newvec = _Frames._Getal().allocate(_Size);
+        // Guarantee that elements are always implicitly created, even when `allocator_type` is user-provided
+        // TRANSITION, should use `start_lifetime_as_array` when it is available
+        ::operator new(sizeof(stacktrace_entry) * _Size, static_cast<void*>(_Unfancy(_Newvec)));
         _Frames._Change_array(_Newvec, _Size, _Size);
     }
 

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -317,7 +317,6 @@ private:
     }
 
     _NODISCARD static unsigned long _Adjust_skip_by_two_frames(size_type _Skip) noexcept {
-        // <NOTICE> ?is the adjustment correct even in previous version? _Skip will be incremented in __std_stacktrace_capture?
         // one for current, another for _Current
         return _Skip < ULONG_MAX - 2 ? static_cast<unsigned long>(_Skip + 2) : ULONG_MAX;
     }

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -281,8 +281,8 @@ private:
 
     // <NOTICE> ?_Try_frames may be subject to further decreasements?
 
-    static constexpr size_t _Try_frames = 128; // Sufficient in most cases.
-    static constexpr size_t _Max_frames = 0xFFFF;
+    static constexpr size_type _Try_frames = 128; // Sufficient in most cases.
+    static constexpr size_type _Max_frames = 0xFFFF;
 
     // __declspec(noinline) to make the same behavior for debug and release.
     // We force the current function to be always noinline and add its frame to skipped.
@@ -293,28 +293,26 @@ private:
         basic_stacktrace _Result(_Al);
 
         stacktrace_entry _Buffer[_Try_frames];
-        const unsigned short _Maybe_actual_size =
+        unsigned short _Caught =
             __std_stacktrace_capture(_Skip, static_cast<unsigned long>((_STD min)(_Max_depth, _Try_frames)),
                 reinterpret_cast<void**>(_Buffer), &_Result._Hash);
-        if (_Maybe_actual_size != _Try_frames) {
-            // Luckily, it's actual size
-            _Result._Frames.assign(_Buffer, _Buffer + _Maybe_actual_size);
+        if (_Caught != _Try_frames) { // actual size
+            _Result._Frames.assign(_Buffer, _Buffer + _Caught);
             return _Result;
         }
 
-        // <NOTICE> The cost introduced the first try is compensable from uninitialized resize.
-        // <NOTICE> ?is `auto` type safe here?
+        // <NOTICE> The cost introduced by the first try should be compensable from uninitialized resize.
         // <NOTICE> No need to do _Tidy; ?add _STL_ASSERT for emptiness?
 
-        auto _Enough_capacity = (_STD min)(_Max_depth, _Max_frames);
+        size_type _Enough_capacity = (_STD min)(_Max_depth, _Max_frames);
         // resize(_Enough_capacity), but without value initialization
         // static_assert(is_implicit_lifetime_v<stacktrace_entry>); TRANSITION, not implemented
         const auto _Newvec = _Result._Frames._Getal().allocate(_Enough_capacity);
         _Result._Frames._Change_array(_Newvec, _Enough_capacity, _Enough_capacity);
 
-        const unsigned short _Actual_size = __std_stacktrace_capture(
+        _Caught = __std_stacktrace_capture(
             _Skip, static_cast<unsigned long>(_Enough_capacity), _Result._To_voidptr_array(), &_Result._Hash);
-        _Result._Frames.resize(_Actual_size);
+        _Result._Frames.resize(_Caught);
         return _Result;
 
         _CATCH_ALL

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -287,7 +287,7 @@ private:
     // __declspec(noinline) to make the same behavior for debug and release.
     // We force the current function to be always noinline and add its frame to skipped.
     _NODISCARD __declspec(noinline) static basic_stacktrace
-        _Current(size_type _Skip, const size_type _Max_depth, const allocator_type& _Al) noexcept {
+        _Current(unsigned long _Skip, const size_type _Max_depth, const allocator_type& _Al) noexcept {
         _Skip = _Adjust_skip(_Skip); // skip this frame
         _TRY_BEGIN
         basic_stacktrace _Result(_Al);

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -282,38 +282,43 @@ private:
     // We force the current function to be always noinline and add its frame to skipped.
 
     _NODISCARD __declspec(noinline) static basic_stacktrace
-        _Current(const unsigned long _Adjusted_skip, const size_type _Max_depth, const allocator_type& _Al) noexcept {
-        // _Adjusted_skip is adjusted outside
+        _Current(const unsigned long _Skip, const size_type _Max_depth, const allocator_type& _Al) noexcept {
+        // _Skip is adjusted outside (in `current`)
         _TRY_BEGIN
         basic_stacktrace _Result(_Al);
 
-        // <NOTICE> _Small_frames may be subject to further decreasements to avoid stack burden and
+        // <NOTICE> _Small_frame_limit may be subject to further decreasements to avoid stack burden, and
         // <NOTICE> the cost introduced by the first try should be compensable from uninitialized resize.
 
-        constexpr size_type _Small_frames = 128; // Sufficient in most cases.
-        stacktrace_entry _Buffer[_Small_frames];
+        constexpr size_type _Small_frame_limit = 128; // Sufficient in most cases.
+        stacktrace_entry _Buffer[_Small_frame_limit];
         unsigned short _Caught =
-            __std_stacktrace_capture(_Adjusted_skip, static_cast<unsigned long>((_STD min)(_Max_depth, _Small_frames)),
+            __std_stacktrace_capture(_Skip, static_cast<unsigned long>((_STD min)(_Max_depth, _Small_frame_limit)),
                 reinterpret_cast<void**>(_Buffer), &_Result._Hash);
-        if (_Caught != _Small_frames) { // actual size
+        if (_Caught != _Small_frame_limit) { // actual size
             _Result._Frames.assign(_Buffer, _Buffer + _Caught);
             return _Result;
         }
 
-        size_type _Enough_capacity = (_STD min)(_Max_depth, _Max_frames);
-        // resize(_Enough_capacity), but without value initialization
-        // static_assert(is_implicit_lifetime_v<stacktrace_entry>); TRANSITION, not implemented
-        const auto _Newvec = _Result._Frames._Getal().allocate(_Enough_capacity);
-        _Result._Frames._Change_array(_Newvec, _Enough_capacity, _Enough_capacity);
-
+        size_type _Enough_size = (_STD min)(_Max_depth, _Max_frames);
+        _Result._Prepare_space(_Enough_size);
         _Caught = __std_stacktrace_capture(
-            _Adjusted_skip, static_cast<unsigned long>(_Enough_capacity), _Result._To_voidptr_array(), &_Result._Hash);
+            _Skip, static_cast<unsigned long>(_Enough_size), _Result._To_voidptr_array(), &_Result._Hash);
         _Result._Frames.resize(_Caught);
         return _Result;
 
         _CATCH_ALL
         return basic_stacktrace{_Al};
         _CATCH_END
+    }
+
+    void _Prepare_space(size_type _Size) {
+        // <NOTICE> resize _Vec without value initialization, discarding previously allocated buffer if there is.
+        // <NOTICE> currently I cannot think of a better name, and the comment rely on the final decision of _Current.
+
+        // static_assert(is_implicit_lifetime_v<stacktrace_entry>); TRANSITION, not implemented
+        const auto _Newvec = _Frames._Getal().allocate(_Size);
+        _Frames._Change_array(_Newvec, _Size, _Size);
     }
 
     _NODISCARD static unsigned long _Adjust_skip_by_two_frames(size_type _Skip) noexcept {

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -279,29 +279,29 @@ private:
     static constexpr bool _Noex_swap = allocator_traits<_Alloc>::propagate_on_container_swap::value
                                     || allocator_traits<_Alloc>::is_always_equal::value;
 
-    // <NOTICE> ?_Try_frames may be subject to further decreasements?
-
-    static constexpr size_type _Try_frames = 128; // Sufficient in most cases.
     static constexpr size_type _Max_frames = 0xFFFF;
 
     // __declspec(noinline) to make the same behavior for debug and release.
     // We force the current function to be always noinline and add its frame to skipped.
+
     _NODISCARD __declspec(noinline) static basic_stacktrace
         _Current(unsigned long _Skip, const size_type _Max_depth, const allocator_type& _Al) noexcept {
         _Skip = _Adjust_skip(_Skip); // skip this frame
         _TRY_BEGIN
         basic_stacktrace _Result(_Al);
 
-        stacktrace_entry _Buffer[_Try_frames];
+        // <NOTICE> _Small_frames may be subject to further decreasements to avoid stack burden and
+        // <NOTICE> the cost introduced by the first try should be compensable from uninitialized resize.
+
+        constexpr size_type _Small_frames = 128; // Sufficient in most cases.
+        stacktrace_entry _Buffer[_Small_frames];
         unsigned short _Caught =
-            __std_stacktrace_capture(_Skip, static_cast<unsigned long>((_STD min)(_Max_depth, _Try_frames)),
+            __std_stacktrace_capture(_Skip, static_cast<unsigned long>((_STD min)(_Max_depth, _Small_frames)),
                 reinterpret_cast<void**>(_Buffer), &_Result._Hash);
-        if (_Caught != _Try_frames) { // actual size
+        if (_Caught != _Small_frames) { // actual size
             _Result._Frames.assign(_Buffer, _Buffer + _Caught);
             return _Result;
         }
-
-        // <NOTICE> The cost introduced by the first try should be compensable from uninitialized resize.
 
         size_type _Enough_capacity = (_STD min)(_Max_depth, _Max_frames);
         // resize(_Enough_capacity), but without value initialization

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -302,7 +302,6 @@ private:
         }
 
         // <NOTICE> The cost introduced by the first try should be compensable from uninitialized resize.
-        // <NOTICE> No need to do _Tidy; ?add _STL_ASSERT for emptiness?
 
         size_type _Enough_capacity = (_STD min)(_Max_depth, _Max_frames);
         // resize(_Enough_capacity), but without value initialization

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -310,7 +310,7 @@ private:
     };
 
     basic_stacktrace(_Internal_t, size_type _Max_depth, const allocator_type& _Al)
-        : _Frames(_Frames_t::_Create_uninitialized(_Max_depth, _Al)) {}
+        : _Frames(_Frames_t::_Create_uninitialized<true>(_Max_depth, _Al)) {}
 
     _NODISCARD static unsigned long _Adjust_skip(size_t _Skip) noexcept {
         return _Skip < ULONG_MAX - 1 ? static_cast<unsigned long>(_Skip + 1) : ULONG_MAX;

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -309,7 +309,8 @@ private:
         explicit _Internal_t() noexcept = default;
     };
 
-    basic_stacktrace(_Internal_t, size_type _Max_depth, const allocator_type& _Al) : _Frames(_Max_depth, _Al) {}
+    basic_stacktrace(_Internal_t, size_type _Max_depth, const allocator_type& _Al)
+        : _Frames(_Frames_t::_Create_uninitialized(_Max_depth, _Al)) {}
 
     _NODISCARD static unsigned long _Adjust_skip(size_t _Skip) noexcept {
         return _Skip < ULONG_MAX - 1 ? static_cast<unsigned long>(_Skip + 1) : ULONG_MAX;

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -310,7 +310,7 @@ private:
     };
 
     basic_stacktrace(_Internal_t, size_type _Max_depth, const allocator_type& _Al)
-        : _Frames(_Frames_t::_Create_uninitialized<true>(_Max_depth, _Al)) {}
+        : _Frames(_Frames_t::template _Create_uninitialized<true>(_Max_depth, _Al)) {}
 
     _NODISCARD static unsigned long _Adjust_skip(size_t _Skip) noexcept {
         return _Skip < ULONG_MAX - 1 ? static_cast<unsigned long>(_Skip + 1) : ULONG_MAX;

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -323,7 +323,7 @@ private:
         const auto _Newvec = _Frames._Getal().allocate(_Size);
         // Guarantee that elements are always implicitly created, even when `allocator_type` is user-provided
         // TRANSITION, should use `start_lifetime_as_array` when it is available
-        ::operator new(sizeof(stacktrace_entry) * _Size, static_cast<void*>(_Unfancy(_Newvec)));
+        (void) ::operator new(sizeof(stacktrace_entry) * _Size, static_cast<void*>(_Unfancy(_Newvec)));
         _Frames._Change_array(_Newvec, _Size, _Size);
     }
 

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -138,20 +138,17 @@ public:
 
     _NODISCARD __declspec(noinline) static basic_stacktrace
         current(const allocator_type& _Al = allocator_type()) noexcept {
-        return _Current(1, _Max_frames, _Al);
+        return _Current(2, _Max_frames, _Al);
     }
 
     _NODISCARD __declspec(noinline) static basic_stacktrace
         current(const size_type _Skip, const allocator_type& _Al = allocator_type()) noexcept {
-        return _Current(_Adjust_skip(_Skip), _Max_frames, _Al);
+        return _Current(_Adjust_skip_by_two_frames(_Skip), _Max_frames, _Al);
     }
 
     _NODISCARD __declspec(noinline) static basic_stacktrace
         current(const size_type _Skip, size_type _Max_depth, const allocator_type& _Al = allocator_type()) noexcept {
-        // <NOTICE> _Current can do _Max_frames clamp inside.
-        // <NOTICE> The two _Adjust_skip in current and _Current can be merged into a single one; The efficiency gain is
-        // <NOTICE> negligible however.
-        return _Current(_Adjust_skip(_Skip), _Max_depth, _Al);
+        return _Current(_Adjust_skip_by_two_frames(_Skip), _Max_depth, _Al);
     }
 
     basic_stacktrace() noexcept(is_nothrow_default_constructible_v<allocator_type>) = default;
@@ -285,8 +282,8 @@ private:
     // We force the current function to be always noinline and add its frame to skipped.
 
     _NODISCARD __declspec(noinline) static basic_stacktrace
-        _Current(unsigned long _Skip, const size_type _Max_depth, const allocator_type& _Al) noexcept {
-        _Skip = _Adjust_skip(_Skip); // skip this frame
+        _Current(const unsigned long _Adjusted_skip, const size_type _Max_depth, const allocator_type& _Al) noexcept {
+        // _Adjusted_skip is adjusted outside
         _TRY_BEGIN
         basic_stacktrace _Result(_Al);
 
@@ -296,7 +293,7 @@ private:
         constexpr size_type _Small_frames = 128; // Sufficient in most cases.
         stacktrace_entry _Buffer[_Small_frames];
         unsigned short _Caught =
-            __std_stacktrace_capture(_Skip, static_cast<unsigned long>((_STD min)(_Max_depth, _Small_frames)),
+            __std_stacktrace_capture(_Adjusted_skip, static_cast<unsigned long>((_STD min)(_Max_depth, _Small_frames)),
                 reinterpret_cast<void**>(_Buffer), &_Result._Hash);
         if (_Caught != _Small_frames) { // actual size
             _Result._Frames.assign(_Buffer, _Buffer + _Caught);
@@ -310,7 +307,7 @@ private:
         _Result._Frames._Change_array(_Newvec, _Enough_capacity, _Enough_capacity);
 
         _Caught = __std_stacktrace_capture(
-            _Skip, static_cast<unsigned long>(_Enough_capacity), _Result._To_voidptr_array(), &_Result._Hash);
+            _Adjusted_skip, static_cast<unsigned long>(_Enough_capacity), _Result._To_voidptr_array(), &_Result._Hash);
         _Result._Frames.resize(_Caught);
         return _Result;
 
@@ -319,8 +316,10 @@ private:
         _CATCH_END
     }
 
-    _NODISCARD static unsigned long _Adjust_skip(size_t _Skip) noexcept {
-        return _Skip < ULONG_MAX - 1 ? static_cast<unsigned long>(_Skip + 1) : ULONG_MAX;
+    _NODISCARD static unsigned long _Adjust_skip_by_two_frames(size_type _Skip) noexcept {
+        // <NOTICE> ?is the adjustment correct even in previous version? _Skip will be incremented in __std_stacktrace_capture?
+        // one for current, another for _Current
+        return _Skip < ULONG_MAX - 2 ? static_cast<unsigned long>(_Skip + 2) : ULONG_MAX;
     }
 
     _Frames_t _Frames;

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -252,7 +252,7 @@ public:
 #endif // ^^^ !__cpp_lib_concepts ^^^
     }
 
-    void swap(basic_stacktrace& _Other) noexcept /* strengthened */ {
+    void swap(basic_stacktrace& _Other) noexcept(_Noex_swap) {
         _Frames.swap(_Other._Frames);
         _STD swap(_Hash, _Other._Hash);
     }
@@ -273,11 +273,11 @@ public:
     }
 
 private:
-    // <NOTICE> Currently vector is enhanced as unconditionally noexcept move-assignable and swappable
-
     static constexpr bool _Noex_move = allocator_traits<_Alloc>::propagate_on_container_move_assignment::value
-                                    || allocator_traits<_Alloc>::is_always_equal::value
-                                    || is_nothrow_move_assignable_v<_Frames_t>; // strengthened
+                                    || allocator_traits<_Alloc>::is_always_equal::value;
+
+    static constexpr bool _Noex_swap = allocator_traits<_Alloc>::propagate_on_container_swap::value
+                                    || allocator_traits<_Alloc>::is_always_equal::value;
 
     // <NOTICE> ?_Try_frames may be subject to further decreasements?
 

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -774,24 +774,6 @@ public:
 #endif // _ITERATOR_DEBUG_LEVEL != 0
     }
 
-public:
-    template <bool _Force_pass = false>
-    _NODISCARD static _CONSTEXPR20 vector _Create_uninitialized(size_type _Size, const allocator_type& _Al) {
-        // Create a vector of size _Size without value initialization.
-        // Currently used by basic_stacktrace.
-        static_assert(_Force_pass || is_trivially_constructible_v<_Ty>, "_Ty must be trivially constructible");
-
-        vector _Vec(_Al);
-        if (_Is_constant_evaluated()) {
-            _Vec.resize(_Size);
-        } else {
-            const pointer _Newvec = _Vec._Getal().allocate(_Size);
-            _Vec._Change_array(_Newvec, _Size, _Size);
-        }
-
-        return _Vec;
-    }
-
 private:
     template <class... _Valty>
     _CONSTEXPR20 _Ty& _Emplace_one_at_back(_Valty&&... _Val) {

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -441,8 +441,10 @@ private:
     friend class _Vb_val;
     friend _Tidy_guard<vector>;
 
+#if _HAS_CXX23
     template <class>
     friend class basic_stacktrace;
+#endif // _HAS_CXX23
 
     using _Alty        = _Rebind_alloc_t<_Alloc, _Ty>;
     using _Alty_traits = allocator_traits<_Alty>;

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -772,10 +772,11 @@ public:
     }
 
 public:
+    template<bool _Force_pass = false>
     _NODISCARD static _CONSTEXPR20 vector _Create_uninitialized(size_type _Size, const allocator_type& _Al) {
         // Create a vector of size _Size without value initialization.
         // Currently used by basic_stacktrace.
-        static_assert(is_trivially_constructible_v<_Ty>, "_Ty must be trivially constructible");
+        static_assert(_Force_pass || is_trivially_constructible_v<_Ty>, "_Ty must be trivially constructible");
 
         vector _Vec(_Al);
         if (_Is_constant_evaluated()) {

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -771,6 +771,23 @@ public:
 #endif // _ITERATOR_DEBUG_LEVEL != 0
     }
 
+public:
+    _NODISCARD static _CONSTEXPR20 vector _Create_uninitialized(size_type _Size, const allocator_type& _Al) {
+        // Create a vector of size _Size without value initialization.
+        // Currently used by basic_stacktrace.
+        static_assert(is_trivially_constructible_v<_Ty>, "_Ty must be trivially constructible");
+
+        vector _Vec(_Al);
+        if (_Is_constant_evaluated()) {
+            _Vec.resize(_Size);
+        } else {
+            const pointer _Newvec = _Vec._Getal().allocate(_Size);
+            _Vec._Change_array(_Newvec, _Size, _Size);
+        }
+
+        return _Vec;
+    }
+
 private:
     template <class... _Valty>
     _CONSTEXPR20 _Ty& _Emplace_one_at_back(_Valty&&... _Val) {

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -772,7 +772,7 @@ public:
     }
 
 public:
-    template<bool _Force_pass = false>
+    template <bool _Force_pass = false>
     _NODISCARD static _CONSTEXPR20 vector _Create_uninitialized(size_type _Size, const allocator_type& _Al) {
         // Create a vector of size _Size without value initialization.
         // Currently used by basic_stacktrace.


### PR DESCRIPTION
Likely to fix #3859; add a benchmark for `basic_stacktrace::current`.

The strategy is to gain guaranteed performance improvement by avoiding vector's value initialization when resizing, and with its help make small case more space-efficient without introducing performance regression in large case.