### PR TITLE
Remove unnecessary `typename`s in all remaining headers

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2716,23 +2716,27 @@ _Ty atomic_fetch_xor_explicit(
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _Ty>
-void atomic_wait(const volatile atomic<_Ty>* const _Mem, const typename atomic<_Ty>::value_type _Expected) noexcept {
+void atomic_wait(const volatile atomic<_Ty>* const _Mem,
+    const typename atomic<_Ty>::value_type _Expected) noexcept { // TRANSITION, VSO-1854115, omit typename
     _Mem->wait(_Expected);
 }
 
 _EXPORT_STD template <class _Ty>
-void atomic_wait(const atomic<_Ty>* const _Mem, const typename atomic<_Ty>::value_type _Expected) noexcept {
+void atomic_wait(const atomic<_Ty>* const _Mem,
+    const typename atomic<_Ty>::value_type _Expected) noexcept { // TRANSITION, VSO-1854115, omit typename
     _Mem->wait(_Expected);
 }
 
 _EXPORT_STD template <class _Ty>
-void atomic_wait_explicit(const volatile atomic<_Ty>* const _Mem, const typename atomic<_Ty>::value_type _Expected,
+void atomic_wait_explicit(const volatile atomic<_Ty>* const _Mem,
+    const typename atomic<_Ty>::value_type _Expected, // TRANSITION, VSO-1854115, omit typename
     const memory_order _Order) noexcept {
     _Mem->wait(_Expected, _Order);
 }
 
 _EXPORT_STD template <class _Ty>
-void atomic_wait_explicit(const atomic<_Ty>* const _Mem, const typename atomic<_Ty>::value_type _Expected,
+void atomic_wait_explicit(const atomic<_Ty>* const _Mem,
+    const typename atomic<_Ty>::value_type _Expected, // TRANSITION, VSO-1854115, omit typename
     const memory_order _Order) noexcept {
     _Mem->wait(_Expected, _Order);
 }

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2155,8 +2155,8 @@ using _Choose_atomic_base2_t =
 
 #if _HAS_CXX20
 template <class _TVal, class _Ty = _TVal>
-using _Choose_atomic_base_t = typename _Select<is_floating_point_v<_TVal>>::template _Apply<_Atomic_floating<_Ty>,
-    _Choose_atomic_base2_t<_TVal, _Ty>>;
+using _Choose_atomic_base_t =
+    _Select<is_floating_point_v<_TVal>>::template _Apply<_Atomic_floating<_Ty>, _Choose_atomic_base2_t<_TVal, _Ty>>;
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 template <class _TVal, class _Ty = _TVal>
 using _Choose_atomic_base_t = _Choose_atomic_base2_t<_TVal, _Ty>;

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -3463,9 +3463,9 @@ namespace chrono {
 
         template <class _Duration1, class _Duration2>
         _NODISCARD static constexpr bool _Can_represent() {
-            using _Rep1    = typename _Duration1::rep;
-            using _Period1 = typename _Duration1::period;
-            using _Period2 = typename _Duration2::period;
+            using _Rep1    = _Duration1::rep;
+            using _Period1 = _Duration1::period;
+            using _Period2 = _Duration2::period;
 
             // Returns whether _Duration1 can represent _Duration2{1}. Assumes 1 <= _Period2 <=
             // 86,400, i.e., we're interested in time periods between seconds and days.
@@ -3730,7 +3730,7 @@ namespace chrono {
         _NODISCARD _InIt _Parse_time_field(_InIt _First, ios_base& _Iosbase, ios_base::iostate& _State,
             const char _Flag, const char _Modifier, const unsigned int _Width,
             const unsigned int _Subsecond_precision) {
-            using _CharT = typename _InIt::value_type;
+            using _CharT = _InIt::value_type;
 
             const auto& _Ctype_fac = _STD use_facet<ctype<_CharT>>(_Iosbase.getloc());
             const auto& _Time_fac  = _STD use_facet<time_get<_CharT>>(_Iosbase.getloc());

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1748,12 +1748,12 @@ _NODISCARD bool operator>=(const deque<_Ty, _Alloc>& _Left, const deque<_Ty, _Al
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _Ty, class _Alloc, class _Uty>
-typename deque<_Ty, _Alloc>::size_type erase(deque<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
+deque<_Ty, _Alloc>::size_type erase(deque<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
     return _Erase_remove(_Cont, _Val);
 }
 
 _EXPORT_STD template <class _Ty, class _Alloc, class _Pr>
-typename deque<_Ty, _Alloc>::size_type erase_if(deque<_Ty, _Alloc>& _Cont, _Pr _Pred) {
+deque<_Ty, _Alloc>::size_type erase_if(deque<_Ty, _Alloc>& _Cont, _Pr _Pred) {
     return _Erase_remove_if(_Cont, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -1614,12 +1614,12 @@ _NODISCARD bool operator>=(const forward_list<_Ty, _Alloc>& _Left, const forward
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _Ty, class _Alloc, class _Uty>
-typename forward_list<_Ty, _Alloc>::size_type erase(forward_list<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
+forward_list<_Ty, _Alloc>::size_type erase(forward_list<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
     return _Cont.remove_if([&](_Ty& _Elem) { return _Elem == _Val; });
 }
 
 _EXPORT_STD template <class _Ty, class _Alloc, class _Pr>
-typename forward_list<_Ty, _Alloc>::size_type erase_if(forward_list<_Ty, _Alloc>& _Cont, _Pr _Pred) {
+forward_list<_Ty, _Alloc>::size_type erase_if(forward_list<_Ty, _Alloc>& _Cont, _Pr _Pred) {
     return _Cont.remove_if(_Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1360,7 +1360,7 @@ public:
         // empty function from a DLL that is unloaded later, and then safely moving/destroying that empty function.
 
         // Calls target
-        typename _Invoke_t<_Noexcept>::_Call _Invoke;
+        _Invoke_t<_Noexcept>::_Call _Invoke;
         // Moves the data, including pointer to "vtable", AND destroys old data (not resetting its "vtable").
         // nullptr if we can trivially move two pointers.
         void(__stdcall* _Move)(_Move_only_function_data&, _Move_only_function_data&) _NOEXCEPT_FNPTR;
@@ -1787,7 +1787,7 @@ public:
             }
         }
 
-        using _VtInvQuals = typename _Call::template _VtInvQuals<_Vt>;
+        using _VtInvQuals = _Call::template _VtInvQuals<_Vt>;
         this->template _Construct_with_fn<_Vt, _VtInvQuals>(_STD forward<_Fn>(_Callable));
     }
 
@@ -1796,7 +1796,7 @@ public:
         using _Vt = decay_t<_Fn>;
         static_assert(is_same_v<_Vt, _Fn>, "_Vt should be the same type as _Fn. (N4950 [func.wrap.move.ctor]/12)");
 
-        using _VtInvQuals = typename _Call::template _VtInvQuals<_Vt>;
+        using _VtInvQuals = _Call::template _VtInvQuals<_Vt>;
         this->template _Construct_with_fn<_Vt, _VtInvQuals>(_STD forward<_CTypes>(_Args)...);
     }
 
@@ -1806,7 +1806,7 @@ public:
         using _Vt = decay_t<_Fn>;
         static_assert(is_same_v<_Vt, _Fn>, "_Vt should be the same type as _Fn. (N4950 [func.wrap.move.ctor]/18)");
 
-        using _VtInvQuals = typename _Call::template _VtInvQuals<_Vt>;
+        using _VtInvQuals = _Call::template _VtInvQuals<_Vt>;
         this->template _Construct_with_fn<_Vt, _VtInvQuals>(_Li, _STD forward<_CTypes>(_Args)...);
     }
 

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -1916,12 +1916,12 @@ _NODISCARD bool operator>=(const list<_Ty, _Alloc>& _Left, const list<_Ty, _Allo
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _Ty, class _Alloc, class _Uty>
-typename list<_Ty, _Alloc>::size_type erase(list<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
+list<_Ty, _Alloc>::size_type erase(list<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
     return _Cont.remove_if([&](_Ty& _Elem) { return _Elem == _Val; });
 }
 
 _EXPORT_STD template <class _Ty, class _Alloc, class _Pr>
-typename list<_Ty, _Alloc>::size_type erase_if(list<_Ty, _Alloc>& _Cont, _Pr _Pred) {
+list<_Ty, _Alloc>::size_type erase_if(list<_Ty, _Alloc>& _Cont, _Pr _Pred) {
     return _Cont.remove_if(_Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20

--- a/stl/inc/map
+++ b/stl/inc/map
@@ -448,7 +448,7 @@ void swap(map<_Kty, _Ty, _Pr, _Alloc>& _Left, map<_Kty, _Ty, _Pr, _Alloc>& _Righ
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _Kty, class _Ty, class _Keylt, class _Alloc, class _Pr>
-typename map<_Kty, _Ty, _Keylt, _Alloc>::size_type erase_if(map<_Kty, _Ty, _Keylt, _Alloc>& _Cont, _Pr _Pred) {
+map<_Kty, _Ty, _Keylt, _Alloc>::size_type erase_if(map<_Kty, _Ty, _Keylt, _Alloc>& _Cont, _Pr _Pred) {
     return _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20
@@ -687,8 +687,7 @@ void swap(multimap<_Kty, _Ty, _Pr, _Alloc>& _Left, multimap<_Kty, _Ty, _Pr, _All
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _Kty, class _Ty, class _Keylt, class _Alloc, class _Pr>
-typename multimap<_Kty, _Ty, _Keylt, _Alloc>::size_type erase_if(
-    multimap<_Kty, _Ty, _Keylt, _Alloc>& _Cont, _Pr _Pred) {
+multimap<_Kty, _Ty, _Keylt, _Alloc>::size_type erase_if(multimap<_Kty, _Ty, _Keylt, _Alloc>& _Cont, _Pr _Pred) {
     return _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1916,7 +1916,7 @@ _NODISCARD bool operator==(const shared_ptr<_Ty>& _Left, nullptr_t) noexcept {
 #if _HAS_CXX20
 _EXPORT_STD template <class _Ty>
 _NODISCARD strong_ordering operator<=>(const shared_ptr<_Ty>& _Left, nullptr_t) noexcept {
-    return _Left.get() <=> static_cast<typename shared_ptr<_Ty>::element_type*>(nullptr);
+    return _Left.get() <=> static_cast<shared_ptr<_Ty>::element_type*>(nullptr);
 }
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 template <class _Ty>
@@ -4134,13 +4134,13 @@ struct _Pointer_of_helper {};
 
 template <_Has_member_pointer _Ty>
 struct _Pointer_of_helper<_Ty> {
-    using type = typename _Ty::pointer;
+    using type = _Ty::pointer;
 };
 
 template <_Has_member_element_type _Ty>
     requires (!_Has_member_pointer<_Ty>)
 struct _Pointer_of_helper<_Ty> {
-    using type = typename _Ty::element_type*;
+    using type = _Ty::element_type*;
 };
 
 // clang-format off
@@ -4148,12 +4148,12 @@ template <class _Ty>
     requires (!_Has_member_element_type<_Ty> && !_Has_member_pointer<_Ty>
         && _Has_member_element_type<pointer_traits<_Ty>>)
 struct _Pointer_of_helper<_Ty> {
-    using type = typename pointer_traits<_Ty>::element_type*;
+    using type = pointer_traits<_Ty>::element_type*;
 };
 // clang-format on
 
 template <class _Ty>
-using _Pointer_of = typename _Pointer_of_helper<_Ty>::type;
+using _Pointer_of = _Pointer_of_helper<_Ty>::type;
 
 template <class _Ty, class _Uty>
 struct _Pointer_of_or_helper {
@@ -4167,7 +4167,7 @@ struct _Pointer_of_or_helper<_Ty, _Uty> {
 };
 
 template <class _Ty, class _Uty>
-using _Pointer_of_or = typename _Pointer_of_or_helper<_Ty, _Uty>::type;
+using _Pointer_of_or = _Pointer_of_or_helper<_Ty, _Uty>::type;
 
 // TRANSITION, requires expression support
 template <class _SmartPtr, class _Sp, class _Pointer, class... _ArgsT>

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -606,7 +606,7 @@ struct _Get_member_comparison_category {
 
 template <class _Ty>
 struct _Get_member_comparison_category<_Ty, void_t<typename _Ty::comparison_category>> {
-    using type = typename _Ty::comparison_category;
+    using type = _Ty::comparison_category;
 };
 #endif // _HAS_CXX20
 
@@ -624,7 +624,7 @@ public:
     using _Size_type = typename string_type::size_type;
 
 #if _HAS_CXX20
-    using _Comparison_category = typename _Get_member_comparison_category<_Traits>::type;
+    using _Comparison_category = _Get_member_comparison_category<_Traits>::type;
 #endif // _HAS_CXX20
 
     constexpr sub_match() : _Mybase(), matched(false) {}
@@ -737,7 +737,7 @@ _NODISCARD bool operator==(const sub_match<_BidIt>& _Left, const sub_match<_BidI
 #if _HAS_CXX20
 _EXPORT_STD template <class _BidIt>
 _NODISCARD auto operator<=>(const sub_match<_BidIt>& _Left, const sub_match<_BidIt>& _Right) {
-    return static_cast<typename sub_match<_BidIt>::_Comparison_category>(_Left.compare(_Right) <=> 0);
+    return static_cast<sub_match<_BidIt>::_Comparison_category>(_Left.compare(_Right) <=> 0);
 }
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 template <class _BidIt>
@@ -774,7 +774,7 @@ _NODISCARD bool operator==(const sub_match<_BidIt>& _Left, const _Iter_value_t<_
 #if _HAS_CXX20
 _EXPORT_STD template <class _BidIt>
 _NODISCARD auto operator<=>(const sub_match<_BidIt>& _Left, const _Iter_value_t<_BidIt>* _Right) {
-    return static_cast<typename sub_match<_BidIt>::_Comparison_category>(_Left.compare(_Right) <=> 0);
+    return static_cast<sub_match<_BidIt>::_Comparison_category>(_Left.compare(_Right) <=> 0);
 }
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 template <class _BidIt>
@@ -841,8 +841,7 @@ _NODISCARD bool operator==(const sub_match<_BidIt>& _Left, const _Iter_value_t<_
 #if _HAS_CXX20
 _EXPORT_STD template <class _BidIt>
 _NODISCARD auto operator<=>(const sub_match<_BidIt>& _Left, const _Iter_value_t<_BidIt>& _Right) {
-    return static_cast<typename sub_match<_BidIt>::_Comparison_category>(
-        _Left._Compare(_STD addressof(_Right), 1) <=> 0);
+    return static_cast<sub_match<_BidIt>::_Comparison_category>(_Left._Compare(_STD addressof(_Right), 1) <=> 0);
 }
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 template <class _BidIt>
@@ -911,7 +910,7 @@ _NODISCARD bool operator==(
 _EXPORT_STD template <class _BidIt, class _Traits, class _Alloc>
 _NODISCARD auto operator<=>(
     const sub_match<_BidIt>& _Left, const basic_string<_Iter_value_t<_BidIt>, _Traits, _Alloc>& _Right) {
-    return static_cast<typename sub_match<_BidIt>::_Comparison_category>(_Left.compare(_Right) <=> 0);
+    return static_cast<sub_match<_BidIt>::_Comparison_category>(_Left.compare(_Right) <=> 0);
 }
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 template <class _BidIt, class _Traits, class _Alloc>

--- a/stl/inc/set
+++ b/stl/inc/set
@@ -256,7 +256,7 @@ void swap(set<_Kty, _Pr, _Alloc>& _Left, set<_Kty, _Pr, _Alloc>& _Right) noexcep
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _Kty, class _Keylt, class _Alloc, class _Pr>
-typename set<_Kty, _Keylt, _Alloc>::size_type erase_if(set<_Kty, _Keylt, _Alloc>& _Cont, _Pr _Pred) {
+set<_Kty, _Keylt, _Alloc>::size_type erase_if(set<_Kty, _Keylt, _Alloc>& _Cont, _Pr _Pred) {
     return _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20
@@ -474,7 +474,7 @@ void swap(multiset<_Kty, _Pr, _Alloc>& _Left, multiset<_Kty, _Pr, _Alloc>& _Righ
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _Kty, class _Keylt, class _Alloc, class _Pr>
-typename multiset<_Kty, _Keylt, _Alloc>::size_type erase_if(multiset<_Kty, _Keylt, _Alloc>& _Cont, _Pr _Pred) {
+multiset<_Kty, _Keylt, _Alloc>::size_type erase_if(multiset<_Kty, _Keylt, _Alloc>& _Cont, _Pr _Pred) {
     return _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20

--- a/stl/inc/spanstream
+++ b/stl/inc/spanstream
@@ -39,9 +39,9 @@ private:
 
 public:
     using char_type   = _Elem;
-    using int_type    = typename _Traits::int_type;
-    using pos_type    = typename _Traits::pos_type;
-    using off_type    = typename _Traits::off_type;
+    using int_type    = _Traits::int_type;
+    using pos_type    = _Traits::pos_type;
+    using off_type    = _Traits::off_type;
     using traits_type = _Traits;
 
     // N4950 [spanbuf.cons], constructors
@@ -201,9 +201,9 @@ private:
 
 public:
     using char_type   = _Elem;
-    using int_type    = typename _Traits::int_type;
-    using pos_type    = typename _Traits::pos_type;
-    using off_type    = typename _Traits::off_type;
+    using int_type    = _Traits::int_type;
+    using pos_type    = _Traits::pos_type;
+    using off_type    = _Traits::off_type;
     using traits_type = _Traits;
 
     // N4950 [ispanstream.cons], constructors
@@ -284,9 +284,9 @@ private:
 
 public:
     using char_type   = _Elem;
-    using int_type    = typename _Traits::int_type;
-    using pos_type    = typename _Traits::pos_type;
-    using off_type    = typename _Traits::off_type;
+    using int_type    = _Traits::int_type;
+    using pos_type    = _Traits::pos_type;
+    using off_type    = _Traits::off_type;
     using traits_type = _Traits;
 
     // N4950 [ospanstream.cons], constructors
@@ -344,9 +344,9 @@ private:
 
 public:
     using char_type   = _Elem;
-    using int_type    = typename _Traits::int_type;
-    using pos_type    = typename _Traits::pos_type;
-    using off_type    = typename _Traits::off_type;
+    using int_type    = _Traits::int_type;
+    using pos_type    = _Traits::pos_type;
+    using off_type    = _Traits::off_type;
     using traits_type = _Traits;
 
     // N4950 [spanstream.cons], constructors

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -213,7 +213,7 @@ struct _Three_way_comparison_result_with_tuple_like<tuple<_TTypes...>, _UTuple, 
 
 template <class _TTuple, _Tuple_like _UTuple>
 using _Three_way_comparison_result_with_tuple_like_t =
-    typename _Three_way_comparison_result_with_tuple_like<_TTuple, _UTuple>::type;
+    _Three_way_comparison_result_with_tuple_like<_TTuple, _UTuple>::type;
 
 template <class _Ty>
 concept _Tuple_like_non_tuple = !_Is_specialization_v<_Ty, tuple> && _Tuple_like<_Ty>;
@@ -1142,7 +1142,7 @@ template <_Tuple_like _TTuple, _Tuple_like _UTuple, template <class> class _TQua
                  typename _Tuple_like_common_reference<_TTuple, _UTuple, _TQual, _UQual>::type;
              }
 struct basic_common_reference<_TTuple, _UTuple, _TQual, _UQual> {
-    using type = typename _Tuple_like_common_reference<_TTuple, _UTuple, _TQual, _UQual>::type;
+    using type = _Tuple_like_common_reference<_TTuple, _UTuple, _TQual, _UQual>::type;
 };
 
 template <_Tuple_like _TTuple, _Tuple_like _UTuple, class _Indices = make_index_sequence<tuple_size_v<_TTuple>>>
@@ -1163,7 +1163,7 @@ template <_Tuple_like _TTuple, _Tuple_like _UTuple>
                  typename _Tuple_like_common_type<_TTuple, _UTuple>::type;
              }
 struct common_type<_TTuple, _UTuple> {
-    using type = typename _Tuple_like_common_type<_TTuple, _UTuple>::type;
+    using type = _Tuple_like_common_type<_TTuple, _UTuple>::type;
 };
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1396,7 +1396,7 @@ struct _Copy_cv_impl<const volatile _From> {
 };
 template <class _From, class _To>
 using _Copy_cv = // N4950 [meta.trans.other]/2.3
-    typename _Copy_cv_impl<_From>::template _Apply<_To>;
+    _Copy_cv_impl<_From>::template _Apply<_To>;
 
 template <class _Ty1>
 struct _Add_qualifiers { // _Add_qualifiers<A>::template _Apply is XREF(A) from N4950 [meta.trans.other]/2.2
@@ -1435,7 +1435,7 @@ struct _Cond_res_workaround<_Ty1, _Ty2, void_t<_Cond_res_if_right<_Ty1, _Ty2>>> 
 };
 
 template <class _Ty1, class _Ty2>
-using _Cond_res = typename _Cond_res_workaround<_Ty1, _Ty2>::type;
+using _Cond_res = _Cond_res_workaround<_Ty1, _Ty2>::type;
 #else // ^^^ workaround / no workaround vvv
 template <class _Ty1, class _Ty2>
 using _Cond_res = // N4950 [meta.trans.other]/2.4
@@ -1446,7 +1446,7 @@ _EXPORT_STD template <class...>
 struct common_reference;
 
 _EXPORT_STD template <class... _Types>
-using common_reference_t = typename common_reference<_Types...>::type;
+using common_reference_t = common_reference<_Types...>::type;
 
 // N4950 [meta.trans.other]/5.1: "If sizeof...(T) is zero ..."
 template <>
@@ -1473,7 +1473,7 @@ struct _Common_reference2C<_Ty1, _Ty2, void_t<_Cond_res<_Ty1, _Ty2>>> {
 
 // N4950 [meta.trans.other]/5.3.2: "if basic_common_reference<[...]>::type is well-formed..."
 template <class _Ty1, class _Ty2>
-using _Basic_specialization = typename basic_common_reference<remove_cvref_t<_Ty1>, remove_cvref_t<_Ty2>,
+using _Basic_specialization = basic_common_reference<remove_cvref_t<_Ty1>, remove_cvref_t<_Ty2>,
     _Add_qualifiers<_Ty1>::template _Apply, _Add_qualifiers<_Ty2>::template _Apply>::type;
 
 template <class _Ty1, class _Ty2, class = void>
@@ -1523,7 +1523,7 @@ struct _Common_reference2AX<_Ty1&&, _Ty2&&,
 };
 
 template <class _Ty1, class _Ty2>
-using _Common_ref_2AX_t = typename _Common_reference2AX<_Ty1, _Ty2>::type;
+using _Common_ref_2AX_t = _Common_reference2AX<_Ty1, _Ty2>::type;
 
 template <class _Ty1, class _Ty2>
 struct _Common_reference2A<_Ty1, _Ty2,
@@ -1552,7 +1552,7 @@ struct type_identity {
     using type = _Ty;
 };
 _EXPORT_STD template <class _Ty>
-using type_identity_t = typename type_identity<_Ty>::type;
+using type_identity_t = type_identity<_Ty>::type;
 #endif // _HAS_CXX20
 
 template <class _Type, template <class...> class _Template>
@@ -2111,7 +2111,7 @@ struct unwrap_reference<reference_wrapper<_Ty>> {
     using type = _Ty&;
 };
 _EXPORT_STD template <class _Ty>
-using unwrap_reference_t = typename unwrap_reference<_Ty>::type;
+using unwrap_reference_t = unwrap_reference<_Ty>::type;
 
 _EXPORT_STD template <class _Ty>
 using unwrap_ref_decay_t = unwrap_reference_t<decay_t<_Ty>>;

--- a/stl/inc/unordered_map
+++ b/stl/inc/unordered_map
@@ -531,7 +531,7 @@ void swap(unordered_map<_Kty, _Ty, _Hasher, _Keyeq, _Alloc>& _Left,
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _Kty, class _Ty, class _Hasher, class _Keyeq, class _Alloc, class _Pr>
-typename unordered_map<_Kty, _Ty, _Hasher, _Keyeq, _Alloc>::size_type erase_if(
+unordered_map<_Kty, _Ty, _Hasher, _Keyeq, _Alloc>::size_type erase_if(
     unordered_map<_Kty, _Ty, _Hasher, _Keyeq, _Alloc>& _Cont, _Pr _Pred) {
     return _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
 }
@@ -902,7 +902,7 @@ void swap(unordered_multimap<_Kty, _Ty, _Hasher, _Keyeq, _Alloc>& _Left,
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _Kty, class _Ty, class _Hasher, class _Keyeq, class _Alloc, class _Pr>
-typename unordered_multimap<_Kty, _Ty, _Hasher, _Keyeq, _Alloc>::size_type erase_if(
+unordered_multimap<_Kty, _Ty, _Hasher, _Keyeq, _Alloc>::size_type erase_if(
     unordered_multimap<_Kty, _Ty, _Hasher, _Keyeq, _Alloc>& _Cont, _Pr _Pred) {
     return _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
 }

--- a/stl/inc/unordered_set
+++ b/stl/inc/unordered_set
@@ -386,7 +386,7 @@ void swap(unordered_set<_Kty, _Hasher, _Keyeq, _Alloc>& _Left,
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _Kty, class _Hasher, class _Keyeq, class _Alloc, class _Pr>
-typename unordered_set<_Kty, _Hasher, _Keyeq, _Alloc>::size_type erase_if(
+unordered_set<_Kty, _Hasher, _Keyeq, _Alloc>::size_type erase_if(
     unordered_set<_Kty, _Hasher, _Keyeq, _Alloc>& _Cont, _Pr _Pred) {
     return _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
 }
@@ -729,7 +729,7 @@ void swap(unordered_multiset<_Kty, _Hasher, _Keyeq, _Alloc>& _Left,
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _Kty, class _Hasher, class _Keyeq, class _Alloc, class _Pr>
-typename unordered_multiset<_Kty, _Hasher, _Keyeq, _Alloc>::size_type erase_if(
+unordered_multiset<_Kty, _Hasher, _Keyeq, _Alloc>::size_type erase_if(
     unordered_multiset<_Kty, _Hasher, _Keyeq, _Alloc>& _Cont, _Pr _Pred) {
     return _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
 }

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -226,7 +226,7 @@ public:
 template <class _Myvec>
 struct pointer_traits<_Vector_const_iterator<_Myvec>> {
     using pointer         = _Vector_const_iterator<_Myvec>;
-    using element_type    = const typename pointer::value_type;
+    using element_type    = const typename pointer::value_type; // TRANSITION, VSO-1854115, omit typename
     using difference_type = pointer::difference_type;
 
     _NODISCARD static constexpr element_type* to_address(const pointer _Iter) noexcept {

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -227,7 +227,7 @@ template <class _Myvec>
 struct pointer_traits<_Vector_const_iterator<_Myvec>> {
     using pointer         = _Vector_const_iterator<_Myvec>;
     using element_type    = const typename pointer::value_type;
-    using difference_type = typename pointer::difference_type;
+    using difference_type = pointer::difference_type;
 
     _NODISCARD static constexpr element_type* to_address(const pointer _Iter) noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
@@ -348,8 +348,8 @@ public:
 template <class _Myvec>
 struct pointer_traits<_Vector_iterator<_Myvec>> {
     using pointer         = _Vector_iterator<_Myvec>;
-    using element_type    = typename pointer::value_type;
-    using difference_type = typename pointer::difference_type;
+    using element_type    = pointer::value_type;
+    using difference_type = pointer::difference_type;
 
     _NODISCARD static constexpr element_type* to_address(const pointer _Iter) noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
@@ -2366,12 +2366,12 @@ _CONSTEXPR20 void swap(vector<_Ty, _Alloc>& _Left, vector<_Ty, _Alloc>& _Right) 
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _Ty, class _Alloc, class _Uty>
-constexpr typename vector<_Ty, _Alloc>::size_type erase(vector<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
+constexpr vector<_Ty, _Alloc>::size_type erase(vector<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
     return _Erase_remove(_Cont, _Val);
 }
 
 _EXPORT_STD template <class _Ty, class _Alloc, class _Pr>
-constexpr typename vector<_Ty, _Alloc>::size_type erase_if(vector<_Ty, _Alloc>& _Cont, _Pr _Pred) {
+constexpr vector<_Ty, _Alloc>::size_type erase_if(vector<_Ty, _Alloc>& _Cont, _Pr _Pred) {
     return _Erase_remove_if(_Cont, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -1237,7 +1237,7 @@ public:
 
 #if _HAS_CXX20
     template <class _Keyty = void>
-    _NODISCARD bool contains(typename _Traits::template _Deduce_key<_Keyty> _Keyval) const {
+    _NODISCARD bool contains(_Traits::template _Deduce_key<_Keyty> _Keyval) const {
         return static_cast<bool>(_Find_last(_Keyval, _Traitsobj(_Keyval))._Duplicate);
     }
 #endif // _HAS_CXX20

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2530,7 +2530,7 @@ template <_RANGES input_range _Rng>
 using _Range_key_type = remove_const_t<typename _RANGES range_value_t<_Rng>::first_type>;
 
 template <_RANGES input_range _Rng>
-using _Range_mapped_type = _RANGES range_value_t<_Rng>::second_type;
+using _Range_mapped_type = typename _RANGES range_value_t<_Rng>::second_type; // TRANSITION, VSO-1854035, omit typename
 
 template <_RANGES input_range _Rng>
 using _Range_to_alloc_type =

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2475,8 +2475,8 @@ _NODISCARD constexpr auto uses_allocator_construction_args(const _Alloc& _Al, _U
                 static_assert(_Is_normally_bindable<_Pair_t, _Uty>,
                     "The argument must be bindable to a reference to the std::pair type.");
 
-                using _Pair_first_t   = typename _Pair_t::first_type;
-                using _Pair_second_t  = typename _Pair_t::second_type;
+                using _Pair_first_t   = _Pair_t::first_type;
+                using _Pair_second_t  = _Pair_t::second_type;
                 using _Pair_ref_t     = _Normally_bound_ref<_Pair_t, _Uty>;
                 _Pair_ref_t _Pair_ref = _STD forward<_Uty>(_Ux);
                 if constexpr (is_same_v<_Pair_ref_t, const _Pair_t&>) {
@@ -2530,7 +2530,7 @@ template <_RANGES input_range _Rng>
 using _Range_key_type = remove_const_t<typename _RANGES range_value_t<_Rng>::first_type>;
 
 template <_RANGES input_range _Rng>
-using _Range_mapped_type = typename _RANGES range_value_t<_Rng>::second_type;
+using _Range_mapped_type = _RANGES range_value_t<_Rng>::second_type;
 
 template <_RANGES input_range _Rng>
 using _Range_to_alloc_type =

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1152,7 +1152,7 @@ private:
 template <class _Traits>
 struct pointer_traits<_String_view_iterator<_Traits>> {
     using pointer         = _String_view_iterator<_Traits>;
-    using element_type    = const typename pointer::value_type;
+    using element_type    = const typename pointer::value_type; // TRANSITION, VSO-1854115, omit typename
     using difference_type = pointer::difference_type;
 
     _NODISCARD static constexpr element_type* to_address(const pointer& _Iter) noexcept {
@@ -2046,7 +2046,7 @@ public:
 template <class _Mystr>
 struct pointer_traits<_String_const_iterator<_Mystr>> {
     using pointer         = _String_const_iterator<_Mystr>;
-    using element_type    = const typename pointer::value_type;
+    using element_type    = const typename pointer::value_type; // TRANSITION, VSO-1854115, omit typename
     using difference_type = pointer::difference_type;
 
     _NODISCARD static constexpr element_type* to_address(const pointer _Iter) noexcept {

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1153,7 +1153,7 @@ template <class _Traits>
 struct pointer_traits<_String_view_iterator<_Traits>> {
     using pointer         = _String_view_iterator<_Traits>;
     using element_type    = const typename pointer::value_type;
-    using difference_type = typename pointer::difference_type;
+    using difference_type = pointer::difference_type;
 
     _NODISCARD static constexpr element_type* to_address(const pointer& _Iter) noexcept {
         return _Iter._Unwrapped();
@@ -1765,14 +1765,14 @@ struct _Get_comparison_category {
 
 template <class _Traits>
 struct _Get_comparison_category<_Traits, void_t<typename _Traits::comparison_category>> {
-    using type = typename _Traits::comparison_category;
+    using type = _Traits::comparison_category;
 
     static_assert(_Is_any_of_v<type, partial_ordering, weak_ordering, strong_ordering>,
         "N4950 [string.view.comparison]/4: Mandates: R denotes a comparison category type.");
 };
 
 template <class _Traits>
-using _Get_comparison_category_t = typename _Get_comparison_category<_Traits>::type;
+using _Get_comparison_category_t = _Get_comparison_category<_Traits>::type;
 
 _EXPORT_STD template <class _Elem, class _Traits>
 _NODISCARD constexpr _Get_comparison_category_t<_Traits> operator<=>(
@@ -2047,7 +2047,7 @@ template <class _Mystr>
 struct pointer_traits<_String_const_iterator<_Mystr>> {
     using pointer         = _String_const_iterator<_Mystr>;
     using element_type    = const typename pointer::value_type;
-    using difference_type = typename pointer::difference_type;
+    using difference_type = pointer::difference_type;
 
     _NODISCARD static constexpr element_type* to_address(const pointer _Iter) noexcept {
 #if _ITERATOR_DEBUG_LEVEL >= 1
@@ -2164,8 +2164,8 @@ public:
 template <class _Mystr>
 struct pointer_traits<_String_iterator<_Mystr>> {
     using pointer         = _String_iterator<_Mystr>;
-    using element_type    = typename pointer::value_type;
-    using difference_type = typename pointer::difference_type;
+    using element_type    = pointer::value_type;
+    using difference_type = pointer::difference_type;
 
     _NODISCARD static constexpr element_type* to_address(const pointer _Iter) noexcept {
 #if _ITERATOR_DEBUG_LEVEL >= 1
@@ -5232,13 +5232,13 @@ inline namespace literals {
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _Elem, class _Traits, class _Alloc, class _Uty>
-constexpr typename basic_string<_Elem, _Traits, _Alloc>::size_type erase(
+constexpr basic_string<_Elem, _Traits, _Alloc>::size_type erase(
     basic_string<_Elem, _Traits, _Alloc>& _Cont, const _Uty& _Val) {
     return _Erase_remove(_Cont, _Val);
 }
 
 _EXPORT_STD template <class _Elem, class _Traits, class _Alloc, class _Pr>
-constexpr typename basic_string<_Elem, _Traits, _Alloc>::size_type erase_if(
+constexpr basic_string<_Elem, _Traits, _Alloc>::size_type erase_if(
     basic_string<_Elem, _Traits, _Alloc>& _Cont, _Pr _Pred) {
     return _Erase_remove_if(_Cont, _Pass_fn(_Pred));
 }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -692,7 +692,7 @@ struct _Indirect_value_impl {
 };
 
 template <indirectly_readable _It>
-using _Indirect_value_t = typename _Indirect_value_impl<_It>::type;
+using _Indirect_value_t = _Indirect_value_impl<_It>::type;
 
 _EXPORT_STD template <indirectly_readable _Ty>
 using iter_common_reference_t = common_reference_t<iter_reference_t<_Ty>, _Indirect_value_t<_Ty>>;
@@ -708,7 +708,7 @@ concept indirectly_writable = requires(_It&& __i, _Ty&& __t) {
 template <bool _Is_integer_class>
 struct _Make_unsigned_like_impl {
     template <class _Ty>
-    using _Apply = typename _Ty::_Unsigned_type;
+    using _Apply = _Ty::_Unsigned_type;
 };
 template <>
 struct _Make_unsigned_like_impl<false> {
@@ -717,7 +717,7 @@ struct _Make_unsigned_like_impl<false> {
 };
 
 template <class _Ty>
-using _Make_unsigned_like_t = typename _Make_unsigned_like_impl<_Integer_class<_Ty>>::template _Apply<_Ty>;
+using _Make_unsigned_like_t = _Make_unsigned_like_impl<_Integer_class<_Ty>>::template _Apply<_Ty>;
 
 template <_Integer_like _Ty>
 _NODISCARD constexpr auto _To_unsigned_like(const _Ty _Value) noexcept {
@@ -727,7 +727,7 @@ _NODISCARD constexpr auto _To_unsigned_like(const _Ty _Value) noexcept {
 template <bool _Is_integer_class>
 struct _Make_signed_like_impl {
     template <class _Ty>
-    using _Apply = typename _Ty::_Signed_type;
+    using _Apply = _Ty::_Signed_type;
 };
 template <>
 struct _Make_signed_like_impl<false> {
@@ -736,7 +736,7 @@ struct _Make_signed_like_impl<false> {
 };
 
 template <class _Ty>
-using _Make_signed_like_t = typename _Make_signed_like_impl<_Integer_class<_Ty>>::template _Apply<_Ty>;
+using _Make_signed_like_t = _Make_signed_like_impl<_Integer_class<_Ty>>::template _Apply<_Ty>;
 
 _EXPORT_STD template <class _Ty>
 concept incrementable = regular<_Ty> && weakly_incrementable<_Ty> && requires(_Ty __t) {
@@ -746,7 +746,7 @@ concept incrementable = regular<_Ty> && weakly_incrementable<_Ty> && requires(_T
 template <bool _Iterator_category_present>
 struct _Iter_concept_impl2 {
     template <class _It, class _Traits>
-    using _Apply = typename _Traits::iterator_category;
+    using _Apply = _Traits::iterator_category;
 };
 template <>
 struct _Iter_concept_impl2<false> {
@@ -758,17 +758,16 @@ struct _Iter_concept_impl2<false> {
 template <bool _Iterator_concept_present>
 struct _Iter_concept_impl1 {
     template <class _It, class _Traits>
-    using _Apply = typename _Traits::iterator_concept;
+    using _Apply = _Traits::iterator_concept;
 };
 template <>
 struct _Iter_concept_impl1<false> {
     template <class _It, class _Traits>
-    using _Apply = typename _Iter_concept_impl2<_Has_member_iterator_category<_Traits>>::template _Apply<_It, _Traits>;
+    using _Apply = _Iter_concept_impl2<_Has_member_iterator_category<_Traits>>::template _Apply<_It, _Traits>;
 };
 
 template <class _It, class _Traits = conditional_t<_Is_from_primary<iterator_traits<_It>>, _It, iterator_traits<_It>>>
-using _Iter_concept =
-    typename _Iter_concept_impl1<_Has_member_iterator_concept<_Traits>>::template _Apply<_It, _Traits>;
+using _Iter_concept = _Iter_concept_impl1<_Has_member_iterator_concept<_Traits>>::template _Apply<_It, _Traits>;
 
 // clang-format off
 _EXPORT_STD template <class _It>
@@ -1989,7 +1988,7 @@ struct _Const_sentinel<_Sent> {
 };
 
 _EXPORT_STD template <semiregular _Sent>
-using const_sentinel = typename _Const_sentinel<_Sent>::type;
+using const_sentinel = _Const_sentinel<_Sent>::type;
 
 template <class _Ty>
 concept _Not_a_const_iterator = !_Is_specialization_v<_Ty, basic_const_iterator>;
@@ -1999,7 +1998,7 @@ struct _Basic_const_iterator_category {};
 
 template <forward_iterator _Iter>
 struct _Basic_const_iterator_category<_Iter> {
-    using iterator_category = typename iterator_traits<_Iter>::iterator_category;
+    using iterator_category = iterator_traits<_Iter>::iterator_category;
 };
 
 _EXPORT_STD template <input_iterator _Iter>


### PR DESCRIPTION
Followup to #3892 and #3893. Works towards #3718 - I believe this finishes the product code, but we're open to cleaning up the test code here.

Reported VSO-1854035 "C++20 Down With Typename is confused by fully qualified names".