### PR TITLE
`<source_location>`: Light up detailed `function_name()` for Clang 17, add escape hatch

### DIFF
--- a/stl/inc/source_location
+++ b/stl/inc/source_location
@@ -20,15 +20,25 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+#ifndef _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
+#ifdef __EDG__ // TRANSITION, DevCom-10199227
+#define _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION 0
+#elif defined(__clang__) // TRANSITION, Clang 17 has this builtin
+#define _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION __has_builtin(__builtin_FUNCSIG)
+#else // ^^^ Clang / MSVC vvv
+#define _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION 1
+#endif // ^^^ MSVC ^^^
+#endif // ^^^ !defined(_USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION) ^^^
+
 _STD_BEGIN
 _EXPORT_STD struct source_location {
     _NODISCARD static consteval source_location current(const uint_least32_t _Line_ = __builtin_LINE(),
         const uint_least32_t _Column_ = __builtin_COLUMN(), const char* const _File_ = __builtin_FILE(),
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10199227 and LLVM-58951
-        const char* const _Function_ = __builtin_FUNCTION()
-#else // ^^^ workaround / no workaround vvv
+#if _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
         const char* const _Function_ = __builtin_FUNCSIG()
-#endif // TRANSITION, DevCom-10199227 and LLVM-58951
+#else
+        const char* const _Function_ = __builtin_FUNCTION()
+#endif
             ) noexcept {
         source_location _Result{};
         _Result._Line     = _Line_;

--- a/stl/inc/source_location
+++ b/stl/inc/source_location
@@ -36,9 +36,9 @@ _EXPORT_STD struct source_location {
         const uint_least32_t _Column_ = __builtin_COLUMN(), const char* const _File_ = __builtin_FILE(),
 #if _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
         const char* const _Function_ = __builtin_FUNCSIG()
-#else
+#else // ^^^ detailed / basic vvv
         const char* const _Function_ = __builtin_FUNCTION()
-#endif
+#endif // ^^^ basic ^^^
             ) noexcept {
         source_location _Result{};
         _Result._Line     = _Line_;

--- a/tests/std/include/test_header_units_and_modules.hpp
+++ b/tests/std/include/test_header_units_and_modules.hpp
@@ -690,9 +690,9 @@ constexpr bool impl_test_source_location() {
 
 #if TEST_DETAILED_FUNCTION_NAME
     assert(sl.function_name() == "bool __cdecl impl_test_source_location(void)"sv);
-#else
+#else // ^^^ detailed / basic vvv
     assert(sl.function_name() == "impl_test_source_location"sv);
-#endif
+#endif // ^^^ basic ^^^
 
     assert(string_view{sl.file_name()}.ends_with("test_header_units_and_modules.hpp"sv));
     return true;

--- a/tests/std/tests/P1208R6_source_location/header.h
+++ b/tests/std/tests/P1208R6_source_location/header.h
@@ -17,10 +17,10 @@ constexpr void header_test() {
 #else // ^^^ EDG / C1XX vvv
     assert(x.column() == 37);
 #endif // ^^^ C1XX ^^^
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10199227 and LLVM-58951
-    assert(x.function_name() == "header_test"sv);
-#else // ^^^ workaround / no workaround vvv
+#if _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
     assert(x.function_name() == "void __cdecl header_test(void)"sv);
-#endif // TRANSITION, DevCom-10199227 and LLVM-58951
+#else
+    assert(x.function_name() == "header_test"sv);
+#endif
     assert(string_view{x.file_name()}.ends_with("header.h"sv));
 }

--- a/tests/std/tests/P1208R6_source_location/header.h
+++ b/tests/std/tests/P1208R6_source_location/header.h
@@ -19,8 +19,8 @@ constexpr void header_test() {
 #endif // ^^^ C1XX ^^^
 #if _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
     assert(x.function_name() == "void __cdecl header_test(void)"sv);
-#else
+#else // ^^^ detailed / basic vvv
     assert(x.function_name() == "header_test"sv);
-#endif
+#endif // ^^^ basic ^^^
     assert(string_view{x.file_name()}.ends_with("header.h"sv));
 }

--- a/tests/std/tests/P1208R6_source_location/test.cpp
+++ b/tests/std/tests/P1208R6_source_location/test.cpp
@@ -61,11 +61,11 @@ constexpr void local_test() {
 #else // ^^^ EDG / C1XX vvv
     assert(x.column() == 37);
 #endif // ^^^ C1XX ^^^
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10199227 and LLVM-58951
-    assert(x.function_name() == "local_test"sv);
-#else // ^^^ workaround / no workaround vvv
+#if _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
     assert(x.function_name() == "void __cdecl local_test(void)"sv);
-#endif // TRANSITION, DevCom-10199227 and LLVM-58951
+#else
+    assert(x.function_name() == "local_test"sv);
+#endif
     assert(string_view{x.file_name()}.ends_with(test_cpp));
 }
 
@@ -73,11 +73,11 @@ constexpr void argument_test(
     const unsigned int line, const unsigned int column, const source_location x = source_location::current()) {
     assert(x.line() == line);
     assert(x.column() == column);
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10199227 and LLVM-58951
-    assert(x.function_name() == "test"sv);
-#else // ^^^ workaround / no workaround vvv
+#if _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
     assert(x.function_name() == "bool __cdecl test(void)"sv);
-#endif // TRANSITION, DevCom-10199227 and LLVM-58951
+#else
+    assert(x.function_name() == "test"sv);
+#endif
     assert(string_view{x.file_name()}.ends_with(test_cpp));
 }
 
@@ -89,15 +89,18 @@ constexpr void sloc_constructor_test() {
 #else // ^^^ defined(__EDG__) / !defined(__EDG__) vvv
     assert(x.loc.column() == 13);
 #endif // ^^^ !defined(__EDG__) ^^^
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10199227 and LLVM-58951
-    assert(x.loc.function_name() == "sloc_constructor_test"sv);
-#else // ^^^ workaround / no workaround vvv
+#if _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
+#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, VSO-1285783
     if (is_constant_evaluated()) {
-        assert(x.loc.function_name() == "int __cdecl main(void)"sv); // TRANSITION, VSO-1285783
-    } else {
+        assert(x.loc.function_name() == "int __cdecl main(void)"sv);
+    } else
+#endif // ^^^ workaround ^^^
+    {
         assert(x.loc.function_name() == "void __cdecl sloc_constructor_test(void)"sv);
     }
-#endif // TRANSITION, DevCom-10199227 and LLVM-58951
+#else
+    assert(x.loc.function_name() == "sloc_constructor_test"sv);
+#endif
     assert(string_view{x.loc.file_name()}.ends_with(test_cpp));
 }
 
@@ -111,13 +114,13 @@ constexpr void different_constructor_test() {
 #else // ^^^ EDG / C1XX vvv
     assert(x.loc.column() == 5);
 #endif // ^^^ C1XX ^^^
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10199227 and LLVM-58951
+#if !_USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
     assert(x.loc.function_name() == "s"sv);
-#elif defined(_M_IX86) // ^^^ workaround / no workaround vvv
+#elif defined(_M_IX86) // ^^^ basic / detailed x86 vvv
     assert(x.loc.function_name() == "__thiscall s::s(int)"sv);
-#else // ^^^ _M_IX86 / !_M_IX86 vvv
+#else // ^^^ detailed x86 / detailed non-x86 vvv
     assert(x.loc.function_name() == "__cdecl s::s(int)"sv);
-#endif // TRANSITION, DevCom-10199227 and LLVM-58951
+#endif // ^^^ detailed non-x86 ^^^
     assert(string_view{x.loc.file_name()}.ends_with(test_cpp));
 }
 
@@ -129,15 +132,18 @@ constexpr void sub_member_test() {
 #else // ^^^ defined(__EDG__) / !defined(__EDG__) vvv
     assert(s.x.loc.column() == 14);
 #endif // ^^^ !defined(__EDG__) ^^^
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10199227 and LLVM-58951
-    assert(s.x.loc.function_name() == "sub_member_test"sv);
-#else // ^^^ workaround / no workaround vvv
+#if _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
+#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, VSO-1285783
     if (is_constant_evaluated()) {
-        assert(s.x.loc.function_name() == "int __cdecl main(void)"sv); // TRANSITION, VSO-1285783
-    } else {
+        assert(s.x.loc.function_name() == "int __cdecl main(void)"sv);
+    } else
+#endif // ^^^ workaround ^^^
+    {
         assert(s.x.loc.function_name() == "void __cdecl sub_member_test(void)"sv);
     }
-#endif // TRANSITION, DevCom-10199227 and LLVM-58951
+#else
+    assert(s.x.loc.function_name() == "sub_member_test"sv);
+#endif
     assert(string_view{s.x.loc.file_name()}.ends_with(test_cpp));
 
     const s2 s_i{1};
@@ -149,13 +155,13 @@ constexpr void sub_member_test() {
 #else // ^^^ EDG / C1XX vvv
     assert(s_i.x.loc.column() == 5);
 #endif // ^^^ C1XX ^^^
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10199227 and LLVM-58951
+#if !_USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
     assert(s_i.x.loc.function_name() == "s2"sv);
-#elif defined(_M_IX86) // ^^^ workaround / no workaround vvv
+#elif defined(_M_IX86) // ^^^ basic / detailed x86 vvv
     assert(s_i.x.loc.function_name() == "__thiscall s2::s2(int)"sv);
-#else // ^^^ _M_IX86 / !_M_IX86 vvv
+#else // ^^^ detailed x86 / detailed non-x86 vvv
     assert(s_i.x.loc.function_name() == "__cdecl s2::s2(int)"sv);
-#endif // TRANSITION, DevCom-10199227 and LLVM-58951
+#endif // ^^^ detailed non-x86 ^^^
     assert(string_view{s_i.x.loc.file_name()}.ends_with(test_cpp));
 }
 
@@ -176,19 +182,27 @@ constexpr void lambda_test() {
     assert(x1.column() == 52);
     assert(x2.column() == 50);
 #endif // ^^^ C1XX ^^^
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10199227 and LLVM-58951
+#if !_USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
     assert(x1.function_name() == "lambda_test"sv);
     assert(x2.function_name() == "operator()"sv);
-#elif defined(_M_IX86) // ^^^ workaround / no workaround vvv
+#elif defined(_M_IX86) // ^^^ basic / detailed x86 vvv
     assert(x1.function_name() == "void __cdecl lambda_test(void)"sv);
+#ifdef __clang__
+    assert(x2.function_name() == "auto __thiscall lambda_test()::(anonymous class)::operator()(void) const"sv);
+#else // ^^^ defined(__clang__) / !defined(__clang__) vvv
     assert(
         string_view{x2.function_name()}.starts_with("struct std::source_location __thiscall lambda_test::<lambda_"sv));
     assert(string_view{x2.function_name()}.ends_with("::operator ()(void) const"sv));
-#else // ^^^ _M_IX86 / !_M_IX86 vvv
+#endif // ^^^ !defined(__clang__) ^^^
+#else // ^^^ detailed x86 / detailed non-x86 vvv
     assert(x1.function_name() == "void __cdecl lambda_test(void)"sv);
+#ifdef __clang__
+    assert(x2.function_name() == "auto __cdecl lambda_test()::(anonymous class)::operator()(void) const"sv);
+#else // ^^^ defined(__clang__) / !defined(__clang__) vvv
     assert(string_view{x2.function_name()}.starts_with("struct std::source_location __cdecl lambda_test::<lambda_"sv));
     assert(string_view{x2.function_name()}.ends_with("::operator ()(void) const"sv));
-#endif // TRANSITION, DevCom-10199227 and LLVM-58951
+#endif // ^^^ !defined(__clang__) ^^^
+#endif // ^^^ detailed non-x86 ^^^
     assert(string_view{x1.file_name()}.ends_with(test_cpp));
     assert(string_view{x2.file_name()}.ends_with(test_cpp));
 }
@@ -208,21 +222,25 @@ constexpr void function_template_test() {
 #else // ^^^ EDG / C1XX vvv
     assert(x1.column() == 29);
 #endif // ^^^ C1XX ^^^
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10199227 and LLVM-58951
+#if !_USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
     assert(x1.function_name() == "function_template"sv);
-#else // ^^^ workaround / no workaround vvv
+#elif defined(__clang__) // ^^^ basic / detailed Clang vvv
+    assert(x1.function_name() == "source_location __cdecl function_template(void) [T = void]"sv);
+#else // ^^^ detailed Clang / detailed non-Clang vvv
     assert(x1.function_name() == "struct std::source_location __cdecl function_template<void>(void)"sv);
-#endif // TRANSITION, DevCom-10199227 and LLVM-58951
+#endif // ^^^ detailed non-Clang ^^^
     assert(string_view{x1.file_name()}.ends_with(test_cpp));
 
     const auto x2 = function_template<int>();
     assert(x1.line() == x2.line());
     assert(x1.column() == x2.column());
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10199227 and LLVM-58951
+#if !_USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
     assert(x2.function_name() == "function_template"sv);
-#else // ^^^ workaround / no workaround vvv
+#elif defined(__clang__) // ^^^ basic / detailed Clang vvv
+    assert(x2.function_name() == "source_location __cdecl function_template(void) [T = int]"sv);
+#else // ^^^ detailed Clang / detailed non-Clang vvv
     assert(x2.function_name() == "struct std::source_location __cdecl function_template<int>(void)"sv);
-#endif // TRANSITION, DevCom-10199227 and LLVM-58951
+#endif // ^^^ detailed non-Clang ^^^
     assert(string_view{x1.file_name()} == string_view{x2.file_name()});
 }
 

--- a/tests/std/tests/P1208R6_source_location/test.cpp
+++ b/tests/std/tests/P1208R6_source_location/test.cpp
@@ -5,15 +5,14 @@
 #include <cassert>
 #include <functional>
 #include <source_location>
-#include <string>
 #include <string_view>
 #include <type_traits>
 using namespace std;
 
 #ifdef _M_IX86
-#define THISCALL_OR_CDECL_STR "__thiscall"s
+#define THISCALL_OR_CDECL "__thiscall"
 #else
-#define THISCALL_OR_CDECL_STR "__cdecl"s
+#define THISCALL_OR_CDECL "__cdecl"
 #endif
 
 static_assert(is_nothrow_default_constructible_v<source_location>);
@@ -122,7 +121,7 @@ constexpr void different_constructor_test() {
     assert(x.loc.column() == 5);
 #endif // ^^^ C1XX ^^^
 #if _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
-    assert(x.loc.function_name() == THISCALL_OR_CDECL_STR + " s::s(int)");
+    assert(x.loc.function_name() == THISCALL_OR_CDECL " s::s(int)"sv);
 #else // ^^^ detailed / basic vvv
     assert(x.loc.function_name() == "s"sv);
 #endif // ^^^ basic ^^^
@@ -161,7 +160,7 @@ constexpr void sub_member_test() {
     assert(s_i.x.loc.column() == 5);
 #endif // ^^^ C1XX ^^^
 #if _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
-    assert(s_i.x.loc.function_name() == THISCALL_OR_CDECL_STR + " s2::s2(int)");
+    assert(s_i.x.loc.function_name() == THISCALL_OR_CDECL " s2::s2(int)"sv);
 #else // ^^^ detailed / basic vvv
     assert(s_i.x.loc.function_name() == "s2"sv);
 #endif // ^^^ basic ^^^
@@ -194,9 +193,9 @@ constexpr void lambda_test() {
 #if !_USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
     assert(fun2 == "operator()"sv);
 #elif defined(__clang__) // ^^^ basic / detailed Clang vvv
-    assert(fun2 == "auto " + THISCALL_OR_CDECL_STR + " lambda_test()::(anonymous class)::operator()(void) const");
+    assert(fun2 == "auto " THISCALL_OR_CDECL " lambda_test()::(anonymous class)::operator()(void) const"sv);
 #else // ^^^ detailed Clang / detailed non-Clang vvv
-    assert(fun2.starts_with("struct std::source_location " + THISCALL_OR_CDECL_STR + " lambda_test::<lambda_"));
+    assert(fun2.starts_with("struct std::source_location " THISCALL_OR_CDECL " lambda_test::<lambda_"sv));
     assert(fun2.ends_with("::operator ()(void) const"sv));
 #endif // ^^^ detailed non-Clang ^^^
     assert(string_view{x1.file_name()}.ends_with(test_cpp));


### PR DESCRIPTION
Fixes #3729.

After #3206 in VS 2022 17.6 made `source_location::function_name()` more detailed, some users experienced significant increases in binary size (see microsoft/cppwinrt#1337), because heavy usage generated lots of long strings which couldn't be folded away. microsoft/cppwinrt#1260 added an escape hatch for that project, but we should add one too, which fixes VSO-1893424 / AB#1893424 .

This uses [Clang's `__has_builtin`](https://clang.llvm.org/docs/LanguageExtensions.html#has-builtin) to detect the upcoming support. When supported, enabling the detailed function name by default is still the right design - it's *much* more useful.

```
C:\Temp>type meow.cpp
```
```cpp
#include <print>
#include <source_location>
#include <vector>
using namespace std;

void purr(source_location loc = source_location::current()) {
    println("{}", loc.function_name());
}

template <typename T>
void cats() {
    purr();
}

int main() {
#ifdef __clang__
    println("Clang {}", __clang_major__);
#else
    println("MSVC");
#endif
    cats<vector<int>>();
}
```
```
C:\Temp>cl /EHsc /nologo /W4 /std:c++latest meow.cpp && meow
meow.cpp
MSVC
void __cdecl cats<class std::vector<int,class std::allocator<int> >>(void)

C:\Temp>cl /EHsc /nologo /W4 /std:c++latest /D_USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION=0 meow.cpp && meow
meow.cpp
MSVC
cats

C:\Temp>clang-cl /EHsc /nologo /W4 /std:c++latest meow.cpp && meow
Clang 16
cats

C:\Temp>set PATH=C:\Users\stl\Downloads\LLVM-17.0.1-win64\bin;%PATH%

C:\Temp>clang-cl /EHsc /nologo /W4 /std:c++latest meow.cpp && meow
Clang 17
void __cdecl cats(void) [T = std::vector<int>]

C:\Temp>clang-cl /EHsc /nologo /W4 /std:c++latest /D_USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION=0 meow.cpp && meow
Clang 17
cats
```