### PR TITLE
Cleanups for `<flat_set>`

### DIFF
--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -483,83 +483,93 @@ private:
     }
 
     template <class _Ty>
-    auto _Emplace(_Ty&& _Val) {
-        if constexpr (_Multi) {
-            _STL_INTERNAL_STATIC_ASSERT(is_same_v<remove_cvref_t<_Ty>, _Kty>);
-            return _Mycont.emplace(upper_bound(_Val), _STD forward<_Ty>(_Val));
-        } else {
-            const iterator _End   = end();
-            const iterator _Where = lower_bound(_Val);
-            if (_Where != _End && !_Compare(_Val, *_Where)) {
-                return pair{_Where, false};
-            }
+        requires _Multi // flat_multiset
+    iterator _Emplace(_Ty&& _Val) {
+        _STL_INTERNAL_STATIC_ASSERT(is_same_v<remove_cvref_t<_Ty>, _Kty>);
+        return _Mycont.emplace(upper_bound(_Val), _STD forward<_Ty>(_Val));
+    }
 
-            if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
-                return pair{_Mycont.emplace(_Where, _STD forward<_Ty>(_Val)), true};
-            } else {
-                // for flat_set::insert(auto&&)
-                _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
-                _Kty _Keyval(_STD forward<_Ty>(_Val));
-                _STL_ASSERT(_Can_insert(_Where, _Keyval), "The input type was not equivalent to key_type!");
-                return pair{_Mycont.emplace(_Where, _STD move(_Keyval)), true};
-            }
+    template <class _Ty>
+        requires (!_Multi) // flat_set
+    pair<iterator, bool> _Emplace(_Ty&& _Val) {
+        const iterator _Where = lower_bound(_Val);
+        if (_Where != end() && !_Compare(_Val, *_Where)) {
+            return pair{_Where, false};
+        }
+
+        if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
+            return pair{_Mycont.emplace(_Where, _STD forward<_Ty>(_Val)), true};
+        } else {
+            // heterogeneous insertion
+            _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
+            _Kty _Keyval(_STD forward<_Ty>(_Val));
+            _STL_ASSERT(_Can_insert(_Where, _Keyval), "The conversion from the heterogeneous key to key_type should "
+                                                      "be consistent with the heterogeneous lookup!");
+            return pair{_Mycont.emplace(_Where, _STD move(_Keyval)), true};
         }
     }
 
     template <class _Ty>
