### PR TITLE
use only `static_assert` for `_EMIT_STL_ERROR`

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -506,10 +506,8 @@
 #define _STL_PRAGMA_MESSAGE(MESSAGE) _STL_PRAGMA(message(MESSAGE))
 #define _EMIT_STL_MESSAGE(MESSAGE)   _STL_PRAGMA_MESSAGE(__FILE__ "(" _CRT_STRINGIZE(__LINE__) "): " MESSAGE)
 
-#define _EMIT_STL_WARNING(NUMBER, MESSAGE)             \
-    _EMIT_STL_MESSAGE("warning " #NUMBER ": " MESSAGE)
-#define _EMIT_STL_ERROR(NUMBER, MESSAGE)             \
-    static_assert(false, "error " #NUMBER ": " MESSAGE)
+#define _EMIT_STL_WARNING(NUMBER, MESSAGE) _EMIT_STL_MESSAGE("warning " #NUMBER ": " MESSAGE)
+#define _EMIT_STL_ERROR(NUMBER, MESSAGE)   static_assert(false, "error " #NUMBER ": " MESSAGE)
 
 #ifndef _STL_WARNING_LEVEL
 #if defined(_MSVC_WARNING_LEVEL) && _MSVC_WARNING_LEVEL >= 4

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -507,11 +507,9 @@
 #define _EMIT_STL_MESSAGE(MESSAGE)   _STL_PRAGMA_MESSAGE(__FILE__ "(" _CRT_STRINGIZE(__LINE__) "): " MESSAGE)
 
 #define _EMIT_STL_WARNING(NUMBER, MESSAGE)             \
-    _EMIT_STL_MESSAGE("warning " #NUMBER ": " MESSAGE) \
-    static_assert(true, "")
+    _EMIT_STL_MESSAGE("warning " #NUMBER ": " MESSAGE)
 #define _EMIT_STL_ERROR(NUMBER, MESSAGE)             \
-    _EMIT_STL_MESSAGE("error " #NUMBER ": " MESSAGE) \
-    static_assert(false, "Error in C++ Standard Library usage.")
+    static_assert(false, "error " #NUMBER ": " MESSAGE)
 
 #ifndef _STL_WARNING_LEVEL
 #if defined(_MSVC_WARNING_LEVEL) && _MSVC_WARNING_LEVEL >= 4


### PR DESCRIPTION
Fixes #4009 

It looks like this in the IDE:
![изображение](https://github.com/microsoft/STL/assets/4289847/8b7853f4-71d8-4740-9dc2-0a7f972935d7)
