### PR TITLE
`<mdspan>`: Product code review

### DIFF
--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1045,12 +1045,12 @@ struct default_accessor {
         requires is_convertible_v<_OtherElementType (*)[], element_type (*)[]>
     constexpr default_accessor(default_accessor<_OtherElementType>) noexcept {}
 
-    _NODISCARD constexpr data_handle_type offset(data_handle_type _Ptr, size_t _Idx) const noexcept {
-        return _Ptr + _Idx;
-    }
-
     _NODISCARD constexpr reference access(data_handle_type _Ptr, size_t _Idx) const noexcept {
         return _Ptr[_Idx];
+    }
+
+    _NODISCARD constexpr data_handle_type offset(data_handle_type _Ptr, size_t _Idx) const noexcept {
+        return _Ptr + _Idx;
     }
 };
 

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1276,7 +1276,15 @@ public:
         noexcept(noexcept(_Access_impl(static_cast<index_type>(_STD move(_Indices))...))) /* strengthened */ {
         return _Access_impl(static_cast<index_type>(_STD move(_Indices))...);
     }
-#endif // __cpp_multidimensional_subscript
+#else // ^^^ defined(__cpp_multidimensional_subscript) / !defined(__cpp_multidimensional_subscript) vvv
+private:
+    template <class... _OtherIndexTypes>
+    _NODISCARD constexpr reference _Multidimensional_access(_OtherIndexTypes... _Indices) const {
+        return _Access_impl(static_cast<index_type>(_STD move(_Indices))...);
+    }
+
+public:
+#endif // ^^^ !defined(__cpp_multidimensional_subscript) ^^^
 
     template <class _OtherIndexType>
         requires is_convertible_v<const _OtherIndexType&, index_type>
@@ -1391,13 +1399,6 @@ public:
     }
 
 private:
-#ifndef __cpp_multidimensional_subscript // TRANSITION, P2128R6
-    template <class... _OtherIndexTypes>
-    _NODISCARD constexpr reference _Multidimensional_access(_OtherIndexTypes... _Indices) const {
-        return _Access_impl(static_cast<index_type>(_STD move(_Indices))...);
-    }
-#endif // ^^^ !defined(__cpp_multidimensional_subscript) ^^^
-
     template <class... _OtherIndexTypes>
     _NODISCARD constexpr reference _Access_impl(_OtherIndexTypes... _Indices) const
         noexcept(noexcept(this->_Acc.access(_Ptr, static_cast<size_t>(this->_Map(_Indices...))))) {

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1200,7 +1200,7 @@ public:
           _Ptr(_STD move(_Ptr_)) {}
 
     template <class _OtherIndexType, size_t _Size>
-        requires is_convertible_v<_OtherIndexType, index_type>
+        requires is_convertible_v<const _OtherIndexType&, index_type>
                   && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
                   && (_Size == rank() || _Size == rank_dynamic())
                   && is_constructible_v<mapping_type, extents_type> && is_default_constructible_v<accessor_type>

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -321,7 +321,7 @@ inline constexpr size_t _Repeat_dynamic_extent = dynamic_extent;
 
 template <class... _Integrals>
     requires (is_convertible_v<_Integrals, size_t> && ...)
-extents(_Integrals...) -> extents<size_t, _Repeat_dynamic_extent<_Integrals>...>;
+explicit extents(_Integrals...) -> extents<size_t, _Repeat_dynamic_extent<_Integrals>...>;
 
 template <class _IndexType, class _Indices>
 struct _Dextents_impl;

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1276,6 +1276,13 @@ public:
         noexcept(noexcept(_Access_impl(static_cast<index_type>(_STD move(_Indices))...))) /* strengthened */ {
         return _Access_impl(static_cast<index_type>(_STD move(_Indices))...);
     }
+
+private:
+    template <class _OtherIndexType, size_t... _Seq>
+    _NODISCARD constexpr reference _Multidimensional_subscript(
+        span<_OtherIndexType, rank()> _Indices, index_sequence<_Seq...>) const {
+        return operator[](_STD as_const(_Indices[_Seq])...);
+    }
 #else // ^^^ defined(__cpp_multidimensional_subscript) / !defined(__cpp_multidimensional_subscript) vvv
 private:
     template <class... _OtherIndexTypes>
@@ -1284,33 +1291,26 @@ private:
         return _Access_impl(static_cast<index_type>(_STD move(_Indices))...);
     }
 
