### PR TITLE
Fix bad tr1/algorithm test cases

### DIFF
--- a/tests/tr1/tests/algorithm/test.cpp
+++ b/tests/tr1/tests/algorithm/test.cpp
@@ -105,8 +105,8 @@ void test_find(char* first, char* last) { // test searching template functions
     CHECK(STD is_permutation(first, last, p1, p1 + 7));
     CHECK(!STD is_permutation(first, last, p1, p1 + CSTD strlen(p1)));
     const char* p2 = "abcgfedxx";
-    CHECK(!STD is_permutation(first, last, p2 + 7));
-    CHECK(!STD is_permutation(first, last, p2 + CSTD strlen(p2)));
+    CHECK(!STD is_permutation(first, last, p2, p2 + 7));
+    CHECK(!STD is_permutation(first, last, p2, p2 + CSTD strlen(p2)));
 
     CHECK(STD is_permutation(first, last, first, last, &cmp_chars));
     const char* p3 = "aBCgfecxx";


### PR DESCRIPTION
These two `is_permutation(first, last, x)` calls violate the precondition that `[x, x + (last - first))` is a valid range.

Fixes VSO-1854237 / AB#1854237
