### PR TITLE
Toolset update: VS 2022 17.8 Preview 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.8 Preview 2 or later.
+1. Install Visual Studio 2022 17.8 Preview 3 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
@@ -157,7 +157,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.8 Preview 2 or later.
+1. Install Visual Studio 2022 17.8 Preview 3 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.

--- a/README.md
+++ b/README.md
@@ -146,8 +146,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.27.0 or later, and [Ninja][] 1.11.0 or later.
-    * We recommend selecting "Python 3 64-bit" in the VS Installer.
-    * Otherwise, make sure [Python][] 3.9 or later is available to CMake.
+    * Make sure [Python][] 3.12 or later is available to CMake.
 2. Open Visual Studio, and choose the "Clone or check out code" option. Enter the URL of this repository,
    `https://github.com/microsoft/STL`.
 3. Open a terminal in the IDE with `` Ctrl + ` `` (by default) or press on "View" in the top bar, and then "Terminal".
@@ -162,8 +161,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.27.0 or later, and [Ninja][] 1.11.0 or later.
-    * We recommend selecting "Python 3 64-bit" in the VS Installer.
-    * Otherwise, make sure [Python][] 3.9 or later is available to CMake.
+    * Make sure [Python][] 3.12 or later is available to CMake.
 2. Open a command prompt.
 3. Change directories to a location where you'd like a clone of this STL repository.
 4. `git clone https://github.com/microsoft/STL --recurse-submodules`
@@ -232,7 +230,7 @@ C:\Users\username\Desktop>dumpbin /DEPENDENTS .\example.exe | findstr msvcp
 # How To Run The Tests With A Native Tools Command Prompt
 
 1. Follow either [How To Build With A Native Tools Command Prompt][] or [How To Build With The Visual Studio IDE][].
-2. Acquire [Python][] 3.9 or newer and have it on the `PATH` (or run it directly using its absolute or relative path).
+2. Acquire [Python][] 3.12 or newer and have it on the `PATH` (or run it directly using its absolute or relative path).
 3. Have LLVM's `bin` directory on the `PATH` (so `clang-cl.exe` is available).
     * We recommend selecting "C++ Clang tools for Windows" in the VS Installer. This will automatically add LLVM to the
     `PATH` of the x86 and x64 Native Tools Command Prompts, and will ensure that you're using a supported version.

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,7 +5,7 @@
 
 variables:
 - name: poolName
-  value: 'StlBuild-2023-09-14T1251-Pool'
+  value: 'StlBuild-2023-10-10T1443-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals true'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -136,7 +136,7 @@ $Workloads = @(
 )
 
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/17/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.11.5/python-3.11.5-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.12.0/python-3.12.0-amd64.exe'
 
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_511.23_windows.exe'
 

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -91,7 +91,7 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
   $PsExecPath = Join-Path $ExtractedPsToolsPath 'PsExec64.exe'
 
   # https://github.com/PowerShell/PowerShell/releases/latest
-  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.3.6/PowerShell-7.3.6-win-x64.zip'
+  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.3.8/PowerShell-7.3.8-win-x64.zip'
   Write-Host "Downloading: $PowerShellZipUrl"
   $ExtractedPowerShellPath = DownloadAndExtractZip -Url $PowerShellZipUrl
   $PwshPath = Join-Path $ExtractedPowerShellPath 'pwsh.exe'

--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -1026,10 +1026,7 @@ _NODISCARD inline uint64_t _Right_shift_with_rounding(
     constexpr uint32_t _Total_number_of_bits = 64;
     if (_Shift >= _Total_number_of_bits) {
         if (_Shift == _Total_number_of_bits) {
-#pragma warning(push)
-#pragma warning(disable : 26454) // TRANSITION, VSO-1826196
             constexpr uint64_t _Extra_bits_mask = (1ULL << (_Total_number_of_bits - 1)) - 1;
-#pragma warning(pop)
             constexpr uint64_t _Round_bit_mask  = (1ULL << (_Total_number_of_bits - 1));
 
             const bool _Round_bit = (_Value & _Round_bit_mask) != 0;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5912,11 +5912,7 @@ namespace ranges {
                     return _RANGES next(_STD move(_First), _Result - _First_ptr);
                 }
 #else // ^^^ _USE_STD_VECTOR_ALGORITHMS / !_USE_STD_VECTOR_ALGORITHMS vvv
-                if constexpr (sizeof(_Iter_value_t<_It>) == 1
-#if defined(_M_ARM64) || defined(_M_ARM64EC) // TRANSITION, VSO-1538014 : memchr inspects bytes after the match
-                              && _Is_sized
-#endif // ^^^ workaround ^^^
-                ) {
+                if constexpr (sizeof(_Iter_value_t<_It>) == 1) {
                     size_t _Count;
                     if constexpr (_Is_sized) {
                         _Count = static_cast<size_t>(_Last - _First);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ add_subdirectory(tr1)
 # chance to add to the config map and test directory global properties.
 add_subdirectory(utils/stl-lit)
 
-find_package(Python "3.9" REQUIRED COMPONENTS Interpreter)
+find_package(Python "3.12" REQUIRED COMPONENTS Interpreter)
 
 if(NOT DEFINED LIT_FLAGS)
     list(APPEND LIT_FLAGS "-o" "${CMAKE_CURRENT_BINARY_DIR}/test_results.json")

--- a/tests/std/tests/VSO_0000000_instantiate_containers/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0000000_instantiate_containers/test.compile.pass.cpp
@@ -702,7 +702,6 @@ void extended_math_functions_test(T value) {
     (void) tanh(value);
 }
 
-// TRANSITION, VSO-251998
 // cbegin() calls begin() fully qualified, so cannot
 // find valarray non-member begin().
 

--- a/tests/std/tests/VSO_0105317_expression_sfinae/test.cpp
+++ b/tests/std/tests/VSO_0105317_expression_sfinae/test.cpp
@@ -613,7 +613,6 @@ STATIC_ASSERT(is_nothrow_invocable_r_v<Puppy, Kitty, int>);
 STATIC_ASSERT(is_invocable_r_v<Zebra, Kitty, int>);
 STATIC_ASSERT(!is_nothrow_invocable_r_v<Zebra, Kitty, int>);
 
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1026729
 // Defend against regression of VSO-963790, in which is_invocable_r mishandles non-movable return types
 struct NonMovable {
     NonMovable(NonMovable&&)      = delete;
@@ -626,7 +625,9 @@ NonMovable getNonMovable() noexcept(Nothrow);
 STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getNonMovable<false>)>);
 STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getNonMovable<true>)>);
 STATIC_ASSERT(!is_nothrow_invocable_r_v<NonMovable, decltype(&getNonMovable<false>)>);
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1899423
 STATIC_ASSERT(is_nothrow_invocable_r_v<NonMovable, decltype(&getNonMovable<true>)>);
+#endif // ^^^ no workaround ^^^
 
 template <bool Nothrow>
 struct ConvertsToNonMovable {
@@ -636,15 +637,18 @@ struct ConvertsToNonMovable {
 template <bool Nothrow, bool NothrowReturn>
 ConvertsToNonMovable<NothrowReturn> getConvertsToNonMovable() noexcept(Nothrow);
 
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1899423
 STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<false, false>)>);
 STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<false, true>)>);
 STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<true, false>)>);
 STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<true, true>)>);
