### PR TITLE
Fix `num_get`'s float-parsing problem

### DIFF
--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -1019,10 +1019,6 @@ private:
                 _Seendigit = true;
             }
 
-            if (_Seendigit) {
-                *_Ptr++ = '0'; // put one back
-            }
-
             for (size_t _Idx; _First != _Last && (_Idx = _STD _Find_elem(_Atoms, *_First)) < _Offset_dec_digit_end;
                  _Seendigit = true, (void) ++_First) {
                 if (_Exponent_part < PTRDIFF_MAX / 10

--- a/tests/std/tests/LWG2381_num_get_floating_point/test.cpp
+++ b/tests/std/tests/LWG2381_num_get_floating_point/test.cpp
@@ -532,6 +532,23 @@ void test_gh_3378() {
     }
 }
 
+// Also test GH-3980 <iostream>: Wrong reading of float values
+template <class Flt>
+void test_gh_3980() {
+    auto test_case = [](const char* str, double expected) {
+        Flt val = 0;
+        istringstream{str} >> val;
+        assert((ostringstream{} << val).str() == (ostringstream{} << expected).str());
+    };
+
+    test_case("0x1p+07", 0x1p+07);
+    test_case("1e+07", 1e+07);
+    test_case("1e+0", 1);
+    test_case("1e-0", 1);
+    test_case("1e-07", 1e-07);
+    test_case("0x1p-07", 0x1p-07);
+}
+
 #if _HAS_CXX17
 void test_float_from_char_cases() {
     for (const auto& test_case : float_from_chars_test_cases) {
@@ -588,6 +605,10 @@ int main() {
 
     test_gh_3378<double>();
     test_gh_3378<long double>();
+
+    test_gh_3980<float>();
+    test_gh_3980<double>();
+    test_gh_3980<long double>();
 
 #if _HAS_CXX17
     test_float_from_char_cases();


### PR DESCRIPTION
Fixes #3980 / DevCom-10450662 / VSO-1876474 / AB#1876474

Also fixes DevCom-10445082 / VSO-1873604 / AB#1873604.

Likely fixes VSO-1874745 / AB#1874745.

Likely fixes VSO-1876601 / AB#1876601.