### PR TITLE
Avoid unnecessary handling in `_ReportUnobservedException`

### DIFF
--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -43,9 +43,9 @@ namespace Concurrency {
             }
 
             std::abort();
-#else // ^^^ __fastfail conditionally avaialble / fastfail always avaialble vvv
+#else // ^^^ __fastfail conditionally available  / fastfail always available  vvv
             __fastfail(FAST_FAIL_INVALID_ARG);
-#endif /// ^^^ fastfail always avaialble ^^^
+#endif /// ^^^ fastfail always available  ^^^
         }
 
         namespace platform {

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -37,14 +37,12 @@ namespace Concurrency {
     namespace details {
         [[noreturn]] _CRTIMP2 void __cdecl _ReportUnobservedException() {
 #if (defined(_M_IX86) || defined(_M_X64)) && !defined(_CRT_APP) && _STL_WIN32_WINNT < _WIN32_WINNT_WIN8
-            if (IsProcessorFeaturePresent(PF_FASTFAIL_AVAILABLE)) {
-                __fastfail(FAST_FAIL_INVALID_ARG);
+            if (!IsProcessorFeaturePresent(PF_FASTFAIL_AVAILABLE)) {
+                std::abort();
             }
+#endif // ^^^ __fastfail conditionally available ^^^
 
-            std::abort();
-#else // ^^^ __fastfail conditionally available / __fastfail always available vvv
             __fastfail(FAST_FAIL_INVALID_ARG);
-#endif // ^^^ __fastfail always available ^^^
         }
 
         namespace platform {

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -36,16 +36,15 @@ namespace Concurrency {
 
     namespace details {
         [[noreturn]] _CRTIMP2 void __cdecl _ReportUnobservedException() {
-
 #if (defined(_M_IX86) || defined(_M_X64)) && !defined(_CRT_APP) && _STL_WIN32_WINNT < _WIN32_WINNT_WIN8
             if (IsProcessorFeaturePresent(PF_FASTFAIL_AVAILABLE)) {
                 __fastfail(FAST_FAIL_INVALID_ARG);
             }
 
             std::abort();
-#else // ^^^ __fastfail conditionally available  / fastfail always available  vvv
+#else // ^^^ __fastfail conditionally available  / __fastfail always available  vvv
             __fastfail(FAST_FAIL_INVALID_ARG);
-#endif /// ^^^ fastfail always available  ^^^
+#endif // ^^^ __fastfail always available  ^^^
         }
 
         namespace platform {

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -37,14 +37,15 @@ namespace Concurrency {
     namespace details {
         [[noreturn]] _CRTIMP2 void __cdecl _ReportUnobservedException() {
 
-#if (defined(_M_IX86) || defined(_M_X64)) && !defined(_CRT_APP)
+#if (defined(_M_IX86) || defined(_M_X64)) && !defined(_CRT_APP) && _STL_WIN32_WINNT < _WIN32_WINNT_WIN8
             if (IsProcessorFeaturePresent(PF_FASTFAIL_AVAILABLE))
 #endif
             {
                 __fastfail(FAST_FAIL_INVALID_ARG);
+                _STL_UNREACHABLE; // TRANSITION, DevCom-10425806 - codegen should have assumed no return from __fastfail
             }
 
-            std::terminate();
+            std::abort();
         }
 
         namespace platform {

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -39,13 +39,14 @@ namespace Concurrency {
 
 #if (defined(_M_IX86) || defined(_M_X64)) && !defined(_CRT_APP) && _STL_WIN32_WINNT < _WIN32_WINNT_WIN8
             if (IsProcessorFeaturePresent(PF_FASTFAIL_AVAILABLE))
-#endif
             {
                 __fastfail(FAST_FAIL_INVALID_ARG);
-                _STL_UNREACHABLE; // TRANSITION, DevCom-10425806 - codegen should have assumed no return from __fastfail
             }
 
             std::abort();
+#else // ^^^ __fastfail conditionally avaialble / fastfail always avaialble vvv
+            __fastfail(FAST_FAIL_INVALID_ARG);
+#endif /// ^^^ fastfail always avaialble ^^^
         }
 
         namespace platform {

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -38,8 +38,7 @@ namespace Concurrency {
         [[noreturn]] _CRTIMP2 void __cdecl _ReportUnobservedException() {
 
 #if (defined(_M_IX86) || defined(_M_X64)) && !defined(_CRT_APP) && _STL_WIN32_WINNT < _WIN32_WINNT_WIN8
-            if (IsProcessorFeaturePresent(PF_FASTFAIL_AVAILABLE))
-            {
+            if (IsProcessorFeaturePresent(PF_FASTFAIL_AVAILABLE)) {
                 __fastfail(FAST_FAIL_INVALID_ARG);
             }
 

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -42,9 +42,9 @@ namespace Concurrency {
             }
 
             std::abort();
-#else // ^^^ __fastfail conditionally available  / __fastfail always available  vvv
+#else // ^^^ __fastfail conditionally available / __fastfail always available vvv
             __fastfail(FAST_FAIL_INVALID_ARG);
-#endif // ^^^ __fastfail always available  ^^^
+#endif // ^^^ __fastfail always available ^^^
         }
 
         namespace platform {


### PR DESCRIPTION
Towards #3888

Changes:
 * In the preprocessor condition, added pre-Win8 check. Starting in Windows8, `__fastfail` is always available. Mostly added as a reminder that this should be cleaned up further when dropping pre-Win8.
 * Changed `terminate` to `abort` as discussed in https://github.com/microsoft/STL/issues/3888#issuecomment-1654482314
 * Restructured the flow to avoid calling `abort()` if always calling `__fastfail`. IMO, the compiler should make the assumption that `__fastfail` does not return by itself, added DevCom-10425806.