+        requires _Multi // flat_multiset
+    iterator _Emplace_hint(const_iterator _Where, _Ty&& _Val) {
+        _STL_INTERNAL_STATIC_ASSERT(is_same_v<remove_cvref_t<_Ty>, _Kty>);
+
+        const const_iterator _Begin = cbegin();
+        const const_iterator _End   = cend();
+
+        // look for upper_bound(_Val)
+        if (_Where == _End || _Compare(_Val, *_Where)) {
+            // _Val < *_Where
+            if (_Where == _Begin || !_Compare(_Val, *(_Where - 1))) {
+                // _Val >= *(_Where-1) ~ upper_bound is _Where
+            } else {
+                // _Val < *(_Where-1) ~ upper_bound is in [_Begin,_Where-1]
+                _Where = _STD upper_bound(_Begin, _Where - 1, _Val, _Pass_comp());
+            }
+        } else {
+            // _Val >= *_Where ~ upper_bound is in [_Where+1,_End]
+            _Where = _STD upper_bound(_Where + 1, _End, _Val, _Pass_comp());
+        }
+
+        _STL_INTERNAL_CHECK(_Can_insert(_Where, _Val));
+        return _Mycont.emplace(_Where, _STD forward<_Ty>(_Val));
+    }
+
+    template <class _Ty>
+        requires (!_Multi) // flat_set
     iterator _Emplace_hint(const_iterator _Where, _Ty&& _Val) {
         const const_iterator _Begin = cbegin();
         const const_iterator _End   = cend();
 
-        if constexpr (_Multi) {
-            // look for the upper_bound for flat_multiset
-            if (_Where == _End || _Compare(_Val, *_Where)) {
-                // _Val < *_Where
-                if (_Where == _Begin || !_Compare(_Val, *(_Where - 1))) {
-                    // _Val >= *(_Where-1) ~ upper_bound is _Where
-                } else {
-                    // _Val < *(_Where-1) ~ upper_bound is in [_Begin,_Where-1]
-                    _Where = _STD upper_bound(_Begin, _Where - 1, _Val, _Pass_comp());
-                }
+        // look for lower_bound(_Val)
+        if (_Where == _End || !_Compare(*_Where, _Val)) {
+            // _Val <= *_Where
+            if (_Where == _Begin || _Compare(*(_Where - 1), _Val)) {
+                // _Val > *(_Where-1) ~ lower_bound is _Where
             } else {
-                // _Val >= *_Where ~ upper_bound is in [_Where+1,_End]
-                _Where = _STD upper_bound(_Where + 1, _End, _Val, _Pass_comp());
+                // _Val <= *(_Where-1) ~ lower_bound is in [_Begin,_Where-1]
+                _Where = _STD lower_bound(_Begin, _Where - 1, _Val, _Pass_comp());
             }
         } else {
-            // look for the lower_bound for flat_set
-            if (_Where == _End || !_Compare(*_Where, _Val)) {
-                // _Val <= *_Where
-                if (_Where == _Begin || _Compare(*(_Where - 1), _Val)) {
-                    // _Val > *(_Where-1) ~ lower_bound is _Where
-                } else {
-                    // _Val <= *(_Where-1) ~ lower_bound is in [_Begin,_Where-1]
-                    _Where = _STD lower_bound(_Begin, _Where - 1, _Val, _Pass_comp());
-                }
-            } else {
-                // _Val > *_Where ~ lower_bound is in [_Where+1,_End]
-                _Where = _STD lower_bound(_Where + 1, _End, _Val, _Pass_comp());
-            }
+            // _Val > *_Where ~ lower_bound is in [_Where+1,_End]
+            _Where = _STD lower_bound(_Where + 1, _End, _Val, _Pass_comp());
         }
 
-        if constexpr (_Multi) {
-            _STL_INTERNAL_STATIC_ASSERT(is_same_v<remove_cvref_t<_Ty>, _Kty>);
+        if (_Where != _End && !_Compare(_Val, *_Where)) {
+            // convert const_iterator to iterator
+            return _Mycont.begin() + (_Where - _Begin);
+        }
+
+        if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
             _STL_INTERNAL_CHECK(_Can_insert(_Where, _Val));
             return _Mycont.emplace(_Where, _STD forward<_Ty>(_Val));
         } else {
-            if (_Where != _End && !_Compare(_Val, *_Where)) {
-                return _Mycont.begin() + (_Where - _Begin);
-            }
-
-            if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
-                _STL_INTERNAL_CHECK(_Can_insert(_Where, _Val));
-                return _Mycont.emplace(_Where, _STD forward<_Ty>(_Val));
-            } else {
-                // for flat_set::insert(hint,auto&&)
-                _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
-                _Kty _Keyval(_STD forward<_Ty>(_Val));
-                _STL_ASSERT(_Can_insert(_Where, _Keyval), "The input type was not equivalent to key_type!");
-                return _Mycont.emplace(_Where, _STD move(_Keyval));
-            }
+            // heterogeneous insertion
+            _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
+            _Kty _Keyval(_STD forward<_Ty>(_Val));
+            _STL_ASSERT(_Can_insert(_Where, _Keyval), "The conversion from the heterogeneous key to key_type should "
+                                                      "be consistent with the heterogeneous lookup!");
+            return _Mycont.emplace(_Where, _STD move(_Keyval));
         }
     }
 

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -369,66 +369,66 @@ public:
     }
 
     _NODISCARD bool contains(const _Kty& _Val) const {
-        return _STD binary_search(cbegin(), cend(), _Val, _Get_comp_v());
+        return _STD binary_search(cbegin(), cend(), _Val, _Pass_comp());
     }
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD bool contains(const _Other& _Val) const {
-        return _STD binary_search(cbegin(), cend(), _Val, _Get_comp_v());
+        return _STD binary_search(cbegin(), cend(), _Val, _Pass_comp());
     }
 
     _NODISCARD iterator lower_bound(const _Kty& _Val) {
-        return _STD lower_bound(begin(), end(), _Val, _Get_comp_v());
+        return _STD lower_bound(begin(), end(), _Val, _Pass_comp());
     }
     _NODISCARD const_iterator lower_bound(const _Kty& _Val) const {
-        return _STD lower_bound(cbegin(), cend(), _Val, _Get_comp_v());
+        return _STD lower_bound(cbegin(), cend(), _Val, _Pass_comp());
     }
 
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD iterator lower_bound(const _Other& _Val) {
-        return _STD lower_bound(begin(), end(), _Val, _Get_comp_v());
+        return _STD lower_bound(begin(), end(), _Val, _Pass_comp());
     }
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD const_iterator lower_bound(const _Other& _Val) const {
-        return _STD lower_bound(cbegin(), cend(), _Val, _Get_comp_v());
+        return _STD lower_bound(cbegin(), cend(), _Val, _Pass_comp());
     }
 
     _NODISCARD iterator upper_bound(const _Kty& _Val) {
-        return _STD upper_bound(begin(), end(), _Val, _Get_comp_v());
+        return _STD upper_bound(begin(), end(), _Val, _Pass_comp());
     }
     _NODISCARD const_iterator upper_bound(const _Kty& _Val) const {
-        return _STD upper_bound(cbegin(), cend(), _Val, _Get_comp_v());
+        return _STD upper_bound(cbegin(), cend(), _Val, _Pass_comp());
     }
 
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD iterator upper_bound(const _Other& _Val) {
-        return _STD upper_bound(begin(), end(), _Val, _Get_comp_v());
+        return _STD upper_bound(begin(), end(), _Val, _Pass_comp());
     }
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD const_iterator upper_bound(const _Other& _Val) const {
-        return _STD upper_bound(cbegin(), cend(), _Val, _Get_comp_v());
+        return _STD upper_bound(cbegin(), cend(), _Val, _Pass_comp());
     }
 
     _NODISCARD pair<iterator, iterator> equal_range(const _Kty& _Val) {
-        return _STD equal_range(begin(), end(), _Val, _Get_comp_v());
+        return _STD equal_range(begin(), end(), _Val, _Pass_comp());
     }
     _NODISCARD pair<const_iterator, const_iterator> equal_range(const _Kty& _Val) const {
-        return _STD equal_range(cbegin(), cend(), _Val, _Get_comp_v());
+        return _STD equal_range(cbegin(), cend(), _Val, _Pass_comp());
     }
 
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD pair<iterator, iterator> equal_range(const _Other& _Val) {
-        return _STD equal_range(begin(), end(), _Val, _Get_comp_v());
+        return _STD equal_range(begin(), end(), _Val, _Pass_comp());
     }
     template <class _Other>
         requires _Keylt_transparent
     _NODISCARD pair<const_iterator, const_iterator> equal_range(const _Other& _Val) const {
-        return _STD equal_range(cbegin(), cend(), _Val, _Get_comp_v());
+        return _STD equal_range(cbegin(), cend(), _Val, _Pass_comp());
     }
 
     _NODISCARD friend bool operator==(const _Deriv& _Lhs, const _Deriv& _Rhs) {
@@ -447,7 +447,7 @@ public:
 private:
     _NODISCARD bool _Check_sorted(const_iterator _It, const const_iterator _End) const {
         if constexpr (_Multi) {
-            return _STD is_sorted(_It, _End, _Get_comp_v());
+            return _STD is_sorted(_It, _End, _Pass_comp());
         } else {
             // sorted-unique
             if (_It == _End) {
@@ -516,11 +516,11 @@ private:
                     // _Val >= *(_Where-1) ~ upper_bound is _Where
                 } else {
                     // _Val < *(_Where-1) ~ upper_bound is in [_Begin,_Where-1]
-                    _Where = _STD upper_bound(_Begin, _Where - 1, _Val, _Get_comp_v());
+                    _Where = _STD upper_bound(_Begin, _Where - 1, _Val, _Pass_comp());
                 }
             } else {
                 // _Val >= *_Where ~ upper_bound is in [_Where+1,_End]
-                _Where = _STD upper_bound(_Where + 1, _End, _Val, _Get_comp_v());
+                _Where = _STD upper_bound(_Where + 1, _End, _Val, _Pass_comp());
             }
         } else {
             // look for the lower_bound for flat_set
@@ -530,11 +530,11 @@ private:
                     // _Val > *(_Where-1) ~ lower_bound is _Where
                 } else {
                     // _Val <= *(_Where-1) ~ lower_bound is in [_Begin,_Where-1]
-                    _Where = _STD lower_bound(_Begin, _Where - 1, _Val, _Get_comp_v());
+                    _Where = _STD lower_bound(_Begin, _Where - 1, _Val, _Pass_comp());
                 }
             } else {
                 // _Val > *_Where ~ lower_bound is in [_Where+1,_End]
-                _Where = _STD lower_bound(_Where + 1, _End, _Val, _Get_comp_v());
+                _Where = _STD lower_bound(_Where + 1, _End, _Val, _Pass_comp());
             }
         }
 
@@ -631,12 +631,12 @@ private:
         const iterator _New_end = end();
 
         if constexpr (!_Presorted) {
-            _STD sort(_Old_end, _New_end, _Get_comp_v());
+            _STD sort(_Old_end, _New_end, _Pass_comp());
         } else {
             _STL_ASSERT(_Check_sorted(_Old_end, _New_end), _Msg_not_sorted);
         }
 
