### PR TITLE
Drop `#pragma once` in STL headers

### DIFF
--- a/stl/inc/__msvc_bit_utils.hpp
+++ b/stl/inc/__msvc_bit_utils.hpp
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef __MSVC_BIT_UTILS_HPP
 #define __MSVC_BIT_UTILS_HPP
 #include <yvals_core.h>

--- a/stl/inc/__msvc_chrono.hpp
+++ b/stl/inc/__msvc_chrono.hpp
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef __MSVC_CHRONO_HPP
 #define __MSVC_CHRONO_HPP
 #include <yvals.h>

--- a/stl/inc/__msvc_cxx_stdatomic.hpp
+++ b/stl/inc/__msvc_cxx_stdatomic.hpp
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef __MSVC_CXX_STDATOMIC_HPP
 #define __MSVC_CXX_STDATOMIC_HPP
 

--- a/stl/inc/__msvc_filebuf.hpp
+++ b/stl/inc/__msvc_filebuf.hpp
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef __MSVC_FILEBUF_HPP
 #define __MSVC_FILEBUF_HPP
 #include <yvals.h>

--- a/stl/inc/__msvc_format_ucd_tables.hpp
+++ b/stl/inc/__msvc_format_ucd_tables.hpp
@@ -54,7 +54,6 @@
 // use or other dealings in these Data Files or Software without prior
 // written authorization of the copyright holder.
 
-#pragma once
 #ifndef __MSVC_FORMAT_UCD_TABLES_HPP
 #define __MSVC_FORMAT_UCD_TABLES_HPP
 #include <yvals_core.h>

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef __MSVC_INT128_HPP
 #define __MSVC_INT128_HPP
 

--- a/stl/inc/__msvc_iter_core.hpp
+++ b/stl/inc/__msvc_iter_core.hpp
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef __MSVC_ITER_CORE_HPP
 #define __MSVC_ITER_CORE_HPP
 #include <yvals_core.h>

--- a/stl/inc/__msvc_print.hpp
+++ b/stl/inc/__msvc_print.hpp
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef __MSVC_PRINT_HPP
 #define __MSVC_PRINT_HPP
 #include <yvals_core.h>

--- a/stl/inc/__msvc_sanitizer_annotate_container.hpp
+++ b/stl/inc/__msvc_sanitizer_annotate_container.hpp
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef __MSVC_SANITIZER_ANNOTATE_CONTAINER_HPP
 #define __MSVC_SANITIZER_ANNOTATE_CONTAINER_HPP
 #include <yvals_core.h>

--- a/stl/inc/__msvc_system_error_abi.hpp
+++ b/stl/inc/__msvc_system_error_abi.hpp
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef __MSVC_SYSTEM_ERROR_ABI_HPP
 #define __MSVC_SYSTEM_ERROR_ABI_HPP
 #include <yvals_core.h>

--- a/stl/inc/__msvc_tzdb.hpp
+++ b/stl/inc/__msvc_tzdb.hpp
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef __MSVC_TZDB_HPP
 #define __MSVC_TZDB_HPP
 #include <yvals.h>

--- a/stl/inc/__msvc_xlocinfo_types.hpp
+++ b/stl/inc/__msvc_xlocinfo_types.hpp
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef __MSVC_XLOCINFO_TYPES_HPP
 #define __MSVC_XLOCINFO_TYPES_HPP
 #include <yvals_core.h>

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _ALGORITHM_
 #define _ALGORITHM_
 #include <yvals_core.h>

--- a/stl/inc/any
+++ b/stl/inc/any
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _ANY_
 #define _ANY_
 #include <yvals_core.h>

--- a/stl/inc/array
+++ b/stl/inc/array
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _ARRAY_
 #define _ARRAY_
 #include <yvals_core.h>

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _ATOMIC_
 #define _ATOMIC_
 #include <yvals.h>

--- a/stl/inc/barrier
+++ b/stl/inc/barrier
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _BARRIER_
 #define _BARRIER_
 #include <yvals.h>

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _BIT_
 #define _BIT_
 #include <yvals_core.h>

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _BITSET_
 #define _BITSET_
 #include <yvals_core.h>

--- a/stl/inc/ccomplex
+++ b/stl/inc/ccomplex
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CCOMPLEX_
 #define _CCOMPLEX_
 #include <yvals_core.h>

--- a/stl/inc/cctype
+++ b/stl/inc/cctype
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CCTYPE_
 #define _CCTYPE_
 #include <yvals_core.h>

--- a/stl/inc/cerrno
+++ b/stl/inc/cerrno
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CERRNO_
 #define _CERRNO_
 #include <yvals_core.h>

--- a/stl/inc/cfenv
+++ b/stl/inc/cfenv
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CFENV_
 #define _CFENV_
 #include <yvals_core.h>

--- a/stl/inc/cfloat
+++ b/stl/inc/cfloat
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CFLOAT_
 #define _CFLOAT_
 #include <yvals_core.h>

--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CHARCONV_
 #define _CHARCONV_
 #include <yvals.h>

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CHRONO_
 #define _CHRONO_
 #include <yvals_core.h>

--- a/stl/inc/cinttypes
+++ b/stl/inc/cinttypes
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CINTTYPES_
 #define _CINTTYPES_
 #include <yvals_core.h>

