### PR TITLE
Partially remove workaround for DevCom-1559808

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -8288,13 +8288,7 @@ namespace ranges {
                 }
 
                 // divide and conquer by quicksort
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-1559808
                 auto [_Mid_first, _Mid_last] = _Partition_by_median_guess_common(_First, _Last, _Pred, _Proj);
-#else // ^^^ no workaround / workaround vvv
-                auto _Mid       = _Partition_by_median_guess_common(_First, _Last, _Pred, _Proj);
-                auto _Mid_first = _Mid.begin();
-                auto _Mid_last  = _Mid.end();
-#endif // TRANSITION, DevCom-1559808
 
                 _Ideal = (_Ideal >> 1) + (_Ideal >> 2); // allow 1.5 log2(N) divisions
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -8288,7 +8288,13 @@ namespace ranges {
                 }
 
                 // divide and conquer by quicksort
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-1559808
                 auto [_Mid_first, _Mid_last] = _Partition_by_median_guess_common(_First, _Last, _Pred, _Proj);
+#else // ^^^ no workaround / workaround vvv
+                auto _Mid       = _Partition_by_median_guess_common(_First, _Last, _Pred, _Proj);
+                auto _Mid_first = _Mid.begin();
+                auto _Mid_last  = _Mid.end();
+#endif // TRANSITION, DevCom-1559808
 
                 _Ideal = (_Ideal >> 1) + (_Ideal >> 2); // allow 1.5 log2(N) divisions
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -8288,13 +8288,13 @@ namespace ranges {
                 }
 
                 // divide and conquer by quicksort
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-1559808
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10452846
                 auto [_Mid_first, _Mid_last] = _Partition_by_median_guess_common(_First, _Last, _Pred, _Proj);
 #else // ^^^ no workaround / workaround vvv
                 auto _Mid       = _Partition_by_median_guess_common(_First, _Last, _Pred, _Proj);
                 auto _Mid_first = _Mid.begin();
                 auto _Mid_last  = _Mid.end();
-#endif // TRANSITION, DevCom-1559808
+#endif // TRANSITION, DevCom-10452846
 
                 _Ideal = (_Ideal >> 1) + (_Ideal >> 2); // allow 1.5 log2(N) divisions
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -5102,13 +5102,7 @@ namespace ranges {
                     return *this;
                 }
 
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-1559808
                 auto [_Begin, _End] = _RANGES search(subrange{_Current, _Last}, _Parent->_Pattern);
-#else // ^^^ no workaround / workaround vvv
-                auto _Match = _RANGES search(subrange{_Current, _Last}, _Parent->_Pattern);
-                auto _Begin = _Match.begin();
-                auto _End   = _Match.end();
-#endif // TRANSITION, DevCom-1559808
                 if (_Begin != _Last && _RANGES empty(_Parent->_Pattern)) {
                     ++_Begin;
                     ++_End;
@@ -5154,13 +5148,7 @@ namespace ranges {
 
         constexpr subrange<iterator_t<_Vw>> _Find_next(iterator_t<_Vw> _It) {
             const auto _Last    = _RANGES end(_Range);
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-1559808
             auto [_Begin, _End] = _RANGES search(subrange{_It, _Last}, _Pattern);
-#else // ^^^ no workaround / workaround vvv
-            auto _Match = _RANGES search(subrange{_It, _Last}, _Pattern);
-            auto _Begin = _Match.begin();
-            auto _End   = _Match.end();
-#endif // TRANSITION, DevCom-1559808
             if (_Begin != _Last && _RANGES empty(_Pattern)) {
                 ++_Begin;
                 ++_End;

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -381,10 +381,6 @@ std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp:0 FAIL
 std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort.pass.cpp:0 FAIL
 std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort_comp.pass.cpp:0 FAIL
 
-# DevCom-1559808: (structured bindings for `subrange` in a constant expression)
-# Skipped as this sometimes emits "fatal error C1001: Internal compiler error." with a crash dialog.
-std/ranges/range.utility/range.subrange/structured_bindings.pass.cpp:0 SKIPPED
-
 # DevCom-1436243 constexpr new initialized array
 std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset_self.pass.cpp:0 FAIL
 std/utilities/smartptr/unique.ptr/unique.ptr.create/make_unique.array.pass.cpp:0 FAIL


### PR DESCRIPTION
Unblocks one libcxx test for MSVC.

I found that DevCom-1559808 is fixed during working on `_STD`-/`_RANGES`-qualifying _Ugly function names.
(And I've realized that structured bindings for `pair`/`subrange` involve ADL, so I'm planning changing the return type of `_Partition_by_median_guess_common` to something like `meow_result`).

Edit: I was wrong. DevCom-1559808 isn't totally fixed.

Edit: I've filed DevCom-10452846 "Customized structured binding of subrange that refers to dynamic buffer incorrectly causes constant evaluation failure" for the remain issue.