### PR TITLE
P1169R4 `static` `operator()`

### DIFF
--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1139,12 +1139,37 @@ public:
 _NON_MEMBER_CALL(_FUNCTION_POINTER_DEDUCTION_GUIDE, X1, X2, X3)
 #undef _FUNCTION_POINTER_DEDUCTION_GUIDE
 
+template <class _Fx, class _Call_op, class = void>
+struct _Deduce_from_call_operator : _Is_memfunptr<_Call_op>::_Guide_type {}; // N4958 [func.wrap.func.con]/16.1
+
+#ifdef __cpp_static_call_operator // TRANSITION, P1169R4
+template <class>
+struct _Inspect_static_call_operator {};
+
+#define _STATIC_CALL_OPERATOR_GUIDES(CALL_OPT, CV_OPT, REF_OPT, NOEXCEPT_OPT)      \
+    template <class _Ret, class... _Args>                                          \
+    struct _Inspect_static_call_operator<_Ret(CALL_OPT*)(_Args...) NOEXCEPT_OPT> { \
+        using type = _Ret(_Args...);                                               \
+    };
+
+_NON_MEMBER_CALL(_STATIC_CALL_OPERATOR_GUIDES, , , )
+#ifdef __cpp_noexcept_function_type
+_NON_MEMBER_CALL(_STATIC_CALL_OPERATOR_GUIDES, , , noexcept)
+#endif // ^^^ defined(__cpp_noexcept_function_type) ^^^
+
+#undef _STATIC_CALL_OPERATOR_GUIDES
+
+template <class _Fx, class _Call_op>
+struct _Deduce_from_call_operator<_Fx, _Call_op, void_t<decltype(_STD declval<_Fx>().operator())>>
+    : _Inspect_static_call_operator<_Call_op> {}; // N4958 [func.wrap.func.con]/16.2
+#endif // ^^^ defined(__cpp_static_call_operator) ^^^
+
 template <class _Fx, class = void>
 struct _Deduce_signature {}; // can't deduce signature when &_Fx::operator() is missing, inaccessible, or ambiguous
 
 template <class _Fx>
 struct _Deduce_signature<_Fx, void_t<decltype(&_Fx::operator())>>
-    : _Is_memfunptr<decltype(&_Fx::operator())>::_Guide_type {}; // N4950 [func.wrap.func.con]/16.1
+    : _Deduce_from_call_operator<_Fx, decltype(&_Fx::operator())> {};
 
 template <class _Fx>
 function(_Fx) -> function<typename _Deduce_signature<_Fx>::type>;

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1142,7 +1142,7 @@ _NON_MEMBER_CALL(_FUNCTION_POINTER_DEDUCTION_GUIDE, X1, X2, X3)
 template <class _Fx, class _Call_op, class = void>
 struct _Deduce_from_call_operator : _Is_memfunptr<_Call_op>::_Guide_type {}; // N4958 [func.wrap.func.con]/16.1
 
-#ifdef __cpp_static_call_operator // TRANSITION, P1169R4
+#ifdef __cpp_static_call_operator
 template <class>
 struct _Inspect_static_call_operator {};
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -328,6 +328,7 @@
 // P1072R10 basic_string::resize_and_overwrite
 // P1132R7 out_ptr(), inout_ptr()
 // P1147R1 Printing volatile Pointers
+// P1169R4 static operator()
 // P1206R7 Conversions From Ranges To Containers
 // P1223R5 ranges::find_last, ranges::find_last_if, ranges::find_last_if_not
 // P1272R4 byteswap()

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -128,6 +128,7 @@
 // P0858R0 Constexpr Iterator Requirements
 // P1065R2 constexpr INVOKE
 //     (the std::invoke function only; other components like bind and reference_wrapper are C++20 only)
+// P1169R4 static operator()
 // P1518R2 Stop Overconstraining Allocators In Container Deduction Guides
 // P2162R2 Inheriting From variant
 // P2251R1 Require span And basic_string_view To Be Trivially Copyable
@@ -328,7 +329,6 @@
 // P1072R10 basic_string::resize_and_overwrite
 // P1132R7 out_ptr(), inout_ptr()
 // P1147R1 Printing volatile Pointers
