### PR TITLE
Don't violate preconditions in tr1/regex3

### DIFF
--- a/tests/tr1/tests/regex3/test.cpp
+++ b/tests/tr1/tests/regex3/test.cpp
@@ -389,12 +389,12 @@ static void test_capturegroups() {
 static void test_iterators() { // needs refining after ++ fixed
     const CHR* pat = T("ax");
     MyIter::regex_type rx(T("a"));
-    MyIter iter(pat, pat + xlen(pat) + 10, rx);
+    MyIter iter(pat, pat + xlen(pat), rx);
     CHECKSTR(iter->str().c_str(), T("a"));
     STD match_results<bidit> mr = *iter;
     CHECK_INT(mr.position(0), 0);
     CHECK_INT(mr.length(0), 1);
-    MyTokIter toIter(pat, pat + xlen(pat) + 10, rx);
+    MyTokIter toIter(pat, pat + xlen(pat), rx);
     CHECKSTR(toIter->str().c_str(), T("a"));
     toIter++;
 #if NO_EXCEPTIONS


### PR DESCRIPTION
This test constructs a `regex_iterator` and a `regex_token_iterator` with invalid character ranges. The first occurrence is benign - the test never directs the library to examine the bogus part of the range - but the second case ventures into the land of pure undefined behavior. Caught by ASan.

Fixes VSO-1854241 / AB#1854241
