### PR TITLE
`<bitset>`: constructor `string_view` support

### DIFF
--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -164,22 +164,21 @@ public:
         _Construct<_Traits>(_Str.data() + _Pos, _Count, _Elem0, _Elem1);
     }
 
-#ifdef _HAS_CXX26
     template <class _Elem>
-    // currently no _CONSTEXPR26, it will be added at the same time with _HAS_CXX26
-    /*_CONSTEXPR26 */ inline explicit bitset(const _Elem* _Ntcts,
-        typename basic_string_view<_Elem>::size_type _Count = basic_string_view<_Elem>::npos,
+    _CONSTEXPR23 explicit bitset(const _Elem* _Ntcts,
+        typename basic_string<_Elem>::size_type _Count = basic_string<_Elem>::npos,
         _Elem _Elem0 = static_cast<_Elem>('0'), _Elem _Elem1 = static_cast<_Elem>('1')) {
-        if (_Count == basic_string_view<_Elem>::npos) {
+        if (_Count == basic_string<_Elem>::npos) {
             _Count = char_traits<_Elem>::length(_Ntcts);
         }
 
         _Construct<char_traits<_Elem>>(_Ntcts, _Count, _Elem0, _Elem1);
     }
 
+#if _HAS_CXX26
     template <class _Elem, class _Traits>
     // currently no _CONSTEXPR26, it will be added at the same time with _HAS_CXX26
-    /* _CONSTEXPR26 */ inline explicit bitset(const basic_string_view<_Elem, _Traits>& _Str,
+    constexpr inline explicit bitset(const basic_string_view<_Elem, _Traits>& _Str,
         typename basic_string_view<_Elem, _Traits>::size_type _Pos   = 0,
         typename basic_string_view<_Elem, _Traits>::size_type _Count = basic_string_view<_Elem, _Traits>::npos,
         _Elem _Elem0 = static_cast<_Elem>('0'), _Elem _Elem1 = static_cast<_Elem>('1')) {
@@ -192,17 +191,6 @@ public:
         }
 
         _Construct<_Traits>(_Str.data() + _Pos, _Count, _Elem0, _Elem1);
-    }
-#else
-    template <class _Elem>
-    _CONSTEXPR23 explicit bitset(const _Elem* _Ntcts,
-        typename basic_string<_Elem>::size_type _Count = basic_string<_Elem>::npos,
-        _Elem _Elem0 = static_cast<_Elem>('0'), _Elem _Elem1 = static_cast<_Elem>('1')) {
-        if (_Count == basic_string<_Elem>::npos) {
-            _Count = char_traits<_Elem>::length(_Ntcts);
-        }
-
-        _Construct<char_traits<_Elem>>(_Ntcts, _Count, _Elem0, _Elem1);
     }
 #endif
 

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -164,6 +164,36 @@ public:
         _Construct<_Traits>(_Str.data() + _Pos, _Count, _Elem0, _Elem1);
     }
 
+#ifdef _HAS_CXX26
+    template <class _Elem>
+    // currently no _CONSTEXPR26, it will be added at the same time with _HAS_CXX26
+    /*_CONSTEXPR26 */ inline explicit bitset(const _Elem* _Ntcts,
+        typename basic_string_view<_Elem>::size_type _Count = basic_string_view<_Elem>::npos,
+        _Elem _Elem0 = static_cast<_Elem>('0'), _Elem _Elem1 = static_cast<_Elem>('1')) {
+        if (_Count == basic_string_view<_Elem>::npos) {
+            _Count = char_traits<_Elem>::length(_Ntcts);
+        }
+
+        _Construct<char_traits<_Elem>>(_Ntcts, _Count, _Elem0, _Elem1);
+    }
+
+    template <class _Elem, class _Traits>
+    // currently no _CONSTEXPR26, it will be added at the same time with _HAS_CXX26
+    /* _CONSTEXPR26 */ inline explicit bitset(const basic_string_view<_Elem, _Traits>& _Str,
+        typename basic_string_view<_Elem, _Traits>::size_type _Pos   = 0,
+        typename basic_string_view<_Elem, _Traits>::size_type _Count = basic_string_view<_Elem, _Traits>::npos,
+        _Elem _Elem0 = static_cast<_Elem>('0'), _Elem _Elem1 = static_cast<_Elem>('1')) {
+        if (_Str.size() < _Pos) {
+            _Xran();
+        }
+
+        if (_Str.size() - _Pos < _Count) {
+            _Count = _Str.size() - _Pos;
+        }
+
+        _Construct<_Traits>(_Str.data() + _Pos, _Count, _Elem0, _Elem1);
+    }
+#else
     template <class _Elem>
     _CONSTEXPR23 explicit bitset(const _Elem* _Ntcts,
         typename basic_string<_Elem>::size_type _Count = basic_string<_Elem>::npos,
@@ -174,6 +204,7 @@ public:
 
         _Construct<char_traits<_Elem>>(_Ntcts, _Count, _Elem0, _Elem1);
     }
+#endif
 
     _CONSTEXPR23 bitset& operator&=(const bitset& _Right) noexcept {
         for (size_t _Wpos = 0; _Wpos <= _Words; ++_Wpos) {

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -192,7 +192,7 @@ public:
 
         _Construct<_Traits>(_Str.data() + _Pos, _Count, _Elem0, _Elem1);
     }
-#endif
+#endif // _HAS_CXX26
 
     _CONSTEXPR23 bitset& operator&=(const bitset& _Right) noexcept {
         for (size_t _Wpos = 0; _Wpos <= _Words; ++_Wpos) {


### PR DESCRIPTION
This PR contains constructor for `bitset`, related with https://github.com/microsoft/STL/issues/3810 and [P2697R1](https://wg21.link/P2697R1). 
C++23 STL development still continue, so I added `_HAS_CXX26` to avoid any collision with `string` one.

an example:

```cpp
#include <iostream>
#include <string_view>
#include <string>
#define _HAS_CXX26
#include <bitset>

#define LOOP_AND_PRINT(var)                 \
    for (size_t n = 0; n < var.size(); ++n) \
        std::cout << var[n];                \
    std::cout << ' ';

int main()
{
    using namespace std::literals;

    constexpr std::string_view bit_string = "110010";

    std::bitset<8> b0{"110010"};
    std::bitset<8> b1{"110010"sv};
    std::bitset<8> b2{"110010"s};
    std::bitset<8> b3{std::string("110010")};
    std::bitset<8> val(bit_string);

    LOOP_AND_PRINT(val)
    LOOP_AND_PRINT(b1)
    LOOP_AND_PRINT(b2)
    LOOP_AND_PRINT(b3)
    LOOP_AND_PRINT(val)

    return 0;
}
```