-public:
+    template <class _OtherIndexType, size_t... _Seq>
+    _NODISCARD constexpr reference _Multidimensional_subscript(
+        span<_OtherIndexType, rank()> _Indices, index_sequence<_Seq...>) const {
+        return _Multidimensional_access(_STD as_const(_Indices[_Seq])...);
+    }
 #endif // ^^^ !defined(__cpp_multidimensional_subscript) ^^^
 
+public:
     template <class _OtherIndexType>
         requires is_convertible_v<const _OtherIndexType&, index_type>
               && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
     _NODISCARD constexpr reference operator[](span<_OtherIndexType, rank()> _Indices) const {
-        return [&]<size_t... _Seq>(index_sequence<_Seq...>) -> reference {
-#ifdef __cpp_multidimensional_subscript // TRANSITION, P2128R6
-            return operator[](_STD as_const(_Indices[_Seq])...);
-#else // ^^^ defined(__cpp_multidimensional_subscript) / !defined(__cpp_multidimensional_subscript) vvv
-            return _Multidimensional_access(_STD as_const(_Indices[_Seq])...);
-#endif // ^^^ !defined(__cpp_multidimensional_subscript) ^^^
-        }(make_index_sequence<rank()>{});
+        return _Multidimensional_subscript(_Indices, make_index_sequence<rank()>{});
     }
 
     template <class _OtherIndexType>
         requires is_convertible_v<const _OtherIndexType&, index_type>
               && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
     _NODISCARD constexpr reference operator[](const array<_OtherIndexType, rank()>& _Indices) const {
-        return [&]<size_t... _Seq>(index_sequence<_Seq...>) -> reference {
-#ifdef __cpp_multidimensional_subscript // TRANSITION, P2128R6
-            return operator[](_STD as_const(_Indices[_Seq])...);
-#else // ^^^ defined(__cpp_multidimensional_subscript) / !defined(__cpp_multidimensional_subscript) vvv
-            return _Multidimensional_access(_STD as_const(_Indices[_Seq])...);
-#endif // ^^^ !defined(__cpp_multidimensional_subscript) ^^^
-        }(make_index_sequence<rank()>{});
+        return _Multidimensional_subscript(span{_Indices}, make_index_sequence<rank()>{});
     }
 
     _NODISCARD constexpr size_type size() const noexcept {

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -304,7 +304,7 @@ public:
         }
     }
 
