### PR TITLE
`stacktrace.cpp`: Fix `snprintf()` usage

### DIFF
--- a/stl/src/stacktrace.cpp
+++ b/stl/src/stacktrace.cpp
@@ -148,7 +148,7 @@ namespace {
             }
 
             if (displacement != 0) {
-                constexpr size_t max_disp_num = sizeof("+0x1122334455667788") - 1; // maximum possible offset
+                constexpr size_t max_disp_num = sizeof("+0x1122334455667788"); // maximum possible offset
 
                 off = string_fill(fill, off + max_disp_num, str, [displacement, off](char* s, size_t) {
                     const int ret = std::snprintf(s + off, max_disp_num, "+0x%llX", displacement);
@@ -214,7 +214,7 @@ namespace {
             off = source_file(address, str, off, &line, fill);
 
             if (line != 0) {
-                constexpr size_t max_line_num = sizeof("(4294967295): ") - 1; // maximum possible line number
+                constexpr size_t max_line_num = sizeof("(4294967295): "); // maximum possible line number
 
                 off = string_fill(fill, off + max_line_num, str, [line, off](char* s, size_t) {
                     const int ret = std::snprintf(s + off, max_line_num, "(%u): ", line);
@@ -317,7 +317,7 @@ void __stdcall __std_stacktrace_to_string(const void* const* const _Addresses, c
             });
         }
 
-        constexpr size_t max_entry_num = sizeof("65536> ") - 1; // maximum possible entry number
+        constexpr size_t max_entry_num = sizeof("65536> "); // maximum possible entry number
 
         off = string_fill(_Fill, off + max_entry_num, _Str, [off, i](char* s, size_t) {
             const int ret = std::snprintf(s + off, max_entry_num, "%u> ", static_cast<unsigned int>(i));

--- a/stl/src/stacktrace.cpp
+++ b/stl/src/stacktrace.cpp
@@ -148,7 +148,7 @@ namespace {
             }
 
             if (displacement != 0) {
-                constexpr size_t max_disp_num = sizeof("+0x1122334455667788"); // maximum possible offset
+                constexpr size_t max_disp_num = sizeof("+0x1122334455667788") - 1; // maximum possible offset
 
                 off = string_fill(fill, off + max_disp_num, str, [displacement, off](char* s, size_t) {
                     const int ret = std::snprintf(s + off, max_disp_num, "+0x%llX", displacement);
@@ -214,7 +214,7 @@ namespace {
             off = source_file(address, str, off, &line, fill);
 
             if (line != 0) {
-                constexpr size_t max_line_num = sizeof("(4294967295): "); // maximum possible line number
+                constexpr size_t max_line_num = sizeof("(4294967295): ") - 1; // maximum possible line number
 
                 off = string_fill(fill, off + max_line_num, str, [line, off](char* s, size_t) {
                     const int ret = std::snprintf(s + off, max_line_num, "(%u): ", line);
@@ -317,7 +317,7 @@ void __stdcall __std_stacktrace_to_string(const void* const* const _Addresses, c
             });
         }
 
-        constexpr size_t max_entry_num = sizeof("65536> "); // maximum possible entry number
+        constexpr size_t max_entry_num = sizeof("65536> ") - 1; // maximum possible entry number
 
         off = string_fill(_Fill, off + max_entry_num, _Str, [off, i](char* s, size_t) {
             const int ret = std::snprintf(s + off, max_entry_num, "%u> ", static_cast<unsigned int>(i));

--- a/stl/src/stacktrace.cpp
+++ b/stl/src/stacktrace.cpp
@@ -151,7 +151,7 @@ namespace {
                 constexpr size_t max_disp_num = sizeof("+0x1122334455667788") - 1; // maximum possible offset
 
                 off = string_fill(fill, off + max_disp_num, str, [displacement, off](char* s, size_t) {
-                    const int ret = std::snprintf(s + off, max_disp_num, "+0x%llX", displacement);
+                    const int ret = std::snprintf(s + off, max_disp_num + 1, "+0x%llX", displacement);
                     if (ret <= 0) {
                         std::abort(); // formatting error
                     }
@@ -217,7 +217,7 @@ namespace {
                 constexpr size_t max_line_num = sizeof("(4294967295): ") - 1; // maximum possible line number
 
                 off = string_fill(fill, off + max_line_num, str, [line, off](char* s, size_t) {
-                    const int ret = std::snprintf(s + off, max_line_num, "(%u): ", line);
+                    const int ret = std::snprintf(s + off, max_line_num + 1, "(%u): ", line);
                     if (ret <= 0) {
                         std::abort(); // formatting error
                     }
@@ -320,7 +320,7 @@ void __stdcall __std_stacktrace_to_string(const void* const* const _Addresses, c
         constexpr size_t max_entry_num = sizeof("65536> ") - 1; // maximum possible entry number
 
         off = string_fill(_Fill, off + max_entry_num, _Str, [off, i](char* s, size_t) {
-            const int ret = std::snprintf(s + off, max_entry_num, "%u> ", static_cast<unsigned int>(i));
+            const int ret = std::snprintf(s + off, max_entry_num + 1, "%u> ", static_cast<unsigned int>(i));
             if (ret <= 0) {
                 std::abort(); // formatting error
             }


### PR DESCRIPTION
[C23 WP N3096](https://open-std.org/JTC1/SC22/WG14/www/docs/n3096.pdf) 7.23.6.5 "The `snprintf` function"/2:

> The `snprintf` function is equivalent to `fprintf`, except that the output is written into an array (specified by argument `s`) rather than to a stream. If `n` is zero, nothing is written, and `s` may be a null pointer. Otherwise, output characters beyond the `n`-1<sup>st</sup> are discarded rather than being written to the array, and a null character is written at the end of the characters actually written into the array.

In English, `n` should be the buffer size, **INCLUDING** room for a null terminator.

`stacktrace.cpp` consistently said `sizeof("meow") - 1`, which excludes the null terminator. This was a mistake.

So far I haven't seen actual misbehavior caused by this.