### PR TITLE
More enhancements for `<flat_set>`

### DIFF
--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -566,9 +566,9 @@ private:
         return _Removed;
     }
 
-    template <class _Other>
-    _NODISCARD iterator _Find(const _Other& _Val) {
-        _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent || is_same_v<_Other, _Kty>);
+    template <class _Ty>
+    _NODISCARD iterator _Find(const _Ty& _Val) {
+        _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent || is_same_v<_Ty, _Kty>);
 
         const iterator _End   = end();
         const iterator _Where = lower_bound(_Val);
@@ -579,9 +579,9 @@ private:
         }
     }
 
-    template <class _Other>
-    _NODISCARD const_iterator _Find(const _Other& _Val) const {
-        _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent || is_same_v<_Other, _Kty>);
+    template <class _Ty>
+    _NODISCARD const_iterator _Find(const _Ty& _Val) const {
+        _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent || is_same_v<_Ty, _Kty>);
 
         const const_iterator _End   = cend();
         const const_iterator _Where = lower_bound(_Val);
@@ -614,7 +614,8 @@ private:
     template <bool _Presorted>
     void _Restore_invariants_after_insert(const size_type _Old_size) {
         const key_compare& _Compare = _Get_comp();
-        const iterator _Old_end     = begin() + static_cast<difference_type>(_Old_size);
+        const iterator _Begin       = begin();
+        const iterator _Old_end     = _Begin + static_cast<difference_type>(_Old_size);
         const iterator _New_end     = end();
 
         if constexpr (!_Presorted) {
@@ -623,9 +624,9 @@ private:
             _STL_ASSERT(_STD is_sorted(_Old_end, _New_end, _Compare), "Input was not sorted!");
         }
 
-        _STD inplace_merge(begin(), _Old_end, _New_end, _Compare);
+        _STD inplace_merge(_Begin, _Old_end, _New_end, _Compare);
 
-        _STL_INTERNAL_CHECK(_STD is_sorted(begin(), end(), _Compare));
+        _STL_INTERNAL_CHECK(_STD is_sorted(_Begin, _New_end, _Compare));
 
         _Erase_dupes_if_needed();
     }

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -556,8 +556,9 @@ private:
     }
 
     template <class _Ty>
-        requires _Keylt_transparent || is_same_v<_Ty, _Kty>
     size_type _Erase(const _Ty& _Val) {
+        _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent || is_same_v<_Ty, _Kty>);
+
         const auto [_First, _Last] = equal_range(_Val);
 
         const auto _Removed = static_cast<size_type>(_Last - _First);
@@ -566,8 +567,9 @@ private:
     }
 
     template <class _Other>
-        requires _Keylt_transparent || is_same_v<_Other, _Kty>
     _NODISCARD iterator _Find(const _Other& _Val) {
+        _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent || is_same_v<_Other, _Kty>);
+
         const iterator _End   = end();
         const iterator _Where = lower_bound(_Val);
         if (_Where != _End && _Keys_equal(*_Where, _Val)) {
@@ -578,8 +580,9 @@ private:
     }
 
     template <class _Other>
-        requires _Keylt_transparent || is_same_v<_Other, _Kty>
     _NODISCARD const_iterator _Find(const _Other& _Val) const {
+        _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent || is_same_v<_Other, _Kty>);
+
         const const_iterator _End   = cend();
         const const_iterator _Where = lower_bound(_Val);
         if (_Where != _End && _Keys_equal(*_Where, _Val)) {
@@ -590,8 +593,9 @@ private:
     }
 
     template <class _Lhty, class _Rhty>
-        requires _Keylt_transparent || (is_same_v<_Kty, _Lhty> && is_same_v<_Lhty, _Rhty>)
     _NODISCARD bool _Keys_equal(const _Lhty& _Lhs, const _Rhty& _Rhs) const {
+        _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent || (is_same_v<_Kty, _Lhty> && is_same_v<_Lhty, _Rhty>) );
+
         const key_compare& _Compare = _Get_comp();
         return !_Compare(_Lhs, _Rhs) && !_Compare(_Rhs, _Lhs);
     }

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -339,8 +339,12 @@ public:
     }
 
     _NODISCARD size_type count(const _Kty& _Val) const {
-        const auto [_First, _Last] = equal_range(_Val);
-        return static_cast<size_type>(_Last - _First);
+        if constexpr (!_Multi) {
+            return contains(_Val);
+        } else {
+            const auto [_First, _Last] = equal_range(_Val);
+            return static_cast<size_type>(_Last - _First);
+        }
     }
     template <class _Other>
         requires _Keylt_transparent
