### PR TITLE
Consistently use `override` in tests

### DIFF
--- a/tests/std/tests/Dev09_199123_tr1_mem_fun_abstract_classes/test.cpp
+++ b/tests/std/tests/Dev09_199123_tr1_mem_fun_abstract_classes/test.cpp
@@ -25,7 +25,7 @@ private:
 
 class Derived : public Base {
 private:
-    virtual void purr() {}
+    void purr() override {}
 };
 
 int main() {

--- a/tests/std/tests/Dev10_654977_655012_shared_ptr_move/test.cpp
+++ b/tests/std/tests/Dev10_654977_655012_shared_ptr_move/test.cpp
@@ -24,7 +24,7 @@ private:
 
 class Derived : public Base {
 public:
-    virtual string str() const {
+    string str() const override {
         return "Derived";
     }
 };

--- a/tests/std/tests/Dev10_847656_shared_ptr_is_convertible/test.cpp
+++ b/tests/std/tests/Dev10_847656_shared_ptr_is_convertible/test.cpp
@@ -18,13 +18,13 @@ private:
 };
 
 struct Lion : public Cat {
-    virtual int meow() const {
+    int meow() const override {
         return 6;
     }
 };
 
 struct Tiger : public Cat {
-    virtual int meow() const {
+    int meow() const override {
         return 7;
     }
 };
@@ -42,13 +42,13 @@ private:
 };
 
 struct Jupiter : public Planet {
-    virtual int orbit() const {
+    int orbit() const override {
         return 8;
     }
 };
 
 struct Saturn : public Planet {
-    virtual int orbit() const {
+    int orbit() const override {
         return 9;
     }
 };

--- a/tests/std/tests/Dev11_0496153_locale_ctor/test.cpp
+++ b/tests/std/tests/Dev11_0496153_locale_ctor/test.cpp
@@ -34,7 +34,7 @@ void test_Dev11_496153_locale_ctor_should_not_throw() noexcept {
 }
 
 struct comma_separator : numpunct<char> {
-    virtual char do_decimal_point() const override {
+    char do_decimal_point() const override {
         return ',';
     }
 };

--- a/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
+++ b/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
@@ -741,7 +741,7 @@ struct BaseMeow {
 };
 
 struct DerivedMeow : BaseMeow {
-    virtual int operator()(int x, int y) override {
+    int operator()(int x, int y) override {
         return x * x * x + y * y * y;
     }
 };

--- a/tests/std/tests/Dev11_1066589_shared_ptr_atomic_deadlock/test.cpp
+++ b/tests/std/tests/Dev11_1066589_shared_ptr_atomic_deadlock/test.cpp
@@ -129,7 +129,7 @@ int main() {
         };
 
         struct Derived final : Base {
-            virtual void test() override {}
+            void test() override {}
         };
 
         shared_ptr<Base> object;

--- a/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
+++ b/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
@@ -158,7 +158,7 @@ namespace {
 
     struct malloc_resource final : std::pmr::memory_resource {
     private:
-        virtual void* do_allocate(std::size_t bytes, std::size_t align) override {
+        void* do_allocate(std::size_t bytes, std::size_t align) override {
             if (!bytes) {
                 return nullptr;
             }
@@ -175,7 +175,7 @@ namespace {
             throw std::bad_alloc{};
         }
 
-        virtual void do_deallocate(void* ptr, std::size_t, std::size_t align) noexcept override {
+        void do_deallocate(void* ptr, std::size_t, std::size_t align) noexcept override {
             if (align > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
                 _aligned_free(ptr);
             } else {
@@ -183,7 +183,7 @@ namespace {
             }
         }
 
-        virtual bool do_is_equal(const memory_resource& that) const noexcept override {
+        bool do_is_equal(const memory_resource& that) const noexcept override {
             return typeid(malloc_resource) == typeid(that);
         }
     };
@@ -194,7 +194,7 @@ namespace {
         void* ptr_{};
 
     private:
-        virtual void* do_allocate(std::size_t bytes, std::size_t align) override {
+        void* do_allocate(std::size_t bytes, std::size_t align) override {
             if (bytes_ != 0) {
                 CHECK(bytes == bytes_);
             } else {
@@ -214,7 +214,7 @@ namespace {
             }
         }
 
-        virtual void do_deallocate(void* ptr, std::size_t bytes, std::size_t align) noexcept override {
+        void do_deallocate(void* ptr, std::size_t bytes, std::size_t align) noexcept override {
             if (ptr_) {
                 CHECK(ptr == ptr_);
                 if (bytes_ != 0) {
@@ -245,7 +245,7 @@ namespace {
             }
         }
 
-        virtual bool do_is_equal(const memory_resource& that) const noexcept override {
+        bool do_is_equal(const memory_resource& that) const noexcept override {
             CHECK(ptr_ == &that);
             return typeid(checked_resource) == typeid(that);
         }
@@ -273,14 +273,13 @@ namespace {
             }
         }
 
-        virtual void* do_allocate(std::size_t const bytes, std::size_t const align) override {
+        void* do_allocate(std::size_t const bytes, std::size_t const align) override {
             void* const result = upstream_->allocate(bytes, align);
             allocations_.push_back({result, bytes, align});
             return result;
         }
 
-        virtual void do_deallocate(
-            void* const ptr, std::size_t const bytes, std::size_t const align) noexcept override {
+        void do_deallocate(void* const ptr, std::size_t const bytes, std::size_t const align) noexcept override {
             allocation const alloc{ptr, bytes, align};
             auto const end = allocations_.end();
             auto pos       = std::find(allocations_.begin(), end, alloc);
@@ -289,7 +288,7 @@ namespace {
             upstream_->deallocate(ptr, bytes, align);
         }
 
-        virtual bool do_is_equal(const memory_resource& that) const noexcept override {
+        bool do_is_equal(const memory_resource& that) const noexcept override {
             return this == &that;
         }
     };
@@ -496,15 +495,15 @@ namespace {
 
                 struct max_align_checker final : std::pmr::memory_resource {
                 private:
-                    virtual void* do_allocate(std::size_t bytes, std::size_t align) override {
+                    void* do_allocate(std::size_t bytes, std::size_t align) override {
                         CHECK(align == alignof(std::max_align_t));
                         return std::malloc(bytes);
                     }
-                    virtual void do_deallocate(void* ptr, std::size_t, std::size_t align) override {
+                    void do_deallocate(void* ptr, std::size_t, std::size_t align) override {
                         CHECK(align == alignof(std::max_align_t));
                         std::free(ptr);
                     }
-                    virtual bool do_is_equal(const memory_resource& that) const noexcept override {
+                    bool do_is_equal(const memory_resource& that) const noexcept override {
                         return typeid(max_align_checker) == typeid(that);
                     }
                 };

--- a/tests/std/tests/P0476R2_bit_cast/test.cpp
+++ b/tests/std/tests/P0476R2_bit_cast/test.cpp
@@ -32,7 +32,7 @@ struct middle_class_2 {
 };
 
 struct derived_class : middle_class_1, middle_class_2 {
-    virtual void a_member_function_2() override {}
+    void a_member_function_2() override {}
 };
 
 struct test_struct_1 {

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -656,11 +656,11 @@ void test_bool_specs() {
     assert(format(locale{"en-US"}, STR("{:L}"), false) == STR("false"));
 
     struct my_bool : numpunct<charT> {
-        virtual basic_string<charT> do_truename() const {
+        basic_string<charT> do_truename() const override {
             return STR("yes");
         }
 
-        virtual basic_string<charT> do_falsename() const {
+        basic_string<charT> do_falsename() const override {
             return STR("no");
         }
     };

--- a/tests/tr1/tests/future1/test.cpp
+++ b/tests/tr1/tests/future1/test.cpp
@@ -105,10 +105,10 @@ private:
 
 template <template <class T> class Future>
 class future_value_tester : public future_tester_base<Future, int> { // class for testing Future<T>
-    virtual void do_set_value() override { // set the value
+    void do_set_value() override { // set the value
         this->pr.set_value(3);
     }
-    virtual void do_check_value() override { // check the value
+    void do_check_value() override { // check the value
         CHECK_INT(this->fut.get(), 3);
     }
 };
@@ -120,11 +120,11 @@ public:
     }
 
 private:
-    virtual void do_set_value() override { // set the value
+    void do_set_value() override { // set the value
         value = 3;
         this->pr.set_value(value);
     }
-    virtual void do_check_value() override { // check the value
+    void do_check_value() override { // check the value
         CHECK_INT(this->fut.get(), 3);
     }
     int value;
@@ -132,10 +132,10 @@ private:
 
 template <template <class T> class Future>
 class future_void_tester : public future_tester_base<Future, void> { // class for testing Future<void>
-    virtual void do_set_value() override { // set the value
+    void do_set_value() override { // set the value
         this->pr.set_value();
     }
-    virtual void do_check_value() override { // get the value
+    void do_check_value() override { // get the value
         this->fut.get(); // do not remove
     }
 };

--- a/tests/tr1/tests/locale1/test.cpp
+++ b/tests/tr1/tests/locale1/test.cpp
@@ -207,23 +207,23 @@ void test_ctype() { // test ctype<char>
 
 struct Myxnpunct : public STD numpunct<char> { // specify numeric punctuation
 protected:
-    virtual char do_decimal_point() const { // return decimal point
+    char do_decimal_point() const override { // return decimal point
         return '_';
     }
 
-    virtual char do_thousands_sep() const { // return thousands separator
+    char do_thousands_sep() const override { // return thousands separator
         return ';';
     }
 
-    virtual STD string do_grouping() const { // return grouping rule
+    STD string do_grouping() const override { // return grouping rule
         return "\2";
     }
 
-    virtual STD string do_truename() const { // return name for true
+    STD string do_truename() const override { // return name for true
         return "yes";
     }
 
-    virtual STD string do_falsename() const { // return name for false
+    STD string do_falsename() const override { // return name for false
         return "no";
     }
 };
@@ -232,7 +232,7 @@ struct Myxctype2 : public STD ctype<char> { // get protected members
     Myxctype2() { // default construct
     }
 
-    virtual char do_widen(char ch) const { // widen a character
+    char do_widen(char ch) const override { // widen a character
         if (ch == '-') {
             return '@';
         } else if (ch == '0') {
@@ -244,8 +244,8 @@ struct Myxctype2 : public STD ctype<char> { // get protected members
         }
     }
 
-    virtual const char* do_widen(const char* first, const char* last,
-        char* dest) const { // widen a character sequence
+    const char* do_widen(const char* first, const char* last,
+        char* dest) const override { // widen a character sequence
         for (; first != last; ++first, ++dest) {
             *dest = do_widen(*first);
         }

--- a/tests/tr1/tests/locale2/test.cpp
+++ b/tests/tr1/tests/locale2/test.cpp
@@ -140,23 +140,23 @@ void test_ctype() { // test ctype<wchar_t>
 
 struct Myxnpunct : public STD numpunct<wchar_t> { // specify numeric punctuation
 protected:
-    virtual wchar_t do_decimal_point() const { // return decimal point
+    wchar_t do_decimal_point() const override { // return decimal point
         return L'_';
     }
 
-    virtual wchar_t do_thousands_sep() const { // return thousands separator
+    wchar_t do_thousands_sep() const override { // return thousands separator
         return L';';
     }
 
-    virtual STD string do_grouping() const { // return grouping rule
+    STD string do_grouping() const override { // return grouping rule
         return "\2";
     }
 
-    virtual STD wstring do_truename() const { // return name for true
+    STD wstring do_truename() const override { // return name for true
         return L"yes";
     }
 
-    virtual STD wstring do_falsename() const { // return name for false
+    STD wstring do_falsename() const override { // return name for false
         return L"no";
     }
 };
@@ -165,7 +165,7 @@ struct Myxctype2 : public STD ctype<wchar_t> { // get protected members
     Myxctype2() { // default construct
     }
 
-    virtual wchar_t do_widen(char ch) const { // widen a character
+    wchar_t do_widen(char ch) const override { // widen a character
         if (ch == '-') {
             return L'@';
         } else if (ch == '0') {
@@ -177,8 +177,8 @@ struct Myxctype2 : public STD ctype<wchar_t> { // get protected members
         }
     }
 
-    virtual const char* do_widen(const char* first, const char* last,
-        wchar_t* dest) const { // widen a character sequence
+    const char* do_widen(const char* first, const char* last,
+        wchar_t* dest) const override { // widen a character sequence
         for (; first != last; ++first, ++dest) {
             *dest = do_widen(*first);
         }

--- a/tests/tr1/tests/locale3/test.cpp
+++ b/tests/tr1/tests/locale3/test.cpp
@@ -72,41 +72,41 @@ void test_messages() { // test messages<char>
 
 struct Myxmpunct : public STD moneypunct<char, false> { // specify money punctuation
 protected:
-    virtual char do_decimal_point() const { // return decimal point
+    char do_decimal_point() const override { // return decimal point
         return '_';
     }
 
-    virtual char do_thousands_sep() const { // return thousands separator
+    char do_thousands_sep() const override { // return thousands separator
         return ';';
     }
 
-    virtual STD string do_grouping() const { // return grouping rule
+    STD string do_grouping() const override { // return grouping rule
         return "\2";
     }
 
-    virtual STD string do_curr_symbol() const { // return currency symbol
+    STD string do_curr_symbol() const override { // return currency symbol
         return "@@";
     }
 
-    virtual STD string do_positive_sign() const { // return positive sign
+    STD string do_positive_sign() const override { // return positive sign
         return "+";
     }
 
-    virtual STD string do_negative_sign() const { // return negative sign
+    STD string do_negative_sign() const override { // return negative sign
         return "-";
     }
 
-    virtual int do_frac_digits() const { // return number of fraction digits
+    int do_frac_digits() const override { // return number of fraction digits
         return 4;
     }
 
-    virtual pattern do_neg_format() const { // return pattern for negative format
+    pattern do_neg_format() const override { // return pattern for negative format
         static STD money_base::pattern pat = {
             {STD money_base::sign, STD money_base::symbol, STD money_base::value, STD money_base::none}};
         return pat;
     }
 
-    virtual pattern do_pos_format() const { // return pattern for positive format
+    pattern do_pos_format() const override { // return pattern for positive format
         static STD money_base::pattern pat = {
             {STD money_base::sign, STD money_base::none, STD money_base::symbol, STD money_base::value}};
         return pat;
@@ -117,7 +117,7 @@ struct Myxctype2 : public STD ctype<char> { // get protected members
     Myxctype2() { // default construct
     }
 
-    virtual char do_widen(char ch) const { // widen a character
+    char do_widen(char ch) const override { // widen a character
         if (ch == '-') {
             return '@';
         } else if (ch == '0') {
@@ -129,15 +129,15 @@ struct Myxctype2 : public STD ctype<char> { // get protected members
         }
     }
 
-    virtual const char* do_widen(const char* first, const char* last,
-        char* dest) const { // widen a character sequence
+    const char* do_widen(const char* first, const char* last,
+        char* dest) const override { // widen a character sequence
         for (; first != last; ++first, ++dest) {
             *dest = do_widen(*first);
         }
         return first;
     }
 
-    virtual char do_narrow(char ch, char) const { // narrow a character
+    char do_narrow(char ch, char) const override { // narrow a character
         if (ch == 'P') {
             return '%';
         } else if (ch == 'K') {
@@ -149,8 +149,8 @@ struct Myxctype2 : public STD ctype<char> { // get protected members
         }
     }
 
-    virtual const char* do_narrow(
-        const char* first, const char* last, char, char* dest) const { // narrow a character sequence
+    const char* do_narrow(
+        const char* first, const char* last, char, char* dest) const override { // narrow a character sequence
         for (; first != last; ++first, ++dest) {
             *dest = do_narrow(*first, '\0');
         }

--- a/tests/tr1/tests/locale4/test.cpp
+++ b/tests/tr1/tests/locale4/test.cpp
@@ -65,41 +65,41 @@ void test_messages() { // test messages<wchar_t>
 
 struct Myxmpunct : public STD moneypunct<wchar_t, false> { // specify money punctuation
 protected:
-    virtual wchar_t do_decimal_point() const { // return decimal point
+    wchar_t do_decimal_point() const override { // return decimal point
         return L'_';
     }
 
-    virtual wchar_t do_thousands_sep() const { // return thousands separator
+    wchar_t do_thousands_sep() const override { // return thousands separator
         return L';';
     }
 
-    virtual STD string do_grouping() const { // return grouping rule
+    STD string do_grouping() const override { // return grouping rule
         return "\2";
     }
 
-    virtual STD wstring do_curr_symbol() const { // return currency symbol
+    STD wstring do_curr_symbol() const override { // return currency symbol
         return L"@@";
     }
 
-    virtual STD wstring do_positive_sign() const { // return positive sign
+    STD wstring do_positive_sign() const override { // return positive sign
         return L"+";
     }
 
-    virtual STD wstring do_negative_sign() const { // return negative sign
+    STD wstring do_negative_sign() const override { // return negative sign
         return L"-";
     }
 
-    virtual int do_frac_digits() const { // return number of fraction digits
+    int do_frac_digits() const override { // return number of fraction digits
         return 4;
     }
 
-    virtual pattern do_neg_format() const { // return pattern for negative format
+    pattern do_neg_format() const override { // return pattern for negative format
         static STD money_base::pattern pat = {
             {STD money_base::sign, STD money_base::symbol, STD money_base::value, STD money_base::none}};
         return pat;
     }
 
-    virtual pattern do_pos_format() const { // return pattern for positive format
+    pattern do_pos_format() const override { // return pattern for positive format
         static STD money_base::pattern pat = {
             {STD money_base::sign, STD money_base::none, STD money_base::symbol, STD money_base::value}};
         return pat;
@@ -110,7 +110,7 @@ struct Myxctype2 : public STD ctype<wchar_t> { // get protected members
     Myxctype2() { // default construct
     }
 
-    virtual wchar_t do_widen(char ch) const { // widen a character
+    wchar_t do_widen(char ch) const override { // widen a character
         if (ch == '-') {
             return L'@';
         } else if (ch == '0') {
@@ -122,15 +122,15 @@ struct Myxctype2 : public STD ctype<wchar_t> { // get protected members
         }
     }
 
-    virtual const char* do_widen(const char* first, const char* last,
-        wchar_t* dest) const { // widen a character sequence
+    const char* do_widen(const char* first, const char* last,
+        wchar_t* dest) const override { // widen a character sequence
         for (; first != last; ++first, ++dest) {
             *dest = do_widen(*first);
         }
         return first;
     }
 
-    virtual char do_narrow(wchar_t ch, char) const { // narrow a character
+    char do_narrow(wchar_t ch, char) const override { // narrow a character
         if (ch == L'P') {
             return '%';
         } else if (ch == L'K') {
@@ -142,8 +142,8 @@ struct Myxctype2 : public STD ctype<wchar_t> { // get protected members
         }
     }
 
-    virtual const wchar_t* do_narrow(
-        const wchar_t* first, const wchar_t* last, char, char* dest) const { // narrow a character sequence
+    const wchar_t* do_narrow(
+        const wchar_t* first, const wchar_t* last, char, char* dest) const override { // narrow a character sequence
         for (; first != last; ++first, ++dest) {
             *dest = do_narrow(*first, '\0');
         }

--- a/tests/tr1/tests/memory1/test.cpp
+++ b/tests/tr1/tests/memory1/test.cpp
@@ -49,8 +49,8 @@ struct X1 { // alternate base object
 };
 
 struct X : public X0, virtual public X1, public STD enable_shared_from_this<X> { // slightly complicated base type
-    virtual void f() {}
-    virtual STD shared_ptr<X> getX() { // return shared_ptr to this
+    void f() override {}
+    STD shared_ptr<X> getX() override { // return shared_ptr to this
         STD shared_ptr<X> sp = shared_from_this();
         CHECK_PTR(sp.get(), this);
         return sp;

--- a/tests/tr1/tests/streambuf1/test.cpp
+++ b/tests/tr1/tests/streambuf1/test.cpp
@@ -36,49 +36,49 @@ public:
     }
 
 protected:
-    virtual STD streambuf* setbuf(char*, STD streamsize) { // fake setbuf
+    STD streambuf* setbuf(char*, STD streamsize) override { // fake setbuf
         return nullptr;
     }
 
-    virtual int overflow(int = EOF) { // fake overflow
+    int overflow(int = EOF) override { // fake overflow
         return 1;
     }
 
-    virtual int pbackfail(int = EOF) { // fake pbackfail
+    int pbackfail(int = EOF) override { // fake pbackfail
         return 2;
     }
 
-    virtual STD streamsize showmanyc() { // fake showmanyc
+    STD streamsize showmanyc() override { // fake showmanyc
         return 3;
     }
 
-    virtual int underflow() { // fake underflow
+    int underflow() override { // fake underflow
         return 4;
     }
 
-    virtual int uflow() { // fake uflow
+    int uflow() override { // fake uflow
         return 5;
     }
 
-    virtual STD streamsize xsgetn(char*, STD streamsize) { // fake xsgetn
+    STD streamsize xsgetn(char*, STD streamsize) override { // fake xsgetn
         return 6;
     }
 
-    virtual STD streamsize xsputn(const char*, STD streamsize) { // fake xsputn
+    STD streamsize xsputn(const char*, STD streamsize) override { // fake xsputn
         return 7;
     }
 
-    virtual STD streampos seekoff(STD streamoff, STD ios::seekdir,
-        STD ios::openmode = STD ios::in | STD ios::out) { // fake seekoff
+    STD streampos seekoff(STD streamoff, STD ios::seekdir,
+        STD ios::openmode = STD ios::in | STD ios::out) override { // fake seekoff
         return 8;
     }
 
-    virtual STD streampos seekpos(STD streampos,
-        STD ios::openmode = STD ios::in | STD ios::out) { // fake seekpos
+    STD streampos seekpos(STD streampos,
+        STD ios::openmode = STD ios::in | STD ios::out) override { // fake seekpos
         return 9;
     }
 
-    virtual int sync() { // fake sync
+    int sync() override { // fake sync
         return 10;
     }
 };

--- a/tests/tr1/tests/streambuf2/test.cpp
+++ b/tests/tr1/tests/streambuf2/test.cpp
@@ -37,49 +37,49 @@ public:
     }
 
 protected:
-    virtual STD wstreambuf* setbuf(wchar_t*, STD streamsize) { // fake setbuf
+    STD wstreambuf* setbuf(wchar_t*, STD streamsize) override { // fake setbuf
         return nullptr;
     }
 
-    virtual CSTD wint_t overflow(CSTD wint_t = WEOF) { // fake overflow
+    CSTD wint_t overflow(CSTD wint_t = WEOF) override { // fake overflow
         return 1;
     }
 
-    virtual CSTD wint_t pbackfail(CSTD wint_t = WEOF) { // fake pbackfail
+    CSTD wint_t pbackfail(CSTD wint_t = WEOF) override { // fake pbackfail
         return 2;
     }
 
-    virtual STD streamsize showmanyc() { // fake showmanyc
+    STD streamsize showmanyc() override { // fake showmanyc
         return 3;
     }
 
-    virtual CSTD wint_t underflow() { // fake underflow
+    CSTD wint_t underflow() override { // fake underflow
         return 4;
     }
 
-    virtual CSTD wint_t uflow() { // fake uflow
+    CSTD wint_t uflow() override { // fake uflow
         return 5;
     }
 
-    virtual STD streamsize xsgetn(wchar_t*, STD streamsize) { // fake xsgetn
+    STD streamsize xsgetn(wchar_t*, STD streamsize) override { // fake xsgetn
         return 6;
     }
 
-    virtual STD streamsize xsputn(const wchar_t*, STD streamsize) { // fake xsputn
+    STD streamsize xsputn(const wchar_t*, STD streamsize) override { // fake xsputn
         return 7;
     }
 
-    virtual STD wstreampos seekoff(STD streamoff, STD ios::seekdir,
-        STD ios::openmode = STD ios::in | STD ios::out) { // fake seekoff
+    STD wstreampos seekoff(STD streamoff, STD ios::seekdir,
+        STD ios::openmode = STD ios::in | STD ios::out) override { // fake seekoff
         return 8;
     }
 
-    virtual STD wstreampos seekpos(STD streampos,
-        STD ios::openmode = STD ios::in | STD ios::out) { // fake seekpos
+    STD wstreampos seekpos(STD streampos,
+        STD ios::openmode = STD ios::in | STD ios::out) override { // fake seekpos
         return 9;
     }
 
-    virtual int sync() { // fake sync
+    int sync() override { // fake sync
         return 10;
     }
 };


### PR DESCRIPTION
As a general rule, we avoid significant cleanups of test code. This is partly because some tests are deliberately doing strange things to exercise weird corners of the product, and "cleaning up" the strangeness could affect test coverage. It's also because test code is much less important for long-term maintainability - if the tests keep passing, we generally don't care about them after they've been written.

However, we do try to enforce some basic conventions across the entire codebase including the tests. In the product code, we now follow a convention of saying only `override`. This avoids redundancy and allows `virtual` and `override` to serve different purposes (now when we see `virtual` we know we're introducing a new virtual member function). And using `override` is *much* safer than not using it.

This is so important for safety, and so non-disruptive, that it's worth making the tests consistent. (Including within the legacy `tr1` test suite that we even more strongly avoid changing.) This PR consists of two commits performing related systematic changes:

* Test style: Drop `virtual` when we `override`.
* Test style: Use `override` instead of `virtual`.
