### PR TITLE
build and test infra cleanup

### DIFF
--- a/azure-devops/asan-pipeline.yml
+++ b/azure-devops/asan-pipeline.yml
@@ -4,36 +4,46 @@
 # Build STL targeting x86 and x64, and run extra ASan testing
 
 variables:
-  tmpDir: 'D:\Temp'
-  buildOutputLocation: 'D:\build'
-  # Restrict to "stlasan" test
-  testSelection: '-R stlasan'
-
-pool:
-  name: 'StlBuild-2023-09-14T1251-Pool'
-  demands: EnableSpotVM -equals true
+  - template: config.yml
+  - name: testSelection
+    value: '-R stlasan' # Restrict to "stlasan" test
 
 pr: none
+trigger: none
+
+schedules:
+- cron: '0 2 * * *'
+  displayName: ASan-Daily-CI
+  branches:
+    include:
+    - main
 
 stages:
   - stage: Build_And_Test_x64
-    displayName: 'Build and Test'
+    displayName: 'Build and Test x64'
+    pool:
+      name: ${{ variables.poolName }}
+      demands: ${{ variables.poolDemands }}
     jobs:
       - template: native-build-test.yml
         parameters:
           targetPlatform: x64
           vsDevCmdArch: amd64
-          benchmarkBuildOutputLocationVar: ''
+          buildBenchmarks: false
           testSelection: ${{ variables.testSelection }}
 
   - stage: Build_And_Test_x86
-    displayName: 'Build and Test'
+    displayName: 'Build and Test x86'
+    dependsOn: []
+    pool:
+      name: ${{ variables.poolName }}
+      demands: ${{ variables.poolDemands }}
     jobs:
       - template: native-build-test.yml
         parameters:
           targetPlatform: x86
           vsDevCmdArch: x86
-          benchmarkBuildOutputLocationVar: ''
+          buildBenchmarks: false
           testSelection: ${{ variables.testSelection }}
 
   # no coverage for ARM and ARM64

--- a/azure-devops/cmake-configure-build.yml
+++ b/azure-devops/cmake-configure-build.yml
@@ -8,15 +8,21 @@ parameters:
   type: string
 - name: targetPlatform
   type: string
-- name: buildOutputLocationVar
-  type: string
-  default: buildOutputLocation
-- name: benchmarkBuildOutputLocationVar
-  type: string
-  default: benchmarkBuildOutputLocation
+- name: buildBenchmarks
+  type: boolean
 - name: cmakeAdditionalFlags
   type: string
   default: ''
+- name: litFlags
+  type: object
+  default:
+    - '--timeout=240'
+    - '-j$(testParallelism)'
+    - '--xunit-xml-output=$(buildOutputLocation)/test-results.xml'
+    - '--order=lexical'
+    - '--num-shards=$(System.TotalJobsInPhase)'
+    - '--run-shard=$(System.JobPositionInPhase)'
+
 steps:
 - task: PowerShell@2
   displayName: 'Get Test Parallelism'
@@ -27,47 +33,47 @@ steps:
       $testParallelism = $env:NUMBER_OF_PROCESSORS
       Write-Host "##vso[task.setvariable variable=testParallelism;]$testParallelism"
 - script: |