-    template <class... _IndexTypes, size_t... _Seq>
+    template <size_t... _Seq, class... _IndexTypes>
     _NODISCARD constexpr bool _Contains_multidimensional_index(
         index_sequence<_Seq...>, _IndexTypes... _Indices) const noexcept {
         _STL_INTERNAL_STATIC_ASSERT((same_as<_IndexTypes, index_type> && ...));

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1401,7 +1401,7 @@ private:
 
     template <class... _OtherIndexTypes>
     _NODISCARD constexpr reference _Access_impl(_OtherIndexTypes... _Indices) const
-        noexcept(noexcept(this->_Acc.access(_Ptr, static_cast<size_t>(this->_Map(_Indices...))))) /* strengthened */ {
+        noexcept(noexcept(this->_Acc.access(_Ptr, static_cast<size_t>(this->_Map(_Indices...))))) {
         _STL_INTERNAL_STATIC_ASSERT((same_as<_OtherIndexTypes, index_type> && ...));
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(this->_Map.extents()._Contains_multidimensional_index(make_index_sequence<rank()>{}, _Indices...),

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1279,7 +1279,8 @@ public:
 #else // ^^^ defined(__cpp_multidimensional_subscript) / !defined(__cpp_multidimensional_subscript) vvv
 private:
     template <class... _OtherIndexTypes>
-    _NODISCARD constexpr reference _Multidimensional_access(_OtherIndexTypes... _Indices) const {
+    _NODISCARD constexpr reference _Multidimensional_access(_OtherIndexTypes... _Indices) const
+        noexcept(noexcept(_Access_impl(static_cast<index_type>(_STD move(_Indices))...))) {
         return _Access_impl(static_cast<index_type>(_STD move(_Indices))...);
     }
 

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -532,7 +532,7 @@ public:
     template <class _OtherExtents>
         requires is_constructible_v<extents_type, _OtherExtents>
     constexpr explicit(extents_type::rank() > 0)
-        mapping(const layout_stride::template mapping<_OtherExtents>& _Other) noexcept // strengthened
+        mapping(const layout_stride::mapping<_OtherExtents>& _Other) noexcept // strengthened
         : _Base(_Other.extents()) {
 #if _CONTAINER_DEBUG_LEVEL > 0
         if constexpr (extents_type::rank() > 0) {
@@ -684,8 +684,7 @@ public:
 
     template <class _OtherExtents>
         requires is_constructible_v<extents_type, _OtherExtents>
-    constexpr explicit(extents_type::rank() > 0)
-        mapping(const layout_stride::template mapping<_OtherExtents>& _Other) noexcept
+    constexpr explicit(extents_type::rank() > 0) mapping(const layout_stride::mapping<_OtherExtents>& _Other) noexcept
         : _Base(_Other.extents()) {
 #if _CONTAINER_DEBUG_LEVEL > 0
         if constexpr (extents_type::rank() > 0) {

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1306,9 +1306,9 @@ public:
     _NODISCARD constexpr reference operator[](const array<_OtherIndexType, rank()>& _Indices) const {
         return [&]<size_t... _Seq>(index_sequence<_Seq...>) -> reference {
 #ifdef __cpp_multidimensional_subscript // TRANSITION, P2128R6
-            return operator[](_Indices[_Seq]...);
+            return operator[](_STD as_const(_Indices[_Seq])...);
 #else // ^^^ defined(__cpp_multidimensional_subscript) / !defined(__cpp_multidimensional_subscript) vvv
-            return _Multidimensional_access(_Indices[_Seq]...);
+            return _Multidimensional_access(_STD as_const(_Indices[_Seq])...);
 #endif // ^^^ !defined(__cpp_multidimensional_subscript) ^^^
         }(make_index_sequence<rank()>{});
     }

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1359,19 +1359,19 @@ public:
         return this->_Acc;
     }
 
-    _NODISCARD static constexpr bool is_always_unique() noexcept(
-        noexcept(mapping_type::is_always_unique())) /* strengthened */ {
-        return mapping_type::is_always_unique();
+    _NODISCARD static constexpr bool is_always_unique() noexcept /* strengthened */ {
+        constexpr bool _Result = mapping_type::is_always_unique();
+        return _Result;
     }
 
-    _NODISCARD static constexpr bool is_always_exhaustive() noexcept(
-        noexcept(mapping_type::is_always_exhaustive())) /* strengthened */ {
-        return mapping_type::is_always_exhaustive();
+    _NODISCARD static constexpr bool is_always_exhaustive() noexcept /* strengthened */ {
+        constexpr bool _Result = mapping_type::is_always_exhaustive();
+        return _Result;
     }
 
-    _NODISCARD static constexpr bool is_always_strided() noexcept(
-        noexcept(mapping_type::is_always_strided())) /* strengthened */ {
-        return mapping_type::is_always_strided();
+    _NODISCARD static constexpr bool is_always_strided() noexcept /* strengthened */ {
+        constexpr bool _Result = mapping_type::is_always_strided();
+        return _Result;
     }
 
     _NODISCARD constexpr bool is_unique() const noexcept(noexcept(this->_Map.is_unique())) /* strengthened */ {

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1279,8 +1279,8 @@ public:
 
 private:
     template <class _OtherIndexType, size_t... _Seq>
-    _NODISCARD constexpr reference _Multidimensional_subscript(
-        span<_OtherIndexType, rank()> _Indices, index_sequence<_Seq...>) const {
+    _NODISCARD constexpr reference _Multidimensional_subscript(span<_OtherIndexType, rank()> _Indices,
+        index_sequence<_Seq...>) const noexcept(noexcept(operator[](_STD as_const(_Indices[_Seq])...))) {
         return operator[](_STD as_const(_Indices[_Seq])...);
     }
 #else // ^^^ defined(__cpp_multidimensional_subscript) / !defined(__cpp_multidimensional_subscript) vvv
@@ -1292,8 +1292,8 @@ private:
     }
 
     template <class _OtherIndexType, size_t... _Seq>
-    _NODISCARD constexpr reference _Multidimensional_subscript(
-        span<_OtherIndexType, rank()> _Indices, index_sequence<_Seq...>) const {
+    _NODISCARD constexpr reference _Multidimensional_subscript(span<_OtherIndexType, rank()> _Indices,
+        index_sequence<_Seq...>) const noexcept(noexcept(_Multidimensional_access(_STD as_const(_Indices[_Seq])...))) {
         return _Multidimensional_access(_STD as_const(_Indices[_Seq])...);
     }
 #endif // ^^^ !defined(__cpp_multidimensional_subscript) ^^^
@@ -1302,14 +1302,18 @@ public:
     template <class _OtherIndexType>
         requires is_convertible_v<const _OtherIndexType&, index_type>
               && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
-    _NODISCARD constexpr reference operator[](span<_OtherIndexType, rank()> _Indices) const {
+    _NODISCARD constexpr reference operator[](span<_OtherIndexType, rank()> _Indices) const
+        noexcept(noexcept(_Multidimensional_subscript(_Indices, make_index_sequence<rank()>{}))) /* strengthened */
+    {
         return _Multidimensional_subscript(_Indices, make_index_sequence<rank()>{});
     }
 
     template <class _OtherIndexType>
         requires is_convertible_v<const _OtherIndexType&, index_type>
               && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
-    _NODISCARD constexpr reference operator[](const array<_OtherIndexType, rank()>& _Indices) const {
+    _NODISCARD constexpr reference operator[](const array<_OtherIndexType, rank()>& _Indices) const noexcept(
+        noexcept(_Multidimensional_subscript(span{_Indices}, make_index_sequence<rank()>{}))) /* strengthened */
+    {
         return _Multidimensional_subscript(span{_Indices}, make_index_sequence<rank()>{});
     }
 


### PR DESCRIPTION
* Unconditionally strengthen `mdspan::is_always_MEOW()`.
  + They return `mapping_type::is_always_MEOW()` which is required to be a constant expression of type `bool` (N4950 \[mdspan.mdspan.overview\]/3, \[mdspan.layout.policy.reqmts\]/1, \[mdspan.layout.reqmts\]/22,24,26). The Standard should simply be enhanced to say `noexcept` here.
  + Also introduce `constexpr bool _Result` to make this extra clear and improve debug codegen.
* Drop strengthened comment; `_Access_impl()` is `_Ugly`.
* Follow N4950 \[mdspan.mdspan.cons\]/8.1 by saying `const _OtherIndexType&` in this constraint.
* In `default_accessor`, define `access()` before `offset()` to follow the order of N4950 \[mdspan.accessor.default.overview\].
* `layout_stride::template mapping` is unnecessary; `layout_stride` is not a template.
* Add `explicit` to the deduction guide `extents(_Integrals...)`, depicted by N4950 \[mdspan.extents.overview\] and \[mdspan.extents.cons\]/12.
* Style: Reorder the template parameters for `_Contains_multidimensional_index()` to match its function parameters; it's always called with template argument deduction.
* Strengthen `operator[]` for `span`/`array`. Fine-grained commits for clarity:
  + Step 1: Move `_Multidimensional_access()` up.
  + Step 2: Add conditional `noexcept` to `_Multidimensional_access()`, not commented as strengthened because it's `_Ugly`.
    - It's now identical to the real multidimensional subscript operator except for the name, the comment, and the intentional lack of constraints.
  + Step 3: Add `as_const()` to the `array` overload, so it exactly matches the `span` overload.
    - This is what N4950 \[mdspan.mdspan.members\]/6 depicts. It was being implicitly skipped before (`const array&` has the same effect), but adding this will make the following unification clearer.
  + Step 4: Replace lambdas with `_Multidimensional_subscript()`.
    - This unifies them by wrapping the `array` in a `span`.
  + Step 5: Add conditional `noexcept` to `_Multidimensional_subscript` (not commented, it's `_Ugly`), then strengthen `operator[]` for `span`/`array`.
    - This brings the `span`/`array` subscript operators up to parity with the multidimensional subscript operator.
