### PR TITLE
Tell `P0881R7_stacktrace` that we `HAS_DEBUG_INFO`

### DIFF
--- a/tests/std/tests/P0881R7_stacktrace/test.cpp
+++ b/tests/std/tests/P0881R7_stacktrace/test.cpp
@@ -156,6 +156,11 @@ string to_string_using_to_string(const stacktrace& st) {
     return to_string(st) + "\n";
 }
 
+#if !defined(HAS_DEBUG_INFO) && defined(__SANITIZE_ADDRESS__)
+// We always use /Zi with /fsanitize=address
+#define HAS_DEBUG_INFO 1
+#endif // ^^^ !defined(HAS_DEBUG_INFO) && defined(__SANITIZE_ADDRESS__) ^^^
+
 #if defined(HAS_DEBUG_INFO) || defined(HAS_EXPORT)
 #define HAS_NAMES
 #endif // ^^^ defined(HAS_DEBUG_INFO) || defined(HAS_EXPORT) ^^^


### PR DESCRIPTION
... when building with ASan enabled.

Fixes VSO-1854234 / AB#1854234