-    if exist "$(${{ parameters.buildOutputLocationVar }})" (
-      rmdir /S /Q "$(${{ parameters.buildOutputLocationVar }})"
+    if exist "$(buildOutputLocation)" (
+      rmdir /S /Q "$(buildOutputLocation)"
     )
     call "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\Common7\Tools\VsDevCmd.bat" ^
     -host_arch=${{ parameters.hostArch }} -arch=${{ parameters.targetArch }} -no_logo
-    cmake ${{ parameters.cmakeAdditionalFlags}} -G Ninja ^
+    cmake ${{ parameters.cmakeAdditionalFlags }} -G Ninja ^
     -DCMAKE_CXX_COMPILER=cl ^
     -DCMAKE_BUILD_TYPE=Release ^
-    -DLIT_FLAGS=$(litFlags) ^
+    -DLIT_FLAGS=${{ join(';', parameters.litFlags) }} ^
     -DSTL_USE_ANALYZE=ON ^
-    -S $(Build.SourcesDirectory) -B $(${{ parameters.buildOutputLocationVar }})
+    -S $(Build.SourcesDirectory) -B "$(buildOutputLocation)"
   displayName: 'Configure the STL'
   timeoutInMinutes: 2
   env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
 - script: |
     call "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\Common7\Tools\VsDevCmd.bat" ^
     -host_arch=${{ parameters.hostArch }} -arch=${{ parameters.targetArch }} -no_logo
-    cmake --build $(${{ parameters.buildOutputLocationVar }})
+    cmake --build "$(buildOutputLocation)"
   displayName: 'Build the STL'
   timeoutInMinutes: 5
   env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
 - script: |
-    if exist "$(${{ parameters.benchmarkBuildOutputLocationVar }})" (
-      rmdir /S /Q "$(${{ parameters.benchmarkBuildOutputLocationVar }})"
+    if exist "$(benchmarkBuildOutputLocation)" (
+      rmdir /S /Q "$(benchmarkBuildOutputLocation)"
     )
     call "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\Common7\Tools\VsDevCmd.bat" ^
     -host_arch=${{ parameters.hostArch }} -arch=${{ parameters.targetArch }} -no_logo
-    cmake ${{ parameters.cmakeAdditionalFlags}} -G Ninja ^
+    cmake ${{ parameters.cmakeAdditionalFlags }} -G Ninja ^
     -DCMAKE_CXX_COMPILER=cl ^
     -DCMAKE_BUILD_TYPE=Release ^
-    -DSTL_BINARY_DIR=$(${{ parameters.buildOutputLocationVar }}) ^
-    -S $(Build.SourcesDirectory)/benchmarks -B $(${{ parameters.benchmarkBuildOutputLocationVar }})
+    -DSTL_BINARY_DIR="$(buildOutputLocation)" ^
+    -S $(Build.SourcesDirectory)/benchmarks -B "$(benchmarkBuildOutputLocation)"
   displayName: 'Configure the benchmarks'
   timeoutInMinutes: 2
   env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
-  condition: ne('${{ parameters.benchmarkBuildOutputLocationVar }}', '')
+  condition: and(succeeded(), ${{ parameters.buildBenchmarks }})
 - script: |
     call "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\Common7\Tools\VsDevCmd.bat" ^
     -host_arch=${{ parameters.hostArch }} -arch=${{ parameters.targetArch }} -no_logo
-    cmake --build $(${{ parameters.benchmarkBuildOutputLocationVar }})
+    cmake --build "$(benchmarkBuildOutputLocation)"
   displayName: 'Build the benchmarks'
   timeoutInMinutes: 2
   env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
-  condition: ne('${{ parameters.benchmarkBuildOutputLocationVar }}', '')
+  condition: and(succeeded(), ${{ parameters.buildBenchmarks }})

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Common configuration used by both pipelines
+
+variables:
+- name: poolName
+  value: 'StlBuild-2023-09-14T1251-Pool'
+  readonly: true
+- name: poolDemands
+  value: 'EnableSpotVM -equals true'
+  readonly: true
+- name: tmpDir
+  value: 'D:\Temp'
+- name: buildOutputLocation
+  value: 'D:\build'
+- name: benchmarkBuildOutputLocation
+  value: 'D:\benchmark'

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -12,7 +12,10 @@ variables:
   readonly: true
 - name: tmpDir
   value: 'D:\Temp'
+  readonly: true
 - name: buildOutputLocation
   value: 'D:\build'
+  readonly: true
 - name: benchmarkBuildOutputLocation
   value: 'D:\benchmark'
+  readonly: true

--- a/azure-devops/cross-build.yml
+++ b/azure-devops/cross-build.yml
@@ -9,23 +9,14 @@ parameters:
   type: string
 - name: vsDevCmdArch
   type: string
-- name: buildOutputLocationVar
-  type: string
-  default: buildOutputLocation
-- name: benchmarkBuildOutputLocationVar
-  type: string
-  default: benchmarkBuildOutputLocation
+- name: buildBenchmarks
+  type: boolean
+  default: true
 - name: numShards
   type: number
   default: 8
 jobs:
 - job: '${{ parameters.targetPlatform }}'
-  variables:
-    fixedFlags: '--timeout=240;--shuffle'
-    parallelismFlag: '-j$(testParallelism)'
-    xmlOutputFlag: '--xunit-xml-output=$(${{ parameters.buildOutputLocationVar }})/test-results.xml'
-    shardFlags: '--order=lexical;--num-shards=$(System.TotalJobsInPhase);--run-shard=$(System.JobPositionInPhase)'
-    litFlags: '$(fixedFlags);$(parallelismFlag);$(xmlOutputFlag);$(shardFlags)'
   strategy:
     parallel: ${{ parameters.numShards }}
   timeoutInMinutes: 25
@@ -42,7 +33,7 @@ jobs:
       hostArch: ${{ parameters.hostArch }}
       targetArch: ${{ parameters.vsDevCmdArch }}
       cmakeAdditionalFlags: '-DTESTS_BUILD_ONLY=ON'
-      benchmarkBuildOutputLocationVar: ${{ parameters.benchmarkBuildOutputLocationVar }}
+      buildBenchmarks: ${{ parameters.buildBenchmarks }}
   - template: run-tests.yml
     parameters:
       hostArch: ${{ parameters.hostArch }}

--- a/azure-devops/native-build-test.yml
+++ b/azure-devops/native-build-test.yml
@@ -6,12 +6,9 @@ parameters:
   type: string
 - name: vsDevCmdArch
   type: string
-- name: buildOutputLocationVar
-  type: string
-  default: buildOutputLocation
-- name: benchmarkBuildOutputLocationVar
-  type: string
-  default: benchmarkBuildOutputLocation
+- name: buildBenchmarks
+  type: boolean
+  default: true
 - name: numShards
   type: number
   default: 8
@@ -22,12 +19,6 @@ parameters:
   default: '-E stlasan'
 jobs:
 - job: '${{ parameters.targetPlatform }}'
-  variables:
-    fixedFlags: '--timeout=240;--shuffle'
-    parallelismFlag: '-j$(testParallelism)'
-    xmlOutputFlag: '--xunit-xml-output=$(${{ parameters.buildOutputLocationVar }})/test-results.xml'
-    shardFlags: '--order=lexical;--num-shards=$(System.TotalJobsInPhase);--run-shard=$(System.JobPositionInPhase)'
-    litFlags: '$(fixedFlags);$(parallelismFlag);$(xmlOutputFlag);$(shardFlags)'
   strategy:
     parallel: ${{ parameters.numShards }}
   timeoutInMinutes: 25
@@ -43,7 +34,7 @@ jobs:
       targetPlatform: ${{ parameters.targetPlatform }}
       targetArch: ${{ parameters.vsDevCmdArch }}
       hostArch: ${{ parameters.vsDevCmdArch }}
-      benchmarkBuildOutputLocationVar: ${{ parameters.benchmarkBuildOutputLocationVar }}
+      buildBenchmarks: ${{ parameters.buildBenchmarks }}
   - template: run-tests.yml
     parameters:
       hostArch: ${{ parameters.vsDevCmdArch }}

--- a/azure-devops/run-tests.yml
+++ b/azure-devops/run-tests.yml
@@ -2,9 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 parameters:
-- name: buildOutputLocationVar
-  type: string
-  default: buildOutputLocation
 - name: targetPlatform
   type: string
 - name: hostArch
@@ -23,7 +20,7 @@ steps:
   timeoutInMinutes: 20
   condition: succeeded()
   inputs:
-    workingDirectory: $(${{ parameters.buildOutputLocationVar }})
+    workingDirectory: $(buildOutputLocation)
     script: |
       call "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\Common7\Tools\VsDevCmd.bat" ^
       -host_arch=${{ parameters.hostArch }} -arch=${{ parameters.targetArch }} -no_logo
@@ -34,11 +31,11 @@ steps:
   timeoutInMinutes: 5
   condition: succeededOrFailed()
   inputs:
-    searchFolder: $(${{ parameters.buildOutputLocationVar }})
+    searchFolder: $(buildOutputLocation)
     testResultsFormat: JUnit
     testResultsFiles: '**/test-results.xml'
     testRunTitle: 'test-${{ parameters.targetPlatform }}-$(System.JobPositionInPhase)'
-- publish: $(${{ parameters.buildOutputLocationVar }})/test-results.xml
+- publish: $(buildOutputLocation)/test-results.xml
   artifact: '${{ parameters.targetPlatform }}-$(System.JobPositionInPhase)-xml-$(System.JobId)'
   condition: failed()
   displayName: 'Publish XML Artifact'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,13 +4,7 @@
 # Build STL targeting x86, x64, arm, arm64
 
 variables:
-  tmpDir: 'D:\Temp'
-  buildOutputLocation: 'D:\build'
-  benchmarkBuildOutputLocation: 'D:\benchmark'
-
-pool:
-  name: 'StlBuild-2023-09-14T1251-Pool'
-  demands: EnableSpotVM -equals true
+  - template: azure-devops/config.yml
 
 pr:
   drafts: false
@@ -18,12 +12,18 @@ pr:
 stages:
   - stage: Code_Format
     displayName: 'Code Format'
+    pool:
+      name: ${{ variables.poolName }}
+      demands: ${{ variables.poolDemands }}
     jobs:
       - template: azure-devops/format-validation.yml
 
   - stage: Build_And_Test_x64
     dependsOn: Code_Format
-    displayName: 'Build and Test'
+    displayName: 'Build and Test x64'
+    pool:
+      name: ${{ variables.poolName }}
+      demands: ${{ variables.poolDemands }}
     jobs:
       - template: azure-devops/native-build-test.yml
         parameters:
@@ -32,7 +32,10 @@ stages:
 
   - stage: Build_And_Test_x86
     dependsOn: Build_And_Test_x64
-    displayName: 'Build and Test'
+    displayName: 'Build and Test x86'
+    pool:
+      name: ${{ variables.poolName }}
+      demands: ${{ variables.poolDemands }}
     jobs:
       - template: azure-devops/native-build-test.yml
         parameters:
@@ -41,17 +44,23 @@ stages:
 
   - stage: Build_ARM
     dependsOn: Build_And_Test_x64
-    displayName: 'Build'
+    displayName: 'Build ARM'
+    pool:
+      name: ${{ variables.poolName }}
+      demands: ${{ variables.poolDemands }}
     jobs:
       - template: azure-devops/cross-build.yml
         parameters:
           targetPlatform: arm
           vsDevCmdArch: arm
-          benchmarkBuildOutputLocationVar: ''
+          buildBenchmarks: false
 
   - stage: Build_ARM64
     dependsOn: Build_And_Test_x64
-    displayName: 'Build'
+    displayName: 'Build ARM64'
+    pool:
+      name: ${{ variables.poolName }}
+      demands: ${{ variables.poolDemands }}
     jobs:
       - template: azure-devops/cross-build.yml
         parameters:


### PR DESCRIPTION
* Extract common pipeline config into a new `azure-devops/config.yml` variable template so we don't need to repeat pool info and target directories in both pipelines.
* Improve the `displayName`s of all the pipeline stages.
* Use `trigger: none` so ASan pipeline runs don't trigger for pushes to _any_ branch. We _do_ want to schedule a daily build, so add `schedules`.
* `benchmarkBuildOutputLocationVar` was actually used to control building the benchmarks; replace with a boolean `buildBenchmarks`.
* We need to explicitly remove `asan-pipeline`'s second stage's dependency on the first with `dependsOn: []`.
* We never set `buildOutputLocationVar` to a non-default value; get rid of it.
* Make `litFlags` a defaulted parameter of `cmake-configure-build.yml` so we don't need to duplicate it.
  + Also remove `--shuffle`, which was overridden by `--order=lexical`; this should have been done in #2795.
* Don't try to build the benchmarks if configuring the benchmarks fails.
* Consistently quote paths in `azure-devops/cmake-configure-build.yml`.

## Reminder: We'll need to update https://github.com/microsoft/STL/wiki/Checklist-for-Toolset-Updates after this merges, the pool name now appears in `azure-devops/config.yml`.