### PR TITLE
Testing: check `c(begin|end)` members of some C++23 ranges

### DIFF
--- a/tests/std/tests/P1899R3_views_stride/test.cpp
+++ b/tests/std/tests/P1899R3_views_stride/test.cpp
@@ -238,7 +238,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
 
         if constexpr (copy_constructible<V>) {
             auto r2                                    = r;
-            const same_as<const_iterator_t<R>> auto i2 = as_const(r2).cbegin();
+            const same_as<const_iterator_t<R>> auto i2 = r2.cbegin();
             if (!is_empty) {
                 assert(*i2 == *i);
             }
@@ -255,7 +255,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
 
         if constexpr (copy_constructible<V>) {
             const auto cr2                                    = r;
-            const same_as<const_iterator_t<const R>> auto ci2 = cr2.cbegin();
+            const same_as<const_iterator_t<const R>> auto ci2 = as_const(cr2).cbegin();
             if (!is_empty) {
                 assert(*ci2 == *ci);
             }
@@ -301,7 +301,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
             if constexpr (copy_constructible<V>) {
                 const auto r2 = r;
                 if (!is_empty) {
-                    assert(*prev(r2.cend()) == *prev(cend(expected)));
+                    assert(*prev(as_const(r2).cend()) == *prev(cend(expected)));
                 }
             }
         }

--- a/tests/std/tests/P1899R3_views_stride/test.cpp
+++ b/tests/std/tests/P1899R3_views_stride/test.cpp
@@ -238,7 +238,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
 
         if constexpr (copy_constructible<V>) {
             auto r2                                    = r;
-            const same_as<const_iterator_t<R>> auto i2 = r2.cbegin();
+            const same_as<const_iterator_t<R>> auto i2 = as_const(r2).cbegin();
             if (!is_empty) {
                 assert(*i2 == *i);
             }

--- a/tests/std/tests/P1899R3_views_stride/test.cpp
+++ b/tests/std/tests/P1899R3_views_stride/test.cpp
@@ -21,7 +21,8 @@ template <ranges::input_range Rng, class Expected>
 constexpr bool test_one(Rng&& rng, Expected&& expected) {
     using ranges::forward_range, ranges::bidirectional_range, ranges::random_access_range, ranges::common_range,
         ranges::sized_range;
-    using ranges::stride_view, ranges::begin, ranges::end, ranges::iterator_t, ranges::sentinel_t, ranges::prev;
+    using ranges::stride_view, ranges::begin, ranges::end, ranges::cbegin, ranges::cend, ranges::iterator_t,
+        ranges::sentinel_t, ranges::const_iterator_t, ranges::const_sentinel_t, ranges::prev;
 
     constexpr bool is_view = ranges::view<remove_cvref_t<Rng>>;
 
@@ -224,6 +225,89 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
 
         if constexpr (!common_range<const R>) {
             STATIC_ASSERT(same_as<sentinel_t<const R>, default_sentinel_t>);
+        }
+    }
+
+    // Validate view_interface::cbegin
+    STATIC_ASSERT(CanMemberCBegin<R>);
+    {
+        const same_as<const_iterator_t<R>> auto i = r.cbegin();
+        if (!is_empty) {
+            assert(*i == *cbegin(expected));
+        }
+
+        if constexpr (copy_constructible<V>) {
+            auto r2                                    = r;
+            const same_as<const_iterator_t<R>> auto i2 = r2.cbegin();
+            if (!is_empty) {
+                assert(*i2 == *i);
+            }
+        }
+    }
+
+    // Validate view_interface::cbegin (const)
+    STATIC_ASSERT(CanMemberCBegin<const R> == ranges::range<const V>);
+    if constexpr (CanMemberCBegin<const R>) {
+        const same_as<const_iterator_t<const R>> auto ci = as_const(r).cbegin();
+        if (!is_empty) {
+            assert(*ci == *cbegin(expected));
+        }
+
+        if constexpr (copy_constructible<V>) {
+            const auto cr2                                    = r;
+            const same_as<const_iterator_t<const R>> auto ci2 = cr2.cbegin();
+            if (!is_empty) {
+                assert(*ci2 == *ci);
+            }
+        }
+    }
+
+    // Validate view_interface::cend
+    STATIC_ASSERT(CanMemberCEnd<R>);
+    {
+        const same_as<const_sentinel_t<R>> auto s = r.cend();
+        assert((r.cbegin() == s) == is_empty);
+        STATIC_ASSERT(common_range<R> == (common_range<V> && (sized_range<V> || !bidirectional_range<V>) ));
+        if constexpr (common_range<R> && bidirectional_range<V>) {
+            if (!is_empty) {
+                assert(*prev(s) == *prev(cend(expected)));
+            }
+
+            if constexpr (copy_constructible<V>) {
+                auto r2 = r;
+                if (!is_empty) {
+                    assert(*prev(r2.cend()) == *prev(cend(expected)));
+                }
+            }
+        }
+
+        if constexpr (!common_range<R>) {
+            STATIC_ASSERT(same_as<const_sentinel_t<R>, default_sentinel_t>);
+        }
+    }
+
+    // Validate view_interface::cend (const)
+    STATIC_ASSERT(CanMemberCEnd<const R> == ranges::range<const V>);
+    if constexpr (CanMemberCEnd<const R>) {
+        const same_as<const_sentinel_t<const R>> auto cs = as_const(r).cend();
+        assert((as_const(r).cbegin() == cs) == is_empty);
+        STATIC_ASSERT(common_range<const R> == //
+                      (common_range<const V> && (sized_range<const V> || !bidirectional_range<const V>) ));
+        if constexpr (common_range<const R> && bidirectional_range<const V>) {
+            if (!is_empty) {
+                assert(*prev(cs) == *prev(cend(expected)));
+            }
+
+            if constexpr (copy_constructible<V>) {
+                const auto r2 = r;
+                if (!is_empty) {
+                    assert(*prev(r2.cend()) == *prev(cend(expected)));
+                }
+            }
+        }
+
+        if constexpr (!common_range<const R>) {
+            STATIC_ASSERT(same_as<const_sentinel_t<const R>, default_sentinel_t>);
         }
     }
 

--- a/tests/std/tests/P1899R3_views_stride/test.cpp
+++ b/tests/std/tests/P1899R3_views_stride/test.cpp
@@ -255,7 +255,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
 
         if constexpr (copy_constructible<V>) {
             const auto cr2                                    = r;
-            const same_as<const_iterator_t<const R>> auto ci2 = as_const(cr2).cbegin();
+            const same_as<const_iterator_t<const R>> auto ci2 = cr2.cbegin();
             if (!is_empty) {
                 assert(*ci2 == *ci);
             }
@@ -291,8 +291,8 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     if constexpr (CanMemberCEnd<const R>) {
         const same_as<const_sentinel_t<const R>> auto cs = as_const(r).cend();
         assert((as_const(r).cbegin() == cs) == is_empty);
-        STATIC_ASSERT(common_range<const R> == //
-                      (common_range<const V> && (sized_range<const V> || !bidirectional_range<const V>) ));
+        STATIC_ASSERT(common_range<const R>
+                      == (common_range<const V> && (sized_range<const V> || !bidirectional_range<const V>) ));
         if constexpr (common_range<const R> && bidirectional_range<const V>) {
             if (!is_empty) {
                 assert(*prev(cs) == *prev(cend(expected)));
@@ -301,7 +301,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
             if constexpr (copy_constructible<V>) {
                 const auto r2 = r;
                 if (!is_empty) {
-                    assert(*prev(as_const(r2).cend()) == *prev(cend(expected)));
+                    assert(*prev(r2.cend()) == *prev(cend(expected)));
                 }
             }
         }

--- a/tests/std/tests/P2278R4_views_as_const/test.cpp
+++ b/tests/std/tests/P2278R4_views_as_const/test.cpp
@@ -442,7 +442,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
 
         if constexpr (copy_constructible<V>) {
             const auto cr2                                    = r;
-            const same_as<const_iterator_t<const R>> auto ci2 = as_const(cr2).cbegin();
+            const same_as<const_iterator_t<const R>> auto ci2 = cr2.cbegin();
             if (!is_empty) {
                 assert(*ci2 == *ci);
             }
@@ -483,7 +483,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
             if constexpr (copy_constructible<V>) {
                 const auto r2 = r;
                 if (!is_empty) {
-                    assert(*prev(as_const(r2).cend()) == *prev(cend(expected)));
+                    assert(*prev(r2.cend()) == *prev(cend(expected)));
                 }
             }
         }

--- a/tests/std/tests/P2278R4_views_as_const/test.cpp
+++ b/tests/std/tests/P2278R4_views_as_const/test.cpp
@@ -442,7 +442,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
 
         if constexpr (copy_constructible<V>) {
             const auto cr2                                    = r;
-            const same_as<const_iterator_t<const R>> auto ci2 = cr2.cbegin();
+            const same_as<const_iterator_t<const R>> auto ci2 = as_const(cr2).cbegin();
             if (!is_empty) {
                 assert(*ci2 == *ci);
             }
@@ -483,7 +483,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
             if constexpr (copy_constructible<V>) {
                 const auto r2 = r;
                 if (!is_empty) {
-                    assert(*prev(r2.cend()) == *prev(cend(expected)));
+                    assert(*prev(as_const(r2).cend()) == *prev(cend(expected)));
                 }
             }
         }

--- a/tests/std/tests/P2321R2_views_zip/test.cpp
+++ b/tests/std/tests/P2321R2_views_zip/test.cpp
@@ -769,6 +769,7 @@ constexpr bool instantiation_test_for_category() {
 
     using test::Sized, test::Common, test::CanDifference;
 
+#ifndef _PREFAST_ // TRANSITION, GH-1030
     InstantiatorType<Category, Sized::no, Common::no, CanDifference::no>::call();
     InstantiatorType<Category, Sized::no, Common::no, CanDifference::yes>::call();
     InstantiatorType<Category, Sized::no, Common::yes, CanDifference::no>::call();
@@ -776,6 +777,7 @@ constexpr bool instantiation_test_for_category() {
     InstantiatorType<Category, Sized::yes, Common::no, CanDifference::no>::call();
     InstantiatorType<Category, Sized::yes, Common::no, CanDifference::yes>::call();
     InstantiatorType<Category, Sized::yes, Common::yes, CanDifference::no>::call();
+#endif // TRANSITION, GH-1030
     InstantiatorType<Category, Sized::yes, Common::yes, CanDifference::yes>::call();
 
     return true;

--- a/tests/std/tests/P2321R2_views_zip/test.cpp
+++ b/tests/std/tests/P2321R2_views_zip/test.cpp
@@ -437,6 +437,35 @@ constexpr bool test_one(TestContainerType& test_container, RangeTypes&&... rngs)
             assert(end == as_const(zipped_range).end());
         }
 
+        // Validate view_interface::cbegin()
+        STATIC_ASSERT(CanMemberCBegin<ZipType>);
+        {
+            const same_as<ranges::const_iterator_t<ZipType>> auto itr = zipped_range.cbegin();
+            assert(do_tuples_reference_same_objects(*itr, tuple_element_arr[0]));
+        }
+
+        STATIC_ASSERT(CanMemberCBegin<const ZipType> == (ranges::range<const AllView<RangeTypes>> && ...));
+        if constexpr (CanMemberCBegin<const ZipType>) {
+            assert(do_tuples_reference_same_objects(*(as_const(zipped_range).cbegin()), const_tuple_element_arr[0]));
+        }
+
+        // Validate view_interface::cend()
+        STATIC_ASSERT(CanMemberCEnd<ZipType>);
+        if constexpr (equality_comparable<ranges::const_iterator_t<ZipType>>) {
+            auto end = zipped_range.cbegin();
+            ranges::advance(end, TestContainerType::smallest_array_size);
+
+            assert(end == zipped_range.cend());
+        }
+
+        STATIC_ASSERT(CanMemberCEnd<const ZipType> == (ranges::range<const AllView<RangeTypes>> && ...));
+        if constexpr (CanMemberCEnd<const ZipType> && equality_comparable<ranges::const_iterator_t<const ZipType>>) {
+            auto end = as_const(zipped_range).cbegin();
+            ranges::advance(end, TestContainerType::smallest_array_size);
+
+            assert(end == as_const(zipped_range).cend());
+        }
+
         const auto validate_iterators_lambda = []<class LocalZipType, class ArrayType, class... LocalRangeTypes>(
                                                    LocalZipType& relevant_range,
                                                    const ArrayType& relevant_tuple_element_arr) {


### PR DESCRIPTION
Towards #3391.

I've encountered some compiler issues with other C++23 range adaptors, so this PR only covers 3 of them.