### PR TITLE
Various bugfixes / enhancements for `<flat_set>`

### DIFF
--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -208,11 +208,21 @@ public:
     // modifiers
     template <class... _Args>
     auto emplace(_Args&&... _Vals) {
-        return _Emplace(_Kty{_STD forward<_Args>(_Vals)...});
+        constexpr bool _Is_key_type = _In_place_key_extract_set<_Kty, remove_cvref_t<_Args>...>::_Extractable;
+        if constexpr (_Is_key_type) {
+            return _Emplace(_STD forward<_Args>(_Vals)...);
+        } else {
+            return _Emplace(_Kty{_STD forward<_Args>(_Vals)...});
+        }
     }
     template <class... _Args>
     iterator emplace_hint(const_iterator _Hint, _Args&&... _Vals) {
-        return _Emplace_hint(_Hint, _Kty{_STD forward<_Args>(_Vals)...});
+        constexpr bool _Is_key_type = _In_place_key_extract_set<_Kty, remove_cvref_t<_Args>...>::_Extractable;
+        if constexpr (_Is_key_type) {
+            return _Emplace_hint(_Hint, _STD forward<_Args>(_Vals)...);
+        } else {
+            return _Emplace_hint(_Hint, _Kty{_STD forward<_Args>(_Vals)...});
+        }
     }
 
     auto insert(const value_type& _Val) {
@@ -435,12 +445,22 @@ private:
         const iterator _End   = end();
         const iterator _Where = lower_bound(_Val);
         if constexpr (_Multi) {
+            _STL_INTERNAL_STATIC_ASSERT(is_same_v<remove_cvref_t<_Ty>, _Kty>);
             return _Cont.emplace(_Where, _STD forward<_Ty>(_Val));
         } else {
             if (_Where != _End && _Keys_equal(*_Where, _Val)) {
                 return pair{_Where, false};
             }
-            return pair{_Cont.emplace(_Where, _STD forward<_Ty>(_Val)), true};
+            if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
+                return pair{_Cont.emplace(_Where, _STD forward<_Ty>(_Val)), true};
+            } else {
+                // flat_set::insert(auto&&)
+                _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
+                _Kty _Keyval{_STD forward<_Ty>(_Val)};
+                _STL_ASSERT(lower_bound(_Keyval) == _Where && !_Keys_equal(_Keyval, *_Where),
+                    "find(val) was not equal to find(key_type{forward(val)})");
+                return pair{_Cont.emplace(_Where, _STD move(_Keyval)), true};
+            }
         }
     }
 
@@ -468,12 +488,22 @@ private:
         }
 
         if constexpr (_Multi) {
+            _STL_INTERNAL_STATIC_ASSERT(is_same_v<remove_cvref_t<_Ty>, _Kty>);
             return _Cont.emplace(_Where, _STD forward<_Ty>(_Val));
         } else {
             if (_Where != _End && _Keys_equal(_Val, *_Where)) {
                 return _Cont.begin() + (_Where - _Begin);
             }
-            return _Cont.emplace(_Where, _STD forward<_Ty>(_Val));
+            if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
+                return _Cont.emplace(_Where, _STD forward<_Ty>(_Val));
+            } else {
+                // flat_set::insert(hint,auto&&)
+                _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
+                _Kty _Keyval{_STD forward<_Ty>(_Val)};
+                _STL_ASSERT(lower_bound(_Keyval) == _Where && !_Keys_equal(_Keyval, *_Where),
+                    "find(val) was not equal to find(key_type{forward(val)})");
+                return _Cont.emplace(_Where, _STD move(_Keyval));
+            }
         }
     }
 

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -612,7 +612,7 @@ private:
     using _Mybase = _Base_flat_set<_Kty, _Keylt, _Container, false, flat_set, sorted_unique_t>;
 
 public:
-    using _Mybase::_Base_flat_set;
+    using _Mybase::_Mybase;
     using _Mybase::operator=;
 };
 
@@ -623,7 +623,7 @@ private:
     using _Mybase = _Base_flat_set<_Kty, _Keylt, _Container, true, flat_multiset, sorted_equivalent_t>;
 
 public:
-    using _Mybase::_Base_flat_set;
+    using _Mybase::_Mybase;
     using _Mybase::operator=;
 };
 

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -247,9 +247,12 @@ public:
         _Restore_invariants_after_insert<false>(_Old_size);
     }
 
-    // TODO, missing
-    void insert(initializer_list<_Kty> _Ilist);
-    void insert(_Tsorted, initializer_list<_Kty> _Ilist);
+    void insert(initializer_list<_Kty> _Ilist) {
+        _Insert_range<false>(_Ilist.begin(), _Ilist.end());
+    }
+    void insert(_Tsorted, initializer_list<_Kty> _Ilist) {
+        _Insert_range<true>(_Ilist.begin(), _Ilist.end());
+    }
 
     _NODISCARD container_type extract() && {
         container_type& _Cont = _Get_cont();

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -111,11 +111,14 @@ public:
     _Base_flat_set(_Iter _First, _Iter _Last, const _Alloc& _Al) : _Base_flat_set(container_type(_First, _Last, _Al)) {}
 
     template <_Container_compatible_range<_Kty> _Rng>
-    _Base_flat_set(from_range_t, _Rng&& _Range, const key_compare& _Comp = key_compare())
-        : _Base_flat_set(container_type(from_range, _STD forward<_Rng>(_Range)), _Comp) {}
+    _Base_flat_set(from_range_t, _Rng&& _Range)
+        : _Base_flat_set(container_type(from_range, _STD forward<_Rng>(_Range))) {}
     template <_Container_compatible_range<_Kty> _Rng, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(from_range_t, _Rng&& _Range, const _Alloc& _Al)
         : _Base_flat_set(container_type(from_range, _STD forward<_Rng>(_Range), _Al)) {}
+    template <_Container_compatible_range<_Kty> _Rng>
+    _Base_flat_set(from_range_t, _Rng&& _Range, const key_compare& _Comp)
+        : _Base_flat_set(container_type(from_range, _STD forward<_Rng>(_Range)), _Comp) {}
     template <_Container_compatible_range<_Kty> _Rng, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(from_range_t, _Rng&& _Range, const key_compare& _Comp, const _Alloc& _Al)
         : _Base_flat_set(container_type(from_range, _STD forward<_Rng>(_Range), _Al), _Comp) {}
@@ -131,7 +134,7 @@ public:
         : _Base_flat_set(_Tsort, container_type(_First, _Last, _Al)) {}
 
     _Base_flat_set(initializer_list<_Kty> _Ilist, const key_compare& _Comp = key_compare())
-        : _Base_flat_set(_Ilist.begin(), _Ilist.end(), _Comp) {}
+        : _Base_flat_set(container_type(_Ilist.begin(), _Ilist.end()), _Comp) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(initializer_list<_Kty> _Ilist, const key_compare& _Comp, const _Alloc& _Al)
         : _Base_flat_set(container_type(_Ilist.begin(), _Ilist.end(), _Al), _Comp) {}
@@ -140,7 +143,7 @@ public:
         : _Base_flat_set(container_type(_Ilist.begin(), _Ilist.end(), _Al)) {}
 
     _Base_flat_set(_Tsorted _Tsort, initializer_list<_Kty> _Ilist, const key_compare& _Comp = key_compare())
-        : _Base_flat_set(_Tsort, _Ilist.begin(), _Ilist.end(), _Comp) {}
+        : _Base_flat_set(_Tsort, container_type(_Ilist.begin(), _Ilist.end()), _Comp) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Tsorted _Tsort, initializer_list<_Kty> _Ilist, const key_compare& _Comp, const _Alloc& _Al)
         : _Base_flat_set(_Tsort, container_type(_Ilist.begin(), _Ilist.end(), _Al), _Comp) {}
