### PR TITLE
Final `mdspan` test fixes

### DIFF
--- a/tests/std/tests/P0009R18_mdspan_extents/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_extents/test.cpp
@@ -426,7 +426,6 @@ constexpr void check_construction_from_array_and_span() {
         static_assert(!is_constructible_v<Ext, span<int, 1>>);
         static_assert(!is_constructible_v<Ext, span<int, 3>>);
         static_assert(!is_constructible_v<Ext, span<int>>);
-        static_assert(!is_constructible_v<Ext, span<int>>);
     }
 
     { // Check implicit conversions

--- a/tests/std/tests/P0009R18_mdspan_extents_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_extents_death/test.cpp
@@ -64,23 +64,22 @@ void test_construction_from_pack_with_unrepresentable_as_index_type_values_3() {
 void test_construction_from_span_with_invalid_values() {
     int vals[] = {1, 2};
     span s{vals};
-    // Value of other.extent(r) must be equal to extent(r) for each r for which extent(r) is a static extent
+    // Value of exts[r] must be equal to extent(r) for each r for which extent(r) is a static extent
     [[maybe_unused]] extents<int, 1, 1> e{s};
 }
 
 void test_construction_from_span_with_unrepresentable_as_index_type_values() {
-    int vals[] = {1, 2};
-    span s{vals};
-    // Value of other.extent(r) must be equal to extent(r) for each r for which extent(r) is a static extent
-    [[maybe_unused]] extents<int, 1, 1> e{s};
-}
-
-void test_construction_from_array_with_invalid_values() {
     int vals[] = {256};
     span s{vals};
     // Either N must be zero or exts[r] must be nonnegative and must be representable as value of type index_type for
     // every rank index r
     [[maybe_unused]] extents<unsigned char, dynamic_extent> e{s};
+}
+
+void test_construction_from_array_with_invalid_values() {
+    array a = {1, 2};
+    // Value of exts[r] must be equal to extent(r) for each r for which extent(r) is a static extent
+    [[maybe_unused]] extents<int, 1, 1> e{a};
 }
 
 void test_construction_from_array_with_unrepresentable_as_index_type_values() {

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -153,6 +153,8 @@ constexpr void check_members(const extents<IndexType, Extents...>& ext, index_se
     { // Check comparisons
         assert(m == m);
         assert(!(m != m));
+        static_assert(noexcept(m == m));
+        static_assert(noexcept(m != m));
         // Other tests are defined in 'check_comparisons' function
     }
 }

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -97,7 +97,7 @@ constexpr void check_members(const extents<IndexType, Extents...>& ext, index_se
             }
         }
 
-        layout_stride::mapping<Ext> m1{ext, span{strides}};
+        layout_stride::mapping<Ext> m1{ext, strides};
         Mapping m2{m1};
         assert(m1.extents() == m2.extents());
         // Other tests are defined in 'check_construction_from_other_stride_mapping' function

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -242,12 +242,10 @@ constexpr void check_construction_from_other_right_mapping() {
     }
 
     { // Check implicit conversions
-        static_assert(!NotImplicitlyConstructibleFrom<layout_left::mapping<extents<int, 3>>,
-                      layout_right::mapping<extents<int, 3>>>);
-        static_assert(NotImplicitlyConstructibleFrom<layout_left::mapping<extents<int, 3>>,
-            layout_right::mapping<extents<long long, 3>>>);
-        static_assert(NotImplicitlyConstructibleFrom<layout_left::mapping<extents<int, 3>>,
-            layout_right::mapping<extents<int, dynamic_extent>>>);
+        using Mapping = layout_left::mapping<extents<int, 3>>;
+        static_assert(!NotImplicitlyConstructibleFrom<Mapping, layout_right::mapping<extents<int, 3>>>);
+        static_assert(NotImplicitlyConstructibleFrom<Mapping, layout_right::mapping<extents<long long, 3>>>);
+        static_assert(NotImplicitlyConstructibleFrom<Mapping, layout_right::mapping<extents<int, dynamic_extent>>>);
     }
 
     { // Check effects

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -8,6 +8,7 @@
 #include <mdspan>
 #include <span>
 #include <type_traits>
+#include <utility>
 
 #include <test_mdspan_support.hpp>
 

--- a/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
@@ -152,6 +152,8 @@ constexpr void check_members(const extents<IndexType, Extents...>& ext, index_se
     { // Check comparisons
         assert(m == m);
         assert(!(m != m));
+        static_assert(noexcept(m == m));
+        static_assert(noexcept(m != m));
         // Other tests are defined in 'check_comparisons' function
     }
 }

--- a/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
@@ -211,6 +211,15 @@ constexpr void check_construction_from_other_right_mapping() {
         static_assert(NotImplicitlyConstructibleFrom<layout_right::mapping<extents<int, 3, 3>>,
             layout_right::mapping<extents<int, dynamic_extent, dynamic_extent>>>);
     }
+
+    { // Check effects
+        layout_right::mapping<extents<unsigned int, 6, 2, 6>> m1;
+        layout_right::mapping<dextents<unsigned short, 3>> m2{m1};
+        assert(m2.extents().extent(0) == 6);
+        assert(m2.extents().extent(1) == 2);
+        assert(m2.extents().extent(2) == 6);
+        assert(m1.extents() == m2.extents());
+    }
 }
 
 constexpr void check_construction_from_other_left_mapping() {
@@ -239,12 +248,9 @@ constexpr void check_construction_from_other_left_mapping() {
     }
 
     { // Check effects
-        layout_right::mapping<extents<unsigned int, 6, 2, 6>> m1;
-        layout_right::mapping<dextents<unsigned short, 3>> m2{m1};
-        assert(m2.extents().extent(0) == 6);
-        assert(m2.extents().extent(1) == 2);
-        assert(m2.extents().extent(2) == 6);
-        assert(m1.extents() == m2.extents());
+        layout_left::mapping<extents<int, 8>> m1;
+        layout_right::mapping<dextents<signed char, 1>> m2{m1};
+        assert(m2.extents().extent(0) == 8);
     }
 }
 

--- a/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
@@ -8,6 +8,7 @@
 #include <mdspan>
 #include <span>
 #include <type_traits>
+#include <utility>
 
 #include <test_mdspan_support.hpp>
 

--- a/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
@@ -35,8 +35,8 @@ struct NotLayoutMappingAlikeAtAll {
 
 static_assert(!_Layout_mapping_alike<NotLayoutMappingAlikeAtAll::mapping<extents<int, 4, 4>>>);
 
-enum class AlwaysUnique { no, yes };
-enum class AlwaysStrided { no, yes };
+enum class AlwaysUnique : bool { no, yes };
+enum class AlwaysStrided : bool { no, yes };
 
 template <AlwaysUnique Unique, AlwaysStrided Strided>
 struct LyingLayout {

--- a/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
@@ -378,8 +378,8 @@ constexpr void check_required_span_size() {
         using M1 = layout_stride::mapping<extents<int>>;
         static_assert(M1{}.required_span_size() == 1);
 
-        layout_stride::mapping<extents<int>> m2;
-        assert(m2.required_span_size() == 1);
+        M1 m1;
+        assert(m1.required_span_size() == 1);
     }
 
     { // Check N4950 [mdspan.layout.stride.expo]/1.2: size of the multidimensional index space e is 0

--- a/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
@@ -222,6 +222,8 @@ constexpr void do_check_members(const extents<IndexType, Extents...>& ext,
     { // Check comparisons
         assert(m == m);
         assert(!(m != m));
+        static_assert(noexcept(m == m));
+        static_assert(noexcept(m != m));
         // Other tests are defined in 'check_comparisons' function
     }
 }

--- a/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
@@ -63,7 +63,7 @@ struct LyingLayout {
         }
 
         static constexpr bool is_always_exhaustive() {
-            return layout_right::mapping<Extents>::is_always_exhaustive();
+            return layout_left::mapping<Extents>::is_always_exhaustive();
         }
 
         static constexpr bool is_always_strided() {

--- a/tests/std/tests/P0009R18_mdspan_layout_stride_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride_death/test.cpp
@@ -33,9 +33,9 @@ void test_construction_from_extents_and_array_2() {
 
 
 void test_construction_from_extents_and_span_1() {
-    array<int, 1> s{-1};
+    array<int, 1> a{-1};
     // Value of s[i] must be greater than 0 for all i in the range [0, rank_)
-    [[maybe_unused]] layout_stride::mapping<dextents<int, 1>> m{extents<int, 1>{}, span{s}};
+    [[maybe_unused]] layout_stride::mapping<dextents<int, 1>> m{extents<int, 1>{}, span{a}};
 }
 
 void test_construction_from_extents_and_span_2() {

--- a/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
@@ -37,27 +37,27 @@ public:
         return *this;
     }
 
-    constexpr int get_id() const noexcept {
+    [[nodiscard]] constexpr int get_id() const noexcept {
         return id;
     }
 
-    constexpr bool is_copy_constructed() const noexcept {
+    [[nodiscard]] constexpr bool is_copy_constructed() const noexcept {
         return copy_constructed;
     }
 
-    constexpr bool is_move_constructed() const noexcept {
+    [[nodiscard]] constexpr bool is_move_constructed() const noexcept {
         return move_constructed;
     }
 
-    constexpr bool is_copy_assigned() const noexcept {
+    [[nodiscard]] constexpr bool is_copy_assigned() const noexcept {
         return copy_assigned;
     }
 
-    constexpr bool is_move_assigned() const noexcept {
+    [[nodiscard]] constexpr bool is_move_assigned() const noexcept {
         return move_assigned;
     }
 
-    constexpr bool is_swapped() const noexcept {
+    [[nodiscard]] constexpr bool is_swapped() const noexcept {
         return swapped;
     }
 

--- a/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
@@ -1062,12 +1062,12 @@ constexpr void check_size() {
         assert(mds3.size() == 0);
     }
 
-    { // Mdspan with 'rank() == 0'
+    { // mdspan with 'rank() == 0'
         mdspan mds{some_data, extents<signed char>{}};
         assert(mds.size() == 1);
     }
 
-    { // Mdspan whose index space size would not be representable as index_type if 0 wasn't there
+    { // mdspan whose index space size would not be representable as index_type if 0 wasn't there
         mdspan mds1{some_data, extents<signed char, 127, 2, 0>{}};
         assert(mds1.size() == 0);
         mdspan mds2{some_data, dextents<short, 3>{32767, 3, 0}};
@@ -1106,12 +1106,12 @@ constexpr void check_empty() {
         assert(mds3.empty());
     }
 
-    { // Mdspan with 'rank() == 0'
+    { // mdspan with 'rank() == 0'
         mdspan mds{some_data, extents<signed char>{}};
         assert(!mds.empty());
     }
 
-    { // Mdspan whose index space size would not be representable as index_type if 0 wasn't there
+    { // mdspan whose index space size would not be representable as index_type if 0 wasn't there
         mdspan mds1{some_data, extents<signed char, 127, 2, 0>{}};
         assert(mds1.empty());
         mdspan mds2{some_data, dextents<short, 3>{32767, 3, 0}};

--- a/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
@@ -77,7 +77,7 @@ private:
     bool swapped          = false;
 };
 
-enum class RequireId { no, yes };
+enum class RequireId : bool { no, yes };
 
 template <class MpPolicy = layout_right, RequireId ReqId = RequireId::yes>
 struct TrackingLayout {


### PR DESCRIPTION
* Include `<utility>` for `make_index_sequence`.
* Use `bool` underlying types when we call `to_underlying()` later.
* `Mdspan` => `mdspan` in comments.
* Rename an `array` from `s` to `a`.
  + The nearby comment is intentionally unchanged.
* Mark `ActionTracker` observers as `[[nodiscard]]`.
* Use `M1` typedef. Rename `m2` => `m1` to avoid looking weird.
* Extract `Mapping` typedef, like the block immediately above, and the `layout_right` test.
* `LyingLayout` inherits from `layout_left::mapping<Extents>`; use that for `is_always_exhaustive()`.
* Drop repeated line; `span<int>` is inherently symmetry-breaking here.
* Construct `layout_stride::mapping` without an extra `span`, matching `P0009R18_mdspan_layout_right`.
* In `P0009R18_mdspan_layout_right`, `check_construction_from_other_right_mapping()` was missing "Check effects", while `check_construction_from_other_left_mapping()` was testing `layout_right::mapping` as the source.
* Test how comparisons are guaranteed to be `noexcept`.
* Fix tangled tests in P0009R18_mdspan_extents_death.
  + Fix comments for `test_construction_from_[span/array]_with_invalid_values()`: `other.extent(r)` => `exts[r]`
  + `test_construction_from_span_with_unrepresentable_as_index_type_values()` and `test_construction_from_array_with_invalid_values()` were tangled up.