-// P1169R4 static operator()
 // P1206R7 Conversions From Ranges To Containers
 // P1223R5 ranges::find_last, ranges::find_last_if, ranges::find_last_if_not
 // P1272R4 byteswap()

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -327,9 +327,6 @@ std/utilities/tuple/tuple.tuple/tuple.cnstr/recursion_depth.pass.cpp SKIPPED
 std/depr/depr.c.headers/uchar_h.compile.pass.cpp FAIL
 std/strings/c.strings/cuchar.compile.pass.cpp FAIL
 
-# P1169R4 static operator()
-std/thread/futures/futures.task/futures.task.members/ctad.static.compile.pass.cpp FAIL
-
 # P2255R2 "Type Traits To Detect References Binding To Temporaries"
 std/language.support/support.limits/support.limits.general/type_traits.version.compile.pass.cpp FAIL
 
@@ -348,6 +345,10 @@ std/utilities/format/format.tuple/set_separator.pass.cpp FAIL
 # *** MISSING COMPILER FEATURES ***
 # MSVC doesn't properly support [[no_unique_address]]
 std/algorithms/algorithms.results/no_unique_address.compile.pass.cpp SKIPPED
+
+# P1169R4 static operator()
+std/thread/futures/futures.task/futures.task.members/ctad.static.compile.pass.cpp:0 FAIL
+std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/ctad.static.compile.pass.cpp:0 FAIL
 
 
 # *** MISSING LWG ISSUE RESOLUTIONS ***
@@ -1065,7 +1066,6 @@ std/ranges/range.factories/range.single.view/cpo.pass.cpp FAIL
 std/thread/futures/futures.task/futures.task.members/ctor2.compile.pass.cpp FAIL
 std/utilities/format/format.functions/escaped_output.ascii.pass.cpp FAIL
 std/utilities/format/format.functions/locale-specific_form.pass.cpp FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/ctad.static.compile.pass.cpp FAIL
 std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.inv/invoke.pass.cpp:0 FAIL
 std/utilities/function.objects/refwrap/refwrap.const/type_conv_ctor.pass.cpp:0 FAIL
 std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/allocate_shared.array.unbounded.pass.cpp FAIL

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -509,6 +509,7 @@ tests\P1135R6_latch
 tests\P1135R6_semaphore
 tests\P1147R1_printing_volatile_pointers
 tests\P1165R1_consistently_propagating_stateful_allocators
+tests\P1169R4_static_call_operator
 tests\P1206R7_deque_append_range
 tests\P1206R7_deque_assign_range
 tests\P1206R7_deque_from_range