@@ -149,7 +152,7 @@ public:
         : _Base_flat_set(_Tsort, container_type(_Ilist.begin(), _Ilist.end(), _Al)) {}
 
     _Deriv& operator=(initializer_list<_Kty> _Ilist) {
-        _Get_cont() = container_type(_Ilist.begin(), _Ilist.end());
+        _Get_cont().assign(_Ilist.begin(), _Ilist.end());
         _Make_invariants_fulfilled();
         return static_cast<_Deriv&>(*this);
     }
@@ -621,7 +624,7 @@ private:
         _STD sort(_Begin_unsorted, _End, _Compare);
         _STD inplace_merge(begin(), _Begin_unsorted, _End, _Compare);
 
-        _STL_INTERNAL_CHECK(_STD is_sorted(begin(), end(), _Compare));
+        _STL_INTERNAL_CHECK(_STD is_sorted(_Begin, _End, _Compare));
 
         _Erase_dupes_if_needed();
     }

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -147,6 +147,7 @@ public:
         return static_cast<_Deriv&>(*this);
     }
 
+    // iterators
     _NODISCARD iterator begin() noexcept {
         return _Get_cont().begin();
     }
@@ -159,6 +160,7 @@ public:
     _NODISCARD const_iterator end() const noexcept {
         return _Get_cont().end();
     }
+
     _NODISCARD reverse_iterator rbegin() noexcept {
         return _Get_cont().rbegin();
     }
@@ -171,6 +173,7 @@ public:
     _NODISCARD const_reverse_iterator rend() const noexcept {
         return _Get_cont().rend();
     }
+
     _NODISCARD const_iterator cbegin() const noexcept {
         return _Get_cont().cbegin();
     }
@@ -184,6 +187,7 @@ public:
         return _Get_cont().crend();
     }
 
+    // capacity
     _NODISCARD_EMPTY_MEMBER bool empty() const noexcept {
         return _Get_cont().empty();
     }
@@ -194,11 +198,11 @@ public:
         return _Get_cont().max_size();
     }
 
+    // modifiers
     template <class... _Args>
     auto emplace(_Args&&... _Vals) {
         insert<_Kty>(_Kty{_STD forward<_Args>(_Vals)...});
     }