-        _STD inplace_merge(_Begin, _Old_end, _New_end, _Get_comp_v());
+        _STD inplace_merge(_Begin, _Old_end, _New_end, _Pass_comp());
         _Erase_dupes_if_not_multi();
 
         _STL_INTERNAL_CHECK(_Check_sorted(cbegin(), cend()));
@@ -651,10 +651,10 @@ private:
         }
 
         // O(N) if already sorted.
-        const iterator _Begin_unsorted = _STD is_sorted_until(_Begin, _End, _Get_comp_v());
+        const iterator _Begin_unsorted = _STD is_sorted_until(_Begin, _End, _Pass_comp());
 
-        _STD sort(_Begin_unsorted, _End, _Get_comp_v());
-        _STD inplace_merge(_Begin, _Begin_unsorted, _End, _Get_comp_v());
+        _STD sort(_Begin_unsorted, _End, _Pass_comp());
+        _STD inplace_merge(_Begin, _Begin_unsorted, _End, _Pass_comp());
         _Erase_dupes_if_not_multi();
 
         _STL_INTERNAL_CHECK(_Check_sorted(cbegin(), cend()));
@@ -668,7 +668,7 @@ private:
         return _DEBUG_LT_PRED(_Mycomp, _Lhs, _Rhs);
     }
 
-    _NODISCARD auto _Get_comp_v() const noexcept {
+    _NODISCARD auto _Pass_comp() const noexcept {
         return _STD _Pass_fn(_Mycomp);
     }
 

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -90,7 +90,7 @@ public:
 
     _Base_flat_set(_Tsorted, container_type _Cont, const key_compare& _Comp = key_compare())
         : _Mycont(_STD move(_Cont)), _Mycomp(_Comp) {
-        _STL_ASSERT(_Check_sorted(cbegin(), cend()), _Msg_not_sorted);
+        _STL_ASSERT(_Is_sorted(cbegin(), cend()), _Msg_not_sorted);
     }
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Tsorted _Tsort, const container_type& _Cont, const _Alloc& _Al)
@@ -293,7 +293,7 @@ public:
         return _STD move(_Mycont);
     }
     void replace(container_type&& _Cont) {
-        _STL_ASSERT(_Check_sorted(_Cont.cbegin(), _Cont.cend()), _Msg_not_sorted);
+        _STL_ASSERT(_Is_sorted(_Cont.cbegin(), _Cont.cend()), _Msg_not_sorted);
         _Clear_guard<_Base_flat_set, is_nothrow_move_assignable_v<_Container>> _Guard{this};
         _Mycont        = _STD move(_Cont);
         _Guard._Target = nullptr;
@@ -445,7 +445,7 @@ public:
     }
 
 private:
