### PR TITLE
Fix `string::assign` and `::resize_and_overwrite` under ASan

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -4142,8 +4142,6 @@ public:
         }
     }
 
-#pragma warning(push)
-#pragma warning(disable : 4018) // '<=': signed/unsigned mismatch (we compare to 0 before _New_size below, so it's safe)
     template <class _Operation>
     constexpr void
 #if _HAS_CXX23
@@ -4162,16 +4160,16 @@ public:
             _Mypair._Myval2._Mysize = _New_size;
         }
 
-        auto _Arg_ptr           = _Mypair._Myval2._Myptr();
-        auto _Arg_size          = _New_size;
-        const auto _Result_size = _STD move(_Op)(_Arg_ptr, _Arg_size);
+        auto _Arg_ptr                   = _Mypair._Myval2._Myptr();
+        auto _Arg_size                  = _New_size;
+        const auto _Result_size         = _STD move(_Op)(_Arg_ptr, _Arg_size);
+        const auto _Result_as_size_type = static_cast<size_type>(_Result_size);
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Result_size >= 0, "the returned size can't be smaller than 0");
-        _STL_VERIFY(_Result_size <= _New_size, "the returned size can't be greater than the passed size");
+        _STL_VERIFY(_Result_as_size_type <= _New_size, "the returned size can't be greater than the passed size");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-        _Eos(static_cast<size_type>(_Result_size));
+        _Eos(_Result_as_size_type);
     }
-#pragma warning(pop)
 
 #if _HAS_CXX23
     template <class _Operation>

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -3371,7 +3371,7 @@ public:
         _In_reads_(_Count) const _Elem* const _Ptr, _CRT_GUARDOVERFLOW const size_type _Count) {
         // assign [_Ptr, _Ptr + _Count)
         if (_Count <= _Mypair._Myval2._Myres) {
-            _Elem* const _Old_ptr   = _Mypair._Myval2._Myptr();
+            _Elem* const _Old_ptr = _Mypair._Myval2._Myptr();
             _Traits::move(_Old_ptr, _Ptr, _Count);
             _Eos(_Count);
             return *this;

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -4157,6 +4157,9 @@ public:
                 [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size) {
                     _Traits::copy(_New_ptr, _Old_ptr, _Old_size + 1);
                 });
+        } else {
+            _ASAN_STRING_MODIFY(*this, _Mypair._Myval2._Mysize, _New_size);
+            _Mypair._Myval2._Mysize = _New_size;
         }
 
         auto _Arg_ptr           = _Mypair._Myval2._Myptr();

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -3371,9 +3371,12 @@ public:
         _In_reads_(_Count) const _Elem* const _Ptr, _CRT_GUARDOVERFLOW const size_type _Count) {
         // assign [_Ptr, _Ptr + _Count)
         if (_Count <= _Mypair._Myval2._Myres) {
-            _Elem* const _Old_ptr = _Mypair._Myval2._Myptr();
+            _ASAN_STRING_REMOVE(*this);
+            _Elem* const _Old_ptr   = _Mypair._Myval2._Myptr();
+            _Mypair._Myval2._Mysize = _Count;
             _Traits::move(_Old_ptr, _Ptr, _Count);
-            _Eos(_Count);
+            _Traits::assign(_Old_ptr[_Count], _Elem());
+            _ASAN_STRING_CREATE(*this);
             return *this;
         }
 

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -3371,11 +3371,9 @@ public:
         _In_reads_(_Count) const _Elem* const _Ptr, _CRT_GUARDOVERFLOW const size_type _Count) {
         // assign [_Ptr, _Ptr + _Count)
         if (_Count <= _Mypair._Myval2._Myres) {
-            _ASAN_STRING_MODIFY(*this, _Mypair._Myval2._Mysize, _Count);
             _Elem* const _Old_ptr   = _Mypair._Myval2._Myptr();
-            _Mypair._Myval2._Mysize = _Count;
             _Traits::move(_Old_ptr, _Ptr, _Count);
-            _Traits::assign(_Old_ptr[_Count], _Elem());
+            _Eos(_Count);
             return *this;
         }
 

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -1920,6 +1920,13 @@ void test_gh_3883() {
     assert(t == "AAAAAAA");
 }
 
+void test_gh_3955() {
+    // GH-3955 <xstring>: ASAN report container-overflow in a legal case
+    std::string s(19, '0');
+    s = &s[3];
+    assert(s == string(16, '0'));
+}
+
 int main() {
     run_allocator_matrix<char>();
 #ifdef __cpp_char8_t
@@ -1932,4 +1939,5 @@ int main() {
     test_DevCom_10116361();
     test_DevCom_10109507();
     test_gh_3883();
+    test_gh_3955();
 }

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -1925,6 +1925,10 @@ void test_gh_3955() {
     string s(19, '0');
     s = &s[3];
     assert(s == string(16, '0'));
+
+    string t(19, '0');
+    s = &t[0];
+    assert(s == t);
 }
 
 int main() {

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -1922,7 +1922,7 @@ void test_gh_3883() {
 
 void test_gh_3955() {
     // GH-3955 <xstring>: ASAN report container-overflow in a legal case
-    std::string s(19, '0');
+    string s(19, '0');
     s = &s[3];
     assert(s == string(16, '0'));
 }


### PR DESCRIPTION
Fixes #3955 / VSO-1854254 / AB#1854254 (fix string's self-assignment with offset via pointers under ASan)
Fixes VSO-1854245 / AB#1854245 "ASan issue in `basic_string::assign(pointer)`"
Fixes VSO-1854251 / AB#1854251 "ASan issue in `basic_string::assign(iterator, iterator)`"
Fixes VSO-1854242 / AB#1854242 "ASan issue in `tests/std/P0980R1_constexpr_strings` [`basic_string::resize_and_overwrite`]"

Drive-by: In `resize_and_overwrite`, compare the converted result size so we need not suppress the "comparing signed and unsigned" warning.

Test coverage for the latter three fixes will be in the ASan test coverage that's incoming in the near future.