+#endif // ^^^ no workaround ^^^
 STATIC_ASSERT(!is_nothrow_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<false, false>)>);
 STATIC_ASSERT(!is_nothrow_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<false, true>)>);
 STATIC_ASSERT(!is_nothrow_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<true, false>)>);
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1899423
 STATIC_ASSERT(is_nothrow_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<true, true>)>);
-#endif // TRANSITION, VSO-1026729
+#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX17
 
 

--- a/tests/tr1/tests/memory1/test.cpp
+++ b/tests/tr1/tests/memory1/test.cpp
@@ -13,9 +13,6 @@
 #include <sstream>
 #include <string>
 
-// TRANSITION, VSO-1281038: False C6287 for C++20 synthesized operators
-#pragma warning(disable : 6287) // Redundant code:  the left and right sub-expressions are identical.
-
 static void t_bad_weak_ptr() { // test bad_weak_ptr
     STD bad_weak_ptr ptr;
     STD exception* eptr = &ptr;
@@ -515,8 +512,14 @@ static void t_shared_ptr() { // test shared_ptr interface
         STD shared_ptr<X0> sp0(it0);
         STD shared_ptr<X0> sp1(it1);
         STD shared_ptr<X0> sp2(sp1);
-        CHECK(!(sp0 == sp1) && sp0 != sp1 && sp1 == sp2 && !(sp1 != sp2));
-        CHECK(!(sp1 < sp2) && !(sp2 < sp1));
+
+        CHECK(!(sp0 == sp1));
+        CHECK(sp0 != sp1);
+        CHECK(sp1 == sp2);
+        CHECK(!(sp1 != sp2));
+
+        CHECK(!(sp1 < sp2));
+        CHECK(!(sp2 < sp1));
 
         CHECK(sp1 <= sp2);
         CHECK(!(sp2 > sp1));


### PR DESCRIPTION
* Updated dependencies.
    + Updated build compiler to VS 2022 17.8 Preview 3.
    + Updated Python to 3.12.0 (now required).
* Remove compiler bug workarounds:
  + Remove workaround for VSO-1826196 "False positive C26454 in charconv" as the internal toolset has been updated. Validated internally, we can resolve this bug when merging.
  + Drop TRANSITION comment about VSO-251998 "File issue for `cbegin` interaction with other std containers with only non-member `begin()` functions". This wasn't a compiler or STL bug; it was a reminder to maybe file an LWG issue someday, which never happened and isn't worth pursuing now.
  + VSO-1281038 "False C6287 for C++20 synthesized operators" was rightfully resolved as By Design. Permanently avoid it by separately asserting each expression, which is our preferred style anyways.
    - Although we generally avoid cleaning up `tr1`, this is worth it.
  + Remove workaround for VSO-1538014 "\[Feedback\] ARM64 `memchr` implementation may not be standard conformant". It was fixed on 2023-06-02 by MSVC-PR-468038 in `prod/be` and is present in both `rel/17.7` and `rel/17.8`. It was marked as fixed in 17.8 Preview 1.
  + Replace coarse-grained workaround for VSO-1026729 "Conformant Copy Elision" (a User Story that's been Proposed since 2019-11-22) with fine-grained workarounds for VSO-1899423 "C1XX mishandles C++17 deferred temporary materialization in `is_invocable_r_v` and `is_nothrow_invocable_r_v`" (newly reported with this exact code).
* Use PowerShell 7.3.8 to create the pool.