-    _NODISCARD bool _Check_sorted(const_iterator _It, const const_iterator _End) const {
+    _NODISCARD bool _Is_sorted(const_iterator _It, const const_iterator _End) const {
         if constexpr (_Multi) {
             return _STD is_sorted(_It, _End, _Pass_comp());
         } else {
@@ -464,7 +464,10 @@ private:
 
     static constexpr const char* _Msg_not_sorted = _Multi ? "Input was not sorted!" : "Input was not sorted-unique!";
 
-    _NODISCARD bool _Check_where(const const_iterator _Where, const _Kty& _Val) const {
+    template <class _Ty>
+    _NODISCARD bool _Can_insert(const const_iterator _Where, const _Ty& _Val) const {
+        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_Ty, _Kty>); // only accepts _Kty
+
         // check that _Val can be inserted before _Where
         if constexpr (_Multi) {
             // check that _Where is the upper_bound for _Val
@@ -497,7 +500,7 @@ private:
                 // for flat_set::insert(auto&&)
                 _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
                 _Kty _Keyval(_STD forward<_Ty>(_Val));
-                _STL_ASSERT(_Check_where(_Where, _Keyval), "The input type was not equivalent to key_type!");
+                _STL_ASSERT(_Can_insert(_Where, _Keyval), "The input type was not equivalent to key_type!");
                 return pair{_Mycont.emplace(_Where, _STD move(_Keyval)), true};
             }
         }
@@ -540,7 +543,7 @@ private:
 
         if constexpr (_Multi) {
             _STL_INTERNAL_STATIC_ASSERT(is_same_v<remove_cvref_t<_Ty>, _Kty>);
-            _STL_INTERNAL_CHECK(_Check_where(_Where, _Val));
+            _STL_INTERNAL_CHECK(_Can_insert(_Where, _Val));
             return _Mycont.emplace(_Where, _STD forward<_Ty>(_Val));
         } else {
             if (_Where != _End && !_Compare(_Val, *_Where)) {
@@ -548,13 +551,13 @@ private:
             }
 
             if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
-                _STL_INTERNAL_CHECK(_Check_where(_Where, _Val));
+                _STL_INTERNAL_CHECK(_Can_insert(_Where, _Val));
                 return _Mycont.emplace(_Where, _STD forward<_Ty>(_Val));
             } else {
                 // for flat_set::insert(hint,auto&&)
                 _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
                 _Kty _Keyval(_STD forward<_Ty>(_Val));
-                _STL_ASSERT(_Check_where(_Where, _Keyval), "The input type was not equivalent to key_type!");
+                _STL_ASSERT(_Can_insert(_Where, _Keyval), "The input type was not equivalent to key_type!");
                 return _Mycont.emplace(_Where, _STD move(_Keyval));
             }
         }
@@ -615,12 +618,11 @@ private:
 
     void _Erase_dupes_if_not_multi() {
         if constexpr (!_Multi) {
-            const auto _Equal_to = [this](const _Kty& _Lhs, const _Kty& _Rhs) {
+            const auto _Equivalent = [this](const _Kty& _Lhs, const _Kty& _Rhs) {
                 return !_Compare(_Lhs, _Rhs) && !_Compare(_Rhs, _Lhs);
             };
-            const iterator _End     = end();
-            const iterator _New_end = _STD unique(begin(), _End, _Equal_to);
-            _Mycont.erase(_New_end, _End);
+            const iterator _End = end();
+            _Mycont.erase(_STD unique(begin(), _End, _Equivalent), _End);
         }
     }
 
@@ -628,18 +630,18 @@ private:
     void _Restore_invariants_after_insert(const size_type _Old_size) {
         const iterator _Begin   = begin();
         const iterator _Old_end = _Begin + static_cast<difference_type>(_Old_size);
-        const iterator _New_end = end();
+        const iterator _End     = end();
 
         if constexpr (!_Presorted) {
-            _STD sort(_Old_end, _New_end, _Pass_comp());
+            _STD sort(_Old_end, _End, _Pass_comp());
         } else {
-            _STL_ASSERT(_Check_sorted(_Old_end, _New_end), _Msg_not_sorted);
+            _STL_ASSERT(_Is_sorted(_Old_end, _End), _Msg_not_sorted);
         }
 
-        _STD inplace_merge(_Begin, _Old_end, _New_end, _Pass_comp());
+        _STD inplace_merge(_Begin, _Old_end, _End, _Pass_comp());
         _Erase_dupes_if_not_multi();
 
-        _STL_INTERNAL_CHECK(_Check_sorted(cbegin(), cend()));
+        _STL_INTERNAL_CHECK(_Is_sorted(cbegin(), cend()));
     }
 
     void _Make_invariants_fulfilled() {
@@ -657,7 +659,7 @@ private:
         _STD inplace_merge(_Begin, _Begin_unsorted, _End, _Pass_comp());
         _Erase_dupes_if_not_multi();
 
-        _STL_INTERNAL_CHECK(_Check_sorted(cbegin(), cend()));
+        _STL_INTERNAL_CHECK(_Is_sorted(cbegin(), cend()));
     }
 
     template <class _Lty, class _Rty>

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -70,17 +70,16 @@ public:
     static_assert(random_access_iterator<iterator>, "The C++ Standard forbids containers without random "
                                                     "access iterators from being adapted. See [flatset.overview].");
 
-    _Base_flat_set() : _My_pair(_Zero_then_variadic_args_t{}) {}
+    _Base_flat_set() : _Mycont(), _Mycomp() {}
 
     template <_Allocator_for<container_type> _Alloc>
-    _Base_flat_set(const _Deriv& _Set, const _Alloc& _Al)
-        : _My_pair(_One_then_variadic_args_t{}, _Set._Get_comp(), _Set._Get_cont(), _Al) {}
+    _Base_flat_set(const _Deriv& _Set, const _Alloc& _Al) : _Mycont(_Set._Mycont, _Al), _Mycomp(_Set._Mycomp) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Deriv&& _Set, const _Alloc& _Al)
-        : _My_pair(_One_then_variadic_args_t{}, _STD move(_Set._Get_comp()), _STD move(_Set._Get_cont()), _Al) {}
+        : _Mycont(_STD move(_Set._Mycont), _Al), _Mycomp(_STD move(_Set._Mycomp)) {}
 
     explicit _Base_flat_set(container_type _Cont, const key_compare& _Comp = key_compare())
-        : _My_pair(_One_then_variadic_args_t{}, _Comp, _STD move(_Cont)) {
+        : _Mycont(_STD move(_Cont)), _Mycomp(_Comp) {
         _Make_invariants_fulfilled();
     }
     template <_Allocator_for<container_type> _Alloc>
@@ -90,7 +89,7 @@ public:
         : _Base_flat_set(container_type(_Cont, _Al), _Comp) {}
 
     _Base_flat_set(_Tsorted, container_type _Cont, const key_compare& _Comp = key_compare())
-        : _My_pair(_One_then_variadic_args_t{}, _Comp, _STD move(_Cont)) {
+        : _Mycont(_STD move(_Cont)), _Mycomp(_Comp) {
         _STL_ASSERT(_Check_sorted(cbegin(), cend()), _Msg_not_sorted);
     }
     template <_Allocator_for<container_type> _Alloc>
@@ -100,11 +99,11 @@ public:
     _Base_flat_set(_Tsorted _Tsort, const container_type& _Cont, const key_compare& _Comp, const _Alloc& _Al)
         : _Base_flat_set(_Tsort, container_type(_Cont, _Al), _Comp) {}
 
-    explicit _Base_flat_set(const key_compare& _Comp) : _My_pair(_One_then_variadic_args_t{}, _Comp) {}
+    explicit _Base_flat_set(const key_compare& _Comp) : _Mycont(), _Mycomp(_Comp) {}
     template <_Allocator_for<container_type> _Alloc>
-    _Base_flat_set(const key_compare& _Comp, const _Alloc& _Al) : _My_pair(_One_then_variadic_args_t{}, _Comp, _Al) {}
+    _Base_flat_set(const key_compare& _Comp, const _Alloc& _Al) : _Mycont(_Al), _Mycomp(_Comp) {}
     template <_Allocator_for<container_type> _Alloc>
-    explicit _Base_flat_set(const _Alloc& _Al) : _My_pair(_Zero_then_variadic_args_t{}, _Al) {}
+    explicit _Base_flat_set(const _Alloc& _Al) : _Mycont(_Al), _Mycomp() {}
 
     template <input_iterator _Iter>
     _Base_flat_set(_Iter _First, _Iter _Last, const key_compare& _Comp = key_compare())
@@ -158,7 +157,7 @@ public:
 
     _Deriv& operator=(initializer_list<_Kty> _Ilist) {
         _Clear_guard<_Base_flat_set> _Guard{this};
-        _Get_cont().assign(_Ilist.begin(), _Ilist.end());
+        _Mycont.assign(_Ilist.begin(), _Ilist.end());
         _Make_invariants_fulfilled();
         _Guard._Target = nullptr;
         return static_cast<_Deriv&>(*this);
@@ -166,16 +165,16 @@ public:
 
     // iterators
     _NODISCARD iterator begin() noexcept {
-        return _Get_cont().begin();
+        return _Mycont.begin();
     }
     _NODISCARD const_iterator begin() const noexcept {
-        return _Get_cont().begin();
+        return _Mycont.begin();
     }
     _NODISCARD iterator end() noexcept {
-        return _Get_cont().end();
+        return _Mycont.end();
     }
     _NODISCARD const_iterator end() const noexcept {
-        return _Get_cont().end();
+        return _Mycont.end();
     }
 
     _NODISCARD reverse_iterator rbegin() noexcept {
@@ -206,13 +205,13 @@ public:
 
     // capacity
     _NODISCARD_EMPTY_MEMBER bool empty() const noexcept {
-        return _Get_cont().empty();
+        return _Mycont.empty();
     }
     _NODISCARD size_type size() const noexcept {
-        return _Get_cont().size();
+        return _Mycont.size();
     }
     _NODISCARD size_type max_size() const noexcept {
-        return _Get_cont().max_size();
+        return _Mycont.max_size();
     }
 
     // modifiers
@@ -271,12 +270,11 @@ public:
     void insert_range(_Rng&& _Range) {
         const size_type _Old_size = size();
 
-        _Container& _Cont = _Get_cont();
-        if constexpr (requires { _Cont.append_range(_STD forward<_Rng>(_Range)); }) {
-            _Cont.append_range(_STD forward<_Rng>(_Range));
+        if constexpr (requires { _Mycont.append_range(_STD forward<_Rng>(_Range)); }) {
+            _Mycont.append_range(_STD forward<_Rng>(_Range));
         } else {
             for (const auto& _Val : _Range) {
-                _Cont.insert(_Cont.end(), _Val);
+                _Mycont.insert(_Mycont.end(), _Val);
             }
         }
         _Restore_invariants_after_insert<false>(_Old_size);
@@ -292,20 +290,20 @@ public:
     _NODISCARD container_type extract() && noexcept(is_nothrow_move_constructible_v<_Container>) /* strengthened */ {
         // always clears the container (N4950 [flat.set.modifiers]/14 and [flat.multiset.modifiers]/10)
         _Clear_guard<_Base_flat_set, is_nothrow_move_constructible_v<_Container>> _Guard{this};
-        return _STD move(_Get_cont());
+        return _STD move(_Mycont);
     }
     void replace(container_type&& _Cont) {
         _STL_ASSERT(_Check_sorted(_Cont.cbegin(), _Cont.cend()), _Msg_not_sorted);
         _Clear_guard<_Base_flat_set, is_nothrow_move_assignable_v<_Container>> _Guard{this};
-        _Get_cont()    = _STD move(_Cont);
+        _Mycont        = _STD move(_Cont);
         _Guard._Target = nullptr;
     }
 
     iterator erase(iterator _Where) {
-        return _Get_cont().erase(_Where);
+        return _Mycont.erase(_Where);
     }
     iterator erase(const_iterator _Where) {
-        return _Get_cont().erase(_Where);
+        return _Mycont.erase(_Where);
     }
     size_type erase(const _Kty& _Val) {
         return _Erase(_Val);
@@ -317,23 +315,23 @@ public:
         return _Erase(_Val);
     }
     iterator erase(const_iterator _First, const_iterator _Last) {
-        return _Get_cont().erase(_First, _Last);
+        return _Mycont.erase(_First, _Last);
     }
 
     void swap(_Deriv& _Other) noexcept {
-        _RANGES swap(_Get_comp(), _Other._Get_comp());
-        _RANGES swap(_Get_cont(), _Other._Get_cont());
+        _RANGES swap(_Mycomp, _Other._Mycomp);
+        _RANGES swap(_Mycont, _Other._Mycont);
     }
     void clear() noexcept {
-        _Get_cont().clear();
+        _Mycont.clear();
     }
 
     // observers
     _NODISCARD key_compare key_comp() const {
-        return _Get_comp();
+        return _Mycomp;
     }
     _NODISCARD value_compare value_comp() const {
-        return _Get_comp();
+        return _Mycomp;
     }
 
     // set operations
@@ -434,7 +432,7 @@ public:
     }
 
     _NODISCARD friend bool operator==(const _Deriv& _Lhs, const _Deriv& _Rhs) {
-        return _RANGES equal(_Lhs._Get_cont(), _Rhs._Get_cont());
+        return _RANGES equal(_Lhs._Mycont, _Rhs._Mycont);
     }
 
     _NODISCARD friend auto operator<=>(const _Deriv& _Lhs, const _Deriv& _Rhs) {
@@ -483,10 +481,9 @@ private:
 
     template <class _Ty>
     auto _Emplace(_Ty&& _Val) {
-        _Container& _Cont = _Get_cont();
         if constexpr (_Multi) {
             _STL_INTERNAL_STATIC_ASSERT(is_same_v<remove_cvref_t<_Ty>, _Kty>);
-            return _Cont.emplace(upper_bound(_Val), _STD forward<_Ty>(_Val));
+            return _Mycont.emplace(upper_bound(_Val), _STD forward<_Ty>(_Val));
         } else {
             const iterator _End   = end();
             const iterator _Where = lower_bound(_Val);
@@ -495,21 +492,19 @@ private:
             }
 
             if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
-                return pair{_Cont.emplace(_Where, _STD forward<_Ty>(_Val)), true};
+                return pair{_Mycont.emplace(_Where, _STD forward<_Ty>(_Val)), true};
             } else {
                 // for flat_set::insert(auto&&)
                 _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
                 _Kty _Keyval(_STD forward<_Ty>(_Val));
                 _STL_ASSERT(_Check_where(_Where, _Keyval), "The input type was not equivalent to key_type!");
-                return pair{_Cont.emplace(_Where, _STD move(_Keyval)), true};
+                return pair{_Mycont.emplace(_Where, _STD move(_Keyval)), true};
             }
         }
     }
 
     template <class _Ty>
     iterator _Emplace_hint(const_iterator _Where, _Ty&& _Val) {
-        _Container& _Cont           = _Get_cont();
-        auto _Comp                  = _Get_comp_v();
         const const_iterator _Begin = cbegin();
         const const_iterator _End   = cend();
 
@@ -521,11 +516,11 @@ private:
                     // _Val >= *(_Where-1) ~ upper_bound is _Where
                 } else {
                     // _Val < *(_Where-1) ~ upper_bound is in [_Begin,_Where-1]
-                    _Where = _STD upper_bound(_Begin, _Where - 1, _Val, _Comp);
+                    _Where = _STD upper_bound(_Begin, _Where - 1, _Val, _Get_comp_v());
                 }
             } else {
                 // _Val >= *_Where ~ upper_bound is in [_Where+1,_End]
-                _Where = _STD upper_bound(_Where + 1, _End, _Val, _Comp);
+                _Where = _STD upper_bound(_Where + 1, _End, _Val, _Get_comp_v());
             }
         } else {
             // look for the lower_bound for flat_set
@@ -535,32 +530,32 @@ private:
                     // _Val > *(_Where-1) ~ lower_bound is _Where
                 } else {
                     // _Val <= *(_Where-1) ~ lower_bound is in [_Begin,_Where-1]
-                    _Where = _STD lower_bound(_Begin, _Where - 1, _Val, _Comp);
+                    _Where = _STD lower_bound(_Begin, _Where - 1, _Val, _Get_comp_v());
                 }
             } else {
                 // _Val > *_Where ~ lower_bound is in [_Where+1,_End]
-                _Where = _STD lower_bound(_Where + 1, _End, _Val, _Comp);
+                _Where = _STD lower_bound(_Where + 1, _End, _Val, _Get_comp_v());
             }
         }
 
         if constexpr (_Multi) {
             _STL_INTERNAL_STATIC_ASSERT(is_same_v<remove_cvref_t<_Ty>, _Kty>);
             _STL_INTERNAL_CHECK(_Check_where(_Where, _Val));
-            return _Cont.emplace(_Where, _STD forward<_Ty>(_Val));
+            return _Mycont.emplace(_Where, _STD forward<_Ty>(_Val));
         } else {
             if (_Where != _End && !_Compare(_Val, *_Where)) {
-                return _Cont.begin() + (_Where - _Begin);
+                return _Mycont.begin() + (_Where - _Begin);
             }
 
             if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
                 _STL_INTERNAL_CHECK(_Check_where(_Where, _Val));
-                return _Cont.emplace(_Where, _STD forward<_Ty>(_Val));
+                return _Mycont.emplace(_Where, _STD forward<_Ty>(_Val));
             } else {
                 // for flat_set::insert(hint,auto&&)
                 _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
                 _Kty _Keyval(_STD forward<_Ty>(_Val));
                 _STL_ASSERT(_Check_where(_Where, _Keyval), "The input type was not equivalent to key_type!");
-                return _Cont.emplace(_Where, _STD move(_Keyval));
+                return _Mycont.emplace(_Where, _STD move(_Keyval));
             }
         }
     }
