### PR TITLE
Make `expected<any, ...>` and `expected<void, any>` copyable

### DIFF
--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -238,6 +238,9 @@ public:
     // clang-format on
 
     template <class _Uty, class _UErr>
+    static constexpr bool _Not_self = !is_same_v<_Ty, _Uty> || !is_same_v<_Err, _UErr>;
+
+    template <class _Uty, class _UErr>
     static constexpr bool _Allow_unwrapping = disjunction_v<is_same<remove_cv_t<_Ty>, bool>,
                                                   negation<disjunction<is_constructible<_Ty, expected<_Uty, _UErr>&>, //
                                                       is_constructible<_Ty, expected<_Uty, _UErr>>, //
@@ -253,8 +256,8 @@ public:
                                            && !is_constructible_v<unexpected<_Err>, const expected<_Uty, _UErr>>;
 
     template <class _Uty, class _UErr>
-        requires is_constructible_v<_Ty, const _Uty&> && is_constructible_v<_Err, const _UErr&>
-              && _Allow_unwrapping<_Uty, _UErr>
+        requires _Not_self<_Uty, _UErr> && is_constructible_v<_Ty, const _Uty&>
+              && is_constructible_v<_Err, const _UErr&> && _Allow_unwrapping<_Uty, _UErr>
     constexpr explicit(!is_convertible_v<const _Uty&, _Ty> || !is_convertible_v<const _UErr&, _Err>)
         expected(const expected<_Uty, _UErr>& _Other) noexcept(is_nothrow_constructible_v<_Ty, const _Uty&> //
                 && is_nothrow_constructible_v<_Err, const _UErr&>) // strengthened
@@ -267,7 +270,8 @@ public:
     }
 
     template <class _Uty, class _UErr>
-        requires is_constructible_v<_Ty, _Uty> && is_constructible_v<_Err, _UErr> && _Allow_unwrapping<_Uty, _UErr>
+        requires _Not_self<_Uty, _UErr> && is_constructible_v<_Ty, _Uty> && is_constructible_v<_Err, _UErr>
+              && _Allow_unwrapping<_Uty, _UErr>
     constexpr explicit(!is_convertible_v<_Uty, _Ty> || !is_convertible_v<_UErr, _Err>)
         expected(expected<_Uty, _UErr>&& _Other) noexcept(
             is_nothrow_constructible_v<_Ty, _Uty>&& is_nothrow_constructible_v<_Err, _UErr>) // strengthened
@@ -342,7 +346,7 @@ public:
     }
 
     // clang-format off
-    ~expected() requires is_trivially_destructible_v<_Ty> && is_trivially_destructible_v<_Err> = default;
+    ~expected() requires is_trivially_destructible_v<_Ty>&& is_trivially_destructible_v<_Err> = default;
     // clang-format on
 
     // [expected.object.assign]
@@ -1202,13 +1206,17 @@ public:
     // clang-format on
 
     template <class _Uty, class _UErr>
+    static constexpr bool _Not_self = !is_same_v<_Ty, _Uty> || !is_same_v<_Err, _UErr>;
+
+    template <class _Uty, class _UErr>
     static constexpr bool _Allow_unwrapping = !is_constructible_v<unexpected<_Err>, expected<_Uty, _UErr>&>
                                            && !is_constructible_v<unexpected<_Err>, expected<_Uty, _UErr>>
                                            && !is_constructible_v<unexpected<_Err>, const expected<_Uty, _UErr>&>
                                            && !is_constructible_v<unexpected<_Err>, const expected<_Uty, _UErr>>;
 
     template <class _Uty, class _UErr>
-        requires is_void_v<_Uty> && is_constructible_v<_Err, const _UErr&> && _Allow_unwrapping<_Uty, _UErr>
+        requires _Not_self<_Uty, _UErr> && is_void_v<_Uty> && is_constructible_v<_Err, const _UErr&>
+              && _Allow_unwrapping<_Uty, _UErr>
     constexpr explicit(!is_convertible_v<const _UErr&, _Err>) expected(const expected<_Uty, _UErr>& _Other) noexcept(
         is_nothrow_constructible_v<_Err, const _UErr&>) // strengthened
         : _Has_value(_Other._Has_value) {
@@ -1218,7 +1226,8 @@ public:
     }
 
     template <class _Uty, class _UErr>
