### PR TITLE
`<xstring>`: Use `memmove` in construction of `basic_string` when the source is a suitable contiguous range

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2725,27 +2725,12 @@ private:
 
         _Tidy_deallocate_guard<basic_string> _Guard{this};
 
-        constexpr bool _Can_construct_by_memcpy = _Is_specialization_v<_Traits, char_traits> && _Is_EcharT<_Elem>
-                                               && _Iterator_is_contiguous<_Iter> && !_Iterator_is_volatile<_Iter>
-                                               && is_integral_v<_Iter_value_t<_Iter>>
-                                               && sizeof(_Iter_value_t<_Iter>) == sizeof(_Elem);
+        constexpr bool _Can_construct_by_copy =
+            _Is_specialization_v<_Traits, char_traits> && _Is_EcharT<_Elem> && is_same_v<_Size, size_type>;
 
-        if constexpr (_Can_construct_by_memcpy) {
-            _STL_INTERNAL_STATIC_ASSERT(is_same_v<_Size, size_type>);
-
-            const auto _Data     = _My_data._Myptr();
-            const auto _Src_data = _STD _To_address(_First);
-
-#if _HAS_CXX20
-            if (_STD is_constant_evaluated()) {
-                for (size_type _Idx = 0; _Idx != _Count; ++_Idx) {
-                    _Data[_Idx] = static_cast<_Elem>(_Src_data[_Idx]);
-                }
-            } else
-#endif // _HAS_CXX20
-            {
-                _CSTD memcpy(_Data, _Src_data, _Count * sizeof(_Elem));
-            }
+        if constexpr (_Can_construct_by_copy) {
+            const auto _Data = _My_data._Myptr();
+            _STD _Copy_n_unchecked4(_STD move(_First), _Count, _Data);
             _My_data._Mysize = _Count;
             _Data[_Count]    = _Elem();
         } else {

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2722,35 +2722,62 @@ private:
         }
 
         _Tidy_deallocate_guard<basic_string> _Guard{this};
-        for (; _First != _Last; ++_First) {
-            if constexpr (!is_same_v<_Size, size_type>) {
-                if (_My_data._Mysize == _My_data._Myres) { // Need to grow
-                    if (_My_data._Mysize == max_size()) {
-                        _Xlen_string(); // result too long
-                    }
 
-                    _Elem* const _Old_ptr   = _My_data._Myptr();
-                    size_type _New_capacity = _Calculate_growth(_My_data._Mysize + 1);
-                    const pointer _New_ptr  = _Allocate_for_capacity(_Al, _New_capacity); // throws
+        constexpr bool _Can_construct_by_memcpy = _Is_specialization_v<_Traits, char_traits> && _Is_EcharT<_Elem>
+                                               && _Iterator_is_contiguous<_Iter> && !_Iterator_is_volatile<_Iter>
+                                               && is_integral_v<_Iter_value_t<_Iter>>
+                                               && sizeof(_Iter_value_t<_Iter>) == sizeof(_Elem);
 
-                    _Traits::copy(_Unfancy(_New_ptr), _Old_ptr, _My_data._Mysize);
-                    if (_My_data._Large_mode_engaged()) { // Need to deallocate old storage
-                        _Deallocate_for_capacity(_Al, _My_data._Bx._Ptr, _My_data._Myres);
-                        _My_data._Bx._Ptr = _New_ptr;
-                    } else {
-                        _Construct_in_place(_My_data._Bx._Ptr, _New_ptr);
-                    }
-                    _My_data._Myres = _New_capacity;
+        if constexpr (_Can_construct_by_memcpy) {
+            _STL_INTERNAL_STATIC_ASSERT(is_same_v<_Size, size_type>);
+
+            const auto _Data     = _My_data._Myptr();
+            const auto _Src_data = _STD _To_address(_First);
+
+#if _HAS_CXX20
+            if (_STD is_constant_evaluated()) {
+                for (size_type _Idx = 0; _Idx != _Count; ++_Idx) {
+                    _Data[_Idx] = static_cast<_Elem>(_Src_data[_Idx]);
                 }
+            } else
+#endif // _HAS_CXX20
+            {
+                _CSTD memcpy(_Data, _Src_data, _Count * sizeof(_Elem));
+            }
+            _My_data._Mysize = _Count;
+            _Data[_Count]    = _Elem();
+        } else {
+            for (; _First != _Last; ++_First) {
+                if constexpr (!is_same_v<_Size, size_type>) {
+                    if (_My_data._Mysize == _My_data._Myres) { // Need to grow
+                        if (_My_data._Mysize == max_size()) {
+                            _Xlen_string(); // result too long
+                        }
+
+                        _Elem* const _Old_ptr   = _My_data._Myptr();
+                        size_type _New_capacity = _Calculate_growth(_My_data._Mysize + 1);
+                        const pointer _New_ptr  = _Allocate_for_capacity(_Al, _New_capacity); // throws
+
+                        _Traits::copy(_Unfancy(_New_ptr), _Old_ptr, _My_data._Mysize);
+                        if (_My_data._Large_mode_engaged()) { // Need to deallocate old storage
+                            _Deallocate_for_capacity(_Al, _My_data._Bx._Ptr, _My_data._Myres);
+                            _My_data._Bx._Ptr = _New_ptr;
+                        } else {
+                            _Construct_in_place(_My_data._Bx._Ptr, _New_ptr);
+                        }
+                        _My_data._Myres = _New_capacity;
+                    }
+                }
+
+                _Elem* const _Ptr = _My_data._Myptr();
+                _Traits::assign(_Ptr[_My_data._Mysize], *_First);
+                ++_My_data._Mysize;
             }
 
             _Elem* const _Ptr = _My_data._Myptr();
-            _Traits::assign(_Ptr[_My_data._Mysize], *_First);
-            ++_My_data._Mysize;
+            _Traits::assign(_Ptr[_My_data._Mysize], _Elem());
         }
 
-        _Elem* const _Ptr = _My_data._Myptr();
-        _Traits::assign(_Ptr[_My_data._Mysize], _Elem());
         _ASAN_STRING_CREATE(*this);
         _Guard._Target = nullptr;
         _Proxy._Release();

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2695,10 +2695,12 @@ private:
 
     template <class _Iter, class _Sent, class _Size = nullptr_t>
     _CONSTEXPR20 void _Construct_from_iter(_Iter _First, const _Sent _Last, _Size _Count = {}) {
-        // Pre: _First models input_iterator or meets the Cpp17InputIterator requirements
-        // Pre: [_First, _Last) is a valid range
+        // Pre: _Iter models input_iterator or meets the Cpp17InputIterator requirements.
+        // Pre: [_First, _Last) is a valid range.
+        // Pre: if _Iter models forward_iterator or meets the Cpp17ForwardIterator requirements,
+        //      then is_same_v<_Size, size_type> holds.
         // Pre: if is_same_v<_Size, size_type>, _Count is the length of [_First, _Last).
-        // Pre: *this is in small mode; the lifetime of the SSO elements has already begun
+        // Pre: *this is in small mode; the lifetime of the SSO elements has already begun.
 
         auto& _My_data  = _Mypair._Myval2;
         auto& _Al       = _Getal();

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2730,7 +2730,10 @@ private:
 
         if constexpr (_Can_construct_by_copy) {
             const auto _Data = _My_data._Myptr();
+#pragma warning(push)
+#pragma warning(disable : 4365) // suppress the warning from signedness mismatch in assignment
             _STD _Copy_n_unchecked4(_STD move(_First), _Count, _Data);
+#pragma warning(pop)
             _My_data._Mysize = _Count;
             _Data[_Count]    = _Elem();
         } else {

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2730,10 +2730,7 @@ private:
 
         if constexpr (_Can_construct_by_copy) {
             const auto _Data = _My_data._Myptr();
-#pragma warning(push)
-#pragma warning(disable : 4365) // suppress the warning from signedness mismatch in assignment
             _STD _Copy_n_unchecked4(_STD move(_First), _Count, _Data);
-#pragma warning(pop)
             _My_data._Mysize = _Count;
             _Data[_Count]    = _Elem();
         } else {

--- a/tests/std/tests/P1206R7_string_from_range/test.cpp
+++ b/tests/std/tests/P1206R7_string_from_range/test.cpp
@@ -128,7 +128,7 @@ static constexpr swchar_t whw_s[]{L'H', L'e', L'l', L'l', L'o', L',', L' ', L'w'
 static constexpr auto span_whw_s = span{whw_s}.first<span{whw_s}.size() - 1>();
 
 static constexpr uwchar_t whw_u[]{L'H', L'e', L'l', L'l', L'o', L',', L' ', L'w', L'o', L'r', L'l', L'd', L'!', L'\0'};
-static constexpr auto span_whw_u = span{whw_u}.first<span{whw_s}.size() - 1>();
+static constexpr auto span_whw_u = span{whw_u}.first<span{whw_u}.size() - 1>();
 
 struct wstring_instantiator {
     template <ranges::input_range R>
@@ -303,7 +303,7 @@ constexpr bool test_lvalue_vector() {
     test_lvalue_vector_helper(span_hw, hw_u8);
     test_lvalue_vector_helper(span_hw_s, hw_u8);
     test_lvalue_vector_helper(span_hw_u, hw_u8);
-#endif // __cpp_char8_t
+#endif // defined(__cpp_char8_t)
 
     test_lvalue_vector_helper(span_hw_u16, hw_u16);
     test_lvalue_vector_helper(span_hw_u16s, hw_u16);
@@ -331,17 +331,17 @@ void test_lvalue_forward_list() {
     }
 #ifdef __cpp_char8_t
     {
-        forward_list vec(span_hw.data(), span_hw.data() + span_hw.size());
-        test_string(vec, hw);
+        forward_list lst(span_hw_u8.data(), span_hw_u8.data() + span_hw_u8.size());
+        test_string(lst, hw_u8);
     }
-#endif // __cpp_char8_t
+#endif // defined(__cpp_char8_t)
     {
-        forward_list vec(span_hw_u16.data(), span_hw_u16.data() + span_hw_u16.size());
-        test_string(vec, hw_u16);
+        forward_list lst(span_hw_u16.data(), span_hw_u16.data() + span_hw_u16.size());
+        test_string(lst, hw_u16);
     }
     {
-        forward_list vec(span_hw_u32.data(), span_hw_u32.data() + span_hw_u32.size());
-        test_string(vec, hw_u32);
+        forward_list lst(span_hw_u32.data(), span_hw_u32.data() + span_hw_u32.size());
+        test_string(lst, hw_u32);
     }
     {
         forward_list lst(span_whw.data(), span_whw.data() + span_whw.size());

--- a/tests/std/tests/P1206R7_string_from_range/test.cpp
+++ b/tests/std/tests/P1206R7_string_from_range/test.cpp
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <algorithm>
+#include <array>
 #include <cassert>
+#include <cstdint>
 #include <forward_list>
 #include <ranges>
 #include <span>
@@ -44,6 +46,12 @@ constexpr bool test_string(Rng&& rng, const T* expected) {
 static constexpr char hw[]    = "Hello, world!";
 static constexpr auto span_hw = span{hw}.first<span{hw}.size() - 1>();
 
+static constexpr signed char hw_s[] = "Hello, world!";
+static constexpr auto span_hw_s     = span{hw_s}.first<span{hw_s}.size() - 1>();
+
+static constexpr unsigned char hw_u[] = "Hello, world!";
+static constexpr auto span_hw_u       = span{hw_u}.first<span{hw_u}.size() - 1>();
+
 struct string_instantiator {
     template <ranges::input_range R>
     static void call() {
@@ -52,8 +60,75 @@ struct string_instantiator {
     }
 };
 
+#ifdef __cpp_char8_t
+static constexpr char8_t hw_u8[] = u8"Hello, world!";
+static constexpr auto span_hw_u8 = span{hw_u8}.first<span{hw_u8}.size() - 1>();
+
+struct u8string_instantiator {
+    template <ranges::input_range R>
+    static void call() {
+        test_string(R{span_hw_u8}, hw_u8);
+        STATIC_ASSERT(test_string(R{span_hw_u8}, hw_u8));
+    }
+};
+#endif // defined(__cpp_char8_t)
+
+static constexpr char16_t hw_u16[] = u"Hello, world!";
+static constexpr auto span_hw_u16  = span{hw_u16}.first<span{hw_u16}.size() - 1>();
+
+static constexpr int_least16_t hw_u16s[]{
+    u'H', u'e', u'l', u'l', u'o', u',', u' ', u'w', u'o', u'r', u'l', u'd', u'!', u'\0'};
+static constexpr auto span_hw_u16s = span{hw_u16s}.first<span{hw_u16s}.size() - 1>();
+
+static constexpr uint_least16_t hw_u16u[]{
+    u'H', u'e', u'l', u'l', u'o', u',', u' ', u'w', u'o', u'r', u'l', u'd', u'!', u'\0'};
+static constexpr auto span_hw_u16u = span{hw_u16u}.first<span{hw_u16u}.size() - 1>();
+
+struct u16string_instantiator {
+    template <ranges::input_range R>
+    static void call() {
+        test_string(R{span_hw_u16}, hw_u16);
+        STATIC_ASSERT(test_string(R{span_hw_u16}, hw_u16));
+    }
+};
+
+static constexpr char32_t hw_u32[] = U"Hello, world!";
+static constexpr auto span_hw_u32  = span{hw_u32}.first<span{hw_u32}.size() - 1>();
+
+static constexpr int_least32_t hw_u32s[]{
+    U'H', U'e', U'l', U'l', U'o', U',', U' ', U'w', U'o', U'r', U'l', U'd', U'!', U'\0'};
+static constexpr auto span_hw_u32s = span{hw_u32s}.first<span{hw_u32s}.size() - 1>();
+
+static constexpr uint_least32_t hw_u32u[]{
+    U'H', U'e', U'l', U'l', U'o', U',', U' ', U'w', U'o', U'r', U'l', U'd', U'!', U'\0'};
+static constexpr auto span_hw_u32u = span{hw_u32u}.first<span{hw_u32u}.size() - 1>();
+
+static constexpr long hw_slong[]{U'H', U'e', U'l', U'l', U'o', U',', U' ', U'w', U'o', U'r', U'l', U'd', U'!', U'\0'};
+static constexpr auto span_hw_slong = span{hw_slong}.first<span{hw_slong}.size() - 1>();
+
+static constexpr unsigned long hw_ulong[]{
+    U'H', U'e', U'l', U'l', U'o', U',', U' ', U'w', U'o', U'r', U'l', U'd', U'!', U'\0'};
+static constexpr auto span_hw_ulong = span{hw_ulong}.first<span{hw_ulong}.size() - 1>();
+
+struct u32string_instantiator {
+    template <ranges::input_range R>
+    static void call() {
+        test_string(R{span_hw_u32}, hw_u32);
+        STATIC_ASSERT(test_string(R{span_hw_u32}, hw_u32));
+    }
+};
+
+using swchar_t = make_signed_t<wchar_t>;
+using uwchar_t = make_unsigned_t<wchar_t>;
+
 static constexpr wchar_t whw[] = L"Hello, world!";
 static constexpr auto span_whw = span{whw}.first<span{whw}.size() - 1>();
+
+static constexpr swchar_t whw_s[]{L'H', L'e', L'l', L'l', L'o', L',', L' ', L'w', L'o', L'r', L'l', L'd', L'!', L'\0'};
+static constexpr auto span_whw_s = span{whw_s}.first<span{whw_s}.size() - 1>();
+
+static constexpr uwchar_t whw_u[]{L'H', L'e', L'l', L'l', L'o', L',', L' ', L'w', L'o', L'r', L'l', L'd', L'!', L'\0'};
+static constexpr auto span_whw_u = span{whw_u}.first<span{whw_s}.size() - 1>();
 
 struct wstring_instantiator {
     template <ranges::input_range R>
@@ -71,7 +146,32 @@ using move_only_view = test::range<Category, const CharT, test::Sized{is_random}
 
 constexpr bool test_copyable_views() {
     test_string(span_hw, hw);
+    test_string(span_hw_s, hw);
+    test_string(span_hw_u, hw);
+#ifdef __cpp_char8_t
+    test_string(span_hw_u8, hw);
+
+    test_string(span_hw_u8, hw_u8);
+    test_string(span_hw, hw_u8);
+    test_string(span_hw_s, hw_u8);
+    test_string(span_hw_u, hw_u8);
+#endif // defined(__cpp_char8_t)
+
+    test_string(span_hw_u16, hw_u16);
+    test_string(span_hw_u16s, hw_u16);
+    test_string(span_hw_u16u, hw_u16);
+    test_string(span_whw, hw_u16);
+
+    test_string(span_hw_u32, hw_u32);
+    test_string(span_hw_u32s, hw_u32);
+    test_string(span_hw_u32u, hw_u32);
+    test_string(span_hw_slong, hw_u32);
+    test_string(span_hw_ulong, hw_u32);
+
     test_string(span_whw, whw);
+    test_string(span_whw_s, whw);
+    test_string(span_whw_u, whw);
+    test_string(span_hw_u16, whw);
 
     return true;
 }
@@ -96,21 +196,130 @@ constexpr bool test_move_only_views() {
     return true;
 }
 
+static constexpr char simple_hw[]{'H', 'e', 'l', 'l', 'o', ',', ' ', 'w', 'o', 'r', 'l', 'd', '!'};
+static constexpr signed char simple_hw_s[]{'H', 'e', 'l', 'l', 'o', ',', ' ', 'w', 'o', 'r', 'l', 'd', '!'};
+static constexpr unsigned char simple_hw_u[]{'H', 'e', 'l', 'l', 'o', ',', ' ', 'w', 'o', 'r', 'l', 'd', '!'};
+#ifdef __cpp_char8_t
+static constexpr char8_t simple_hw_u8[]{
+    u8'H', u8'e', u8'l', u8'l', u8'o', u8',', u8' ', u8'w', u8'o', u8'r', u8'l', u8'd', u8'!'};
+#endif // defined(__cpp_char8_t)
+
+static constexpr char16_t simple_hw_u16[]{u'H', u'e', u'l', u'l', u'o', u',', u' ', u'w', u'o', u'r', u'l', u'd', u'!'};
+static constexpr int_least16_t simple_hw_u16s[]{
+    u'H', u'e', u'l', u'l', u'o', u',', u' ', u'w', u'o', u'r', u'l', u'd', u'!'};
+static constexpr uint_least16_t simple_hw_u16u[]{
+    u'H', u'e', u'l', u'l', u'o', u',', u' ', u'w', u'o', u'r', u'l', u'd', u'!'};
+
+static constexpr char32_t simple_hw_u32[]{U'H', U'e', U'l', U'l', U'o', U',', U' ', U'w', U'o', U'r', U'l', U'd', U'!'};
+static constexpr int_least32_t simple_hw_u32s[]{
+    U'H', U'e', U'l', U'l', U'o', U',', U' ', U'w', U'o', U'r', U'l', U'd', U'!'};
+static constexpr uint_least32_t simple_hw_u32u[]{
+    U'H', U'e', U'l', U'l', U'o', U',', U' ', U'w', U'o', U'r', U'l', U'd', U'!'};
+static constexpr long simple_hw_slong[]{U'H', U'e', U'l', U'l', U'o', U',', U' ', U'w', U'o', U'r', U'l', U'd', U'!'};
+static constexpr unsigned long simple_hw_ulong[]{
+    U'H', U'e', U'l', U'l', U'o', U',', U' ', U'w', U'o', U'r', U'l', U'd', U'!'};
+
+static constexpr wchar_t simple_whw[]{L'H', L'e', L'l', L'l', L'o', L',', L' ', L'w', L'o', L'r', L'l', L'd', L'!'};
+static constexpr swchar_t simple_whw_s[]{L'H', L'e', L'l', L'l', L'o', L',', L' ', L'w', L'o', L'r', L'l', L'd', L'!'};
+static constexpr uwchar_t simple_whw_u[]{L'H', L'e', L'l', L'l', L'o', L',', L' ', L'w', L'o', L'r', L'l', L'd', L'!'};
+
 constexpr bool test_c_array() {
-    test_string(span_hw, hw);
-    test_string(span_whw, whw);
+    test_string(simple_hw, hw);
+    test_string(simple_hw_s, hw);
+    test_string(simple_hw_u, hw);
+#ifdef __cpp_char8_t
+    test_string(simple_hw_u8, hw);
+
+    test_string(simple_hw_u8, hw_u8);
+    test_string(simple_hw, hw_u8);
+    test_string(simple_hw_s, hw_u8);
+    test_string(simple_hw_u, hw_u8);
+#endif // defined(__cpp_char8_t)
+
+    test_string(simple_hw_u16, hw_u16);
+    test_string(simple_hw_u16s, hw_u16);
+    test_string(simple_hw_u16u, hw_u16);
+    test_string(simple_whw, hw_u16);
+
+    test_string(simple_hw_u32, hw_u32);
+    test_string(simple_hw_u32s, hw_u32);
+    test_string(simple_hw_u32u, hw_u32);
+    test_string(simple_hw_slong, hw_u32);
+    test_string(simple_hw_ulong, hw_u32);
+
+    test_string(simple_whw, whw);
+    test_string(simple_whw_s, whw);
+    test_string(simple_whw_u, whw);
+    test_string(simple_hw_u16, whw);
+
+    return true;
+}
+
+constexpr bool test_std_array() {
+    test_string(to_array(simple_hw), hw);
+    test_string(to_array(simple_hw_s), hw);
+    test_string(to_array(simple_hw_u), hw);
+#ifdef __cpp_char8_t
+    test_string(to_array(simple_hw_u8), hw);
+
+    test_string(to_array(simple_hw_u8), hw_u8);
+    test_string(to_array(simple_hw), hw_u8);
+    test_string(to_array(simple_hw_s), hw_u8);
+    test_string(to_array(simple_hw_u), hw_u8);
+#endif // defined(__cpp_char8_t)
+
+    test_string(to_array(simple_hw_u16), hw_u16);
+    test_string(to_array(simple_hw_u16s), hw_u16);
+    test_string(to_array(simple_hw_u16u), hw_u16);
+    test_string(to_array(simple_whw), hw_u16);
+
+    test_string(to_array(simple_hw_u32), hw_u32);
+    test_string(to_array(simple_hw_u32s), hw_u32);
+    test_string(to_array(simple_hw_u32u), hw_u32);
+    test_string(to_array(simple_hw_slong), hw_u32);
+    test_string(to_array(simple_hw_ulong), hw_u32);
+
+    test_string(to_array(simple_whw), whw);
+    test_string(to_array(simple_whw_s), whw);
+    test_string(to_array(simple_whw_u), whw);
+    test_string(to_array(simple_hw_u16), whw);
+
     return true;
 }
 
 constexpr bool test_lvalue_vector() {
-    {
-        vector vec(span_hw.data(), span_hw.data() + span_hw.size());
-        test_string(vec, hw);
-    }
-    {
-        vector vec(span_whw.data(), span_whw.data() + span_whw.size());
-        test_string(vec, whw);
-    }
+    constexpr auto test_lvalue_vector_helper = []<class Span, class CharT>(const Span& sp, const CharT* cstr) {
+        vector vec(sp.data(), sp.data() + sp.size());
+        test_string(vec, cstr);
+    };
+
+    test_lvalue_vector_helper(span_hw, hw);
+    test_lvalue_vector_helper(span_hw_s, hw);
+    test_lvalue_vector_helper(span_hw_u, hw);
+#ifdef __cpp_char8_t
+    test_lvalue_vector_helper(span_hw_u8, hw);
+
+    test_lvalue_vector_helper(span_hw_u8, hw_u8);
+    test_lvalue_vector_helper(span_hw, hw_u8);
+    test_lvalue_vector_helper(span_hw_s, hw_u8);
+    test_lvalue_vector_helper(span_hw_u, hw_u8);
+#endif // __cpp_char8_t
+
+    test_lvalue_vector_helper(span_hw_u16, hw_u16);
+    test_lvalue_vector_helper(span_hw_u16s, hw_u16);
+    test_lvalue_vector_helper(span_hw_u16u, hw_u16);
+    test_lvalue_vector_helper(span_whw, hw_u16);
+
+    test_lvalue_vector_helper(span_hw_u32, hw_u32);
+    test_lvalue_vector_helper(span_hw_u32s, hw_u32);
+    test_lvalue_vector_helper(span_hw_u32u, hw_u32);
+    test_lvalue_vector_helper(span_hw_slong, hw_u32);
+    test_lvalue_vector_helper(span_hw_ulong, hw_u32);
+
+    test_lvalue_vector_helper(span_whw, whw);
+    test_lvalue_vector_helper(span_whw_s, whw);
+    test_lvalue_vector_helper(span_whw_u, whw);
+    test_lvalue_vector_helper(span_hw_u16, whw);
 
     return true;
 }
@@ -119,6 +328,20 @@ void test_lvalue_forward_list() {
     {
         forward_list lst(span_hw.data(), span_hw.data() + span_hw.size());
         test_string(lst, hw);
+    }
+#ifdef __cpp_char8_t
+    {
+        forward_list vec(span_hw.data(), span_hw.data() + span_hw.size());
+        test_string(vec, hw);
+    }
+#endif // __cpp_char8_t
+    {
+        forward_list vec(span_hw_u16.data(), span_hw_u16.data() + span_hw_u16.size());
+        test_string(vec, hw_u16);
+    }
+    {
+        forward_list vec(span_hw_u32.data(), span_hw_u32.data() + span_hw_u32.size());
+        test_string(vec, hw_u32);
     }
     {
         forward_list lst(span_whw.data(), span_whw.data() + span_whw.size());
@@ -138,6 +361,9 @@ int main() {
     test_c_array();
     STATIC_ASSERT(test_c_array());
 
+    test_std_array();
+    STATIC_ASSERT(test_std_array());
+
     test_lvalue_vector();
     STATIC_ASSERT(test_lvalue_vector());
 
@@ -145,4 +371,10 @@ int main() {
 
     test_in<string_instantiator, const char>();
     test_in<wstring_instantiator, const wchar_t>();
+
+#ifdef __cpp_char8_t
+    test_contiguous<u8string_instantiator, const char8_t>();
+#endif // defined(__cpp_char8_t)
+    test_contiguous<u16string_instantiator, const char16_t>();
+    test_contiguous<u32string_instantiator, const char32_t>();
 }

--- a/tests/std/tests/P1206R7_string_from_range/test.cpp
+++ b/tests/std/tests/P1206R7_string_from_range/test.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#pragma warning(disable : 4365) // conversion from 'X' to 'Y', signed/unsigned mismatch
+
 #include <algorithm>
 #include <array>
 #include <cassert>


### PR DESCRIPTION
Fixes #2901.

Criteria:
- the source element type is integral
- the target element type is an `EcharT` (encoded character type, i.e. `char`, `wchar_t`, `char8_t`, `char16_t`, `char32_t`)
- the source and target element types are the same size
- the target traits type is library-provided (thanks @CaseyCarter)
- the source iterator is a contiguous iterator which doesn't dereference to a volatile lvalue.

Perhaps we can extend the criteria to `move_iterator` and unscoped enumeration types later.

Clang's `__builtin_memcpy` doesn't work when copying a `char` array to a `char8_t` array in constant evaluation (nor does GCC's), so this PR isn't using it in the involved construction.

The test `P1206R7_string_from_range` is largely extended to cover some related contiguous ranges and character types. The original `test_c_array` seemed to be a duplicate of `test_copyable_views`, so I changed it to properly cover built-in arrays.