### PR TITLE
Silence a couple of `/Wall` warnings

### DIFF
--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -25,6 +25,11 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+// TRANSITION, VSO-1885306: warning C5039 shouldn't be emitted when an extern "C" function is marked noexcept(false)
+#pragma warning(disable : 5039) // '__std_stacktrace_meow': pointer or reference to potentially throwing function
+                                // passed to 'extern "C"' function under -EHc. Undefined behavior may occur if this
+                                // function throws an exception. (/Wall)
+
 // The separately compiled part of the <stacktrace> implementation calls a function pointer of _Stacktrace_string_fill
 // type to allocate a buffer for string output. The called function does the buffer allocation and calls a function
 // pointer of _Stacktrace_string_fill_callback type to fill the buffer. This is needed to type-erase <string> or

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -796,6 +796,8 @@
 // warning C5026: move constructor was implicitly defined as deleted (/Wall)
 // warning C5027: move assignment operator was implicitly defined as deleted (/Wall)
 // warning C5045: Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified (/Wall)
+// warning C5220: a non-static data member with a volatile qualified type no longer implies that compiler generated
+//                copy/move constructors and copy/move assignment operators are not trivial (/Wall)
 // warning C6294: Ill-defined for-loop: initial condition does not satisfy test. Loop body not executed
 
 #ifndef _STL_DISABLED_WARNINGS
@@ -803,7 +805,7 @@
 #define _STL_DISABLED_WARNINGS                        \
     4180 4412 4455 4494 4514 4574 4582 4583 4587 4588 \
     4619 4623 4625 4626 4643 4648 4702 4793 4820 4988 \
-    5026 5027 5045 6294                               \
+    5026 5027 5045 5220 6294                          \
     _STL_DISABLED_WARNING_C4577                       \
     _STL_DISABLED_WARNING_C4984                       \
     _STL_DISABLED_WARNING_C5053                       \


### PR DESCRIPTION
Works towards DevCom-10368801 / VSO-1822115 "compiling `std.ixx` causes compiler warnings, even with `/external:anglebrackets` and `/external:W0`". (Additional changes are needed in the MSVC-internal repo: MSVC-PR-497556)

We don't attempt to be `/Wall` clean in general, but users are experiencing this as a regression due to the addition of the automatic build of the Standard Library Modules. Only a few warnings are being emitted so we can just clean them up. While this is motivated by the Modules, the changes are not modules-related.

I'm dealing with two warnings in this PR. First, I reported VSO-1885306 "warning C5039 shouldn't be emitted when an `extern "C"` function is marked `noexcept(false)`". `<stacktrace>` is correctly using `noexcept(false)`, so we should suppress this warning in the header. The warning is potentially useful elsewhere, so I don't want to globally suppress it for the STL.

The second change is to globally suppress warning C5220 for the STL in `<yvals_core.h>`. This is a classically obnoxious warning saying that the compiler is going to do what the Standard requires it to do, which we never need to be told. (It affects `<pplcancellation_token.h>` and `<ppltasks.h>`; my MSVC-internal changes will enhance those headers to use the `<yvals_core.h>` suppression machinery.)