### PR TITLE
Fix the `_Choose_pocca_v` branch in `basic_string::operator=(const&)`

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -3052,8 +3052,9 @@ private:
 
         if (_Right_data._Large_mode_engaged()) { // steal buffer
             _Construct_in_place(_My_data._Bx._Ptr, _Right_data._Bx._Ptr);
-            _Right_data._Bx._Ptr = nullptr;
             _Swap_proxy_and_iterators(_Right);
+
+            _Destroy_in_place(_Right_data._Bx._Ptr);
         } else { // copy small string buffer
             _My_data._Activate_SSO_buffer();
             _Traits::copy(_My_data._Bx._Buf, _Right_data._Bx._Buf, _Right_data._Mysize + 1);

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -3166,12 +3166,13 @@ public:
                     size_type _New_capacity = _Calculate_growth(_Right_size, _Small_string_capacity, _Right.max_size());
                     auto _Right_al_non_const = _Right_al;
                     const pointer _New_ptr   = _Allocate_for_capacity(_Right_al_non_const, _New_capacity); // throws
-
                     _Traits::copy(_Unfancy(_New_ptr), _Right_ptr, _Right_size + 1);
+
                     _Tidy_deallocate();
-                    _Mypair._Myval2._Bx._Ptr = _New_ptr;
-                    _Mypair._Myval2._Mysize  = _Right_size;
-                    _Mypair._Myval2._Myres   = _New_capacity;
+                    _Construct_in_place(_Mypair._Myval2._Bx._Ptr, _New_ptr);
+                    _Mypair._Myval2._Mysize = _Right_size;
+                    _Mypair._Myval2._Myres  = _New_capacity;
+                    _ASAN_STRING_CREATE(*this);
                 } else {
                     _Tidy_deallocate();
                     _Traits::copy(_Mypair._Myval2._Bx._Buf, _Right_ptr, _Right_size + 1);

--- a/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
+++ b/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
@@ -457,7 +457,7 @@ _CONSTEXPR20 bool test_sequence() {
     test_sequence_copy_assign<Sequence, CopyAlloc<int>>(11, 22, 11); // POCCA, non-equal allocators
     test_sequence_copy_assign<Sequence, CopyEqualAlloc<int>>(11, 22, 11); // POCCA, always-equal allocators
 
-    test_sequence_move_ctor<Sequence>();
+    // test_sequence_move_ctor<Sequence>();
 
     test_sequence_move_alloc_ctor<Sequence>(11, 11); // equal allocators
     test_sequence_move_alloc_ctor<Sequence>(11, 22); // non-equal allocators

--- a/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
+++ b/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
@@ -66,7 +66,11 @@ public:
     _CONSTEXPR20 ~nontrivial_pointer() = default;
 
     _CONSTEXPR20 explicit operator bool() const noexcept {
+#ifdef __EDG__ // TRANSITION, VSO-1888157
         return static_cast<bool>(ptr);
+#else // ^^^ workaround / no workaround vvv
+        return ptr != nullptr;
+#endif // ^^^ no workaround ^^^
     }
     _CONSTEXPR20 add_lvalue_reference_t<T> operator*() const noexcept {
         return *ptr;

--- a/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
+++ b/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
@@ -110,49 +110,49 @@ public:
     }
 
     template <class I, enable_if_t<is_integral_v<I>, int> = 0>
-    _CONSTEXPR20 friend nontrivial_pointer operator+(nontrivial_pointer ptr, I diff) noexcept {
+    friend _CONSTEXPR20 nontrivial_pointer operator+(nontrivial_pointer ptr, I diff) noexcept {
         return ptr += diff;
     }
     template <class I, enable_if_t<is_integral_v<I>, int> = 0>
-    _CONSTEXPR20 friend nontrivial_pointer operator+(I diff, nontrivial_pointer ptr) noexcept {
+    friend _CONSTEXPR20 nontrivial_pointer operator+(I diff, nontrivial_pointer ptr) noexcept {
         return ptr += diff;
     }
-    _CONSTEXPR20 friend ptrdiff_t operator-(nontrivial_pointer lhs, nontrivial_pointer rhs) noexcept {
+    friend _CONSTEXPR20 ptrdiff_t operator-(nontrivial_pointer lhs, nontrivial_pointer rhs) noexcept {
         return lhs.ptr - rhs.ptr;
     }
     template <class I, enable_if_t<is_integral_v<I>, int> = 0>
-    _CONSTEXPR20 friend nontrivial_pointer operator-(nontrivial_pointer ptr, I diff) noexcept {
+    friend _CONSTEXPR20 nontrivial_pointer operator-(nontrivial_pointer ptr, I diff) noexcept {
         return ptr -= diff;
     }
 
-    _CONSTEXPR20 friend bool operator==(nontrivial_pointer lhs, nontrivial_pointer rhs) noexcept {
+    friend _CONSTEXPR20 bool operator==(nontrivial_pointer lhs, nontrivial_pointer rhs) noexcept {
         return lhs.ptr == rhs.ptr;
     }
-    _CONSTEXPR20 friend bool operator==(nontrivial_pointer ptr, nullptr_t) noexcept {
+    friend _CONSTEXPR20 bool operator==(nontrivial_pointer ptr, nullptr_t) noexcept {
         return !ptr;
     }
-    _CONSTEXPR20 friend bool operator==(nullptr_t, nontrivial_pointer ptr) noexcept {
+    friend _CONSTEXPR20 bool operator==(nullptr_t, nontrivial_pointer ptr) noexcept {
         return !ptr;
     }
-    _CONSTEXPR20 friend bool operator!=(nontrivial_pointer lhs, nontrivial_pointer rhs) noexcept {
+    friend _CONSTEXPR20 bool operator!=(nontrivial_pointer lhs, nontrivial_pointer rhs) noexcept {
         return lhs.ptr != rhs.ptr;
     }
-    _CONSTEXPR20 friend bool operator!=(nontrivial_pointer ptr, nullptr_t) noexcept {
+    friend _CONSTEXPR20 bool operator!=(nontrivial_pointer ptr, nullptr_t) noexcept {
         return static_cast<bool>(ptr);
     }
-    _CONSTEXPR20 friend bool operator!=(nullptr_t, nontrivial_pointer ptr) noexcept {
+    friend _CONSTEXPR20 bool operator!=(nullptr_t, nontrivial_pointer ptr) noexcept {
         return static_cast<bool>(ptr);
     }
-    _CONSTEXPR20 friend bool operator<(nontrivial_pointer lhs, nontrivial_pointer rhs) noexcept {
+    friend _CONSTEXPR20 bool operator<(nontrivial_pointer lhs, nontrivial_pointer rhs) noexcept {
         return lhs.ptr < rhs.ptr;
     }
-    _CONSTEXPR20 friend bool operator<=(nontrivial_pointer lhs, nontrivial_pointer rhs) noexcept {
+    friend _CONSTEXPR20 bool operator<=(nontrivial_pointer lhs, nontrivial_pointer rhs) noexcept {
         return lhs.ptr <= rhs.ptr;
     }
-    _CONSTEXPR20 friend bool operator>(nontrivial_pointer lhs, nontrivial_pointer rhs) noexcept {
+    friend _CONSTEXPR20 bool operator>(nontrivial_pointer lhs, nontrivial_pointer rhs) noexcept {
         return lhs.ptr > rhs.ptr;
     }
-    _CONSTEXPR20 friend bool operator>=(nontrivial_pointer lhs, nontrivial_pointer rhs) noexcept {
+    friend _CONSTEXPR20 bool operator>=(nontrivial_pointer lhs, nontrivial_pointer rhs) noexcept {
         return lhs.ptr >= rhs.ptr;
     }
 };

--- a/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
+++ b/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
@@ -35,15 +35,15 @@ _CONSTEXPR20 void assert_is_permutation(const Container& cont, initializer_list<
 }
 
 class test_leak {
-    char* ptr;
+    char* res;
 
 public:
     test_leak(const test_leak&)            = delete;
     test_leak& operator=(const test_leak&) = delete;
 
-    _CONSTEXPR20 test_leak() noexcept /* terminates */ : ptr(allocator<char>{}.allocate(1)) {}
+    _CONSTEXPR20 test_leak() noexcept /* terminates */ : res(allocator<char>{}.allocate(1)) {}
     _CONSTEXPR20 ~test_leak() {
-        allocator<char>{}.deallocate(ptr, 1);
+        allocator<char>{}.deallocate(res, 1);
     }
 };
 
@@ -128,19 +128,19 @@ public:
         return lhs.ptr == rhs.ptr;
     }
     _CONSTEXPR20 friend bool operator==(nontrivial_pointer ptr, nullptr_t) noexcept {
-        return !static_cast<bool>(ptr.ptr);
+        return !ptr;
     }
     _CONSTEXPR20 friend bool operator==(nullptr_t, nontrivial_pointer ptr) noexcept {
-        return !static_cast<bool>(ptr.ptr);
+        return !ptr;
     }
     _CONSTEXPR20 friend bool operator!=(nontrivial_pointer lhs, nontrivial_pointer rhs) noexcept {
         return lhs.ptr != rhs.ptr;
     }
     _CONSTEXPR20 friend bool operator!=(nontrivial_pointer ptr, nullptr_t) noexcept {
-        return static_cast<bool>(ptr.ptr);
+        return static_cast<bool>(ptr);
     }
     _CONSTEXPR20 friend bool operator!=(nullptr_t, nontrivial_pointer ptr) noexcept {
-        return static_cast<bool>(ptr.ptr);
+        return static_cast<bool>(ptr);
     }
     _CONSTEXPR20 friend bool operator<(nontrivial_pointer lhs, nontrivial_pointer rhs) noexcept {
         return lhs.ptr < rhs.ptr;

--- a/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
+++ b/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
@@ -170,7 +170,7 @@ struct impl_pointer_to<T, false> {
 };
 
 template <class T>
-struct std::pointer_traits<nontrivial_pointer<T>> : public impl_pointer_to<T> {
+struct std::pointer_traits<nontrivial_pointer<T>> : impl_pointer_to<T> {
     using pointer         = nontrivial_pointer<T>;
     using element_type    = T;
     using difference_type = ptrdiff_t;

--- a/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
+++ b/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
@@ -159,14 +159,14 @@ public:
 
 template <class T, bool IsVoid = is_void_v<T>>
 struct impl_pointer_to {
-    static constexpr nontrivial_pointer<T> pointer_to(T& r) noexcept {
-        return nontrivial_pointer<T>(addressof(r));
-    }
+    // no pointer_to for void
 };
 
 template <class T>
-struct impl_pointer_to<T, true> {
-    // no pointer_to for void
+struct impl_pointer_to<T, false> {
+    static constexpr nontrivial_pointer<T> pointer_to(T& r) noexcept {
+        return nontrivial_pointer<T>(addressof(r));
+    }
 };
 
 template <class T>

--- a/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
+++ b/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
@@ -462,7 +462,9 @@ _CONSTEXPR20 bool test_sequence() {
     test_sequence_copy_assign<Sequence, CopyAlloc<int>>(11, 22, 11); // POCCA, non-equal allocators
     test_sequence_copy_assign<Sequence, CopyEqualAlloc<int>>(11, 22, 11); // POCCA, always-equal allocators
 
-    // test_sequence_move_ctor<Sequence>();
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1888462
+    test_sequence_move_ctor<Sequence>();
+#endif // ^^^ no workaround ^^^
 
     test_sequence_move_alloc_ctor<Sequence>(11, 11); // equal allocators
     test_sequence_move_alloc_ctor<Sequence>(11, 22); // non-equal allocators

--- a/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
+++ b/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
@@ -35,6 +35,7 @@ _CONSTEXPR20 void assert_is_permutation(const Container& cont, initializer_list<
 }
 
 class test_leak {
+private:
     char* res;
 
 public:

--- a/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
+++ b/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
@@ -462,9 +462,12 @@ _CONSTEXPR20 bool test_sequence() {
     test_sequence_copy_assign<Sequence, CopyAlloc<int>>(11, 22, 11); // POCCA, non-equal allocators
     test_sequence_copy_assign<Sequence, CopyEqualAlloc<int>>(11, 22, 11); // POCCA, always-equal allocators
 
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1888462
-    test_sequence_move_ctor<Sequence>();
-#endif // ^^^ no workaround ^^^
+#if _HAS_CXX20 && !defined(__clang__) && !defined(__EDG__) // TRANSITION, VSO-1888462
+    if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+    {
+        test_sequence_move_ctor<Sequence>();
+    }
 
     test_sequence_move_alloc_ctor<Sequence>(11, 11); // equal allocators
     test_sequence_move_alloc_ctor<Sequence>(11, 22); // non-equal allocators


### PR DESCRIPTION
Fixes #3997; also adds test coverages for non-trivial pointers.
---update---
Fixes another lifetime problem in `_Take_contents`. Hopefully fixes all the lifetime issue of `_Ptr` in `basic_string`. Possibly related to #3949.

Thanks to @frederick-vs-ja for suggesting adding test coverage for non-trivial pointers! Also thanks for implementing `VSO_0000000_fancy_pointers`, that test helps me a lot

---update (solved with workaround)---
The updated test meets another problem in `static_assert(test_sequence<vector>)`'s `test_sequence_move_ctor`... (see https://github.com/microsoft/STL/pull/4031#discussion_r1328413358)