--- a/stl/inc/ciso646
+++ b/stl/inc/ciso646
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CISO646_
 #define _CISO646_
 #include <yvals.h>

--- a/stl/inc/climits
+++ b/stl/inc/climits
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CLIMITS_
 #define _CLIMITS_
 #include <yvals_core.h>

--- a/stl/inc/clocale
+++ b/stl/inc/clocale
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CLOCALE_
 #define _CLOCALE_
 #include <yvals_core.h>

--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CMATH_
 #define _CMATH_
 #include <yvals.h>

--- a/stl/inc/codecvt
+++ b/stl/inc/codecvt
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CODECVT_
 #define _CODECVT_
 #include <yvals_core.h>

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _COMPARE_
 #define _COMPARE_
 #include <yvals_core.h>

--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _COMPLEX_
 #define _COMPLEX_
 #include <yvals_core.h>

--- a/stl/inc/concepts
+++ b/stl/inc/concepts
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CONCEPTS_
 #define _CONCEPTS_
 #include <yvals_core.h>

--- a/stl/inc/condition_variable
+++ b/stl/inc/condition_variable
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CONDITION_VARIABLE_
 #define _CONDITION_VARIABLE_
 #include <yvals_core.h>

--- a/stl/inc/coroutine
+++ b/stl/inc/coroutine
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _COROUTINE_
 #define _COROUTINE_
 #include <yvals_core.h>

--- a/stl/inc/csetjmp
+++ b/stl/inc/csetjmp
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CSETJMP_
 #define _CSETJMP_
 #include <yvals_core.h>

--- a/stl/inc/csignal
+++ b/stl/inc/csignal
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CSIGNAL_
 #define _CSIGNAL_
 #include <yvals_core.h>

--- a/stl/inc/cstdalign
+++ b/stl/inc/cstdalign
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CSTDALIGN_
 #define _CSTDALIGN_
 #include <yvals.h>

--- a/stl/inc/cstdarg
+++ b/stl/inc/cstdarg
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CSTDARG_
 #define _CSTDARG_
 #include <yvals_core.h>

--- a/stl/inc/cstdbool
+++ b/stl/inc/cstdbool
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CSTDBOOL_
 #define _CSTDBOOL_
 #include <yvals.h>

--- a/stl/inc/cstddef
+++ b/stl/inc/cstddef
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CSTDDEF_
 #define _CSTDDEF_
 #include <yvals_core.h>

--- a/stl/inc/cstdint
+++ b/stl/inc/cstdint
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CSTDINT_
 #define _CSTDINT_
 #include <yvals_core.h>

--- a/stl/inc/cstdio
+++ b/stl/inc/cstdio
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CSTDIO_
 #define _CSTDIO_
 #include <yvals_core.h>

--- a/stl/inc/cstdlib
+++ b/stl/inc/cstdlib
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CSTDLIB_
 #define _CSTDLIB_
 #include <yvals_core.h>

--- a/stl/inc/cstring
+++ b/stl/inc/cstring
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CSTRING_
 #define _CSTRING_
 #include <yvals_core.h>

--- a/stl/inc/ctgmath
+++ b/stl/inc/ctgmath
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CTGMATH_
 #define _CTGMATH_
 #include <yvals_core.h>

--- a/stl/inc/ctime
+++ b/stl/inc/ctime
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CTIME_
 #define _CTIME_
 #include <yvals_core.h>

--- a/stl/inc/cuchar
+++ b/stl/inc/cuchar
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CUCHAR_
 #define _CUCHAR_
 #include <yvals_core.h>

--- a/stl/inc/cvt/8859_1
+++ b/stl/inc/cvt/8859_1
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_8859_1_
 #define _CVT_8859_1_
 #include <yvals_core.h>

--- a/stl/inc/cvt/8859_10
+++ b/stl/inc/cvt/8859_10
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_8859_10_
 #define _CVT_8859_10_
 #include <yvals_core.h>

--- a/stl/inc/cvt/8859_13
+++ b/stl/inc/cvt/8859_13
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_8859_13_
 #define _CVT_8859_13_
 #include <yvals_core.h>

--- a/stl/inc/cvt/8859_14
+++ b/stl/inc/cvt/8859_14
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_8859_14_
 #define _CVT_8859_14_
 #include <yvals_core.h>

--- a/stl/inc/cvt/8859_15
+++ b/stl/inc/cvt/8859_15
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_8859_15_
 #define _CVT_8859_15_
 #include <yvals_core.h>

--- a/stl/inc/cvt/8859_16
+++ b/stl/inc/cvt/8859_16
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_8859_16_
 #define _CVT_8859_16_
 #include <yvals_core.h>

--- a/stl/inc/cvt/8859_2
+++ b/stl/inc/cvt/8859_2
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_8859_2_
 #define _CVT_8859_2_
 #include <yvals_core.h>

--- a/stl/inc/cvt/8859_3
+++ b/stl/inc/cvt/8859_3
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_8859_3_
 #define _CVT_8859_3_
 #include <yvals_core.h>

--- a/stl/inc/cvt/8859_4
+++ b/stl/inc/cvt/8859_4
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_8859_4_
 #define _CVT_8859_4_
 #include <yvals_core.h>

--- a/stl/inc/cvt/8859_5
+++ b/stl/inc/cvt/8859_5
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_8859_5_
 #define _CVT_8859_5_
 #include <yvals_core.h>

