### PR TITLE
Remove some functions defined in `_CRTBLD` blocks

### DIFF
--- a/stl/inc/__msvc_filebuf.hpp
+++ b/stl/inc/__msvc_filebuf.hpp
@@ -64,10 +64,6 @@ _INLINE_VAR constexpr bool _Is_any_path = _Is_any_of_v<_Ty
 extern "C++" _CRTIMP2_PURE FILE* __CLRCALL_PURE_OR_CDECL _Fiopen(const char*, ios_base::openmode, int);
 extern "C++" _CRTIMP2_PURE FILE* __CLRCALL_PURE_OR_CDECL _Fiopen(const wchar_t*, ios_base::openmode, int);
 
-#ifdef _CRTBLD
-extern "C++" _CRTIMP2_PURE FILE* __CLRCALL_PURE_OR_CDECL _Fiopen(const unsigned short*, ios_base::openmode, int);
-#endif // defined(_CRTBLD)
-
 template <class _Elem>
 bool _Fgetc(_Elem& _Ch, FILE* _File) { // get an element from a C stream
     return _CSTD fread(&_Ch, sizeof(_Elem), 1, _File) == 1;
@@ -353,32 +349,6 @@ public:
         return open(_Filename, static_cast<ios_base::openmode>(_Mode));
     }
 #endif // _HAS_OLD_IOSTREAMS_MEMBERS
-
-#ifdef _CRTBLD
-    basic_filebuf* open(
-        const unsigned short* _Filename, ios_base::openmode _Mode, int _Prot = ios_base::_Default_open_prot) {
-        // in standard as const std::filesystem::path::value_type *; _Prot is an extension
-        if (_Myfile) {
-            return nullptr;
-        }
-
-        const auto _File = _Fiopen(_Filename, _Mode, _Prot);
-        if (!_File) {
-            return nullptr; // open failed
-        }
-
-        _Init(_File, _Openfl);
-        _Initcvt(_STD use_facet<_Cvt>(_Mysb::getloc()));
-        return this; // open succeeded
-    }
-
-#if _HAS_OLD_IOSTREAMS_MEMBERS
-    basic_filebuf* open(const unsigned short* _Filename, ios_base::open_mode _Mode) {
-        // in standard as const std::filesystem::path::value_type *
-        return open(_Filename, static_cast<ios_base::openmode>(_Mode));
-    }
-#endif // _HAS_OLD_IOSTREAMS_MEMBERS
-#endif // defined(_CRTBLD)
 
     basic_filebuf* close() {
         basic_filebuf* _Ans;

--- a/stl/inc/fstream
+++ b/stl/inc/fstream
@@ -59,17 +59,6 @@ public:
         const _Ty& _Path, ios_base::openmode _Mode = ios_base::in, int _Prot = ios_base::_Default_open_prot)
         : basic_ifstream(_Path.c_str(), _Mode, _Prot) {} // _Prot is an extension
 
-#ifdef _CRTBLD
-    explicit basic_ifstream(const unsigned short* _Filename, ios_base::openmode _Mode = ios_base::in,
-        int _Prot = ios_base::_Default_open_prot)
-        : _Mybase(_STD addressof(_Filebuffer)) {
-        // in standard as const std::filesystem::path::value_type *; _Prot is an extension
-        if (_Filebuffer.open(_Filename, _Mode | ios_base::in, _Prot) == 0) {
-            _Myios::setstate(ios_base::failbit);
-        }
-    }
-#endif // defined(_CRTBLD)
-
     explicit basic_ifstream(FILE* _File) : _Mybase(_STD addressof(_Filebuffer)), _Filebuffer(_File) {} // extension
 
     basic_ifstream(basic_ifstream&& _Right) : _Mybase(_STD addressof(_Filebuffer)) {
@@ -137,25 +126,6 @@ public:
         open(_Filename, static_cast<ios_base::openmode>(_Mode));
     }
 #endif // _HAS_OLD_IOSTREAMS_MEMBERS
-
-#ifdef _CRTBLD
-    void open(const unsigned short* _Filename, ios_base::openmode _Mode = ios_base::in,
-        int _Prot = ios_base::_Default_open_prot) {
-        // in standard as const std::filesystem::path::value_type *; _Prot is an extension
-        if (_Filebuffer.open(_Filename, _Mode | ios_base::in, _Prot) == 0) {
-            _Myios::setstate(ios_base::failbit);
-        } else {
-            _Myios::clear();
-        }
-    }
-
-#if _HAS_OLD_IOSTREAMS_MEMBERS
-    void open(const unsigned short* _Filename, ios_base::open_mode _Mode) {
-        // in standard as const std::filesystem::path::value_type *
-        open(_Filename, static_cast<ios_base::openmode>(_Mode));
-    }
-#endif // _HAS_OLD_IOSTREAMS_MEMBERS
-#endif // defined(_CRTBLD)
 
     __CLR_OR_THIS_CALL ~basic_ifstream() noexcept override {}
 
@@ -242,17 +212,6 @@ public:
         const _Ty& _Path, ios_base::openmode _Mode = ios_base::out, int _Prot = ios_base::_Default_open_prot)
         : basic_ofstream(_Path.c_str(), _Mode, _Prot) {} // _Prot is an extension
 