-
     template <class... _Args>
     iterator emplace_hint(const_iterator _Hint, _Args&&... _Vals) {
         return _Emplace_hint(_Hint, _Kty{_STD forward<_Args>(_Vals)...});
@@ -210,17 +214,10 @@ public:
     auto insert(value_type&& _Val) {
         return _Insert(_STD move(_Val));
     }
-
     template <class _Other>
         requires (!_Multi && _Keylt_transparent && is_constructible_v<_Kty, _Other>)
     auto insert(_Other&& _Val) {
         return _Insert(_STD forward<_Other>(_Val));
-    }
-
-    template <class _Other>
-        requires (!_Multi && _Keylt_transparent && is_constructible_v<_Kty, _Other>)
-    iterator insert(const_iterator _Hint, _Other&& _Val) {
-        return _Emplace_hint(_Hint, _STD forward<_Other>(_Val));
     }
 
     iterator insert(const_iterator _Hint, const value_type& _Val) {
@@ -229,23 +226,30 @@ public:
     iterator insert(const_iterator _Hint, value_type&& _Val) {
         return _Emplace_hint(_Hint, _STD move(_Val));
     }
+    template <class _Other>
+        requires (!_Multi && _Keylt_transparent && is_constructible_v<_Kty, _Other>)
+    iterator insert(const_iterator _Hint, _Other&& _Val) {
+        return _Emplace_hint(_Hint, _STD forward<_Other>(_Val));
+    }
 
     template <input_iterator _Iter>
     void insert(const _Iter& _First, const _Iter& _Last) {
         _Insert_range<false>(_First, _Last);
     }
-
     template <input_iterator _Iter>
     void insert(_Tsorted, _Iter _First, _Iter _Last) {
         _Insert_range<true>(_First, _Last);
     }
-
     template <_Container_compatible_range<_Kty> _Rng>
     void insert_range(_Rng&& _Range) {
         const size_type _Old_size = size();
         _Get_cont().append_range(_STD forward<_Rng>(_Range));
         _Restore_invariants_after_insert<false>(_Old_size);
     }
+
+    // TODO, missing
+    void insert(initializer_list<_Kty> _Ilist);
+    void insert(_Tsorted, initializer_list<_Kty> _Ilist);
 
     _NODISCARD container_type extract() && {
         container_type& _Cont = _Get_cont();
@@ -254,7 +258,6 @@ public:
         container_type _Temp = _STD move(_Cont);
         return _Temp;
     }
-
     void replace(container_type&& _Cont) {
         _Get_cont() = _STD move(_Cont);
         _Assert_after_sorted_input();
@@ -269,13 +272,11 @@ public:
     size_type erase(const _Kty& _Val) {
         return _Erase(_Val);
     }
-
     template <class _Other>
         requires _Keylt_transparent
     size_type erase(_Other&& _Val) {
         return _Erase(_STD forward<_Other>(_Val));
     }
-
     iterator erase(const_iterator _First, const_iterator _Last) {
         return _Get_cont().erase(_First, _Last);
     }
@@ -284,11 +285,11 @@ public:
         _RANGES swap(_Get_comp(), _Other._Get_comp());
         _RANGES swap(_Get_cont(), _Other._Get_cont());
     }
-
     void clear() noexcept {
         _Get_cont().clear();
     }
 
+    // observers
     _NODISCARD key_compare key_comp() const {
         return _Get_comp();
     }
@@ -296,20 +297,18 @@ public:
         return _Get_comp();
     }
 
+    // set operations
     _NODISCARD iterator find(const _Kty& _Val) {
         return _Find(_Val);
     }
-
     _NODISCARD const_iterator find(const _Kty& _Val) const {
         return _Find(_Val);
     }
-
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD iterator find(const _Other& _Val) {
         return _Find(_Val);
     }
-
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD const_iterator find(const _Other& _Val) const {
@@ -320,7 +319,6 @@ public:
         const auto [_First, _Last] = equal_range(_Val);
         return _STD distance(_First, _Last);
     }
-
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD size_type count(const _Other& _Val) const {
@@ -336,19 +334,18 @@ public:
     _NODISCARD bool contains(const _Other& _Val) const {
         return find(_Val) != end();
     }
+
     _NODISCARD iterator lower_bound(const _Kty& _Val) {
         return _STD lower_bound(begin(), end(), _Val, _Get_comp());
     }
     _NODISCARD const_iterator lower_bound(const _Kty& _Val) const {
         return _STD lower_bound(cbegin(), cend(), _Val, _Get_comp());
     }
-
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD iterator lower_bound(const _Other& _Val) {
         return _STD lower_bound(begin(), end(), _Val, _Get_comp());
     }
-
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD const_iterator lower_bound(const _Other& _Val) const {
@@ -358,17 +355,14 @@ public:
     _NODISCARD iterator upper_bound(const _Kty& _Val) {
         return _STD upper_bound(begin(), end(), _Val, _Get_comp());
     }
-
     _NODISCARD const_iterator upper_bound(const _Kty& _Val) const {
         return _STD upper_bound(cbegin(), cend(), _Val, _Get_comp());
     }
-
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD iterator upper_bound(const _Other& _Val) {
         return _STD upper_bound(begin(), end(), _Val, _Get_comp());
     }
-
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD const_iterator upper_bound(const _Other& _Val) const {
@@ -378,17 +372,14 @@ public:
     _NODISCARD pair<iterator, iterator> equal_range(const _Kty& _Val) {
         return _STD equal_range(begin(), end(), _Val, _Get_comp());
     }
-
     _NODISCARD pair<const_iterator, const_iterator> equal_range(const _Kty& _Val) const {
         return _STD equal_range(cbegin(), cend(), _Val, _Get_comp());
     }
-
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD pair<iterator, iterator> equal_range(const _Other& _Val) {
         return _STD equal_range(begin(), end(), _Val, _Get_comp());
     }
-
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD pair<const_iterator, const_iterator> equal_range(const _Other& _Val) const {
@@ -421,7 +412,7 @@ private:
             return true;
         }
         const const_iterator _End = cend();
-        const_iterator _It  = cbegin();
+        const_iterator _It        = cbegin();
         while (++_It != _End) {
             if (_Keys_equal(*(_It - 1), *_It)) {
                 return false;

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -513,8 +513,8 @@ private:
     template <class _Other>
         requires _Keylt_transparent || is_same_v<_Other, _Kty>
     _NODISCARD const_iterator _Find(const _Other& _Val) const {
-        const iterator _End   = end();
-        const iterator _Where = lower_bound(_Val);
+        const const_iterator _End   = end();
+        const const_iterator _Where = lower_bound(_Val);
         if (_Where != _End && _Keys_equal(*_Where, _Val)) {
             return _Where;
         } else {

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -201,7 +201,7 @@ public:
     // modifiers
     template <class... _Args>
     auto emplace(_Args&&... _Vals) {
-        insert<_Kty>(_Kty{_STD forward<_Args>(_Vals)...});
+        _Emplace(_Kty{_STD forward<_Args>(_Vals)...});
     }
     template <class... _Args>
     iterator emplace_hint(const_iterator _Hint, _Args&&... _Vals) {
@@ -209,15 +209,15 @@ public:
     }
 
     auto insert(const value_type& _Val) {
-        return _Insert<_Kty>(_Val);
+        return _Emplace(_Val);
     }
     auto insert(value_type&& _Val) {
-        return _Insert(_STD move(_Val));
+        return _Emplace(_STD move(_Val));
     }
     template <class _Other>
         requires (!_Multi && _Keylt_transparent && is_constructible_v<_Kty, _Other>)
     auto insert(_Other&& _Val) {
-        return _Insert(_STD forward<_Other>(_Val));
+        return _Emplace(_STD forward<_Other>(_Val));
     }
 
     iterator insert(const_iterator _Hint, const value_type& _Val) {
@@ -425,7 +425,6 @@ private:
     }
 
     template <class _Ty>
-        requires (_Keylt_transparent && is_constructible_v<_Kty, _Ty>) || is_same_v<_Ty, _Kty>
     iterator _Emplace_hint(const_iterator _Where, _Ty&& _Val) {
         _Container& _Cont           = _Get_cont();
         _Keylt& _Compare            = _Get_comp();
@@ -467,8 +466,7 @@ private:
     }
 
     template <class _Ty>
-        requires (!_Multi && _Keylt_transparent && is_constructible_v<_Kty, _Ty>) || is_same_v<_Ty, _Kty>
-    auto _Insert(_Ty&& _Val) {
+    auto _Emplace(_Ty&& _Val) {
         _Container& _Cont     = _Get_cont();
         const iterator _End   = end();
         const iterator _Where = lower_bound(_Val);

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -208,7 +208,7 @@ public:
     // modifiers
     template <class... _Args>
     auto emplace(_Args&&... _Vals) {
-        _Emplace(_Kty{_STD forward<_Args>(_Vals)...});
+        return _Emplace(_Kty{_STD forward<_Args>(_Vals)...});
     }
     template <class... _Args>
     iterator emplace_hint(const_iterator _Hint, _Args&&... _Vals) {
@@ -430,9 +430,24 @@ private:
     }
 
     template <class _Ty>
+    auto _Emplace(_Ty&& _Val) {
+        _Container& _Cont     = _Get_cont();
+        const iterator _End   = end();
+        const iterator _Where = lower_bound(_Val);
+        if constexpr (_Multi) {
+            return _Cont.emplace(_Where, _STD forward<_Ty>(_Val));
+        } else {
+            if (_Where != _End && _Keys_equal(*_Where, _Val)) {
+                return pair{_Where, false};
+            }
+            return pair{_Cont.emplace(_Where, _STD forward<_Ty>(_Val)), true};
+        }
+    }
+
+    template <class _Ty>
     iterator _Emplace_hint(const_iterator _Where, _Ty&& _Val) {
         _Container& _Cont           = _Get_cont();
-        _Keylt& _Compare            = _Get_comp();
+        const key_compare& _Compare = _Get_comp();
         const const_iterator _Begin = cbegin();
         const const_iterator _End   = cend();
 
@@ -453,12 +468,12 @@ private:
         }
 
         if constexpr (_Multi) {
-            return _Cont.insert(_Where, _STD forward<_Ty>(_Val));
+            return _Cont.emplace(_Where, _STD forward<_Ty>(_Val));
         } else {
-            if (_Where == _End || !_Keys_equal(_Val, *_Where)) {
-                return _Cont.insert(_Where, _STD forward<_Ty>(_Val));
+            if (_Where != _End && _Keys_equal(_Val, *_Where)) {
+                return _Cont.begin() + (_Where - _Begin);
             }
-            return _Cont.begin() + (_Where - _Begin);
+            return _Cont.emplace(_Where, _STD forward<_Ty>(_Val));
         }
     }
 
@@ -468,21 +483,6 @@ private:
         _Container& _Cont         = _Get_cont();
         _Cont.insert(_Cont.end(), _First, _Last);
         _Restore_invariants_after_insert<_Presorted>(_Old_size);
-    }
-
-    template <class _Ty>
-    auto _Emplace(_Ty&& _Val) {
-        _Container& _Cont     = _Get_cont();
-        const iterator _End   = end();
-        const iterator _Where = lower_bound(_Val);
-        if constexpr (_Multi) {
-            return _Cont.emplace(_Where, _STD forward<_Ty>(_Val));
-        } else {
-            if (_Where != _End && _Keys_equal(*_Where, _Val)) {
-                return pair{_Where, false};
-            }
-            return pair{_Cont.emplace(_Where, _STD forward<_Ty>(_Val)), true};
-        }
     }
 
     template <class _Ty>
@@ -539,9 +539,9 @@ private:
 
     template <bool _Presorted>
     void _Restore_invariants_after_insert(const size_type _Old_size) {
-        key_compare& _Compare   = _Get_comp();
-        const iterator _Old_end = begin() + static_cast<difference_type>(_Old_size);
-        const iterator _New_end = end();
+        const key_compare& _Compare = _Get_comp();
+        const iterator _Old_end     = begin() + static_cast<difference_type>(_Old_size);
+        const iterator _New_end     = end();
 
         if constexpr (!_Presorted) {
             _STD sort(_Old_end, _New_end, _Compare);
@@ -565,7 +565,7 @@ private:
         }
 
         // O(N) if already sorted.
-        key_compare& _Compare          = _Get_comp();
+        const key_compare& _Compare    = _Get_comp();
         const iterator _Begin_unsorted = _STD is_sorted_until(_Begin, _End, _Compare);
 
         _STD sort(_Begin_unsorted, _End, _Compare);

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -97,9 +97,9 @@ public:
 
     explicit _Base_flat_set(const key_compare& _Comp) : _My_pair(_One_then_variadic_args_t{}, _Comp) {}
     template <_Allocator_for<container_type> _Alloc>
-    _Base_flat_set(const key_compare& _Comp, const _Alloc& _Al) : _Base_flat_set(_Comp, container_type(_Al)) {}
+    _Base_flat_set(const key_compare& _Comp, const _Alloc& _Al) : _My_pair(_One_then_variadic_args_t{}, _Comp, _Al) {}
     template <_Allocator_for<container_type> _Alloc>
-    explicit _Base_flat_set(const _Alloc& _Al) : _Base_flat_set(container_type(_Al)) {}
+    explicit _Base_flat_set(const _Alloc& _Al) : _My_pair(_Zero_then_variadic_args_t{}, _Al) {}
 
     template <input_iterator _Iter>
     _Base_flat_set(_Iter _First, _Iter _Last, const key_compare& _Comp = key_compare())
@@ -424,7 +424,7 @@ private:
     void _Assert_after_sorted_input() const {
         _STL_ASSERT(_STD is_sorted(cbegin(), cend(), _Get_comp()), "Input was not sorted!");
         if constexpr (!_Multi) {
-            _STL_ASSERT(_Is_unique(), "Input was not unique!");
+            _STL_ASSERT(_Is_unique(), "Input was sorted but not unique!");
         }
     }
 

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -330,12 +330,12 @@ public:
     }
 
     _NODISCARD bool contains(const _Kty& _Val) const {
-        return find(_Val) != end();
+        return _STD binary_search(cbegin(), cend(), _Val, _Get_comp());
     }
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD bool contains(const _Other& _Val) const {
-        return find(_Val) != end();
+        return _STD binary_search(cbegin(), cend(), _Val, _Get_comp());
     }
 
     _NODISCARD iterator lower_bound(const _Kty& _Val) {

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -410,7 +410,7 @@ public:
 
 private:
     void _Assert_after_sorted_input() const {
-        _STL_ASSERT(_STD is_sorted(begin(), end(), _Get_comp()), "Input was not sorted!");
+        _STL_ASSERT(_STD is_sorted(cbegin(), cend(), _Get_comp()), "Input was not sorted!");
         if constexpr (!_Multi) {
             _STL_ASSERT(_Is_unique(), "Input was not unique!");
         }
@@ -420,8 +420,8 @@ private:
         if (empty()) {
             return true;
         }
-        const_iterator _End = cend();
-        const_iterator _It  = begin();
+        const const_iterator _End = cend();
+        const_iterator _It  = cbegin();
         while (++_It != _End) {
             if (_Keys_equal(*(_It - 1), *_It)) {
                 return false;
@@ -513,7 +513,7 @@ private:
     template <class _Other>
         requires _Keylt_transparent || is_same_v<_Other, _Kty>
     _NODISCARD const_iterator _Find(const _Other& _Val) const {
-        const const_iterator _End   = end();
+        const const_iterator _End   = cend();
         const const_iterator _Where = lower_bound(_Val);
         if (_Where != _End && _Keys_equal(*_Where, _Val)) {
             return _Where;
@@ -541,12 +541,11 @@ private:
 
     void _Erase_dupes_if_needed() {
         if constexpr (!_Multi) {
-            iterator _End = end();
-            iterator _New_end =
+            const iterator _End = end();
+            const iterator _New_end =
                 _STD unique(begin(), _End, [&](const _Kty& _Lhs, const _Kty& _Rhs) { return _Keys_equal(_Lhs, _Rhs); });
             _Get_cont().erase(_New_end, _End);
-        }
-        if constexpr (!_Multi) {
+
             _STL_INTERNAL_CHECK(_Is_unique());
         }
     }

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -58,10 +58,10 @@ public:
     static_assert(random_access_iterator<iterator>, "The C++ Standard forbids containers without random "
                                                     "access iterators from being adapted. See [flatset.overview].");
 
-    _Base_flat_set() : _My_pair(_Zero_then_variadic_args_t{}, _Keylt()) {}
+    _Base_flat_set() : _My_pair(_Zero_then_variadic_args_t{}) {}
 
     explicit _Base_flat_set(container_type _Cont, const key_compare& _Comp = key_compare())
-        : _My_pair(_One_then_variadic_args_t{}, _STD move(_Cont), _Comp) {
+        : _My_pair(_One_then_variadic_args_t{}, _Comp, _STD move(_Cont)) {
         _Make_invariants_fulfilled();
     }
     template <_Allocator_for<container_type> _Alloc>
@@ -71,7 +71,7 @@ public:
         : _Base_flat_set(container_type(_Cont, _Al), _Comp) {}
 
     _Base_flat_set(_Tsorted, container_type _Cont, const key_compare& _Comp = key_compare())
-        : _My_pair(_One_then_variadic_args_t{}, _STD move(_Cont), _Comp) {
+        : _My_pair(_One_then_variadic_args_t{}, _Comp, _STD move(_Cont)) {
         _Assert_after_sorted_input();
     }
     template <_Allocator_for<container_type> _Alloc>
@@ -81,7 +81,7 @@ public:
     _Base_flat_set(_Tsorted _Tsort, const container_type& _Cont, const key_compare& _Comp, const _Alloc& _Al)
         : _Base_flat_set(_Tsort, container_type(_Cont, _Al), _Comp) {}
 
-    explicit _Base_flat_set(const key_compare& _Comp) : _My_pair(_Zero_then_variadic_args_t{}, _Comp) {}
+    explicit _Base_flat_set(const key_compare& _Comp) : _My_pair(_One_then_variadic_args_t{}, _Comp) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(const key_compare& _Comp, const _Alloc& _Al) : _Base_flat_set(_Comp, container_type(_Al)) {}
     template <_Allocator_for<container_type> _Alloc>
@@ -578,22 +578,22 @@ private:
     }
 
     _NODISCARD const _Container& _Get_cont() const noexcept {
-        return _My_pair._Get_first();
+        return _My_pair._Myval2;
     }
 
     _NODISCARD _Container& _Get_cont() noexcept {
-        return _My_pair._Get_first();
+        return _My_pair._Myval2;
     }
 
     _NODISCARD const key_compare& _Get_comp() const noexcept {
-        return _My_pair._Myval2;
+        return _My_pair._Get_first();
     }
 
     _NODISCARD key_compare& _Get_comp() noexcept {
-        return _My_pair._Myval2;
+        return _My_pair._Get_first();
     }
 
-    _Compressed_pair<container_type, key_compare> _My_pair;
+    _Compressed_pair<key_compare, container_type> _My_pair;
 };
 
 _EXPORT_STD struct sorted_unique_t {

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -432,11 +432,11 @@ private:
 
     template <class _Ty>
         requires (_Keylt_transparent && is_constructible_v<_Kty, _Ty>) || is_same_v<_Ty, _Kty>
-    void _Emplace_hint(const_iterator _Where, _Ty&& _Val) {
-        _Container& _Cont     = _Get_cont();
-        _Keylt& _Compare      = _Get_comp();
-        const iterator _Begin = begin();
-        const iterator _End   = end();
+    iterator _Emplace_hint(const_iterator _Where, _Ty&& _Val) {
+        _Container& _Cont           = _Get_cont();
+        _Keylt& _Compare            = _Get_comp();
+        const const_iterator _Begin = cbegin();
+        const const_iterator _End   = cend();
 
         if (_Where == _End || !_Compare(*_Where, _Val)) {
             // _Val <= *_Where
@@ -460,7 +460,7 @@ private:
             if (_Where == _End || !_Keys_equal(_Val, *_Where)) {
                 return _Cont.insert(_Where, _STD forward<_Ty>(_Val));
             }
-            return _Where;
+            return _Cont.begin() + (_Where - _Begin);
         }
     }
 

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -471,20 +471,40 @@ private:
         const const_iterator _Begin = cbegin();
         const const_iterator _End   = cend();
 
-        if (_Where == _End || !_Compare(*_Where, _Val)) {
-            // _Val <= *_Where
-            // Left of _Where
-            if (_Where == _Begin || !_Compare(_Val, *(_Where - 1))) {
-                // _Val >= (*_Where - 1)
-                // Insert before _Where
+        if constexpr (_Multi) {
+            // Find upper_bound for flat_multiset
+            if (_Where == _End || _Compare(_Val, *_Where)) {
+                // _Val < *_Where
+                if (_Where == _Begin || !_Compare(_Val, *(_Where - 1))) {
+                    // _Val >= *(_Where-1)
+                    // upper_bound is _Where
+                } else {
+                    // _Val < *(_Where-1)
+                    // upper_bound is in [_Begin,_Where-1]
+                    _Where = _STD upper_bound(_Begin, _Where - 1, _Val);
+                }
             } else {
-                // _Val < (*_Where - 1)
-                _Where = _STD upper_bound(_Begin, _Where, _Val, _Compare);
+                // _Val >= *_Where
+                // upper_bound is in [_Where+1,_End]
+                _Where = _STD upper_bound(_Where + 1, _End, _Val);
             }
         } else {
-            // _Val > *_Where
-            // Right of _Where
-            _Where = _STD lower_bound(_Where + 1, _End, _Val, _Compare);
+            // Find lower_bound for flat_set
+            if (_Where == _End || !_Compare(*_Where, _Val)) {
+                // _Val <= *_Where
+                if (_Where == _Begin || _Compare(*(_Where - 1), _Val)) {
+                    // _Val > *(_Where-1)
+                    // lower_bound is _Where
+                } else {
+                    // _Val <= *(_Where-1)
+                    // lower_bound is in [_Begin,_Where-1]
+                    _Where = _STD lower_bound(_Begin, _Where - 1, _Val);
+                }
+            } else {
+                // _Val > *_Where
+                // lower_bound is in [_Where+1,_End]
+                _Where = _STD lower_bound(_Where + 1, _End, _Val);
+            }
         }
 
         if constexpr (_Multi) {

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -441,13 +441,13 @@ private:
 
     template <class _Ty>
     auto _Emplace(_Ty&& _Val) {
-        _Container& _Cont     = _Get_cont();
-        const iterator _End   = end();
-        const iterator _Where = lower_bound(_Val);
+        _Container& _Cont = _Get_cont();
         if constexpr (_Multi) {
             _STL_INTERNAL_STATIC_ASSERT(is_same_v<remove_cvref_t<_Ty>, _Kty>);
-            return _Cont.emplace(_Where, _STD forward<_Ty>(_Val));
+            return _Cont.emplace(upper_bound(_Val), _STD forward<_Ty>(_Val));
         } else {
+            const iterator _End   = end();
+            const iterator _Where = lower_bound(_Val);
             if (_Where != _End && _Keys_equal(*_Where, _Val)) {
                 return pair{_Where, false};
             }

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -607,15 +607,21 @@ _EXPORT_STD inline constexpr sorted_equivalent_t sorted_equivalent{};
 _EXPORT_STD template <class _Kty, class _Keylt = less<_Kty>, class _Container = vector<_Kty>>
 class flat_set
     : public _Base_flat_set<_Kty, _Keylt, _Container, false, flat_set<_Kty, _Keylt, _Container>, sorted_unique_t> {
+private:
+    using _Mybase = _Base_flat_set<_Kty, _Keylt, _Container, false, flat_set, sorted_unique_t>;
 public:
-    using _Base_flat_set<_Kty, _Keylt, _Container, false, flat_set, sorted_unique_t>::_Base_flat_set;
+    using _Mybase::_Base_flat_set;
+    using _Mybase::operator=;
 };
 
 _EXPORT_STD template <class _Kty, class _Keylt = less<_Kty>, class _Container = vector<_Kty>>
 class flat_multiset : public _Base_flat_set<_Kty, _Keylt, _Container, true, flat_multiset<_Kty, _Keylt, _Container>,
-                          sorted_equivalent_t> {
+    sorted_equivalent_t> {
+private:
+    using _Mybase = _Base_flat_set<_Kty, _Keylt, _Container, true, flat_multiset, sorted_equivalent_t>;
 public:
-    using _Base_flat_set<_Kty, _Keylt, _Container, true, flat_multiset, sorted_equivalent_t>::_Base_flat_set;
+    using _Mybase::_Base_flat_set;
+    using _Mybase::operator=;
 };
 
 _EXPORT_STD template <class _Kty, class _Keylt, class _Container, class _Pred>

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -16,6 +16,13 @@ _EMIT_STL_WARNING(STL4038, "The contents of <flat_set> are available only with C
 #include <vector>
 #include <xutility>
 
+#pragma pack(push, _CRT_PACKING)
+#pragma warning(push, _STL_WARNING_LEVEL)
+#pragma warning(disable : _STL_DISABLED_WARNINGS)
+_STL_DISABLE_CLANG_WARNINGS
+#pragma push_macro("new")
+#undef new
+
 _STD_BEGIN
 
 template <class _Ty>
@@ -718,6 +725,11 @@ template <class _Kty, class _Keylt = less<_Kty>>
 flat_multiset(sorted_equivalent_t, initializer_list<_Kty>, _Keylt = _Keylt()) -> flat_multiset<_Kty, _Keylt>;
 
 _STD_END
+
+#pragma pop_macro("new")
+_STL_RESTORE_CLANG_WARNINGS
+#pragma warning(pop)
+#pragma pack(pop)
 
 #endif // ^^^ supported language mode ^^^
 #endif // _STL_COMPILER_PREPROCESSOR

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -255,11 +255,9 @@ public:
     }
 
     _NODISCARD container_type extract() && {
-        container_type& _Cont = _Get_cont();
         // always clears the container (N4950 [flat.set.modifiers]/14 and [flat.multiset.modifiers]/10)
         _Clear_scope_guard<_Base_flat_set> _Guard{this};
-        container_type _Temp = _STD move(_Cont);
-        return _Temp;
+        return _STD move(_Get_cont());
     }
     void replace(container_type&& _Cont) {
         _Get_cont() = _STD move(_Cont);
@@ -390,7 +388,7 @@ public:
     }
 
     _NODISCARD friend bool operator==(const _Deriv& _Lhs, const _Deriv& _Rhs) {
-        return _RANGES equal(_Lhs, _Rhs);
+        return _RANGES equal(_Lhs._Get_cont(), _Rhs._Get_cont());
     }
 
     _NODISCARD friend _Synth_three_way_result<_Kty> operator<=>(const _Deriv& _Lhs, const _Deriv& _Rhs) {
@@ -521,16 +519,6 @@ private:
         return !_Compare(_Lhs, _Rhs) && !_Compare(_Rhs, _Lhs);
     }
 
-    // O(N) if already sorted.
-    void _Sort_potentially_sorted(const iterator& _Begin, const iterator& _End) {
-        key_compare& _Compare          = _Get_comp();
-        const iterator _Begin_unsorted = _STD is_sorted_until(_Begin, _End, _Compare);
-
-        _STD sort(_Begin_unsorted, _End, _Compare);
-
-        _STD inplace_merge(begin(), _Begin_unsorted, _End, _Compare);
-    }
-
     void _Erase_dupes_if_needed() {
         if constexpr (!_Multi) {
             const iterator _End = end();
@@ -569,7 +557,13 @@ private:
             return;
         }
 
-        _Sort_potentially_sorted(_Begin, _End);
+        // O(N) if already sorted.
+        key_compare& _Compare          = _Get_comp();
+        const iterator _Begin_unsorted = _STD is_sorted_until(_Begin, _End, _Compare);
+
+        _STD sort(_Begin_unsorted, _End, _Compare);
+        _STD inplace_merge(begin(), _Begin_unsorted, _End, _Compare);
+
         _STL_INTERNAL_CHECK(_STD is_sorted(begin(), end(), _Get_comp()));
 
         _Erase_dupes_if_needed();
@@ -609,6 +603,7 @@ class flat_set
     : public _Base_flat_set<_Kty, _Keylt, _Container, false, flat_set<_Kty, _Keylt, _Container>, sorted_unique_t> {
 private:
     using _Mybase = _Base_flat_set<_Kty, _Keylt, _Container, false, flat_set, sorted_unique_t>;
+
 public:
     using _Mybase::_Base_flat_set;
     using _Mybase::operator=;
@@ -616,9 +611,10 @@ public:
 
 _EXPORT_STD template <class _Kty, class _Keylt = less<_Kty>, class _Container = vector<_Kty>>
 class flat_multiset : public _Base_flat_set<_Kty, _Keylt, _Container, true, flat_multiset<_Kty, _Keylt, _Container>,
-    sorted_equivalent_t> {
+                          sorted_equivalent_t> {
 private:
     using _Mybase = _Base_flat_set<_Kty, _Keylt, _Container, true, flat_multiset, sorted_equivalent_t>;
+
 public:
     using _Mybase::_Base_flat_set;
     using _Mybase::operator=;

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -233,7 +233,7 @@ public:
     }
 
     template <input_iterator _Iter>
-    void insert(const _Iter& _First, const _Iter& _Last) {
+    void insert(_Iter _First, _Iter _Last) {
         _Insert_range<false>(_First, _Last);
     }
     template <input_iterator _Iter>
@@ -456,7 +456,7 @@ private:
     }
 
     template <bool _Presorted, class _Iter>
-    void _Insert_range(_Iter _First, _Iter _Last) {
+    void _Insert_range(const _Iter _First, const _Iter _Last) {
         const size_type _Old_size = size();
         _Container& _Cont         = _Get_cont();
         _Cont.insert(_Cont.end(), _First, _Last);
@@ -531,7 +531,7 @@ private:
     }
 
     template <bool _Presorted>
-    void _Restore_invariants_after_insert(const size_type& _Old_size) {
+    void _Restore_invariants_after_insert(const size_type _Old_size) {
         key_compare& _Compare   = _Get_comp();
         const iterator _Old_end = begin() + static_cast<difference_type>(_Old_size);
         const iterator _New_end = end();
@@ -544,7 +544,7 @@ private:
 
         _STD inplace_merge(begin(), _Old_end, _New_end, _Compare);
 
-        _STL_INTERNAL_CHECK(_STD is_sorted(begin(), end(), _Get_comp()));
+        _STL_INTERNAL_CHECK(_STD is_sorted(begin(), end(), _Compare));
 
         _Erase_dupes_if_needed();
     }
@@ -564,7 +564,7 @@ private:
         _STD sort(_Begin_unsorted, _End, _Compare);
         _STD inplace_merge(begin(), _Begin_unsorted, _End, _Compare);
 
-        _STL_INTERNAL_CHECK(_STD is_sorted(begin(), end(), _Get_comp()));
+        _STL_INTERNAL_CHECK(_STD is_sorted(begin(), end(), _Compare));
 
         _Erase_dupes_if_needed();
     }

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -67,6 +67,13 @@ public:
 
     _Base_flat_set() : _My_pair(_Zero_then_variadic_args_t{}) {}
 
+    template <_Allocator_for<container_type> _Alloc>
+    _Base_flat_set(const _Deriv& _Set, const _Alloc& _Al)
+        : _My_pair(_One_then_variadic_args_t{}, _Set._Get_comp(), _Set._Get_cont(), _Al) {}
+    template <_Allocator_for<container_type> _Alloc>
+    _Base_flat_set(_Deriv&& _Set, const _Alloc& _Al)
+        : _My_pair(_One_then_variadic_args_t{}, _STD move(_Set._Get_comp()), _STD move(_Set._Get_cont()), _Al) {}
+
     explicit _Base_flat_set(container_type _Cont, const key_compare& _Comp = key_compare())
         : _My_pair(_One_then_variadic_args_t{}, _Comp, _STD move(_Cont)) {
         _Make_invariants_fulfilled();

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -156,7 +156,7 @@ void test_insert() {
         assert_all_requirements_and_equals(a, {0, 1, 2, 5, 8, 9});
         a.insert_range(_dat);
         assert_all_requirements_and_equals(a, {0, 1, 2, 5, 8, 9});
-        a.insert({3, 6});
+        a.insert({6, 3});
         assert_all_requirements_and_equals(a, {0, 1, 2, 3, 5, 6, 8, 9});
         a.insert(sorted_unique, {4, 5, 7});
         assert_all_requirements_and_equals(a, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
@@ -182,7 +182,7 @@ void test_insert() {
         assert_all_requirements_and_equals(b, {0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 5, 5, 8, 9});
         b.insert_range(_dat);
         assert_all_requirements_and_equals(b, {0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 5, 5, 8, 9});
-        b.insert({3, 6});
+        b.insert({6, 3});
         assert_all_requirements_and_equals(b, {0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 5, 5, 6, 8, 9});
         b.insert(sorted_equivalent, {4, 5, 7});
         assert_all_requirements_and_equals(b, {0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 4, 5, 5, 5, 6, 7, 8, 9});

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -129,7 +129,7 @@ void test_constructors() {
 }
 
 template <class C>
-void test_insert() {
+void test_insert_1() {
     using lt = std::less<int>;
 
     const int _dat[]{0, 1, 2};
@@ -138,54 +138,77 @@ void test_insert() {
     {
         flat_set<int, lt, C> a{5, 5};
         assert_all_requirements_and_equals(a, {5});
-        a.emplace(0);
+        a.emplace();
         assert_all_requirements_and_equals(a, {0, 5});
-        a.emplace_hint(a.end(), 8);
-        assert_all_requirements_and_equals(a, {0, 5, 8});
+        a.emplace(1);
+        assert_all_requirements_and_equals(a, {0, 1, 5});
         a.insert(_dat[2]);
-        assert_all_requirements_and_equals(a, {0, 2, 5, 8});
+        assert_all_requirements_and_equals(a, {0, 1, 2, 5});
         a.insert(2);
-        assert_all_requirements_and_equals(a, {0, 2, 5, 8});
-        a.insert(a.begin(), _dat[1]);
-        assert_all_requirements_and_equals(a, {0, 1, 2, 5, 8});
-        a.insert(a.begin(), 9);
-        assert_all_requirements_and_equals(a, {0, 1, 2, 5, 8, 9});
+        assert_all_requirements_and_equals(a, {0, 1, 2, 5});
         a.insert(_beg, _end);
-        assert_all_requirements_and_equals(a, {0, 1, 2, 5, 8, 9});
+        assert_all_requirements_and_equals(a, {0, 1, 2, 5});
         a.insert(sorted_unique, _beg, _end);
-        assert_all_requirements_and_equals(a, {0, 1, 2, 5, 8, 9});
+        assert_all_requirements_and_equals(a, {0, 1, 2, 5});
         a.insert_range(_dat);
-        assert_all_requirements_and_equals(a, {0, 1, 2, 5, 8, 9});
-        a.insert({6, 3});
-        assert_all_requirements_and_equals(a, {0, 1, 2, 3, 5, 6, 8, 9});
-        a.insert(sorted_unique, {4, 5, 7});
-        assert_all_requirements_and_equals(a, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+        assert_all_requirements_and_equals(a, {0, 1, 2, 5});
+        a.insert({6, 2, 3});
+        assert_all_requirements_and_equals(a, {0, 1, 2, 3, 5, 6});
+        a.insert(sorted_unique, {4, 5});
+        assert_all_requirements_and_equals(a, {0, 1, 2, 3, 4, 5, 6});
     }
     {
-        flat_multiset<int, lt, C> b{5, 5};
-        assert_all_requirements_and_equals(b, {5, 5});
-        b.emplace(0);
-        assert_all_requirements_and_equals(b, {0, 5, 5});
-        b.emplace_hint(b.end(), 8);
-        assert_all_requirements_and_equals(b, {0, 5, 5, 8});
-        b.insert(_dat[2]);
-        assert_all_requirements_and_equals(b, {0, 2, 5, 5, 8});
-        b.insert(2);
-        assert_all_requirements_and_equals(b, {0, 2, 2, 5, 5, 8});
-        b.insert(b.begin(), _dat[1]);
-        assert_all_requirements_and_equals(b, {0, 1, 2, 2, 5, 5, 8});
-        b.insert(b.begin(), 9);
-        assert_all_requirements_and_equals(b, {0, 1, 2, 2, 5, 5, 8, 9});
-        b.insert(_beg, _end);
-        assert_all_requirements_and_equals(b, {0, 0, 1, 1, 2, 2, 2, 5, 5, 8, 9});
-        b.insert(sorted_equivalent, _beg, _end);
-        assert_all_requirements_and_equals(b, {0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 5, 5, 8, 9});
-        b.insert_range(_dat);
-        assert_all_requirements_and_equals(b, {0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 5, 5, 8, 9});
-        b.insert({6, 3});
-        assert_all_requirements_and_equals(b, {0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 5, 5, 6, 8, 9});
-        b.insert(sorted_equivalent, {4, 5, 7});
-        assert_all_requirements_and_equals(b, {0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 4, 5, 5, 5, 6, 7, 8, 9});
+        flat_multiset<int, lt, C> a{5, 5};
+        assert_all_requirements_and_equals(a, {5, 5});
+        a.emplace();
+        assert_all_requirements_and_equals(a, {0, 5, 5});
+        a.emplace(1);
+        assert_all_requirements_and_equals(a, {0, 1, 5, 5});
+        a.insert(_dat[2]);
+        assert_all_requirements_and_equals(a, {0, 1, 2, 5, 5});
+        a.insert(2);
+        assert_all_requirements_and_equals(a, {0, 1, 2, 2, 5, 5});
+        a.insert(_beg, _end);
+        assert_all_requirements_and_equals(a, {0, 0, 1, 1, 2, 2, 2, 5, 5});
+        a.insert(sorted_equivalent, _beg, _end);
+        assert_all_requirements_and_equals(a, {0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 5, 5});
+        a.insert_range(_dat);
+        assert_all_requirements_and_equals(a, {0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 5, 5});
+        a.insert({6, 2, 3});
+        assert_all_requirements_and_equals(a, {0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 5, 5, 6});
+        a.insert(sorted_equivalent, {4, 5});
+        assert_all_requirements_and_equals(a, {0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 4, 5, 5, 5, 6});
+    }
+}
+
+template <class C>
+void test_insert_2() {
+    using lt = std::less<int>;
+
+    const int _dat[]{0, 1, 2};
+    {
+        flat_set<int, lt, C> a{0, 5};
+        assert_all_requirements_and_equals(a, {0, 5});
+        a.emplace_hint(a.end());
+        assert_all_requirements_and_equals(a, {0, 5});
+        a.emplace_hint(a.end(), 0);
+        assert_all_requirements_and_equals(a, {0, 5});
+        a.insert(a.begin(), 6);
+        assert_all_requirements_and_equals(a, {0, 5, 6});
+        a.insert(a.begin(), _dat[1]);
+        assert_all_requirements_and_equals(a, {0, 1, 5, 6});
+    }
+    {
+        flat_multiset<int, lt, C> a{0, 5};
+        assert_all_requirements_and_equals(a, {0, 5});
+        a.emplace_hint(a.end());
+        assert_all_requirements_and_equals(a, {0, 0, 5});
+        a.emplace_hint(a.end(), 0);
+        assert_all_requirements_and_equals(a, {0, 0, 0, 5});
+        a.insert(a.begin(), 6);
+        assert_all_requirements_and_equals(a, {0, 0, 0, 5, 6});
+        a.insert(a.begin(), _dat[1]);
+        assert_all_requirements_and_equals(a, {0, 0, 0, 1, 5, 6});
     }
 }
 
@@ -290,8 +313,12 @@ int main() {
     test_constructors<deque<int>>();
 
     test_ebco();
-    test_insert<vector<int>>();
-    test_insert<deque<int>>();
+
+    test_insert_1<vector<int>>();
+    test_insert_1<deque<int>>();
+    test_insert_2<vector<int>>();
+    test_insert_2<deque<int>>();
+
     test_non_static_comparer();
 
     test_extract<flat_set<int>>();


### PR DESCRIPTION
`This pr is becoming large and hard to review, I'm going to replace this pr with a new one with all commits re-grouped when it is finished.`

This pr contains a lot of bugfixes/enhancements for `<flat_set>`:

About each commit:
- `1st`: Fix usage of `_Compressed_pair`. `_Compressed_pair` tries to compress its first member, but the implementation was erroneously trying to compress the container instead of `key_compare`.
- `2nd`: Add `#pragma pack(push, _CRT_PACKING)` etc.
- `3rd`: (This turns out to be merely a nitpick. see [this comment](https://github.com/microsoft/STL/pull/3985#discussion_r1302665643).)
- `4th`: `_Emplace_hint` should return `iterator` instead of `void`, and `const_iterator _Where` may be not be convertible to `iterator`. (As to `const const_iterator _Begin = cbegin(); const const_iterator _End   = cend();`, they are enhancements to match with `_Where`.)
- `5th`: Nitpicks to enhance constness.
- `6th`: Regroup/reorder non-constructor methods to match with the standard. `insert(initializer_list)` is found missing.
- `7th`: Implement `insert(initializer_list)`.
- `8th`: Improve implementation of `contains` by using `binary_search`.
- `9th`: Fix `insert` methods. Especially, `insert(const _Kty&)` was broken before this commit.
- `10th`: `operator=(initializer_list)` was not observable from `flat_set/multiset`. `flat_set/multiset` should `using _Mybase::operator=;`. (this turns out to be problematic; fixed by 14th commit)
- `11th`: Various cleanups.
- `12th`: `insert(const iter&, const iter&)` should be `insert(iter, iter)`
- `13th` : Implement LWG-3884 (`*flat_foo is missing allocator-extended copy/move constructors*`), as applied in N4958.
- `14th`: Fix 10th commit. Add tests for insertion methods, the new constructor and ebco optimization; `test_insert` is a general test covering commit `4, 7, 9 and 12`.
- `15th`: `emplace` forgot to return the result of `_Emplace`; use `const key_compare&` for comparision consistently; some other nitpicks.
- `16th`: `emplace` and `emplace_hint` should not construct temporary for `key_type` (so that a `key_type&&` will not be `move`d away if insertion fails); try to add debug check for `flat_set::insert([hint,]auto&&)`.
- `17th`: For conformance and efficiency, `flat_multiset::emplace` should use `upper_bound` instead of `lower_bound`.
- `18th`: Fix incorrect bound-finding behavior of `emplace_hint` (`flat_set` should always look for `lower_bound`); update test.

Works towards https://github.com/microsoft/STL/issues/2912.