### PR TITLE
Tolerate 80-bit `long double` in `<xlocnum>`

### DIFF
--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -614,7 +614,9 @@ protected:
 
     virtual _InIt __CLR_OR_THIS_CALL do_get(_InIt _First, _InIt _Last, ios_base& _Iosbase, ios_base::iostate& _State,
         long double& _Val) const { // get long double from [_First, _Last) into _Val
-        static_assert(sizeof(double) == sizeof(long double), "Bad assumption: sizeof(double) == sizeof(long double).");
+        // Assumes sizeof(double) == sizeof(long double).
+        // For 80-bit long double (which is not supported by MSVC in general), this will compile
+        // but will not attempt to handle the increased precision at runtime.
         double _Result;
         _First = num_get::do_get(_First, _Last, _Iosbase, _State, _Result); // avoid virtual call for perf
         _Val   = _Result;


### PR DESCRIPTION
https://github.com/microsoft/STL/blob/8f67ece4a654625220642c92fa029a5cfc77afa8/stl/inc/xlocnum#L615-L622

This was introduced by MSVC-PR-113746 on 2018-03-29.

In DevCom-10465513, a user has reported that this prevents compilation with the Intel compiler in 80-bit `long double` mode. We don't support the Intel compiler and we especially don't support 80-bit `long double`, but we have an unofficial policy of avoiding gratuitous breakage when doing so is easy. In this case, merely omitting the `static_assert` and explaining the assumption with a comment has no impact for MSVC/Clang users, and allows Intel 80-bit users to compile.

I checked the STL for other occurrences and this appears to be the only such `static_assert` about `long double`'s size in the product code.