### PR TITLE
extract code format validation into a new template

### DIFF
--- a/azure-devops/format-validation.yml
+++ b/azure-devops/format-validation.yml
@@ -1,0 +1,52 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# run the `validator` tool, and ensure code is properly clang-formatted
+
+jobs:
+- job: Code_Format_Validation
+  timeoutInMinutes: 5
+  displayName: 'Validation'
+  steps:
+    - script: |
+        if exist "$(tmpDir)" (
+          rmdir /S /Q $(tmpDir)
+        )
+        mkdir $(tmpDir)
+      displayName: 'Setup TMP Directory'
+    - checkout: self
+      clean: true
+      submodules: false
+    - script: |
+        cd $(Build.SourcesDirectory)
+        git clean --quiet -x -d -f -f
+      displayName: 'Clean after checkout'
+    - script: |
+        call "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\Common7\Tools\VsDevCmd.bat" ^
+          -host_arch=amd64 -arch=amd64 -no_logo
+        cmake -G Ninja -S $(Build.SourcesDirectory)/tools -B $(tmpDir)/format-validate-build
+        cmake --build $(tmpDir)/format-validate-build
+      displayName: 'Build format and validation'
+      timeoutInMinutes: 5
+      env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
+    - script: |
+        call "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\Common7\Tools\VsDevCmd.bat" ^
+          -host_arch=amd64 -arch=amd64 -no_logo
+        cmake --build $(tmpDir)/format-validate-build --target run-format
+      displayName: 'clang-format Files'
+      timeoutInMinutes: 5
+      env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
+    - script: |
+        call "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\Common7\Tools\VsDevCmd.bat" ^
+          -host_arch=amd64 -arch=amd64 -no_logo
+        cmake --build $(tmpDir)/format-validate-build --target run-validate
+      displayName: 'Validate Files'
+      timeoutInMinutes: 2
+      env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
+    - task: Powershell@2
+      displayName: 'Create Diff'
+      inputs:
+        filePath: azure-devops/create-prdiff.ps1
+        pwsh: false
+      condition: succeededOrFailed()
+      env: { TMP: $(tmpDir), TEMP: $(tmpDir) }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,52 +19,7 @@ stages:
   - stage: Code_Format
     displayName: 'Code Format'
     jobs:
-      - job: Code_Format_Validation
-        timeoutInMinutes: 5
-        displayName: 'Validation'
-        steps:
-          - script: |
-              if exist "$(tmpDir)" (
-                rmdir /S /Q $(tmpDir)
-              )
-              mkdir $(tmpDir)
-            displayName: 'Setup TMP Directory'
-          - checkout: self
-            clean: true
-            submodules: false
-          - script: |
-              cd $(Build.SourcesDirectory)
-              git clean --quiet -x -d -f -f
-            displayName: 'Clean after checkout'
-          - script: |
-              call "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\Common7\Tools\VsDevCmd.bat" ^
-                -host_arch=amd64 -arch=amd64 -no_logo
-              cmake -G Ninja -S $(Build.SourcesDirectory)/tools -B $(tmpDir)/format-validate-build
-              cmake --build $(tmpDir)/format-validate-build
-            displayName: 'Build format and validation'
-            timeoutInMinutes: 5
-            env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
-          - script: |
-              call "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\Common7\Tools\VsDevCmd.bat" ^
-                -host_arch=amd64 -arch=amd64 -no_logo
-              cmake --build $(tmpDir)/format-validate-build --target run-format
-            displayName: 'clang-format Files'
-            timeoutInMinutes: 5
-            env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
-          - script: |
-              call "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\Common7\Tools\VsDevCmd.bat" ^
-                -host_arch=amd64 -arch=amd64 -no_logo
-              cmake --build $(tmpDir)/format-validate-build --target run-validate
-            displayName: 'Validate Files'
-            timeoutInMinutes: 2
-            env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
-          - task: Powershell@2
-            displayName: 'Create Diff'
-            inputs:
-              filePath: azure-devops/create-prdiff.ps1
-              pwsh: false
-            condition: succeededOrFailed()
-            env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
+      - template: azure-devops/format-validation.yml
 
   - stage: Build_And_Test_x64
     dependsOn: Code_Format


### PR DESCRIPTION
To avoid duplication if and when we add other pipelines in the future.

* [Test run demonstrating the new template works](https://dev.azure.com/vclibs/STL/_build/results?buildId=15045&view=results)
* [Test run demonstrating that validation failures are still handled properly](https://dev.azure.com/vclibs/STL/_build/results?buildId=15048&view=results)
* [Test run demonstrating that formatting failures are still handled properly](https://dev.azure.com/vclibs/STL/_build/results?buildId=15046&view=results)