--- a/stl/inc/cvt/8859_6
+++ b/stl/inc/cvt/8859_6
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_8859_6_
 #define _CVT_8859_6_
 #include <yvals_core.h>

--- a/stl/inc/cvt/8859_7
+++ b/stl/inc/cvt/8859_7
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_8859_7_
 #define _CVT_8859_7_
 #include <yvals_core.h>

--- a/stl/inc/cvt/8859_8
+++ b/stl/inc/cvt/8859_8
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_8859_8_
 #define _CVT_8859_8_
 #include <yvals_core.h>

--- a/stl/inc/cvt/8859_9
+++ b/stl/inc/cvt/8859_9
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_8859_9_
 #define _CVT_8859_9_
 #include <yvals_core.h>

--- a/stl/inc/cvt/baltic
+++ b/stl/inc/cvt/baltic
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_BALTIC_
 #define _CVT_BALTIC_
 #include <yvals_core.h>

--- a/stl/inc/cvt/big5
+++ b/stl/inc/cvt/big5
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_BIG5_
 #define _CVT_BIG5_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp037
+++ b/stl/inc/cvt/cp037
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP037_
 #define _CVT_CP037_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp1006
+++ b/stl/inc/cvt/cp1006
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP1006_
 #define _CVT_CP1006_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp1026
+++ b/stl/inc/cvt/cp1026
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP1026_
 #define _CVT_CP1026_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp1250
+++ b/stl/inc/cvt/cp1250
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP1250_
 #define _CVT_CP1250_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp1251
+++ b/stl/inc/cvt/cp1251
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP1251_
 #define _CVT_CP1251_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp1252
+++ b/stl/inc/cvt/cp1252
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP1252_
 #define _CVT_CP1252_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp1253
+++ b/stl/inc/cvt/cp1253
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP1253_
 #define _CVT_CP1253_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp1254
+++ b/stl/inc/cvt/cp1254
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP1254_
 #define _CVT_CP1254_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp1255
+++ b/stl/inc/cvt/cp1255
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP1255_
 #define _CVT_CP1255_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp1256
+++ b/stl/inc/cvt/cp1256
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP1256_
 #define _CVT_CP1256_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp1257
+++ b/stl/inc/cvt/cp1257
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP1257_
 #define _CVT_CP1257_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp1258
+++ b/stl/inc/cvt/cp1258
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP1258_
 #define _CVT_CP1258_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp424
+++ b/stl/inc/cvt/cp424
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP424_
 #define _CVT_CP424_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp437
+++ b/stl/inc/cvt/cp437
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP437_
 #define _CVT_CP437_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp500
+++ b/stl/inc/cvt/cp500
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP500_
 #define _CVT_CP500_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp737
+++ b/stl/inc/cvt/cp737
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP737_
 #define _CVT_CP737_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp775
+++ b/stl/inc/cvt/cp775
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP775_
 #define _CVT_CP775_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp850
+++ b/stl/inc/cvt/cp850
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP850_
 #define _CVT_CP850_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp852
+++ b/stl/inc/cvt/cp852
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP852_
 #define _CVT_CP852_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp855
+++ b/stl/inc/cvt/cp855
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP855_
 #define _CVT_CP855_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp856
+++ b/stl/inc/cvt/cp856
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP856_
 #define _CVT_CP856_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp857
+++ b/stl/inc/cvt/cp857
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP857_
 #define _CVT_CP857_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp860
+++ b/stl/inc/cvt/cp860
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP860_
 #define _CVT_CP860_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp861
+++ b/stl/inc/cvt/cp861
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP861_
 #define _CVT_CP861_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp862
+++ b/stl/inc/cvt/cp862
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP862_
 #define _CVT_CP862_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp863
+++ b/stl/inc/cvt/cp863
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP863_
 #define _CVT_CP863_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp864
+++ b/stl/inc/cvt/cp864
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP864_
 #define _CVT_CP864_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp865
+++ b/stl/inc/cvt/cp865
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP865_
 #define _CVT_CP865_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp866
+++ b/stl/inc/cvt/cp866
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP866_
 #define _CVT_CP866_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp869
+++ b/stl/inc/cvt/cp869
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP869_
 #define _CVT_CP869_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp874
+++ b/stl/inc/cvt/cp874
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP874_
 #define _CVT_CP874_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp875
+++ b/stl/inc/cvt/cp875
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP875_
 #define _CVT_CP875_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp932
+++ b/stl/inc/cvt/cp932
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP932_
 #define _CVT_CP932_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp936
+++ b/stl/inc/cvt/cp936
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP936_
 #define _CVT_CP936_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp949
+++ b/stl/inc/cvt/cp949
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP949_
 #define _CVT_CP949_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cp950
+++ b/stl/inc/cvt/cp950
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CP950_
 #define _CVT_CP950_
 #include <yvals_core.h>

--- a/stl/inc/cvt/cyrillic
+++ b/stl/inc/cvt/cyrillic
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_CYRILLIC_
 #define _CVT_CYRILLIC_
 #include <yvals_core.h>

--- a/stl/inc/cvt/ebcdic
+++ b/stl/inc/cvt/ebcdic
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CVT_EBCDIC_
 #define _CVT_EBCDIC_
 #include <yvals_core.h>

--- a/stl/inc/cvt/euc
+++ b/stl/inc/cvt/euc
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_EUC_
 #define _CVT_EUC_
 #include <yvals_core.h>

