### PR TITLE
`<flat_set>`: Drop `#pragma once`

### DIFF
--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -3,7 +3,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#pragma once
 #ifndef _FLAT_SET_
 #define _FLAT_SET_
 #include <yvals_core.h>


### PR DESCRIPTION
Follow up to #3895.