### PR TITLE
Lifetime cleanups for `basic_string`

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2968,10 +2968,14 @@ public:
         _Released_buffer _Result;
         auto& _My_data = _Mypair._Myval2;
         _Result._Size  = _My_data._Mysize;
+        _My_data._Orphan_all();
         _ASAN_STRING_REMOVE(*this);
         if (_My_data._Large_mode_engaged()) {
             _Result._Ptr                    = _My_data._Bx._Ptr;
             _Result._Actual_allocation_size = _My_data._Myres + 1;
+
+            _Destroy_in_place(_My_data._Bx._Ptr);
+            _My_data._Activate_SSO_buffer();
         } else {
             // use _Least_allocation_size to avoid small mode, if the buffer is assigned back
             size_type _Allocated = _Least_allocation_size;
@@ -2979,8 +2983,9 @@ public:
             _Traits::copy(_Unfancy(_Result._Ptr), _My_data._Bx._Buf, _BUF_SIZE);
             _Result._Actual_allocation_size = _Allocated;
         }
-        _My_data._Orphan_all();
-        _Tidy_init();
+        _My_data._Mysize = 0;
+        _My_data._Myres  = _Small_string_capacity;
+        _Traits::assign(_My_data._Bx._Buf[0], _Elem());
         return _Result;
     }
 #endif // _HAS_CXX20
@@ -4831,17 +4836,6 @@ private:
     _CONSTEXPR20 void _Eos(const size_type _New_size) noexcept { // set new length and null terminator
         _ASAN_STRING_MODIFY(*this, _Mypair._Myval2._Mysize, _New_size);
         _Traits::assign(_Mypair._Myval2._Myptr()[_Mypair._Myval2._Mysize = _New_size], _Elem());
-    }
-
-    _CONSTEXPR20 void _Tidy_init() noexcept {
-        // initialize basic_string data members
-        auto& _My_data   = _Mypair._Myval2;
-        _My_data._Mysize = 0;
-        _My_data._Myres  = _Small_string_capacity;
-        _My_data._Activate_SSO_buffer();
-
-        // the _Traits::assign is last so the codegen doesn't think the char write can alias this
-        _Traits::assign(_My_data._Bx._Buf[0], _Elem());
     }
 
     _CONSTEXPR20 void _Tidy_deallocate() noexcept { // initialize buffer, deallocating any storage

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2287,6 +2287,19 @@ public:
         value_type _Buf[_BUF_SIZE];
         pointer _Ptr;
         char _Alias[_BUF_SIZE]; // TRANSITION, ABI: _Alias is preserved for binary compatibility (especially /clr)
+
+        _CONSTEXPR20 void _Switch_to_buf() noexcept {
+            _STD _Destroy_in_place(_Ptr);
+
+#if _HAS_CXX20
+            // start the lifetime of the array elements
+            if (_STD is_constant_evaluated()) {
+                for (size_type _Idx = 0; _Idx < _BUF_SIZE; ++_Idx) {
+                    _Buf[_Idx] = value_type();
+                }
+            }
+#endif // _HAS_CXX20
+        }
     };
     _Bxty _Bx;
 
@@ -2974,8 +2987,7 @@ public:
             _Result._Ptr                    = _My_data._Bx._Ptr;
             _Result._Actual_allocation_size = _My_data._Myres + 1;
 
-            _Destroy_in_place(_My_data._Bx._Ptr);
-            _My_data._Activate_SSO_buffer();
+            _My_data._Bx._Switch_to_buf();
         } else {
             // use _Least_allocation_size to avoid small mode, if the buffer is assigned back
             size_type _Allocated = _Least_allocation_size;
@@ -3067,8 +3079,7 @@ private:
             _Swap_proxy_and_iterators(_Right);
 
             _Construct_in_place(_My_data._Bx._Ptr, _Right_data._Bx._Ptr);
-            _Destroy_in_place(_Right_data._Bx._Ptr);
-            _Right_data._Activate_SSO_buffer();
+            _Right_data._Bx._Switch_to_buf();
         } else { // copy small string buffer
             _Right_data._Orphan_all();
 
@@ -4275,9 +4286,7 @@ public:
     static _CONSTEXPR20 void _Swap_bx_large_with_small(_Scary_val& _Starts_large, _Scary_val& _Starts_small) noexcept {
         // exchange a string in large mode with one in small mode
         const pointer _Ptr = _Starts_large._Bx._Ptr;
-        _Destroy_in_place(_Starts_large._Bx._Ptr);
-
-        _Starts_large._Activate_SSO_buffer();
+        _Starts_large._Bx._Switch_to_buf();
         _Traits::copy(_Starts_large._Bx._Buf, _Starts_small._Bx._Buf, _BUF_SIZE);
 
         _Construct_in_place(_Starts_small._Bx._Ptr, _Ptr);
@@ -4825,10 +4834,9 @@ private:
         _My_data._Orphan_all();
         _ASAN_STRING_REMOVE(*this);
         const pointer _Ptr = _My_data._Bx._Ptr;
-        auto& _Al          = _Getal();
-        _Destroy_in_place(_My_data._Bx._Ptr);
-        _My_data._Activate_SSO_buffer();
+        _My_data._Bx._Switch_to_buf();
         _Traits::copy(_My_data._Bx._Buf, _Unfancy(_Ptr), _My_data._Mysize + 1);
+        auto& _Al = _Getal();
         _Deallocate_for_capacity(_Al, _Ptr, _My_data._Myres);
         _My_data._Myres = _Small_string_capacity;
     }
@@ -4843,11 +4851,9 @@ private:
         _My_data._Orphan_all();
         if (_My_data._Large_mode_engaged()) {
             _ASAN_STRING_REMOVE(*this);
-            const pointer _Ptr = _My_data._Bx._Ptr;
-            auto& _Al          = _Getal();
-            _Destroy_in_place(_My_data._Bx._Ptr);
-            _My_data._Activate_SSO_buffer();
-            _Deallocate_for_capacity(_Al, _Ptr, _My_data._Myres);
+            auto& _Al = _Getal();
+            _Deallocate_for_capacity(_Al, _My_data._Bx._Ptr, _My_data._Myres);
+            _My_data._Bx._Switch_to_buf();
         }
 
         _My_data._Mysize = 0;

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2627,6 +2627,20 @@ private:
         _Al.deallocate(_Old_ptr, _Capacity + 1); // +1 for null terminator
     }
 