--- a/stl/inc/cvt/euc_0208
+++ b/stl/inc/cvt/euc_0208
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CVT_EUC_0208_
 #define _CVT_EUC_0208_
 #include <yvals_core.h>

--- a/stl/inc/cvt/gb12345
+++ b/stl/inc/cvt/gb12345
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_GB12345_
 #define _CVT_GB12345_
 #include <yvals_core.h>

--- a/stl/inc/cvt/gb2312
+++ b/stl/inc/cvt/gb2312
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_GB2312_
 #define _CVT_GB2312_
 #include <yvals_core.h>

--- a/stl/inc/cvt/greek
+++ b/stl/inc/cvt/greek
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_GREEK_
 #define _CVT_GREEK_
 #include <yvals_core.h>

--- a/stl/inc/cvt/iceland
+++ b/stl/inc/cvt/iceland
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_ICELAND_
 #define _CVT_ICELAND_
 #include <yvals_core.h>

--- a/stl/inc/cvt/jis
+++ b/stl/inc/cvt/jis
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_JIS_
 #define _CVT_JIS_
 #include <yvals_core.h>

--- a/stl/inc/cvt/jis0201
+++ b/stl/inc/cvt/jis0201
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_JIS0201_
 #define _CVT_JIS0201_
 #include <yvals_core.h>

--- a/stl/inc/cvt/jis_0208
+++ b/stl/inc/cvt/jis_0208
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CVT_JIS_0208_
 #define _CVT_JIS_0208_
 #include <yvals_core.h>

--- a/stl/inc/cvt/ksc5601
+++ b/stl/inc/cvt/ksc5601
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_KSC5601_
 #define _CVT_KSC5601_
 #include <yvals_core.h>

--- a/stl/inc/cvt/latin2
+++ b/stl/inc/cvt/latin2
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_LATIN2_
 #define _CVT_LATIN2_
 #include <yvals_core.h>

--- a/stl/inc/cvt/one_one
+++ b/stl/inc/cvt/one_one
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CVT_ONE_ONE_
 #define _CVT_ONE_ONE_
 #include <yvals_core.h>

--- a/stl/inc/cvt/roman
+++ b/stl/inc/cvt/roman
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_ROMAN_
 #define _CVT_ROMAN_
 #include <yvals_core.h>

--- a/stl/inc/cvt/sjis
+++ b/stl/inc/cvt/sjis
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_SJIS_
 #define _CVT_SJIS_
 #include <yvals_core.h>

--- a/stl/inc/cvt/sjis_0208
+++ b/stl/inc/cvt/sjis_0208
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CVT_SJIS_0208_
 #define _CVT_SJIS_0208_
 #include <yvals_core.h>

--- a/stl/inc/cvt/turkish
+++ b/stl/inc/cvt/turkish
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _CVT_TURKISH_
 #define _CVT_TURKISH_
 #include <yvals_core.h>

--- a/stl/inc/cvt/utf16
+++ b/stl/inc/cvt/utf16
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CVT_UTF16_
 #define _CVT_UTF16_
 #include <yvals_core.h>

--- a/stl/inc/cvt/utf8
+++ b/stl/inc/cvt/utf8
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CVT_UTF8_
 #define _CVT_UTF8_
 #include <yvals_core.h>

--- a/stl/inc/cvt/utf8_utf16
+++ b/stl/inc/cvt/utf8_utf16
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CVT_UTF8_UTF16_
 #define _CVT_UTF8_UTF16_
 #include <yvals_core.h>

--- a/stl/inc/cvt/wbuffer
+++ b/stl/inc/cvt/wbuffer
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CVT_WBUFFER_
 #define _CVT_WBUFFER_
 #include <yvals_core.h>

--- a/stl/inc/cvt/wstring
+++ b/stl/inc/cvt/wstring
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CVT_WSTRING_
 #define _CVT_WSTRING_
 #include <yvals_core.h>

--- a/stl/inc/cvt/xjis
+++ b/stl/inc/cvt/xjis
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CVT_XJIS_
 #define _CVT_XJIS_
 #include <yvals_core.h>

--- a/stl/inc/cvt/xone_byte
+++ b/stl/inc/cvt/xone_byte
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CVT_XONE_BYTE_
 #define _CVT_XONE_BYTE_
 #include <yvals_core.h>

--- a/stl/inc/cvt/xtwo_byte
+++ b/stl/inc/cvt/xtwo_byte
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CVT_XTWO_BYTE_
 #define _CVT_XTWO_BYTE_
 #include <yvals_core.h>

--- a/stl/inc/cwchar
+++ b/stl/inc/cwchar
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CWCHAR_
 #define _CWCHAR_
 #include <yvals_core.h>

--- a/stl/inc/cwctype
+++ b/stl/inc/cwctype
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _CWCTYPE_
 #define _CWCTYPE_
 #include <yvals_core.h>

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _DEQUE_
 #define _DEQUE_
 #include <yvals_core.h>

--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _EXCEPTION_
 #define _EXCEPTION_
 #include <yvals.h>

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _EXECUTION_
 #define _EXECUTION_
 #include <yvals.h>

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _EXPECTED_
 #define _EXPECTED_
 #include <yvals.h>

--- a/stl/inc/experimental/coroutine
+++ b/stl/inc/experimental/coroutine
@@ -5,7 +5,6 @@
 
 // Library support of coroutines TS, https://wg21.link/p0057
 
