### PR TITLE
Remove unnecessary `typename`s for all standard headers introduced in C++20

### DIFF
--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -423,7 +423,7 @@ namespace _Strong_order {
             } else if constexpr (_Strat == _St::_Floating) {
                 using _Floating_type = decay_t<_Ty1>;
                 using _Traits        = _Floating_type_traits<_Floating_type>;
-                using _Uint_type     = typename _Traits::_Uint_type;
+                using _Uint_type     = _Traits::_Uint_type;
                 using _Sint_type     = make_signed_t<_Uint_type>;
 
                 const auto _Left_uint  = _Bit_cast<_Uint_type>(_Left);
@@ -530,7 +530,7 @@ namespace _Weak_order {
             } else if constexpr (_Strat == _St::_Floating) {
                 using _Floating_type = decay_t<_Ty1>;
                 using _Traits        = _Floating_type_traits<_Floating_type>;
-                using _Uint_type     = typename _Traits::_Uint_type;
+                using _Uint_type     = _Traits::_Uint_type;
                 using _Sint_type     = make_signed_t<_Uint_type>;
 
                 auto _Left_uint  = _Bit_cast<_Uint_type>(_Left);

--- a/stl/inc/coroutine
+++ b/stl/inc/coroutine
@@ -40,7 +40,7 @@ struct _Coroutine_traits {};
 
 template <class _Ret>
 struct _Coroutine_traits<_Ret, void_t<typename _Ret::promise_type>> {
-    using promise_type = typename _Ret::promise_type;
+    using promise_type = _Ret::promise_type;
 };
 
 _EXPORT_STD template <class _Ret, class...>

--- a/stl/inc/coroutine
+++ b/stl/inc/coroutine
@@ -40,7 +40,7 @@ struct _Coroutine_traits {};
 
 template <class _Ret>
 struct _Coroutine_traits<_Ret, void_t<typename _Ret::promise_type>> {
-    using promise_type = _Ret::promise_type;
+    using promise_type = typename _Ret::promise_type;
 };
 
 _EXPORT_STD template <class _Ret, class...>

--- a/stl/inc/numbers
+++ b/stl/inc/numbers
@@ -95,7 +95,7 @@ namespace numbers {
     };
 
     template <class _Ty>
-    using _Reject_invalid_t = typename _Reject_invalid<_Ty>::type;
+    using _Reject_invalid_t = _Reject_invalid<_Ty>::type;
 
     _EXPORT_STD template <class _Ty>
     inline constexpr _Ty e_v = static_cast<_Reject_invalid_t<_Ty>>(2.718281828459045);

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1499,7 +1499,7 @@ namespace ranges {
             using iterator_concept  = random_access_iterator_tag;
             using iterator_category = random_access_iterator_tag;
             using value_type        = _Ty;
-            using difference_type   = typename _Repeat_view_difference_type<_Index_type>::type;
+            using difference_type   = _Repeat_view_difference_type<_Index_type>::type;
 
             _Iterator() = default;
 
@@ -4814,7 +4814,7 @@ namespace ranges {
         template <forward_range _BaseTy>
         class _Inner_iter_base<_BaseTy> {
         private:
-            using _BaseCategory = typename iterator_traits<iterator_t<_BaseTy>>::iterator_category;
+            using _BaseCategory = iterator_traits<iterator_t<_BaseTy>>::iterator_category;
 
         public:
             using iterator_category =
@@ -4881,7 +4881,7 @@ namespace ranges {
             }
 
         public:
-            using iterator_concept = typename _Outer_iter<_Const>::iterator_concept;
+            using iterator_concept = _Outer_iter<_Const>::iterator_concept;
             using value_type       = range_value_t<_BaseTy>;
             using difference_type  = range_difference_t<_BaseTy>;
 
@@ -7729,7 +7729,7 @@ namespace ranges {
         template <forward_range _BaseTy>
         class _Category_base<_BaseTy> {
         private:
-            using _BaseCategory = typename iterator_traits<iterator_t<_BaseTy>>::iterator_category;
+            using _BaseCategory = iterator_traits<iterator_t<_BaseTy>>::iterator_category;
 
         public:
             using iterator_category = conditional_t<derived_from<_BaseCategory, random_access_iterator_tag>,
@@ -8684,7 +8684,7 @@ namespace ranges {
                 : _Parent(_STD addressof(_Parent_)), _Inner(_STD move(_Inner_)) {}
 
         public:
-            using iterator_concept = typename _Ziperator<_IsConst>::iterator_concept;
+            using iterator_concept = _Ziperator<_IsConst>::iterator_concept;
             using value_type       = remove_cvref_t<invoke_result_t<_Maybe_const<_IsConst, _Func>&,
                 range_reference_t<_Maybe_const<_IsConst, _ViewTypes>>...>>;
             using difference_type  = range_difference_t<_Base_t>;
@@ -9006,7 +9006,7 @@ namespace ranges {
     };
 
     template <class _Ty, size_t _Nx>
-    using _Repeated_tuple = typename _Repeated_tuple_impl<_Ty, make_index_sequence<_Nx>>::type;
+    using _Repeated_tuple = _Repeated_tuple_impl<_Ty, make_index_sequence<_Nx>>::type;
 
     template <class _Fn, class _Ty, class _Indices>
     inline constexpr bool _Regular_invocable_with_repeated_type_impl = false;
@@ -9033,7 +9033,7 @@ namespace ranges {
 
     template <class _Fn, class _Ty, size_t _Nx>
     using _Invoke_result_with_repeated_type =
-        typename _Invoke_result_with_repeated_type_impl<_Fn, _Ty, make_index_sequence<_Nx>>::type;
+        _Invoke_result_with_repeated_type_impl<_Fn, _Ty, make_index_sequence<_Nx>>::type;
 
     template <class _Vw, class _Fn, size_t _Nx>
     concept _Adjacent_transform_constraints =
@@ -9478,7 +9478,7 @@ namespace ranges {
                                   range_reference_t<_Base>, _Nx>>) {
                     return input_iterator_tag{};
                 } else {
-                    using _Cat = typename iterator_traits<iterator_t<_Base>>::iterator_category;
+                    using _Cat = iterator_traits<iterator_t<_Base>>::iterator_category;
 
                     if constexpr (derived_from<_Cat, random_access_iterator_tag>) {
                         return random_access_iterator_tag{};
@@ -9500,7 +9500,7 @@ namespace ranges {
 
         public:
             using iterator_category = decltype(_Get_iterator_category());
-            using iterator_concept  = typename _Inner_iterator<_Const>::iterator_concept;
+            using iterator_concept  = _Inner_iterator<_Const>::iterator_concept;
             using value_type        = remove_cvref_t<
                 _Invoke_result_with_repeated_type<_Maybe_const<_Const, _Fn>&, range_reference_t<_Base>, _Nx>>;
             using difference_type = range_difference_t<_Base>;

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -125,12 +125,12 @@ public:
     using value_type             = stacktrace_entry;
     using const_reference        = const value_type&;
     using reference              = value_type&;
-    using const_iterator         = typename _Frames_t::const_iterator;
+    using const_iterator         = _Frames_t::const_iterator;
     using iterator               = const_iterator;
     using reverse_iterator       = _STD reverse_iterator<iterator>;
     using const_reverse_iterator = _STD reverse_iterator<const_iterator>;
-    using difference_type        = typename _Frames_t::difference_type;
-    using size_type              = typename _Frames_t::size_type;
+    using difference_type        = _Frames_t::difference_type;
+    using size_type              = _Frames_t::size_type;
     using allocator_type         = _Alloc;
 
     // __declspec(noinline) to make the same behavior for debug and release.

--- a/stl/inc/syncstream
+++ b/stl/inc/syncstream
@@ -69,15 +69,15 @@ protected:
 _EXPORT_STD template <class _Elem, class _Traits, class _Alloc>
 class basic_syncbuf : public _Basic_syncbuf_impl<_Elem, _Traits> {
 public:
-    using int_type       = typename _Traits::int_type;
-    using pos_type       = typename _Traits::pos_type;
-    using off_type       = typename _Traits::off_type;
+    using int_type       = _Traits::int_type;
+    using pos_type       = _Traits::pos_type;
+    using off_type       = _Traits::off_type;
     using allocator_type = _Alloc;
     using streambuf_type = basic_streambuf<_Elem, _Traits>;
 
     using _Mybase    = _Basic_syncbuf_impl<_Elem, _Traits>;
-    using _Pointer   = typename allocator_traits<_Alloc>::pointer;
-    using _Size_type = typename allocator_traits<_Alloc>::size_type;
+    using _Pointer   = allocator_traits<_Alloc>::pointer;
+    using _Size_type = allocator_traits<_Alloc>::size_type;
 
     using _Mybase::set_emit_on_sync;
 
@@ -319,9 +319,9 @@ _EXPORT_STD template <class _Elem, class _Traits, class _Alloc>
 class basic_osyncstream : public basic_ostream<_Elem, _Traits> {
 public:
     using char_type      = _Elem;
-    using int_type       = typename _Traits::int_type;
-    using pos_type       = typename _Traits::pos_type;
-    using off_type       = typename _Traits::off_type;
+    using int_type       = _Traits::int_type;
+    using pos_type       = _Traits::pos_type;
+    using off_type       = _Traits::off_type;
     using traits_type    = _Traits;
     using allocator_type = _Alloc;
     using streambuf_type = basic_streambuf<_Elem, _Traits>;


### PR DESCRIPTION
The headers newly introduced in C++20 are:
```
<bit>
<compare>
<concepts>
<coroutine>
<format>
<numbers>
<ranges>
<source_location>
<span>
<syncstream>
<version>
<barrier>
<latch>
<semaphore>
<stop_token>
```

The headers that contain `typename` are:
```
<compare>: Removes two `typename` in `using` clauses; one left as necessary.
<concepts>: All necessary.
<coroutine>: X(Removes one in `using` clause; one left as necessary) update: kept unchanged
<format>: Tackled in last pr.
<numbers>: Removes the only one.
<ranges>: Removes those in `using` clause; the rest(a lot) are necessary.
<span>: All necessary.
<syncstream>: Removes those in `using` clause; one left as necessary.
```

Also removes all `typename` in `<stacktrace>`

Works towards #3718.