### PR TITLE
Fix `deque`'s usage of `_Allocate_at_least_helper`

### DIFF
--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1557,9 +1557,15 @@ private:
             _Newsize *= 2;
         }
 
+        size_type _Allocsize = _Newsize;
+
         size_type _Myboff = _Myoff() / _Block_size;
-        _Mapptr _Newmap   = _Allocate_at_least_helper(_Almap, _Newsize);
+        _Mapptr _Newmap   = _Allocate_at_least_helper(_Almap, _Allocsize);
         _Mapptr _Myptr    = _Newmap + _Myboff;
+        _STL_ASSERT(_Allocsize >= _Newsize, "_Allocsize >= _Newsize");
+        while (_Allocsize / 2 >= _Newsize) {
+            _Newsize *= 2;
+        }
 
         _Count = _Newsize - _Mapsize();
 

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1563,7 +1563,7 @@ private:
         _Mapptr _Newmap   = _Allocate_at_least_helper(_Almap, _Allocsize);
         _Mapptr _Myptr    = _Newmap + _Myboff;
         _STL_ASSERT(_Allocsize >= _Newsize, "_Allocsize >= _Newsize");
-        while (_Allocsize / 2 >= _Newsize) {
+        while (_Newsize <= _Allocsize / 2) {
             _Newsize *= 2;
         }
 

--- a/tests/std/tests/GH_003570_allocate_at_least/test.cpp
+++ b/tests/std/tests/GH_003570_allocate_at_least/test.cpp
@@ -51,7 +51,7 @@ struct signalling_allocator {
 
     allocation_result<T*> allocate_at_least(size_t count) {
         allocate_at_least_signal.set();
-        return {allocate(count * 2), count * 2};
+        return {allocate(count * 2 + 1), count * 2 + 1};
     }
 
     void deallocate(T* ptr, size_t) noexcept {
@@ -72,10 +72,15 @@ void test_container() {
 }
 
 void test_deque() {
-    deque<int, signalling_allocator<int>> d;
-    d.resize(100);
+    deque<size_t, signalling_allocator<size_t>> d;
+    for (size_t i = 0; i < 100; i++) {
+        d.push_back(i);
+    }
     assert(allocate_at_least_signal.consume());
     assert(d.size() == 100);
+    for (size_t i = 0; i < 100; i++) {
+        assert(d[i] == i);
+    }
 }
 
 void test_stream_overflow(auto& stream) {

--- a/tests/std/tests/GH_003570_allocate_at_least/test.cpp
+++ b/tests/std/tests/GH_003570_allocate_at_least/test.cpp
@@ -73,12 +73,12 @@ void test_container() {
 
 void test_deque() {
     deque<size_t, signalling_allocator<size_t>> d;
-    for (size_t i = 0; i < 100; i++) {
+    for (size_t i = 0; i < 100; ++i) {
         d.push_back(i);
     }
     assert(allocate_at_least_signal.consume());
     assert(d.size() == 100);
-    for (size_t i = 0; i < 100; i++) {
+    for (size_t i = 0; i < 100; ++i) {
         assert(d[i] == i);
     }
 }


### PR DESCRIPTION
`deque::_Mapsize()` should always be power of 2. Therefore, in `deque::_Growmap`, `_Allocate_at_least_helper` should not have chance to change `_Newsize` directly.