-#pragma once
 #ifndef _EXPERIMENTAL_COROUTINE_
 #define _EXPERIMENTAL_COROUTINE_
 #include <yvals_core.h>

--- a/stl/inc/experimental/deque
+++ b/stl/inc/experimental/deque
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _EXPERIMENTAL_DEQUE_
 #define _EXPERIMENTAL_DEQUE_
 #include <yvals_core.h>

--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _EXPERIMENTAL_FILESYSTEM_
 #define _EXPERIMENTAL_FILESYSTEM_
 #include <yvals_core.h>

--- a/stl/inc/experimental/forward_list
+++ b/stl/inc/experimental/forward_list
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _EXPERIMENTAL_FORWARD_LIST_
 #define _EXPERIMENTAL_FORWARD_LIST_
 #include <yvals_core.h>

--- a/stl/inc/experimental/generator
+++ b/stl/inc/experimental/generator
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _EXPERIMENTAL_GENERATOR_
 #define _EXPERIMENTAL_GENERATOR_
 #include <yvals_core.h>

--- a/stl/inc/experimental/list
+++ b/stl/inc/experimental/list
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _EXPERIMENTAL_LIST_
 #define _EXPERIMENTAL_LIST_
 #include <yvals_core.h>

--- a/stl/inc/experimental/map
+++ b/stl/inc/experimental/map
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _EXPERIMENTAL_MAP_
 #define _EXPERIMENTAL_MAP_
 #include <yvals_core.h>

--- a/stl/inc/experimental/resumable
+++ b/stl/inc/experimental/resumable
@@ -5,7 +5,6 @@
 
 // Library support of coroutines TS, https://wg21.link/p0057
 
-#pragma once
 #ifndef _EXPERIMENTAL_RESUMABLE_
 #define _EXPERIMENTAL_RESUMABLE_
 #include <yvals_core.h>

--- a/stl/inc/experimental/set
+++ b/stl/inc/experimental/set
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _EXPERIMENTAL_SET_
 #define _EXPERIMENTAL_SET_
 #include <yvals_core.h>

--- a/stl/inc/experimental/string
+++ b/stl/inc/experimental/string
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _EXPERIMENTAL_STRING_
 #define _EXPERIMENTAL_STRING_
 #include <yvals_core.h>

--- a/stl/inc/experimental/unordered_map
+++ b/stl/inc/experimental/unordered_map
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _EXPERIMENTAL_UNORDERED_MAP_
 #define _EXPERIMENTAL_UNORDERED_MAP_
 #include <yvals_core.h>

--- a/stl/inc/experimental/unordered_set
+++ b/stl/inc/experimental/unordered_set
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _EXPERIMENTAL_UNORDERED_SET_
 #define _EXPERIMENTAL_UNORDERED_SET_
 #include <yvals_core.h>

--- a/stl/inc/experimental/vector
+++ b/stl/inc/experimental/vector
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _EXPERIMENTAL_VECTOR_
 #define _EXPERIMENTAL_VECTOR_
 #include <yvals_core.h>

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _FILESYSTEM_
 #define _FILESYSTEM_
 #include <yvals_core.h>

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -34,7 +34,6 @@
 // source code, you may redistribute such embedded portions in such object form
 // without including the above copyright and permission notices.
 
-#pragma once
 #ifndef _FORMAT_
 #define _FORMAT_
 #include <yvals_core.h>

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _FORWARD_LIST_
 #define _FORWARD_LIST_
 #include <yvals_core.h>

--- a/stl/inc/fstream
+++ b/stl/inc/fstream
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _FSTREAM_
 #define _FSTREAM_
 #include <yvals_core.h>

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _FUNCTIONAL_
 #define _FUNCTIONAL_
 #include <yvals_core.h>

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _FUTURE_
 #define _FUTURE_
 #include <yvals_core.h>

--- a/stl/inc/hash_map
+++ b/stl/inc/hash_map
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _HASH_MAP_
 #define _HASH_MAP_
 #include <yvals_core.h>

--- a/stl/inc/hash_set
+++ b/stl/inc/hash_set
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _HASH_SET_
 #define _HASH_SET_
 #include <yvals_core.h>

--- a/stl/inc/initializer_list
+++ b/stl/inc/initializer_list
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _INITIALIZER_LIST_
 #define _INITIALIZER_LIST_
 #include <yvals_core.h>

--- a/stl/inc/iomanip
+++ b/stl/inc/iomanip
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _IOMANIP_
 #define _IOMANIP_
 #include <yvals_core.h>

--- a/stl/inc/ios
+++ b/stl/inc/ios
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _IOS_
 #define _IOS_
 #include <yvals_core.h>

--- a/stl/inc/iosfwd
+++ b/stl/inc/iosfwd
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _IOSFWD_
 #define _IOSFWD_
 #include <yvals.h>

--- a/stl/inc/iostream
+++ b/stl/inc/iostream
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _IOSTREAM_
 #define _IOSTREAM_
 #include <yvals_core.h>

--- a/stl/inc/iso646.h
+++ b/stl/inc/iso646.h
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _ISO646
 #define _ISO646
 

--- a/stl/inc/istream
+++ b/stl/inc/istream
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _ISTREAM_
 #define _ISTREAM_
 #include <yvals_core.h>

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _ITERATOR_
 #define _ITERATOR_
 #include <yvals_core.h>