-        requires is_void_v<_Uty> && is_constructible_v<_Err, _UErr> && _Allow_unwrapping<_Uty, _UErr>
+        requires _Not_self<_Uty, _UErr> && is_void_v<_Uty> && is_constructible_v<_Err, _UErr>
+              && _Allow_unwrapping<_Uty, _UErr>
     constexpr explicit(!is_convertible_v<_UErr, _Err>)
         expected(expected<_Uty, _UErr>&& _Other) noexcept(is_nothrow_constructible_v<_Err, _UErr>) // strengthened
         : _Has_value(_Other._Has_value) {

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -237,6 +237,7 @@ public:
         is_trivially_move_constructible_v<_Ty> && is_trivially_move_constructible_v<_Err> = default;
     // clang-format on
 
+private:
     template <class _Uty, class _UErr>
     static constexpr bool _Not_self = !is_same_v<_Ty, _Uty> || !is_same_v<_Err, _UErr>;
 
@@ -255,6 +256,7 @@ public:
                                            && !is_constructible_v<unexpected<_Err>, const expected<_Uty, _UErr>&> //
                                            && !is_constructible_v<unexpected<_Err>, const expected<_Uty, _UErr>>;
 
+public:
     template <class _Uty, class _UErr>
         requires _Not_self<_Uty, _UErr> && is_constructible_v<_Ty, const _Uty&>
               && is_constructible_v<_Err, const _UErr&> && _Allow_unwrapping<_Uty, _UErr>
@@ -1205,6 +1207,7 @@ public:
     expected(expected&&) requires is_trivially_move_constructible_v<_Err> = default;
     // clang-format on
 
+private:
     template <class _Uty, class _UErr>
     static constexpr bool _Not_self = !is_same_v<_Ty, _Uty> || !is_same_v<_Err, _UErr>;
 
@@ -1214,6 +1217,7 @@ public:
                                            && !is_constructible_v<unexpected<_Err>, const expected<_Uty, _UErr>&>
                                            && !is_constructible_v<unexpected<_Err>, const expected<_Uty, _UErr>>;
 
+public:
     template <class _Uty, class _UErr>
         requires _Not_self<_Uty, _UErr> && is_void_v<_Uty> && is_constructible_v<_Err, const _UErr&>
               && _Allow_unwrapping<_Uty, _UErr>
@@ -1389,26 +1393,7 @@ public:
         is_nothrow_move_constructible_v<_Err>&& is_nothrow_swappable_v<_Err>)
         requires is_swappable_v<_Err> && is_move_constructible_v<_Err>
     {
-        using _STD swap;
-        if (_Left._Has_value && _Right._Has_value) {
-            // nothing
-        } else if (_Left._Has_value) {
-            _STD construct_at(_STD addressof(_Left._Unexpected), _STD move(_Right._Unexpected));
-            if constexpr (!is_trivially_destructible_v<_Err>) {
-                _Right._Unexpected.~_Err();
-            }
-            _Left._Has_value  = false;
-            _Right._Has_value = true;
-        } else if (_Right._Has_value) {
-            _STD construct_at(_STD addressof(_Right._Unexpected), _STD move(_Left._Unexpected));
-            if constexpr (!is_trivially_destructible_v<_Err>) {
-                _Left._Unexpected.~_Err();
-            }
-            _Left._Has_value  = true;
-            _Right._Has_value = false;
-        } else {
-            swap(_Left._Unexpected, _Right._Unexpected); // intentional ADL
-        }
+        _Left.swap(_Right);
     }
 
     // [expected.void.obs]

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -190,6 +190,21 @@ class expected {
     template <class _UTy, class _UErr>
     friend class expected;
 
+    template <class _Uty, class _UErr>
+    static constexpr bool _Allow_unwrapping = disjunction_v<is_same<remove_cv_t<_Ty>, bool>,
+                                                  negation<disjunction<is_constructible<_Ty, expected<_Uty, _UErr>&>, //
+                                                      is_constructible<_Ty, expected<_Uty, _UErr>>, //
+                                                      is_constructible<_Ty, const expected<_Uty, _UErr>&>, //
+                                                      is_constructible<_Ty, const expected<_Uty, _UErr>>, //
+                                                      is_convertible<expected<_Uty, _UErr>&, _Ty>, //
+                                                      is_convertible<expected<_Uty, _UErr>&&, _Ty>, //
+                                                      is_convertible<const expected<_Uty, _UErr>&, _Ty>, //
+                                                      is_convertible<const expected<_Uty, _UErr>&&, _Ty>>>> //
+                                           && !is_constructible_v<unexpected<_Err>, expected<_Uty, _UErr>&> //
+                                           && !is_constructible_v<unexpected<_Err>, expected<_Uty, _UErr>> //
+                                           && !is_constructible_v<unexpected<_Err>, const expected<_Uty, _UErr>&> //
+                                           && !is_constructible_v<unexpected<_Err>, const expected<_Uty, _UErr>>;
+
 public:
     using value_type      = _Ty;
     using error_type      = _Err;
@@ -237,28 +252,8 @@ public:
         is_trivially_move_constructible_v<_Ty> && is_trivially_move_constructible_v<_Err> = default;
     // clang-format on
 
-private:
     template <class _Uty, class _UErr>
-    static constexpr bool _Not_self = !is_same_v<_Ty, _Uty> || !is_same_v<_Err, _UErr>;
-
-    template <class _Uty, class _UErr>
-    static constexpr bool _Allow_unwrapping = disjunction_v<is_same<remove_cv_t<_Ty>, bool>,
-                                                  negation<disjunction<is_constructible<_Ty, expected<_Uty, _UErr>&>, //
-                                                      is_constructible<_Ty, expected<_Uty, _UErr>>, //
-                                                      is_constructible<_Ty, const expected<_Uty, _UErr>&>, //
-                                                      is_constructible<_Ty, const expected<_Uty, _UErr>>, //
-                                                      is_convertible<expected<_Uty, _UErr>&, _Ty>, //
-                                                      is_convertible<expected<_Uty, _UErr>&&, _Ty>, //
-                                                      is_convertible<const expected<_Uty, _UErr>&, _Ty>, //
-                                                      is_convertible<const expected<_Uty, _UErr>&&, _Ty>>>> //
-                                           && !is_constructible_v<unexpected<_Err>, expected<_Uty, _UErr>&> //
-                                           && !is_constructible_v<unexpected<_Err>, expected<_Uty, _UErr>> //
-                                           && !is_constructible_v<unexpected<_Err>, const expected<_Uty, _UErr>&> //
-                                           && !is_constructible_v<unexpected<_Err>, const expected<_Uty, _UErr>>;
-
-public:
-    template <class _Uty, class _UErr>
-        requires _Not_self<_Uty, _UErr> && is_constructible_v<_Ty, const _Uty&>
+        requires _Different_from<expected<_Uty, _UErr>, expected> && is_constructible_v<_Ty, const _Uty&>
               && is_constructible_v<_Err, const _UErr&> && _Allow_unwrapping<_Uty, _UErr>
     constexpr explicit(!is_convertible_v<const _Uty&, _Ty> || !is_convertible_v<const _UErr&, _Err>)
         expected(const expected<_Uty, _UErr>& _Other) noexcept(is_nothrow_constructible_v<_Ty, const _Uty&> //
@@ -272,8 +267,8 @@ public:
     }
 
     template <class _Uty, class _UErr>
-        requires _Not_self<_Uty, _UErr> && is_constructible_v<_Ty, _Uty> && is_constructible_v<_Err, _UErr>
-              && _Allow_unwrapping<_Uty, _UErr>
+        requires _Different_from<expected<_Uty, _UErr>, expected> && is_constructible_v<_Ty, _Uty>
+              && is_constructible_v<_Err, _UErr> && _Allow_unwrapping<_Uty, _UErr>
     constexpr explicit(!is_convertible_v<_Uty, _Ty> || !is_convertible_v<_UErr, _Err>)
         expected(expected<_Uty, _UErr>&& _Other) noexcept(
             is_nothrow_constructible_v<_Ty, _Uty>&& is_nothrow_constructible_v<_Err, _UErr>) // strengthened
@@ -1172,6 +1167,12 @@ class expected<_Ty, _Err> {
     template <class _UTy, class _UErr>
     friend class expected;
 
+    template <class _Uty, class _UErr>
+    static constexpr bool _Allow_unwrapping = !is_constructible_v<unexpected<_Err>, expected<_Uty, _UErr>&>
+                                           && !is_constructible_v<unexpected<_Err>, expected<_Uty, _UErr>>
+                                           && !is_constructible_v<unexpected<_Err>, const expected<_Uty, _UErr>&>
+                                           && !is_constructible_v<unexpected<_Err>, const expected<_Uty, _UErr>>;
+
 public:
     using value_type      = _Ty;
     using error_type      = _Err;
@@ -1207,20 +1208,9 @@ public:
     expected(expected&&) requires is_trivially_move_constructible_v<_Err> = default;
     // clang-format on
 
-private:
     template <class _Uty, class _UErr>
-    static constexpr bool _Not_self = !is_same_v<_Ty, _Uty> || !is_same_v<_Err, _UErr>;
-
-    template <class _Uty, class _UErr>
-    static constexpr bool _Allow_unwrapping = !is_constructible_v<unexpected<_Err>, expected<_Uty, _UErr>&>
-                                           && !is_constructible_v<unexpected<_Err>, expected<_Uty, _UErr>>
-                                           && !is_constructible_v<unexpected<_Err>, const expected<_Uty, _UErr>&>
-                                           && !is_constructible_v<unexpected<_Err>, const expected<_Uty, _UErr>>;
-
-public:
-    template <class _Uty, class _UErr>
-        requires _Not_self<_Uty, _UErr> && is_void_v<_Uty> && is_constructible_v<_Err, const _UErr&>
-              && _Allow_unwrapping<_Uty, _UErr>
+        requires _Different_from<expected<_Uty, _UErr>, expected> && is_void_v<_Uty>
+              && is_constructible_v<_Err, const _UErr&> && _Allow_unwrapping<_Uty, _UErr>
     constexpr explicit(!is_convertible_v<const _UErr&, _Err>) expected(const expected<_Uty, _UErr>& _Other) noexcept(
         is_nothrow_constructible_v<_Err, const _UErr&>) // strengthened
         : _Has_value(_Other._Has_value) {
@@ -1230,7 +1220,7 @@ public:
     }
 
     template <class _Uty, class _UErr>
-        requires _Not_self<_Uty, _UErr> && is_void_v<_Uty> && is_constructible_v<_Err, _UErr>
+        requires _Different_from<expected<_Uty, _UErr>, expected> && is_void_v<_Uty> && is_constructible_v<_Err, _UErr>
               && _Allow_unwrapping<_Uty, _UErr>
     constexpr explicit(!is_convertible_v<_UErr, _Err>)
         expected(expected<_Uty, _UErr>&& _Other) noexcept(is_nothrow_constructible_v<_Err, _UErr>) // strengthened

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -346,7 +346,7 @@ public:
     }
 
     // clang-format off
-    ~expected() requires is_trivially_destructible_v<_Ty>&& is_trivially_destructible_v<_Err> = default;
+    ~expected() requires is_trivially_destructible_v<_Ty> && is_trivially_destructible_v<_Err> = default;
     // clang-format on
 
     // [expected.object.assign]

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -184,6 +184,7 @@ struct _Check_expected_argument : true_type {
 
 _EXPORT_STD template <class _Ty, class _Err>
 class expected {
+private:
     static_assert(_Check_expected_argument<_Ty>::value);
     static_assert(_Check_unexpected_argument<_Err>::value);
 
@@ -1162,6 +1163,7 @@ private:
 template <class _Ty, class _Err>
     requires is_void_v<_Ty>
 class expected<_Ty, _Err> {
+private:
     static_assert(_Check_unexpected_argument<_Err>::value);
 
     template <class _UTy, class _UErr>

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -2136,10 +2136,9 @@ void test_lwg_3843() {
     }
 }
 
-void test_gh_4011() {
-    static_assert(copyable<expected<any, int>>);
-    static_assert(copyable<expected<void, any>>);
-}
+// Test GH-4011: these predicates triggered constraint recursion.
+static_assert(copyable<expected<any, int>>);
+static_assert(copyable<expected<void, any>>);
 
 int main() {
     test_unexpected::test_all();
@@ -2157,5 +2156,4 @@ int main() {
 
     test_reinit_regression();
     test_lwg_3843();
-    test_gh_4011();
 }

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -3,6 +3,7 @@
 
 #define _CONTAINER_DEBUG_LEVEL 1
 
+#include <any>
 #include <cassert>
 #include <concepts>
 #include <exception>
@@ -2135,6 +2136,11 @@ void test_lwg_3843() {
     }
 }
 
+void test_gh_4011() {
+    static_assert(copyable<expected<any, int>>);
+    static_assert(copyable<expected<void, any>>);
+}
+
 int main() {
     test_unexpected::test_all();
     static_assert(test_unexpected::test_all());
@@ -2151,4 +2157,5 @@ int main() {
 
     test_reinit_regression();
     test_lwg_3843();
+    test_gh_4011();
 }


### PR DESCRIPTION
Fixes #4011.