-#ifdef _CRTBLD
-    explicit basic_ofstream(const unsigned short* _Filename, ios_base::openmode _Mode = ios_base::out,
-        int _Prot = ios_base::_Default_open_prot)
-        : _Mybase(_STD addressof(_Filebuffer)) {
-        // in standard as const std::filesystem::path::value_type *; _Prot is an extension
-        if (_Filebuffer.open(_Filename, _Mode | ios_base::out, _Prot) == 0) {
-            _Myios::setstate(ios_base::failbit);
-        }
-    }
-#endif // defined(_CRTBLD)
-
     explicit basic_ofstream(FILE* _File) : _Mybase(_STD addressof(_Filebuffer)), _Filebuffer(_File) {} // extension
 
     basic_ofstream(basic_ofstream&& _Right) : _Mybase(_STD addressof(_Filebuffer)) {
@@ -320,25 +279,6 @@ public:
         open(_Filename, static_cast<ios_base::openmode>(_Mode));
     }
 #endif // _HAS_OLD_IOSTREAMS_MEMBERS
-
-#ifdef _CRTBLD
-    void open(const unsigned short* _Filename, ios_base::openmode _Mode = ios_base::out,
-        int _Prot = ios_base::_Default_open_prot) {
-        // in standard as const std::filesystem::path::value_type *; _Prot is an extension
-        if (_Filebuffer.open(_Filename, _Mode | ios_base::out, _Prot) == 0) {
-            _Myios::setstate(ios_base::failbit);
-        } else {
-            _Myios::clear();
-        }
-    }
-
-#if _HAS_OLD_IOSTREAMS_MEMBERS
-    void open(const unsigned short* _Filename, ios_base::open_mode _Mode) {
-        // in standard as const std::filesystem::path::value_type *
-        open(_Filename, static_cast<ios_base::openmode>(_Mode));
-    }
-#endif // _HAS_OLD_IOSTREAMS_MEMBERS
-#endif // defined(_CRTBLD)
 
     __CLR_OR_THIS_CALL ~basic_ofstream() noexcept override {}
 
@@ -430,17 +370,6 @@ public:
         int _Prot = ios_base::_Default_open_prot)
         : basic_fstream(_Path.c_str(), _Mode, _Prot) {} // _Prot is an extension
 
-#ifdef _CRTBLD
-    explicit basic_fstream(const unsigned short* _Filename, ios_base::openmode _Mode = ios_base::in | ios_base::out,
-        int _Prot = ios_base::_Default_open_prot)
-        : _Mybase(_STD addressof(_Filebuffer)) {
-        // in standard as const std::filesystem::path::value_type *; _Prot is an extension
-        if (_Filebuffer.open(_Filename, _Mode, _Prot) == 0) {
-            _Myios::setstate(ios_base::failbit);
-        }
-    }
-#endif // defined(_CRTBLD)
-
     explicit basic_fstream(FILE* _File) : _Mybase(_STD addressof(_Filebuffer)), _Filebuffer(_File) {} // extension
 
     basic_fstream(basic_fstream&& _Right) : _Mybase(_STD addressof(_Filebuffer)) {
@@ -509,25 +438,6 @@ public:
         open(_Filename, static_cast<ios_base::openmode>(_Mode));
     }
 #endif // _HAS_OLD_IOSTREAMS_MEMBERS
-
-#ifdef _CRTBLD
-    void open(const unsigned short* _Filename, ios_base::openmode _Mode = ios_base::in | ios_base::out,
-        int _Prot = ios_base::_Default_open_prot) {
-        // in standard as const std::filesystem::path::value_type *; _Prot is an extension
-        if (_Filebuffer.open(_Filename, _Mode, _Prot) == 0) {
-            _Myios::setstate(ios_base::failbit);
-        } else {
-            _Myios::clear();
-        }
-    }
-
-#if _HAS_OLD_IOSTREAMS_MEMBERS
-    void open(const unsigned short* _Filename, ios_base::open_mode _Mode) {
-        // in standard as const std::filesystem::path::value_type *
-        open(_Filename, static_cast<ios_base::openmode>(_Mode));
-    }
-#endif // _HAS_OLD_IOSTREAMS_MEMBERS
-#endif // defined(_CRTBLD)
 
     __CLR_OR_THIS_CALL ~basic_fstream() noexcept override {}
 

--- a/stl/src/fiopen.cpp
+++ b/stl/src/fiopen.cpp
@@ -96,6 +96,7 @@ _CRTIMP2_PURE FILE* __CLRCALL_PURE_OR_CDECL _Fiopen(
     return _Xfiopen(filename, mode, prot);
 }
 
+// TRANSITION, ABI: preserved for binary compatibility
 _CRTIMP2_PURE FILE* __CLRCALL_PURE_OR_CDECL _Fiopen(
     const unsigned short* _Filename, ios_base::openmode _Mode, int _Prot) { // open file with wide name
     return _Fiopen(reinterpret_cast<const wchar_t*>(_Filename), _Mode, _Prot);


### PR DESCRIPTION
Removes `open(const unsigned short*,...)` functions from the library.

These functions are defined in `_CRTBLD` blocks, and are not used elsewhere in the library.
The project can build successfully after their removal (or `=delete` them). The `xxx.dll` and `msvcprt(d).lib` files are unchanged.

Works towards #3941.