+    _CONSTEXPR20 void _Construct_empty() noexcept {
+        // this function needs to be noexcept for conformance to the standard.
+        _Mypair._Myval2._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal()));
+
+        // initialize basic_string data members
+        auto& _My_data   = _Mypair._Myval2;
+        _My_data._Mysize = 0;
+        _My_data._Myres  = _Small_string_capacity;
+        _My_data._Activate_SSO_buffer();
+
+        // the _Traits::assign is last so the codegen doesn't think the char write can alias this
+        _Traits::assign(_My_data._Bx._Buf[0], _Elem());
+    }
+
     enum class _Construct_strategy : uint8_t { _From_char, _From_ptr, _From_string };
 
     template <_Construct_strategy _Strat, class _Char_or_ptr>
@@ -4812,20 +4826,6 @@ private:
     }
 
     _CONSTEXPR20 void _Tidy_init() noexcept {
-        // initialize basic_string data members
-        auto& _My_data   = _Mypair._Myval2;
-        _My_data._Mysize = 0;
-        _My_data._Myres  = _Small_string_capacity;
-        _My_data._Activate_SSO_buffer();
-
-        // the _Traits::assign is last so the codegen doesn't think the char write can alias this
-        _Traits::assign(_My_data._Bx._Buf[0], _Elem());
-    }
-
-    _CONSTEXPR20 void _Construct_empty() noexcept {
-        // this function needs to be noexcept for conformance to the standard.
-        _Mypair._Myval2._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal()));
-
         // initialize basic_string data members
         auto& _My_data   = _Mypair._Myval2;
         _My_data._Mysize = 0;

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -3059,14 +3059,16 @@ private:
 #endif // !defined(_INSERT_STRING_ANNOTATION)
 
         if (_Right_data._Large_mode_engaged()) { // steal buffer
-            _Construct_in_place(_My_data._Bx._Ptr, _Right_data._Bx._Ptr);
             _Swap_proxy_and_iterators(_Right);
 
+            _Construct_in_place(_My_data._Bx._Ptr, _Right_data._Bx._Ptr);
             _Destroy_in_place(_Right_data._Bx._Ptr);
+            _Right_data._Activate_SSO_buffer();
         } else { // copy small string buffer
+            _Right_data._Orphan_all();
+
             _My_data._Activate_SSO_buffer();
             _Traits::copy(_My_data._Bx._Buf, _Right_data._Bx._Buf, _Right_data._Mysize + 1);
-            _Right_data._Orphan_all();
         }
 
         _My_data._Myres  = _Right_data._Myres;
@@ -3074,7 +3076,6 @@ private:
 
         _Right_data._Mysize = 0;
         _Right_data._Myres  = _Small_string_capacity;
-        _Right_data._Activate_SSO_buffer();
         _Traits::assign(_Right_data._Bx._Buf[0], _Elem());
     }
 

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2641,10 +2641,10 @@ private:
     }
 
     _CONSTEXPR20 void _Construct_empty() {
-        _Mypair._Myval2._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal()));
+        auto& _My_data = _Mypair._Myval2;
+        _My_data._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal()));
 
         // initialize basic_string data members
-        auto& _My_data   = _Mypair._Myval2;
         _My_data._Mysize = 0;
         _My_data._Myres  = _Small_string_capacity;
         _My_data._Activate_SSO_buffer();

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2640,8 +2640,7 @@ private:
         _Al.deallocate(_Old_ptr, _Capacity + 1); // +1 for null terminator
     }
 
