### PR TITLE
Use `string::resize_and_overwrite` in `bitset` to avoid buffer initialization

### DIFF
--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -347,13 +347,13 @@ public:
     _NODISCARD _CONSTEXPR23 basic_string<_Elem, _Tr, _Alloc> to_string(
         const _Elem _Elem0 = static_cast<_Elem>('0'), const _Elem _Elem1 = static_cast<_Elem>('1')) const {
         // convert bitset to string
-        basic_string<_Elem, _Tr, _Alloc> _Str(_Bits, _Elem0);
-        for (size_t _Pos = 0; _Pos < _Bits; ++_Pos) {
-            if (_Subscript(_Bits - 1 - _Pos)) {
-                _Str[_Pos] = _Elem1;
+        basic_string<_Elem, _Tr, _Alloc> _Str;
+        _Str._Resize_and_overwrite(_Bits, [this, _Elem0, _Elem1](_Elem* _Buf, size_t _Len) {
+            for (size_t _Pos = 0; _Pos < _Len; ++_Pos) {
+                _Buf[_Pos] = _Subscript(_Len - 1 - _Pos) ? _Elem1 : _Elem0;
             }
-        }
-
+            return _Len;
+        });
         return _Str;
     }
 

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -4161,7 +4161,7 @@ public:
 #pragma warning(push)
 #pragma warning(disable : 4018) // '<=': signed/unsigned mismatch (we compare to 0 before _New_size below, so it's safe)
     template <class _Operation>
-    constexpr void 
+    constexpr void
 #if _HAS_CXX23
         resize_and_overwrite
 #else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
@@ -4191,7 +4191,7 @@ public:
     constexpr void _Resize_and_overwrite(_CRT_GUARDOVERFLOW const size_type _New_size, _Operation _Op) {
         return resize_and_overwrite(_New_size, _Op);
     }
-#endif // !_HAS_CXX23
+#endif // _HAS_CXX23
 
     _NODISCARD _CONSTEXPR20 size_type capacity() const noexcept {
         return _Mypair._Myval2._Myres;

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -4189,7 +4189,7 @@ public:
 #if _HAS_CXX23
     template <class _Operation>
     constexpr void _Resize_and_overwrite(_CRT_GUARDOVERFLOW const size_type _New_size, _Operation _Op) {
-        return resize_and_overwrite(_New_size, _Op);
+        resize_and_overwrite(_New_size, _Op);
     }
 #endif // _HAS_CXX23
 

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -4158,11 +4158,16 @@ public:
         }
     }
 
-#if _HAS_CXX23
 #pragma warning(push)
 #pragma warning(disable : 4018) // '<=': signed/unsigned mismatch (we compare to 0 before _New_size below, so it's safe)
     template <class _Operation>
-    constexpr void resize_and_overwrite(_CRT_GUARDOVERFLOW const size_type _New_size, _Operation _Op) {
+    constexpr void 
+#if _HAS_CXX23
+        resize_and_overwrite
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
+        _Resize_and_overwrite
+#endif // ^^^ !_HAS_CXX23 ^^^
+        (_CRT_GUARDOVERFLOW const size_type _New_size, _Operation _Op) {
         if (_Mypair._Myval2._Myres < _New_size) {
             _Reallocate_grow_by(_New_size - _Mypair._Myval2._Mysize,
                 [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size) {
@@ -4180,7 +4185,13 @@ public:
         _Eos(static_cast<size_type>(_Result_size));
     }
 #pragma warning(pop)
-#endif // _HAS_CXX23
+
+#if _HAS_CXX23
+    template <class _Operation>
+    constexpr void _Resize_and_overwrite(_CRT_GUARDOVERFLOW const size_type _New_size, _Operation _Op) {
+        return resize_and_overwrite(_New_size, _Op);
+    }
+#endif // !_HAS_CXX23
 
     _NODISCARD _CONSTEXPR20 size_type capacity() const noexcept {
         return _Mypair._Myval2._Myres;


### PR DESCRIPTION
Towards #3858.

> * @AlexGuteniev suggested using `basic_string::resize_and_overwrite`, creating an `_Ugly` version for unconditional use internally. (We generally avoid adding totally novel secret machinery to Standard classes as it can become a maintenance burden, but simply having `_Ugly` names to access Future Technology is easy and common.)

This is what was addressed

> * @AlexGuteniev also suggested investigating whether branchless codegen for assigning `_Elem0` vs. `_Elem1` would be superior. (Note: we cannot assume that their values are consecutive, they could be `'M'` and `'E'`.)

This is confirmed to be non applicable. Before the change it was `cmovne` to set `'1'`. After it became `setne al` to set to 0 or 1, then `add al, '0'`. Both are branchless. I think, the compiler will be able to make efficient branchless code for non-consecutive values by going back to `cmovcc`

Benchmark is already there - thanks @achabense!

Benchmark results before:
```
------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations
------------------------------------------------------------------------------------
BM_bitset_to_string<15, char>                    922 ns          924 ns       896000
BM_bitset_to_string<64, char>                 125791 ns       125558 ns         5600
BM_bitset_to_string_large_single<char>          2449 ns         2431 ns       263529
BM_bitset_to_string<7, wchar_t>                  539 ns          547 ns      1000000
BM_bitset_to_string<64, wchar_t>                4399 ns         4325 ns       144516
BM_bitset_to_string_large_single<wchar_t>       4792 ns         4708 ns       149333
```
after
```
------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations
------------------------------------------------------------------------------------
BM_bitset_to_string<15, char>                    235 ns          234 ns      3200000
BM_bitset_to_string<64, char>                 119085 ns       119978 ns         5600
BM_bitset_to_string_large_single<char>          2111 ns         2100 ns       320000
BM_bitset_to_string<7, wchar_t>                  153 ns          153 ns      4480000
BM_bitset_to_string<64, wchar_t>                4106 ns         4081 ns       172308
BM_bitset_to_string_large_single<wchar_t>       2137 ns         2148 ns       320000
```

The anomality of `BM_bitset_to_string<64, char>` is caused by too angry loop unrolling, and, IMO, should be fixed in compiler, if needs fixing.