### PR TITLE
Toolset update: VS 2022 17.8 Preview 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.7 Preview 3 or later.
+1. Install Visual Studio 2022 17.8 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
@@ -157,7 +157,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.7 Preview 3 or later.
+1. Install Visual Studio 2022 17.8 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -91,7 +91,7 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
   $PsExecPath = Join-Path $ExtractedPsToolsPath 'PsExec64.exe'
 
   # https://github.com/PowerShell/PowerShell/releases/latest
-  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.3.5/PowerShell-7.3.5-win-x64.zip'
+  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.3.6/PowerShell-7.3.6-win-x64.zip'
   Write-Host "Downloading: $PowerShellZipUrl"
   $ExtractedPowerShellPath = DownloadAndExtractZip -Url $PowerShellZipUrl
   $PwshPath = Join-Path $ExtractedPowerShellPath 'pwsh.exe'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ variables:
   benchmarkBuildOutputLocation: 'D:\benchmark'
 
 pool:
-  name: 'StlBuild-2023-07-11T1513-Pool'
+  name: 'StlBuild-2023-08-08T1145-Pool'
   demands: EnableSpotVM -equals true
 
 pr:

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -12,7 +12,7 @@
 #include <type_traits>
 #include <utility>
 
-#ifdef _M_CEE // TRANSITION, VSO-1659408
+#ifdef _M_CEE // TRANSITION, VSO-1867037
 #include <memory>
 #endif // ^^^ workaround ^^^
 