--- a/stl/inc/latch
+++ b/stl/inc/latch
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _LATCH_
 #define _LATCH_
 #include <yvals.h>

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _LIMITS_
 #define _LIMITS_
 #include <yvals_core.h>

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _LIST_
 #define _LIST_
 #include <yvals_core.h>

--- a/stl/inc/locale
+++ b/stl/inc/locale
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _LOCALE_
 #define _LOCALE_
 #include <yvals_core.h>

--- a/stl/inc/map
+++ b/stl/inc/map
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _MAP_
 #define _MAP_
 #include <yvals_core.h>

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _MEMORY_
 #define _MEMORY_
 #include <yvals_core.h>

--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _MEMORY_RESOURCE_
 #define _MEMORY_RESOURCE_
 #include <yvals.h>

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _MUTEX_
 #define _MUTEX_
 #include <yvals_core.h>

--- a/stl/inc/new
+++ b/stl/inc/new
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _NEW_
 #define _NEW_
 #include <yvals_core.h>

--- a/stl/inc/numbers
+++ b/stl/inc/numbers
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _NUMBERS_
 #define _NUMBERS_
 #include <yvals_core.h>

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _NUMERIC_
 #define _NUMERIC_
 #include <yvals_core.h>

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _OPTIONAL_
 #define _OPTIONAL_
 #include <yvals.h>

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _OSTREAM_
 #define _OSTREAM_
 #include <yvals_core.h>

--- a/stl/inc/print
+++ b/stl/inc/print
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _PRINT_
 #define _PRINT_
 #include <yvals_core.h>

--- a/stl/inc/queue
+++ b/stl/inc/queue
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _QUEUE_
 #define _QUEUE_
 #include <yvals_core.h>

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _RANDOM_
 #define _RANDOM_
 #include <yvals_core.h>

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _RANGES_
 #define _RANGES_
 #include <yvals_core.h>

--- a/stl/inc/ratio
+++ b/stl/inc/ratio
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _RATIO_
 #define _RATIO_
 #include <yvals_core.h>

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _REGEX_
 #define _REGEX_
 #include <yvals_core.h>

--- a/stl/inc/scoped_allocator
+++ b/stl/inc/scoped_allocator
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _SCOPED_ALLOCATOR_
 #define _SCOPED_ALLOCATOR_
 #include <yvals_core.h>

--- a/stl/inc/semaphore
+++ b/stl/inc/semaphore
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _SEMAPHORE_
 #define _SEMAPHORE_
 #include <yvals.h>

--- a/stl/inc/set
+++ b/stl/inc/set
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _SET_
 #define _SET_
 #include <yvals_core.h>

--- a/stl/inc/shared_mutex
+++ b/stl/inc/shared_mutex
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _SHARED_MUTEX_
 #define _SHARED_MUTEX_
 #include <yvals_core.h>

--- a/stl/inc/source_location
+++ b/stl/inc/source_location
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _SOURCE_LOCATION_
 #define _SOURCE_LOCATION_
 #include <yvals_core.h>

--- a/stl/inc/span
+++ b/stl/inc/span
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _SPAN_
 #define _SPAN_
 #include <yvals_core.h>

--- a/stl/inc/spanstream
+++ b/stl/inc/spanstream
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _SPANSTREAM_
 #define _SPANSTREAM_
 #include <yvals.h>

--- a/stl/inc/sstream
+++ b/stl/inc/sstream
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _SSTREAM_
 #define _SSTREAM_
 #include <yvals_core.h>

--- a/stl/inc/stack
+++ b/stl/inc/stack
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _STACK_
 #define _STACK_
 #include <yvals_core.h>

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _STACKTRACE_
 #define _STACKTRACE_
 #include <yvals_core.h>

--- a/stl/inc/stdexcept
+++ b/stl/inc/stdexcept
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _STDEXCEPT_
 #define _STDEXCEPT_
 #include <yvals_core.h>

--- a/stl/inc/stdfloat
+++ b/stl/inc/stdfloat
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _STDFLOAT_
 #define _STDFLOAT_
 #include <yvals_core.h>

--- a/stl/inc/stop_token
+++ b/stl/inc/stop_token
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _STOP_TOKEN_
 #define _STOP_TOKEN_
 #include <yvals.h>

--- a/stl/inc/streambuf
+++ b/stl/inc/streambuf
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _STREAMBUF_
 #define _STREAMBUF_
 #include <yvals_core.h>

--- a/stl/inc/string
+++ b/stl/inc/string
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _STRING_
 #define _STRING_
 #include <yvals_core.h>

--- a/stl/inc/string_view
+++ b/stl/inc/string_view
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _STRING_VIEW_
 #define _STRING_VIEW_
 #include <yvals.h>

--- a/stl/inc/strstream
+++ b/stl/inc/strstream
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _STRSTREAM_
 #define _STRSTREAM_
 #include <yvals_core.h>

--- a/stl/inc/syncstream
+++ b/stl/inc/syncstream
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _SYNCSTREAM_
 #define _SYNCSTREAM_
 #include <yvals.h>

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _SYSTEM_ERROR_
 #define _SYSTEM_ERROR_
 #include <yvals.h>

--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _THREAD_
 #define _THREAD_
 #include <yvals_core.h>

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _TUPLE_
 #define _TUPLE_
 #include <yvals_core.h>

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _TYPE_TRAITS_
 #define _TYPE_TRAITS_
 #include <yvals_core.h>

