### PR TITLE
update stl/inc/xtr1common: _Is_any_of_v

### DIFF
--- a/stl/inc/xtr1common
+++ b/stl/inc/xtr1common
@@ -168,7 +168,11 @@ _INLINE_VAR constexpr bool disjunction_v = disjunction<_Traits...>::value;
 
 template <class _Ty, class... _Types>
 _INLINE_VAR constexpr bool _Is_any_of_v = // true if and only if _Ty is in _Types
+#if _HAS_CXX17
+    (is_same_v<_Ty, _Types> || ...);
+#else
     disjunction_v<is_same<_Ty, _Types>...>;
+#endif /* _HAS_CXX17 */
 
 _NODISCARD constexpr bool _Is_constant_evaluated() noexcept { // Internal function for any standard mode
     return __builtin_is_constant_evaluated();

--- a/stl/inc/xtr1common
+++ b/stl/inc/xtr1common
@@ -170,9 +170,9 @@ template <class _Ty, class... _Types>
 _INLINE_VAR constexpr bool _Is_any_of_v = // true if and only if _Ty is in _Types
 #if _HAS_CXX17
     (is_same_v<_Ty, _Types> || ...);
-#else
+#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
     disjunction_v<is_same<_Ty, _Types>...>;
-#endif /* _HAS_CXX17 */
+#endif // _HAS_CXX17
 
 _NODISCARD constexpr bool _Is_constant_evaluated() noexcept { // Internal function for any standard mode
     return __builtin_is_constant_evaluated();


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->

This is a very simple modification. The original _Is_any_of_v produces a lot of bloated unrolling. Using fold-expression is a better alternative. Because the change was so simple, I didn't issue it, and the tests were fine.