### PR TITLE
Strengthen exception specification for numeric operations

### DIFF
--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -1333,21 +1333,24 @@ _GENERIC_MATH_SPECIAL_UINT1(sph_neumann)
 #undef _GENERIC_MATH_SPECIAL_UINT1
 #undef _GENERIC_MATH_SPECIAL_UINT2
 
-_EXPORT_STD _NODISCARD inline double hypot(const double _Dx, const double _Dy, const double _Dz) {
+_EXPORT_STD _NODISCARD inline double hypot(const double _Dx, const double _Dy, const double _Dz) noexcept
+/* strengthened */ {
     return __std_smf_hypot3(_Dx, _Dy, _Dz);
 }
 
-_EXPORT_STD _NODISCARD inline float hypot(const float _Dx, const float _Dy, const float _Dz) {
+_EXPORT_STD _NODISCARD inline float hypot(const float _Dx, const float _Dy, const float _Dz) noexcept
+/* strengthened */ {
     return __std_smf_hypot3f(_Dx, _Dy, _Dz);
 }
 
-_EXPORT_STD _NODISCARD inline long double hypot(const long double _Dx, const long double _Dy, const long double _Dz) {
+_EXPORT_STD _NODISCARD inline long double hypot(
+    const long double _Dx, const long double _Dy, const long double _Dz) noexcept /* strengthened */ {
     return __std_smf_hypot3(static_cast<double>(_Dx), static_cast<double>(_Dy), static_cast<double>(_Dz));
 }
 
 _EXPORT_STD template <class _Ty1, class _Ty2, class _Ty3,
     enable_if_t<is_arithmetic_v<_Ty1> && is_arithmetic_v<_Ty2> && is_arithmetic_v<_Ty3>, int> = 0>
-_NODISCARD auto hypot(const _Ty1 _Dx, const _Ty2 _Dy, const _Ty3 _Dz) {
+_NODISCARD auto hypot(const _Ty1 _Dx, const _Ty2 _Dy, const _Ty3 _Dz) noexcept /* strengthened */ {
     // N4950 [cmath.syn]/3 "Sufficient additional overloads"
     // Note that this template is selected by overload resolution only when at least one
     // argument is double/long double/integral but not all three are double or long double.
@@ -1358,7 +1361,7 @@ _NODISCARD auto hypot(const _Ty1 _Dx, const _Ty2 _Dy, const _Ty3 _Dz) {
 
 #if _HAS_CXX20
 template <class _Ty>
-_NODISCARD constexpr _Ty _Linear_for_lerp(const _Ty _ArgA, const _Ty _ArgB, const _Ty _ArgT) {
+_NODISCARD constexpr _Ty _Linear_for_lerp(const _Ty _ArgA, const _Ty _ArgB, const _Ty _ArgT) noexcept {
     if (_STD is_constant_evaluated()) {
         auto _Smaller     = _ArgT;
         auto _Larger      = _ArgB - _ArgA;

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -1865,11 +1865,11 @@ public:
     struct param_type { // parameter package
         using distribution_type = uniform_int;
 
-        param_type() noexcept /* strengthened */ {
+        param_type() noexcept {
             _Init(0, 9);
         }
 
-        explicit param_type(result_type _Min0, result_type _Max0 = 9) noexcept /* strengthened */ {
+        explicit param_type(result_type _Min0, result_type _Max0 = 9) noexcept {
             _Init(_Min0, _Max0);
         }
 
@@ -1892,6 +1892,7 @@ public:
         _NODISCARD result_type b() const noexcept /* strengthened */ {
             return _Max;
         }
+
         void _Init(_Ty _Min0, _Ty _Max0) noexcept { // set internal state
             _STL_ASSERT(_Min0 <= _Max0, "invalid min and max arguments for uniform_int");
             _Min = _Min0;
@@ -2240,7 +2241,7 @@ public:
             return _Px;
         }
 
-        void _Init(_Ty1 _Px0) noexcept /* strengthened */ { // initialize
+        void _Init(_Ty1 _Px0) noexcept { // initialize
             _STL_ASSERT(0.0 < _Px0 && _Px0 < 1.0, "invalid probability argument for geometric_distribution");
             _Px      = _Px0;
             _Log_1_p = _CSTD log(1 - _Px);
@@ -2728,11 +2729,11 @@ public:
     struct param_type { // parameter package
         using distribution_type = uniform_real;
 
-        param_type() noexcept /* strengthened */ {
+        param_type() noexcept {
             _Init(_Ty{0}, _Ty{1});
         }
 
-        explicit param_type(_Ty _Min0, _Ty _Max0 = _Ty{1}) noexcept /* strengthened */ {
+        explicit param_type(_Ty _Min0, _Ty _Max0 = _Ty{1}) noexcept {
             _Init(_Min0, _Max0);
         }
 

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -66,9 +66,9 @@ _INLINE_VAR constexpr long double _Exp1   = 2.7182818284590452353602874713526625
 _INLINE_VAR constexpr long double _Two32  = 4294967296.0L;
 _INLINE_VAR constexpr long double _Two31  = 2147483648.0L;
 
-extern "C++" _CRTIMP2_PURE float __CLRCALL_PURE_OR_CDECL _XLgamma(float);
-extern "C++" _CRTIMP2_PURE double __CLRCALL_PURE_OR_CDECL _XLgamma(double);
-extern "C++" _CRTIMP2_PURE long double __CLRCALL_PURE_OR_CDECL _XLgamma(long double);
+extern "C++" _CRTIMP2_PURE float __CLRCALL_PURE_OR_CDECL _XLgamma(float) noexcept;
+extern "C++" _CRTIMP2_PURE double __CLRCALL_PURE_OR_CDECL _XLgamma(double) noexcept;
+extern "C++" _CRTIMP2_PURE long double __CLRCALL_PURE_OR_CDECL _XLgamma(long double) noexcept;
 
 _INLINE_VAR constexpr int _Nwords = 4;
 
@@ -236,7 +236,7 @@ private:
         }
     }
 
-    result_type _Xor27(result_type _Val) const { // shift and merge
+    result_type _Xor27(result_type _Val) const noexcept { // shift and merge
         return _Val ^ (_Val >> 27);
     }
 
@@ -610,11 +610,11 @@ private:
 
 template <class _Ty, size_t _Nw>
 struct _Circ_buf { // holds historical values for generators
-    _Ty _At(size_t _Ix) const {
+    _Ty _At(size_t _Ix) const noexcept {
         return _Ax[_Base(_Ix)];
     }
 
-    bool _Equals(const _Circ_buf& _Right) const {
+    bool _Equals(const _Circ_buf& _Right) const noexcept {
         const _Ty* _Last1 = _Ax + _Idx;
         const _Ty* _Last2 = _Right._Ax + _Right._Idx;
         const _Ty* _First;
@@ -656,7 +656,7 @@ struct _Circ_buf { // holds historical values for generators
         return true;
     }
 
-    size_t _Base(size_t _Ix = 0) const {
+    size_t _Base(size_t _Ix = 0) const noexcept {
         return (_Ix += _Idx) < _Nw ? (_Ix + _Nw) : (_Ix - _Nw);
     }
 
@@ -699,15 +699,15 @@ public:
         _Reset(_Gx, _Readcy);
     }
 
-    _NODISCARD result_type(min)() const {
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ {
         return 0;
     }
 
-    _NODISCARD result_type(max)() const {
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ {
         return _Swc_Traits::_Max;
     }
 
-    _NODISCARD result_type operator()() {
+    _NODISCARD result_type operator()() noexcept /* strengthened */ {
         const auto _Ix = 2 * _Rx <= this->_Idx ? 0 : this->_Idx;
         if (_Ix < _Sx) {
             _Setx(_Ix, this->_Ax[_Ix + 2 * _Rx - _Sx], this->_Ax[_Ix + _Rx]);
@@ -727,12 +727,12 @@ public:
         }
     }
 
-    _NODISCARD_FRIEND bool operator==(const _Swc_base& _Left, const _Swc_base& _Right) {
+    _NODISCARD_FRIEND bool operator==(const _Swc_base& _Left, const _Swc_base& _Right) noexcept /* strengthened */ {
         return static_cast<const _Swc_base::_Mybase&>(_Left)._Equals(_Right) && _Left._Carry == _Right._Carry;
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const _Swc_base& _Left, const _Swc_base& _Right) {
+    _NODISCARD_FRIEND bool operator!=(const _Swc_base& _Left, const _Swc_base& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -765,7 +765,7 @@ protected:
         this->_Idx = _Rx;
     }
 
-    void _Setx(size_t _Ix, _Ty _Xis, _Ty _Xir) { // update _Ax[_Ix] and _Carry
+    void _Setx(size_t _Ix, _Ty _Xis, _Ty _Xir) noexcept { // update _Ax[_Ix] and _Carry
         bool _Underflowed = false;
         _Ty _Newx         = _Xis;
         if (_Newx < _Xir) {
@@ -802,7 +802,7 @@ struct _Swc_traits { // traits for subtract_with_carry generator
     static constexpr _Mod_t _Mod = _Mx;
     static constexpr _Ty _Max    = _Mx - 1;
 
-    static int _Get_wc() { // compute number of 32-bit words per element
+    static int _Get_wc() noexcept { // compute number of 32-bit words per element
         int _Kx;
 
         if constexpr (_Mx == 0) {
@@ -840,7 +840,7 @@ struct _Swc_traits { // traits for subtract_with_carry generator
 
 #pragma warning(push)
 #pragma warning(disable : 4724) // potential mod by 0
-    static _Cy_t _Reduce(_Ty* _Ax) { // reduce values to allowed range
+    static _Cy_t _Reduce(_Ty* _Ax) noexcept { // reduce values to allowed range
         if constexpr (_Mx != 0) {
             for (size_t _Ix = 0; _Ix < _Nw; ++_Ix) {
                 _Ax[_Ix] = _Ax[_Ix] % _Mx;
@@ -952,11 +952,11 @@ public:
         this->_Idx   = _Rx;
     }
 
-    _NODISCARD static constexpr _Ty(min)() {
+    _NODISCARD static constexpr _Ty(min)() noexcept /* strengthened */ {
         return 0;
     }
 
-    _NODISCARD static constexpr _Ty(max)() {
+    _NODISCARD static constexpr _Ty(max)() noexcept /* strengthened */ {
         return _Mx - 1;
     }
 
@@ -1138,12 +1138,14 @@ public:
         this->_Idx = _Nx;
     }
 
-    _NODISCARD_FRIEND bool operator==(const mersenne_twister& _Left, const mersenne_twister& _Right) {
+    _NODISCARD_FRIEND bool operator==(const mersenne_twister& _Left, const mersenne_twister& _Right) noexcept
+    /* strengthened */ {
         return _Left._Equals(_Right);
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const mersenne_twister& _Left, const mersenne_twister& _Right) {
+    _NODISCARD_FRIEND bool operator!=(const mersenne_twister& _Left, const mersenne_twister& _Right) noexcept
+    /* strengthened */ {
         return !_Left._Equals(_Right);
     }
 #endif // !_HAS_CXX20
@@ -1168,11 +1170,11 @@ public:
         return _Ostr;
     }
 
-    _NODISCARD result_type(min)() const {
+    _NODISCARD result_type(min)() const noexcept {
         return 0;
     }
 
-    _NODISCARD result_type(max)() const {
+    _NODISCARD result_type(max)() const noexcept {
         return _WMSK;
     }
 
@@ -1330,11 +1332,11 @@ public:
         this->_Idx = _Nx;
     }
 
-    _NODISCARD static constexpr result_type(min)() {
+    _NODISCARD static constexpr result_type(min)() noexcept /* strengthened */ {
         return 0;
     }
 
-    _NODISCARD static constexpr result_type(max)() {
+    _NODISCARD static constexpr result_type(max)() noexcept /* strengthened */ {
         return _Mybase::_WMSK;
     }
 };
@@ -1449,11 +1451,11 @@ public:
     template <class _Seed_seq, _Enable_if_seed_seq_t<_Seed_seq, discard_block_engine, _Engine> = 0>
     explicit discard_block_engine(_Seed_seq& _Seq) : _Mybase(_Seq) {}
 
-    _NODISCARD static constexpr typename _Engine::result_type(min)() {
+    _NODISCARD static constexpr typename _Engine::result_type(min)() noexcept /* strengthened */ {
         return (_Engine::min)();
     }
 
-    _NODISCARD static constexpr typename _Engine::result_type(max)() {
+    _NODISCARD static constexpr typename _Engine::result_type(max)() noexcept /* strengthened */ {
         return (_Engine::max)();
     }
 };
@@ -1508,11 +1510,11 @@ public:
         return _Eng;
     }
 
-    _NODISCARD static constexpr result_type(min)() {
+    _NODISCARD static constexpr result_type(min)() noexcept /* strengthened */ {
         return 0;
     }
 
-    _NODISCARD static constexpr result_type(max)() {
+    _NODISCARD static constexpr result_type(max)() noexcept /* strengthened */ {
         return ((result_type{1} << (_Wx - 1)) << 1) - 1;
     }
 
@@ -1660,11 +1662,11 @@ public:
         return _Eng;
     }
 
-    _NODISCARD static constexpr result_type(min)() {
+    _NODISCARD static constexpr result_type(min)() noexcept /* strengthened */ {
         return (_Engine::min)();
     }
 
-    _NODISCARD static constexpr result_type(max)() {
+    _NODISCARD static constexpr result_type(max)() noexcept /* strengthened */ {
         return (_Engine::max)();
     }
 
@@ -1743,7 +1745,7 @@ public:
     static constexpr unsigned int _Udiff_bits = sizeof(_Udiff) * CHAR_BIT;
     using _Uprod = conditional_t<_Udiff_bits <= 16, uint32_t, conditional_t<_Udiff_bits <= 32, uint64_t, _Unsigned128>>;
 
-    explicit _Rng_from_urng_v2(_Urng& _Func) : _Ref(_Func) {}
+    explicit _Rng_from_urng_v2(_Urng& _Func) noexcept : _Ref(_Func) {}
 
     _Diff operator()(_Diff _Index) { // adapt _Urng closed range to [0, _Index)
         // From Daniel Lemire, "Fast Random Integer Generation in an Interval", ACM Trans. Model. Comput. Simul. 29 (1),
@@ -1863,33 +1865,36 @@ public:
     struct param_type { // parameter package
         using distribution_type = uniform_int;
 
-        param_type() {
+        param_type() noexcept // strengthened
+        {
             _Init(0, 9);
         }
 
-        explicit param_type(result_type _Min0, result_type _Max0 = 9) {
+        explicit param_type(result_type _Min0, result_type _Max0 = 9) noexcept // strengthened
+        {
             _Init(_Min0, _Max0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return _Left._Min == _Right._Min && _Left._Max == _Right._Max;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
 
-        _NODISCARD result_type a() const {
+        _NODISCARD result_type a() const noexcept /* strengthened */ {
             return _Min;
         }
 
-        _NODISCARD result_type b() const {
+        _NODISCARD result_type b() const noexcept /* strengthened */ {
             return _Max;
         }
-
-        void _Init(_Ty _Min0, _Ty _Max0) { // set internal state
+        void _Init(_Ty _Min0, _Ty _Max0) noexcept { // set internal state
             _STL_ASSERT(_Min0 <= _Max0, "invalid min and max arguments for uniform_int");
             _Min = _Min0;
             _Max = _Max0;
@@ -1899,37 +1904,37 @@ public:
         result_type _Max;
     };
 
-    uniform_int() : _Par(0, 9) {}
+    uniform_int() noexcept : _Par(0, 9) {}
 
-    explicit uniform_int(_Ty _Min0, _Ty _Max0 = 9) : _Par(_Min0, _Max0) {}
+    explicit uniform_int(_Ty _Min0, _Ty _Max0 = 9) noexcept : _Par(_Min0, _Max0) {}
 
-    explicit uniform_int(const param_type& _Par0) : _Par(_Par0) {}
+    explicit uniform_int(const param_type& _Par0) noexcept : _Par(_Par0) {}
 
-    _NODISCARD result_type a() const {
+    _NODISCARD result_type a() const noexcept /* strengthened */ {
         return _Par.a();
     }
 
-    _NODISCARD result_type b() const {
+    _NODISCARD result_type b() const noexcept /* strengthened */ {
         return _Par.b();
     }
 
-    _NODISCARD param_type param() const {
+    _NODISCARD param_type param() const noexcept /* strengthened */ {
         return _Par;
     }
 
-    void param(const param_type& _Par0) { // set parameter package
+    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
         _Par = _Par0;
     }
 
-    _NODISCARD result_type(min)() const {
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ {
         return _Par._Min;
     }
 
-    _NODISCARD result_type(max)() const {
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ {
         return _Par._Max;
     }
 
-    void reset() {} // clear internal state
+    void reset() noexcept /* strengthened */ {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -1985,7 +1990,7 @@ private:
         return static_cast<_Ty>(_Adjust(static_cast<_Uty>(_Uret + _Umin)));
     }
 
-    static _Uty _Adjust(_Uty _Uval) { // convert signed ranges to unsigned ranges and vice versa
+    static _Uty _Adjust(_Uty _Uval) noexcept { // convert signed ranges to unsigned ranges and vice versa
         if constexpr (is_signed_v<_Ty>) {
             constexpr _Uty _Adjuster = (static_cast<_Uty>(-1) >> 1) + 1; // 2^(N-1)
 
@@ -2014,26 +2019,33 @@ public:
     struct param_type : _Mypbase { // parameter package
         using distribution_type = uniform_int_distribution;
 
-        param_type() : _Mypbase(0, (numeric_limits<_Ty>::max)()) {}
+        param_type() noexcept // strengthened
+            : _Mypbase(0, (numeric_limits<_Ty>::max)()) {}
 
-        explicit param_type(result_type _Min0, result_type _Max0 = (numeric_limits<_Ty>::max)())
+        explicit param_type(
+            result_type _Min0, result_type _Max0 = (numeric_limits<_Ty>::max)()) noexcept // strengthened
             : _Mypbase(_Min0, _Max0) {}
 
-        param_type(const _Mypbase& _Right) : _Mypbase(_Right) {}
+        param_type(const _Mypbase& _Right) noexcept : _Mypbase(_Right) {}
     };
 
-    uniform_int_distribution() : _Mybase(0, (numeric_limits<_Ty>::max)()) {}
+    uniform_int_distribution() noexcept // strengthened
+        : _Mybase(0, (numeric_limits<_Ty>::max)()) {}
 
-    explicit uniform_int_distribution(_Ty _Min0, _Ty _Max0 = (numeric_limits<_Ty>::max)()) : _Mybase(_Min0, _Max0) {}
+    explicit uniform_int_distribution(_Ty _Min0, _Ty _Max0 = (numeric_limits<_Ty>::max)()) noexcept // strengthened
+        : _Mybase(_Min0, _Max0) {}
 
-    explicit uniform_int_distribution(const param_type& _Par0) : _Mybase(_Par0) {}
+    explicit uniform_int_distribution(const param_type& _Par0) noexcept // strengthened
+        : _Mybase(_Par0) {}
 
-    _NODISCARD_FRIEND bool operator==(const uniform_int_distribution& _Left, const uniform_int_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator==(
+        const uniform_int_distribution& _Left, const uniform_int_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const uniform_int_distribution& _Left, const uniform_int_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator!=(
+        const uniform_int_distribution& _Left, const uniform_int_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -2046,29 +2058,33 @@ public:
     struct param_type { // parameter package
         using distribution_type = bernoulli_distribution;
 
-        param_type() {
+        param_type() noexcept // strengthened
+        {
             _Init(0.5);
         }
 
-        explicit param_type(double _Px0) {
+        explicit param_type(double _Px0) noexcept // strengthened
+        {
             _Init(_Px0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return _Left._Px == _Right._Px;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
 
-        _NODISCARD double p() const {
+        _NODISCARD double p() const noexcept /* strengthened */ {
             return _Px;
         }
 
-        void _Init(double _Px0) { // set internal state
+        void _Init(double _Px0) noexcept { // set internal state
             _STL_ASSERT(0.0 <= _Px0 && _Px0 <= 1.0, "invalid probability argument for bernoulli_distribution");
 
             _Px = _Px0;
@@ -2077,33 +2093,36 @@ public:
         double _Px;
     };
 
-    bernoulli_distribution() : _Par(0.5) {}
+    bernoulli_distribution() noexcept // strengthened
+        : _Par(0.5) {}
 
-    explicit bernoulli_distribution(double _Px0) : _Par(_Px0) {}
+    explicit bernoulli_distribution(double _Px0) noexcept // strengthened
+        : _Par(_Px0) {}
 
-    explicit bernoulli_distribution(const param_type& _Par0) : _Par(_Par0) {}
+    explicit bernoulli_distribution(const param_type& _Par0) noexcept // strengthened
+        : _Par(_Par0) {}
 
-    _NODISCARD double p() const {
+    _NODISCARD double p() const noexcept /* strengthened */ {
         return _Par.p();
     }
 
-    _NODISCARD param_type param() const {
+    _NODISCARD param_type param() const noexcept /* strengthened */ {
         return _Par;
     }
 
-    void param(const param_type& _Par0) { // set parameter package
+    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
         _Par = _Par0;
     }
 
-    _NODISCARD result_type(min)() const { // get smallest possible result
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ { // get smallest possible result
         return false;
     }
 
-    _NODISCARD result_type(max)() const { // get largest possible result
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ { // get largest possible result
         return true;
     }
 
-    void reset() {} // clear internal state
+    void reset() noexcept /* strengthened */ {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -2115,12 +2134,14 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const bernoulli_distribution& _Left, const bernoulli_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator==(
+        const bernoulli_distribution& _Left, const bernoulli_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const bernoulli_distribution& _Left, const bernoulli_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator!=(
+        const bernoulli_distribution& _Left, const bernoulli_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -2154,7 +2175,7 @@ private:
 // First truncate to largest _Flt <= _Val, then add ceil(ulp).
 
 template <class _Flt, class _Ty>
-_NODISCARD _Flt _Float_upper_bound(_Ty _Val) {
+_NODISCARD _Flt _Float_upper_bound(_Ty _Val) noexcept {
     static_assert(is_unsigned_v<_Ty> && is_integral_v<_Ty> && is_floating_point_v<_Flt>,
         "invalid template argument for _Float_upper_bound");
     constexpr auto _Ty_digits  = numeric_limits<_Ty>::digits;
@@ -2199,29 +2220,33 @@ public:
     struct param_type { // parameter package
         using distribution_type = geometric_distribution;
 
-        param_type() {
+        param_type() noexcept // strengthened
+        {
             _Init(_Ty1(0.5));
         }
 
-        explicit param_type(_Ty1 _Px0) {
+        explicit param_type(_Ty1 _Px0) // strengthened
+        {
             _Init(_Px0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return _Left._Px == _Right._Px;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
 
-        _NODISCARD _Ty1 p() const {
+        _NODISCARD _Ty1 p() const noexcept /* strengthened */ {
             return _Px;
         }
 
-        void _Init(_Ty1 _Px0) { // initialize
+        void _Init(_Ty1 _Px0) noexcept /* strengthened */ { // initialize
             _STL_ASSERT(0.0 < _Px0 && _Px0 < 1.0, "invalid probability argument for geometric_distribution");
             _Px      = _Px0;
             _Log_1_p = _CSTD log(1 - _Px);
@@ -2231,33 +2256,36 @@ public:
         _Ty1 _Log_1_p;
     };
 
-    geometric_distribution() : _Par(_Ty1(0.5)) {}
+    geometric_distribution() noexcept // strengthened
+        : _Par(_Ty1(0.5)) {}
 
-    explicit geometric_distribution(_Ty1 _Px0) : _Par(_Px0) {}
+    explicit geometric_distribution(_Ty1 _Px0) noexcept // strengthened
+        : _Par(_Px0) {}
 
-    explicit geometric_distribution(const param_type& _Par0) : _Par(_Par0) {}
+    explicit geometric_distribution(const param_type& _Par0) noexcept // strengthened
+        : _Par(_Par0) {}
 
-    _NODISCARD _Ty1 p() const {
+    _NODISCARD _Ty1 p() const noexcept /* strengthened */ {
         return _Par.p();
     }
 
-    _NODISCARD param_type param() const {
+    _NODISCARD param_type param() const noexcept /* strengthened */ {
         return _Par;
     }
 
-    void param(const param_type& _Par0) { // set parameter package
+    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
         _Par = _Par0;
     }
 
-    _NODISCARD result_type(min)() const { // get smallest possible result
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ { // get smallest possible result
         return 0;
     }
 
-    _NODISCARD result_type(max)() const { // get largest possible result
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ { // get largest possible result
         return (numeric_limits<result_type>::max)();
     }
 
-    void reset() {} // clear internal state
+    void reset() noexcept /* strengthened */ {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -2269,12 +2297,14 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const geometric_distribution& _Left, const geometric_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator==(
+        const geometric_distribution& _Left, const geometric_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const geometric_distribution& _Left, const geometric_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator!=(
+        const geometric_distribution& _Left, const geometric_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -2328,7 +2358,7 @@ public:
         }
     }
 
-    void _Init(const _Ty1& _Mean0) { // set internal state
+    void _Init(const _Ty1& _Mean0) noexcept { // set internal state
         _Gx0 = _CSTD exp(-_Mean0);
     }
 
@@ -2348,29 +2378,33 @@ public:
     struct param_type { // parameter package
         using distribution_type = poisson_distribution;
 
-        param_type() {
+        param_type() noexcept // strengthened
+        {
             _Init(_Ty1(1));
         }
 
-        explicit param_type(_Ty1 _Mean0) {
+        explicit param_type(_Ty1 _Mean0) noexcept // strengthened
+        {
             _Init(_Mean0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return _Left._Mean == _Right._Mean;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
 
-        _NODISCARD _Ty1 mean() const {
+        _NODISCARD _Ty1 mean() const noexcept /* strengthened */ {
             return _Mean;
         }
 
-        void _Init(_Ty1 _Mean0) { // set internal state
+        void _Init(_Ty1 _Mean0) noexcept { // set internal state
             _STL_ASSERT(0.0 < _Mean0, "invalid mean argument for poisson_distribution");
             _Mean = _Mean0;
             _Sqrt = _CSTD sqrt(2.0 * _Mean0);
@@ -2387,33 +2421,36 @@ public:
         _Small_poisson_distribution<_Ty> _Small;
     };
 
-    poisson_distribution() : _Par(_Ty1(1)) {}
+    poisson_distribution() noexcept // strengthened
+        : _Par(_Ty1(1)) {}
 
-    explicit poisson_distribution(_Ty1 _Mean0) : _Par(_Mean0) {}
+    explicit poisson_distribution(_Ty1 _Mean0) noexcept // strengthened
+        : _Par(_Mean0) {}
 
-    explicit poisson_distribution(const param_type& _Par0) : _Par(_Par0) {}
+    explicit poisson_distribution(const param_type& _Par0) noexcept // strengthened
+        : _Par(_Par0) {}
 
-    _NODISCARD _Ty1 mean() const {
+    _NODISCARD _Ty1 mean() const noexcept /* strengthened */ {
         return _Par.mean();
     }
 
-    _NODISCARD param_type param() const {
+    _NODISCARD param_type param() const noexcept /* strengthened */ {
         return _Par;
     }
 
-    void param(const param_type& _Par0) { // set parameter package
+    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
         _Par = _Par0;
     }
 
-    _NODISCARD result_type(min)() const { // get smallest possible result
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ { // get smallest possible result
         return 0;
     }
 
-    _NODISCARD result_type(max)() const { // get largest possible result
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ { // get largest possible result
         return (numeric_limits<result_type>::max)();
     }
 
-    void reset() {} // clear internal state
+    void reset() noexcept /* strengthened */ {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -2425,12 +2462,14 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const poisson_distribution& _Left, const poisson_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator==(const poisson_distribution& _Left, const poisson_distribution& _Right) noexcept
+    /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const poisson_distribution& _Left, const poisson_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator!=(const poisson_distribution& _Left, const poisson_distribution& _Right) noexcept
+    /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -2496,33 +2535,37 @@ public:
     struct param_type { // parameter package
         using distribution_type = binomial_distribution;
 
-        param_type() {
+        param_type() noexcept // strengthened
+        {
             _Init(1, _Ty1(0.5));
         }
 
-        explicit param_type(_Ty _Tx0, _Ty1 _Px0 = _Ty1(0.5)) {
+        explicit param_type(_Ty _Tx0, _Ty1 _Px0 = _Ty1(0.5)) noexcept // strengthened
+        {
             _Init(_Tx0, _Px0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return _Left._Tx == _Right._Tx && _Left._Px == _Right._Px;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
 
-        _NODISCARD _Ty t() const {
+        _NODISCARD _Ty t() const noexcept /* strengthened */ {
             return _Tx;
         }
 
-        _NODISCARD _Ty1 p() const {
+        _NODISCARD _Ty1 p() const noexcept /* strengthened */ {
             return _Px;
         }
 
-        void _Init(_Ty _Tx0, _Ty1 _Px0) { // initialize
+        void _Init(_Ty _Tx0, _Ty1 _Px0) noexcept { // initialize
             _STL_ASSERT(0.0 <= _Tx0, "invalid max argument for binomial_distribution");
             _STL_ASSERT(0.0 <= _Px0 && _Px0 <= 1.0, "invalid probability argument for binomial_distribution");
             _Tx    = _Tx0;
@@ -2548,37 +2591,40 @@ public:
         _Small_poisson_distribution<_Ty> _Small; // TRANSITION, ABI: unused
     };
 
-    binomial_distribution() : _Par(1, _Ty1(0.5)) {}
+    binomial_distribution() noexcept // strengthened
+        : _Par(1, _Ty1(0.5)) {}
 
-    explicit binomial_distribution(_Ty _Tx0, _Ty1 _Px0 = _Ty1(0.5)) : _Par(_Tx0, _Px0) {}
+    explicit binomial_distribution(_Ty _Tx0, _Ty1 _Px0 = _Ty1(0.5)) noexcept // strengthened
+        : _Par(_Tx0, _Px0) {}
 
-    explicit binomial_distribution(const param_type& _Par0) : _Par(_Par0) {}
+    explicit binomial_distribution(const param_type& _Par0) noexcept // strengthened
+        : _Par(_Par0) {}
 
-    _NODISCARD _Ty t() const {
+    _NODISCARD _Ty t() const noexcept /* strengthened */ {
         return _Par.t();
     }
 
-    _NODISCARD _Ty1 p() const {
+    _NODISCARD _Ty1 p() const noexcept /* strengthened */ {
         return _Par.p();
     }
 
-    _NODISCARD param_type param() const {
+    _NODISCARD param_type param() const noexcept /* strengthened */ {
         return _Par;
     }
 
-    void param(const param_type& _Par0) { // set parameter package
+    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
         _Par = _Par0;
     }
 
-    _NODISCARD result_type(min)() const { // get smallest possible result
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ { // get smallest possible result
         return 0;
     }
 
-    _NODISCARD result_type(max)() const { // get largest possible result
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ { // get largest possible result
         return _Par.t();
     }
 
-    void reset() {} // clear internal state
+    void reset() noexcept /* strengthened */ {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -2590,12 +2636,14 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const binomial_distribution& _Left, const binomial_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator==(const binomial_distribution& _Left, const binomial_distribution& _Right) noexcept
+    /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const binomial_distribution& _Left, const binomial_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator!=(const binomial_distribution& _Left, const binomial_distribution& _Right) noexcept
+    /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -2690,33 +2738,37 @@ public:
     struct param_type { // parameter package
         using distribution_type = uniform_real;
 
-        param_type() {
+        param_type() noexcept // strengthened
+        {
             _Init(_Ty{0}, _Ty{1});
         }
 
-        explicit param_type(_Ty _Min0, _Ty _Max0 = _Ty{1}) {
+        explicit param_type(_Ty _Min0, _Ty _Max0 = _Ty{1}) noexcept // strengthened
+        {
             _Init(_Min0, _Max0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return _Left._Min == _Right._Min && _Left._Max == _Right._Max;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
 
-        _NODISCARD result_type a() const {
+        _NODISCARD result_type a() const noexcept /* strengthened */ {
             return _Min;
         }
 
-        _NODISCARD result_type b() const {
+        _NODISCARD result_type b() const noexcept /* strengthened */ {
             return _Max;
         }
 
-        void _Init(_Ty _Min0, _Ty _Max0) { // set internal state
+        void _Init(_Ty _Min0, _Ty _Max0) noexcept { // set internal state
             _STL_ASSERT(_Min0 <= _Max0 && (0 <= _Min0 || _Max0 <= _Min0 + (numeric_limits<_Ty>::max)()),
                 "invalid min and max arguments for uniform_real");
             _Min = _Min0;
@@ -2727,37 +2779,37 @@ public:
         result_type _Max;
     };
 
-    uniform_real() : _Par(_Ty{0}, _Ty{1}) {}
+    uniform_real() noexcept : _Par(_Ty{0}, _Ty{1}) {}
 
-    explicit uniform_real(_Ty _Min0, _Ty _Max0 = _Ty{1}) : _Par(_Min0, _Max0) {}
+    explicit uniform_real(_Ty _Min0, _Ty _Max0 = _Ty{1}) noexcept : _Par(_Min0, _Max0) {}
 
-    explicit uniform_real(const param_type& _Par0) : _Par(_Par0) {}
+    explicit uniform_real(const param_type& _Par0) noexcept : _Par(_Par0) {}
 
-    _NODISCARD result_type a() const {
+    _NODISCARD result_type a() const noexcept /* strengthened */ {
         return _Par.a();
     }
 
-    _NODISCARD result_type b() const {
+    _NODISCARD result_type b() const noexcept /* strengthened */ {
         return _Par.b();
     }
 
-    _NODISCARD param_type param() const {
+    _NODISCARD param_type param() const noexcept /* strengthened */ {
         return _Par;
     }
 
-    void param(const param_type& _Par0) { // set parameter package
+    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
         _Par = _Par0;
     }
 
-    _NODISCARD result_type(min)() const {
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ {
         return _Par._Min;
     }
 
-    _NODISCARD result_type(max)() const {
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ {
         return _Par._Max;
     }
 
-    void reset() {} // clear internal state
+    void reset() noexcept /* strengthened */ {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -2819,25 +2871,32 @@ public:
     struct param_type : _Mypbase { // parameter package
         using distribution_type = uniform_real_distribution;
 
-        param_type() : _Mypbase(_Ty{0}, _Ty{1}) {}
+        param_type() noexcept // strengthened
+            : _Mypbase(_Ty{0}, _Ty{1}) {}
 
-        explicit param_type(_Ty _Min0, _Ty _Max0 = _Ty{1}) : _Mypbase(_Min0, _Max0) {}
+        explicit param_type(_Ty _Min0, _Ty _Max0 = _Ty{1}) noexcept // strengthened
+            : _Mypbase(_Min0, _Max0) {}
 
-        param_type(const _Mypbase& _Right) : _Mypbase(_Right) {}
+        param_type(const _Mypbase& _Right) noexcept : _Mypbase(_Right) {}
     };
 
-    uniform_real_distribution() : _Mybase(_Ty{0}, _Ty{1}) {}
+    uniform_real_distribution() noexcept // strengthened
+        : _Mybase(_Ty{0}, _Ty{1}) {}
 
-    explicit uniform_real_distribution(_Ty _Min0, _Ty _Max0 = _Ty{1}) : _Mybase(_Min0, _Max0) {}
+    explicit uniform_real_distribution(_Ty _Min0, _Ty _Max0 = _Ty{1}) noexcept // strengthened
+        : _Mybase(_Min0, _Max0) {}
 
-    explicit uniform_real_distribution(const param_type& _Par0) : _Mybase(_Par0) {}
+    explicit uniform_real_distribution(const param_type& _Par0) noexcept // strengthened
+        : _Mybase(_Par0) {}
 
-    _NODISCARD_FRIEND bool operator==(const uniform_real_distribution& _Left, const uniform_real_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator==(
+        const uniform_real_distribution& _Left, const uniform_real_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const uniform_real_distribution& _Left, const uniform_real_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator!=(
+        const uniform_real_distribution& _Left, const uniform_real_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -2853,29 +2912,33 @@ public:
     struct param_type { // parameter package
         using distribution_type = exponential_distribution;
 
-        param_type() {
+        param_type() noexcept // strengthened
+        {
             _Init(_Ty{1});
         }
 
-        explicit param_type(_Ty _Lambda0) {
+        explicit param_type(_Ty _Lambda0) noexcept // strengthened
+        {
             _Init(_Lambda0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return _Left._Lambda == _Right._Lambda;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
 
-        _NODISCARD _Ty lambda() const {
+        _NODISCARD _Ty lambda() const noexcept /* strengthened */ {
             return _Lambda;
         }
 
-        void _Init(_Ty _Lambda0) { // set internal state
+        void _Init(_Ty _Lambda0) noexcept { // set internal state
             _STL_ASSERT(0.0 < _Lambda0, "invalid lambda argument for exponential_distribution");
             _Lambda = _Lambda0;
         }
@@ -2883,33 +2946,36 @@ public:
         _Ty _Lambda;
     };
 
-    exponential_distribution() : _Par(_Ty{1}) {}
+    exponential_distribution() noexcept // strengthened
+        : _Par(_Ty{1}) {}
 
-    explicit exponential_distribution(_Ty _Lambda0) : _Par(_Lambda0) {}
+    explicit exponential_distribution(_Ty _Lambda0) noexcept // strengthened
+        : _Par(_Lambda0) {}
 
-    explicit exponential_distribution(const param_type& _Par0) : _Par(_Par0) {}
+    explicit exponential_distribution(const param_type& _Par0) noexcept // strengthened
+        : _Par(_Par0) {}
 
-    _NODISCARD _Ty lambda() const {
+    _NODISCARD _Ty lambda() const noexcept /* strengthened */ {
         return _Par.lambda();
     }
 
-    _NODISCARD param_type param() const {
+    _NODISCARD param_type param() const noexcept /* strengthened */ {
         return _Par;
     }
 
-    void param(const param_type& _Par0) { // set parameter package
+    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
         _Par = _Par0;
     }
 
-    _NODISCARD result_type(min)() const { // get smallest possible result
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ { // get smallest possible result
         return 0;
     }
 
-    _NODISCARD result_type(max)() const { // get largest possible result
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ { // get largest possible result
         return numeric_limits<result_type>::infinity();
     }
 
-    void reset() {} // clear internal state
+    void reset() noexcept /* strengthened */ {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -2921,12 +2987,14 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const exponential_distribution& _Left, const exponential_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator==(
+        const exponential_distribution& _Left, const exponential_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const exponential_distribution& _Left, const exponential_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator!=(
+        const exponential_distribution& _Left, const exponential_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -2966,37 +3034,41 @@ public:
     struct param_type { // parameter package
         using distribution_type = normal_distribution;
 
-        param_type() {
+        param_type() noexcept // strengthened
+        {
             _Init(0.0, 1.0);
         }
 
-        explicit param_type(_Ty _Mean0, _Ty _Sigma0 = 1.0) {
+        explicit param_type(_Ty _Mean0, _Ty _Sigma0 = 1.0) noexcept // strengthened
+        {
             _Init(_Mean0, _Sigma0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return _Left._Mean == _Right._Mean && _Left._Sigma == _Right._Sigma;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
 
-        _NODISCARD _Ty mean() const {
+        _NODISCARD _Ty mean() const noexcept /* strengthened */ {
             return _Mean;
         }
 
-        _NODISCARD _Ty sigma() const {
+        _NODISCARD _Ty sigma() const noexcept /* strengthened */ {
             return _Sigma;
         }
 
-        _NODISCARD _Ty stddev() const {
+        _NODISCARD _Ty stddev() const noexcept /* strengthened */ {
             return _Sigma;
         }
 
-        void _Init(_Ty _Mean0, _Ty _Sigma0) { // set internal state
+        void _Init(_Ty _Mean0, _Ty _Sigma0) noexcept { // set internal state
             _STL_ASSERT(0.0 < _Sigma0, "invalid sigma argument for normal_distribution");
             _Mean  = _Mean0;
             _Sigma = _Sigma0;
@@ -3006,42 +3078,45 @@ public:
         _Ty _Sigma;
     };
 
-    normal_distribution() : _Par(0.0, 1.0), _Valid(false), _Xx2(0) {}
+    normal_distribution() noexcept // strengthened
+        : _Par(0.0, 1.0), _Valid(false), _Xx2(0) {}
 
-    explicit normal_distribution(_Ty _Mean0, _Ty _Sigma0 = 1.0) : _Par(_Mean0, _Sigma0), _Valid(false), _Xx2(0) {}
+    explicit normal_distribution(_Ty _Mean0, _Ty _Sigma0 = 1.0) noexcept // strengthened
+        : _Par(_Mean0, _Sigma0), _Valid(false), _Xx2(0) {}
 
-    explicit normal_distribution(const param_type& _Par0) : _Par(_Par0), _Valid(false), _Xx2(0) {}
+    explicit normal_distribution(const param_type& _Par0) noexcept // strengthened
+        : _Par(_Par0), _Valid(false), _Xx2(0) {}
 
-    _NODISCARD _Ty mean() const {
+    _NODISCARD _Ty mean() const noexcept /* strengthened */ {
         return _Par.mean();
     }
 
-    _NODISCARD _Ty sigma() const {
+    _NODISCARD _Ty sigma() const noexcept /* strengthened */ {
         return _Par.sigma();
     }
 
-    _NODISCARD _Ty stddev() const {
+    _NODISCARD _Ty stddev() const noexcept /* strengthened */ {
         return _Par.sigma();
     }
 
-    _NODISCARD param_type param() const {
+    _NODISCARD param_type param() const noexcept /* strengthened */ {
         return _Par;
     }
 
-    void param(const param_type& _Par0) { // set parameter package
+    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
         _Par = _Par0;
         reset();
     }
 
-    _NODISCARD result_type(min)() const { // get smallest possible result
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ { // get smallest possible result
         return -numeric_limits<result_type>::infinity();
     }
 
-    _NODISCARD result_type(max)() const { // get largest possible result
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ { // get largest possible result
         return numeric_limits<result_type>::infinity();
     }
 
-    void reset() { // clear internal state
+    void reset() noexcept /* strengthened */ { // clear internal state
         _Valid = false;
     }
 
@@ -3056,12 +3131,14 @@ public:
         return _Eval(_Eng, _Par0, false);
     }
 
-    _NODISCARD_FRIEND bool operator==(const normal_distribution& _Left, const normal_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator==(const normal_distribution& _Left, const normal_distribution& _Right) noexcept
+    /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const normal_distribution& _Left, const normal_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator!=(const normal_distribution& _Left, const normal_distribution& _Right) noexcept
+    /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -3154,33 +3231,37 @@ public:
     struct param_type { // parameter package
         using distribution_type = gamma_distribution;
 
-        param_type() {
+        param_type() noexcept // strengthened
+        {
             _Init(_Ty{1}, _Ty{1});
         }
 
-        explicit param_type(_Ty _Alpha0, _Ty _Beta0 = _Ty{1}) {
+        explicit param_type(_Ty _Alpha0, _Ty _Beta0 = _Ty{1}) noexcept // strengthened
+        {
             _Init(_Alpha0, _Beta0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return _Left._Alpha == _Right._Alpha && _Left._Beta == _Right._Beta;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
 
-        _NODISCARD _Ty alpha() const {
+        _NODISCARD _Ty alpha() const noexcept /* strengthened */ {
             return _Alpha;
         }
 
-        _NODISCARD _Ty beta() const {
+        _NODISCARD _Ty beta() const noexcept /* strengthened */ {
             return _Beta;
         }
 
-        void _Init(_Ty _Alpha0, _Ty _Beta0) { // initialize
+        void _Init(_Ty _Alpha0, _Ty _Beta0) noexcept { // initialize
             _STL_ASSERT(0.0 < _Alpha0, "invalid alpha argument for gamma_distribution");
             _STL_ASSERT(0.0 < _Beta0, "invalid beta argument for gamma_distribution");
             _Alpha = _Alpha0;
@@ -3196,37 +3277,40 @@ public:
         exponential_distribution<_Ty> _Exp;
     };
 
-    gamma_distribution() : _Par(_Ty{1}, _Ty{1}) {}
+    gamma_distribution() noexcept // strengthened
+        : _Par(_Ty{1}, _Ty{1}) {}
 
-    explicit gamma_distribution(_Ty _Alpha0, _Ty _Beta0 = _Ty{1}) : _Par(_Alpha0, _Beta0) {}
+    explicit gamma_distribution(_Ty _Alpha0, _Ty _Beta0 = _Ty{1}) noexcept // strengthened
+        : _Par(_Alpha0, _Beta0) {}
 
-    explicit gamma_distribution(const param_type& _Par0) : _Par(_Par0) {}
+    explicit gamma_distribution(const param_type& _Par0) noexcept // strengthened
+        : _Par(_Par0) {}
 
-    _NODISCARD _Ty alpha() const {
+    _NODISCARD _Ty alpha() const noexcept /* strengthened */ {
         return _Par.alpha();
     }
 
-    _NODISCARD _Ty beta() const {
+    _NODISCARD _Ty beta() const noexcept /* strengthened */ {
         return _Par.beta();
     }
 
-    _NODISCARD param_type param() const {
+    _NODISCARD param_type param() const noexcept /* strengthened */ {
         return _Par;
     }
 
-    void param(const param_type& _Par0) { // set parameter package
+    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
         _Par = _Par0;
     }
 
-    _NODISCARD result_type(min)() const { // get smallest possible result
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ { // get smallest possible result
         return result_type{0.0};
     }
 
-    _NODISCARD result_type(max)() const { // get largest possible result
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ { // get largest possible result
         return numeric_limits<result_type>::infinity();
     }
 
-    void reset() {} // clear internal state
+    void reset() noexcept /* strengthened */ {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -3238,12 +3322,14 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const gamma_distribution& _Left, const gamma_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator==(const gamma_distribution& _Left, const gamma_distribution& _Right) noexcept
+    /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const gamma_distribution& _Left, const gamma_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator!=(const gamma_distribution& _Left, const gamma_distribution& _Right) noexcept
+    /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -3341,33 +3427,37 @@ public:
     struct param_type { // parameter package
         using distribution_type = weibull_distribution;
 
-        param_type() {
+        param_type() noexcept // strengthened
+        {
             _Init(_Ty{1}, _Ty{1});
         }
 
-        explicit param_type(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) {
+        explicit param_type(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) noexcept // strengthened
+        {
             _Init(_Ax0, _Bx0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return _Left._Ax == _Right._Ax && _Left._Bx == _Right._Bx;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
 
-        _NODISCARD _Ty a() const {
+        _NODISCARD _Ty a() const noexcept /* strengthened */ {
             return _Ax;
         }
 
-        _NODISCARD _Ty b() const {
+        _NODISCARD _Ty b() const noexcept /* strengthened */ {
             return _Bx;
         }
 
-        void _Init(_Ty _Ax0, _Ty _Bx0) { // initialize
+        void _Init(_Ty _Ax0, _Ty _Bx0) noexcept { // initialize
             _STL_ASSERT(0.0 < _Ax0, "invalid a argument for weibull_distribution");
             _STL_ASSERT(0.0 < _Bx0, "invalid b argument for weibull_distribution");
             _Ax = _Ax0;
@@ -3378,37 +3468,40 @@ public:
         _Ty _Bx;
     };
 
-    weibull_distribution() : _Par(_Ty{1}, _Ty{1}) {}
+    weibull_distribution() noexcept // strengthened
+        : _Par(_Ty{1}, _Ty{1}) {}
 
-    explicit weibull_distribution(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) : _Par(_Ax0, _Bx0) {}
+    explicit weibull_distribution(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) noexcept // strengthened
+        : _Par(_Ax0, _Bx0) {}
 
-    explicit weibull_distribution(const param_type& _Par0) : _Par(_Par0) {}
+    explicit weibull_distribution(const param_type& _Par0) noexcept // strengthened
+        : _Par(_Par0) {}
 
-    _NODISCARD _Ty a() const {
+    _NODISCARD _Ty a() const noexcept /* strengthened */ {
         return _Par.a();
     }
 
-    _NODISCARD _Ty b() const {
+    _NODISCARD _Ty b() const noexcept /* strengthened */ {
         return _Par.b();
     }
 
-    _NODISCARD param_type param() const {
+    _NODISCARD param_type param() const noexcept /* strengthened */ {
         return _Par;
     }
 
-    void param(const param_type& _Par0) { // set parameter package
+    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
         _Par = _Par0;
     }
 
-    _NODISCARD result_type(min)() const { // get smallest possible result
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ { // get smallest possible result
         return 0;
     }
 
-    _NODISCARD result_type(max)() const { // get largest possible result
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ { // get largest possible result
         return numeric_limits<result_type>::infinity();
     }
 
-    void reset() {} // clear internal state
+    void reset() noexcept /* strengthened */ {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -3420,12 +3513,14 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const weibull_distribution& _Left, const weibull_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator==(const weibull_distribution& _Left, const weibull_distribution& _Right) noexcept
+    /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const weibull_distribution& _Left, const weibull_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator!=(const weibull_distribution& _Left, const weibull_distribution& _Right) noexcept
+    /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -3469,33 +3564,37 @@ public:
     struct param_type { // parameter package
         using distribution_type = extreme_value_distribution;
 
-        param_type() {
+        param_type() noexcept // strengthened
+        {
             _Init(_Ty{0}, _Ty{1});
         }
 
-        explicit param_type(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) {
+        explicit param_type(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) noexcept // strengthened
+        {
             _Init(_Ax0, _Bx0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return _Left._Ax == _Right._Ax && _Left._Bx == _Right._Bx;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
 
-        _NODISCARD _Ty a() const {
+        _NODISCARD _Ty a() const noexcept /* strengthened */ {
             return _Ax;
         }
 
-        _NODISCARD _Ty b() const {
+        _NODISCARD _Ty b() const noexcept /* strengthened */ {
             return _Bx;
         }
 
-        void _Init(_Ty _Ax0, _Ty _Bx0) { // initialize
+        void _Init(_Ty _Ax0, _Ty _Bx0) noexcept { // initialize
             _STL_ASSERT(0.0 < _Bx0, "invalid b argument for extreme_value_distribution");
             _Ax = _Ax0;
             _Bx = _Bx0;
@@ -3505,37 +3604,40 @@ public:
         _Ty _Bx;
     };
 
-    extreme_value_distribution() : _Par(_Ty{0}, _Ty{1}) {}
+    extreme_value_distribution() noexcept // strengthened
+        : _Par(_Ty{0}, _Ty{1}) {}
 
-    explicit extreme_value_distribution(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) : _Par(_Ax0, _Bx0) {}
+    explicit extreme_value_distribution(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) noexcept // strengthened
+        : _Par(_Ax0, _Bx0) {}
 
-    explicit extreme_value_distribution(const param_type& _Par0) : _Par(_Par0) {}
+    explicit extreme_value_distribution(const param_type& _Par0) noexcept // strengthened
+        : _Par(_Par0) {}
 
-    _NODISCARD _Ty a() const {
+    _NODISCARD _Ty a() const noexcept /* strengthened */ {
         return _Par.a();
     }
 
-    _NODISCARD _Ty b() const {
+    _NODISCARD _Ty b() const noexcept /* strengthened */ {
         return _Par.b();
     }
 
-    _NODISCARD param_type param() const {
+    _NODISCARD param_type param() const noexcept /* strengthened */ {
         return _Par;
     }
 
-    void param(const param_type& _Par0) { // set parameter package
+    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
         _Par = _Par0;
     }
 
-    _NODISCARD result_type(min)() const { // get smallest possible result
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ { // get smallest possible result
         return -numeric_limits<result_type>::infinity();
     }
 
-    _NODISCARD result_type(max)() const { // get largest possible result
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ { // get largest possible result
         return numeric_limits<result_type>::infinity();
     }
 
-    void reset() {} // clear internal state
+    void reset() noexcept /* strengthened */ {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -3548,13 +3650,13 @@ public:
     }
 
     _NODISCARD_FRIEND bool operator==(
-        const extreme_value_distribution& _Left, const extreme_value_distribution& _Right) {
+        const extreme_value_distribution& _Left, const extreme_value_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
     _NODISCARD_FRIEND bool operator!=(
-        const extreme_value_distribution& _Left, const extreme_value_distribution& _Right) {
+        const extreme_value_distribution& _Left, const extreme_value_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -3598,33 +3700,37 @@ public:
     struct param_type { // parameter package
         using distribution_type = lognormal_distribution;
 
-        param_type() {
+        param_type() noexcept // strengthened
+        {
             _Init(_Ty{0}, _Ty{1});
         }
 
-        explicit param_type(_Ty _Mx0, _Ty _Sx0 = _Ty{1}) {
+        explicit param_type(_Ty _Mx0, _Ty _Sx0 = _Ty{1}) noexcept // strengthened
+        {
             _Init(_Mx0, _Sx0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return _Left._Mx == _Right._Mx && _Left._Sx == _Right._Sx;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
 
-        _NODISCARD _Ty m() const {
+        _NODISCARD _Ty m() const noexcept /* strengthened */ {
             return _Mx;
         }
 
-        _NODISCARD _Ty s() const {
+        _NODISCARD _Ty s() const noexcept /* strengthened */ {
             return _Sx;
         }
 
-        void _Init(_Ty _Mx0, _Ty _Sx0) { // initialize
+        void _Init(_Ty _Mx0, _Ty _Sx0) noexcept { // initialize
             _STL_ASSERT(0.0 < _Sx0, "invalid s argument for lognormal_distribution");
             _Mx = _Mx0;
             _Sx = _Sx0;
@@ -3634,37 +3740,40 @@ public:
         _Ty _Sx;
     };
 
-    lognormal_distribution() : _Par(_Ty{0}, _Ty{1}) {}
+    lognormal_distribution() noexcept // strengthened
+        : _Par(_Ty{0}, _Ty{1}) {}
 
-    explicit lognormal_distribution(_Ty _Mx0, _Ty _Sx0 = _Ty{1}) : _Par(_Mx0, _Sx0) {}
+    explicit lognormal_distribution(_Ty _Mx0, _Ty _Sx0 = _Ty{1}) noexcept // strengthened
+        : _Par(_Mx0, _Sx0) {}
 
-    explicit lognormal_distribution(const param_type& _Par0) : _Par(_Par0) {}
+    explicit lognormal_distribution(const param_type& _Par0) noexcept // strengthened
+        : _Par(_Par0) {}
 
-    _NODISCARD _Ty m() const {
+    _NODISCARD _Ty m() const noexcept /* strengthened */ {
         return _Par.m();
     }
 
-    _NODISCARD _Ty s() const {
+    _NODISCARD _Ty s() const noexcept /* strengthened */ {
         return _Par.s();
     }
 
-    _NODISCARD param_type param() const {
+    _NODISCARD param_type param() const noexcept /* strengthened */ {
         return _Par;
     }
 
-    void param(const param_type& _Par0) { // set parameter package
+    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
         _Par = _Par0;
     }
 
-    _NODISCARD result_type(min)() const { // get smallest possible result
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ { // get smallest possible result
         return result_type{0.0};
     }
 
-    _NODISCARD result_type(max)() const { // get largest possible result
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ { // get largest possible result
         return numeric_limits<result_type>::infinity();
     }
 
-    void reset() {} // clear internal state
+    void reset() noexcept /* strengthened */ {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -3676,12 +3785,14 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const lognormal_distribution& _Left, const lognormal_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator==(
+        const lognormal_distribution& _Left, const lognormal_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const lognormal_distribution& _Left, const lognormal_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator!=(
+        const lognormal_distribution& _Left, const lognormal_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -3725,29 +3836,33 @@ public:
     struct param_type { // parameter package
         using distribution_type = chi_squared_distribution;
 
-        param_type() {
+        param_type() noexcept // strengthened
+        {
             _Init(_Ty{1});
         }
 
-        explicit param_type(_Ty _Nx0) {
+        explicit param_type(_Ty _Nx0) noexcept // strengthened
+        {
             _Init(_Nx0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return _Left._Nx == _Right._Nx;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
 
-        _NODISCARD _Ty n() const {
+        _NODISCARD _Ty n() const noexcept /* strengthened */ {
             return _Nx;
         }
 
-        void _Init(_Ty _Nx0) { // initialize
+        void _Init(_Ty _Nx0) noexcept { // initialize
             _STL_ASSERT(0 < _Nx0, "invalid n argument for chi_squared_distribution");
             _Nx = _Nx0;
         }
@@ -3755,33 +3870,36 @@ public:
         _Ty _Nx;
     };
 
-    chi_squared_distribution() : _Par(_Ty{1}) {}
+    chi_squared_distribution() noexcept // strengthened
+        : _Par(_Ty{1}) {}
 
-    explicit chi_squared_distribution(_Ty _Nx0) : _Par(_Nx0) {}
+    explicit chi_squared_distribution(_Ty _Nx0) noexcept // strengthened
+        : _Par(_Nx0) {}
 
-    explicit chi_squared_distribution(const param_type& _Par0) : _Par(_Par0) {}
+    explicit chi_squared_distribution(const param_type& _Par0) noexcept // strengthened
+        : _Par(_Par0) {}
 
-    _NODISCARD _Ty n() const {
+    _NODISCARD _Ty n() const noexcept /* strengthened */ {
         return _Par.n();
     }
 
-    _NODISCARD param_type param() const {
+    _NODISCARD param_type param() const noexcept /* strengthened */ {
         return _Par;
     }
 
-    void param(const param_type& _Par0) { // set parameter package
+    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
         _Par = _Par0;
     }
 
-    _NODISCARD result_type(min)() const { // get smallest possible result
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ { // get smallest possible result
         return result_type{0.0};
     }
 
-    _NODISCARD result_type(max)() const { // get largest possible result
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ { // get largest possible result
         return numeric_limits<result_type>::infinity();
     }
 
-    void reset() {} // clear internal state
+    void reset() noexcept /* strengthened */ {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -3793,12 +3911,14 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const chi_squared_distribution& _Left, const chi_squared_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator==(
+        const chi_squared_distribution& _Left, const chi_squared_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const chi_squared_distribution& _Left, const chi_squared_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator!=(
+        const chi_squared_distribution& _Left, const chi_squared_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -3838,33 +3958,37 @@ public:
     struct param_type { // parameter package
         using distribution_type = cauchy_distribution;
 
-        param_type() {
+        param_type() noexcept // strengthened
+        {
             _Init(_Ty{0}, _Ty{1});
         }
 
-        explicit param_type(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) {
+        explicit param_type(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) noexcept // strengthened
+        {
             _Init(_Ax0, _Bx0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return _Left._Ax == _Right._Ax && _Left._Bx == _Right._Bx;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
 
-        _NODISCARD _Ty a() const {
+        _NODISCARD _Ty a() const noexcept /* strengthened */ {
             return _Ax;
         }
 
-        _NODISCARD _Ty b() const {
+        _NODISCARD _Ty b() const noexcept /* strengthened */ {
             return _Bx;
         }
 
-        void _Init(_Ty _Ax0, _Ty _Bx0) { // initialize
+        void _Init(_Ty _Ax0, _Ty _Bx0) noexcept { // initialize
             _STL_ASSERT(0.0 < _Bx0, "invalid b argument for cauchy_distribution");
             _Ax = _Ax0;
             _Bx = _Bx0;
@@ -3874,37 +3998,40 @@ public:
         _Ty _Bx;
     };
 
-    cauchy_distribution() : _Par(_Ty{0}, _Ty{1}) {}
+    cauchy_distribution() noexcept // strengthened
+        : _Par(_Ty{0}, _Ty{1}) {}
 
-    explicit cauchy_distribution(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) : _Par(_Ax0, _Bx0) {}
+    explicit cauchy_distribution(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) noexcept // strengthened
+        : _Par(_Ax0, _Bx0) {}
 
-    explicit cauchy_distribution(const param_type& _Par0) : _Par(_Par0) {}
+    explicit cauchy_distribution(const param_type& _Par0) noexcept // strengthened
+        : _Par(_Par0) {}
 
-    _NODISCARD _Ty a() const {
+    _NODISCARD _Ty a() const noexcept /* strengthened */ {
         return _Par.a();
     }
 
-    _NODISCARD _Ty b() const {
+    _NODISCARD _Ty b() const noexcept /* strengthened */ {
         return _Par.b();
     }
 
-    _NODISCARD param_type param() const {
+    _NODISCARD param_type param() const noexcept /* strengthened */ {
         return _Par;
     }
 
-    void param(const param_type& _Par0) { // set parameter package
+    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
         _Par = _Par0;
     }
 
-    _NODISCARD result_type(min)() const { // get smallest possible result
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ { // get smallest possible result
         return -numeric_limits<result_type>::infinity();
     }
 
-    _NODISCARD result_type(max)() const { // get largest possible result
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ { // get largest possible result
         return numeric_limits<result_type>::infinity();
     }
 
-    void reset() {} // clear internal state
+    void reset() noexcept /* strengthened */ {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -3916,12 +4043,14 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const cauchy_distribution& _Left, const cauchy_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator==(const cauchy_distribution& _Left, const cauchy_distribution& _Right) noexcept
+    /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const cauchy_distribution& _Left, const cauchy_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator!=(const cauchy_distribution& _Left, const cauchy_distribution& _Right) noexcept
+    /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -3960,7 +4089,7 @@ class _Beta_distribution { // beta distribution
 public:
     using result_type = _Ty;
 
-    explicit _Beta_distribution(const _Ty& _Ax0 = _Ty{1}, const _Ty& _Bx0 = _Ty{1}) {
+    explicit _Beta_distribution(const _Ty& _Ax0 = _Ty{1}, const _Ty& _Bx0 = _Ty{1}) noexcept {
         _Init(_Ax0, _Bx0);
     }
 
@@ -4003,7 +4132,7 @@ public:
     }
 
 private:
-    void _Init(_Ty _Ax0, _Ty _Bx0) { // initialize
+    void _Init(_Ty _Ax0, _Ty _Bx0) noexcept { // initialize
         _STL_ASSERT(0.0 < _Ax0, "invalid a argument for _Beta_distribution");
         _STL_ASSERT(0.0 < _Bx0, "invalid b argument for _Beta_distribution");
         _Ax = _Ax0;
@@ -4024,33 +4153,37 @@ public:
     struct param_type { // parameter package
         using distribution_type = fisher_f_distribution;
 
-        param_type() {
+        param_type() noexcept // strengthened
+        {
             _Init(_Ty{1}, _Ty{1});
         }
 
-        explicit param_type(_Ty _Mx0, _Ty _Nx0 = _Ty{1}) {
+        explicit param_type(_Ty _Mx0, _Ty _Nx0 = _Ty{1}) noexcept // strengthened
+        {
             _Init(_Mx0, _Nx0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return _Left._Mx == _Right._Mx && _Left._Nx == _Right._Nx;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
 
-        _NODISCARD _Ty m() const {
+        _NODISCARD _Ty m() const noexcept /* strengthened */ {
             return _Mx;
         }
 
-        _NODISCARD _Ty n() const {
+        _NODISCARD _Ty n() const noexcept /* strengthened */ {
             return _Nx;
         }
 
-        void _Init(_Ty _Mx0, _Ty _Nx0) { // initialize
+        void _Init(_Ty _Mx0, _Ty _Nx0) noexcept { // initialize
             _STL_ASSERT(0 < _Mx0, "invalid m argument for fisher_f_distribution");
             _STL_ASSERT(0 < _Nx0, "invalid n argument for fisher_f_distribution");
             _Mx = _Mx0;
@@ -4061,37 +4194,40 @@ public:
         _Ty _Nx;
     };
 
-    fisher_f_distribution() : _Par(_Ty{1}, _Ty{1}) {}
+    fisher_f_distribution() noexcept // strengthened
+        : _Par(_Ty{1}, _Ty{1}) {}
 
-    explicit fisher_f_distribution(_Ty _Mx0, _Ty _Nx0 = _Ty{1}) : _Par(_Mx0, _Nx0) {}
+    explicit fisher_f_distribution(_Ty _Mx0, _Ty _Nx0 = _Ty{1}) noexcept // strengthened
+        : _Par(_Mx0, _Nx0) {}
 
-    explicit fisher_f_distribution(const param_type& _Par0) : _Par(_Par0) {}
+    explicit fisher_f_distribution(const param_type& _Par0) noexcept // strengthened
+        : _Par(_Par0) {}
 
-    _NODISCARD _Ty m() const {
+    _NODISCARD _Ty m() const noexcept /* strengthened */ {
         return _Par.m();
     }
 
-    _NODISCARD _Ty n() const {
+    _NODISCARD _Ty n() const noexcept /* strengthened */ {
         return _Par.n();
     }
 
-    _NODISCARD param_type param() const {
+    _NODISCARD param_type param() const noexcept /* strengthened */ {
         return _Par;
     }
 
-    void param(const param_type& _Par0) { // set parameter package
+    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
         _Par = _Par0;
     }
 
-    _NODISCARD result_type(min)() const { // get smallest possible result
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ { // get smallest possible result
         return result_type(0);
     }
 
-    _NODISCARD result_type(max)() const { // get largest possible result
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ { // get largest possible result
         return numeric_limits<result_type>::infinity();
     }
 
-    void reset() {} // clear internal state
+    void reset() noexcept /* strengthened */ {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -4103,12 +4239,14 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const fisher_f_distribution& _Left, const fisher_f_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator==(const fisher_f_distribution& _Left, const fisher_f_distribution& _Right) noexcept
+    /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const fisher_f_distribution& _Left, const fisher_f_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator!=(const fisher_f_distribution& _Left, const fisher_f_distribution& _Right) noexcept
+    /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -4163,29 +4301,33 @@ public:
     struct param_type { // parameter package
         using distribution_type = student_t_distribution;
 
-        param_type() {
+        param_type() noexcept // strengthened
+        {
             _Init(_Ty{1});
         }
 
-        explicit param_type(_Ty _Nx0) {
+        explicit param_type(_Ty _Nx0) noexcept // strengthened
+        {
             _Init(_Nx0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return _Left._Nx == _Right._Nx;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
 
-        _NODISCARD _Ty n() const {
+        _NODISCARD _Ty n() const noexcept /* strengthened */ {
             return _Nx;
         }
 
-        void _Init(_Ty _Nx0) { // initialize
+        void _Init(_Ty _Nx0) noexcept { // initialize
             _STL_ASSERT(0 < _Nx0, "invalid n argument for student_t_distribution");
             _Nx = _Nx0;
         }
@@ -4193,33 +4335,36 @@ public:
         _Ty _Nx;
     };
 
-    student_t_distribution() : _Par(_Ty{1}) {}
+    student_t_distribution() noexcept // strengthened
+        : _Par(_Ty{1}) {}
 
-    explicit student_t_distribution(_Ty _Nx0) : _Par(_Nx0) {}
+    explicit student_t_distribution(_Ty _Nx0) noexcept // strengthened
+        : _Par(_Nx0) {}
 
-    explicit student_t_distribution(const param_type& _Par0) : _Par(_Par0) {}
+    explicit student_t_distribution(const param_type& _Par0) noexcept // strengthened
+        : _Par(_Par0) {}
 
-    _NODISCARD _Ty n() const {
+    _NODISCARD _Ty n() const noexcept /* strengthened */ {
         return _Par.n();
     }
 
-    _NODISCARD param_type param() const {
+    _NODISCARD param_type param() const noexcept /* strengthened */ {
         return _Par;
     }
 
-    void param(const param_type& _Par0) { // set parameter package
+    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
         _Par = _Par0;
     }
 
-    _NODISCARD result_type(min)() const { // get smallest possible result
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ { // get smallest possible result
         return -numeric_limits<result_type>::infinity();
     }
 
-    _NODISCARD result_type(max)() const { // get largest possible result
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ { // get largest possible result
         return numeric_limits<result_type>::infinity();
     }
 
-    void reset() {} // clear internal state
+    void reset() noexcept /* strengthened */ {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -4231,12 +4376,14 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const student_t_distribution& _Left, const student_t_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator==(
+        const student_t_distribution& _Left, const student_t_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const student_t_distribution& _Left, const student_t_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator!=(
+        const student_t_distribution& _Left, const student_t_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -4291,33 +4438,37 @@ public:
     struct param_type { // parameter package
         using distribution_type = negative_binomial_distribution;
 
-        param_type() {
+        param_type() noexcept // strengthened
+        {
             _Init(1, 0.5);
         }
 
-        explicit param_type(_Ty _Kx0, double _Px0 = 0.5) {
+        explicit param_type(_Ty _Kx0, double _Px0 = 0.5) noexcept // strengthened
+        {
             _Init(_Kx0, _Px0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return _Left._Kx == _Right._Kx && _Left._Px == _Right._Px;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        /* strengthened */ {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
 
-        _NODISCARD _Ty k() const {
+        _NODISCARD _Ty k() const noexcept /* strengthened */ {
             return _Kx;
         }
 
-        _NODISCARD double p() const {
+        _NODISCARD double p() const noexcept /* strengthened */ {
             return _Px;
         }
 
-        void _Init(_Ty _Kx0, double _Px0) { // initialize
+        void _Init(_Ty _Kx0, double _Px0) noexcept { // initialize
             _STL_ASSERT(0.0 < _Kx0, "invalid max argument for negative_binomial_distribution");
             _STL_ASSERT(0.0 < _Px0 && _Px0 <= 1.0, "invalid probability argument for negative_binomial_distribution");
             _Kx = _Kx0;
@@ -4328,37 +4479,40 @@ public:
         double _Px;
     };
 
-    negative_binomial_distribution() : _Par(1, 0.5) {}
+    negative_binomial_distribution() noexcept // strengthened
+        : _Par(1, 0.5) {}
 
-    explicit negative_binomial_distribution(_Ty _Kx0, double _Px0 = 0.5) : _Par(_Kx0, _Px0) {}
+    explicit negative_binomial_distribution(_Ty _Kx0, double _Px0 = 0.5) noexcept // strengthened
+        : _Par(_Kx0, _Px0) {}
 
-    explicit negative_binomial_distribution(const param_type& _Par0) : _Par(_Par0) {}
+    explicit negative_binomial_distribution(const param_type& _Par0) noexcept // strengthened
+        : _Par(_Par0) {}
 
-    _NODISCARD _Ty k() const {
+    _NODISCARD _Ty k() const noexcept /* strengthened */ {
         return _Par.k();
     }
 
-    _NODISCARD double p() const {
+    _NODISCARD double p() const noexcept /* strengthened */ {
         return _Par.p();
     }
 
-    _NODISCARD param_type param() const {
+    _NODISCARD param_type param() const noexcept /* strengthened */ {
         return _Par;
     }
 
-    void param(const param_type& _Par0) { // set parameter package
+    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
         _Par = _Par0;
     }
 
-    _NODISCARD result_type(min)() const { // get smallest possible result
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ { // get smallest possible result
         return 0;
     }
 
-    _NODISCARD result_type(max)() const { // get largest possible result
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ { // get largest possible result
         return (numeric_limits<result_type>::max)();
     }
 
-    void reset() {} // clear internal state
+    void reset() noexcept /* strengthened */ {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -4370,14 +4524,14 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(
-        const negative_binomial_distribution& _Left, const negative_binomial_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator==(const negative_binomial_distribution& _Left,
+        const negative_binomial_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(
-        const negative_binomial_distribution& _Left, const negative_binomial_distribution& _Right) {
+    _NODISCARD_FRIEND bool operator!=(const negative_binomial_distribution& _Left,
+        const negative_binomial_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -4427,7 +4581,7 @@ public:
     struct param_type { // parameter package
         using distribution_type = discrete_distribution;
 
-        param_type(_Uninitialized) {} // do-nothing constructor for derived classes
+        param_type(_Uninitialized) noexcept {} // do-nothing constructor for derived classes
 
         param_type() {
             _Init();
@@ -4556,15 +4710,15 @@ public:
         _Par = _Par0;
     }
 
-    _NODISCARD result_type(min)() const {
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ {
         return 0;
     }
 
-    _NODISCARD result_type(max)() const {
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ {
         return static_cast<result_type>(_Par._Pvec.size() - 1);
     }
 
-    void reset() {} // clear internal state
+    void reset() noexcept /* strengthened */ {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -4740,7 +4894,7 @@ public:
         return _Par._Bvec.back();
     }
 
-    void reset() {} // clear internal state
+    void reset() noexcept /* strengthened */ {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -4956,15 +5110,15 @@ public:
         _Par = _Par0;
     }
 
-    _NODISCARD result_type(min)() const {
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ {
         return _Par._Bvec.front();
     }
 
-    _NODISCARD result_type(max)() const {
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ {
         return _Par._Bvec.back();
     }
 
-    void reset() {} // clear internal state
+    void reset() noexcept /* strengthened */ {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -5070,15 +5224,15 @@ _EXPORT_STD class random_device { // class to generate random numbers (from hard
 public:
     using result_type = unsigned int;
 
-    random_device() {}
+    random_device() = default;
 
-    explicit random_device(const string&) {}
+    explicit random_device(const string&) noexcept /* strengthened */ {}
 
-    _NODISCARD static constexpr result_type(min)() {
+    _NODISCARD static constexpr result_type(min)() noexcept /* strengthened */ {
         return 0;
     }
 
-    _NODISCARD static constexpr result_type(max)() {
+    _NODISCARD static constexpr result_type(max)() noexcept /* strengthened */ {
         return static_cast<result_type>(-1);
     }
 

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -1865,13 +1865,11 @@ public:
     struct param_type { // parameter package
         using distribution_type = uniform_int;
 
-        param_type() noexcept // strengthened
-        {
+        param_type() noexcept /* strengthened */ {
             _Init(0, 9);
         }
 
-        explicit param_type(result_type _Min0, result_type _Max0 = 9) noexcept // strengthened
-        {
+        explicit param_type(result_type _Min0, result_type _Max0 = 9) noexcept /* strengthened */ {
             _Init(_Min0, _Max0);
         }
 
@@ -2058,13 +2056,11 @@ public:
     struct param_type { // parameter package
         using distribution_type = bernoulli_distribution;
 
-        param_type() noexcept // strengthened
-        {
+        param_type() noexcept /* strengthened */ {
             _Init(0.5);
         }
 
-        explicit param_type(double _Px0) noexcept // strengthened
-        {
+        explicit param_type(double _Px0) noexcept /* strengthened */ {
             _Init(_Px0);
         }
 
@@ -2220,13 +2216,11 @@ public:
     struct param_type { // parameter package
         using distribution_type = geometric_distribution;
 
-        param_type() noexcept // strengthened
-        {
+        param_type() noexcept /* strengthened */ {
             _Init(_Ty1(0.5));
         }
 
-        explicit param_type(_Ty1 _Px0) // strengthened
-        {
+        explicit param_type(_Ty1 _Px0) noexcept /* strengthened */ {
             _Init(_Px0);
         }
 
@@ -2378,13 +2372,11 @@ public:
     struct param_type { // parameter package
         using distribution_type = poisson_distribution;
 
-        param_type() noexcept // strengthened
-        {
+        param_type() noexcept /* strengthened */ {
             _Init(_Ty1(1));
         }
 
-        explicit param_type(_Ty1 _Mean0) noexcept // strengthened
-        {
+        explicit param_type(_Ty1 _Mean0) noexcept /* strengthened */ {
             _Init(_Mean0);
         }
 
@@ -2535,13 +2527,11 @@ public:
     struct param_type { // parameter package
         using distribution_type = binomial_distribution;
 
-        param_type() noexcept // strengthened
-        {
+        param_type() noexcept /* strengthened */ {
             _Init(1, _Ty1(0.5));
         }
 
-        explicit param_type(_Ty _Tx0, _Ty1 _Px0 = _Ty1(0.5)) noexcept // strengthened
-        {
+        explicit param_type(_Ty _Tx0, _Ty1 _Px0 = _Ty1(0.5)) noexcept /* strengthened */ {
             _Init(_Tx0, _Px0);
         }
 
@@ -2738,13 +2728,11 @@ public:
     struct param_type { // parameter package
         using distribution_type = uniform_real;
 
-        param_type() noexcept // strengthened
-        {
+        param_type() noexcept /* strengthened */ {
             _Init(_Ty{0}, _Ty{1});
         }
 
-        explicit param_type(_Ty _Min0, _Ty _Max0 = _Ty{1}) noexcept // strengthened
-        {
+        explicit param_type(_Ty _Min0, _Ty _Max0 = _Ty{1}) noexcept /* strengthened */ {
             _Init(_Min0, _Max0);
         }
 
@@ -2912,13 +2900,11 @@ public:
     struct param_type { // parameter package
         using distribution_type = exponential_distribution;
 
-        param_type() noexcept // strengthened
-        {
+        param_type() noexcept /* strengthened */ {
             _Init(_Ty{1});
         }
 
-        explicit param_type(_Ty _Lambda0) noexcept // strengthened
-        {
+        explicit param_type(_Ty _Lambda0) noexcept /* strengthened */ {
             _Init(_Lambda0);
         }
 
@@ -3034,13 +3020,11 @@ public:
     struct param_type { // parameter package
         using distribution_type = normal_distribution;
 
-        param_type() noexcept // strengthened
-        {
+        param_type() noexcept /* strengthened */ {
             _Init(0.0, 1.0);
         }
 
-        explicit param_type(_Ty _Mean0, _Ty _Sigma0 = 1.0) noexcept // strengthened
-        {
+        explicit param_type(_Ty _Mean0, _Ty _Sigma0 = 1.0) noexcept /* strengthened */ {
             _Init(_Mean0, _Sigma0);
         }
 
@@ -3231,13 +3215,11 @@ public:
     struct param_type { // parameter package
         using distribution_type = gamma_distribution;
 
-        param_type() noexcept // strengthened
-        {
+        param_type() noexcept /* strengthened */ {
             _Init(_Ty{1}, _Ty{1});
         }
 
-        explicit param_type(_Ty _Alpha0, _Ty _Beta0 = _Ty{1}) noexcept // strengthened
-        {
+        explicit param_type(_Ty _Alpha0, _Ty _Beta0 = _Ty{1}) noexcept /* strengthened */ {
             _Init(_Alpha0, _Beta0);
         }
 
@@ -3427,13 +3409,11 @@ public:
     struct param_type { // parameter package
         using distribution_type = weibull_distribution;
 
-        param_type() noexcept // strengthened
-        {
+        param_type() noexcept /* strengthened */ {
             _Init(_Ty{1}, _Ty{1});
         }
 
-        explicit param_type(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) noexcept // strengthened
-        {
+        explicit param_type(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) noexcept /* strengthened */ {
             _Init(_Ax0, _Bx0);
         }
 
@@ -3564,13 +3544,11 @@ public:
     struct param_type { // parameter package
         using distribution_type = extreme_value_distribution;
 
-        param_type() noexcept // strengthened
-        {
+        param_type() noexcept /* strengthened */ {
             _Init(_Ty{0}, _Ty{1});
         }
 
-        explicit param_type(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) noexcept // strengthened
-        {
+        explicit param_type(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) noexcept /* strengthened */ {
             _Init(_Ax0, _Bx0);
         }
 
@@ -3700,13 +3678,11 @@ public:
     struct param_type { // parameter package
         using distribution_type = lognormal_distribution;
 
-        param_type() noexcept // strengthened
-        {
+        param_type() noexcept /* strengthened */ {
             _Init(_Ty{0}, _Ty{1});
         }
 
-        explicit param_type(_Ty _Mx0, _Ty _Sx0 = _Ty{1}) noexcept // strengthened
-        {
+        explicit param_type(_Ty _Mx0, _Ty _Sx0 = _Ty{1}) noexcept /* strengthened */ {
             _Init(_Mx0, _Sx0);
         }
 
@@ -3836,13 +3812,11 @@ public:
     struct param_type { // parameter package
         using distribution_type = chi_squared_distribution;
 
-        param_type() noexcept // strengthened
-        {
+        param_type() noexcept /* strengthened */ {
             _Init(_Ty{1});
         }
 
-        explicit param_type(_Ty _Nx0) noexcept // strengthened
-        {
+        explicit param_type(_Ty _Nx0) noexcept /* strengthened */ {
             _Init(_Nx0);
         }
 
@@ -3958,13 +3932,11 @@ public:
     struct param_type { // parameter package
         using distribution_type = cauchy_distribution;
 
-        param_type() noexcept // strengthened
-        {
+        param_type() noexcept /* strengthened */ {
             _Init(_Ty{0}, _Ty{1});
         }
 
-        explicit param_type(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) noexcept // strengthened
-        {
+        explicit param_type(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) noexcept /* strengthened */ {
             _Init(_Ax0, _Bx0);
         }
 
@@ -4153,13 +4125,11 @@ public:
     struct param_type { // parameter package
         using distribution_type = fisher_f_distribution;
 
-        param_type() noexcept // strengthened
-        {
+        param_type() noexcept /* strengthened */ {
             _Init(_Ty{1}, _Ty{1});
         }
 
-        explicit param_type(_Ty _Mx0, _Ty _Nx0 = _Ty{1}) noexcept // strengthened
-        {
+        explicit param_type(_Ty _Mx0, _Ty _Nx0 = _Ty{1}) noexcept /* strengthened */ {
             _Init(_Mx0, _Nx0);
         }
 
@@ -4301,13 +4271,11 @@ public:
     struct param_type { // parameter package
         using distribution_type = student_t_distribution;
 
-        param_type() noexcept // strengthened
-        {
+        param_type() noexcept /* strengthened */ {
             _Init(_Ty{1});
         }
 
-        explicit param_type(_Ty _Nx0) noexcept // strengthened
-        {
+        explicit param_type(_Ty _Nx0) noexcept /* strengthened */ {
             _Init(_Nx0);
         }
 
@@ -4438,13 +4406,11 @@ public:
     struct param_type { // parameter package
         using distribution_type = negative_binomial_distribution;
 
-        param_type() noexcept // strengthened
-        {
+        param_type() noexcept /* strengthened */ {
             _Init(1, 0.5);
         }
 
-        explicit param_type(_Ty _Kx0, double _Px0 = 0.5) noexcept // strengthened
-        {
+        explicit param_type(_Ty _Kx0, double _Px0 = 0.5) noexcept /* strengthened */ {
             _Init(_Kx0, _Px0);
         }
 

--- a/stl/inc/valarray
+++ b/stl/inc/valarray
@@ -61,84 +61,67 @@ public:
     friend _Tidy_deallocate_guard<valarray>;
 
     template <class _Ty2>
-    friend _Ty2* begin(valarray<_Ty2>& _Array);
+    friend _Ty2* begin(valarray<_Ty2>& _Array) noexcept /* strengthened */;
 
     template <class _Ty2>
-    friend const _Ty2* begin(const valarray<_Ty2>& _Array);
+    friend const _Ty2* begin(const valarray<_Ty2>& _Array) noexcept /* strengthened */;
 
     template <class _Ty2>
-    friend _Ty2* end(valarray<_Ty2>& _Array);
+    friend _Ty2* end(valarray<_Ty2>& _Array) noexcept /* strengthened */;
 
     template <class _Ty2>
-    friend const _Ty2* end(const valarray<_Ty2>& _Array);
+    friend const _Ty2* end(const valarray<_Ty2>& _Array) noexcept /* strengthened */;
 
     using value_type = _Ty;
 
-    valarray() { // construct empty valarray
-        _Tidy_init();
-    }
+    valarray() = default; // construct empty valarray
 
     explicit valarray(size_t _Count) { // construct with _Count * _Ty()
-        _Tidy_init();
         _Grow(_Count);
     }
 
     valarray(const _Ty& _Val, size_t _Count) { // construct with _Count * _Val
-        _Tidy_init();
         _Grow(_Count, &_Val);
     }
 
     valarray(const _Ty* _Ptr, size_t _Count) { // construct with [_Ptr, _Ptr + _Count)
-        _Tidy_init();
         _Grow(_Count, _Ptr, 1);
     }
 
     valarray(const valarray& _Right) {
-        _Tidy_init();
         _Grow(_Right.size(), _Right._Myptr, 1);
     }
 
     valarray(const slice_array<_Ty>& _Slicearr) {
-        _Tidy_init();
         *this = _Slicearr;
     }
 
     valarray(const gslice_array<_Ty>& _Gslicearr) {
-        _Tidy_init();
         *this = _Gslicearr;
     }
 
     valarray(const mask_array<_Ty>& _Maskarr) {
-        _Tidy_init();
         *this = _Maskarr;
     }
 
     valarray(const indirect_array<_Ty>& _Indarr) {
-        _Tidy_init();
         *this = _Indarr;
     }
 
-    valarray(valarray&& _Right) noexcept {
-        _Tidy_init();
-        _Assign_rv(_STD move(_Right));
-    }
+    valarray(valarray&& _Right) noexcept
+        : _Myptr(_STD exchange(_Right._Myptr, static_cast<_Ty*>(nullptr))),
+          _Mysize(_STD exchange(_Right._Mysize, size_t{0})) {}
 
     valarray& operator=(valarray&& _Right) noexcept {
-        _Assign_rv(_STD move(_Right));
+        if (this != _STD addressof(_Right)) { // clear this and steal from _Right
+            _Tidy_deallocate();
+            _Myptr  = _STD exchange(_Right._Myptr, static_cast<_Ty*>(nullptr));
+            _Mysize = _STD exchange(_Right._Mysize, size_t{0});
+        }
         return *this;
     }
 
-    void _Assign_rv(valarray&& _Right) {
-        if (this != _STD addressof(_Right)) { // clear this and steal from _Right
-            _Tidy_deallocate();
-            _Myptr  = _Right._Myptr;
-            _Mysize = _Right._Mysize;
-            _Right._Tidy_init();
-        }
-    }
-
     valarray(initializer_list<_Ty> _Ilist) {
-        _Tidy_init();
         _Grow(_Ilist.size(), _Ilist.begin(), 1);
     }
 
@@ -410,7 +393,7 @@ public:
 
     _NODISCARD valarray operator[](slice _Slicearr) const; // defined below
 
-    _NODISCARD slice_array<_Ty> operator[](slice _Slicearr); // defined below
+    _NODISCARD slice_array<_Ty> operator[](slice _Slicearr) noexcept /* strengthened */; // defined below
 
     _NODISCARD valarray operator[](const gslice& _Gslicearr) const; // defined below
 
@@ -549,11 +532,6 @@ private:
         }
     }
 
-    void _Tidy_init() noexcept {
-        _Mysize = 0;
-        _Myptr  = nullptr;
-    }
-
     void _Tidy_deallocate() noexcept {
         if (_Myptr) { // destroy elements
             for (size_t _Idx = 0; _Idx < _Mysize; ++_Idx) {
@@ -571,7 +549,8 @@ private:
             }
         }
 
-        _Tidy_init();
+        _Mysize = 0;
+        _Myptr  = nullptr;
     }
 
     void _Assign(size_t _Newsize, const _Ty* _Ptr) {
@@ -586,8 +565,8 @@ private:
         }
     }
 
-    _Ty* _Myptr; // current storage reserved for array
-    size_t _Mysize; // current length of sequence
+    _Ty* _Myptr    = nullptr; // current storage reserved for array
+    size_t _Mysize = 0; // current length of sequence
 };
 
 #if _HAS_CXX17
@@ -601,22 +580,22 @@ void swap(valarray<_Ty>& _Left, valarray<_Ty>& _Right) noexcept {
 }
 
 _EXPORT_STD template <class _Ty>
-_NODISCARD _Ty* begin(valarray<_Ty>& _Array) {
+_NODISCARD _Ty* begin(valarray<_Ty>& _Array) noexcept /* strengthened */ {
     return _Array._Myptr;
 }
 
 _EXPORT_STD template <class _Ty>
-_NODISCARD const _Ty* begin(const valarray<_Ty>& _Array) {
+_NODISCARD const _Ty* begin(const valarray<_Ty>& _Array) noexcept /* strengthened */ {
     return _Array._Myptr;
 }
 
 _EXPORT_STD template <class _Ty>
-_NODISCARD _Ty* end(valarray<_Ty>& _Array) {
+_NODISCARD _Ty* end(valarray<_Ty>& _Array) noexcept /* strengthened */ {
     return _Array._Myptr + _Array.size();
 }
 
 _EXPORT_STD template <class _Ty>
-_NODISCARD const _Ty* end(const valarray<_Ty>& _Array) {
+_NODISCARD const _Ty* end(const valarray<_Ty>& _Array) noexcept /* strengthened */ {
     return _Array._Myptr + _Array.size();
 }
 
@@ -1481,7 +1460,7 @@ public:
         }
     }
 
-    _Ty& _Data(size_t _Idx) const {
+    _Ty& _Data(size_t _Idx) const noexcept {
         return _Myptr[_Idx];
     }
 
@@ -1489,7 +1468,7 @@ public:
 
     slice_array(const slice_array&) = default;
 
-    const slice_array& operator=(const slice_array& _Right) const {
+    const slice_array& operator=(const slice_array& _Right) const noexcept /* strengthened */ {
         size_t _Dst_off = _Start;
         size_t _Src_off = _Right._Start;
         for (size_t _Idx = 0; _Idx < _Len; ++_Idx, _Dst_off += _Stride, _Src_off += _Right._Stride) {
@@ -1501,19 +1480,19 @@ public:
 private:
     friend valarray<_Ty>;
 
-    slice_array(const slice& _Slice, _Ty* _Pdata) : slice(_Slice), _Myptr(_Pdata) {}
+    slice_array(const slice& _Slice, _Ty* _Pdata) noexcept : slice(_Slice), _Myptr(_Pdata) {}
 
     _Ty* _Myptr; // pointer to valarray contents
 };
 
 _EXPORT_STD class gslice { // define a generalized (multidimensional) slice of a valarray
 public:
-    gslice() : _Start(0) {} // construct with all zeros
+    gslice() = default; // construct with all zeros
 
     gslice(size_t _Off, const _Sizarray& _Lenarr, const _Sizarray& _Incarr)
         : _Start(_Off), _Len(_Lenarr), _Stride(_Incarr) {}
 
-    _NODISCARD size_t start() const {
+    _NODISCARD size_t start() const noexcept /* strengthened */ {
         return _Start;
     }
 
@@ -1525,11 +1504,11 @@ public:
         return _Stride;
     }
 
-    size_t _Nslice() const {
+    size_t _Nslice() const noexcept {
         return _Len.size();
     }
 
-    size_t _Off(_Sizarray& _Indexarr) const {
+    size_t _Off(_Sizarray& _Indexarr) const noexcept {
         size_t _Idx;
         size_t _Ans        = _Start;
         const size_t _Size = _Indexarr.size();
@@ -1549,7 +1528,7 @@ public:
         return _Ans;
     }
 
-    _NODISCARD size_t _Totlen() const {
+    _NODISCARD size_t _Totlen() const noexcept {
         const size_t _Size = _Len.size();
         if (_Size == 0) {
             return 0;
@@ -1564,7 +1543,7 @@ public:
     }
 
 private:
-    size_t _Start; // the starting offset
+    size_t _Start = 0; // the starting offset
     _Sizarray _Len; // array of numbers of elements
     _Sizarray _Stride; // array of distances between elements
 };
@@ -1785,15 +1764,15 @@ public:
         }
     }
 
-    _NODISCARD _Ty& _Data(size_t _Idx) const {
+    _NODISCARD _Ty& _Data(size_t _Idx) const noexcept {
         return _Myptr[_Idx];
     }
 
-    _NODISCARD bool _Mask(size_t _Idx) const {
+    _NODISCARD bool _Mask(size_t _Idx) const noexcept {
         return _Mybool[_Idx];
     }
 
-    _NODISCARD size_t _Start_off() const {
+    _NODISCARD size_t _Start_off() const noexcept {
         size_t _Off        = 0;
         const size_t _Size = _Mybool.size();
         while (_Off < _Size && !_Mybool[_Off]) {
@@ -1802,7 +1781,7 @@ public:
         return _Off;
     }
 
-    _NODISCARD size_t _Next_off(size_t _Off) const {
+    _NODISCARD size_t _Next_off(size_t _Off) const noexcept {
         const size_t _Size = _Mybool.size();
         do {
             ++_Off;
@@ -1826,7 +1805,7 @@ public:
 
     mask_array(const mask_array&) = default;
 
-    const mask_array& operator=(const mask_array& _Right) const {
+    const mask_array& operator=(const mask_array& _Right) const noexcept /* strengthened */ {
         const size_t _Size = _Mybool.size();
         size_t _Dst_off    = _Start_off();
         size_t _Src_off    = _Right._Start_off();
@@ -1938,11 +1917,11 @@ public:
         return _Myptr[_Idx];
     }
 
-    _NODISCARD size_t _Indir(size_t _Idx) const {
+    _NODISCARD size_t _Indir(size_t _Idx) const noexcept {
         return _Myindarr[_Idx];
     }
 
-    _NODISCARD size_t _Totlen() const {
+    _NODISCARD size_t _Totlen() const noexcept {
         return _Myindarr.size();
     }
 
@@ -1950,7 +1929,7 @@ public:
 
     indirect_array(const indirect_array&) = default;
 
-    const indirect_array& operator=(const indirect_array& _Right) const {
+    const indirect_array& operator=(const indirect_array& _Right) const noexcept /* strengthened */ {
         const size_t _Size = _Totlen();
         for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
             _Myptr[_Indir(_Idx)] = _Right._Myptr[_Right._Indir(_Idx)];
@@ -1980,7 +1959,7 @@ _NODISCARD valarray<_Ty> valarray<_Ty>::operator[](slice _Slice) const {
 }
 
 template <class _Ty>
-_NODISCARD slice_array<_Ty> valarray<_Ty>::operator[](slice _Slice) {
+_NODISCARD slice_array<_Ty> valarray<_Ty>::operator[](slice _Slice) noexcept /* strengthened */ {
     return slice_array<_Ty>(_Slice, _Myptr);
 }
 

--- a/stl/inc/valarray
+++ b/stl/inc/valarray
@@ -74,54 +74,71 @@ public:
 
     using value_type = _Ty;
 
-    valarray() = default; // construct empty valarray
+    valarray() noexcept /* strengthened */ { // construct empty valarray
+        _Tidy_init();
+    }
 
     explicit valarray(size_t _Count) { // construct with _Count * _Ty()
+        _Tidy_init();
         _Grow(_Count);
     }
 
     valarray(const _Ty& _Val, size_t _Count) { // construct with _Count * _Val
+        _Tidy_init();
         _Grow(_Count, &_Val);
     }
 
     valarray(const _Ty* _Ptr, size_t _Count) { // construct with [_Ptr, _Ptr + _Count)
+        _Tidy_init();
         _Grow(_Count, _Ptr, 1);
     }
 
     valarray(const valarray& _Right) {
+        _Tidy_init();
         _Grow(_Right.size(), _Right._Myptr, 1);
     }
 
     valarray(const slice_array<_Ty>& _Slicearr) {
+        _Tidy_init();
         *this = _Slicearr;
     }
 
     valarray(const gslice_array<_Ty>& _Gslicearr) {
+        _Tidy_init();
         *this = _Gslicearr;
     }
 
     valarray(const mask_array<_Ty>& _Maskarr) {
+        _Tidy_init();
         *this = _Maskarr;
     }
 
     valarray(const indirect_array<_Ty>& _Indarr) {
+        _Tidy_init();
         *this = _Indarr;
     }
 
-    valarray(valarray&& _Right) noexcept
-        : _Myptr(_STD exchange(_Right._Myptr, static_cast<_Ty*>(nullptr))),
-          _Mysize(_STD exchange(_Right._Mysize, size_t{0})) {}
+    valarray(valarray&& _Right) noexcept {
+        _Tidy_init();
+        _Assign_rv(_STD move(_Right));
+    }
 
     valarray& operator=(valarray&& _Right) noexcept {
-        if (this != _STD addressof(_Right)) { // clear this and steal from _Right
-            _Tidy_deallocate();
-            _Myptr  = _STD exchange(_Right._Myptr, static_cast<_Ty*>(nullptr));
-            _Mysize = _STD exchange(_Right._Mysize, size_t{0});
-        }
+        _Assign_rv(_STD move(_Right));
         return *this;
     }
 
+    void _Assign_rv(valarray&& _Right) noexcept {
+        if (this != _STD addressof(_Right)) { // clear this and steal from _Right
+            _Tidy_deallocate();
+            _Myptr  = _Right._Myptr;
+            _Mysize = _Right._Mysize;
+            _Right._Tidy_init();
+        }
+    }
+
     valarray(initializer_list<_Ty> _Ilist) {
+        _Tidy_init();
         _Grow(_Ilist.size(), _Ilist.begin(), 1);
     }
 
@@ -532,6 +549,11 @@ private:
         }
     }
 
+    void _Tidy_init() noexcept {
+        _Mysize = 0;
+        _Myptr  = nullptr;
+    }
+
     void _Tidy_deallocate() noexcept {
         if (_Myptr) { // destroy elements
             for (size_t _Idx = 0; _Idx < _Mysize; ++_Idx) {
@@ -549,8 +571,7 @@ private:
             }
         }
 
-        _Mysize = 0;
-        _Myptr  = nullptr;
+        _Tidy_init();
     }
 
     void _Assign(size_t _Newsize, const _Ty* _Ptr) {
@@ -565,8 +586,8 @@ private:
         }
     }
 
-    _Ty* _Myptr    = nullptr; // current storage reserved for array
-    size_t _Mysize = 0; // current length of sequence
+    _Ty* _Myptr; // current storage reserved for array
+    size_t _Mysize; // current length of sequence
 };
 
 #if _HAS_CXX17

--- a/stl/src/xlgamma.cpp
+++ b/stl/src/xlgamma.cpp
@@ -9,11 +9,11 @@
 
 //  #include <random>
 _STD_BEGIN
-_CRTIMP2_PURE float __CLRCALL_PURE_OR_CDECL _XLgamma(float);
-_CRTIMP2_PURE double __CLRCALL_PURE_OR_CDECL _XLgamma(double);
-_CRTIMP2_PURE long double __CLRCALL_PURE_OR_CDECL _XLgamma(long double);
+_CRTIMP2_PURE float __CLRCALL_PURE_OR_CDECL _XLgamma(float) noexcept;
+_CRTIMP2_PURE double __CLRCALL_PURE_OR_CDECL _XLgamma(double) noexcept;
+_CRTIMP2_PURE long double __CLRCALL_PURE_OR_CDECL _XLgamma(long double) noexcept;
 
-float __CLRCALL_PURE_OR_CDECL _XLgamma(float x) { // moderately accurate log gamma
+float __CLRCALL_PURE_OR_CDECL _XLgamma(float x) noexcept { // moderately accurate log gamma
     static const float coeff[6] = {76.18009172947146F, -86.50532032941677F, 24.01409824083091F, -1.23173972450155F,
         0.1208650973866179E-2F, -0.5395239384953E-5F};
 
@@ -29,7 +29,7 @@ float __CLRCALL_PURE_OR_CDECL _XLgamma(float x) { // moderately accurate log gam
     return -val0 + _STD log(2.5066282746310005F * val1 / x);
 }
 
-double __CLRCALL_PURE_OR_CDECL _XLgamma(double x) { // moderately accurate log gamma
+double __CLRCALL_PURE_OR_CDECL _XLgamma(double x) noexcept { // moderately accurate log gamma
     static const double coeff[6] = {76.18009172947146, -86.50532032941677, 24.01409824083091, -1.23173972450155,
         0.1208650973866179E-2, -0.5395239384953E-5};
 
@@ -45,7 +45,7 @@ double __CLRCALL_PURE_OR_CDECL _XLgamma(double x) { // moderately accurate log g
     return -val0 + _STD log(2.5066282746310005 * val1 / x);
 }
 
-long double __CLRCALL_PURE_OR_CDECL _XLgamma(long double x) { // moderately accurate log gamma
+long double __CLRCALL_PURE_OR_CDECL _XLgamma(long double x) noexcept { // moderately accurate log gamma
     static const long double coeff[6] = {76.18009172947146, -86.50532032941677, 24.01409824083091, -1.23173972450155,
         0.1208650973866179E-2, -0.5395239384953E-5};
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -714,6 +714,7 @@ std/time/time.syn/formatter.year_month_day_last.pass.cpp:0 FAIL
 std/time/time.syn/formatter.year_month_weekday.pass.cpp:0 FAIL
 
 # unused-variable warning
+std/numerics/rand/rand.device/ctor.pass.cpp FAIL
 std/thread/thread.mutex/thread.lock/thread.lock.scoped/mutex.pass.cpp FAIL
 std/thread/thread.mutex/thread.mutex.requirements/thread.shared_mutex.requirements/thread.shared_mutex.class/default.pass.cpp:1 FAIL
 

--- a/tests/std/tests/GH_000940_missing_valarray_copy/test.cpp
+++ b/tests/std/tests/GH_000940_missing_valarray_copy/test.cpp
@@ -78,10 +78,41 @@ void test_indirect() {
     assert(eq(v, {3, 1, 2, 3, 2}));
 }
 
+template <class T>
+void test_strengthened_exception_specification() {
+    STATIC_ASSERT(std::is_nothrow_default_constructible_v<std::valarray<T>>);
+
+    std::valarray<T> va{};
+    const auto& cva = va;
+    STATIC_ASSERT(noexcept(std::begin(va)));
+    STATIC_ASSERT(noexcept(std::end(va)));
+    STATIC_ASSERT(noexcept(std::begin(cva)));
+    STATIC_ASSERT(noexcept(std::end(cva)));
+
+    STATIC_ASSERT(std::is_nothrow_assignable_v<const std::slice_array<T>, const std::slice_array<T>&>);
+    STATIC_ASSERT(std::is_nothrow_assignable_v<const std::slice_array<T>, std::slice_array<T>>);
+
+    STATIC_ASSERT(std::is_nothrow_assignable_v<const std::mask_array<T>, const std::mask_array<T>&>);
+    STATIC_ASSERT(std::is_nothrow_assignable_v<const std::mask_array<T>, std::mask_array<T>>);
+
+    STATIC_ASSERT(std::is_nothrow_assignable_v<const std::indirect_array<T>, const std::indirect_array<T>&>);
+    STATIC_ASSERT(std::is_nothrow_assignable_v<const std::indirect_array<T>, std::indirect_array<T>>);
+}
+
 int main() {
     test_slice();
     test_gslice();
     test_mask();
     test_indirect();
-    return 0;
+
+    // Also test strengthened exception specifications
+    test_strengthened_exception_specification<bool>();
+    test_strengthened_exception_specification<std::size_t>();
+    test_strengthened_exception_specification<double>();
+
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10416247
+    STATIC_ASSERT(std::is_nothrow_default_constructible_v<std::gslice>); // strengthened
+#endif // defined(__clang__) || defined(__EDG__)
+    std::gslice gs{};
+    STATIC_ASSERT(noexcept(gs.start())); // strengthened
 }

--- a/tests/std/tests/GH_000940_missing_valarray_copy/test.cpp
+++ b/tests/std/tests/GH_000940_missing_valarray_copy/test.cpp
@@ -7,6 +7,8 @@
 #include <iostream>
 #include <valarray>
 
+#define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
+
 template <class T>
 bool eq(const std::valarray<T>& v, std::initializer_list<T> il) {
     return std::equal(begin(v), end(v), il.begin(), il.end());

--- a/tests/std/tests/GH_000940_missing_valarray_copy/test.cpp
+++ b/tests/std/tests/GH_000940_missing_valarray_copy/test.cpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <cstddef>
 #include <iostream>
+#include <type_traits>
 #include <valarray>
 
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)


### PR DESCRIPTION
Adding unconditional `noexcept` to suitable functions in `<cmath>`, `<random>`, and `<valarray>`.
(Conditional `noexcept` may be suitable for many functions in `<random>`...)

Currently only test for `<valarray>` is added. I hope we can add the test coverage to a new test suit for MS-specific properties and extensions in the future (see #502).

A bug of MSVC (DevCom-10416247) is discovered during testing.
