### PR TITLE
`<istream>`, `<ostream>`: Deprecate pre-Standard `ipfx`, `isfx`, `opfx`, and `osfx` functions

### DIFF
--- a/stl/inc/istream
+++ b/stl/inc/istream
@@ -146,12 +146,13 @@ public:
     }
 
     // TRANSITION, ABI: non-Standard ipfx() is preserved for binary compatibility
-    bool __CLR_OR_THIS_CALL ipfx(bool _Noskip = false) { // test stream state and skip whitespace as needed
+    _DEPRECATE_IO_PFX_SFX bool __CLR_OR_THIS_CALL ipfx(bool _Noskip = false) {
+        // test stream state and skip whitespace as needed
         return _Ipfx(_Noskip);
     }
 
     // TRANSITION, ABI: non-Standard isfx() is preserved for binary compatibility
-    void __CLR_OR_THIS_CALL isfx() {} // perform any wrapup
+    _DEPRECATE_IO_PFX_SFX void __CLR_OR_THIS_CALL isfx() {} // perform any wrapup
 
 #ifdef _M_CEE_PURE
     basic_istream& __CLR_OR_THIS_CALL operator>>(basic_istream&(__clrcall* _Pfn)(basic_istream&) ) {

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -137,7 +137,7 @@ public:
     };
 
     // TRANSITION, ABI: non-Standard opfx() is preserved for binary compatibility
-    bool __CLR_OR_THIS_CALL opfx() { // test stream state and flush tie stream as needed
+    _DEPRECATE_IO_PFX_SFX bool __CLR_OR_THIS_CALL opfx() { // test stream state and flush tie stream as needed
         if (!this->good()) {
             return false;
         }
@@ -152,7 +152,7 @@ public:
     }
 
     // TRANSITION, ABI: non-Standard osfx() is preserved for binary compatibility
-    void __CLR_OR_THIS_CALL osfx() noexcept { // perform any wrapup
+    _DEPRECATE_IO_PFX_SFX void __CLR_OR_THIS_CALL osfx() noexcept { // perform any wrapup
         _Osfx();
     }
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1511,7 +1511,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
     [[deprecated(                                                                                                      \
         "warning STL4045: The ipfx(), isfx(), opfx(), and osfx() functions are removed before C++98 (see WG21-N0794) " \
         "but kept as non-Standard extensions. They will be removed in the future, and the member classes sentry "      \
-        "should be used instread. You can define _SILENCE_IO_PFX_SFX_DEPRECATION_WARNING or "                          \
+        "should be used instead. You can define _SILENCE_IO_PFX_SFX_DEPRECATION_WARNING or "                          \
         "_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS to suppress this warning.")]]
 #else // ^^^ warning enabled / warning disabled vvv
 #define _DEPRECATE_IO_PFX_SFX

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1511,7 +1511,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
     [[deprecated(                                                                                                      \
         "warning STL4045: The ipfx(), isfx(), opfx(), and osfx() functions are removed before C++98 (see WG21-N0794) " \
         "but kept as non-Standard extensions. They will be removed in the future, and the member classes sentry "      \
-        "should be used instead. You can define _SILENCE_IO_PFX_SFX_DEPRECATION_WARNING or "                          \
+        "should be used instead. You can define _SILENCE_IO_PFX_SFX_DEPRECATION_WARNING or "                           \
         "_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS to suppress this warning.")]]
 #else // ^^^ warning enabled / warning disabled vvv
 #define _DEPRECATE_IO_PFX_SFX

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1505,7 +1505,19 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define _DEPRECATE_STDEXT_CVT
 #endif // ^^^ warning disabled ^^^
 
-// next warning number: STL4045
+#if _HAS_CXX17 && !defined(_SILENCE_IO_PFX_SFX_DEPRECATION_WARNING) \
+    && !defined(_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS)
+#define _DEPRECATE_IO_PFX_SFX                                                                                          \
+    [[deprecated(                                                                                                      \
+        "warning STL4045: The ipfx(), isfx(), opfx(), and osfx() functions are removed before C++98 (see WG21-N0794) " \
+        "but kept as non-Standard extensions. They will be removed in the future, and the member classes sentry "      \
+        "should be used instread. You can define _SILENCE_IO_PFX_SFX_DEPRECATION_WARNING or "                          \
+        "_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS to suppress this warning.")]]
+#else // ^^^ warning enabled / warning disabled vvv
+#define _DEPRECATE_IO_PFX_SFX
+#endif // ^^^ warning disabled ^^^
+
+// next warning number: STL4046
 
 // next error number: STL1006
 


### PR DESCRIPTION
I found that these functions were present in some early prehistoric working drafts but removed before C++98 (see [WG21-N0794](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/1995/N0794.pdf) for rationale). I think it's helpful to say `sentry` classes should be used instead.