### PR TITLE
Cleanup `_Execute_once()`

### DIFF
--- a/stl/inc/xcall_once.h
+++ b/stl/inc/xcall_once.h
@@ -28,15 +28,6 @@ _EXPORT_STD struct once_flag { // opaque data structure for call_once()
     void* _Opaque;
 };
 
-#ifdef _CRTBLD
-// Returns BOOL, nonzero to indicate success, zero for failure
-using _Execute_once_fp_t = int(__stdcall*)(void*, void*, void**);
-
-// Returns BOOL, nonzero to indicate success, zero for failure
-extern "C++" _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Execute_once(
-    once_flag& _Flag, _Execute_once_fp_t _Callback, void* _Pv) noexcept;
-#endif // _CRTBLD
-
 template <class _Ty>
 union _Immortalizer_impl { // constructs _Ty, never destroys
     constexpr _Immortalizer_impl() noexcept : _Storage{} {}

--- a/stl/src/dllmain.cpp
+++ b/stl/src/dllmain.cpp
@@ -5,18 +5,6 @@
 
 #include <Windows.h>
 
-#ifdef _CRT_APP
-// free static resource used by causality
-extern "C" void __cdecl __crtCleanupCausalityStaticFactories();
-#endif // defined(_CRT_APP)
-
-extern "C" BOOL APIENTRY DllMain(HMODULE /* hModule */, DWORD ul_reason_for_call, [[maybe_unused]] LPVOID lpReserved) {
-    if (ul_reason_for_call == DLL_PROCESS_DETACH) {
-#ifdef _CRT_APP
-        if (lpReserved == nullptr) { // only when the process is not terminating
-            __crtCleanupCausalityStaticFactories();
-        }
-#endif // defined(_CRT_APP)
-    }
+extern "C" BOOL APIENTRY DllMain(HMODULE /* hModule */, DWORD /* ul_reason_for_call */, LPVOID /* lpReserved */) {
     return TRUE;
 }

--- a/stl/src/dllmain.cpp
+++ b/stl/src/dllmain.cpp
@@ -5,6 +5,6 @@
 
 #include <Windows.h>
 
-extern "C" BOOL APIENTRY DllMain(HMODULE /* hModule */, DWORD /* ul_reason_for_call */, LPVOID /* lpReserved */) {
+extern "C" BOOL APIENTRY DllMain(HMODULE, DWORD, LPVOID) noexcept {
     return TRUE;
 }

--- a/stl/src/excptptr.cpp
+++ b/stl/src/excptptr.cpp
@@ -69,21 +69,10 @@ namespace {
     }
 #else // ^^^ !defined(_M_CEE) / defined(_M_CEE), TRANSITION, VSO-1153256 vvv
     template <class _Ty>
-    int __stdcall _Immortalize_impl(void*, void* _Storage_ptr, void**) noexcept {
-        // adapt True Placement New to _Execute_once
-        ::new (_Storage_ptr) _Ty();
-        return 1;
-    }
-
-    template <class _Ty>
     _Ty& _Immortalize() { // return a reference to an object that will live forever
         static once_flag _Flag;
         alignas(_Ty) static unsigned char _Storage[sizeof(_Ty)];
-        if (!_Execute_once(_Flag, _Immortalize_impl<_Ty>, &_Storage)) {
-            // _Execute_once should never fail if the callback never fails
-            _CSTD abort();
-        }
-
+        call_once(_Flag, [&_Storage] { ::new (static_cast<void*>(&_Storage)) _Ty(); });
         return reinterpret_cast<_Ty&>(_Storage);
     }
 #endif // ^^^ !defined(_M_CEE_PURE) && defined(_M_CEE), TRANSITION, VSO-1153256 ^^^

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -94,35 +94,15 @@ namespace Concurrency {
 
         public:
             IAsyncCausalityTracerStatics* get() const {
-                return m_causalityAPIs;
+                return nullptr;
             }
 
             AsyncCausalityTracer() : m_causalityAPIs(nullptr), m_isSupported(false) {}
 
-            void release() {
-                if (m_causalityAPIs) {
-                    APTTYPE aptType;
-                    APTTYPEQUALIFIER aptTypeQualifier;
-                    if (CoGetApartmentType(&aptType, &aptTypeQualifier) == S_OK) {
-                        // Release causality APIs only if current apartment is still RoInitialized
-                        m_causalityAPIs->Release();
-                        m_causalityAPIs = nullptr;
-                        m_isSupported   = false;
-                    }
-                }
-            }
+            void release() {}
 
             bool isCausalitySupported() {
-                std::call_once(m_stateFlag, [this] {
-                    ComPtr<IAsyncCausalityTracerStatics> causalityAPIs;
-                    if (SUCCEEDED(GetActivationFactory(
-                            HStringReference(RuntimeClass_Windows_Foundation_Diagnostics_AsyncCausalityTracer).Get(),
-                            &causalityAPIs))) {
-                        this->m_causalityAPIs = causalityAPIs.Detach();
-                        this->m_isSupported   = true;
-                    }
-                });
-                return m_isSupported;
+                return false;
             }
         };
         AsyncCausalityTracer asyncCausalityTracer;

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -111,17 +111,7 @@ namespace Concurrency {
         const GUID PPLTaskCausalityPlatformID = {
             0x7A76B220, 0xA758, 0x4E6E, 0xB0, 0xE0, 0xD7, 0xC6, 0xD7, 0x4A, 0x88, 0xFE};
 
-        _CRTIMP2 void __thiscall _TaskEventLogger::_LogScheduleTask(bool _IsContinuation) {
-            if (asyncCausalityTracer.isCausalitySupported()) {
-                asyncCausalityTracer.get()->TraceOperationCreation(CausalityTraceLevel_Required,
-                    CausalitySource_Library, PPLTaskCausalityPlatformID, reinterpret_cast<unsigned long long>(_M_task),
-                    HStringReference(_IsContinuation ? L"Concurrency::PPLTask::ScheduleContinuationTask"
-                                                     : L"Concurrency::PPLTask::ScheduleTask")
-                        .Get(),
-                    0);
-                _M_scheduled = true;
-            }
-        }
+        _CRTIMP2 void __thiscall _TaskEventLogger::_LogScheduleTask(bool _IsContinuation) {}
         _CRTIMP2 void __thiscall _TaskEventLogger::_LogTaskCompleted() {
             if (_M_scheduled) {
                 AsyncStatus status;
@@ -132,49 +122,16 @@ namespace Concurrency {
                 } else {
                     status = AsyncStatus::Canceled;
                 }
-
-                if (asyncCausalityTracer.isCausalitySupported()) {
-                    asyncCausalityTracer.get()->TraceOperationCompletion(CausalityTraceLevel_Required,
-                        CausalitySource_Library, PPLTaskCausalityPlatformID,
-                        reinterpret_cast<unsigned long long>(_M_task), status);
-                }
             }
         }
 
-        _CRTIMP2 void __thiscall _TaskEventLogger::_LogCancelTask() {
-            if (asyncCausalityTracer.isCausalitySupported()) {
-                asyncCausalityTracer.get()->TraceOperationRelation(CausalityTraceLevel_Important,
-                    CausalitySource_Library, PPLTaskCausalityPlatformID, reinterpret_cast<unsigned long long>(_M_task),
-                    CausalityRelation_Cancel);
-            }
-        }
+        _CRTIMP2 void __thiscall _TaskEventLogger::_LogCancelTask() {}
 
-        _CRTIMP2 void __thiscall _TaskEventLogger::_LogTaskExecutionCompleted() {
-            if (asyncCausalityTracer.isCausalitySupported()) {
-                asyncCausalityTracer.get()->TraceSynchronousWorkCompletion(CausalityTraceLevel_Required,
-                    CausalitySource_Library, CausalitySynchronousWork_CompletionNotification);
-            }
-        }
+        _CRTIMP2 void __thiscall _TaskEventLogger::_LogTaskExecutionCompleted() {}
 
-        _CRTIMP2 void __thiscall _TaskEventLogger::_LogWorkItemStarted() {
-            if (asyncCausalityTracer.isCausalitySupported()) {
-                asyncCausalityTracer.get()->TraceSynchronousWorkStart(CausalityTraceLevel_Required,
-                    CausalitySource_Library, PPLTaskCausalityPlatformID, reinterpret_cast<unsigned long long>(_M_task),
-                    CausalitySynchronousWork_Execution);
-            }
-        }
+        _CRTIMP2 void __thiscall _TaskEventLogger::_LogWorkItemStarted() {}
 
-        _CRTIMP2 void __thiscall _TaskEventLogger::_LogWorkItemCompleted() {
-            if (asyncCausalityTracer.isCausalitySupported()) {
-                asyncCausalityTracer.get()->TraceSynchronousWorkCompletion(
-                    CausalityTraceLevel_Required, CausalitySource_Library, CausalitySynchronousWork_Execution);
-
-                asyncCausalityTracer.get()->TraceSynchronousWorkStart(CausalityTraceLevel_Required,
-                    CausalitySource_Library, PPLTaskCausalityPlatformID, reinterpret_cast<unsigned long long>(_M_task),
-                    CausalitySynchronousWork_CompletionNotification);
-                _M_taskPostEventStarted = true;
-            }
-        }
+        _CRTIMP2 void __thiscall _TaskEventLogger::_LogWorkItemCompleted() {}
 
 #else // ^^^ defined(_CRT_APP) / !defined(_CRT_APP) vvv
         _CRTIMP2 void __thiscall _TaskEventLogger::_LogScheduleTask(bool) {}

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -82,35 +82,6 @@ namespace Concurrency {
         } // namespace platform
 
 #if defined(_CRT_APP)
-        using namespace ABI::Windows::Foundation;
-        using namespace ABI::Windows::Foundation::Diagnostics;
-        using namespace Microsoft::WRL;
-        using namespace Microsoft::WRL::Wrappers;
-
-        class AsyncCausalityTracer {
-            IAsyncCausalityTracerStatics* m_causalityAPIs;
-            std::once_flag m_stateFlag;
-            bool m_isSupported;
-
-        public:
-            IAsyncCausalityTracerStatics* get() const {
-                return nullptr;
-            }
-
-            AsyncCausalityTracer() : m_causalityAPIs(nullptr), m_isSupported(false) {}
-
-            void release() {}
-
-            bool isCausalitySupported() {
-                return false;
-            }
-        };
-        AsyncCausalityTracer asyncCausalityTracer;
-
-        // GUID used for identifying causality logs from PPLTask
-        const GUID PPLTaskCausalityPlatformID = {
-            0x7A76B220, 0xA758, 0x4E6E, 0xB0, 0xE0, 0xD7, 0xC6, 0xD7, 0x4A, 0x88, 0xFE};
-
         _CRTIMP2 void __thiscall _TaskEventLogger::_LogScheduleTask(bool _IsContinuation) {}
         _CRTIMP2 void __thiscall _TaskEventLogger::_LogTaskCompleted() {}
 

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -112,18 +112,7 @@ namespace Concurrency {
             0x7A76B220, 0xA758, 0x4E6E, 0xB0, 0xE0, 0xD7, 0xC6, 0xD7, 0x4A, 0x88, 0xFE};
 
         _CRTIMP2 void __thiscall _TaskEventLogger::_LogScheduleTask(bool _IsContinuation) {}
-        _CRTIMP2 void __thiscall _TaskEventLogger::_LogTaskCompleted() {
-            if (_M_scheduled) {
-                AsyncStatus status;
-                if (_M_task->_IsCompleted()) {
-                    status = AsyncStatus::Completed;
-                } else if (_M_task->_HasUserException()) {
-                    status = AsyncStatus::Error;
-                } else {
-                    status = AsyncStatus::Canceled;
-                }
-            }
-        }
+        _CRTIMP2 void __thiscall _TaskEventLogger::_LogTaskCompleted() {}
 
         _CRTIMP2 void __thiscall _TaskEventLogger::_LogCancelTask() {}
 

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -113,23 +113,15 @@ namespace Concurrency {
             }
 
             bool isCausalitySupported() {
-                // TRANSITION, ABI
-                _Execute_once(
-                    m_stateFlag,
-                    [](void*, void* _This_raw, void**) -> int {
-                        const auto _This = static_cast<AsyncCausalityTracer*>(_This_raw);
-                        ComPtr<IAsyncCausalityTracerStatics> causalityAPIs;
-                        if (SUCCEEDED(GetActivationFactory(
-                                HStringReference(RuntimeClass_Windows_Foundation_Diagnostics_AsyncCausalityTracer)
-                                    .Get(),
-                                &causalityAPIs))) {
-                            _This->m_causalityAPIs = causalityAPIs.Detach();
-                            _This->m_isSupported   = true;
-                        }
-
-                        return 1;
-                    },
-                    this);
+                std::call_once(m_stateFlag, [this] {
+                    ComPtr<IAsyncCausalityTracerStatics> causalityAPIs;
+                    if (SUCCEEDED(GetActivationFactory(
+                            HStringReference(RuntimeClass_Windows_Foundation_Diagnostics_AsyncCausalityTracer).Get(),
+                            &causalityAPIs))) {
+                        this->m_causalityAPIs = causalityAPIs.Detach();
+                        this->m_isSupported   = true;
+                    }
+                });
                 return m_isSupported;
             }
         };

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -81,19 +81,6 @@ namespace Concurrency {
 
         } // namespace platform
 
-#if defined(_CRT_APP)
-        _CRTIMP2 void __thiscall _TaskEventLogger::_LogScheduleTask(bool _IsContinuation) {}
-        _CRTIMP2 void __thiscall _TaskEventLogger::_LogTaskCompleted() {}
-
-        _CRTIMP2 void __thiscall _TaskEventLogger::_LogCancelTask() {}
-
-        _CRTIMP2 void __thiscall _TaskEventLogger::_LogTaskExecutionCompleted() {}
-
-        _CRTIMP2 void __thiscall _TaskEventLogger::_LogWorkItemStarted() {}
-
-        _CRTIMP2 void __thiscall _TaskEventLogger::_LogWorkItemCompleted() {}
-
-#else // ^^^ defined(_CRT_APP) / !defined(_CRT_APP) vvv
         _CRTIMP2 void __thiscall _TaskEventLogger::_LogScheduleTask(bool) {}
 
         _CRTIMP2 void __thiscall _TaskEventLogger::_LogTaskCompleted() {}
@@ -105,7 +92,6 @@ namespace Concurrency {
         _CRTIMP2 void __thiscall _TaskEventLogger::_LogWorkItemStarted() {}
 
         _CRTIMP2 void __thiscall _TaskEventLogger::_LogWorkItemCompleted() {}
-#endif // ^^^ !defined(_CRT_APP) ^^^
 
 #if defined(_CRT_APP) || defined(UNDOCKED_WINDOWS_UCRT)
         using namespace ABI::Windows::Foundation;

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -320,9 +320,3 @@ namespace Concurrency {
 #endif // ^^^ !defined(_CRT_APP) ^^^
 
 } // namespace Concurrency
-
-#ifdef _CRT_APP
-extern "C" void __cdecl __crtCleanupCausalityStaticFactories() {
-    Concurrency::details::asyncCausalityTracer.release();
-}
-#endif

--- a/stl/src/xonce.cpp
+++ b/stl/src/xonce.cpp
@@ -8,6 +8,9 @@
 #include <Windows.h>
 
 _STD_BEGIN
+// Returns BOOL, nonzero to indicate success, zero for failure
+using _Execute_once_fp_t = int(__stdcall*)(void*, void*, void**);
+
 // TRANSITION, ABI
 _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Execute_once(
     once_flag& _Flag, _Execute_once_fp_t _Callback, void* _Pv) noexcept { // wrap Win32 InitOnceExecuteOnce()

--- a/stl/src/xonce.cpp
+++ b/stl/src/xonce.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _Execute_once function
-
 #include <mutex>
 
 #include <Windows.h>
@@ -11,7 +9,7 @@ _STD_BEGIN
 // Returns BOOL, nonzero to indicate success, zero for failure
 using _Execute_once_fp_t = int(__stdcall*)(void*, void*, void**);
 
-// TRANSITION, ABI
+// TRANSITION, ABI: _Execute_once() is preserved for binary compatibility
 _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Execute_once(
     once_flag& _Flag, _Execute_once_fp_t _Callback, void* _Pv) noexcept { // wrap Win32 InitOnceExecuteOnce()
     static_assert(sizeof(_Flag._Opaque) == sizeof(INIT_ONCE), "invalid size");

--- a/stl/src/xonce.cpp
+++ b/stl/src/xonce.cpp
@@ -7,33 +7,14 @@
 
 #include <Windows.h>
 
-namespace {
-    struct _Xfg_trampoline_parameter {
-        void* _Pv;
-        _STD _Execute_once_fp_t _Callback;
-    };
-} // unnamed namespace
-
 _STD_BEGIN
-
 // TRANSITION, ABI
 _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Execute_once(
     once_flag& _Flag, _Execute_once_fp_t _Callback, void* _Pv) noexcept { // wrap Win32 InitOnceExecuteOnce()
     static_assert(sizeof(_Flag._Opaque) == sizeof(INIT_ONCE), "invalid size");
 
-    // _Execute_once_fp_t and PINIT_ONCE_FN differ in type signature, therefore
-    // we introduce _Xfg_trampoline which has PINIT_ONCE_FN's type signature and
-    // calls into _Callback as an _Execute_once_fp_t for XFG compatibility.
-
-    _Xfg_trampoline_parameter _Trampoline_parameter = {_Pv, _Callback};
-
-    PINIT_ONCE_FN _Xfg_trampoline = [](PINIT_ONCE _InitOnce, PVOID _Parameter, PVOID* _Context) {
-        const auto _Trampoline_parameter = static_cast<_Xfg_trampoline_parameter*>(_Parameter);
-        return static_cast<BOOL>(_Trampoline_parameter->_Callback(_InitOnce, _Trampoline_parameter->_Pv, _Context));
-    };
-
     return InitOnceExecuteOnce(
-        reinterpret_cast<PINIT_ONCE>(&_Flag._Opaque), _Xfg_trampoline, &_Trampoline_parameter, nullptr);
+        reinterpret_cast<PINIT_ONCE>(&_Flag._Opaque), reinterpret_cast<PINIT_ONCE_FN>(_Callback), _Pv, nullptr);
 }
 
 [[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL


### PR DESCRIPTION
* Revert #1318, #1356, and #1398 (`xonce.cpp` only) while preserving #1194's change to directly call `InitOnceExecuteOnce()`.
  + XFG is being removed from the toolset (see internal VSO-1726733, MSVC-PR-462377). Some things like ASan still need to handle XFG hashes, but things like the STL no longer need unusual contortions. I checked with @amyw-msft and she said this should be okay to remove.
* Drop `_Execute_once()` usage in `ppltasks.cpp`, and as an associated change, simplify `dllmain.cpp`.
  + See below.
* Use `call_once()` instead of `_Execute_once()` in `excptptr.cpp`.
  + After #3861, they're both declared by `xcall_once.h`, so we don't need to use the internal `_Execute_once()` (with a worse interface) anymore.
  + We're `using namespace std;` so we don't need qualification.
  + Because `call_once()` supports stateful lambdas, we can simply capture `_Storage` by reference.
  + We're in `stl/src` so we don't really need to worry about True Placement New being hijacked, but let's `static_cast<void*>` to preserve the original code and make it clear that we are indeed invoking True Placement New.
* Remove declarations from `xcall_once.h`.
  + They were guarded by `_CRTBLD` after #3935, so this doesn't affect users.
  + The definition of `_Execute_once()` exactly repeated the declaration, except for `extern "C++"` which is fine to drop because `stl/src` is always built classically.
* Update comment now that `_Execute_once()` is unused.
  + Also drop pointless "`_Execute_once` function" comment.

The code removal in `ppltasks.cpp` looks like I'm just thoughtlessly annihilating a bunch of weird logic, but I actually performed it carefully step-by-step. This code was `_CRT_APP`-only, for "async causality tracing". As far as I can tell (looking up TFS changesets 923210 on 2013-04-02 and 1175213 on 2014-02-07, as this code was introduced and moved around), this was implemented in the hopes of improving debugging, back when ppltasks was envisioned as a top-level feature and the new major model for concurrency, instead of the minor implementation detail of `<future>` that it eventually ended up as. The async causality logging mechanism never existed for Desktop, and was conditionally available for App (it depended on OS version). That is, it's not necessary for any of `<future>`'s work, and this was so undocumented, I strongly doubt that anyone aside from the original developer in 2013-2014 ever used it (I certainly haven't).

Attempting to use real `std::call_once()` here ran into problems, because App didn't have access to the necessary Windows API functions that power it instead of `_Execute_once()`. In theory that could have been solvable with enough MSBuild effort, but I think that we can simply remove this code, and I'm willing to take the risk and bear any potential servicing burden if I'm wrong.

This doesn't affect bincompat because it's internal to `stl/src` and There's Only One STL (`stl/src` is always consistent with itself). I also verified that the exports of `binaries\x86chk\bin\i386\app\msvcp140d_app.dll` are unchanged.

The steps that I followed started by considering what would happen if the causality APIs weren't detected as present, and then performing logical transformations after that.

* Step 1: Suppose we can never get the causality APIs.
  + In `AsyncCausalityTracer`, `m_causalityAPIs` and `m_isSupported` are private data members, initialized to `nullptr` and `false`. Let's pretend that `GetActivationFactory()` fails. In that case, the data members remain `nullptr` and `false` forever. Accordingly, we can hardcode the return values of `get()` and `isCausalitySupported()`. Also, `release()` becomes a no-op.
* Step 2: There are no causality static factories to cleanup.
  + Now that `asyncCausalityTracer.release()` is a no-op, `__crtCleanupCausalityStaticFactories()` does nothing. Note that it wasn't exported - it was used only for cross-TU interaction between `ppltasks.cpp` and `dllmain.cpp` in `stl/src`, so we can remove this function outright. Then, `dllmain.cpp` becomes a stub.
* Step 3: `asyncCausalityTracer.isCausalitySupported()` is always `false` now.
  + Accordingly, we can drop all of these branches. Note that this drops `_M_scheduled = true;`.
* Step 4: `_M_scheduled` is always `false` now.
  + In `<ppltasks.h>`, `_TaskEventLogger`'s constructor assigned `_M_scheduled = false;`, and we previously removed the only way for it to be set to `true`. Accordingly, we can drop this branch.
* Step 5: Remove unused code.
  + From bottom to top:
  + `const GUID PPLTaskCausalityPlatformID` wasn't exported. It had internal linkage, so we can definitely drop it.
  + Nothing mentions the `AsyncCausalityTracer` type or the `asyncCausalityTracer` global variable anymore.
  + Finally, we don't need the using-directives here.
* Step 6: Unify Vulcan and Romulus.
  + The app implementation of `_TaskEventLogger` is now identical to the desktop implementation (after we drop the `_IsContinuation` parameter name). Unify them.
* Pre-merge with #4106 by marking `extern "C"` `DllMain()` as `noexcept`.
  + Also drop the commented-out parameter names to avoid wrapping; they aren't useful when the function does nothing.
