### PR TITLE
Require VS 2022 17.8, remove workaround

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -9012,11 +9012,7 @@ namespace ranges {
 
     template <class _Fn, class _Ty, size_t... _Indices>
     struct _Invoke_result_with_repeated_type_impl<_Fn, _Ty, index_sequence<_Indices...>> {
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1761088
         using type = invoke_result_t<_Fn, _Repeat_type<_Ty, _Indices>...>;
-#else // ^^^ no workaround / workaround vvv
-        using type = decltype(_STD invoke(_STD declval<_Fn>(), _STD declval<_Repeat_type<_Ty, _Indices>>()...));
-#endif // ^^^ workaround ^^^
     };
 
     template <class _Fn, class _Ty, size_t _Nx>

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -890,8 +890,8 @@ _EMIT_STL_ERROR(STL1002, "Unexpected compiler version, expected CUDA 11.6 or new
 _EMIT_STL_ERROR(STL1000, "Unexpected compiler version, expected Clang 16.0.0 or newer.");
 #endif // ^^^ old Clang ^^^
 #elif defined(_MSC_VER)
-#if _MSC_VER < 1936 // Coarse-grained, not inspecting _MSC_FULL_VER
-_EMIT_STL_ERROR(STL1001, "Unexpected compiler version, expected MSVC 19.36 or newer.");
+#if _MSC_VER < 1938 // Coarse-grained, not inspecting _MSC_FULL_VER
+_EMIT_STL_ERROR(STL1001, "Unexpected compiler version, expected MSVC 19.38 or newer.");
 #endif // ^^^ old MSVC ^^^
 #else // vvv other compilers vvv
 // not attempting to detect other compilers


### PR DESCRIPTION
The MSVC-internal toolset (i.e. the checked-in compiler binaries that build the compiler) has finally been updated, so we can begin requiring VS 2022 17.8, and we can remove a workaround for a compiler bug that was fixed in 17.7 Preview 1.