### PR TITLE
Toolset update: VS 2022 17.8 Preview 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.26.0)
+cmake_minimum_required(VERSION 3.27.0)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)

--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.8 Preview 1 or later.
+1. Install Visual Studio 2022 17.8 Preview 2 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.26.0 or later, and [Ninja][] 1.11.0 or later.
+    * Otherwise, install [CMake][] 3.27.0 or later, and [Ninja][] 1.11.0 or later.
     * We recommend selecting "Python 3 64-bit" in the VS Installer.
     * Otherwise, make sure [Python][] 3.9 or later is available to CMake.
 2. Open Visual Studio, and choose the "Clone or check out code" option. Enter the URL of this repository,
@@ -157,11 +157,11 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.8 Preview 1 or later.
+1. Install Visual Studio 2022 17.8 Preview 2 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.26.0 or later, and [Ninja][] 1.11.0 or later.
+    * Otherwise, install [CMake][] 3.27.0 or later, and [Ninja][] 1.11.0 or later.
     * We recommend selecting "Python 3 64-bit" in the VS Installer.
     * Otherwise, make sure [Python][] 3.9 or later is available to CMake.
 2. Open a command prompt.

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -136,7 +136,7 @@ $Workloads = @(
 )
 
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/17/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.11.4/python-3.11.4-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.11.5/python-3.11.5-amd64.exe'
 
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_511.23_windows.exe'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ variables:
   benchmarkBuildOutputLocation: 'D:\benchmark'
 
 pool:
-  name: 'StlBuild-2023-08-08T1145-Pool'
+  name: 'StlBuild-2023-09-14T1251-Pool'
   demands: EnableSpotVM -equals true
 
 pr:

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.26.0)
+cmake_minimum_required(VERSION 3.27.0)
 project(msvc_standard_libraries_benchmarks LANGUAGES CXX)
 
 if(DEFINED STL_BINARY_DIR)

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -274,10 +274,7 @@ public:
             return true;
         } else {
             index_type _Result{1};
-#pragma warning(push)
-#pragma warning(disable : 6287) // TRANSITION, DevCom-10398426
             const bool _Overflow = (_Mul_overflow(static_cast<index_type>(_Extents), _Result, _Result) || ...);
-#pragma warning(pop)
             return !_Overflow;
         }
     }
@@ -864,20 +861,17 @@ public:
 
     constexpr mapping(const mapping&) noexcept = default;
 
-    // TRANSITION, VSO-1852021: `_Extents::rank()` should be `extents_type::rank()`
-    // TRANSITION, VSO-1852030: `typename _Extents::index_type` should be `index_type`
     template <class _OtherIndexType>
-        requires is_convertible_v<const _OtherIndexType&, typename _Extents::index_type>
-              && is_nothrow_constructible_v<typename _Extents::index_type, const _OtherIndexType&>
-    constexpr mapping(const extents_type& _Exts_, span<_OtherIndexType, _Extents::rank()> _Strides_) noexcept
+        requires is_convertible_v<const _OtherIndexType&, index_type>
+              && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
+    constexpr mapping(const extents_type& _Exts_, span<_OtherIndexType, extents_type::rank()> _Strides_) noexcept
         : mapping(_Exts_, _Strides_, make_index_sequence<extents_type::rank()>{}) {}
 
-    // TRANSITION, VSO-1852021: `_Extents::rank()` should be `extents_type::rank()`
-    // TRANSITION, VSO-1852030: `typename _Extents::index_type` should be `index_type`
     template <class _OtherIndexType>
-        requires is_convertible_v<const _OtherIndexType&, typename _Extents::index_type>
-              && is_nothrow_constructible_v<typename _Extents::index_type, const _OtherIndexType&>
-    constexpr mapping(const extents_type& _Exts_, const array<_OtherIndexType, _Extents::rank()>& _Strides_) noexcept
+        requires is_convertible_v<const _OtherIndexType&, index_type>
+              && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
+    constexpr mapping(
+        const extents_type& _Exts_, const array<_OtherIndexType, extents_type::rank()>& _Strides_) noexcept
         : mapping(_Exts_, span{_Strides_}, make_index_sequence<extents_type::rank()>{}) {}
 
     template <class _StridedLayoutMapping>

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.26.0)
+cmake_minimum_required(VERSION 3.27.0)
 project(msvc_standard_libraries_tools LANGUAGES CXX)
 
 add_subdirectory(format)

--- a/tools/format/CMakeLists.txt
+++ b/tools/format/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.26.0)
+cmake_minimum_required(VERSION 3.27.0)
 project(msvc_standard_libraries_format NONE)
 
 set(did_search OFF)

--- a/tools/validate/CMakeLists.txt
+++ b/tools/validate/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.26.0)
+cmake_minimum_required(VERSION 3.27.0)
 project(msvc_standard_libraries_validate LANGUAGES CXX)
 
 add_executable(validate-binary validate.cpp)


### PR DESCRIPTION
* Updated dependencies.
  + Updated build compiler to VS 2022 17.8 Preview 2.
  + Updated CMake to 3.27 (now required).
  + Updated Python to 3.11.5.
* Removed compiler bug workarounds.
  + VSO-1852021, VSO-1852030, and DevCom-10398426 affected `<mdspan>`.
