### PR TITLE
Follow-up enhancements for `<filesystem>`

### DIFF
--- a/benchmarks/src/path_lexically_normal.cpp
+++ b/benchmarks/src/path_lexically_normal.cpp
@@ -12,7 +12,7 @@ namespace {
             LR"(X:DriveRelative)"sv,
             LR"(\\server\\\share)"sv,
             LR"(STL/.github/workflows/../..)"sv,
-            LR"(C:\Program Files\Azure Data Studio\resources\app\extensions\bat\snippets\batchfile.code-snippets)"sv,
+            LR"(C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\VC\Snippets)"sv,
             LR"(/\server/\share/\a/\b/\c/\./\./\d/\../\../\../\../\../\../\../\other/x/y/z/.././..\meow.txt)"sv,
         };
 

--- a/benchmarks/src/path_lexically_normal.cpp
+++ b/benchmarks/src/path_lexically_normal.cpp
@@ -9,9 +9,9 @@ namespace {
     void BM_lexically_normal(benchmark::State& state) {
         using namespace std::literals;
         static constexpr std::wstring_view args[5]{
-            LR"(X:DriveRelative)"sv,
-            LR"(\\server\\\share)"sv,
-            LR"(STL/.github/workflows/../..)"sv,
+            LR"(C:Snippets)"sv,
+            LR"(.\Snippets)"sv,
+            LR"(..\..\IDE\VC\Snippets)"sv,
             LR"(C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\VC\Snippets)"sv,
             LR"(/\server/\share/\a/\b/\c/\./\./\d/\../\../\../\../\../\../\../\other/x/y/z/.././..\meow.txt)"sv,
         };

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -621,7 +621,7 @@ namespace filesystem {
         friend inline path current_path(error_code& _Ec);
         friend inline void current_path(const path& _To);
         friend inline void current_path(const path& _To, error_code& _Ec) noexcept;
-        friend inline __std_win_error _Read_symlink(const path& _Symlink_path, path& _Result) noexcept;
+        friend inline __std_win_error _Read_symlink(const path& _Symlink_path, path& _Result);
 
     public:
         using value_type  = wchar_t;
@@ -3206,7 +3206,7 @@ namespace filesystem {
         return __std_win_error::_Success;
     }
 
-    _NODISCARD inline __std_win_error _Read_symlink(const path& _Symlink_path, path& _Result) noexcept {
+    _NODISCARD inline __std_win_error _Read_symlink(const path& _Symlink_path, path& _Result) {
         __std_win_error _Err;
         unique_ptr<char[]> _Buffer_unique_ptr;
         {
@@ -3230,8 +3230,7 @@ namespace filesystem {
             return _Err;
         }
 
-        _Result._Text.resize(_Length);
-        _CSTD memcpy(_Result._Text.data(), _Offset, _Length * sizeof(wchar_t));
+        _Result._Text.assign(_Offset, _Length);
 
         return __std_win_error::_Success;
     }

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -615,7 +615,7 @@ namespace filesystem {
     _EXPORT_STD class path {
         template <class _Base_iter>
         friend class _Path_iterator;
-        friend path absolute(const path& _Input, error_code& _Ec);
+        friend inline path absolute(const path& _Input, error_code& _Ec);
         friend inline __std_win_error _Canonical(path& _Result, const wstring& _Text);
         friend inline path temp_directory_path(error_code& _Ec);
         friend inline path current_path(error_code& _Ec);

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -615,7 +615,7 @@ namespace filesystem {
     _EXPORT_STD class path {
         template <class _Base_iter>
         friend class _Path_iterator;
-        friend inline __std_win_error _Absolute(path& _Result, const wstring& _Text);
+        friend path absolute(const path& _Input, error_code& _Ec);
         friend inline __std_win_error _Canonical(path& _Result, const wstring& _Text);
         friend inline path temp_directory_path(error_code& _Ec);
         friend inline path current_path(error_code& _Ec);
@@ -2969,45 +2969,35 @@ namespace filesystem {
         return {};
     }
 
-    _NODISCARD inline __std_win_error _Absolute(path& _Result, const wstring& _Text) { // pre: _Result.empty()
-        if (_Text.empty()) {
-            return __std_win_error::_Success;
-        }
-
-        _Result._Text.resize(__std_fs_max_path);
-        __std_win_error _Err;
-        for (;;) {
-            const auto _Requested_size = static_cast<unsigned long>(_Result._Text.size());
-            const auto _Full_path_result =
-                __std_fs_get_full_path_name(_Text.c_str(), _Requested_size, _Result._Text.data());
-            _Err = _Full_path_result._Error;
-            _Result._Text.resize(_Full_path_result._Size);
-            if (_Full_path_result._Size < _Requested_size) {
-                break;
-            }
-        }
-
-        return _Err;
-    }
-
-    _EXPORT_STD _NODISCARD inline path absolute(const path& _Input) {
-        // normalize path according to system semantics, without touching the disk
-        // calls GetFullPathNameW
-        path _Result;
-        const auto _Err = _Absolute(_Result, _Input.native());
-        if (_Err != __std_win_error::_Success) {
-            _Throw_fs_error("absolute", _Err, _Input);
-        }
-
-        return _Result;
-    }
-
     _EXPORT_STD _NODISCARD inline path absolute(const path& _Input, error_code& _Ec) {
         // normalize path according to system semantics, without touching the disk
         // calls GetFullPathNameW
         _Ec.clear(); // for exception safety
         path _Result;
-        _Ec = _Make_ec(_Absolute(_Result, _Input.native()));
+        if (!_Input._Text.empty()) {
+            _Result._Text.resize(__std_fs_max_path);
+            for (;;) {
+                const auto _Requested_size = static_cast<unsigned long>(_Result._Text.size());
+                const auto _Full_path_result =
+                    __std_fs_get_full_path_name(_Input._Text.c_str(), _Requested_size, _Result._Text.data());
+                _Result._Text.resize(_Full_path_result._Size);
+                if (_Full_path_result._Size < _Requested_size) {
+                    _Ec = _Make_ec(_Full_path_result._Error);
+                    break;
+                }
+            }
+        }
+        return _Result;
+    }
+
+    _EXPORT_STD _NODISCARD inline path absolute(const path& _Input) {
+        // normalize path according to system semantics, without touching the disk
+        // calls GetFullPathNameW
+        error_code _Ec;
+        path _Result(_STD filesystem::absolute(_Input, _Ec));
+        if (_Ec) {
+            _Throw_fs_error("absolute", _Ec, _Input);
+        }
         return _Result;
     }
 
@@ -4054,7 +4044,7 @@ namespace filesystem {
     }
 
     _EXPORT_STD _NODISCARD inline path current_path(error_code& _Ec) {
-        _Ec.clear();
+        _Ec.clear(); // for exception safety
         path _Result;
         _Result._Text.resize(__std_fs_max_path);
         for (;;) {

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -1208,7 +1208,7 @@ namespace filesystem {
             vector<wstring_view> _Vec; // Empty wstring_view means directory-separator
                                        // that will be normalized to a preferred-separator.
                                        // Non-empty wstring_view means filename.
-            _Vec.reserve(13); // avoid frequent re-allocations
+            _Vec.reserve(19); // avoid frequent re-allocations
             bool _Has_root_directory = false; // true: there is a slash right after root-name.
             auto _Ptr                = _Root_name_end;
             if (_Ptr != _Last && _Is_slash(*_Ptr)) {


### PR DESCRIPTION
- Fix another problematic `noexcept` signature for `_Read_symlink`
https://github.com/microsoft/STL/blob/f51733ca5352c712165e46fdbc5d0d395971f0e7/stl/inc/filesystem#L3233
- Merge `_Absolute` into `absolute`, as it's simple enough
- Nitpicks for my previous prs: add a missed `// for exception safety` comment; make benchmark cases look better; make the vector reserve slightly more space in `lexically_normal`