### PR TITLE
Fix ASAN CI failure caused by stealth merge conflict

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -367,7 +367,9 @@ std/algorithms/algorithms.results/no_unique_address.compile.pass.cpp SKIPPED
 
 # P1169R4 static operator()
 std/thread/futures/futures.task/futures.task.members/ctad.static.compile.pass.cpp:0 FAIL
+std/thread/futures/futures.task/futures.task.members/ctad.static.compile.pass.cpp:1 FAIL
 std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/ctad.static.compile.pass.cpp:0 FAIL
+std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/ctad.static.compile.pass.cpp:1 FAIL
 
 
 # *** MISSING LWG ISSUE RESOLUTIONS ***


### PR DESCRIPTION
Originally, these `ctad.static.compile.pass.cpp` tests were marked as failing for all compilers. After #4053, they were marked as failing for MSVC only (configuration 0). After #4069 finished setting up the ASan-Daily-CI pipeline, these tests additionally need to be marked as failing for MSVC with ASAN (configuration 1).