### PR TITLE
Clean up emitted files as the test harness runs

### DIFF
--- a/tests/utils/stl/test/format.py
+++ b/tests/utils/stl/test/format.py
@@ -156,7 +156,8 @@ class STLTestFormat:
             ('Build', self.getBuildSteps(test, litConfig, shared), True),
             ('Intellisense response file', self.getIsenseRspFileSteps(test, litConfig, shared), False),
             ('Test setup', self.getTestSetupSteps(test, litConfig, shared), False),
-            ('Test', self.getTestSteps(test, litConfig, shared), False)]
+            ('Test', self.getTestSteps(test, litConfig, shared), False),
+            ('Clean', self.getCleanSteps(test, litConfig, shared), True)]
 
     def getBuildSetupSteps(self, test, litConfig, shared):
         shutil.rmtree(shared.execDir, ignore_errors=True)
@@ -203,6 +204,11 @@ class STLTestFormat:
 
         shouldFail = TestType.FAIL in test.testType
         yield TestStep([shared.execFile], shared.execDir, shared.env, shouldFail)
+
+    def getCleanSteps(self, test, litConfig, shared):
+        shutil.rmtree(shared.execDir, ignore_errors=True)
+
+        yield from []
 
     def execute(self, test, litConfig):
         try:


### PR DESCRIPTION
Fixes #4082.

## Overview
Currently, the test harness leaves behind the OBJ, EXE, etc. files that it builds. These are safely contained within the `out` subdirectory, and they're easily dealt with via `git clean`. However, this means that large test runs leave behind a *lot* of emitted files. After ASAN configurations were added to the matrix, I observed that a full test pass left behind ~200 GB of files on my local machine, causing my 1 TB SSD to run out of space. :scream_cat:

These emitted files are never useful to us. If we have to investigate a particular test, we always want to rebuild it by hand, and extracting the relevant command line from the logs is easy (for all except the header units test, and the emitted artifacts aren't any more helpful there). This is because the vast majority of our plain test configurations don't use `/Zi` (so if we want debug info we have to add it), and because we typically want to do something like hack a header and rebuild with an overlay `/I` option while investigating a potential fix.

## How I developed this PR
I knew that our test harness created different subdirectories for different test configurations. While trying to find where this happened, I noticed that `format.py` was organized into comprehensible "steps", and it starts with a "build setup" step that deletes and recreates the test subdirectory:

https://github.com/microsoft/STL/blob/f362f7d7bea87bd199c927a89718e929ed89b187/tests/utils/stl/test/format.py#L161-L163

Immediately above, `getStages()` was designed in a really nice way to return an array of stages. This was extensible, instead of having a specific sequence of stages hardcoded everywhere. So all I had to do was introduce a "Clean" stage at the end, performing the same `shutil.rmtree()` command that's run at the very beginning.

The one thing to pay attention to is the bool at the end of each listed stage. This is `isBuildStep`, which is used to handle build-only configurations:

https://github.com/microsoft/STL/blob/f362f7d7bea87bd199c927a89718e929ed89b187/tests/utils/stl/test/format.py#L220-L222

When `isBuildStep` is `True`, the step is always run (which is what we want for this new Clean step). `False` steps are for running tests, which are skipped for build-only configurations.

## How I tested this PR

After building the STL, I captured the `out\x64` directory contents before and after running a pair of tests (compile-only and runtime). (`%STL%` is my repo root.)

```cmd
pushd out\x64

dir /s /b /a-d > C:\temp\beforetests.txt

python tests\utils\stl-lit\stl-lit.py -o testing_x64.log %STL%\tests\std\tests\P0295R0_gcd_lcm %STL%\tests\std\tests\P0768R1_spaceship_operator

dir /s /b /a-d > C:\temp\aftertests.txt
```

For `main`, the before-and-after difference displayed a bunch of emitted files. In addition to the `testing_x64.log` that I explicitly requested, LLVM `lit` generated one file, and then each subdirectory contained a bunch. Trimmed my repo root for clarity:

```
out\x64\testing_x64.log

out\x64\tests\std\.lit_test_times.txt

out\x64\tests\std\tests\P0295R0_gcd_lcm\Output\00\test.compile.pass.obj
out\x64\tests\std\tests\P0295R0_gcd_lcm\Output\01\test.compile.pass.obj
out\x64\tests\std\tests\P0295R0_gcd_lcm\Output\01\vc140.pdb
out\x64\tests\std\tests\P0295R0_gcd_lcm\Output\02\test.compile.pass.obj
out\x64\tests\std\tests\P0295R0_gcd_lcm\Output\03\test.compile.pass.obj
out\x64\tests\std\tests\P0295R0_gcd_lcm\Output\03\vc140.pdb
[...]
out\x64\tests\std\tests\P0768R1_spaceship_operator\Output\00\_CL_2577c3f4lk
out\x64\tests\std\tests\P0768R1_spaceship_operator\Output\00\P0768R1_spaceship_operator.exe
out\x64\tests\std\tests\P0768R1_spaceship_operator\Output\00\test.obj
out\x64\tests\std\tests\P0768R1_spaceship_operator\Output\01\_CL_7a4d587blk
out\x64\tests\std\tests\P0768R1_spaceship_operator\Output\01\P0768R1_spaceship_operator.exe
out\x64\tests\std\tests\P0768R1_spaceship_operator\Output\01\P0768R1_spaceship_operator.pdb
out\x64\tests\std\tests\P0768R1_spaceship_operator\Output\01\test.obj
out\x64\tests\std\tests\P0768R1_spaceship_operator\Output\01\vc140.pdb
[...]
```

With this PR, only the explicitly requested log file and the LLVM `lit` generated file survive:

```
out\x64\testing_x64.log

out\x64\tests\std\.lit_test_times.txt
```