### PR TITLE
More bugfixes for `flat_set`

### DIFF
--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -294,9 +294,10 @@ public:
         return _Erase(_Val);
     }
     template <class _Other>
-        requires _Keylt_transparent
+        requires (
+            _Keylt_transparent && !is_convertible_v<_Other &&, iterator> && !is_convertible_v<_Other &&, iterator>)
     size_type erase(_Other&& _Val) {
-        return _Erase(_STD forward<_Other>(_Val));
+        return _Erase(_Val);
     }
     iterator erase(const_iterator _First, const_iterator _Last) {
         return _Get_cont().erase(_First, _Last);
@@ -556,7 +557,7 @@ private:
 
     template <class _Ty>
         requires _Keylt_transparent || is_same_v<_Ty, _Kty>
-    size_type _Erase(_Ty&& _Val) {
+    size_type _Erase(const _Ty& _Val) {
         const auto [_First, _Last] = equal_range(_Val);
 
         const auto _Removed = static_cast<size_type>(_Last - _First);

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -502,11 +502,11 @@ private:
                     // _Val >= *(_Where-1) ~ upper_bound is _Where
                 } else {
                     // _Val < *(_Where-1) ~ upper_bound is in [_Begin,_Where-1]
-                    _Where = _STD upper_bound(_Begin, _Where - 1, _Val);
+                    _Where = _STD upper_bound(_Begin, _Where - 1, _Val, _Compare);
                 }
             } else {
                 // _Val >= *_Where ~ upper_bound is in [_Where+1,_End]
-                _Where = _STD upper_bound(_Where + 1, _End, _Val);
+                _Where = _STD upper_bound(_Where + 1, _End, _Val, _Compare);
             }
         } else {
             // look for the lower_bound for flat_set
@@ -516,11 +516,11 @@ private:
                     // _Val > *(_Where-1) ~ lower_bound is _Where
                 } else {
                     // _Val <= *(_Where-1) ~ lower_bound is in [_Begin,_Where-1]
-                    _Where = _STD lower_bound(_Begin, _Where - 1, _Val);
+                    _Where = _STD lower_bound(_Begin, _Where - 1, _Val, _Compare);
                 }
             } else {
                 // _Val > *_Where ~ lower_bound is in [_Where+1,_End]
-                _Where = _STD lower_bound(_Where + 1, _End, _Val);
+                _Where = _STD lower_bound(_Where + 1, _End, _Val, _Compare);
             }
         }
 

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -339,13 +339,13 @@ public:
 
     _NODISCARD size_type count(const _Kty& _Val) const {
         const auto [_First, _Last] = equal_range(_Val);
-        return _STD distance(_First, _Last);
+        return static_cast<size_type>(_Last - _First);
     }
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD size_type count(const _Other& _Val) const {
         const auto [_First, _Last] = equal_range(_Val);
-        return _STD distance(_First, _Last);
+        return static_cast<size_type>(_Last - _First);
     }
 
     _NODISCARD bool contains(const _Kty& _Val) const {
@@ -559,7 +559,7 @@ private:
     size_type _Erase(_Ty&& _Val) {
         const auto [_First, _Last] = equal_range(_Val);
 
-        const difference_type _Removed = _STD distance(_First, _Last);
+        const auto _Removed = static_cast<size_type>(_Last - _First);
         _Get_cont().erase(_First, _Last);
         return _Removed;
     }

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -295,7 +295,7 @@ public:
     }
     template <class _Other>
         requires (
-            _Keylt_transparent && !is_convertible_v<_Other &&, iterator> && !is_convertible_v<_Other &&, iterator>)
+            _Keylt_transparent && !is_convertible_v<_Other, iterator> && !is_convertible_v<_Other, const_iterator>)
     size_type erase(_Other&& _Val) {
         return _Erase(_Val);
     }

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -316,9 +316,11 @@ struct holder {
 
 void test_erase_2() {
     using C = flat_set<int, std::less<>>;
-    C fs{1, 2, 3};
-    assert_all_requirements_and_equals(fs, {1, 2, 3});
+    C fs{0, 1, 2, 3};
+    assert_all_requirements_and_equals(fs, {0, 1, 2, 3});
     // this should be allowed per P2077R3:
+    fs.erase(holder<C::const_iterator>{fs.cbegin()});
+    assert_all_requirements_and_equals(fs, {1, 2, 3});
     fs.erase(holder<C::iterator>{fs.begin()});
     assert_all_requirements_and_equals(fs, {2, 3});
     int i = 2;

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -299,6 +299,33 @@ void test_extract() {
     assert(ranges::equal(cont, elements));
 }
 
+// TRANSITION, too simple
+void test_erase_1() {
+    flat_set<int> fs{1};
+    fs.erase(1);
+    assert_all_requirements_and_equals(fs, {});
+}
+
+template <class T>
+struct holder {
+    T t;
+    operator T() && {
+        return std::move(t);
+    }
+};
+
+void test_erase_2() {
+    using C = flat_set<int, std::less<>>;
+    C fs{1, 2, 3};
+    assert_all_requirements_and_equals(fs, {1, 2, 3});
+    // this should be allowed per P2077R3:
+    fs.erase(holder<C::iterator>{fs.begin()});
+    assert_all_requirements_and_equals(fs, {2, 3});
+    int i = 2;
+    fs.erase(std::ref(i));
+    assert_all_requirements_and_equals(fs, {3});
+}
+
 template <class C>
 void test_erase_if() {
     constexpr int erased_result[]{1, 3};
@@ -339,6 +366,9 @@ int main() {
 
     test_extract<flat_set<int>>();
     test_extract<flat_multiset<int>>();
+
+    test_erase_1();
+    test_erase_2();
 
     test_erase_if<flat_set<int>>();
     test_erase_if<flat_multiset<int>>();

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -222,6 +222,17 @@ void test_insert_2() {
         a.insert(a.begin(), val);
         assert_all_requirements_and_equals(a, {0, 0, 0, 1, 5, 6});
     }
+
+    // TRANSITION, too simple
+    using gt = std::greater<int>;
+    {
+        flat_set<int, gt, C> a{0, 5};
+        assert_all_requirements_and_equals(a, {5, 0});
+        a.insert(a.begin(), 3);
+        assert_all_requirements_and_equals(a, {5, 3, 0});
+        a.insert(a.end(), 4);
+        assert_all_requirements_and_equals(a, {5, 4, 3, 0});
+    }
 }
 
 template <class T>

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -324,7 +324,7 @@ void test_erase_2() {
     fs.erase(holder<C::iterator>{fs.begin()});
     assert_all_requirements_and_equals(fs, {2, 3});
     int i = 2;
-    fs.erase(std::ref(i));
+    fs.erase(ref(i));
     assert_all_requirements_and_equals(fs, {3});
 }
 

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -297,6 +297,15 @@ void test_erase_if() {
     assert(ranges::equal(fs, erased_result));
 }
 
+// TRANSITION, too simple
+void test_count() {
+    flat_set<int> fs{2};
+    assert(fs.count(1) == 0);
+
+    flat_multiset<int> fs2{1, 2, 2, 3};
+    assert(fs2.count(2) == 2);
+}
+
 int main() {
     test_spaceship_operator<flat_set<int>>();
     test_spaceship_operator<flat_multiset<int>>();
@@ -322,4 +331,6 @@ int main() {
 
     test_erase_if<flat_set<int>>();
     test_erase_if<flat_multiset<int>>();
+
+    test_count();
 }


### PR DESCRIPTION
This pr is separated from #4019 and contains all (and only) the bugfixes in it. Contents in this pr:
1. (Not strictly a bug) Fix `signed/unsigned` mismatch in `count` and `_Erase`.
2. Fix missed comp in `_Emplace_hint` (my mistake :(
3. Fix `erase(auto&&)`'s constraint. (Thanks to @cpplearner for sharing the link about [heterogeneous erasure](https://wg21.link/P2077R3#whyfwd)!