-    _CONSTEXPR20 void _Construct_empty() noexcept {
-        // this function needs to be noexcept for conformance to the standard.
+    _CONSTEXPR20 void _Construct_empty() {
         _Mypair._Myval2._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal()));
 
         // initialize basic_string data members

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2484,13 +2484,11 @@ private:
 public:
     _CONSTEXPR20
     basic_string() noexcept(is_nothrow_default_constructible_v<_Alty>) : _Mypair(_Zero_then_variadic_args_t{}) {
-        _Mypair._Myval2._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal()));
-        _Tidy_init();
+        _Construct_empty();
     }
 
     _CONSTEXPR20 explicit basic_string(const _Alloc& _Al) noexcept : _Mypair(_One_then_variadic_args_t{}, _Al) {
-        _Mypair._Myval2._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal()));
-        _Tidy_init();
+        _Construct_empty();
     }
 
     _CONSTEXPR20 basic_string(const basic_string& _Right)
@@ -2578,8 +2576,7 @@ public:
         auto _UFirst = _Get_unwrapped(_First);
         auto _ULast  = _Get_unwrapped(_Last);
         if (_UFirst == _ULast) {
-            _Mypair._Myval2._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal()));
-            _Tidy_init();
+            _Construct_empty();
         } else {
             if constexpr (_Is_elem_cptr<decltype(_UFirst)>::value) {
                 _Construct<_Construct_strategy::_From_ptr>(
@@ -2918,8 +2915,7 @@ public:
     basic_string(_String_constructor_rvalue_allocator_tag, _Alloc&& _Al)
         : _Mypair(_One_then_variadic_args_t{}, _STD move(_Al)) {
         // Used exclusively by basic_stringbuf
-        _Mypair._Myval2._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal()));
-        _Tidy_init();
+        _Construct_empty();
     }
 
     _NODISCARD bool _Move_assign_from_buffer(
@@ -4816,6 +4812,20 @@ private:
     }
 
     _CONSTEXPR20 void _Tidy_init() noexcept {
+        // initialize basic_string data members
+        auto& _My_data   = _Mypair._Myval2;
+        _My_data._Mysize = 0;
+        _My_data._Myres  = _Small_string_capacity;
+        _My_data._Activate_SSO_buffer();
+
+        // the _Traits::assign is last so the codegen doesn't think the char write can alias this
+        _Traits::assign(_My_data._Bx._Buf[0], _Elem());
+    }
+
+    _CONSTEXPR20 void _Construct_empty() noexcept {
+        // this function needs to be noexcept for conformance to the standard.
+        _Mypair._Myval2._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal()));
+
         // initialize basic_string data members
         auto& _My_data   = _Mypair._Myval2;
         _My_data._Mysize = 0;

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -3048,7 +3048,11 @@ private:
                 const auto _Right_data_mem =
                     reinterpret_cast<const unsigned char*>(_STD addressof(_Right._Mypair._Myval2)) + _Memcpy_val_offset;
                 _CSTD memcpy(_My_data_mem, _Right_data_mem, _Memcpy_val_size);
-                _Right._Tidy_init();
+
+                _Right_data._Mysize = 0;
+                _Right_data._Myres  = _Small_string_capacity;
+                _Right_data._Activate_SSO_buffer();
+                _Traits::assign(_Right_data._Bx._Buf[0], _Elem());
                 return;
             }
         }
@@ -3068,7 +3072,10 @@ private:
         _My_data._Myres  = _Right_data._Myres;
         _My_data._Mysize = _Right_data._Mysize;
 
-        _Right._Tidy_init();
+        _Right_data._Mysize = 0;
+        _Right_data._Myres  = _Small_string_capacity;
+        _Right_data._Activate_SSO_buffer();
+        _Traits::assign(_Right_data._Bx._Buf[0], _Elem());
     }
 
 #if _HAS_CXX23


### PR DESCRIPTION
Resolves the comments [(1)](https://github.com/microsoft/STL/pull/4031#discussion_r1331063123) [(2)](https://github.com/microsoft/STL/pull/4031#issuecomment-1727571761) in pr 4031. Hope that is the last lifetime bug of `basic_string` using fancy pointers (`3.1.`).
<hr>

Sometimes the pointer's destruction and buffer's activation are dangerously separated into different functions, in an obscure way (mainly relevant to the usage of `_Tidy_init`).
This pr introduces a helper function `_String_val::_Bxty::_Switch_to_buf` to make the transition state (where both `_Ptr` and `_Buf` are inactive) invisible to `basic_string`'s ctors and methods.
<hr>

Remaining issue after this pr:
https://github.com/microsoft/STL/blob/48eedd369d6c88130fff4d15afb88f016fa6e648/stl/inc/xstring#L2282-L2284
As `_String_val` already initializes the buffer on construction, and every switch back to small mode is now protected by the helper function, in `basic_string`'s ctor and methods, when we can decide a string is in small mode, we can also assume that elements in `_Buf` are activated. *Therefore, every remaining usage of `_Activate_SSO_buffer` (including the one in newly added `_Construct_empty`) becomes redundant*...
Or, `Don't rely on the new behavior`? Does this mean we should not assume that `_Buf` is initialized in ctor, even if it does so now? Can we remove the remaining `_Activate_SSO_buffer` then? I'm highly horrified by this; especially, what's its relation with the lifetime issue of fancy pointers?

Related: #1735 #3235 and #3273.