@@ -568,8 +563,7 @@ private:
     template <bool _Presorted, class _Iter>
     void _Insert_range(const _Iter _First, const _Iter _Last) {
         const size_type _Old_size = size();
-        _Container& _Cont         = _Get_cont();
-        _Cont.insert(_Cont.end(), _First, _Last);
+        _Mycont.insert(_Mycont.end(), _First, _Last);
         _Restore_invariants_after_insert<_Presorted>(_Old_size);
     }
 
@@ -580,7 +574,7 @@ private:
         if constexpr (!_Multi && is_same_v<_Ty, _Kty>) {
             const iterator _Where = lower_bound(_Val);
             if (_Where != end() && !_Compare(_Val, *_Where)) {
-                _Get_cont().erase(_Where);
+                _Mycont.erase(_Where);
                 return 1;
             }
             return 0;
@@ -588,7 +582,7 @@ private:
             const auto [_First, _Last] = equal_range(_Val);
 
             const auto _Removed = static_cast<size_type>(_Last - _First);
-            _Get_cont().erase(_First, _Last);
+            _Mycont.erase(_First, _Last);
             return _Removed;
         }
     }
@@ -626,24 +620,23 @@ private:
             };
             const iterator _End     = end();
             const iterator _New_end = _STD unique(begin(), _End, _Equal_to);
