### PR TITLE
Detect allocate_at_least with a concept

### DIFF
--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -471,12 +471,17 @@ struct _Is_default_allocator<allocator<_Ty>, void_t<typename allocator<_Ty>::_Fr
     : is_same<typename allocator<_Ty>::_From_primary, allocator<_Ty>>::type {};
 
 #if _HAS_CXX23
+#ifdef __cpp_lib_concepts // TRANSITION, GH-395
+template <class _Alloc, class _SizeTy, class = void>
+concept _Has_member_allocate_at_least = requires(_Alloc& _Al, const _SizeTy& _Count) { _Al.allocate_at_least(_Count); };
+#else // ^^^ no workaround / workaround vvv
 template <class _Alloc, class _SizeTy, class = void>
 inline constexpr bool _Has_member_allocate_at_least = false;
 
 template <class _Alloc, class _SizeTy>
 inline constexpr bool _Has_member_allocate_at_least<_Alloc, _SizeTy,
     void_t<decltype(_STD declval<_Alloc&>().allocate_at_least(_STD declval<const _SizeTy&>()))>> = true;
+#endif // __cpp_lib_concepts
 #endif // _HAS_CXX23
 
 template <class _Void, class... _Types>

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -472,7 +472,7 @@ struct _Is_default_allocator<allocator<_Ty>, void_t<typename allocator<_Ty>::_Fr
 
 #if _HAS_CXX23
 #ifdef __cpp_lib_concepts // TRANSITION, GH-395
-template <class _Alloc, class _SizeTy, class = void>
+template <class _Alloc, class _SizeTy>
 concept _Has_member_allocate_at_least = requires(_Alloc& _Al, const _SizeTy& _Count) { _Al.allocate_at_least(_Count); };
 #else // ^^^ no workaround / workaround vvv
 template <class _Alloc, class _SizeTy, class = void>

--- a/tests/std/tests/GH_003570_allocate_at_least/test.cpp
+++ b/tests/std/tests/GH_003570_allocate_at_least/test.cpp
@@ -122,6 +122,31 @@ void test_inheriting_allocator() {
     assert(accumulate(vec.begin(), vec.end(), 0, plus<>{}) == 36);
 }
 
+// Also test VSO-1852860, in which we incorrectly tried to use allocate_at_least from an inaccessible std::allocator
+// base due to an MSVC bug.
+template <class T>
+struct less_icky_allocator : private allocator<T> {
+    using value_type = T;
+
+    less_icky_allocator() = default;
+    template <class U>
+    less_icky_allocator(const less_icky_allocator<U>&) {}
+
+    T* allocate(size_t n) {
+        return allocator<T>::allocate(n);
+    }
+
+    void deallocate(T* ptr, size_t n) {
+        return allocator<T>::deallocate(ptr, n);
+    }
+
+    template <class U>
+    bool operator==(const less_icky_allocator<U>&) const {
+        return true;
+    }
+};
+static_assert(!std::_Should_allocate_at_least<less_icky_allocator<int>>);
+
 int main() {
     test_deque();
     test_container<basic_string<char, char_traits<char>, signalling_allocator<char>>>();

--- a/tests/std/tests/GH_003570_allocate_at_least/test.cpp
+++ b/tests/std/tests/GH_003570_allocate_at_least/test.cpp
@@ -122,7 +122,7 @@ void test_inheriting_allocator() {
     assert(accumulate(vec.begin(), vec.end(), 0, plus<>{}) == 36);
 }
 
-// Also test VSO-1852860, in which we incorrectly tried to use allocate_at_least from an inaccessible std::allocator
+// Also test GH-3890, in which we incorrectly tried to use allocate_at_least from an inaccessible std::allocator
 // base due to an MSVC bug.
 template <class T>
 struct less_icky_allocator : private allocator<T> {


### PR DESCRIPTION
... to avoid DevCom-10419218, a C1XX bug in the non-requires-expression detection.

Fixes VSO-1852860 / AB#1852860
