### PR TITLE
README.md: Update Azure Pipelines status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ which ships as part of the MSVC toolset and the Visual Studio IDE.
 * Our [Changelog][] tracks which updates to this repository appear in each VS release.
 * Our [Status Chart][] displays our overall progress over time.
 * Join our [Discord server][].
-* [![Build Status][STL-CI-badge]][STL-CI-link] (STL-CI build status)
-* [![Build Status][STL-ASan-CI-badge]][STL-ASan-CI-link] (STL-ASan-CI build status)
+* [![CI Status Badge][STL-CI-badge]][STL-CI-link] (STL-CI build status)
+* [![ASan CI Status Badge][STL-ASan-CI-badge]][STL-ASan-CI-link] (STL-ASan-CI build status)
 
 # What This Repo Is Useful For
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ which ships as part of the MSVC toolset and the Visual Studio IDE.
 * Our [Changelog][] tracks which updates to this repository appear in each VS release.
 * Our [Status Chart][] displays our overall progress over time.
 * Join our [Discord server][].
-
-[![Build Status](https://dev.azure.com/vclibs/STL/_apis/build/status/microsoft.STL?branchName=main)][Pipelines]
+* [![Build Status][STL-CI-badge]][STL-CI-link] (STL-CI build status)
+* [![Build Status][STL-ASan-CI-badge]][STL-ASan-CI-link] (STL-ASan-CI build status)
 
 # What This Repo Is Useful For
 
@@ -535,7 +535,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 [N4958]: https://wg21.link/n4958
 [NOTICE.txt]: NOTICE.txt
 [Ninja]: https://ninja-build.org
-[Pipelines]: https://dev.azure.com/vclibs/STL/_build/latest?definitionId=4&branchName=main
+[STL-CI-badge]: https://dev.azure.com/vclibs/STL/_apis/build/status%2FSTL-CI?branchName=main "STL-CI"
+[STL-CI-link]: https://dev.azure.com/vclibs/STL/_build/latest?definitionId=4&branchName=main
+[STL-ASan-CI-badge]: https://dev.azure.com/vclibs/STL/_apis/build/status%2FSTL-ASan-CI?branchName=main "STL-ASan-CI"
+[STL-ASan-CI-link]: https://dev.azure.com/vclibs/STL/_build/latest?definitionId=5&branchName=main
 [Python]: https://www.python.org/downloads/windows/
 [Roadmap]: https://github.com/microsoft/STL/wiki/Roadmap
 [Status Chart]: https://microsoft.github.io/STL/


### PR DESCRIPTION
This adds a status badge for the daily ASAN CI that @CaseyCarter finished implementing with #4069. It also updates our existing badge.

* The existing badge image was still mentioning `microsoft.STL`, so I suspect that the image was stale, i.e. it would appear green even if the newly renamed STL-CI was failing.
* I've generated/regenerated the badges and then further edited their Markdown. The way is to look at the pipeline, e.g. https://dev.azure.com/vclibs/STL/_build?definitionId=4&_a=summary , click on the vertical ellipsis at the upper right, click "Status badge", set the Branch to `main`, and then look at the Sample Markdown.
* It helps to be familiar with GitHub Flavored Markdown's image syntax: https://github.github.com/gfm/#images
* As suggested by @CaseyCarter, I'm using "CI Status Badge" and "ASan CI Status Badge" as the alt text (for accessibility).
* I'm extracting both the badge URL (for the image) and the link (for clicking on it) in reference style, making it easier to visually read the Markdown, and avoiding column length limitations.
* I'm saying "(STL-CI build status)" and "(STL-ASan-CI build status)" to explain why we have two badges. They appear at the end so that the badges are aligned on the left.
* For the reference links, I'm abandoning any attempt to keep them sorted (we had already accumulated non-sorted links).
* These links are freshly generated - the generator now emits `%2F` instead of `/`, in addition to fixing the previously mentioned `microsoft.STL` staleness.
* The quoted `"STL-CI"` and `"STL-ASan-CI"` at the end of the badge URLs produces title text that's displayed on hover. I thought it was nice to have these be distinct, even though the ordinary text in the bullet points is right there. I suppose we could drop these titles, though (we didn't have them before).

:white_check_mark: :white_check_mark: Live preview: https://github.com/StephanTLavavej/STL/tree/asan-badge#microsofts-c-standard-library
