### PR TITLE
Fix `is_assignable` test coverage

### DIFF
--- a/tests/std/tests/P0608R3_improved_variant_converting_constructor/test.cpp
+++ b/tests/std/tests/P0608R3_improved_variant_converting_constructor/test.cpp
@@ -46,19 +46,19 @@ void assert_P0608R3() {
     static_assert(!is_constructible_v<variant<float, vector<int>>, int>);
     static_assert(!is_constructible_v<variant<float, char>, int>);
 
-    static_assert(is_assignable_v<variant<string, bool>, const char*>);
-    static_assert(is_assignable_v<variant<string, bool>, string>);
-    static_assert(is_assignable_v<variant<char, optional<char16_t>>, char16_t>);
-    static_assert(is_assignable_v<variant<int, reference_wrapper<double>>, double&>);
-    static_assert(is_assignable_v<variant<float, int>, char>);
-    static_assert(is_assignable_v<variant<float, long>, int>);
-    static_assert(is_assignable_v<variant<float, long long>, int>);
-    static_assert(is_assignable_v<variant<float, long, double>, int>);
-    static_assert(is_assignable_v<variant<float, vector<int>, long long>, int>);
-    static_assert(is_assignable_v<variant<float, int, long long>, char>);
-    static_assert(!is_assignable_v<variant<float>, int>);
-    static_assert(!is_assignable_v<variant<float, vector<int>>, int>);
-    static_assert(!is_assignable_v<variant<float, char>, int>);
+    static_assert(is_assignable_v<variant<string, bool>&, const char*>);
+    static_assert(is_assignable_v<variant<string, bool>&, string>);
+    static_assert(is_assignable_v<variant<char, optional<char16_t>>&, char16_t>);
+    static_assert(is_assignable_v<variant<int, reference_wrapper<double>>&, double&>);
+    static_assert(is_assignable_v<variant<float, int>&, char>);
+    static_assert(is_assignable_v<variant<float, long>&, int>);
+    static_assert(is_assignable_v<variant<float, long long>&, int>);
+    static_assert(is_assignable_v<variant<float, long, double>&, int>);
+    static_assert(is_assignable_v<variant<float, vector<int>, long long>&, int>);
+    static_assert(is_assignable_v<variant<float, int, long long>&, char>);
+    static_assert(!is_assignable_v<variant<float>&, int>);
+    static_assert(!is_assignable_v<variant<float, vector<int>>&, int>);
+    static_assert(!is_assignable_v<variant<float, char>&, int>);
 }
 
 void assert_P1957R2() {
@@ -67,9 +67,9 @@ void assert_P1957R2() {
     static_assert(is_constructible_v<variant<bool, int>, bitset<4>::reference>);
     static_assert(is_constructible_v<variant<bool>, bitset<4>::reference>);
 
-    static_assert(is_assignable_v<variant<bool, int>, bool>);
-    static_assert(is_assignable_v<variant<bool, int>, bitset<4>::reference>);
-    static_assert(is_assignable_v<variant<bool>, bitset<4>::reference>);
+    static_assert(is_assignable_v<variant<bool, int>&, bool>);
+    static_assert(is_assignable_v<variant<bool, int>&, bitset<4>::reference>);
+    static_assert(is_assignable_v<variant<bool>&, bitset<4>::reference>);
 }
 
 void assert_more_examples() {
@@ -89,20 +89,20 @@ void assert_more_examples() {
     static_assert(!is_constructible_v<variant<char, default_struct>, int>);
     static_assert(!is_constructible_v<variant<float, long, long long>, int>);
 
-    static_assert(is_assignable_v<variant<double_double>, double>);
-    static_assert(is_assignable_v<variant<vector<vector<int>>, optional<int>, int>, int>);
-    static_assert(is_assignable_v<variant<vector<vector<int>>, optional<int>>, int>);
-    static_assert(is_assignable_v<variant<vector<int>, optional<int>, float>, int>);
-    static_assert(is_assignable_v<variant<bool>, convertible_bool>);
-    static_assert(is_assignable_v<variant<bool, int>, convertible_bool>);
-    static_assert(is_assignable_v<variant<convertible_bool>, bool>);
-    static_assert(is_assignable_v<variant<float, bool, convertible_bool>, convertible_bool>);
-    static_assert(is_assignable_v<variant<float, bool, convertible_bool>, bool>);
-    static_assert(is_assignable_v<variant<char, int>, bool>);
-    static_assert(is_assignable_v<variant<double_double>, int>);
-    static_assert(!is_assignable_v<variant<float>, unsigned int>);
-    static_assert(!is_assignable_v<variant<char, default_struct>, int>);
-    static_assert(!is_assignable_v<variant<float, long, long long>, int>);
+    static_assert(is_assignable_v<variant<double_double>&, double>);
+    static_assert(is_assignable_v<variant<vector<vector<int>>, optional<int>, int>&, int>);
+    static_assert(is_assignable_v<variant<vector<vector<int>>, optional<int>>&, int>);
+    static_assert(is_assignable_v<variant<vector<int>, optional<int>, float>&, int>);
+    static_assert(is_assignable_v<variant<bool>&, convertible_bool>);
+    static_assert(is_assignable_v<variant<bool, int>&, convertible_bool>);
+    static_assert(is_assignable_v<variant<convertible_bool>&, bool>);
+    static_assert(is_assignable_v<variant<float, bool, convertible_bool>&, convertible_bool>);
+    static_assert(is_assignable_v<variant<float, bool, convertible_bool>&, bool>);
+    static_assert(is_assignable_v<variant<char, int>&, bool>);
+    static_assert(is_assignable_v<variant<double_double>&, int>);
+    static_assert(!is_assignable_v<variant<float>&, unsigned int>);
+    static_assert(!is_assignable_v<variant<char, default_struct>&, int>);
+    static_assert(!is_assignable_v<variant<float, long, long long>&, int>);
 }
 
 void test_variant_constructor_P0608R3() {

--- a/tests/std/tests/P0718R2_atomic_smart_ptrs/test.cpp
+++ b/tests/std/tests/P0718R2_atomic_smart_ptrs/test.cpp
@@ -634,12 +634,12 @@ int main() {
     ensure_member_calls_compile<atomic<shared_ptr<int[2][2]>>>();
     ensure_member_calls_compile<atomic<weak_ptr<int[2][2]>>>();
 
-    // LWG-3893: LWG 3661 broke atomic<shared_ptr<T>> a; a = nullptr;
-    static_assert(is_nothrow_assignable_v<atomic<shared_ptr<bool>>, nullptr_t>);
-    static_assert(is_nothrow_assignable_v<atomic<shared_ptr<int>>, nullptr_t>);
-    static_assert(is_nothrow_assignable_v<atomic<shared_ptr<int[]>>, nullptr_t>);
-    static_assert(is_nothrow_assignable_v<atomic<shared_ptr<int[][2]>>, nullptr_t>);
-    static_assert(is_nothrow_assignable_v<atomic<shared_ptr<int[2][2]>>, nullptr_t>);
+    // LWG-3893: LWG-3661 broke atomic<shared_ptr<T>> a; a = nullptr;
+    static_assert(is_nothrow_assignable_v<atomic<shared_ptr<bool>>&, nullptr_t>);
+    static_assert(is_nothrow_assignable_v<atomic<shared_ptr<int>>&, nullptr_t>);
+    static_assert(is_nothrow_assignable_v<atomic<shared_ptr<int[]>>&, nullptr_t>);
+    static_assert(is_nothrow_assignable_v<atomic<shared_ptr<int[][2]>>&, nullptr_t>);
+    static_assert(is_nothrow_assignable_v<atomic<shared_ptr<int[2][2]>>&, nullptr_t>);
 
 #ifdef _DEBUG
     sptr0 = {};

--- a/tests/std/tests/P2321R2_proxy_reference/test.cpp
+++ b/tests/std/tests/P2321R2_proxy_reference/test.cpp
@@ -274,6 +274,7 @@ constexpr bool test() {
 
     { // Test vector<bool>::reference
         static_assert(is_assignable_v<const vector<bool>::reference, bool>);
+        static_assert(is_assignable_v<const vector<bool>::reference&, bool>);
 
         vector<bool> vb{false};
         const vector<bool>::reference r = vb[0];


### PR DESCRIPTION
* Use lvalue references for the LHS of `is_assignable_v` and `is_nothrow_assignable_v` for `variant` and `atomic<shared_ptr>`.
  + We expect lvalues even though it technically works with rvalues.
* Check const rvalues and const lvalues in `P2321R2_proxy_reference`.
  + This is a "nice to have" expansion of test coverage, as both work, and this makes it clear that we didn't test them unintentionally.
* Cite LWG-3661 with the usual syntax.