@@ -558,11 +562,20 @@ private:
     size_type _Erase(const _Ty& _Val) {
         _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent || is_same_v<_Ty, _Kty>);
 
-        const auto [_First, _Last] = equal_range(_Val);
+        if constexpr (!_Multi && is_same_v<_Ty, _Kty>) {
+            const iterator _Where = lower_bound(_Val);
+            if (_Where != end() && !_Compare(_Val, *_Where)) {
+                _Get_cont().erase(_Where);
+                return 1;
+            }
+            return 0;
+        } else {
+            const auto [_First, _Last] = equal_range(_Val);
 
-        const auto _Removed = static_cast<size_type>(_Last - _First);
-        _Get_cont().erase(_First, _Last);
-        return _Removed;
+            const auto _Removed = static_cast<size_type>(_Last - _First);
+            _Get_cont().erase(_First, _Last);
+            return _Removed;
+        }
     }
 
     template <class _Ty>

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -350,66 +350,66 @@ public:
     }
 
     _NODISCARD bool contains(const _Kty& _Val) const {
-        return _STD binary_search(cbegin(), cend(), _Val, _Get_comp());
+        return _STD binary_search(cbegin(), cend(), _Val, _Get_comp_v());
     }
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD bool contains(const _Other& _Val) const {
-        return _STD binary_search(cbegin(), cend(), _Val, _Get_comp());
+        return _STD binary_search(cbegin(), cend(), _Val, _Get_comp_v());
     }
 
     _NODISCARD iterator lower_bound(const _Kty& _Val) {
-        return _STD lower_bound(begin(), end(), _Val, _Get_comp());
+        return _STD lower_bound(begin(), end(), _Val, _Get_comp_v());
     }
     _NODISCARD const_iterator lower_bound(const _Kty& _Val) const {
-        return _STD lower_bound(cbegin(), cend(), _Val, _Get_comp());
+        return _STD lower_bound(cbegin(), cend(), _Val, _Get_comp_v());
     }
 
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD iterator lower_bound(const _Other& _Val) {
-        return _STD lower_bound(begin(), end(), _Val, _Get_comp());
+        return _STD lower_bound(begin(), end(), _Val, _Get_comp_v());
     }
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD const_iterator lower_bound(const _Other& _Val) const {
-        return _STD lower_bound(cbegin(), cend(), _Val, _Get_comp());
+        return _STD lower_bound(cbegin(), cend(), _Val, _Get_comp_v());
     }
 
     _NODISCARD iterator upper_bound(const _Kty& _Val) {
-        return _STD upper_bound(begin(), end(), _Val, _Get_comp());
+        return _STD upper_bound(begin(), end(), _Val, _Get_comp_v());
     }
     _NODISCARD const_iterator upper_bound(const _Kty& _Val) const {
-        return _STD upper_bound(cbegin(), cend(), _Val, _Get_comp());
+        return _STD upper_bound(cbegin(), cend(), _Val, _Get_comp_v());
     }
 
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD iterator upper_bound(const _Other& _Val) {
-        return _STD upper_bound(begin(), end(), _Val, _Get_comp());
+        return _STD upper_bound(begin(), end(), _Val, _Get_comp_v());
     }
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD const_iterator upper_bound(const _Other& _Val) const {
-        return _STD upper_bound(cbegin(), cend(), _Val, _Get_comp());
+        return _STD upper_bound(cbegin(), cend(), _Val, _Get_comp_v());
     }
 
     _NODISCARD pair<iterator, iterator> equal_range(const _Kty& _Val) {
-        return _STD equal_range(begin(), end(), _Val, _Get_comp());
+        return _STD equal_range(begin(), end(), _Val, _Get_comp_v());
     }
     _NODISCARD pair<const_iterator, const_iterator> equal_range(const _Kty& _Val) const {
-        return _STD equal_range(cbegin(), cend(), _Val, _Get_comp());
+        return _STD equal_range(cbegin(), cend(), _Val, _Get_comp_v());
     }
 
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD pair<iterator, iterator> equal_range(const _Other& _Val) {
-        return _STD equal_range(begin(), end(), _Val, _Get_comp());
+        return _STD equal_range(begin(), end(), _Val, _Get_comp_v());
     }
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD pair<const_iterator, const_iterator> equal_range(const _Other& _Val) const {
-        return _STD equal_range(cbegin(), cend(), _Val, _Get_comp());
+        return _STD equal_range(cbegin(), cend(), _Val, _Get_comp_v());
     }
 
     _NODISCARD friend bool operator==(const _Deriv& _Lhs, const _Deriv& _Rhs) {
@@ -427,7 +427,7 @@ public:
 
 private:
     void _Assert_after_sorted_input() const {
-        _STL_ASSERT(_STD is_sorted(cbegin(), cend(), _Get_comp()), "Input was not sorted!");
+        _STL_ASSERT(_STD is_sorted(cbegin(), cend(), _Get_comp_v()), "Input was not sorted!");
         if constexpr (!_Multi) {
             _STL_ASSERT(_Is_unique(), "Input was sorted but not unique!");
         }
@@ -449,7 +449,6 @@ private:
 
     bool _Check_where(const const_iterator _Where, const _Kty& _Val) const {
         // check that _Val can be inserted before _Where
-        const key_compare& _Compare = _Get_comp();
         if constexpr (_Multi) {
             // check that _Where is the upper_bound for _Val
             // equivalent to checking *(_Where-1) <= _Val < *_Where
@@ -491,7 +490,7 @@ private:
     template <class _Ty>
     iterator _Emplace_hint(const_iterator _Where, _Ty&& _Val) {
         _Container& _Cont           = _Get_cont();
-        const key_compare& _Compare = _Get_comp();
+        auto _Comp                  = _Get_comp_v();
         const const_iterator _Begin = cbegin();
         const const_iterator _End   = cend();
 
@@ -503,11 +502,11 @@ private:
                     // _Val >= *(_Where-1) ~ upper_bound is _Where
                 } else {
                     // _Val < *(_Where-1) ~ upper_bound is in [_Begin,_Where-1]
-                    _Where = _STD upper_bound(_Begin, _Where - 1, _Val, _Compare);
+                    _Where = _STD upper_bound(_Begin, _Where - 1, _Val, _Comp);
                 }
             } else {
                 // _Val >= *_Where ~ upper_bound is in [_Where+1,_End]
-                _Where = _STD upper_bound(_Where + 1, _End, _Val, _Compare);
+                _Where = _STD upper_bound(_Where + 1, _End, _Val, _Comp);
             }
         } else {
             // look for the lower_bound for flat_set
@@ -517,11 +516,11 @@ private:
                     // _Val > *(_Where-1) ~ lower_bound is _Where
                 } else {
                     // _Val <= *(_Where-1) ~ lower_bound is in [_Begin,_Where-1]
-                    _Where = _STD lower_bound(_Begin, _Where - 1, _Val, _Compare);
+                    _Where = _STD lower_bound(_Begin, _Where - 1, _Val, _Comp);
                 }
             } else {
                 // _Val > *_Where ~ lower_bound is in [_Where+1,_End]
-                _Where = _STD lower_bound(_Where + 1, _End, _Val, _Compare);
+                _Where = _STD lower_bound(_Where + 1, _End, _Val, _Comp);
             }
         }
 
