### PR TITLE
Remove `/clr` test workarounds

### DIFF
--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -12,10 +12,6 @@
 #include <type_traits>
 #include <utility>
 
-#ifdef _M_CEE // TRANSITION, VSO-1867037
-#include <memory>
-#endif // ^^^ workaround ^^^
-
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
 
 namespace ranges = std::ranges;
@@ -72,21 +68,11 @@ template <class T, std::size_t N>
 struct holder {
     STATIC_ASSERT(N < ~std::size_t{0} / sizeof(T));
 
-#ifdef _M_CEE // TRANSITION, VSO-1867037
-    unsigned char space[(N + 1) * sizeof(T)];
-
-    auto as_span() {
-        void* buffer_ptr       = space;
-        std::size_t buffer_len = sizeof(space);
-        return std::span<T, N>{static_cast<T*>(std::align(alignof(T), sizeof(T), buffer_ptr, buffer_len)), N};
-    }
-#else // ^^^ workaround / no workaround vvv
     alignas(T) unsigned char space[N * sizeof(T)];
 
     auto as_span() {
         return std::span<T, N>{reinterpret_cast<T*>(space + 0), N};
     }
-#endif // ^^^ no workaround ^^^
 };
 
 namespace test {

--- a/tests/std/include/test_atomic_wait.hpp
+++ b/tests/std/include/test_atomic_wait.hpp
@@ -74,13 +74,7 @@ void test_atomic_wait_func(UnderlyingType old_value, const UnderlyingType new_va
 template <class UnderlyingType>
 void test_atomic_wait_func_ptr(UnderlyingType old_value, const UnderlyingType new_value,
     const std::chrono::steady_clock::duration waiting_duration) {
-#ifdef _M_CEE // TRANSITION, VSO-1665654
-    (void) old_value;
-    (void) new_value;
-    (void) waiting_duration;
-#else // ^^^ workaround / no workaround vvv
     test_atomic_wait_func_impl<std::atomic, UnderlyingType>(old_value, new_value, waiting_duration);
-#endif // ^^^ no workaround ^^^
 }
 
 
@@ -114,14 +108,8 @@ void test_notify_all_notifies_all(UnderlyingType old_value, const UnderlyingType
 template <class UnderlyingType>
 void test_notify_all_notifies_all_ptr(UnderlyingType old_value, const UnderlyingType new_value,
     const std::chrono::steady_clock::duration waiting_duration) {
-#ifdef _M_CEE // TRANSITION, VSO-1665654
-    (void) old_value;
-    (void) new_value;
-    (void) waiting_duration;
-#else // ^^^ workaround / no workaround vvv
     // increased waiting_duration because timing assumption might not hold for atomic smart pointers
     test_notify_all_notifies_all_impl<std::atomic, UnderlyingType>(old_value, new_value, 3 * waiting_duration);
-#endif // ^^^ no workaround ^^^
 }
 
 
@@ -172,12 +160,8 @@ void test_pad_bits_impl(const std::chrono::steady_clock::duration waiting_durati
 
 template <class UnderlyingType>
 void test_pad_bits(const std::chrono::steady_clock::duration waiting_duration) {
-#ifdef _M_CEE // TRANSITION, VSO-1665654
-    (void) waiting_duration;
-#else // ^^^ workaround / no workaround vvv
     test_pad_bits_impl<std::atomic, UnderlyingType>(waiting_duration);
     test_pad_bits_impl<std::atomic_ref, UnderlyingType>(waiting_duration);
-#endif // ^^^ no workaround ^^^
 }
 
 struct two_shorts {
@@ -302,7 +286,9 @@ inline void test_atomic_wait() {
 #ifndef __clang__ // TRANSITION, LLVM-46685
     test_pad_bits<with_padding_bits<2>>(waiting_duration);
     test_pad_bits<with_padding_bits<4>>(waiting_duration);
+#if !(defined(_M_CEE) && defined(_M_IX86)) // TRANSITION, VSO-1881472
     test_pad_bits<with_padding_bits<8>>(waiting_duration);
+#endif // ^^^ no workaround ^^^
 #ifndef _M_ARM
     test_pad_bits<with_padding_bits<16>>(waiting_duration);
     test_pad_bits<with_padding_bits<32>>(waiting_duration);

--- a/tests/std/tests/P0019R8_atomic_ref/test.cpp
+++ b/tests/std/tests/P0019R8_atomic_ref/test.cpp
@@ -37,7 +37,6 @@ struct int128 {
 
 template <bool AddViaCas, typename ValueType>
 void test_ops() {
-#ifndef _M_CEE // TRANSITION, VSO-1659695
     constexpr std::size_t unique      = 80; // small to avoid overflow even for char
     constexpr std::size_t repetitions = 8000;
     constexpr std::size_t total       = unique * repetitions;
@@ -85,7 +84,6 @@ void test_ops() {
     assert(std::transform_reduce(par, refs.begin(), refs.end(), 0, std::plus{}, load) == range * repetitions * 2);
     assert(std::transform_reduce(par, refs.begin(), refs.end(), 0, std::plus{}, xchg0) == range * 2);
     assert(std::transform_reduce(par, refs.begin(), refs.end(), 0, std::plus{}, load) == 0);
-#endif // _M_CEE
 }
 
 template <class Integer>

--- a/tests/std/tests/P0024R2_parallel_algorithms_equal/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_equal/test.cpp
@@ -80,9 +80,7 @@ void test_case_equal_parallel(const size_t testSize) {
 }
 
 int main() {
-#ifndef _M_CEE // TRANSITION, VSO-1659695
     parallel_test_case(test_case_equal_parallel<forward_list>);
     parallel_test_case(test_case_equal_parallel<list>);
     parallel_test_case(test_case_equal_parallel<vector>);
-#endif // _M_CEE
 }

--- a/tests/std/tests/P0024R2_parallel_algorithms_for_each/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_for_each/test.cpp
@@ -69,7 +69,6 @@ struct test_case_for_each_n_parallel {
 };
 
 int main() {
-#ifndef _M_CEE // TRANSITION, VSO-1659695
     test_case_for_each_n();
     parallel_test_case(test_case_for_each_parallel<forward_list>{}, par);
     parallel_test_case(test_case_for_each_parallel<list>{}, par);
@@ -85,5 +84,4 @@ int main() {
     parallel_test_case(test_case_for_each_n_parallel<list>{}, unseq);
     parallel_test_case(test_case_for_each_n_parallel<vector>{}, unseq);
 #endif // _HAS_CXX20
-#endif // _M_CEE
 }

--- a/tests/std/tests/P0024R2_parallel_algorithms_inclusive_scan/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_inclusive_scan/test.cpp
@@ -207,7 +207,6 @@ void test_case_inclusive_scan_init_writes_intermediate_type() {
 }
 
 int main() {
-#ifndef _M_CEE // TRANSITION, VSO-1659695
     mt19937 gen(1729);
 
     parallel_test_case(test_case_inclusive_scan_parallel, gen);
@@ -218,5 +217,4 @@ int main() {
     parallel_test_case(test_case_inclusive_scan_bop_init_parallel_associative);
     parallel_test_case(test_case_inclusive_scan_bop_init_parallel_associative_in_place);
     test_case_inclusive_scan_init_writes_intermediate_type();
-#endif // _M_CEE
 }

--- a/tests/std/tests/P0024R2_parallel_algorithms_mismatch/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_mismatch/test.cpp
@@ -77,7 +77,6 @@ void test_case_mismatch_lengths(const size_t testSize) {
 }
 
 int main() {
-#ifndef _M_CEE // TRANSITION, VSO-1659489
     parallel_test_case(test_case_mismatch_signatures<forward_list>);
     parallel_test_case(test_case_mismatch_signatures<list>);
     parallel_test_case(test_case_mismatch_signatures<vector>);
@@ -86,5 +85,4 @@ int main() {
     parallel_test_case(test_case_mismatch_lengths<list, list>);
     parallel_test_case(test_case_mismatch_lengths<list, vector>);
     parallel_test_case(test_case_mismatch_lengths<vector, list>);
-#endif // _M_CEE
 }

--- a/tests/std/tests/P0024R2_parallel_algorithms_reduce/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_reduce/test.cpp
@@ -75,11 +75,9 @@ void test_case_incorrect_special_case_reasoning() {
 }
 
 int main() {
-#ifndef _M_CEE // TRANSITION, VSO-1659695
     mt19937 gen(1729);
     parallel_test_case(test_case_reduce, gen);
     parallel_test_case([](const size_t testSize) { test_case_move_only(seq, testSize); });
     parallel_test_case([](const size_t testSize) { test_case_move_only(par, testSize); });
     test_case_incorrect_special_case_reasoning();
-#endif // _M_CEE
 }

--- a/tests/std/tests/P0024R2_parallel_algorithms_replace/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_replace/test.cpp
@@ -37,10 +37,8 @@ void test_case_replace_if_parallel(const size_t testSize, mt19937& gen) {
 }
 
 int main() {
-#ifndef _M_CEE // TRANSITION, VSO-1659695
     mt19937 gen(1729);
 
     parallel_test_case(test_case_replace_parallel, gen);
     parallel_test_case(test_case_replace_if_parallel, gen);
-#endif // _M_CEE
 }

--- a/tests/std/tests/P0024R2_parallel_algorithms_transform_inclusive_scan/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_transform_inclusive_scan/test.cpp
@@ -218,7 +218,6 @@ void test_case_transform_inclusive_scan_init_writes_intermediate_type() {
 }
 
 int main() {
-#ifndef _M_CEE // TRANSITION, VSO-1659695
     mt19937 gen(1729);
 
     parallel_test_case(test_case_transform_inclusive_scan_parallel, gen);
@@ -228,5 +227,4 @@ int main() {
     parallel_test_case(test_case_transform_inclusive_scan_init_parallel_associative);
     parallel_test_case(test_case_transform_inclusive_scan_init_parallel_associative_in_place);
     test_case_transform_inclusive_scan_init_writes_intermediate_type();
-#endif // _M_CEE
 }

--- a/tests/std/tests/P0024R2_parallel_algorithms_transform_reduce/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_transform_reduce/test.cpp
@@ -145,7 +145,6 @@ void test_case_incorrect_special_case_reasoning() {
 }
 
 int main() {
-#ifndef _M_CEE // TRANSITION, VSO-1659695
     mt19937 gen(1729);
     parallel_test_case(test_case_transform_reduce_binary, gen);
     parallel_test_case(test_case_transform_reduce, gen);
@@ -154,5 +153,4 @@ int main() {
     parallel_test_case([](const size_t testSize) { test_case_move_only(seq, testSize); });
     parallel_test_case([](const size_t testSize) { test_case_move_only(par, testSize); });
     test_case_incorrect_special_case_reasoning();
-#endif // _M_CEE
 }

--- a/tests/std/tests/P0896R4_ranges_alg_equal/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_equal/test.cpp
@@ -79,13 +79,11 @@ constexpr void smoke_test() {
         assert(!equal(begin(arr1), unreachable_sentinel, begin(arr2), end(arr2)));
         assert(!equal(begin(arr1), end(arr1), begin(arr2), unreachable_sentinel));
     }
-#ifndef _M_CEE // TRANSITION, VSO-1666180
     {
         // Validate GH-3550: "<ranges>: ranges::equal does not work for ranges with integer-class range_difference_t"
         auto v = ranges::subrange{std::views::iota(0ull, 10ull)} | std::views::drop(2);
         assert(equal(v, v));
     }
-#endif // _M_CEE
 }
 
 int main() {

--- a/tests/std/tests/P0896R4_views_drop/test.cpp
+++ b/tests/std/tests/P0896R4_views_drop/test.cpp
@@ -559,7 +559,6 @@ int main() {
     STATIC_ASSERT((instantiation_test(), true));
     instantiation_test();
 
-#ifndef _M_CEE // TRANSITION, VSO-1666180
     {
         // Validate a view borrowed range
         constexpr auto v =
@@ -567,7 +566,6 @@ int main() {
         STATIC_ASSERT(test_one(v, only_four_ints));
         test_one(v, only_four_ints);
     }
-#endif // _M_CEE
 
     { // Validate that we can use something that is convertible to integral (GH-1957)
         constexpr span s{some_ints};

--- a/tests/std/tests/P0896R4_views_elements/test.cpp
+++ b/tests/std/tests/P0896R4_views_elements/test.cpp
@@ -438,12 +438,10 @@ int main() {
         instantiation_test();
     }
 
-#ifndef _M_CEE // TRANSITION, VSO-1666180
     { // Validate a view borrowed range
         constexpr auto v = views::iota(0ull, ranges::size(expected_keys))
                          | views::transform([](auto i) { return make_pair(expected_keys[i], expected_values[i]); });
         STATIC_ASSERT(test_one(v));
         test_one(v);
     }
-#endif // _M_CEE
 }

--- a/tests/std/tests/P0896R4_views_iota/test.cpp
+++ b/tests/std/tests/P0896R4_views_iota/test.cpp
@@ -314,13 +314,11 @@ constexpr bool test_difference() {
 }
 
 constexpr bool test_gh_3025() {
-#ifndef _M_CEE // TRANSITION, VSO-1666180
     // GH-3025 <iterator>: ranges::prev maybe ill-formed in debug mode
     auto r  = views::iota(0ull, 5ull);
     auto it = r.end();
     auto pr = ranges::prev(it, 3);
     assert(*pr == 2ull);
-#endif // _M_CEE
 
     return true;
 }

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -671,7 +671,6 @@ int main() {
     STATIC_ASSERT((instantiation_test(), true));
     instantiation_test();
 
-#ifndef _M_CEE // TRANSITION, VSO-1666180
     {
         // Validate a view borrowed range
         constexpr auto v =
@@ -679,7 +678,6 @@ int main() {
         STATIC_ASSERT(test_one(v, only_four_ints));
         test_one(v, only_four_ints);
     }
-#endif // _M_CEE
 
     { // Validate that we can use something that is convertible to integral (GH-1957)
         constexpr span s{some_ints};

--- a/tests/std/tests/P1135R6_atomic_flag_test/test.cpp
+++ b/tests/std/tests/P1135R6_atomic_flag_test/test.cpp
@@ -82,8 +82,6 @@ void test_flag_type() {
 }
 
 int main() {
-#ifndef _M_CEE // TRANSITION, VSO-1659695
     test_flag_type<std::atomic_flag>();
     test_flag_type<volatile std::atomic_flag>();
-#endif // _M_CEE
 }

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -1293,11 +1293,7 @@ constexpr bool test_cross() {
         x = -26;
         TEST(u *= 2, x);
         y = 12;
-#ifdef _M_CEE // TRANSITION, VSO-1658184 (/clr silent bad codegen)
-        i = 12;
-#else // ^^^ workaround / no workaround vvv
         TEST(i *= -2, y);
-#endif // ^^^ no workaround ^^^
 
         x = _Unsigned128{0x55555555'5555554c, 0x55555555'55555555};
         TEST(u /= 3, x); // Yes, u is still unsigned =)


### PR DESCRIPTION
Thanks to Shayne Hiet-Block's wonderful internal MSVC-PR-487530, we can remove numerous test workarounds for the following internal bugs:

* VSO-1658184 `/clr` silent bad codegen with `std::_Signed128` multiplication
* VSO-1659489 `/clr` System.AccessViolationException with parallel `std::mismatch`
* VSO-1659695 `/clr` x86 runtime assertions/crashes with parallel algorithms
* VSO-1665654 `/clr` C++20 x86 System.AccessViolationException with `atomic<shared_ptr>`
* VSO-1666180 `/clr` C++20 x64 System.AccessViolationException with `views::iota` and `views::transform`
* VSO-1867037 `/clr` C++20 System.AccessViolationException with ranges uninitialized algorithms

I had to report and add a highly targeted workaround for one remaining bug:

* VSO-1881472 `/clr` C++20 x86 System.AccessViolationException with `atomic<with_padding_bits<8>>`

Because `/clr` isn't built on GitHub (yet), we can immediately remove these workarounds and "lock in" the fixes, without waiting for a VS Preview to ship.