-            _Get_cont().erase(_New_end, _End);
+            _Mycont.erase(_New_end, _End);
         }
     }
 
     template <bool _Presorted>
     void _Restore_invariants_after_insert(const size_type _Old_size) {
-        auto _Comp              = _Get_comp_v();
         const iterator _Begin   = begin();
         const iterator _Old_end = _Begin + static_cast<difference_type>(_Old_size);
         const iterator _New_end = end();
 
         if constexpr (!_Presorted) {
-            _STD sort(_Old_end, _New_end, _Comp);
+            _STD sort(_Old_end, _New_end, _Get_comp_v());
         } else {
             _STL_ASSERT(_Check_sorted(_Old_end, _New_end), _Msg_not_sorted);
         }
 
-        _STD inplace_merge(_Begin, _Old_end, _New_end, _Comp);
+        _STD inplace_merge(_Begin, _Old_end, _New_end, _Get_comp_v());
         _Erase_dupes_if_not_multi();
 
         _STL_INTERNAL_CHECK(_Check_sorted(cbegin(), cend()));
@@ -658,11 +651,10 @@ private:
         }
 
         // O(N) if already sorted.
-        auto _Comp                     = _Get_comp_v();
-        const iterator _Begin_unsorted = _STD is_sorted_until(_Begin, _End, _Comp);
+        const iterator _Begin_unsorted = _STD is_sorted_until(_Begin, _End, _Get_comp_v());
 
-        _STD sort(_Begin_unsorted, _End, _Comp);
-        _STD inplace_merge(_Begin, _Begin_unsorted, _End, _Comp);
+        _STD sort(_Begin_unsorted, _End, _Get_comp_v());
+        _STD inplace_merge(_Begin, _Begin_unsorted, _End, _Get_comp_v());
         _Erase_dupes_if_not_multi();
 
         _STL_INTERNAL_CHECK(_Check_sorted(cbegin(), cend()));
@@ -670,33 +662,18 @@ private:
 
     template <class _Lty, class _Rty>
     _NODISCARD bool _Compare(const _Lty& _Lhs, const _Rty& _Rhs) const
-        noexcept(noexcept(_DEBUG_LT_PRED(_My_pair._Get_first(), _Lhs, _Rhs))) {
+        noexcept(noexcept(_DEBUG_LT_PRED(_Mycomp, _Lhs, _Rhs))) {
         _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent || (is_same_v<_Kty, _Lty> && is_same_v<_Kty, _Rty>) );
 
-        return _DEBUG_LT_PRED(_My_pair._Get_first(), _Lhs, _Rhs);
-    }
-
-    _NODISCARD const _Container& _Get_cont() const noexcept {
-        return _My_pair._Myval2;
-    }
-
-    _NODISCARD _Container& _Get_cont() noexcept {
-        return _My_pair._Myval2;
-    }
-
-    _NODISCARD const key_compare& _Get_comp() const noexcept {
-        return _My_pair._Get_first();
-    }
-
-    _NODISCARD key_compare& _Get_comp() noexcept {
-        return _My_pair._Get_first();
+        return _DEBUG_LT_PRED(_Mycomp, _Lhs, _Rhs);
     }
 
     _NODISCARD auto _Get_comp_v() const noexcept {
-        return _STD _Pass_fn(_My_pair._Get_first());
+        return _STD _Pass_fn(_Mycomp);
     }
 
-    _Compressed_pair<key_compare, container_type> _My_pair;
+    container_type _Mycont;
+    /* [[no_unique_address]] */ key_compare _Mycomp;
 };
 
 _EXPORT_STD struct sorted_unique_t {

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -138,26 +138,25 @@ public:
         : _Base_flat_set(_Tsort, container_type(_First, _Last, _Al)) {}
 
     _Base_flat_set(initializer_list<_Kty> _Ilist, const key_compare& _Comp = key_compare())
-        : _Base_flat_set(container_type(_Ilist.begin(), _Ilist.end()), _Comp) {}
+        : _Base_flat_set(container_type(_Ilist), _Comp) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(initializer_list<_Kty> _Ilist, const key_compare& _Comp, const _Alloc& _Al)
-        : _Base_flat_set(container_type(_Ilist.begin(), _Ilist.end(), _Al), _Comp) {}
+        : _Base_flat_set(container_type(_Ilist, _Al), _Comp) {}
     template <_Allocator_for<container_type> _Alloc>
-    _Base_flat_set(initializer_list<_Kty> _Ilist, const _Alloc& _Al)
-        : _Base_flat_set(container_type(_Ilist.begin(), _Ilist.end(), _Al)) {}
+    _Base_flat_set(initializer_list<_Kty> _Ilist, const _Alloc& _Al) : _Base_flat_set(container_type(_Ilist, _Al)) {}
 
     _Base_flat_set(_Tsorted _Tsort, initializer_list<_Kty> _Ilist, const key_compare& _Comp = key_compare())
-        : _Base_flat_set(_Tsort, container_type(_Ilist.begin(), _Ilist.end()), _Comp) {}
+        : _Base_flat_set(_Tsort, container_type(_Ilist), _Comp) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Tsorted _Tsort, initializer_list<_Kty> _Ilist, const key_compare& _Comp, const _Alloc& _Al)
-        : _Base_flat_set(_Tsort, container_type(_Ilist.begin(), _Ilist.end(), _Al), _Comp) {}
+        : _Base_flat_set(_Tsort, container_type(_Ilist, _Al), _Comp) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Tsorted _Tsort, initializer_list<_Kty> _Ilist, const _Alloc& _Al)
-        : _Base_flat_set(_Tsort, container_type(_Ilist.begin(), _Ilist.end(), _Al)) {}
+        : _Base_flat_set(_Tsort, container_type(_Ilist, _Al)) {}
 
     _Deriv& operator=(initializer_list<_Kty> _Ilist) {
         _Clear_guard<_Base_flat_set> _Guard{this};
-        _Mycont.assign(_Ilist.begin(), _Ilist.end());
+        _Mycont.assign(_Ilist);
         _Make_invariants_fulfilled();
         _Guard._Target = nullptr;
         return static_cast<_Deriv&>(*this);
@@ -273,9 +272,7 @@ public:
         if constexpr (requires { _Mycont.append_range(_STD forward<_Rng>(_Range)); }) {
             _Mycont.append_range(_STD forward<_Rng>(_Range));
         } else {
-            for (const auto& _Val : _Range) {
-                _Mycont.insert(_Mycont.end(), _Val);
-            }
+            _Mycont.insert_range(_Mycont.end(), _STD forward<_Rng>(_Range));
         }
         _Restore_invariants_after_insert<false>(_Old_size);
     }

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -67,7 +67,7 @@ public:
 
     _Base_flat_set() : _Mycont(), _Mycomp() {}
 
