### PR TITLE
Repeat export specifiers on definitions, so that they stay if the declarations are gone

### DIFF
--- a/stl/src/StlCompareStringA.cpp
+++ b/stl/src/StlCompareStringA.cpp
@@ -29,7 +29,7 @@
 //                 2 - if lpString1 == lpString2
 //                 3 - if lpString1 >  lpString2
 //        Failure: 0
-extern "C" int __cdecl __crtCompareStringA(_In_z_ LPCWSTR LocaleName, _In_ DWORD dwCmpFlags,
+extern "C" _CRTIMP2 int __cdecl __crtCompareStringA(_In_z_ LPCWSTR LocaleName, _In_ DWORD dwCmpFlags,
     _In_reads_(cchCount1) LPCSTR lpString1, _In_ int cchCount1, _In_reads_(cchCount2) LPCSTR lpString2,
     _In_ int cchCount2, _In_ int code_page) {
     // CompareString will compare past null terminator. Must find null terminator if in string before cchCountn chars.

--- a/stl/src/StlCompareStringW.cpp
+++ b/stl/src/StlCompareStringW.cpp
@@ -24,7 +24,7 @@
 //            2 - if lpString1 == lpString2
 //            3 - if lpString1 >  lpString2
 //   Failure: 0
-extern "C" int __cdecl __crtCompareStringW(_In_z_ LPCWSTR LocaleName, _In_ DWORD dwCmpFlags,
+extern "C" _CRTIMP2 int __cdecl __crtCompareStringW(_In_z_ LPCWSTR LocaleName, _In_ DWORD dwCmpFlags,
     _In_reads_(cchCount1) LPCWSTR lpString1, _In_ int cchCount1, _In_reads_(cchCount2) LPCWSTR lpString2,
     _In_ int cchCount2) {
     // CompareString will compare past null terminator. Must find null terminator if in string before cchCountn wide

--- a/stl/src/StlLCMapStringA.cpp
+++ b/stl/src/StlLCMapStringA.cpp
@@ -28,7 +28,7 @@
 // Exit:
 //        Success: number of chars written to lpDestStr (including null terminator)
 //        Failure: 0
-extern "C" int __cdecl __crtLCMapStringA(_In_opt_z_ LPCWSTR LocaleName, _In_ DWORD dwMapFlags,
+extern "C" _CRTIMP2 int __cdecl __crtLCMapStringA(_In_opt_z_ LPCWSTR LocaleName, _In_ DWORD dwMapFlags,
     _In_reads_(cchSrc) LPCSTR lpSrcStr, _In_ int cchSrc, _Out_writes_opt_(cchDest) char* lpDestStr, _In_ int cchDest,
     _In_ int code_page, _In_ BOOL bError) {
     // LCMapString will map past the null terminator.  We must find the null

--- a/stl/src/StlLCMapStringW.cpp
+++ b/stl/src/StlLCMapStringW.cpp
@@ -30,7 +30,7 @@
 //                 else
 //                    number of wide characters written to destination (including null terminator)
 //        Failure: 0
-extern "C" int __cdecl __crtLCMapStringW(_In_opt_z_ LPCWSTR const locale_name, _In_ DWORD const map_flags,
+extern "C" _CRTIMP2 int __cdecl __crtLCMapStringW(_In_opt_z_ LPCWSTR const locale_name, _In_ DWORD const map_flags,
     _In_reads_(source_count) LPCWSTR const source, _In_ int source_count,
     _Out_writes_opt_(destination_count) wchar_t* const destination, _In_ int const destination_count) {
     // LCMapString will map past the null terminator.  We must find the null terminator if it occurs in the string

--- a/stl/src/xmtx.cpp
+++ b/stl/src/xmtx.cpp
@@ -11,16 +11,16 @@ _EXTERN_C_UNLESS_PURE
 
 // Win32 critical sections are recursive
 
-void __CLRCALL_PURE_OR_CDECL _Mtxinit(_Rmtx* _Mtx) noexcept { // initialize mutex
+_MRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Mtxinit(_Rmtx* _Mtx) noexcept { // initialize mutex
     InitializeCriticalSectionEx(_Mtx, 4000, 0);
 }
 
-void __CLRCALL_PURE_OR_CDECL _Mtxdst(_Rmtx* _Mtx) noexcept { // delete mutex
+_MRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Mtxdst(_Rmtx* _Mtx) noexcept { // delete mutex
     DeleteCriticalSection(_Mtx);
 }
 
 _RELIABILITY_CONTRACT
-void __CLRCALL_PURE_OR_CDECL _Mtxlock(_Rmtx* _Mtx) noexcept { // lock mutex
+_MRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Mtxlock(_Rmtx* _Mtx) noexcept { // lock mutex
 #ifdef _M_CEE
     System::Threading::Thread::BeginThreadAffinity();
 #endif // _M_CEE
@@ -28,7 +28,7 @@ void __CLRCALL_PURE_OR_CDECL _Mtxlock(_Rmtx* _Mtx) noexcept { // lock mutex
 }
 
 _RELIABILITY_CONTRACT
-void __CLRCALL_PURE_OR_CDECL _Mtxunlock(_Rmtx* _Mtx) noexcept { // unlock mutex
+_MRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Mtxunlock(_Rmtx* _Mtx) noexcept { // unlock mutex
     LeaveCriticalSection(_Mtx);
 #ifdef _M_CEE
     System::Threading::Thread::EndThreadAffinity();

--- a/stl/src/xmtx.hpp
+++ b/stl/src/xmtx.hpp
@@ -13,17 +13,9 @@ _EXTERN_C_UNLESS_PURE
 
 using _Rmtx = CRITICAL_SECTION;
 
-#ifdef _M_CEE_PURE
-void __clrcall _Mtxinit(_Rmtx*) noexcept;
-void __clrcall _Mtxdst(_Rmtx*) noexcept;
-void __clrcall _Mtxlock(_Rmtx*) noexcept;
-void __clrcall _Mtxunlock(_Rmtx*) noexcept;
-
-#else // _M_CEE_PURE
-_MRTIMP2 void __cdecl _Mtxinit(_Rmtx*) noexcept;
-_MRTIMP2 void __cdecl _Mtxdst(_Rmtx*) noexcept;
-_MRTIMP2 void __cdecl _Mtxlock(_Rmtx*) noexcept;
-_MRTIMP2 void __cdecl _Mtxunlock(_Rmtx*) noexcept;
-#endif // _M_CEE_PURE
+_MRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Mtxinit(_Rmtx*) noexcept;
+_MRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Mtxdst(_Rmtx*) noexcept;
+_MRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Mtxlock(_Rmtx*) noexcept;
+_MRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Mtxunlock(_Rmtx*) noexcept;
 
 _END_EXTERN_C_UNLESS_PURE


### PR DESCRIPTION
We should have export specifiers on both function declaration **and** definition.
This is because after some future changes the declaration may be gone - either entirely, or header be no longer included.
By repeating export specifiers we make sure the function type and its impact on export surface stays the same.

See https://github.com/microsoft/STL/pull/3912#issuecomment-1661423190

Additionally, this simplifies the declarations in `stl/src/xmtx.hpp` to match the definitions (the declarations are functionally unchanged).