### PR TITLE
Add C4868 to _STL_DISABLED_WARNINGS

### DIFF
--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -1867,9 +1867,6 @@ struct _Static_partitioned_mismatch3 {
     }
 };
 
-#pragma warning(push)
-#pragma warning(disable : 4868) // compiler may not enforce left-to-right evaluation order
-                                // in braced initializer list (/Wall)
 _EXPORT_STD template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr,
     _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
@@ -1911,7 +1908,6 @@ _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
     _Seek_wrapped(_First1, _Result.first);
     return {_First1, _First2};
 }
-#pragma warning(pop)
 
 _EXPORT_STD template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr,
     _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
@@ -2396,9 +2392,6 @@ struct _Static_partitioned_binary_transform2 {
     }
 };
 
-#pragma warning(push)
-#pragma warning(disable : 4868) // compiler may not enforce left-to-right evaluation order
-                                // in braced initializer list (/Wall)
 _EXPORT_STD template <class _ExPo, class _FwdIt1, class _FwdIt2, class _FwdIt3, class _Fn,
     _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _FwdIt3 transform(_ExPo&&, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2, _FwdIt3 _Dest,
@@ -2443,7 +2436,6 @@ _FwdIt3 transform(_ExPo&&, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _F
         return _Dest;
     }
 }
-#pragma warning(pop)
 
 _EXPORT_STD template <class _ExPo, class _FwdIt, class _Ty, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 void replace(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt _Last, const _Ty& _Oldval, const _Ty& _Newval) noexcept
@@ -4162,9 +4154,6 @@ struct _Static_partitioned_transform_reduce_binary2 { // transform-reduction tas
     }
 };
 
-#pragma warning(push)
-#pragma warning(disable : 4868) // compiler may not enforce left-to-right evaluation order
-                                // in braced initializer list (/Wall)
 _EXPORT_STD template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Ty, class _BinOp1, class _BinOp2,
     _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD _Ty transform_reduce(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _Ty _Val, _BinOp1 _Reduce_op,
@@ -4219,7 +4208,6 @@ _NODISCARD _Ty transform_reduce(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt
         _Get_unwrapped_n(_First2, _Idl_distance<_FwdIt1>(_UFirst1, _ULast1)), _STD move(_Val), _Pass_fn(_Reduce_op),
         _Pass_fn(_Transform_op));
 }
-#pragma warning(pop)
 
 template <class _FwdIt, class _Ty, class _BinOp, class _UnaryOp>
 struct _Static_partitioned_transform_reduce2 { // transformed reduction task scheduled on the system thread pool

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -793,6 +793,7 @@
 // warning C4702: unreachable code
 // warning C4793: function compiled as native
 // warning C4820: 'N' bytes padding added after data member 'meow' (/Wall)
+// warning C4868: compiler may not enforce left-to-right evaluation order in braced initializer list
 // warning C4988: variable declared outside class/function scope (/Wall /d1WarnOnGlobals)
 // warning C5026: move constructor was implicitly defined as deleted (/Wall)
 // warning C5027: move assignment operator was implicitly defined as deleted (/Wall)
@@ -805,8 +806,8 @@
 // clang-format off
 #define _STL_DISABLED_WARNINGS                        \
     4180 4412 4455 4494 4514 4574 4582 4583 4587 4588 \
-    4619 4623 4625 4626 4643 4648 4702 4793 4820 4988 \
-    5026 5027 5045 5220 6294                          \
+    4619 4623 4625 4626 4643 4648 4702 4793 4820 4868 \
+    4988 5026 5027 5045 5220 6294                     \
     _STL_DISABLED_WARNING_C4577                       \
     _STL_DISABLED_WARNING_C4984                       \
     _STL_DISABLED_WARNING_C5053                       \

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -793,7 +793,7 @@
 // warning C4702: unreachable code
 // warning C4793: function compiled as native
 // warning C4820: 'N' bytes padding added after data member 'meow' (/Wall)
-// warning C4868: compiler may not enforce left-to-right evaluation order in braced initializer list
+// warning C4868: compiler may not enforce left-to-right evaluation order in braced initializer list (/Wall)
 // warning C4988: variable declared outside class/function scope (/Wall /d1WarnOnGlobals)
 // warning C5026: move constructor was implicitly defined as deleted (/Wall)
 // warning C5027: move assignment operator was implicitly defined as deleted (/Wall)


### PR DESCRIPTION
[warning C4868: compiler may not enforce left-to-right evaluation order in braced initializer list](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4868?view=msvc-170)

Office is seeing instances of C4868 being emitted inside of the STL. Example:
`xutility(5637) : warning C4868: compiler may not enforce left-to-right evaluation order in braced initializer list`

After discussing the issue with Stephan he suggested adding the supression to the STL itself:
```
You can non-intrusively add this to _STL_EXTRA_DISABLED_WARNINGS.
We would also consider a PR to add it to _STL_DISABLED_WARNINGS for
everyone (as we do globally suppress a number of /Wall warnings there).
We basically never have such ordering assumptions in the STL, so this
warning provides no value to us.
```