@@ -592,14 +591,6 @@ private:
         }
     }
 
-    template <class _Lhty, class _Rhty>
-    _NODISCARD bool _Keys_equal(const _Lhty& _Lhs, const _Rhty& _Rhs) const {
-        _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent || (is_same_v<_Kty, _Lhty> && is_same_v<_Lhty, _Rhty>) );
-
-        const key_compare& _Compare = _Get_comp();
-        return !_Compare(_Lhs, _Rhs) && !_Compare(_Rhs, _Lhs);
-    }
-
     void _Erase_dupes_if_needed() {
         if constexpr (!_Multi) {
             const iterator _End = end();
@@ -613,20 +604,20 @@ private:
 
     template <bool _Presorted>
     void _Restore_invariants_after_insert(const size_type _Old_size) {
-        const key_compare& _Compare = _Get_comp();
-        const iterator _Begin       = begin();
-        const iterator _Old_end     = _Begin + static_cast<difference_type>(_Old_size);
-        const iterator _New_end     = end();
+        auto _Comp              = _Get_comp_v();
+        const iterator _Begin   = begin();
+        const iterator _Old_end = _Begin + static_cast<difference_type>(_Old_size);
+        const iterator _New_end = end();
 
         if constexpr (!_Presorted) {
-            _STD sort(_Old_end, _New_end, _Compare);
+            _STD sort(_Old_end, _New_end, _Comp);
         } else {
-            _STL_ASSERT(_STD is_sorted(_Old_end, _New_end, _Compare), "Input was not sorted!");
+            _STL_ASSERT(_STD is_sorted(_Old_end, _New_end, _Comp), "Input was not sorted!");
         }
 
-        _STD inplace_merge(_Begin, _Old_end, _New_end, _Compare);
+        _STD inplace_merge(_Begin, _Old_end, _New_end, _Comp);
 
-        _STL_INTERNAL_CHECK(_STD is_sorted(_Begin, _New_end, _Compare));
+        _STL_INTERNAL_CHECK(_STD is_sorted(_Begin, _New_end, _Comp));
 
         _Erase_dupes_if_needed();
     }
@@ -640,15 +631,31 @@ private:
         }
 
         // O(N) if already sorted.
-        const key_compare& _Compare    = _Get_comp();
-        const iterator _Begin_unsorted = _STD is_sorted_until(_Begin, _End, _Compare);
+        auto _Comp                     = _Get_comp_v();
+        const iterator _Begin_unsorted = _STD is_sorted_until(_Begin, _End, _Comp);
 
-        _STD sort(_Begin_unsorted, _End, _Compare);
-        _STD inplace_merge(_Begin, _Begin_unsorted, _End, _Compare);
+        _STD sort(_Begin_unsorted, _End, _Comp);
+        _STD inplace_merge(_Begin, _Begin_unsorted, _End, _Comp);
 
-        _STL_INTERNAL_CHECK(_STD is_sorted(_Begin, _End, _Compare));
+        _STL_INTERNAL_CHECK(_STD is_sorted(_Begin, _End, _Comp));
 
         _Erase_dupes_if_needed();
+    }
+
+    template <class _Lty, class _Rty>
+    _NODISCARD bool _Compare(const _Lty& _Lhs, const _Rty& _Rhs) const
+        noexcept(noexcept(_DEBUG_LT_PRED(_My_pair._Get_first(), _Lhs, _Rhs))) {
+        _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent || (is_same_v<_Kty, _Lty> && is_same_v<_Kty, _Rty>) );
+
+        return _DEBUG_LT_PRED(_My_pair._Get_first(), _Lhs, _Rhs);
+    }
+
+    template <class _Lty, class _Rty>
+    _NODISCARD bool _Keys_equal(const _Lty& _Lhs, const _Rty& _Rhs) const
+        noexcept(noexcept(!_Compare(_Lhs, _Rhs) && !_Compare(_Rhs, _Lhs))) {
+        _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent || (is_same_v<_Kty, _Lty> && is_same_v<_Kty, _Rty>) );
+
+        return !_Compare(_Lhs, _Rhs) && !_Compare(_Rhs, _Lhs);
     }
 
     _NODISCARD const _Container& _Get_cont() const noexcept {
@@ -665,6 +672,10 @@ private:
 
     _NODISCARD key_compare& _Get_comp() noexcept {
         return _My_pair._Get_first();
+    }
+
+    _NODISCARD auto _Get_comp_v() const noexcept {
+        return _STD _Pass_fn(_My_pair._Get_first());
     }
 
     _Compressed_pair<key_compare, container_type> _My_pair;

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -471,7 +471,7 @@ private:
         } else {
             const iterator _End   = end();
             const iterator _Where = lower_bound(_Val);
-            if (_Where != _End && _Keys_equal(*_Where, _Val)) {
+            if (_Where != _End && !_Compare(_Val, *_Where)) {
                 return pair{_Where, false};
             }
 
@@ -529,7 +529,7 @@ private:
             _STL_INTERNAL_CHECK(_Check_where(_Where, _Val));
             return _Cont.emplace(_Where, _STD forward<_Ty>(_Val));
         } else {
-            if (_Where != _End && _Keys_equal(_Val, *_Where)) {
+            if (_Where != _End && !_Compare(_Val, *_Where)) {
                 return _Cont.begin() + (_Where - _Begin);
             }
 
@@ -571,7 +571,7 @@ private:
 
         const iterator _End   = end();
         const iterator _Where = lower_bound(_Val);
-        if (_Where != _End && _Keys_equal(*_Where, _Val)) {
+        if (_Where != _End && !_Compare(_Val, *_Where)) {
             return _Where;
         } else {
             return _End;
@@ -584,7 +584,7 @@ private:
 
         const const_iterator _End   = cend();
         const const_iterator _Where = lower_bound(_Val);
-        if (_Where != _End && _Keys_equal(*_Where, _Val)) {
+        if (_Where != _End && !_Compare(_Val, *_Where)) {
             return _Where;
         } else {
             return _End;

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -172,29 +172,29 @@ public:
     }
 
     _NODISCARD reverse_iterator rbegin() noexcept {
-        return _Get_cont().rbegin();
+        return reverse_iterator(end());
     }
     _NODISCARD const_reverse_iterator rbegin() const noexcept {
-        return _Get_cont().rbegin();
+        return const_reverse_iterator(end());
     }
     _NODISCARD reverse_iterator rend() noexcept {
-        return _Get_cont().rend();
+        return reverse_iterator(begin());
     }
     _NODISCARD const_reverse_iterator rend() const noexcept {
-        return _Get_cont().rend();
+        return const_reverse_iterator(begin());
     }
 
     _NODISCARD const_iterator cbegin() const noexcept {
-        return _Get_cont().cbegin();
+        return begin();
     }
     _NODISCARD const_iterator cend() const noexcept {
-        return _Get_cont().cend();
+        return end();
     }
     _NODISCARD const_reverse_iterator crbegin() const noexcept {
-        return _Get_cont().crbegin();
+        return rbegin();
     }
     _NODISCARD const_reverse_iterator crend() const noexcept {
-        return _Get_cont().crend();
+        return rend();
     }
 
     // capacity


### PR DESCRIPTION
Reopened for the remaining enhancements.
<hr>

Contents in this pr:
1. Enable `rbegin/...` for non-reversible containers.
2. Add debug check for comparisions (`_DEBUG_LT_PRED`), and avoid copying the comparator when passing to algorithm functions (`_Pass_fn`)
3. Replace some `_Keys_equal` with single comparision, and optimize `flat_set.count/erase(const key&)`.
4. Some other cleanups.
<hr>

Some remaining problems in `flat_set`:
1. https://github.com/microsoft/STL/commit/1ce8fc666d67abe4e727d0c099c91afe1042f2fb This commit tries to copy construct `comp` in move construction as suggested in [this comment](https://github.com/microsoft/STL/pull/3993#issuecomment-1712213203). I find it hard to decide whether to make a push. The standard says `priority_queue(&&,const alloc&)` should move-construct `comp`(and we are doing so [accordingly](https://github.com/microsoft/STL/blob/d8ed02d2ec7ba8216848a33dec2b5fb385febf4e/stl/inc/queue#L310-L313)), and there is no direct specification about `comp`'s construction in `map/set(&&)` (we are doing [copy-construction](https://github.com/microsoft/STL/blob/d8ed02d2ec7ba8216848a33dec2b5fb385febf4e/stl/inc/xtree#L902-L904) for them).
2. I'm still highly uncertain about the correctness of `insert([hint,]auto&&)`. The main problem is explained in [this comment](https://github.com/microsoft/STL/pull/3993#issuecomment-1699066181) and in this commit: https://github.com/microsoft/STL/commit/312c496ab22efbf08808fc3103c23a15ed2cd240 The main problem is, is `lower_bound(other)` always same as `lower_bound(key{forward(other)})`? If not, I believe the `amortized-constant` complexity is not possible, as at least one full `lower_bound` search is required, either to decide `?contains(other)` or to find `lower_bound(key(other))` for insertion position.
3. The standard says `flat_set` should keep in valid state against exceptions. I'm afraid some functions (maybe including copy/move assignments) still lack this guarantee.