### PR TITLE
Various bugfixes / enhancements for `<flat_set>`

### DIFF
--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -211,31 +211,33 @@ public:
     // modifiers
     template <class... _Args>
     auto emplace(_Args&&... _Vals) {
-        insert<_Kty>(_Kty{_STD forward<_Args>(_Vals)...});
+        constexpr bool _Is_key_type = _In_place_key_extract_set<_Kty, remove_cvref_t<_Args>...>::_Extractable;
+        if constexpr (_Is_key_type) {
+            return _Emplace(_STD forward<_Args>(_Vals)...);
+        } else {
+            return _Emplace(_Kty{_STD forward<_Args>(_Vals)...});
+        }
     }
-
     template <class... _Args>
     iterator emplace_hint(const_iterator _Hint, _Args&&... _Vals) {
-        return _Emplace_hint(_Hint, _Kty{_STD forward<_Args>(_Vals)...});
+        constexpr bool _Is_key_type = _In_place_key_extract_set<_Kty, remove_cvref_t<_Args>...>::_Extractable;
+        if constexpr (_Is_key_type) {
+            return _Emplace_hint(_Hint, _STD forward<_Args>(_Vals)...);
+        } else {
+            return _Emplace_hint(_Hint, _Kty{_STD forward<_Args>(_Vals)...});
+        }
     }
 
     auto insert(const value_type& _Val) {
-        return _Insert<_Kty>(_Val);
+        return _Emplace(_Val);
     }
     auto insert(value_type&& _Val) {
-        return _Insert(_STD move(_Val));
+        return _Emplace(_STD move(_Val));
     }
