### PR TITLE
Justify `terminate()` calls

### DIFF
--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -343,7 +343,7 @@ public:
         if (_Exc) {
             _STD rethrow_exception(_Exc);
         } else {
-            _STD terminate();
+            _STD terminate(); // per N4950 [except.nested]/4
         }
     }
 

--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -89,7 +89,7 @@ public:
 
     ~thread() noexcept {
         if (joinable()) {
-            _STD terminate();
+            _STD terminate(); // per N4950 [thread.thread.destr]/1
         }
     }
 
@@ -97,7 +97,7 @@ public:
 
     thread& operator=(thread&& _Other) noexcept {
         if (joinable()) {
-            _STD terminate();
+            _STD terminate(); // per N4950 [thread.thread.assign]/1
         }
 
         _Thr = _STD exchange(_Other._Thr, {});


### PR DESCRIPTION
Towards #3888

Will talk about `std::terminate()` in `ppltasks.cpp` later.