@@ -72,7 +72,7 @@ template <class T, std::size_t N>
 struct holder {
     STATIC_ASSERT(N < ~std::size_t{0} / sizeof(T));
 
-#ifdef _M_CEE // TRANSITION, VSO-1659408
+#ifdef _M_CEE // TRANSITION, VSO-1867037
     unsigned char space[(N + 1) * sizeof(T)];
 
     auto as_span() {

--- a/tests/std/tests/P0019R8_atomic_ref/test.cpp
+++ b/tests/std/tests/P0019R8_atomic_ref/test.cpp
@@ -37,7 +37,6 @@ struct int128 {
 
 template <bool AddViaCas, typename ValueType>
 void test_ops() {
-#ifndef _M_CEE // TRANSITION, VSO-1659408
     constexpr std::size_t unique      = 80; // small to avoid overflow even for char
     constexpr std::size_t repetitions = 8000;
     constexpr std::size_t total       = unique * repetitions;
@@ -85,7 +84,6 @@ void test_ops() {
     assert(std::transform_reduce(par, refs.begin(), refs.end(), 0, std::plus{}, load) == range * repetitions * 2);
     assert(std::transform_reduce(par, refs.begin(), refs.end(), 0, std::plus{}, xchg0) == range * 2);
     assert(std::transform_reduce(par, refs.begin(), refs.end(), 0, std::plus{}, load) == 0);
-#endif // _M_CEE
 }
 
 template <class Integer>

--- a/tests/std/tests/P0019R8_atomic_ref/test.cpp
+++ b/tests/std/tests/P0019R8_atomic_ref/test.cpp
@@ -37,6 +37,7 @@ struct int128 {
 
 template <bool AddViaCas, typename ValueType>
 void test_ops() {
+#ifndef _M_CEE // TRANSITION, VSO-1659695
     constexpr std::size_t unique      = 80; // small to avoid overflow even for char
     constexpr std::size_t repetitions = 8000;
     constexpr std::size_t total       = unique * repetitions;
@@ -84,6 +85,7 @@ void test_ops() {
     assert(std::transform_reduce(par, refs.begin(), refs.end(), 0, std::plus{}, load) == range * repetitions * 2);
     assert(std::transform_reduce(par, refs.begin(), refs.end(), 0, std::plus{}, xchg0) == range * 2);
     assert(std::transform_reduce(par, refs.begin(), refs.end(), 0, std::plus{}, load) == 0);
+#endif // _M_CEE
 }
 
 template <class Integer>

--- a/tests/std/tests/P0040R3_extending_memory_management_tools/test.cpp
+++ b/tests/std/tests/P0040R3_extending_memory_management_tools/test.cpp
@@ -56,21 +56,11 @@ struct uninitialized_fixture {
 
 template <typename T, size_t Count>
 struct uninitialized_storage {
-#ifdef _M_CEE // TRANSITION, VSO-1659408
-    char storage[sizeof(T) * Count + sizeof(T)];
-
-    T* begin() {
-        void* storageVoid = storage;
-        size_t space      = sizeof(storage);
-        return static_cast<T*>(align(alignof(T), sizeof(T), storageVoid, space));
-    }
-#else // ^^^ _M_CEE / !_M_CEE vvv
     alignas(T) char storage[sizeof(T) * Count];
 
     T* begin() {
         return &reinterpret_cast<T&>(storage);
     }
-#endif // _M_CEE
 
     T* end() {
         return begin() + Count;

--- a/tests/std/tests/P0466R5_layout_compatibility_and_pointer_interconvertibility_traits/test.cpp
+++ b/tests/std/tests/P0466R5_layout_compatibility_and_pointer_interconvertibility_traits/test.cpp
@@ -71,13 +71,9 @@ constexpr bool test() {
         ASSERT(is_layout_compatible_v<volatile E3, const E4>);
         ASSERT(is_layout_compatible_v<int[], int[]>);
         ASSERT(is_layout_compatible_v<int[3], int[3]>);
-
-#ifndef __EDG__ // TRANSITION, VSO-1849458
         ASSERT(is_layout_compatible_v<const int[], int[]>);
         ASSERT(is_layout_compatible_v<const int[3], int[3]>);
         ASSERT(is_layout_compatible_v<int[], volatile int[]>);
-#endif // ^^^ no workaround ^^^
-
         ASSERT(!is_layout_compatible_v<int, char>);
         ASSERT(!is_layout_compatible_v<int, void>);
         ASSERT(!is_layout_compatible_v<S1, void>);

--- a/tests/std/tests/P0660R10_stop_token/test.cpp
+++ b/tests/std/tests/P0660R10_stop_token/test.cpp
@@ -55,7 +55,6 @@ struct cb_destroying_functor {
 };
 
 int main() noexcept {
-#ifndef _M_CEE // TRANSITION, VSO-1659408
     reset_new_counters(0);
     { // all the following must not allocate, and must work with a nostopstate source; in rough synopsis order
         stop_token token;
@@ -416,5 +415,4 @@ int main() noexcept {
     reset_new_counters(0);
 
     puts("pass");
-#endif // _M_CEE
 }

--- a/tests/std/tests/P1135R6_atomic_flag_test/test.cpp
+++ b/tests/std/tests/P1135R6_atomic_flag_test/test.cpp
@@ -82,8 +82,6 @@ void test_flag_type() {
 }
 
 int main() {
-#ifndef _M_CEE // TRANSITION, VSO-1659408
     test_flag_type<std::atomic_flag>();
     test_flag_type<volatile std::atomic_flag>();
-#endif // _M_CEE
 }

--- a/tests/std/tests/P1135R6_atomic_flag_test/test.cpp
+++ b/tests/std/tests/P1135R6_atomic_flag_test/test.cpp
@@ -82,6 +82,8 @@ void test_flag_type() {
 }
 
 int main() {
+#ifndef _M_CEE // TRANSITION, VSO-1659695
     test_flag_type<std::atomic_flag>();
     test_flag_type<volatile std::atomic_flag>();
+#endif // _M_CEE
 }


### PR DESCRIPTION
This updates the pool for VS 2022 17.8 Preview 1, including August's Patch Tuesday.

We're not yet able to require 17.8 because the internal build is still starting with 17.6 (!). No changes to CMake/Ninja/Clang versions.

Update to PowerShell 7.3.6 when building the pool.

We're able to remove a couple of compiler bug workarounds:

* Remove workaround for VSO-1659408 "`/clr` `alignas` emits error C2711 "this function cannot be compiled as managed" instead of falling back to native codegen"
  + Validated internally.
  + One workaround had to be retained due to an apparently different bug that has now been revealed. I filed VSO-1867037 "`/clr` C++20 System.AccessViolationException with ranges uninitialized algorithms".
  + Two more workarounds had to be retained due to VSO-1659695 "`/clr` x86 runtime assertions/crashes with parallel algorithms".
* Remove workaround for VSO-1849458 "REPORTED: EDG mishandles `is_layout_compatible_v<const int[], int[]>`"