--- a/tests/std/tests/P1169R4_static_call_operator/env.lst
+++ b/tests/std/tests/P1169R4_static_call_operator/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P1169R4_static_call_operator/test.compile.pass.cpp
+++ b/tests/std/tests/P1169R4_static_call_operator/test.compile.pass.cpp
@@ -43,8 +43,10 @@ void test_ctad() {
     static_assert(is_same_v<decltype(Temp{Derived{}}), Temp<bool(unsigned int)>>);
     static_assert(is_same_v<decltype(Temp{Nothrow{}}), Temp<char16_t(char32_t)>>);
 
+#if !(defined(__clang__) && defined(_M_IX86)) // TRANSITION, LLVM-62594, fixed in Clang 18
     auto lambda = [](int* p, int** q) static { return *p + **q; };
     static_assert(is_same_v<decltype(Temp{lambda}), Temp<int(int*, int**)>>);
+#endif // ^^^ no workaround ^^^
 }
 
 void all_tests() {

--- a/tests/std/tests/P1169R4_static_call_operator/test.compile.pass.cpp
+++ b/tests/std/tests/P1169R4_static_call_operator/test.compile.pass.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifdef __cpp_static_call_operator // TRANSITION, P1169R4
+#ifdef __cpp_static_call_operator
 
 #include <functional>
 #include <future>

--- a/tests/std/tests/P1169R4_static_call_operator/test.compile.pass.cpp
+++ b/tests/std/tests/P1169R4_static_call_operator/test.compile.pass.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifdef __cpp_static_call_operator // TRANSITION, P1169R4
+
+#include <functional>
+#include <future>
+#include <type_traits>
+using namespace std;
+
+struct F0 {
+    static char operator()();
+};
+
+struct F1 {
+    static short operator()(float);
+};
+
+struct F2 {
+    static int operator()(double*, double&);
+};
+
+struct F3 {
+    static void operator()(const long&, long&&, const long&&);
+};
+
+struct Base {
+    static bool operator()(unsigned int);
+};
+
+struct Derived : Base {};
+
+struct Nothrow {
+    static char16_t operator()(char32_t) noexcept;
+};
+
+template <template <class> class Temp>
+void test_ctad() {
+    static_assert(is_same_v<decltype(Temp{F0{}}), Temp<char()>>);
+    static_assert(is_same_v<decltype(Temp{F1{}}), Temp<short(float)>>);
+    static_assert(is_same_v<decltype(Temp{F2{}}), Temp<int(double*, double&)>>);
+    static_assert(is_same_v<decltype(Temp{F3{}}), Temp<void(const long&, long&&, const long&&)>>);
+    static_assert(is_same_v<decltype(Temp{Derived{}}), Temp<bool(unsigned int)>>);
+    static_assert(is_same_v<decltype(Temp{Nothrow{}}), Temp<char16_t(char32_t)>>);
+
+    auto lambda = [](int* p, int** q) static { return *p + **q; };
+    static_assert(is_same_v<decltype(Temp{lambda}), Temp<int(int*, int**)>>);
+}
+
+void all_tests() {
+    test_ctad<function>();
+    test_ctad<packaged_task>();
+}
+
+#endif // ^^^ defined(__cpp_static_call_operator) ^^^


### PR DESCRIPTION
Fixes #2954.

This updates the STL's CTAD for `std::function` and `packaged_task` to work with a C++23 Core Language feature that was implemented in Clang 16 (which we began requiring in VS 2022 17.7). It will automatically "light up" when MSVC and EDG claim support by defining the feature-test macro.

## `<functional>`
* This alters the structure, but not the behavior, of the existing code by adding another layer. First, `_Deduce_signature` performs SFINAE for `&_Fx::operator()`, which needs to be well-formed for both the old and new cases. Then, we send `_Fx` (because the new path will need it) and `decltype(&_Fx::operator())` (so both paths don't need to recompute it) up to the layer `_Deduce_from_call_operator`.
* Without the new compiler feature, or with the new compiler feature but a classically non-static call operator, the primary template for `_Deduce_from_call_operator` is chosen, and we use the `_Is_memfunptr` machinery exactly as before. (I updated the WP citation, but the paragraph number is the same.)
* `#ifdef __cpp_static_call_operator` isn't commented as TRANSITION, because Clang backported it unconditionally (thanks @frederick-vs-ja).
* When the new compiler feature is available, we need to detect whether the call operator is `static` separately from inspecting its type (see note here). I'm using the technique mentioned in the paper, detecting whether we can form `f.operator()`. Note that the value category doesn't matter, so I'm just passing `_Fx` to `declval`.
  + Note: This is because "explicit `this`", which we previously implemented, also produces a plain function pointer (instead of a PMF), but for that we need to drop the "self" parameter. All that happens in the old `_Is_memfunptr` path.
* When the call operator is `static`, we don't take the old `_Is_memfunptr` path. Instead we use the new `_Inspect_static_call_operator` path, with a citation for the relevant paragraph. This path is dedicated, instead of intertwined with other `<functional>` logic, so we don't need to bother with a `_Guide_type` and `_Identity` etc., we'll just directly have a `type` at the end, which is what `_Deduce_signature` ultimately needs to provide.
* If `noexcept` is part of the type, we're required to ignore it. (As usual this is guarded by `__cpp_noexcept_function_type` because the compiler has an escape hatch that is permanently supported.)

## `<yvals_core.h>`
* Mention the paper in the `_HAS_CXX23` section, at least until we get clarity on whether MSVC and EDG will backport.

## Tests
* Add a compile-only test. The entire test is guarded by the Core feature-test macro (which I verified is actually defined by Clang), so we don't need to include any headers before it. I test arities from 0 to 3 inclusive, using distinct types. I test one case where the `static` operator is inherited from a base class. I also test what happens if the `static` operator is marked `noexcept`; regardless of whether it's part of the type system (`usual_latest_matrix.lst` provides that coverage), we deduce the same signature. Everything is tested for both `std::function` and `packaged_task`.
  + I also test a lambda with a `static` call operator to keep the compiler honest. We need to work around LLVM-62594 (thanks @cpplearner), indicating that this coverage was a good idea! :smile_cat:
* libcxx had a couple of tests that are now passing for Clang; mark them as expected to fail for MSVC.