--- a/stl/inc/typeindex
+++ b/stl/inc/typeindex
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _TYPEINDEX_
 #define _TYPEINDEX_
 #include <yvals_core.h>

--- a/stl/inc/typeinfo
+++ b/stl/inc/typeinfo
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _TYPEINFO_
 #define _TYPEINFO_
 #include <yvals_core.h>

--- a/stl/inc/unordered_map
+++ b/stl/inc/unordered_map
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _UNORDERED_MAP_
 #define _UNORDERED_MAP_
 #include <yvals_core.h>

--- a/stl/inc/unordered_set
+++ b/stl/inc/unordered_set
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _UNORDERED_SET_
 #define _UNORDERED_SET_
 #include <yvals_core.h>

--- a/stl/inc/use_ansi.h
+++ b/stl/inc/use_ansi.h
@@ -3,8 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
-
 #ifndef _USE_ANSI_CPP
 #define _USE_ANSI_CPP
 

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _UTILITY_
 #define _UTILITY_
 #include <yvals_core.h>

--- a/stl/inc/valarray
+++ b/stl/inc/valarray
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _VALARRAY_
 #define _VALARRAY_
 #include <yvals_core.h>

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _VARIANT_
 #define _VARIANT_
 #include <yvals.h>

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _VECTOR_
 #define _VECTOR_
 #include <yvals_core.h>

--- a/stl/inc/version
+++ b/stl/inc/version
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _STD_VERSION_HEADER_
 #define _STD_VERSION_HEADER_
 #include <yvals_core.h>

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XATOMIC_H
 #define _XATOMIC_H
 #include <yvals_core.h>

--- a/stl/inc/xatomic_wait.h
+++ b/stl/inc/xatomic_wait.h
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XATOMIC_WAIT_H
 #define _XATOMIC_WAIT_H
 #include <yvals.h>

--- a/stl/inc/xbit_ops.h
+++ b/stl/inc/xbit_ops.h
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XBIT_OPS_H
 #define _XBIT_OPS_H
 #include <yvals_core.h>

--- a/stl/inc/xcall_once.h
+++ b/stl/inc/xcall_once.h
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XCALL_ONCE_H
 #define _XCALL_ONCE_H
 #include <yvals.h>

--- a/stl/inc/xcharconv.h
+++ b/stl/inc/xcharconv.h
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XCHARCONV_H
 #define _XCHARCONV_H
 #include <yvals_core.h>

--- a/stl/inc/xcharconv_ryu.h
+++ b/stl/inc/xcharconv_ryu.h
@@ -32,7 +32,6 @@
 // DEALINGS IN THE SOFTWARE.
 
 
-#pragma once
 #ifndef _XCHARCONV_RYU_H
 #define _XCHARCONV_RYU_H
 #include <yvals_core.h>

--- a/stl/inc/xcharconv_ryu_tables.h
+++ b/stl/inc/xcharconv_ryu_tables.h
@@ -32,7 +32,6 @@
 // DEALINGS IN THE SOFTWARE.
 
 
-#pragma once
 #ifndef _XCHARCONV_RYU_TABLES_H
 #define _XCHARCONV_RYU_TABLES_H
 #include <yvals_core.h>

--- a/stl/inc/xcharconv_tables.h
+++ b/stl/inc/xcharconv_tables.h
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XCHARCONV_TABLES_H
 #define _XCHARCONV_TABLES_H
 #include <yvals_core.h>

--- a/stl/inc/xerrc.h
+++ b/stl/inc/xerrc.h
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XERRC_H
 #define _XERRC_H
 #include <yvals_core.h>

--- a/stl/inc/xfacet
+++ b/stl/inc/xfacet
@@ -7,7 +7,6 @@
 // MAJOR LIMITATIONS apply to what can be included here!
 // Before editing this file, read: /docs/import_library.md
 
-#pragma once
 #ifndef _XFACET_
 #define _XFACET_
 #include <yvals.h>

--- a/stl/inc/xfilesystem_abi.h
+++ b/stl/inc/xfilesystem_abi.h
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XFILESYSTEM_ABI_H
 #define _XFILESYSTEM_ABI_H
 #include <yvals_core.h>

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XHASH_
 #define _XHASH_
 #include <yvals_core.h>

--- a/stl/inc/xiosbase
+++ b/stl/inc/xiosbase
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XIOSBASE_
 #define _XIOSBASE_
 #include <yvals_core.h>

--- a/stl/inc/xkeycheck.h
+++ b/stl/inc/xkeycheck.h
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XKEYCHECK_H
 #define _XKEYCHECK_H
 

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XLOCALE_
 #define _XLOCALE_
 #include <yvals_core.h>

--- a/stl/inc/xlocbuf
+++ b/stl/inc/xlocbuf
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XLOCBUF_
 #define _XLOCBUF_
 #include <yvals_core.h>

--- a/stl/inc/xlocinfo
+++ b/stl/inc/xlocinfo
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XLOCINFO_
 #define _XLOCINFO_
 #include <yvals.h>

--- a/stl/inc/xlocmes
+++ b/stl/inc/xlocmes
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XLOCMES_
 #define _XLOCMES_
 #include <yvals_core.h>

