### PR TITLE
Prepare for impending LLVM 17 release

### DIFF
--- a/stl/inc/__msvc_iter_core.hpp
+++ b/stl/inc/__msvc_iter_core.hpp
@@ -51,6 +51,12 @@ _EXPORT_STD struct random_access_iterator_tag : bidirectional_iterator_tag {};
 _EXPORT_STD struct contiguous_iterator_tag : random_access_iterator_tag {};
 
 template <class _Ty>
+using _With_reference = _Ty&;
+
+template <class _Ty>
+concept _Can_reference = requires { typename _With_reference<_Ty>; };
+
+template <class _Ty>
 concept _Dereferenceable = requires(_Ty& __t) {
     { *__t } -> _Can_reference;
 };

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -8213,9 +8213,13 @@ namespace ranges {
         private:
             friend zip_view;
 
+#ifdef __clang__ // TRANSITION, LLVM-61763
+        public:
+#else // ^^^ workaround / no workaround vvv
             template <class _Func, class... _OtherViews>
                 requires _Zip_transform_constraints<_Func, _OtherViews...>
             friend class zip_transform_view;
+#endif // ^^^ no workaround ^^^
 
             using _My_tuple = tuple<iterator_t<_Maybe_const<_IsConst, _ViewTypes>>...>;
 
@@ -9047,7 +9051,7 @@ namespace ranges {
         private:
             friend adjacent_view;
 
-#ifdef __clang__ // TRANSITION, Clang 17
+#ifdef __clang__ // TRANSITION, LLVM-61763
         public:
 #else // ^^^ workaround / no workaround vvv
             template <class _Vw2, class _Fn, size_t _Nx2>

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -105,9 +105,6 @@ namespace ranges {
     template <class _It>
     concept _Has_arrow = input_iterator<_It> && (is_pointer_v<_It> || _Has_member_arrow<_It&>);
 
-    template <bool _IsConst, class _Ty>
-    using _Maybe_const = conditional_t<_IsConst, const _Ty, _Ty>;
-
     template <bool _IsWrapped, class _Ty>
     using _Maybe_wrapped = conditional_t<_IsWrapped, _Ty, _Unwrapped_t<_Ty>>;
 

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -2513,6 +2513,9 @@ _NODISCARD constexpr _To _Bit_cast(const _From& _Val) noexcept {
     return __builtin_bit_cast(_To, _Val);
 }
 
+template <bool _IsConst, class _Ty>
+using _Maybe_const = conditional_t<_IsConst, const _Ty, _Ty>;
+
 #if _HAS_TR1_NAMESPACE
 _STL_DISABLE_DEPRECATED_WARNING
 namespace _DEPRECATE_TR1_NAMESPACE tr1 {

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -927,6 +927,41 @@ _EXPORT_STD [[noreturn]] __forceinline void unreachable() noexcept /* strengthen
 #endif // defined(_DEBUG)
 }
 
+#ifdef __clang__
+// Clang 17 implements forward_like directly but is confused by our deduced return type
+template <int>
+struct _Dispatch_forward_like;
+template <>
+struct _Dispatch_forward_like<0> {
+    template <class _Ty>
+    using _Apply = _Ty&&;
+};
+template <>
+struct _Dispatch_forward_like<1> {
+    template <class _Ty>
+    using _Apply = _Ty&;
+};
+template <>
+struct _Dispatch_forward_like<2> {
+    template <class _Ty>
+    using _Apply = const _Ty&&;
+};
+template <>
+struct _Dispatch_forward_like<3> {
+    template <class _Ty>
+    using _Apply = const _Ty&;
+};
+
+template <class _Ty, class _Uty>
+using _Forward_like_t =
+    typename _Dispatch_forward_like<2 * is_const_v<remove_reference_t<_Ty>>
+                                    + is_lvalue_reference_v<_Ty>>::template _Apply<remove_reference_t<_Uty>>;
+
+_EXPORT_STD template <class _Ty, class _Uty>
+_NODISCARD constexpr _Forward_like_t<_Ty, _Uty> forward_like(_Uty&& _Ux) noexcept {
+    return static_cast<_Forward_like_t<_Ty, _Uty>>(_Ux);
+}
+#else // ^^^ Clang / non-Clang vvv
 _EXPORT_STD template <class _Ty, class _Uty>
 _NODISCARD _MSVC_INTRINSIC constexpr auto&& forward_like(_Uty&& _Ux) noexcept {
     static_assert(_Can_reference<_Ty>, "std::forward_like's first template argument must be a referenceable type.");
@@ -950,6 +985,7 @@ _NODISCARD _MSVC_INTRINSIC constexpr auto&& forward_like(_Uty&& _Ux) noexcept {
 
 template <class _Ty, class _Uty>
 using _Forward_like_t = decltype(_STD forward_like<_Ty>(_STD declval<_Uty&>()));
+#endif // ^^^ non-Clang ^^^
 #endif // _HAS_CXX23
 
 #if _HAS_TR1_NAMESPACE

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -927,62 +927,14 @@ _EXPORT_STD [[noreturn]] __forceinline void unreachable() noexcept /* strengthen
 #endif // defined(_DEBUG)
 }
 
-#ifdef __clang__ // TRANSITION, LLVM-64029
-// Clang 17 implements forward_like directly and is confused by our deduced return type
-template <bool _IsConst, bool _IsLvalue>
-struct _Dispatch_forward_like {
-    template <class _Ty>
-    using _Apply = const _Ty&;
-};
-template <>
-struct _Dispatch_forward_like<false, false> {
-    template <class _Ty>
-    using _Apply = _Ty&&;
-};
-template <>
-struct _Dispatch_forward_like<false, true> {
-    template <class _Ty>
-    using _Apply = _Ty&;
-};
-template <>
-struct _Dispatch_forward_like<true, false> {
-    template <class _Ty>
-    using _Apply = const _Ty&&;
-};
-
-template <class _Ty, class _Uty>
-using _Forward_like_t = typename _Dispatch_forward_like<is_const_v<remove_reference_t<_Ty>>,
-    is_lvalue_reference_v<_Ty>>::template _Apply<remove_reference_t<_Uty>>;
+template <class _Ty, class _Uty,
+    class _Tmp = _Maybe_const<is_const_v<remove_reference_t<_Ty>>, remove_reference_t<_Uty>>>
+using _Forward_like_t = conditional_t<is_rvalue_reference_v<_Ty&&>, _Tmp&&, _Tmp&>;
 
 _EXPORT_STD template <class _Ty, class _Uty>
 _NODISCARD constexpr _Forward_like_t<_Ty, _Uty> forward_like(_Uty&& _Ux) noexcept {
     return static_cast<_Forward_like_t<_Ty, _Uty>>(_Ux);
 }
-#else // ^^^ workaround / no workaround vvv
-_EXPORT_STD template <class _Ty, class _Uty>
-_NODISCARD _MSVC_INTRINSIC constexpr auto&& forward_like(_Uty&& _Ux) noexcept {
-    static_assert(_Can_reference<_Ty>, "std::forward_like's first template argument must be a referenceable type.");
-
-    using _UnrefT = remove_reference_t<_Ty>;
-    using _UnrefU = remove_reference_t<_Uty>;
-    if constexpr (is_const_v<_UnrefT>) {
-        if constexpr (is_lvalue_reference_v<_Ty>) {
-            return static_cast<const _UnrefU&>(_Ux);
-        } else {
-            return static_cast<const _UnrefU&&>(_Ux);
-        }
-    } else {
-        if constexpr (is_lvalue_reference_v<_Ty>) {
-            return static_cast<_UnrefU&>(_Ux);
-        } else {
-            return static_cast<_UnrefU&&>(_Ux);
-        }
-    }
-}
-
-template <class _Ty, class _Uty>
-using _Forward_like_t = decltype(_STD forward_like<_Ty>(_STD declval<_Uty&>()));
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
 #if _HAS_TR1_NAMESPACE

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -918,7 +918,7 @@ template <class _Ty, class _Uty,
 using _Forward_like_t = conditional_t<is_rvalue_reference_v<_Ty&&>, _Tmp&&, _Tmp&>;
 
 _EXPORT_STD template <class _Ty, class _Uty>
-_NODISCARD constexpr _Forward_like_t<_Ty, _Uty> forward_like(_Uty&& _Ux) noexcept {
+_NODISCARD _MSVC_INTRINSIC constexpr _Forward_like_t<_Ty, _Uty> forward_like(_Uty&& _Ux) noexcept {
     return static_cast<_Forward_like_t<_Ty, _Uty>>(_Ux);
 }
 #endif // _HAS_CXX23

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -898,20 +898,6 @@ _NODISCARD constexpr bool in_range(const _Ty _Value) noexcept {
 
     return true;
 }
-
-#ifdef __cpp_lib_concepts
-template <class _Ty>
-using _With_reference = _Ty&;
-
-template <class _Ty>
-concept _Can_reference = requires { typename _With_reference<_Ty>; };
-#else // ^^^ defined(__cpp_lib_concepts) / !defined(__cpp_lib_concepts) vvv
-template <class _Ty, class = void>
-inline constexpr bool _Can_reference = false;
-
-template <class _Ty>
-inline constexpr bool _Can_reference<_Ty, void_t<_Ty&>> = true;
-#endif // ^^^ !defined(__cpp_lib_concepts) ^^^
 #endif // _HAS_CXX20
 
 #if _HAS_CXX23

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -927,41 +927,38 @@ _EXPORT_STD [[noreturn]] __forceinline void unreachable() noexcept /* strengthen
 #endif // defined(_DEBUG)
 }
 
-#ifdef __clang__
-// Clang 17 implements forward_like directly but is confused by our deduced return type
-template <int>
-struct _Dispatch_forward_like;
+#ifdef __clang__ // TRANSITION, LLVM-64029
+// Clang 17 implements forward_like directly and is confused by our deduced return type
+template <bool isConst, bool isLvalue>
+struct _Dispatch_forward_like {
+    template <class _Ty>
+    using _Apply = const _Ty&;
+};
 template <>
-struct _Dispatch_forward_like<0> {
+struct _Dispatch_forward_like<false, false> {
     template <class _Ty>
     using _Apply = _Ty&&;
 };
 template <>
-struct _Dispatch_forward_like<1> {
+struct _Dispatch_forward_like<false, true> {
     template <class _Ty>
     using _Apply = _Ty&;
 };
 template <>
-struct _Dispatch_forward_like<2> {
+struct _Dispatch_forward_like<true, false> {
     template <class _Ty>
     using _Apply = const _Ty&&;
 };
-template <>
-struct _Dispatch_forward_like<3> {
-    template <class _Ty>
-    using _Apply = const _Ty&;
-};
 
 template <class _Ty, class _Uty>
-using _Forward_like_t =
-    typename _Dispatch_forward_like<2 * is_const_v<remove_reference_t<_Ty>>
-                                    + is_lvalue_reference_v<_Ty>>::template _Apply<remove_reference_t<_Uty>>;
+using _Forward_like_t = typename _Dispatch_forward_like<is_const_v<remove_reference_t<_Ty>>,
+    is_lvalue_reference_v<_Ty>>::template _Apply<remove_reference_t<_Uty>>;
 
 _EXPORT_STD template <class _Ty, class _Uty>
 _NODISCARD constexpr _Forward_like_t<_Ty, _Uty> forward_like(_Uty&& _Ux) noexcept {
     return static_cast<_Forward_like_t<_Ty, _Uty>>(_Ux);
 }
-#else // ^^^ Clang / non-Clang vvv
+#else // ^^^ workaround / no workaround vvv
 _EXPORT_STD template <class _Ty, class _Uty>
 _NODISCARD _MSVC_INTRINSIC constexpr auto&& forward_like(_Uty&& _Ux) noexcept {
     static_assert(_Can_reference<_Ty>, "std::forward_like's first template argument must be a referenceable type.");
@@ -985,7 +982,7 @@ _NODISCARD _MSVC_INTRINSIC constexpr auto&& forward_like(_Uty&& _Ux) noexcept {
 
 template <class _Ty, class _Uty>
 using _Forward_like_t = decltype(_STD forward_like<_Ty>(_STD declval<_Uty&>()));
-#endif // ^^^ non-Clang ^^^
+#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
 #if _HAS_TR1_NAMESPACE

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -929,7 +929,7 @@ _EXPORT_STD [[noreturn]] __forceinline void unreachable() noexcept /* strengthen
 
 #ifdef __clang__ // TRANSITION, LLVM-64029
 // Clang 17 implements forward_like directly and is confused by our deduced return type
-template <bool isConst, bool isLvalue>
+template <bool _IsConst, bool _IsLvalue>
 struct _Dispatch_forward_like {
     template <class _Ty>
     using _Apply = const _Ty&;

--- a/tests/std/tests/P2321R2_views_zip_transform/test.cpp
+++ b/tests/std/tests/P2321R2_views_zip_transform/test.cpp
@@ -9,6 +9,7 @@
 #include <ranges>
 #include <span>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
@@ -18,9 +19,12 @@ using namespace std;
 template <class RangeType>
 using AllView = views::all_t<RangeType>;
 
+template <bool IsConst, class T>
+using maybe_const = conditional_t<IsConst, const T, T>;
+
 template <bool IsConst, class TransformType, ranges::input_range... RangeTypes>
-using TransformResultType = invoke_result_t<ranges::_Maybe_const<IsConst, TransformType>&,
-    ranges::range_reference_t<ranges::_Maybe_const<IsConst, RangeTypes>>...>;
+using TransformResultType = invoke_result_t<maybe_const<IsConst, TransformType>&,
+    ranges::range_reference_t<maybe_const<IsConst, RangeTypes>>...>;
 
 template <bool IsConst, class T>
 constexpr auto& maybe_as_const(T& value) {
@@ -50,8 +54,8 @@ constexpr bool validate_iterators_sentinels(
     constexpr bool is_const = same_as<LocalZipTransformType, add_const_t<LocalZipTransformType>>;
 
     using InnerView            = ranges::zip_view<AllView<RangeTypes>...>;
-    using BaseType             = ranges::_Maybe_const<is_const, InnerView>;
-    using ZipIteratorTupleType = tuple<ranges::iterator_t<ranges::_Maybe_const<is_const, AllView<RangeTypes>>>...>;
+    using BaseType             = maybe_const<is_const, InnerView>;
+    using ZipIteratorTupleType = tuple<ranges::iterator_t<maybe_const<is_const, AllView<RangeTypes>>>...>;
 
     // Validate iterator type aliases
     {
@@ -66,8 +70,8 @@ constexpr bool validate_iterators_sentinels(
                 STATIC_ASSERT(same_as<Cat, input_iterator_tag>);
             } else {
                 constexpr auto check_iterator_tags_closure = []<class TagType>() {
-                    return (derived_from<typename iterator_traits<ranges::iterator_t<
-                                             ranges::_Maybe_const<is_const, RangeTypes>>>::iterator_category,
+                    return (derived_from<typename iterator_traits<
+                                             ranges::iterator_t<maybe_const<is_const, RangeTypes>>>::iterator_category,
                                 TagType>
                             && ...);
                 };
@@ -125,10 +129,9 @@ constexpr bool validate_iterators_sentinels(
         //
         // Notably, parent_t is a pointer and inner_.current_ is a tuple, and operator->() on a pointer and
         // std::get(std::tuple<...>) are both noexcept. We thus simplify the noexcept check as follows:
-        STATIC_ASSERT(
-            noexcept(*itr)
-            == noexcept(invoke(*declval<const ranges::_Movable_box<TransformType>&>(),
-                *declval<const ranges::iterator_t<ranges::_Maybe_const<is_const, AllView<RangeTypes>>>&>()...)));
+        STATIC_ASSERT(noexcept(*itr)
+                      == noexcept(invoke(*declval<const ranges::_Movable_box<TransformType>&>(),
+                          *declval<const ranges::iterator_t<maybe_const<is_const, AllView<RangeTypes>>>&>()...)));
     }
 
     STATIC_ASSERT(noexcept(++itr) == noexcept(++declval<ranges::iterator_t<BaseType>&>()));
@@ -232,7 +235,7 @@ constexpr bool validate_iterators_sentinels(
         // Validate sentinel operator overloads
         {
             const auto validate_iterator_sentinel_equality_closure = [&]<bool IteratorConst>() {
-                using comparison_iterator_t = ranges::iterator_t<ranges::_Maybe_const<IteratorConst, InnerView>>;
+                using comparison_iterator_t = ranges::iterator_t<maybe_const<IteratorConst, InnerView>>;
                 using comparison_sentinel_t = ranges::sentinel_t<BaseType>;
 
                 if constexpr (sentinel_for<comparison_sentinel_t, comparison_iterator_t>) {
@@ -254,11 +257,11 @@ constexpr bool validate_iterators_sentinels(
 
         {
             const auto validate_iterator_sentinel_difference_closure = [&]<bool IteratorConst>() {
-                using comparison_iterator_t = ranges::iterator_t<ranges::_Maybe_const<IteratorConst, InnerView>>;
+                using comparison_iterator_t = ranges::iterator_t<maybe_const<IteratorConst, InnerView>>;
                 using comparison_sentinel_t = ranges::sentinel_t<BaseType>;
 
                 if constexpr (sized_sentinel_for<comparison_sentinel_t, comparison_iterator_t>) {
-                    using difference_type = ranges::range_difference_t<ranges::_Maybe_const<IteratorConst, InnerView>>;
+                    using difference_type = ranges::range_difference_t<maybe_const<IteratorConst, InnerView>>;
 
                     const auto comparison_itr = maybe_as_const<IteratorConst>(relevant_range).begin();
 
@@ -515,9 +518,9 @@ constexpr bool test_one(TransformType_&& transformer, const TransformedElementsC
             // Validate view_interface::front()
             {
                 const auto validate_front_closure = [&]<bool IsConst>() {
-                    STATIC_ASSERT(CanMemberFront<ranges::_Maybe_const<IsConst, ZipTransformType>>
-                                  == ranges::forward_range<ranges::_Maybe_const<IsConst, ZipTransformType>>);
-                    if constexpr (CanMemberFront<ranges::_Maybe_const<IsConst, ZipTransformType>>) {
+                    STATIC_ASSERT(CanMemberFront<maybe_const<IsConst, ZipTransformType>>
+                                  == ranges::forward_range<maybe_const<IsConst, ZipTransformType>>);
+                    if constexpr (CanMemberFront<maybe_const<IsConst, ZipTransformType>>) {
                         using transform_result_t = TransformResultType<IsConst, TransformType, RangeTypes...>;
                         same_as<transform_result_t> auto first_result =
                             maybe_as_const<IsConst>(zipped_transformed_range).front();
@@ -533,10 +536,10 @@ constexpr bool test_one(TransformType_&& transformer, const TransformedElementsC
             // Validate view_interface::back()
             {
                 const auto validate_back_closure = [&]<bool IsConst>() {
-                    STATIC_ASSERT(CanMemberBack<ranges::_Maybe_const<IsConst, ZipTransformType>>
-                                  == (ranges::bidirectional_range<ranges::_Maybe_const<IsConst, ZipTransformType>>
-                                      && ranges::common_range<ranges::_Maybe_const<IsConst, ZipTransformType>>) );
-                    if constexpr (CanMemberBack<ranges::_Maybe_const<IsConst, ZipTransformType>>) {
+                    STATIC_ASSERT(CanMemberBack<maybe_const<IsConst, ZipTransformType>>
+                                  == (ranges::bidirectional_range<maybe_const<IsConst, ZipTransformType>>
+                                      && ranges::common_range<maybe_const<IsConst, ZipTransformType>>) );
+                    if constexpr (CanMemberBack<maybe_const<IsConst, ZipTransformType>>) {
                         using transform_result_t = TransformResultType<IsConst, TransformType, RangeTypes...>;
                         same_as<transform_result_t> auto last_result =
                             maybe_as_const<IsConst>(zipped_transformed_range).back();
@@ -552,9 +555,9 @@ constexpr bool test_one(TransformType_&& transformer, const TransformedElementsC
             // Validate view_interface::operator[]
             {
                 const auto validate_random_access_closure = [&]<bool IsConst>() {
-                    STATIC_ASSERT(CanIndex<ranges::_Maybe_const<IsConst, ZipTransformType>>
-                                  == ranges::random_access_range<ranges::_Maybe_const<IsConst, ZipTransformType>>);
-                    if constexpr (CanIndex<ranges::_Maybe_const<IsConst, ZipTransformType>>) {
+                    STATIC_ASSERT(CanIndex<maybe_const<IsConst, ZipTransformType>>
+                                  == ranges::random_access_range<maybe_const<IsConst, ZipTransformType>>);
+                    if constexpr (CanIndex<maybe_const<IsConst, ZipTransformType>>) {
                         using transform_result_t = TransformResultType<IsConst, TransformType, RangeTypes...>;
                         same_as<transform_result_t> auto first_result =
                             maybe_as_const<IsConst>(zipped_transformed_range)[0];


### PR DESCRIPTION
I tested with LLVM 17.0.0-rc4 and found a couple of issues / regressions:
* Instead of fixing the friend declaration issues as we expected, they get worse in Clang 17. I relabeled the workaround in `<ranges>` with LLVM-61763 and added another similar workaround for `zip_transform_view`.
* Clang seems to be confused by the deduced return type of our implementation of `forward_like` (LLVM-64029)