-
     template <class _Other>
         requires (!_Multi && _Keylt_transparent && is_constructible_v<_Kty, _Other>)
     auto insert(_Other&& _Val) {
-        return _Insert(_STD forward<_Other>(_Val));
-    }
-
-    template <class _Other>
-        requires (!_Multi && _Keylt_transparent && is_constructible_v<_Kty, _Other>)
-    iterator insert(const_iterator _Hint, _Other&& _Val) {
-        return _Emplace_hint(_Hint, _STD forward<_Other>(_Val));
+        return _Emplace(_STD forward<_Other>(_Val));
     }
 
     iterator insert(const_iterator _Hint, const value_type& _Val) {
@@ -244,22 +246,32 @@ public:
     iterator insert(const_iterator _Hint, value_type&& _Val) {
         return _Emplace_hint(_Hint, _STD move(_Val));
     }
-
-    template <input_iterator _Iter>
-    void insert(const _Iter& _First, const _Iter& _Last) {
-        _Insert_range<false>(_First, _Last);
+    template <class _Other>
+        requires (!_Multi && _Keylt_transparent && is_constructible_v<_Kty, _Other>)
+    iterator insert(const_iterator _Hint, _Other&& _Val) {
+        return _Emplace_hint(_Hint, _STD forward<_Other>(_Val));
     }
 
+    template <input_iterator _Iter>
+    void insert(_Iter _First, _Iter _Last) {
+        _Insert_range<false>(_First, _Last);
+    }
     template <input_iterator _Iter>
     void insert(_Tsorted, _Iter _First, _Iter _Last) {
         _Insert_range<true>(_First, _Last);
     }
-
     template <_Container_compatible_range<_Kty> _Rng>
     void insert_range(_Rng&& _Range) {
         const size_type _Old_size = size();
         _Get_cont().append_range(_STD forward<_Rng>(_Range));
         _Restore_invariants_after_insert<false>(_Old_size);
+    }
+
+    void insert(initializer_list<_Kty> _Ilist) {
+        _Insert_range<false>(_Ilist.begin(), _Ilist.end());
+    }
+    void insert(_Tsorted, initializer_list<_Kty> _Ilist) {
+        _Insert_range<true>(_Ilist.begin(), _Ilist.end());
     }
 
     _NODISCARD container_type extract() && {
@@ -435,36 +447,84 @@ private:
     }
 
     template <class _Ty>
-        requires (_Keylt_transparent && is_constructible_v<_Kty, _Ty>) || is_same_v<_Ty, _Kty>
-    void _Emplace_hint(const_iterator _Where, _Ty&& _Val) {
-        _Container& _Cont     = _Get_cont();
-        _Keylt& _Compare      = _Get_comp();
-        const iterator _Begin = begin();
-        const iterator _End   = end();
-
-        if (_Where == _End || !_Compare(*_Where, _Val)) {
-            // _Val <= *_Where
-            // Left of _Where
-            if (_Where == _Begin || !_Compare(_Val, *(_Where - 1))) {
-                // _Val >= (*_Where - 1)
-                // Insert before _Where
+    auto _Emplace(_Ty&& _Val) {
+        _Container& _Cont = _Get_cont();
+        if constexpr (_Multi) {
+            _STL_INTERNAL_STATIC_ASSERT(is_same_v<remove_cvref_t<_Ty>, _Kty>);
+            return _Cont.emplace(upper_bound(_Val), _STD forward<_Ty>(_Val));
+        } else {
+            const iterator _End   = end();
+            const iterator _Where = lower_bound(_Val);
+            if (_Where != _End && _Keys_equal(*_Where, _Val)) {
+                return pair{_Where, false};
+            }
+            if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
+                return pair{_Cont.emplace(_Where, _STD forward<_Ty>(_Val)), true};
             } else {
-                // _Val < (*_Where - 1)
-                _Where = _STD upper_bound(_Begin, _Where, _Val, _Compare);
+                // flat_set::insert(auto&&)
+                _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
+                _Kty _Keyval{_STD forward<_Ty>(_Val)};
+                _STL_ASSERT(lower_bound(_Keyval) == _Where && !_Keys_equal(_Keyval, *_Where),
+                    "find(val) was not equal to find(key_type{forward(val)})");
+                return pair{_Cont.emplace(_Where, _STD move(_Keyval)), true};
+            }
+        }
+    }
+
+    template <class _Ty>
+    iterator _Emplace_hint(const_iterator _Where, _Ty&& _Val) {
+        _Container& _Cont           = _Get_cont();
+        const key_compare& _Compare = _Get_comp();
+        const const_iterator _Begin = cbegin();
+        const const_iterator _End   = cend();
+
+        if constexpr (_Multi) {
+            // Find upper_bound for flat_multiset
+            if (_Where == _End || _Compare(_Val, *_Where)) {
+                // _Val < *_Where
+                if (_Where == _Begin || !_Compare(_Val, *(_Where - 1))) {
+                    // _Val >= *(_Where-1) ~ upper_bound is _Where
+                } else {
+                    // _Val < *(_Where-1) ~ upper_bound is in [_Begin,_Where-1]
+                    _Where = _STD upper_bound(_Begin, _Where - 1, _Val);
+                }
+            } else {
+                // _Val >= *_Where ~ upper_bound is in [_Where+1,_End]
+                _Where = _STD upper_bound(_Where + 1, _End, _Val);
             }
         } else {
-            // _Val > *_Where
-            // Right of _Where
-            _Where = _STD lower_bound(_Where + 1, _End, _Val, _Compare);
+            // Find lower_bound for flat_set
+            if (_Where == _End || !_Compare(*_Where, _Val)) {
+                // _Val <= *_Where
+                if (_Where == _Begin || _Compare(*(_Where - 1), _Val)) {
+                    // _Val > *(_Where-1) ~ lower_bound is _Where
+                } else {
+                    // _Val <= *(_Where-1) ~ lower_bound is in [_Begin,_Where-1]
+                    _Where = _STD lower_bound(_Begin, _Where - 1, _Val);
+                }
+            } else {
+                // _Val > *_Where ~ lower_bound is in [_Where+1,_End]
+                _Where = _STD lower_bound(_Where + 1, _End, _Val);
+            }
         }
 
         if constexpr (_Multi) {
-            return _Cont.insert(_Where, _STD forward<_Ty>(_Val));
+            _STL_INTERNAL_STATIC_ASSERT(is_same_v<remove_cvref_t<_Ty>, _Kty>);
+            return _Cont.emplace(_Where, _STD forward<_Ty>(_Val));
         } else {
-            if (_Where == _End || !_Keys_equal(_Val, *_Where)) {
-                return _Cont.insert(_Where, _STD forward<_Ty>(_Val));
+            if (_Where != _End && _Keys_equal(_Val, *_Where)) {
+                return _Cont.begin() + (_Where - _Begin);
             }
-            return _Where;
+            if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
+                return _Cont.emplace(_Where, _STD forward<_Ty>(_Val));
+            } else {
+                // flat_set::insert(hint,auto&&)
+                _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
+                _Kty _Keyval{_STD forward<_Ty>(_Val)};
+                _STL_ASSERT(lower_bound(_Keyval) == _Where && !_Keys_equal(_Keyval, *_Where),
+                    "find(val) was not equal to find(key_type{forward(val)})");
+                return _Cont.emplace(_Where, _STD move(_Keyval));
+            }
         }
     }
 
@@ -474,22 +534,6 @@ private:
         _Container& _Cont         = _Get_cont();
         _Cont.insert(_Cont.end(), _First, _Last);
         _Restore_invariants_after_insert<_Presorted>(_Old_size);
-    }
-
-    template <class _Ty>
-        requires (!_Multi && _Keylt_transparent && is_constructible_v<_Kty, _Ty>) || is_same_v<_Ty, _Kty>
-    auto _Insert(_Ty&& _Val) {
-        _Container& _Cont     = _Get_cont();
-        const iterator _End   = end();
-        const iterator _Where = lower_bound(_Val);
-        if constexpr (_Multi) {
-            return _Cont.emplace(_Where, _STD forward<_Ty>(_Val));
-        } else {
-            if (_Where != _End && _Keys_equal(*_Where, _Val)) {
-                return pair{_Where, false};
-            }
-            return pair{_Cont.emplace(_Where, _STD forward<_Ty>(_Val)), true};
-        }
     }
 
     template <class _Ty>

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -170,6 +170,7 @@ public:
     _NODISCARD const_iterator end() const noexcept {
         return _Get_cont().end();
     }
+
     _NODISCARD reverse_iterator rbegin() noexcept {
         return _Get_cont().rbegin();
     }
@@ -182,6 +183,7 @@ public:
     _NODISCARD const_reverse_iterator rend() const noexcept {
         return _Get_cont().rend();
     }
+
     _NODISCARD const_iterator cbegin() const noexcept {
         return _Get_cont().cbegin();
     }
@@ -261,13 +263,10 @@ public:
     }
 
     _NODISCARD container_type extract() && {
-        container_type& _Cont = _Get_cont();
         // always clears the container (N4950 [flat.set.modifiers]/14 and [flat.multiset.modifiers]/10)
         _Clear_scope_guard<_Base_flat_set> _Guard{this};
-        container_type _Temp = _STD move(_Cont);
-        return _Temp;
+        return _STD move(_Get_cont());
     }
-
     void replace(container_type&& _Cont) {
         _Get_cont() = _STD move(_Cont);
         _Assert_after_sorted_input();
@@ -282,13 +281,11 @@ public:
     size_type erase(const _Kty& _Val) {
         return _Erase(_Val);
     }
-
     template <class _Other>
         requires _Keylt_transparent
     size_type erase(_Other&& _Val) {
         return _Erase(_STD forward<_Other>(_Val));
     }
-
     iterator erase(const_iterator _First, const_iterator _Last) {
         return _Get_cont().erase(_First, _Last);
     }
@@ -297,7 +294,6 @@ public:
         _RANGES swap(_Get_comp(), _Other._Get_comp());
         _RANGES swap(_Get_cont(), _Other._Get_cont());
     }
-
     void clear() noexcept {
         _Get_cont().clear();
     }
@@ -314,7 +310,6 @@ public:
     _NODISCARD iterator find(const _Kty& _Val) {
         return _Find(_Val);
     }
-
     _NODISCARD const_iterator find(const _Kty& _Val) const {
         return _Find(_Val);
     }
@@ -324,7 +319,6 @@ public:
     _NODISCARD iterator find(const _Other& _Val) {
         return _Find(_Val);
     }
-
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD const_iterator find(const _Other& _Val) const {
@@ -335,7 +329,6 @@ public:
         const auto [_First, _Last] = equal_range(_Val);
         return _STD distance(_First, _Last);
     }
-
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD size_type count(const _Other& _Val) const {
@@ -344,13 +337,14 @@ public:
     }
 
     _NODISCARD bool contains(const _Kty& _Val) const {
-        return find(_Val) != end();
+        return _STD binary_search(cbegin(), cend(), _Val, _Get_comp());
     }
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD bool contains(const _Other& _Val) const {
-        return find(_Val) != end();
+        return _STD binary_search(cbegin(), cend(), _Val, _Get_comp());
     }
+
     _NODISCARD iterator lower_bound(const _Kty& _Val) {
         return _STD lower_bound(begin(), end(), _Val, _Get_comp());
     }
@@ -363,7 +357,6 @@ public:
     _NODISCARD iterator lower_bound(const _Other& _Val) {
         return _STD lower_bound(begin(), end(), _Val, _Get_comp());
     }
-
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD const_iterator lower_bound(const _Other& _Val) const {
@@ -373,7 +366,6 @@ public:
     _NODISCARD iterator upper_bound(const _Kty& _Val) {
         return _STD upper_bound(begin(), end(), _Val, _Get_comp());
     }
-
     _NODISCARD const_iterator upper_bound(const _Kty& _Val) const {
         return _STD upper_bound(cbegin(), cend(), _Val, _Get_comp());
     }
@@ -383,7 +375,6 @@ public:
     _NODISCARD iterator upper_bound(const _Other& _Val) {
         return _STD upper_bound(begin(), end(), _Val, _Get_comp());
     }
-
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD const_iterator upper_bound(const _Other& _Val) const {
@@ -393,7 +384,6 @@ public:
     _NODISCARD pair<iterator, iterator> equal_range(const _Kty& _Val) {
         return _STD equal_range(begin(), end(), _Val, _Get_comp());
     }
-
     _NODISCARD pair<const_iterator, const_iterator> equal_range(const _Kty& _Val) const {
         return _STD equal_range(cbegin(), cend(), _Val, _Get_comp());
     }
@@ -403,7 +393,6 @@ public:
     _NODISCARD pair<iterator, iterator> equal_range(const _Other& _Val) {
         return _STD equal_range(begin(), end(), _Val, _Get_comp());
     }
-
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD pair<const_iterator, const_iterator> equal_range(const _Other& _Val) const {
@@ -411,7 +400,7 @@ public:
     }
 
     _NODISCARD friend bool operator==(const _Deriv& _Lhs, const _Deriv& _Rhs) {
-        return _RANGES equal(_Lhs, _Rhs);
+        return _RANGES equal(_Lhs._Get_cont(), _Rhs._Get_cont());
     }
 
     _NODISCARD friend _Synth_three_way_result<_Kty> operator<=>(const _Deriv& _Lhs, const _Deriv& _Rhs) {
@@ -425,9 +414,9 @@ public:
 
 private:
     void _Assert_after_sorted_input() const {
-        _STL_ASSERT(_STD is_sorted(begin(), end(), _Get_comp()), "Input was not sorted!");
+        _STL_ASSERT(_STD is_sorted(cbegin(), cend(), _Get_comp()), "Input was not sorted!");
         if constexpr (!_Multi) {
-            _STL_ASSERT(_Is_unique(), "Input was not unique!");
+            _STL_ASSERT(_Is_unique(), "Input was sorted but not unique!");
         }
     }
 
@@ -435,8 +424,8 @@ private:
         if (empty()) {
             return true;
         }
-        const_iterator _End = cend();
-        const_iterator _It  = begin();
+        const const_iterator _End = cend();
+        const_iterator _It        = cbegin();
         while (++_It != _End) {
             if (_Keys_equal(*(_It - 1), *_It)) {
                 return false;
@@ -480,7 +469,7 @@ private:
     }
 
     template <bool _Presorted, class _Iter>
-    void _Insert_range(_Iter _First, _Iter _Last) {
+    void _Insert_range(const _Iter _First, const _Iter _Last) {
         const size_type _Old_size = size();
         _Container& _Cont         = _Get_cont();
         _Cont.insert(_Cont.end(), _First, _Last);
@@ -528,8 +517,8 @@ private:
     template <class _Other>
         requires _Keylt_transparent || is_same_v<_Other, _Kty>
     _NODISCARD const_iterator _Find(const _Other& _Val) const {
-        const iterator _End   = end();
-        const iterator _Where = lower_bound(_Val);
+        const const_iterator _End   = cend();
+        const const_iterator _Where = lower_bound(_Val);
         if (_Where != _End && _Keys_equal(*_Where, _Val)) {
             return _Where;
         } else {
@@ -556,21 +545,20 @@ private:
 
     void _Erase_dupes_if_needed() {
         if constexpr (!_Multi) {
-            iterator _End = end();
-            iterator _New_end =
+            const iterator _End = end();
+            const iterator _New_end =
                 _STD unique(begin(), _End, [&](const _Kty& _Lhs, const _Kty& _Rhs) { return _Keys_equal(_Lhs, _Rhs); });
             _Get_cont().erase(_New_end, _End);
-        }
-        if constexpr (!_Multi) {
+
             _STL_INTERNAL_CHECK(_Is_unique());
         }
     }
 
     template <bool _Presorted>
-    void _Restore_invariants_after_insert(const size_type& _Old_size) {
-        key_compare& _Compare   = _Get_comp();
-        const iterator _Old_end = begin() + static_cast<difference_type>(_Old_size);
-        const iterator _New_end = end();
+    void _Restore_invariants_after_insert(const size_type _Old_size) {
+        const key_compare& _Compare = _Get_comp();
+        const iterator _Old_end     = begin() + static_cast<difference_type>(_Old_size);
+        const iterator _New_end     = end();
 
         if constexpr (!_Presorted) {
             _STD sort(_Old_end, _New_end, _Compare);
@@ -580,7 +568,7 @@ private:
 
         _STD inplace_merge(begin(), _Old_end, _New_end, _Compare);
 
-        _STL_INTERNAL_CHECK(_STD is_sorted(begin(), end(), _Get_comp()));
+        _STL_INTERNAL_CHECK(_STD is_sorted(begin(), end(), _Compare));
 
         _Erase_dupes_if_needed();
     }
@@ -594,7 +582,7 @@ private:
         }
 
         _Sort_potentially_sorted(_Begin, _End);
-        _STL_INTERNAL_CHECK(_STD is_sorted(begin(), end(), _Get_comp()));
+        _STL_INTERNAL_CHECK(_STD is_sorted(_Begin, _End, _Compare));
 
         _Erase_dupes_if_needed();
     }

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -533,16 +533,6 @@ private:
         return !_Compare(_Lhs, _Rhs) && !_Compare(_Rhs, _Lhs);
     }
 
-    // O(N) if already sorted.
-    void _Sort_potentially_sorted(const iterator& _Begin, const iterator& _End) {
-        key_compare& _Compare          = _Get_comp();
-        const iterator _Begin_unsorted = _STD is_sorted_until(_Begin, _End, _Compare);
-
-        _STD sort(_Begin_unsorted, _End, _Compare);
-
-        _STD inplace_merge(begin(), _Begin_unsorted, _End, _Compare);
-    }
-
     void _Erase_dupes_if_needed() {
         if constexpr (!_Multi) {
             const iterator _End = end();
@@ -581,7 +571,13 @@ private:
             return;
         }
 
-        _Sort_potentially_sorted(_Begin, _End);
+        // O(N) if already sorted.
+        const key_compare& _Compare    = _Get_comp();
+        const iterator _Begin_unsorted = _STD is_sorted_until(_Begin, _End, _Compare);
+
+        _STD sort(_Begin_unsorted, _End, _Compare);
+        _STD inplace_merge(begin(), _Begin_unsorted, _End, _Compare);
+
         _STL_INTERNAL_CHECK(_STD is_sorted(_Begin, _End, _Compare));
 
         _Erase_dupes_if_needed();

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -67,6 +67,13 @@ public:
 
     _Base_flat_set() : _My_pair(_Zero_then_variadic_args_t{}) {}
 
+    template <_Allocator_for<container_type> _Alloc>
+    _Base_flat_set(const _Deriv& _Set, const _Alloc& _Al)
+        : _My_pair(_One_then_variadic_args_t{}, _Set._Get_comp(), _Set._Get_cont(), _Al) {}
+    template <_Allocator_for<container_type> _Alloc>
+    _Base_flat_set(_Deriv&& _Set, const _Alloc& _Al)
+        : _My_pair(_One_then_variadic_args_t{}, _STD move(_Set._Get_comp()), _STD move(_Set._Get_cont()), _Al) {}
+
     explicit _Base_flat_set(container_type _Cont, const key_compare& _Comp = key_compare())
         : _My_pair(_One_then_variadic_args_t{}, _Comp, _STD move(_Cont)) {
         _Make_invariants_fulfilled();
@@ -90,9 +97,9 @@ public:
 
     explicit _Base_flat_set(const key_compare& _Comp) : _My_pair(_One_then_variadic_args_t{}, _Comp) {}
     template <_Allocator_for<container_type> _Alloc>
-    _Base_flat_set(const key_compare& _Comp, const _Alloc& _Al) : _Base_flat_set(_Comp, container_type(_Al)) {}
+    _Base_flat_set(const key_compare& _Comp, const _Alloc& _Al) : _My_pair(_One_then_variadic_args_t{}, _Comp, _Al) {}
     template <_Allocator_for<container_type> _Alloc>
-    explicit _Base_flat_set(const _Alloc& _Al) : _Base_flat_set(container_type(_Al)) {}
+    explicit _Base_flat_set(const _Alloc& _Al) : _My_pair(_Zero_then_variadic_args_t{}, _Al) {}
 
     template <input_iterator _Iter>
     _Base_flat_set(_Iter _First, _Iter _Last, const key_compare& _Comp = key_compare())
@@ -104,11 +111,14 @@ public:
     _Base_flat_set(_Iter _First, _Iter _Last, const _Alloc& _Al) : _Base_flat_set(container_type(_First, _Last, _Al)) {}
 
     template <_Container_compatible_range<_Kty> _Rng>
-    _Base_flat_set(from_range_t, _Rng&& _Range, const key_compare& _Comp = key_compare())
-        : _Base_flat_set(container_type(from_range, _STD forward<_Rng>(_Range)), _Comp) {}
+    _Base_flat_set(from_range_t, _Rng&& _Range)
+        : _Base_flat_set(container_type(from_range, _STD forward<_Rng>(_Range))) {}
     template <_Container_compatible_range<_Kty> _Rng, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(from_range_t, _Rng&& _Range, const _Alloc& _Al)
         : _Base_flat_set(container_type(from_range, _STD forward<_Rng>(_Range), _Al)) {}
+    template <_Container_compatible_range<_Kty> _Rng>
+    _Base_flat_set(from_range_t, _Rng&& _Range, const key_compare& _Comp)
+        : _Base_flat_set(container_type(from_range, _STD forward<_Rng>(_Range)), _Comp) {}
     template <_Container_compatible_range<_Kty> _Rng, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(from_range_t, _Rng&& _Range, const key_compare& _Comp, const _Alloc& _Al)
         : _Base_flat_set(container_type(from_range, _STD forward<_Rng>(_Range), _Al), _Comp) {}
@@ -124,7 +134,7 @@ public:
         : _Base_flat_set(_Tsort, container_type(_First, _Last, _Al)) {}
 
     _Base_flat_set(initializer_list<_Kty> _Ilist, const key_compare& _Comp = key_compare())
-        : _Base_flat_set(_Ilist.begin(), _Ilist.end(), _Comp) {}
+        : _Base_flat_set(container_type(_Ilist.begin(), _Ilist.end()), _Comp) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(initializer_list<_Kty> _Ilist, const key_compare& _Comp, const _Alloc& _Al)
         : _Base_flat_set(container_type(_Ilist.begin(), _Ilist.end(), _Al), _Comp) {}
@@ -133,7 +143,7 @@ public:
         : _Base_flat_set(container_type(_Ilist.begin(), _Ilist.end(), _Al)) {}
 
     _Base_flat_set(_Tsorted _Tsort, initializer_list<_Kty> _Ilist, const key_compare& _Comp = key_compare())
-        : _Base_flat_set(_Tsort, _Ilist.begin(), _Ilist.end(), _Comp) {}
+        : _Base_flat_set(_Tsort, container_type(_Ilist.begin(), _Ilist.end()), _Comp) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Tsorted _Tsort, initializer_list<_Kty> _Ilist, const key_compare& _Comp, const _Alloc& _Al)
         : _Base_flat_set(_Tsort, container_type(_Ilist.begin(), _Ilist.end(), _Al), _Comp) {}
@@ -142,11 +152,12 @@ public:
         : _Base_flat_set(_Tsort, container_type(_Ilist.begin(), _Ilist.end(), _Al)) {}
 
     _Deriv& operator=(initializer_list<_Kty> _Ilist) {
-        _Get_cont() = container_type(_Ilist.begin(), _Ilist.end());
+        _Get_cont().assign(_Ilist.begin(), _Ilist.end());
         _Make_invariants_fulfilled();
         return static_cast<_Deriv&>(*this);
     }
 
+    // iterators
     _NODISCARD iterator begin() noexcept {
         return _Get_cont().begin();
     }
@@ -184,6 +195,7 @@ public:
         return _Get_cont().crend();
     }
 
+    // capacity
     _NODISCARD_EMPTY_MEMBER bool empty() const noexcept {
         return _Get_cont().empty();
     }
@@ -194,6 +206,7 @@ public:
         return _Get_cont().max_size();
     }
 
+    // modifiers
     template <class... _Args>
     auto emplace(_Args&&... _Vals) {
         insert<_Kty>(_Kty{_STD forward<_Args>(_Vals)...});
@@ -289,6 +302,7 @@ public:
         _Get_cont().clear();
     }
 
+    // observers
     _NODISCARD key_compare key_comp() const {
         return _Get_comp();
     }
@@ -296,6 +310,7 @@ public:
         return _Get_comp();
     }
 
+    // set operations
     _NODISCARD iterator find(const _Kty& _Val) {
         return _Find(_Val);
     }
@@ -616,15 +631,23 @@ _EXPORT_STD inline constexpr sorted_equivalent_t sorted_equivalent{};
 _EXPORT_STD template <class _Kty, class _Keylt = less<_Kty>, class _Container = vector<_Kty>>
 class flat_set
     : public _Base_flat_set<_Kty, _Keylt, _Container, false, flat_set<_Kty, _Keylt, _Container>, sorted_unique_t> {
+private:
+    using _Mybase = _Base_flat_set<_Kty, _Keylt, _Container, false, flat_set, sorted_unique_t>;
+
 public:
-    using _Base_flat_set<_Kty, _Keylt, _Container, false, flat_set, sorted_unique_t>::_Base_flat_set;
+    using _Mybase::_Mybase;
+    using _Mybase::operator=;
 };
 
 _EXPORT_STD template <class _Kty, class _Keylt = less<_Kty>, class _Container = vector<_Kty>>
 class flat_multiset : public _Base_flat_set<_Kty, _Keylt, _Container, true, flat_multiset<_Kty, _Keylt, _Container>,
                           sorted_equivalent_t> {
+private:
+    using _Mybase = _Base_flat_set<_Kty, _Keylt, _Container, true, flat_multiset, sorted_equivalent_t>;
+
 public:
-    using _Base_flat_set<_Kty, _Keylt, _Container, true, flat_multiset, sorted_equivalent_t>::_Base_flat_set;
+    using _Mybase::_Mybase;
+    using _Mybase::operator=;
 };
 
 _EXPORT_STD template <class _Kty, class _Keylt, class _Container, class _Pred>

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -446,6 +446,22 @@ private:
         return true;
     }
 
+    bool _Check_where(const const_iterator _Where, const _Kty& _Val) const {
+        // check that _Val can be inserted before _Where
+        const key_compare& _Compare = _Get_comp();
+        if constexpr (_Multi) {
+            // check that _Where is the upper_bound for _Val
+            // equivalent to checking *(_Where-1) <= _Val < *_Where
+            return (_Where == cend() || _Compare(_Val, *_Where))
+                && (_Where == cbegin() || !_Compare(_Val, *(_Where - 1)));
+        } else {
+            // check that _Where is the lower_bound for _Val, and *_Where is not equivalent to _Val
+            // equivalent to checking *(_Where-1) < _Val < *_Where
+            return (_Where == cend() || _Compare(_Val, *_Where))
+                && (_Where == cbegin() || _Compare(*(_Where - 1), _Val));
+        }
+    }
+
     template <class _Ty>
     auto _Emplace(_Ty&& _Val) {
         _Container& _Cont = _Get_cont();
@@ -461,11 +477,10 @@ private:
             if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
                 return pair{_Cont.emplace(_Where, _STD forward<_Ty>(_Val)), true};
             } else {
-                // flat_set::insert(auto&&)
+                // for flat_set::insert(auto&&)
                 _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
                 _Kty _Keyval{_STD forward<_Ty>(_Val)};
-                _STL_ASSERT(lower_bound(_Keyval) == _Where && !_Keys_equal(_Keyval, *_Where),
-                    "find(val) was not equal to find(key_type{forward(val)})");
+                _STL_ASSERT(_Check_where(_Where, _Keyval), "The input type was not equivalent to key_type!");
                 return pair{_Cont.emplace(_Where, _STD move(_Keyval)), true};
             }
         }
@@ -479,7 +494,7 @@ private:
         const const_iterator _End   = cend();
 
         if constexpr (_Multi) {
-            // Find upper_bound for flat_multiset
+            // look for the upper_bound for flat_multiset
             if (_Where == _End || _Compare(_Val, *_Where)) {
                 // _Val < *_Where
                 if (_Where == _Begin || !_Compare(_Val, *(_Where - 1))) {
@@ -493,7 +508,7 @@ private:
                 _Where = _STD upper_bound(_Where + 1, _End, _Val);
             }
         } else {
-            // Find lower_bound for flat_set
+            // look for the lower_bound for flat_set
             if (_Where == _End || !_Compare(*_Where, _Val)) {
                 // _Val <= *_Where
                 if (_Where == _Begin || _Compare(*(_Where - 1), _Val)) {
@@ -510,19 +525,20 @@ private:
 
         if constexpr (_Multi) {
             _STL_INTERNAL_STATIC_ASSERT(is_same_v<remove_cvref_t<_Ty>, _Kty>);
+            _STL_INTERNAL_CHECK(_Check_where(_Where, _Val));
             return _Cont.emplace(_Where, _STD forward<_Ty>(_Val));
         } else {
             if (_Where != _End && _Keys_equal(_Val, *_Where)) {
                 return _Cont.begin() + (_Where - _Begin);
             }
             if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
+                _STL_INTERNAL_CHECK(_Check_where(_Where, _Val));
                 return _Cont.emplace(_Where, _STD forward<_Ty>(_Val));
             } else {
-                // flat_set::insert(hint,auto&&)
+                // for flat_set::insert(hint,auto&&)
                 _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
                 _Kty _Keyval{_STD forward<_Ty>(_Val)};
-                _STL_ASSERT(lower_bound(_Keyval) == _Where && !_Keys_equal(_Keyval, *_Where),
-                    "find(val) was not equal to find(key_type{forward(val)})");
+                _STL_ASSERT(_Check_where(_Where, _Keyval), "The input type was not equivalent to key_type!");
                 return _Cont.emplace(_Where, _STD move(_Keyval));
             }
         }

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -636,7 +636,7 @@ private:
         const iterator _Begin_unsorted = _STD is_sorted_until(_Begin, _End, _Compare);
 
         _STD sort(_Begin_unsorted, _End, _Compare);
-        _STD inplace_merge(begin(), _Begin_unsorted, _End, _Compare);
+        _STD inplace_merge(_Begin, _Begin_unsorted, _End, _Compare);
 
         _STL_INTERNAL_CHECK(_STD is_sorted(_Begin, _End, _Compare));
 

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -215,7 +215,7 @@ public:
         if constexpr (_Is_key_type) {
             return _Emplace(_STD forward<_Args>(_Vals)...);
         } else {
-            return _Emplace(_Kty{_STD forward<_Args>(_Vals)...});
+            return _Emplace(_Kty(_STD forward<_Args>(_Vals)...));
         }
     }
     template <class... _Args>
@@ -224,7 +224,7 @@ public:
         if constexpr (_Is_key_type) {
             return _Emplace_hint(_Hint, _STD forward<_Args>(_Vals)...);
         } else {
-            return _Emplace_hint(_Hint, _Kty{_STD forward<_Args>(_Vals)...});
+            return _Emplace_hint(_Hint, _Kty(_STD forward<_Args>(_Vals)...));
         }
     }
 
@@ -479,7 +479,7 @@ private:
             } else {
                 // for flat_set::insert(auto&&)
                 _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
-                _Kty _Keyval{_STD forward<_Ty>(_Val)};
+                _Kty _Keyval(_STD forward<_Ty>(_Val));
                 _STL_ASSERT(_Check_where(_Where, _Keyval), "The input type was not equivalent to key_type!");
                 return pair{_Cont.emplace(_Where, _STD move(_Keyval)), true};
             }
@@ -537,7 +537,7 @@ private:
             } else {
                 // for flat_set::insert(hint,auto&&)
                 _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
-                _Kty _Keyval{_STD forward<_Ty>(_Val)};
+                _Kty _Keyval(_STD forward<_Ty>(_Val));
                 _STL_ASSERT(_Check_where(_Where, _Keyval), "The input type was not equivalent to key_type!");
                 return _Cont.emplace(_Where, _STD move(_Keyval));
             }

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -474,6 +474,7 @@ private:
             if (_Where != _End && _Keys_equal(*_Where, _Val)) {
                 return pair{_Where, false};
             }
+
             if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
                 return pair{_Cont.emplace(_Where, _STD forward<_Ty>(_Val)), true};
             } else {
@@ -531,6 +532,7 @@ private:
             if (_Where != _End && _Keys_equal(_Val, *_Where)) {
                 return _Cont.begin() + (_Where - _Begin);
             }
+
             if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
                 _STL_INTERNAL_CHECK(_Check_where(_Where, _Val));
                 return _Cont.emplace(_Where, _STD forward<_Ty>(_Val));

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -16,6 +16,13 @@ _EMIT_STL_WARNING(STL4038, "The contents of <flat_set> are available only with C
 #include <vector>
 #include <xutility>
 
+#pragma pack(push, _CRT_PACKING)
+#pragma warning(push, _STL_WARNING_LEVEL)
+#pragma warning(disable : _STL_DISABLED_WARNINGS)
+_STL_DISABLE_CLANG_WARNINGS
+#pragma push_macro("new")
+#undef new
+
 _STD_BEGIN
 
 template <class _Ty>
@@ -718,6 +725,11 @@ template <class _Kty, class _Keylt = less<_Kty>>
 flat_multiset(sorted_equivalent_t, initializer_list<_Kty>, _Keylt = _Keylt()) -> flat_multiset<_Kty, _Keylt>;
 
 _STD_END
+
+#pragma pop_macro("new")
+_STL_RESTORE_CLANG_WARNINGS
+#pragma warning(pop)
+#pragma pack(pop)
 
 #endif // ^^^ supported language mode ^^^
 #endif // _STL_COMPILER_PREPROCESSOR

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -65,10 +65,10 @@ public:
     static_assert(random_access_iterator<iterator>, "The C++ Standard forbids containers without random "
                                                     "access iterators from being adapted. See [flatset.overview].");
 
-    _Base_flat_set() : _My_pair(_Zero_then_variadic_args_t{}, _Keylt()) {}
+    _Base_flat_set() : _My_pair(_Zero_then_variadic_args_t{}) {}
 
     explicit _Base_flat_set(container_type _Cont, const key_compare& _Comp = key_compare())
-        : _My_pair(_One_then_variadic_args_t{}, _STD move(_Cont), _Comp) {
+        : _My_pair(_One_then_variadic_args_t{}, _Comp, _STD move(_Cont)) {
         _Make_invariants_fulfilled();
     }
     template <_Allocator_for<container_type> _Alloc>
@@ -78,7 +78,7 @@ public:
         : _Base_flat_set(container_type(_Cont, _Al), _Comp) {}
 
     _Base_flat_set(_Tsorted, container_type _Cont, const key_compare& _Comp = key_compare())
-        : _My_pair(_One_then_variadic_args_t{}, _STD move(_Cont), _Comp) {
+        : _My_pair(_One_then_variadic_args_t{}, _Comp, _STD move(_Cont)) {
         _Assert_after_sorted_input();
     }
     template <_Allocator_for<container_type> _Alloc>
@@ -88,7 +88,7 @@ public:
     _Base_flat_set(_Tsorted _Tsort, const container_type& _Cont, const key_compare& _Comp, const _Alloc& _Al)
         : _Base_flat_set(_Tsort, container_type(_Cont, _Al), _Comp) {}
 
-    explicit _Base_flat_set(const key_compare& _Comp) : _My_pair(_Zero_then_variadic_args_t{}, _Comp) {}
+    explicit _Base_flat_set(const key_compare& _Comp) : _My_pair(_One_then_variadic_args_t{}, _Comp) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(const key_compare& _Comp, const _Alloc& _Al) : _Base_flat_set(_Comp, container_type(_Al)) {}
     template <_Allocator_for<container_type> _Alloc>
@@ -585,22 +585,22 @@ private:
     }
 
     _NODISCARD const _Container& _Get_cont() const noexcept {
-        return _My_pair._Get_first();
+        return _My_pair._Myval2;
     }
 
     _NODISCARD _Container& _Get_cont() noexcept {
-        return _My_pair._Get_first();
+        return _My_pair._Myval2;
     }
 
     _NODISCARD const key_compare& _Get_comp() const noexcept {
-        return _My_pair._Myval2;
+        return _My_pair._Get_first();
     }
 
     _NODISCARD key_compare& _Get_comp() noexcept {
-        return _My_pair._Myval2;
+        return _My_pair._Get_first();
     }
 
-    _Compressed_pair<container_type, key_compare> _My_pair;
+    _Compressed_pair<key_compare, container_type> _My_pair;
 };
 
 _EXPORT_STD struct sorted_unique_t {

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -7,6 +7,7 @@
 #include <flat_set>
 #include <functional>
 #include <iostream>
+#include <memory>
 #include <vector>
 
 using namespace std;

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -132,9 +132,13 @@ void test_constructors() {
     flat_set<int> a{};
     a = {1, 7, 7, 7, 2, 100, -1};
     assert_all_requirements_and_equals(a, {-1, 1, 2, 7, 100});
+    assert_all_requirements_and_equals(flat_set<int>(a, allocator<int>{}), {-1, 1, 2, 7, 100});
+    assert_all_requirements_and_equals(flat_set<int>(std::move(a), allocator<int>{}), {-1, 1, 2, 7, 100});
     flat_multiset<int> b{};
     b = {1, 7, 7, 7, 2, 100, -1};
     assert_all_requirements_and_equals(b, {-1, 1, 2, 7, 7, 7, 100});
+    assert_all_requirements_and_equals(flat_multiset<int>(b, allocator<int>{}), {-1, 1, 2, 7, 7, 7, 100});
+    assert_all_requirements_and_equals(flat_multiset<int>(std::move(b), allocator<int>{}), {-1, 1, 2, 7, 7, 7, 100});
 }
 
 template <class T>

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -67,6 +67,7 @@ void assert_reversible_container_requirements(const T& s) {
 
 template <class T>
 void test_ebco() {
+    // This tests an implementation-specific optimization.
     using key_compare    = T::key_compare;
     using container_type = T::container_type;
     if constexpr (is_empty_v<key_compare> && !is_final_v<key_compare>) {

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -191,6 +191,21 @@ void test_non_static_comparer() {
     assert_all_requirements_and_equals(a, {9, 7, 5, -1});
 }
 
+void test_ebco() {
+    using vec = vector<int>;
+    using deq = deque<int>;
+
+    static_assert(sizeof(vec) == sizeof(flat_set<int, std::less<int>, vec>));
+    static_assert(sizeof(deq) == sizeof(flat_set<int, std::less<int>, deq>));
+    static_assert(sizeof(vec) == sizeof(flat_multiset<int, std::less<int>, vec>));
+    static_assert(sizeof(deq) == sizeof(flat_multiset<int, std::less<int>, deq>));
+
+    static_assert(sizeof(vec) < sizeof(flat_set<int, proxy_comparer<int>, vec>));
+    static_assert(sizeof(deq) < sizeof(flat_set<int, proxy_comparer<int>, deq>));
+    static_assert(sizeof(vec) < sizeof(flat_multiset<int, proxy_comparer<int>, vec>));
+    static_assert(sizeof(deq) < sizeof(flat_multiset<int, proxy_comparer<int>, deq>));
+}
+
 template <class C>
 void test_extract() {
     constexpr int elements[]{1, 2, 3, 4};
@@ -221,6 +236,8 @@ int main() {
 
     test_constructors<vector<int>>();
     test_constructors<deque<int>>();
+
+    test_ebco();
 
     test_non_static_comparer();
 


### PR DESCRIPTION
Works towards #2912.

Replace #3985; the commits are reorganized for ease of review.
Major changes are:
1. Fix usage of `_Compressed_pair`; the implementation was erroneously trying to compress the container instead of `key_compare`.
2. Implement LWG-3884 (`flat_meow(flat_meow&&, al)`).
3. Implement missing `insert(initializer_list)`, and make `operator=(initializer_list)` available for users of `flat_meow`.
4. Fix `emplace[_hint]` and `insert([hint,]val)` functions.
4.1. Some functions couldn't compile, including `insert(const key&)` and hint functions.
4.2. Some function signatures were non-conformant.
4.3. The bound searching algorithm in `_Emplace_hint` was wrong. `flat_set` must find `lower_bound` for correctness, and `flat_multiset` should find `upper_bound` for efficiency and conformance to the standard.
5. Various other cleanups and enhancements.

Thanks to @duanqn and @frederick-vs-ja for previous review on #3985 😽