### PR TITLE
`<future>` cleanups

### DIFF
--- a/stl/inc/future
+++ b/stl/inc/future
@@ -1258,12 +1258,13 @@ class packaged_task; // not defined
 template <class _Ret, class... _ArgTypes>
 class packaged_task<_Ret(_ArgTypes...)> {
     // class that defines an asynchronous provider that returns the result of a call to a function object
-public:
+private:
     using _Ptype              = typename _P_arg_type<_Ret>::type;
     using _MyPromiseType      = _Promise<_Ptype>;
     using _MyStateManagerType = _State_manager<_Ptype>;
     using _MyStateType        = _Packaged_state<_Ret(_ArgTypes...)>;
 
+public:
     packaged_task() = default;
 
     template <class _Fty2, enable_if_t<!is_same_v<_Remove_cvref_t<_Fty2>, packaged_task>, int> = 0>
@@ -1320,8 +1321,8 @@ public:
     }
 
     void reset() { // reset to newly constructed state
-        _MyStateManagerType& _State         = _MyPromise._Get_state_for_set();
-        _MyStateType* _MyState              = static_cast<_MyStateType*>(_State._Ptr());
+        _MyStateManagerType& _State = _MyPromise._Get_state_for_set();
+        _MyStateType* _MyState      = static_cast<_MyStateType*>(_State._Ptr());
         _MyPromiseType _New_promise(new _MyStateType(_MyState->_Get_fn()));
         _MyPromise._Get_state()._Abandon();
         _MyPromise._Swap(_New_promise);

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -1385,14 +1385,13 @@ void swap(packaged_task<_Ty>& _Left, packaged_task<_Ty>& _Right) noexcept {
 }
 
 template <class... _Types, size_t... _Indices>
-auto _Invoke_stored_explicit(tuple<_Types...>&& _Tuple, index_sequence<_Indices...>) -> decltype(_STD invoke(
-    _STD get<_Indices>(_STD move(_Tuple))...)) { // invoke() a tuple with explicit parameter ordering
+decltype(auto) _Invoke_stored_explicit(
+    tuple<_Types...>&& _Tuple, index_sequence<_Indices...>) { // invoke() a tuple with explicit parameter ordering
     return _STD invoke(_STD get<_Indices>(_STD move(_Tuple))...);
 }
 
 template <class... _Types>
-auto _Invoke_stored(tuple<_Types...>&& _Tuple)
-    -> decltype(_Invoke_stored_explicit(_STD move(_Tuple), index_sequence_for<_Types...>{})) { // invoke() a tuple
+decltype(auto) _Invoke_stored(tuple<_Types...>&& _Tuple) { // invoke() a tuple
     return _Invoke_stored_explicit(_STD move(_Tuple), index_sequence_for<_Types...>{});
 }
 
@@ -1419,7 +1418,7 @@ public:
     _Fake_no_copy_callable_adapter& operator=(const _Fake_no_copy_callable_adapter&) = delete;
     _Fake_no_copy_callable_adapter& operator=(_Fake_no_copy_callable_adapter&&)      = delete;
 
-    auto operator()() -> decltype(_Invoke_stored(_STD move(_STD declval<_Storaget&>()))) {
+    decltype(auto) operator()() {
         return _Invoke_stored(_STD move(_Storage));
     }
 

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -1372,7 +1372,7 @@ template <class... _Types>
 class _Fake_no_copy_callable_adapter {
     // async() is built on packaged_task internals which incorrectly use
     // std::function, which requires that things be copyable. We can't fix this in an
-    // update, so this adapter turns copies into terminate(). When VSO-153581 is
+    // update, so this adapter turns copies into abort(). When VSO-153581 is
     // fixed, remove this adapter.
 private:
     using _Storaget = tuple<decay_t<_Types>...>;

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -933,7 +933,7 @@ public:
 
     shared_future& operator=(const shared_future&) = default;
 
-    shared_future(future<_Ty>&& _Other) noexcept : _Mybase(_STD forward<_Mybase>(_Other)) {}
+    shared_future(future<_Ty>&& _Other) noexcept : _Mybase(static_cast<_Mybase&&>(_Other)) {}
 
     shared_future(shared_future&& _Other) noexcept : _Mybase(_STD move(_Other)) {}
 
@@ -958,7 +958,7 @@ public:
 
     shared_future& operator=(const shared_future&) = default;
 
-    shared_future(future<_Ty&>&& _Other) noexcept : _Mybase(_STD forward<_Mybase>(_Other)) {}
+    shared_future(future<_Ty&>&& _Other) noexcept : _Mybase(static_cast<_Mybase&&>(_Other)) {}
 
     shared_future(shared_future&& _Other) noexcept : _Mybase(_STD move(_Other)) {}
 
@@ -985,7 +985,7 @@ public:
 
     shared_future(shared_future&& _Other) noexcept : _Mybase(_STD move(_Other)) {}
 
-    shared_future(future<void>&& _Other) noexcept : _Mybase(_STD forward<_Mybase>(_Other)) {}
+    shared_future(future<void>&& _Other) noexcept : _Mybase(static_cast<_Mybase&&>(_Other)) {}
 
     shared_future& operator=(shared_future&&) = default;
 

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -1384,7 +1384,7 @@ public:
 
     [[noreturn]] _Fake_no_copy_callable_adapter(const _Fake_no_copy_callable_adapter& _Other)
         : _Storage(_STD move(_Other._Storage)) {
-        _CSTD abort(); // shouldn't be called, see GH-3888
+        _CSTD abort(); // shouldn't be called
     }
 
     _Fake_no_copy_callable_adapter(_Fake_no_copy_callable_adapter&& _Other)          = default;

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -498,7 +498,7 @@ public:
         _CATCH_END
     }
 
-    const function<_Ret(_ArgTypes...)>& _Get_fn() {
+    const auto& _Get_fn() const {
         return _Fn;
     }
 
@@ -542,7 +542,7 @@ public:
         _CATCH_END
     }
 
-    const function<_Ret&(_ArgTypes...)>& _Get_fn() {
+    const auto& _Get_fn() const {
         return _Fn;
     }
 
@@ -588,7 +588,7 @@ public:
         _CATCH_END
     }
 
-    const function<void(_ArgTypes...)>& _Get_fn() {
+    const auto& _Get_fn() const {
         return _Fn;
     }
 
@@ -1322,8 +1322,7 @@ public:
     void reset() { // reset to newly constructed state
         _MyStateManagerType& _State         = _MyPromise._Get_state_for_set();
         _MyStateType* _MyState              = static_cast<_MyStateType*>(_State._Ptr());
-        function<_Ret(_ArgTypes...)> _Fnarg = _MyState->_Get_fn();
-        _MyPromiseType _New_promise(new _MyStateType(_Fnarg));
+        _MyPromiseType _New_promise(new _MyStateType(_MyState->_Get_fn()));
         _MyPromise._Get_state()._Abandon();
         _MyPromise._Swap(_New_promise);
     }

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -470,15 +470,6 @@ public:
     using _Mydel  = typename _Mybase::_Mydel;
 
     template <class _Fty2>
-    _Packaged_state(const _Fty2& _Fnarg) : _Fn(_Fnarg) {}
-
-#if _HAS_FUNCTION_ALLOCATOR_SUPPORT
-    template <class _Fty2, class _Alloc>
-    _Packaged_state(const _Fty2& _Fnarg, const _Alloc& _Al, _Mydel* _Dp)
-        : _Mybase(_Dp), _Fn(allocator_arg, _Al, _Fnarg) {}
-#endif // _HAS_FUNCTION_ALLOCATOR_SUPPORT
-
-    template <class _Fty2>
     _Packaged_state(_Fty2&& _Fnarg) : _Fn(_STD forward<_Fty2>(_Fnarg)) {}
 
 #if _HAS_FUNCTION_ALLOCATOR_SUPPORT
@@ -523,15 +514,6 @@ public:
     using _Mydel  = typename _Mybase::_Mydel;
 
     template <class _Fty2>
-    _Packaged_state(const _Fty2& _Fnarg) : _Fn(_Fnarg) {}
-
-#if _HAS_FUNCTION_ALLOCATOR_SUPPORT
-    template <class _Fty2, class _Alloc>
-    _Packaged_state(const _Fty2& _Fnarg, const _Alloc& _Al, _Mydel* _Dp)
-        : _Mybase(_Dp), _Fn(allocator_arg, _Al, _Fnarg) {}
-#endif // _HAS_FUNCTION_ALLOCATOR_SUPPORT
-
-    template <class _Fty2>
     _Packaged_state(_Fty2&& _Fnarg) : _Fn(_STD forward<_Fty2>(_Fnarg)) {}
 
 #if _HAS_FUNCTION_ALLOCATOR_SUPPORT
@@ -574,15 +556,6 @@ class _Packaged_state<void(_ArgTypes...)>
 public:
     using _Mybase = _Associated_state<int>;
     using _Mydel  = typename _Mybase::_Mydel;
-
-    template <class _Fty2>
-    _Packaged_state(const _Fty2& _Fnarg) : _Fn(_Fnarg) {}
-
-#if _HAS_FUNCTION_ALLOCATOR_SUPPORT
-    template <class _Fty2, class _Alloc>
-    _Packaged_state(const _Fty2& _Fnarg, const _Alloc& _Al, _Mydel* _Dp)
-        : _Mybase(_Dp), _Fn(allocator_arg, _Al, _Fnarg) {}
-#endif // _HAS_FUNCTION_ALLOCATOR_SUPPORT
 
     template <class _Fty2>
     _Packaged_state(_Fty2&& _Fnarg) : _Fn(_STD forward<_Fty2>(_Fnarg)) {}


### PR DESCRIPTION
- replaces long trailing `decltype` return types with `decltype(auto)` in several places
- removes some redundant `_Packaged_state` constructors
- simplifies signatures of `_Packaged_state::_Get_fn`, and remove an extra copy construction around it
- makes some `using`s private in `packaged_task`
- removes some uncommon `forward` patterns