-    // TRANSITION, "_My_comp" may need to be copied, even in move construction / assignment.
+    // TRANSITION, "_Mycomp" may need to be copied, even in move construction / assignment.
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(const _Deriv& _Set, const _Alloc& _Al) : _Mycont(_Set._Mycont, _Al), _Mycomp(_Set._Mycomp) {}
     template <_Allocator_for<container_type> _Alloc>

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -25,7 +25,7 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 
-template <class _Ty, bool _Noexcept = false>
+template <class _Ty>
 struct _NODISCARD _Clear_guard {
     _Ty* _Target;
     ~_Clear_guard() {
@@ -33,11 +33,6 @@ struct _NODISCARD _Clear_guard {
             _Target->clear();
         }
     }
-};
-
-template <class _Ty>
-struct [[maybe_unused]] _NODISCARD _Clear_guard<_Ty, true> {
-    _Ty* _Target; // do nothing as the guarded operations don't throw.
 };
 
 template <class _Alloc, class _Container>
@@ -292,12 +287,12 @@ public:
 
     _NODISCARD container_type extract() && noexcept(is_nothrow_move_constructible_v<_Container>) /* strengthened */ {
         // always clears the container (N4950 [flat.set.modifiers]/14 and [flat.multiset.modifiers]/10)
-        _Clear_guard<_Base_flat_set, is_nothrow_move_constructible_v<_Container>> _Guard{this};
+        _Clear_guard<_Base_flat_set> _Guard{this};
         return _STD move(_Mycont);
     }
     void replace(container_type&& _Cont) {
         _STL_ASSERT(_Is_sorted(_Cont.cbegin(), _Cont.cend()), _Msg_not_sorted);
-        _Clear_guard<_Base_flat_set, is_nothrow_move_assignable_v<_Container>> _Guard{this};
+        _Clear_guard<_Base_flat_set> _Guard{this};
         _Mycont        = _STD move(_Cont);
         _Guard._Target = nullptr;
     }

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -72,6 +72,7 @@ public:
 
     _Base_flat_set() : _Mycont(), _Mycomp() {}
 
+    // TRANSITION, "_My_comp" may need to be copied, even in move construction / assignment.
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(const _Deriv& _Set, const _Alloc& _Al) : _Mycont(_Set._Mycont, _Al), _Mycomp(_Set._Mycomp) {}
     template <_Allocator_for<container_type> _Alloc>
@@ -105,6 +106,7 @@ public:
     template <_Allocator_for<container_type> _Alloc>
     explicit _Base_flat_set(const _Alloc& _Al) : _Mycont(_Al), _Mycomp() {}
 
+    // TRANSITION, an allocator-aware container may not support "C(_First, _Last, _Al)".
     template <input_iterator _Iter>
     _Base_flat_set(_Iter _First, _Iter _Last, const key_compare& _Comp = key_compare())
         : _Base_flat_set(container_type(_First, _Last), _Comp) {}
@@ -114,6 +116,7 @@ public:
     template <input_iterator _Iter, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Iter _First, _Iter _Last, const _Alloc& _Al) : _Base_flat_set(container_type(_First, _Last, _Al)) {}
 
+    // TRANSITION, an allocator-aware container may not support "C(from_range, _STD forward<_Rng>(_Range), _Al)".
     template <_Container_compatible_range<_Kty> _Rng>
     _Base_flat_set(from_range_t, _Rng&& _Range)
         : _Base_flat_set(container_type(from_range, _STD forward<_Rng>(_Range))) {}
@@ -137,6 +140,7 @@ public:
     _Base_flat_set(_Tsorted _Tsort, _Iter _First, _Iter _Last, const _Alloc& _Al)
         : _Base_flat_set(_Tsort, container_type(_First, _Last, _Al)) {}
 
+    // TRANSITION, an allocator-aware container may not support "C(_Ilist, _Al)".
     _Base_flat_set(initializer_list<_Kty> _Ilist, const key_compare& _Comp = key_compare())
         : _Base_flat_set(container_type(_Ilist), _Comp) {}
     template <_Allocator_for<container_type> _Alloc>
@@ -214,6 +218,8 @@ public:
     }
 
     // modifiers
+    // TRANSITION, the "insert" and "erase" methods may not be able to restore the invariant, if the underlying
+    // container is unable to provide strong guarantee for "erase" and "insert" methods.
     template <class... _Args>
     auto emplace(_Args&&... _Vals) {
         constexpr bool _Is_key_type = _In_place_key_extract_set<_Kty, remove_cvref_t<_Args>...>::_Extractable;
@@ -498,6 +504,7 @@ private:
             return pair{_Mycont.emplace(_Where, _STD forward<_Ty>(_Val)), true};
         } else {
             // heterogeneous insertion
+            // TRANSITION, the requirements may be stricter than needed by the standard.
             _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
             _Kty _Keyval(_STD forward<_Ty>(_Val));
             _STL_ASSERT(_Can_insert(_Where, _Keyval), "The conversion from the heterogeneous key to key_type should "
@@ -562,6 +569,7 @@ private:
             return _Mycont.emplace(_Where, _STD forward<_Ty>(_Val));
         } else {
             // heterogeneous insertion
+            // TRANSITION, the requirements may be stricter than needed by the standard.
             _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
             _Kty _Keyval(_STD forward<_Ty>(_Val));
             _STL_ASSERT(_Can_insert(_Where, _Keyval), "The conversion from the heterogeneous key to key_type should "

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -86,7 +86,7 @@ public:
 
     _Base_flat_set(_Tsorted, container_type _Cont, const key_compare& _Comp = key_compare())
         : _Mycont(_STD move(_Cont)), _Mycomp(_Comp) {
-        _STL_ASSERT(_Is_sorted(cbegin(), cend()), _Msg_not_sorted);
+        _STL_ASSERT(_Is_sorted(_Mycont), _Msg_not_sorted);
     }
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Tsorted _Tsort, const container_type& _Cont, const _Alloc& _Al)
@@ -189,10 +189,10 @@ public:
     }
 
     _NODISCARD const_iterator cbegin() const noexcept {
-        return begin();
+        return _Mycont.cbegin();
     }
     _NODISCARD const_iterator cend() const noexcept {
-        return end();
+        return _Mycont.cend();
     }
     _NODISCARD const_reverse_iterator crbegin() const noexcept {
         return rbegin();
@@ -285,13 +285,14 @@ public:
         _Insert_range<true>(_Ilist.begin(), _Ilist.end());
     }
 
-    _NODISCARD container_type extract() && noexcept(is_nothrow_move_constructible_v<_Container>) /* strengthened */ {
+    _NODISCARD container_type extract() && noexcept(
+        is_nothrow_move_constructible_v<container_type>) /* strengthened */ {
         // always clears the container (N4950 [flat.set.modifiers]/14 and [flat.multiset.modifiers]/10)
         _Clear_guard<_Base_flat_set> _Guard{this};
         return _STD move(_Mycont);
     }
     void replace(container_type&& _Cont) {
-        _STL_ASSERT(_Is_sorted(_Cont.cbegin(), _Cont.cend()), _Msg_not_sorted);
+        _STL_ASSERT(_Is_sorted(_Cont), _Msg_not_sorted);
         _Clear_guard<_Base_flat_set> _Guard{this};
         _Mycont        = _STD move(_Cont);
         _Guard._Target = nullptr;
@@ -458,6 +459,10 @@ private:
             }
             return true;
         }
+    }
+
+    _NODISCARD bool _Is_sorted(const container_type& _Cont) const {
+        return _Is_sorted(_Cont.cbegin(), _Cont.cend());
     }
 
     static constexpr const char* _Msg_not_sorted = _Multi ? "Input was not sorted!" : "Input was not sorted-unique!";
