### PR TITLE
Validity check simple replacement fields

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -3517,7 +3517,10 @@ struct _Format_checker {
     consteval explicit _Format_checker(basic_string_view<_CharT> _Fmt) noexcept
         : _Parse_context(_Fmt, _Num_args), _Parse_funcs{&_Compile_time_parse_format_specs<_Args, _ParseContext>...} {}
     constexpr void _On_text(const _CharT*, const _CharT*) const noexcept {}
-    constexpr void _On_replacement_field(size_t, const _CharT*) const noexcept {}
+    constexpr void _On_replacement_field(size_t, const _CharT*) const {
+        _ParseContext _Parse_ctx({});
+        _Parse_ctx.advance_to(_Parse_funcs[_Id](_Parse_ctx));
+    }
     constexpr const _CharT* _On_format_specs(const size_t _Id, const _CharT* _First, const _CharT*) {
         _Parse_context.advance_to(_Parse_context.begin() + (_First - _Parse_context.begin()._Unwrapped()));
         if (_Id < _Num_args) {


### PR DESCRIPTION
A custom formatter for a user-defined type might reject omitted format-specs:

```c++
struct A {};
template<>
struct std::formatter<A> {
    constexpr auto parse(std::format_parse_context const& ctx) {
        std::string_view s("narf");
        auto [i, j] = std::mismatch(ctx.begin(), ctx.end(), s.begin(), s.end());
        if (j != s.end())
            throw std::runtime_error("you didn't say the magic word!");
        return i;
    }
    auto format(A, std::format_context& ctx) const {
        return ctx.out();
    }
};
int main() {
    std::ignore = std::format("{}", A());
}
```

Per [format.fmt.string]/3 this should be rejected, but MSVC instead accepts and throws at runtime.

This implementation seems most likely to not cause problems with existing code; it matches the runtime behavior of _Default_arg_formatter on custom formatters (basic_format_arg<_Context>::handle), so it should accept any format() call that would succeed at runtime.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