--- a/stl/inc/xlocmon
+++ b/stl/inc/xlocmon
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XLOCMON_
 #define _XLOCMON_
 #include <yvals_core.h>

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XLOCNUM_
 #define _XLOCNUM_
 #include <yvals_core.h>

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XLOCTIME_
 #define _XLOCTIME_
 #include <yvals_core.h>

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XMEMORY_
 #define _XMEMORY_
 #include <yvals_core.h>

--- a/stl/inc/xnode_handle.h
+++ b/stl/inc/xnode_handle.h
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XNODE_HANDLE_H
 #define _XNODE_HANDLE_H
 #include <yvals_core.h>

--- a/stl/inc/xpolymorphic_allocator.h
+++ b/stl/inc/xpolymorphic_allocator.h
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XPOLYMORPHIC_ALLOCATOR_H
 #define _XPOLYMORPHIC_ALLOCATOR_H
 #include <yvals_core.h>

--- a/stl/inc/xsmf_control.h
+++ b/stl/inc/xsmf_control.h
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XSMF_CONTROL_H
 #define _XSMF_CONTROL_H
 #include <yvals_core.h>

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -5,7 +5,6 @@
 
 // (<string_view> without emitting non-C++17 warnings)
 
-#pragma once
 #ifndef _XSTRING_
 #define _XSTRING_
 #include <yvals_core.h>

--- a/stl/inc/xthreads.h
+++ b/stl/inc/xthreads.h
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _THR_XTHREADS_H
 #define _THR_XTHREADS_H
 #include <yvals_core.h>

--- a/stl/inc/xtimec.h
+++ b/stl/inc/xtimec.h
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _THR_XTIMEC_H
 #define _THR_XTIMEC_H
 #include <yvals.h>

--- a/stl/inc/xtr1common
+++ b/stl/inc/xtr1common
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XTR1COMMON_
 #define _XTR1COMMON_
 #include <yvals_core.h>

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XTREE_
 #define _XTREE_
 #include <yvals_core.h>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _XUTILITY_
 #define _XUTILITY_
 #include <yvals.h>

--- a/stl/inc/ymath.h
+++ b/stl/inc/ymath.h
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _YMATH
 #define _YMATH
 #include <yvals.h>

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -7,7 +7,6 @@
 // MAJOR LIMITATIONS apply to what can be included here!
 // Before editing this file, read: /docs/import_library.md
 
-#pragma once
 #ifndef _YVALS
 #define _YVALS
 #include <yvals_core.h>

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _YVALS_CORE_H_
 #define _YVALS_CORE_H_
 #ifndef _STL_COMPILER_PREPROCESSOR

--- a/tests/std/include/new_counter.hpp
+++ b/tests/std/include/new_counter.hpp
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#pragma once
+
 #include <cassert>
 #include <cstddef>
 #include <cstdlib>
 #include <new>
 
-#pragma once
 #pragma warning(push)
 #pragma warning(disable : 28251) // Inconsistent annotation for 'new': this instance has no annotations.
 

--- a/tests/tr1/include/cvt_xtest.h
+++ b/tests/tr1/include/cvt_xtest.h
@@ -3,8 +3,7 @@
 
 // test a codecvt facet
 #pragma once
-#ifndef _CVT_XTEST_
-#define _CVT_XTEST_
+
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 #include <cstdlib>
@@ -181,4 +180,3 @@ _STL_RESTORE_CLANG_WARNINGS
 #pragma pack(pop)
 
 #endif // _STL_COMPILER_PREPROCESSOR
-#endif // _CVT_XTEST_

--- a/tools/unicode_properties_parse/grapheme_break_property_data_gen.py
+++ b/tools/unicode_properties_parse/grapheme_break_property_data_gen.py
@@ -142,7 +142,6 @@ MSVC_FORMAT_UCD_TABLES_HPP_TEMPLATE = """
 // use or other dealings in these Data Files or Software without prior
 // written authorization of the copyright holder.
 
-#pragma once
 #ifndef __MSVC_FORMAT_UCD_TABLES_HPP
 #define __MSVC_FORMAT_UCD_TABLES_HPP
 #include <yvals_core.h>


### PR DESCRIPTION
This drops `#pragma once` in `stl/inc` (and the generator `grapheme_break_property_data_gen.py`), relying on our classic idempotency guards (combined with modern compiler abilities to recognize and optimize them; C1XX gained that ability a while ago, so there should be no throughput regressions). This is an attempt to fix VSO-1830439 "\[Feedback\]\[std:c++latest\] C++: 'is not a member' error when importing modules", a scenario which I don't fully understand, but which @cdacamar says will be fixed if the STL stops using `#pragma once`.

Elsewhere, we generally rely on `#pragma once` alone, which is fine. This contains a couple of tiny related cleanups for that (as they are extremely tiny and isolated into separate commits, they shouldn't interfere with reviewing the large mechanical change):

* Move `#pragma once` to the top of `tests/std/include/new_counter.hpp`.
  + This may not be strictly necessary, but it is absolutely conventional elsewhere.
* Rely on `#pragma once` in `tests/tr1/include/cvt_xtest.h`, as it isn't product code anymore.
  + There are all sorts of other cleanups that could be performed here, but we generally avoid messing with `tr1`. In this case, I thought it was worth a change to follow the principle "product code avoids `#pragma once`, test code uses it".

:warning: We should also create PRs for the feature branches in order to avoid this re-appearing.