@@ -651,7 +656,7 @@ private:
         _STD inplace_merge(_Begin, _Old_end, _End, _Pass_comp());
         _Erase_dupes_if_not_multi();
 
-        _STL_INTERNAL_CHECK(_Is_sorted(cbegin(), cend()));
+        _STL_INTERNAL_CHECK(_Is_sorted(_Mycont));
     }
 
     void _Make_invariants_fulfilled() {
@@ -669,7 +674,7 @@ private:
         _STD inplace_merge(_Begin, _Begin_unsorted, _End, _Pass_comp());
         _Erase_dupes_if_not_multi();
 
-        _STL_INTERNAL_CHECK(_Is_sorted(cbegin(), cend()));
+        _STL_INTERNAL_CHECK(_Is_sorted(_Mycont));
     }
 
     template <class _Lty, class _Rty>

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -395,9 +395,9 @@ void test_non_static_comparer() {
     assert_all_requirements_and_equals(a, {9, 7, 5, -1});
 }
 
-template <template <class, class, class> class Set>
+template <template <class...> class Set>
 void test_extract_1() {
-    // Test that the container will be emptied, regardless of whether an exception is thrown.
+    // Test that the container will be emptied, even if the container's move ctor exits via an exception.
 
     static bool will_throw = false;
 
@@ -412,7 +412,6 @@ void test_extract_1() {
 
         test_exception(test_exception&& other) : base(static_cast<base&&>(other)) {
             if (will_throw) {
-                will_throw = false;
                 throw 0; // will be caught by "catch (...)"
             }
         }
@@ -431,6 +430,7 @@ void test_extract_1() {
         will_throw = true;
         (void) std::move(fs).extract();
     } catch (...) {
+        will_throw = false;
         assert_all_requirements_and_equals(fs, {}); // assert empty
         return;
     }
@@ -438,9 +438,9 @@ void test_extract_1() {
     assert(false);
 }
 
-template <template <class, class, class> class Set>
+template <template <class...> class Set>
 void test_extract_2() {
-    // Test that the container will be emptied, even if the container's move constructor doesn't empty the container.
+    // Test that the container will be emptied, even if the container's move ctor doesn't empty the container.
 
     class always_copy : public vector<int> {
         using base = vector<int>;

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -457,8 +457,6 @@ void test_extract_2() {
         }
     };
 
-    // constexpr int elements[]{1, 2, 3, 4};
-
     Set<int, std::less<int>, always_copy> fs{4, 3, 2, 1};
     assert_all_requirements_and_equals(fs, {1, 2, 3, 4});
     auto extr = std::move(fs).extract();

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -68,22 +68,9 @@ void assert_reversible_container_requirements(const T& s) {
 }
 
 template <class T>
-void test_ebco() {
-    // This tests an implementation-specific optimization.
-    using key_compare    = T::key_compare;
-    using container_type = T::container_type;
-    if constexpr (is_empty_v<key_compare> && !is_final_v<key_compare>) {
-        static_assert(sizeof(container_type) == sizeof(T));
-    } else {
-        static_assert(sizeof(container_type) < sizeof(T));
-    }
-}
-
-template <class T>
 void assert_all_requirements_and_equals(const T& s, const initializer_list<typename T::value_type>& il) {
     assert_container_requirements(s);
     assert_reversible_container_requirements(s);
-    test_ebco<T>();
 
     auto val_comp = s.value_comp();
     auto begin_it = s.cbegin();

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <memory>
 #include <random>
+#include <utility>
 #include <vector>
 
 using namespace std;
@@ -402,6 +403,7 @@ void test_extract_1() {
     static bool will_throw = false;
 
     class test_exception : public vector<int> {
+    private:
         using base = vector<int>;
 
     public:
@@ -443,6 +445,7 @@ void test_extract_2() {
     // Test that the container will be emptied, even if the container's move ctor doesn't empty the container.
 
     class always_copy : public vector<int> {
+    private:
         using base = vector<int>;
 
     public:
@@ -450,7 +453,7 @@ void test_extract_2() {
         always_copy(const always_copy&)            = default;
         always_copy& operator=(const always_copy&) = default;
 
-        // the move ctor & assignment will not empty the container.
+        // the move ctor and assignment will not empty the container.
         always_copy(always_copy&& other) noexcept /* intentional */ : always_copy(as_const(other)) {}
         always_copy& operator=(always_copy&& other) noexcept /* intentional */ {
             return operator=(as_const(other));


### PR DESCRIPTION
Contents in this pr:
- Drop `_Compressed_pair` optimization, using separate container and comparer.
~ I think it will be ok to drop this optimization, as the spatial gain is not significant, and it greatly complicates constructors and brings indirection when accessing members. The spatial optimization will become easily achievable (and without the `final` constraint) when `[[no_unique_address]]` becomes available. I notice that `mdspan` has already adopted this approach.
- Various refactorings, including some renamings, and giving separate definitions for `_Emplace[_hint]:_Multi/!_Multi`, for better clarity.
- Record some remaining issues in the current codebase (`// TRANSITION` ones). Some of them are really tough :|
- Fix a bug introduced by previous pr (my fault :( The problem is that even a successful noexcept `move` may not empty the container.