### PR TITLE
Turn niebloids into function objects

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -292,10 +292,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Fun>
     using for_each_result = in_fun_result<_In, _Fun>;
 
-    class _For_each_fn : private _Not_quite_object {
+    class _For_each_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirectly_unary_invocable<projected<_It, _Pj>> _Fn>
         constexpr for_each_result<_It, _Fn> operator()(_It _First, _Se _Last, _Fn _Func, _Pj _Proj = {}) const {
@@ -337,15 +335,13 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _For_each_fn for_each{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _For_each_fn for_each;
 
     _EXPORT_STD template <class _In, class _Fun>
     using for_each_n_result = in_fun_result<_In, _Fun>;
 
-    class _For_each_n_fn : private _Not_quite_object {
+    class _For_each_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, class _Pj = identity, indirectly_unary_invocable<projected<_It, _Pj>> _Fn>
         constexpr for_each_n_result<_It, _Fn> operator()(
             _It _First, iter_difference_t<_It> _Count, _Fn _Func, _Pj _Proj = {}) const {
@@ -364,7 +360,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _For_each_n_fn for_each_n{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _For_each_n_fn for_each_n;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -431,10 +427,8 @@ _NODISCARD _FwdIt adjacent_find(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Count_fn : private _Not_quite_object {
+    class _Count_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity>
             requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
         _NODISCARD constexpr iter_difference_t<_It> operator()(
@@ -485,7 +479,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Count_fn count{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Count_fn count;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -512,10 +506,8 @@ _NODISCARD _Iter_diff_t<_FwdIt> count_if(_ExPo&& _Exec, _FwdIt _First, _FwdIt _L
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Count_if_fn : private _Not_quite_object {
+    class _Count_if_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr iter_difference_t<_It> operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -549,7 +541,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Count_if_fn count_if{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Count_if_fn count_if;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -666,7 +658,7 @@ namespace ranges {
         return true;
     }
 
-    class _Equal_fn : private _Not_quite_object {
+    class _Equal_fn {
     private:
         template <class _It1, class _Se1, class _It2, class _Se2, class _Pr, class _Pj1, class _Pj2>
         _NODISCARD static constexpr bool _Equal_4(
@@ -692,8 +684,6 @@ namespace ranges {
         }
 
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::equal_to, class _Pj1 = identity, class _Pj2 = identity>
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
@@ -741,7 +731,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Equal_fn equal{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Equal_fn equal;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -841,10 +831,8 @@ _NODISCARD _CONSTEXPR20 bool is_permutation(_FwdIt1 _First1, _FwdIt1 _Last1, _Fw
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Is_permutation_fn : private _Not_quite_object {
+    class _Is_permutation_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It1, sentinel_for<_It1> _Se1, forward_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pj1 = identity, class _Pj2 = identity,
             indirect_equivalence_relation<projected<_It1, _Pj1>, projected<_It2, _Pj2>> _Pr = ranges::equal_to>
@@ -1109,7 +1097,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Is_permutation_fn is_permutation{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Is_permutation_fn is_permutation;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -1134,10 +1122,8 @@ _NODISCARD bool all_of(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) noexcept
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _All_of_fn : private _Not_quite_object {
+    class _All_of_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -1170,7 +1156,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _All_of_fn all_of{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _All_of_fn all_of;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -1196,10 +1182,8 @@ _NODISCARD bool any_of(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) noexcept
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Any_of_fn : private _Not_quite_object {
+    class _Any_of_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -1232,7 +1216,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Any_of_fn any_of{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Any_of_fn any_of;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -1258,10 +1242,8 @@ _NODISCARD bool none_of(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) noexcep
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _None_of_fn : private _Not_quite_object {
+    class _None_of_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -1294,13 +1276,11 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _None_of_fn none_of{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _None_of_fn none_of;
 
 #if _HAS_CXX23
-    class _Contains_fn : private _Not_quite_object {
+    class _Contains_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity>
             requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, const _Ty& _Val, _Pj _Proj = {}) const {
@@ -1319,12 +1299,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Contains_fn contains{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Contains_fn contains;
 
-    class _Contains_subrange_fn : private _Not_quite_object {
+    class _Contains_subrange_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It1, sentinel_for<_It1> _Se1, forward_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::equal_to, class _Pj1 = identity, class _Pj2 = identity>
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
@@ -1357,16 +1335,14 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Contains_subrange_fn contains_subrange{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Contains_subrange_fn contains_subrange;
 #endif // _HAS_CXX23
 
     _EXPORT_STD template <class _In, class _Out>
     using copy_n_result = in_out_result<_In, _Out>;
 
-    class _Copy_n_fn : private _Not_quite_object {
+    class _Copy_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, weakly_incrementable _Out>
             requires indirectly_copyable<_It, _Out>
         constexpr copy_n_result<_It, _Out> operator()(_It _First, iter_difference_t<_It> _Count, _Out _Result) const {
@@ -1389,15 +1365,13 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Copy_n_fn copy_n{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Copy_n_fn copy_n;
 
     _EXPORT_STD template <class _In, class _Out>
     using copy_backward_result = in_out_result<_In, _Out>;
 
-    class _Copy_backward_fn : private _Not_quite_object {
+    class _Copy_backward_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It1, sentinel_for<_It1> _Se1, bidirectional_iterator _It2>
             requires indirectly_copyable<_It1, _It2>
         constexpr copy_backward_result<_It1, _It2> operator()(_It1 _First, _Se1 _Last, _It2 _Result) const {
@@ -1418,7 +1392,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Copy_backward_fn copy_backward{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Copy_backward_fn copy_backward;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -1455,10 +1429,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using copy_if_result = in_out_result<_In, _Out>;
 
-    class _Copy_if_fn : private _Not_quite_object {
+    class _Copy_if_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
             requires indirectly_copyable<_It, _Out>
@@ -1503,7 +1475,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Copy_if_fn copy_if{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Copy_if_fn copy_if;
 
     _EXPORT_STD template <class _In, class _Out>
     using move_result = in_out_result<_In, _Out>;
@@ -1526,10 +1498,8 @@ namespace ranges {
         return {_STD move(_First), _STD move(_Result)};
     }
 
-    class _Move_fn : private _Not_quite_object {
+    class _Move_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
             requires indirectly_movable<_It, _Out>
         constexpr move_result<_It, _Out> operator()(_It _First, _Se _Last, _Out _Result) const {
@@ -1553,7 +1523,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Move_fn move{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Move_fn move;
 
     _EXPORT_STD template <class _In, class _Out>
     using move_backward_result = in_out_result<_In, _Out>;
@@ -1575,10 +1545,8 @@ namespace ranges {
         return _Result;
     }
 
-    class _Move_backward_fn : private _Not_quite_object {
+    class _Move_backward_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It1, sentinel_for<_It1> _Se1, bidirectional_iterator _It2>
             requires indirectly_movable<_It1, _It2>
         constexpr move_backward_result<_It1, _It2> operator()(_It1 _First, _Se1 _Last, _It2 _Result) const {
@@ -1599,7 +1567,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Move_backward_fn move_backward{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Move_backward_fn move_backward;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -1645,10 +1613,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out1, class _Out2>
     using partition_copy_result = in_out_out_result<_In, _Out1, _Out2>;
 
-    class _Partition_copy_fn : private _Not_quite_object {
+    class _Partition_copy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out1, weakly_incrementable _Out2,
             class _Pj = identity, indirect_unary_predicate<projected<_It, _Pj>> _Pr>
             requires indirectly_copyable<_It, _Out1> && indirectly_copyable<_It, _Out2>
@@ -1704,7 +1670,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Partition_copy_fn partition_copy{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Partition_copy_fn partition_copy;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -1742,10 +1708,8 @@ _NODISCARD bool is_partitioned(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) 
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Is_partitioned_fn : private _Not_quite_object {
+    class _Is_partitioned_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -1788,7 +1752,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Is_partitioned_fn is_partitioned{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Is_partitioned_fn is_partitioned;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -1818,10 +1782,8 @@ _NODISCARD _CONSTEXPR20 _FwdIt partition_point(_FwdIt _First, _FwdIt _Last, _Pr 
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Partition_point_fn : private _Not_quite_object {
+    class _Partition_point_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -1910,7 +1872,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Partition_point_fn partition_point{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Partition_point_fn partition_point;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -2103,10 +2065,8 @@ _NODISCARD _FwdIt search_n(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt _Las
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Search_n_fn : private _Not_quite_object {
+    class _Search_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pr = ranges::equal_to,
             class _Pj = identity>
             requires indirectly_comparable<_It, const _Ty*, _Pr, _Pj>
@@ -2258,13 +2218,11 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Search_n_fn search_n{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Search_n_fn search_n;
 
 #if _HAS_CXX23
-    class _Starts_with_fn : private _Not_quite_object {
+    class _Starts_with_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::equal_to, class _Pj1 = identity, class _Pj2 = identity>
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
@@ -2319,12 +2277,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Starts_with_fn starts_with{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Starts_with_fn starts_with;
 
-    class _Ends_with_fn : private _Not_quite_object {
+    class _Ends_with_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::equal_to, class _Pj1 = identity, class _Pj2 = identity>
             requires (forward_iterator<_It1> || sized_sentinel_for<_Se1, _It1>)
@@ -2542,7 +2498,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Ends_with_fn ends_with{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Ends_with_fn ends_with;
 
     template <class _Fn>
     class _Flipped {
@@ -2577,10 +2533,8 @@ namespace ranges {
     _EXPORT_STD template <class _It, class _Ty>
     using fold_left_first_with_iter_result = in_value_result<_It, _Ty>;
 
-    class _Fold_left_with_iter_fn : private _Not_quite_object {
+    class _Fold_left_with_iter_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, _Indirectly_binary_left_foldable<_Ty, _It> _Fn>
         _NODISCARD constexpr auto operator()(_It _First, _Se _Last, _Ty _Init, _Fn _Func) const {
             _Adl_verify_range(_First, _Last);
@@ -2621,12 +2575,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Fold_left_with_iter_fn fold_left_with_iter{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Fold_left_with_iter_fn fold_left_with_iter;
 
-    class _Fold_left_fn : private _Not_quite_object {
+    class _Fold_left_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, _Indirectly_binary_left_foldable<_Ty, _It> _Fn>
         _NODISCARD constexpr auto operator()(_It _First, _Se _Last, _Ty _Init, _Fn _Func) const {
             return _RANGES fold_left_with_iter(_STD move(_First), _Last, _STD move(_Init), _Pass_fn(_Func)).value;
@@ -2638,12 +2590,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Fold_left_fn fold_left{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Fold_left_fn fold_left;
 
-    class _Fold_left_first_with_iter_fn : private _Not_quite_object {
+    class _Fold_left_first_with_iter_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se,
             _Indirectly_binary_left_foldable<iter_value_t<_It>, _It> _Fn>
             requires constructible_from<iter_value_t<_It>, iter_reference_t<_It>>
@@ -2688,13 +2638,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Fold_left_first_with_iter_fn fold_left_first_with_iter{
-        _Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Fold_left_first_with_iter_fn fold_left_first_with_iter;
 
-    class _Fold_left_first_fn : private _Not_quite_object {
+    class _Fold_left_first_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se,
             _Indirectly_binary_left_foldable<iter_value_t<_It>, _It> _Fn>
             requires constructible_from<iter_value_t<_It>, iter_reference_t<_It>>
@@ -2709,7 +2656,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Fold_left_first_fn fold_left_first{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Fold_left_first_fn fold_left_first;
 
     template <class _It, class _Se, class _Ty, class _Fn>
     _NODISCARD constexpr auto _Fold_right_unchecked(_It _First, _Se _Last, _Ty _Init, _Fn _Func) {
@@ -2730,10 +2677,8 @@ namespace ranges {
         }
     }
 
-    class _Fold_right_fn : private _Not_quite_object {
+    class _Fold_right_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It, sentinel_for<_It> _Se, class _Ty,
             _Indirectly_binary_right_foldable<_Ty, _It> _Fn>
         _NODISCARD constexpr auto operator()(_It _First, _Se _Last, _Ty _Init, _Fn _Func) const {
@@ -2748,12 +2693,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Fold_right_fn fold_right{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Fold_right_fn fold_right;
 
-    class _Fold_right_last_fn : private _Not_quite_object {
+    class _Fold_right_last_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It, sentinel_for<_It> _Se,
             _Indirectly_binary_right_foldable<iter_value_t<_It>, _It> _Fn>
             requires constructible_from<iter_value_t<_It>, iter_reference_t<_It>>
@@ -2789,12 +2732,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Fold_right_last_fn fold_right_last{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Fold_right_last_fn fold_right_last;
 
-    class _Find_last_fn : private _Not_quite_object {
+    class _Find_last_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity>
             requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
         _NODISCARD constexpr subrange<_It> operator()(_It _First, _Se _Last, const _Ty& _Value, _Pj _Proj = {}) const {
@@ -2870,13 +2811,11 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Find_last_fn find_last{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Find_last_fn find_last;
 
     template <bool _Search_for>
-    class _Find_last_if_fn : private _Not_quite_object {
+    class _Find_last_if_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr subrange<_It> operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -2953,8 +2892,8 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Find_last_if_fn<true> find_last_if{_Not_quite_object::_Construct_tag{}};
-    _EXPORT_STD inline constexpr _Find_last_if_fn<false> find_last_if_not{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Find_last_if_fn<true> find_last_if;
+    _EXPORT_STD inline constexpr _Find_last_if_fn<false> find_last_if_not;
 #endif // _HAS_CXX23
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
@@ -3061,7 +3000,7 @@ _NODISCARD _FwdIt1 find_end(_ExPo&& _Exec, _FwdIt1 _First1, _FwdIt1 _Last1, _Fwd
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Find_end_fn : private _Not_quite_object {
+    class _Find_end_fn {
     private:
         template <class _It1, class _It2, class _Pr, class _Pj1, class _Pj2>
         _NODISCARD static constexpr subrange<_It1> _Random_access_sized_ranges(_It1 _First1,
@@ -3164,8 +3103,6 @@ namespace ranges {
         }
 
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It1, sentinel_for<_It1> _Se1, forward_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::equal_to, class _Pj1 = identity, class _Pj2 = identity>
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
@@ -3218,7 +3155,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Find_end_fn find_end{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Find_end_fn find_end;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -3265,10 +3202,8 @@ _NODISCARD _FwdIt1 find_first_of(_ExPo&& _Exec, const _FwdIt1 _First1, const _Fw
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Find_first_of_fn : private _Not_quite_object {
+    class _Find_first_of_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, forward_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::equal_to, class _Pj1 = identity, class _Pj2 = identity>
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
@@ -3321,15 +3256,13 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Find_first_of_fn find_first_of{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Find_first_of_fn find_first_of;
 
     _EXPORT_STD template <class _In1, class _In2>
     using swap_ranges_result = in_in_result<_In1, _In2>;
 
-    class _Swap_ranges_fn : private _Not_quite_object {
+    class _Swap_ranges_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2>
             requires indirectly_swappable<_It1, _It2>
         constexpr swap_ranges_result<_It1, _It2> operator()(
@@ -3413,7 +3346,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Swap_ranges_fn swap_ranges{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Swap_ranges_fn swap_ranges;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -3498,10 +3431,8 @@ namespace ranges {
     _EXPORT_STD template <class _In1, class _In2, class _Out>
     using binary_transform_result = in_in_out_result<_In1, _In2, _Out>;
 
-    class _Transform_fn : private _Not_quite_object {
+    class _Transform_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out, copy_constructible _Fn,
             class _Pj = identity>
             requires indirectly_writable<_Out, indirect_result_t<_Fn&, projected<_It, _Pj>>>
@@ -3595,7 +3526,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Transform_fn transform{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Transform_fn transform;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -3620,10 +3551,8 @@ void replace(_ExPo&& _Exec, _FwdIt _First, _FwdIt _Last, const _Ty& _Oldval,
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Replace_fn : private _Not_quite_object {
+    class _Replace_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty1, class _Ty2, class _Pj = identity>
             requires indirectly_writable<_It, const _Ty2&>
                   && indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty1*>
@@ -3670,7 +3599,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Replace_fn replace{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Replace_fn replace;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -3694,10 +3623,8 @@ void replace_if(_ExPo&& _Exec, _FwdIt _First, _FwdIt _Last, _Pr _Pred, const _Ty
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Replace_if_fn : private _Not_quite_object {
+    class _Replace_if_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
             requires indirectly_writable<_It, const _Ty&>
@@ -3743,7 +3670,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Replace_if_fn replace_if{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Replace_if_fn replace_if;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -3783,10 +3710,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using replace_copy_result = in_out_result<_In, _Out>;
 
-    class _Replace_copy_fn : private _Not_quite_object {
+    class _Replace_copy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty1, class _Ty2, output_iterator<const _Ty2&> _Out,
             class _Pj = identity>
             requires indirectly_copyable<_It, _Out>
@@ -3837,7 +3762,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Replace_copy_fn replace_copy{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Replace_copy_fn replace_copy;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -3878,10 +3803,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using replace_copy_if_result = in_out_result<_In, _Out>;
 
-    class _Replace_copy_if_fn : private _Not_quite_object {
+    class _Replace_copy_if_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, output_iterator<const _Ty&> _Out,
             class _Pj = identity, indirect_unary_predicate<projected<_It, _Pj>> _Pr>
             requires indirectly_copyable<_It, _Out>
@@ -3931,12 +3854,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Replace_copy_if_fn replace_copy_if{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Replace_copy_if_fn replace_copy_if;
 
-    class _Fill_fn : private _Not_quite_object {
+    class _Fill_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <class _Ty, output_iterator<const _Ty&> _It, sentinel_for<_It> _Se>
         constexpr _It operator()(_It _First, _Se _Last, const _Ty& _Value) const {
             _Adl_verify_range(_First, _Last);
@@ -3976,12 +3897,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Fill_fn fill{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Fill_fn fill;
 
-    class _Generate_fn : private _Not_quite_object {
+    class _Generate_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_or_output_iterator _Out, sentinel_for<_Out> _Se, copy_constructible _Fn>
             requires invocable<_Fn&> && indirectly_writable<_Out, invoke_result_t<_Fn&>>
         constexpr _Out operator()(_Out _First, _Se _Last, _Fn _Gen) const {
@@ -4017,12 +3936,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Generate_fn generate{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Generate_fn generate;
 
-    class _Generate_n_fn : private _Not_quite_object {
+    class _Generate_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_or_output_iterator _Out, copy_constructible _Fn>
             requires invocable<_Fn&> && indirectly_writable<_Out, invoke_result_t<_Fn&>>
         constexpr _Out operator()(_Out _First, iter_difference_t<_Out> _Count, _Fn _Gen) const {
@@ -4040,7 +3957,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Generate_n_fn generate_n{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Generate_n_fn generate_n;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -4158,10 +4075,8 @@ _NODISCARD_REMOVE_ALG _FwdIt remove_if(_ExPo&& _Exec, _FwdIt _First, _FwdIt _Las
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Remove_fn : private _Not_quite_object {
+    class _Remove_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <permutable _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity>
             requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
         _NODISCARD_REMOVE_ALG constexpr subrange<_It> operator()(
@@ -4209,12 +4124,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Remove_fn remove{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Remove_fn remove;
 
-    class _Remove_if_fn : private _Not_quite_object {
+    class _Remove_if_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <permutable _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD_REMOVE_ALG constexpr subrange<_It> operator()(
@@ -4262,15 +4175,13 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Remove_if_fn remove_if{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Remove_if_fn remove_if;
 
     _EXPORT_STD template <class _In, class _Out>
     using remove_copy_result = in_out_result<_In, _Out>;
 
-    class _Remove_copy_fn : private _Not_quite_object {
+    class _Remove_copy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out, class _Ty, class _Pj = identity>
             requires indirectly_copyable<_It, _Out>
                   && indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
@@ -4322,15 +4233,13 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Remove_copy_fn remove_copy{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Remove_copy_fn remove_copy;
 
     _EXPORT_STD template <class _In, class _Out>
     using remove_copy_if_result = in_out_result<_In, _Out>;
 
-    class _Remove_copy_if_fn : private _Not_quite_object {
+    class _Remove_copy_if_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
             requires indirectly_copyable<_It, _Out>
@@ -4382,7 +4291,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Remove_copy_if_fn remove_copy_if{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Remove_copy_if_fn remove_copy_if;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -4436,10 +4345,8 @@ _NODISCARD_UNIQUE_ALG _FwdIt unique(_ExPo&&, _FwdIt _First, _FwdIt _Last) noexce
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Unique_fn : private _Not_quite_object {
+    class _Unique_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <permutable _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_equivalence_relation<projected<_It, _Pj>> _Pr = ranges::equal_to>
         _NODISCARD_UNIQUE_ALG constexpr subrange<_It> operator()(
@@ -4497,7 +4404,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Unique_fn unique{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Unique_fn unique;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -4602,10 +4509,8 @@ namespace ranges {
     concept _Can_reread_or_store = forward_iterator<_It> || _Is_input_with_value_type<_Out, iter_value_t<_It>>
                                 || indirectly_copyable_storable<_It, _Out>;
 
-    class _Unique_copy_fn : private _Not_quite_object {
+    class _Unique_copy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out, class _Pj = identity,
             indirect_equivalence_relation<projected<_It, _Pj>> _Pr = ranges::equal_to>
             requires indirectly_copyable<_It, _Out> && _Can_reread_or_store<_It, _Out>
@@ -4693,7 +4598,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Unique_copy_fn unique_copy{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Unique_copy_fn unique_copy;
 
     // concept-constrained for strict enforcement as it is used by several algorithms
     template <bidirectional_iterator _It>
@@ -4731,10 +4636,8 @@ namespace ranges {
         }
     }
 
-    class _Reverse_fn : private _Not_quite_object {
+    class _Reverse_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It, sentinel_for<_It> _Se>
             requires permutable<_It>
         constexpr _It operator()(_It _First, _Se _Last) const {
@@ -4755,7 +4658,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Reverse_fn reverse{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Reverse_fn reverse;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -4820,10 +4723,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using reverse_copy_result = in_out_result<_In, _Out>;
 
-    class _Reverse_copy_fn : private _Not_quite_object {
+    class _Reverse_copy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
             requires indirectly_copyable<_It, _Out>
         constexpr reverse_copy_result<_It, _Out> operator()(_It _First, _Se _Last, _Out _Result) const {
@@ -4893,7 +4794,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Reverse_copy_fn reverse_copy{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Reverse_copy_fn reverse_copy;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -4977,10 +4878,8 @@ namespace ranges {
         }
     }
 
-    class _Rotate_fn : private _Not_quite_object {
+    class _Rotate_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <permutable _It, sentinel_for<_It> _Se>
         constexpr subrange<_It> operator()(_It _First, _It _Mid, _Se _Last) const {
             _Adl_verify_range(_First, _Mid);
@@ -5003,7 +4902,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Rotate_fn rotate{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Rotate_fn rotate;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -5036,10 +4935,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using rotate_copy_result = in_out_result<_In, _Out>;
 
-    class _Rotate_copy_fn : private _Not_quite_object {
+    class _Rotate_copy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
             requires indirectly_copyable<_It, _Out>
         constexpr rotate_copy_result<_It, _Out> operator()(_It _First, _It _Mid, _Se _Last, _Out _Result) const {
@@ -5080,7 +4977,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Rotate_copy_fn rotate_copy{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Rotate_copy_fn rotate_copy;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -5244,10 +5141,8 @@ concept uniform_random_bit_generator = invocable<_Ty&>
 // clang-format on
 
 namespace ranges {
-    class _Sample_fn : private _Not_quite_object {
+    class _Sample_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out, class _Urng>
             requires (forward_iterator<_It> || random_access_iterator<_Out>)
                   && indirectly_copyable<_It, _Out> && uniform_random_bit_generator<remove_reference_t<_Urng>>
@@ -5342,7 +5237,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Sample_fn sample{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Sample_fn sample;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -5378,10 +5273,8 @@ void shuffle(_RanIt _First, _RanIt _Last, _Urng&& _Func) { // shuffle [_First, _
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Shuffle_fn : private _Not_quite_object {
+    class _Shuffle_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Urng>
             requires permutable<_It> && uniform_random_bit_generator<remove_reference_t<_Urng>>
         _It operator()(_It _First, _Se _Last, _Urng&& _Func) const {
@@ -5430,7 +5323,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Shuffle_fn shuffle{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Shuffle_fn shuffle;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -5592,10 +5485,8 @@ _FwdIt shift_right(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Iter_diff_t<_FwdIt> _P
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 namespace ranges {
-    class _Shift_left_fn : private _Not_quite_object {
+    class _Shift_left_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <permutable _It, sentinel_for<_It> _Se>
         constexpr subrange<_It> operator()(_It _First, const _Se _Last, iter_difference_t<_It> _Pos_to_shift) const {
             _STL_ASSERT(_Pos_to_shift >= 0, "shift count must be non-negative (N4950 [alg.shift]/1)");
@@ -5655,12 +5546,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Shift_left_fn shift_left{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Shift_left_fn shift_left;
 
-    class _Shift_right_fn : private _Not_quite_object {
+    class _Shift_right_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <permutable _It, sentinel_for<_It> _Se>
         constexpr subrange<_It> operator()(_It _First, const _Se _Last, iter_difference_t<_It> _Pos_to_shift) const {
             _Adl_verify_range(_First, _Last);
@@ -5814,7 +5703,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Shift_right_fn shift_right{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Shift_right_fn shift_right;
 } // namespace ranges
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
@@ -5882,10 +5771,8 @@ _FwdIt partition(_ExPo&& _Exec, _FwdIt _First, _FwdIt _Last, _Pr _Pred) noexcept
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Partition_fn : private _Not_quite_object {
+    class _Partition_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <permutable _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         constexpr subrange<_It> operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -5958,7 +5845,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Partition_fn partition{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Partition_fn partition;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -6169,10 +6056,8 @@ namespace ranges {
         return _RANGES _Rotate_unchecked(_STD move(_First), _STD move(_Mid), _STD move(_Last)).begin();
     }
 
-    class _Stable_partition_fn : private _Not_quite_object {
+    class _Stable_partition_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
             requires permutable<_It>
@@ -6328,7 +6213,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Stable_partition_fn stable_partition{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Stable_partition_fn stable_partition;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -6389,10 +6274,8 @@ namespace ranges {
         *(_First + _Hole) = _STD forward<_Ty>(_Val); // drop _Val into final hole
     }
 
-    class _Push_heap_fn : private _Not_quite_object {
+    class _Push_heap_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -6435,7 +6318,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Push_heap_fn push_heap{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Push_heap_fn push_heap;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -6568,10 +6451,8 @@ namespace ranges {
         _RANGES _Pop_heap_hole_unchecked(_STD move(_First), _Last, _Last, _STD move(_Val), _Pred, _Proj, _Proj);
     }
 
-    class _Pop_heap_fn : private _Not_quite_object {
+    class _Pop_heap_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -6597,7 +6478,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Pop_heap_fn pop_heap{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Pop_heap_fn pop_heap;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -6642,10 +6523,8 @@ namespace ranges {
         }
     }
 
-    class _Make_heap_fn : private _Not_quite_object {
+    class _Make_heap_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -6671,7 +6550,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Make_heap_fn make_heap{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Make_heap_fn make_heap;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -6766,10 +6645,8 @@ namespace ranges {
         return _First + _Off;
     }
 
-    class _Is_heap_fn : private _Not_quite_object {
+    class _Is_heap_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_strict_weak_order<projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -6792,12 +6669,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Is_heap_fn is_heap{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Is_heap_fn is_heap;
 
-    class _Is_heap_until_fn : private _Not_quite_object {
+    class _Is_heap_until_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_strict_weak_order<projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -6819,7 +6694,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Is_heap_until_fn is_heap_until{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Is_heap_until_fn is_heap_until;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -6862,10 +6737,8 @@ namespace ranges {
         }
     }
 
-    class _Sort_heap_fn : private _Not_quite_object {
+    class _Sort_heap_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -6891,7 +6764,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Sort_heap_fn sort_heap{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Sort_heap_fn sort_heap;
 
     template <class _It, class _Ty, class _Pr, class _Pj>
     _NODISCARD constexpr _It _Lower_bound_unchecked(
@@ -6916,10 +6789,8 @@ namespace ranges {
         return _First;
     }
 
-    class _Lower_bound_fn : private _Not_quite_object {
+    class _Lower_bound_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity,
             indirect_strict_weak_order<const _Ty*, projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr _It operator()(
@@ -6944,7 +6815,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Lower_bound_fn lower_bound{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Lower_bound_fn lower_bound;
 
     template <class _It, class _Ty, class _Pr, class _Pj>
     _NODISCARD constexpr _It _Upper_bound_unchecked(
@@ -6969,10 +6840,8 @@ namespace ranges {
         return _First;
     }
 
-    class _Upper_bound_fn : private _Not_quite_object {
+    class _Upper_bound_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity,
             indirect_strict_weak_order<const _Ty*, projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr _It operator()(
@@ -6997,7 +6866,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Upper_bound_fn upper_bound{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Upper_bound_fn upper_bound;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -7046,10 +6915,8 @@ _NODISCARD _CONSTEXPR20 pair<_FwdIt, _FwdIt> equal_range(_FwdIt _First, _FwdIt _
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Equal_range_fn : private _Not_quite_object {
+    class _Equal_range_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity,
             indirect_strict_weak_order<const _Ty*, projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr subrange<_It> operator()(
@@ -7103,7 +6970,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Equal_range_fn equal_range{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Equal_range_fn equal_range;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -7125,10 +6992,8 @@ _NODISCARD _CONSTEXPR20 bool binary_search(_FwdIt _First, _FwdIt _Last, const _T
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Binary_search_fn : private _Not_quite_object {
+    class _Binary_search_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity,
             indirect_strict_weak_order<const _Ty*, projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr bool operator()(
@@ -7152,7 +7017,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Binary_search_fn binary_search{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Binary_search_fn binary_search;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -7252,10 +7117,8 @@ namespace ranges {
     _EXPORT_STD template <class _In1, class _In2, class _Out>
     using merge_result = in_in_out_result<_In1, _In2, _Out>;
 
-    class _Merge_fn : private _Not_quite_object {
+    class _Merge_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             weakly_incrementable _Out, class _Pr = ranges::less, class _Pj1 = identity, class _Pj2 = identity>
             requires mergeable<_It1, _It2, _Out, _Pr, _Pj1, _Pj2>
@@ -7322,7 +7185,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Merge_fn merge{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Merge_fn merge;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -7811,10 +7674,8 @@ namespace ranges {
         }
     }
 
-    class _Inplace_merge_fn : private _Not_quite_object {
+    class _Inplace_merge_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         _It operator()(_It _First, _It _Mid, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -7911,7 +7772,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Inplace_merge_fn inplace_merge{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Inplace_merge_fn inplace_merge;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -8242,10 +8103,8 @@ namespace ranges {
         }
     }
 
-    class _Sort_fn : private _Not_quite_object {
+    class _Sort_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -8309,7 +8168,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Sort_fn sort{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Sort_fn sort;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -8508,10 +8367,8 @@ void stable_sort(_ExPo&& _Exec, _BidIt _First, _BidIt _Last) noexcept /* termina
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Stable_sort_fn : private _Not_quite_object {
+    class _Stable_sort_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -8755,7 +8612,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Stable_sort_fn stable_sort{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Stable_sort_fn stable_sort;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -8808,10 +8665,8 @@ void partial_sort(_ExPo&&, _RanIt _First, _RanIt _Mid, _RanIt _Last) noexcept /*
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Partial_sort_fn : private _Not_quite_object {
+    class _Partial_sort_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         constexpr _It operator()(_It _First, _It _Mid, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -8876,7 +8731,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Partial_sort_fn partial_sort{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Partial_sort_fn partial_sort;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -8945,10 +8800,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using partial_sort_copy_result = in_out_result<_In, _Out>;
 
-    class _Partial_sort_copy_fn : private _Not_quite_object {
+    class _Partial_sort_copy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, random_access_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::less, class _Pj1 = identity, class _Pj2 = identity>
             requires indirectly_copyable<_It1, _It2> && sortable<_It2, _Pr, _Pj2>
@@ -9024,7 +8877,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Partial_sort_copy_fn partial_sort_copy{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Partial_sort_copy_fn partial_sort_copy;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -9080,10 +8933,8 @@ void nth_element(_ExPo&&, _RanIt _First, _RanIt _Nth, _RanIt _Last) noexcept /* 
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Nth_element_fn : private _Not_quite_object {
+    class _Nth_element_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         constexpr _It operator()(_It _First, _It _Nth, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -9148,7 +8999,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Nth_element_fn nth_element{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Nth_element_fn nth_element;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -9206,10 +9057,8 @@ _NODISCARD bool includes(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _Firs
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Includes_fn : private _Not_quite_object {
+    class _Includes_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pj1 = identity, class _Pj2 = identity,
             indirect_strict_weak_order<projected<_It1, _Pj1>, projected<_It2, _Pj2>> _Pr = ranges::less>
@@ -9272,7 +9121,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Includes_fn includes{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Includes_fn includes;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -9344,10 +9193,8 @@ namespace ranges {
     _EXPORT_STD template <class _In1, class _In2, class _Out>
     using set_union_result = in_in_out_result<_In1, _In2, _Out>;
 
-    class _Set_union_fn : private _Not_quite_object {
+    class _Set_union_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             weakly_incrementable _Out, class _Pr = ranges::less, class _Pj1 = identity, class _Pj2 = identity>
             requires mergeable<_It1, _It2, _Out, _Pr, _Pj1, _Pj2>
@@ -9411,7 +9258,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Set_union_fn set_union{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Set_union_fn set_union;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -9471,10 +9318,8 @@ namespace ranges {
     _EXPORT_STD template <class _In1, class _In2, class _Out>
     using set_intersection_result = in_in_out_result<_In1, _In2, _Out>;
 
-    class _Set_intersection_fn : private _Not_quite_object {
+    class _Set_intersection_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             weakly_incrementable _Out, class _Pr = ranges::less, class _Pj1 = identity, class _Pj2 = identity>
             requires mergeable<_It1, _It2, _Out, _Pr, _Pj1, _Pj2>
@@ -9544,7 +9389,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Set_intersection_fn set_intersection{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Set_intersection_fn set_intersection;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -9605,10 +9450,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using set_difference_result = in_out_result<_In, _Out>;
 
-    class _Set_difference_fn : private _Not_quite_object {
+    class _Set_difference_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             weakly_incrementable _Out, class _Pr = ranges::less, class _Pj1 = identity, class _Pj2 = identity>
             requires mergeable<_It1, _It2, _Out, _Pr, _Pj1, _Pj2>
@@ -9674,7 +9517,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Set_difference_fn set_difference{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Set_difference_fn set_difference;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -9749,10 +9592,8 @@ namespace ranges {
     _EXPORT_STD template <class _In1, class _In2, class _Out>
     using set_symmetric_difference_result = in_in_out_result<_In1, _In2, _Out>;
 
-    class _Set_symmetric_difference_fn : private _Not_quite_object {
+    class _Set_symmetric_difference_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             weakly_incrementable _Out, class _Pr = ranges::less, class _Pj1 = identity, class _Pj2 = identity>
             requires mergeable<_It1, _It2, _Out, _Pr, _Pj1, _Pj2>
@@ -9826,8 +9667,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Set_symmetric_difference_fn set_symmetric_difference{
-        _Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Set_symmetric_difference_fn set_symmetric_difference;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -9925,10 +9765,8 @@ namespace ranges {
     _EXPORT_STD template <class _Ty>
     using minmax_element_result = min_max_result<_Ty>;
 
-    class _Minmax_element_fn : private _Not_quite_object {
+    class _Minmax_element_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_strict_weak_order<projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr minmax_element_result<_It> operator()(
@@ -10019,7 +9857,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Minmax_element_fn minmax_element{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Minmax_element_fn minmax_element;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -10066,10 +9904,8 @@ namespace ranges {
     _EXPORT_STD template <class _Ty>
     using minmax_result = min_max_result<_Ty>;
 
-    class _Minmax_fn : private _Not_quite_object {
+    class _Minmax_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <class _Ty, class _Pj = identity,
             indirect_strict_weak_order<projected<const _Ty*, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr minmax_result<const _Ty&> operator()(const _Ty& _Left _MSVC_LIFETIMEBOUND,
@@ -10221,7 +10057,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Minmax_fn minmax{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Minmax_fn minmax;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -10267,10 +10103,8 @@ namespace ranges {
     _EXPORT_STD template <class _In>
     using next_permutation_result = in_found_result<_In>;
 
-    class _Next_permutation_fn : private _Not_quite_object {
+    class _Next_permutation_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         constexpr next_permutation_result<_It> operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -10325,7 +10159,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Next_permutation_fn next_permutation{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Next_permutation_fn next_permutation;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -10371,10 +10205,8 @@ namespace ranges {
     _EXPORT_STD template <class _In>
     using prev_permutation_result = in_found_result<_In>;
 
-    class _Prev_permutation_fn : private _Not_quite_object {
+    class _Prev_permutation_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         constexpr prev_permutation_result<_It> operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -10429,7 +10261,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Prev_permutation_fn prev_permutation{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Prev_permutation_fn prev_permutation;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -10496,10 +10328,8 @@ _NODISCARD bool is_sorted(_ExPo&& _Exec, _FwdIt _First, _FwdIt _Last) noexcept /
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Is_sorted_fn : private _Not_quite_object {
+    class _Is_sorted_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_strict_weak_order<projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -10520,12 +10350,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Is_sorted_fn is_sorted{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Is_sorted_fn is_sorted;
 
-    class _Is_sorted_until_fn : private _Not_quite_object {
+    class _Is_sorted_until_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_strict_weak_order<projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -10545,7 +10373,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Is_sorted_until_fn is_sorted_until{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Is_sorted_until_fn is_sorted_until;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -10585,10 +10413,8 @@ _NODISCARD constexpr const _Ty& clamp(const _Ty& _Val, const _Ty& _Min_val, cons
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Clamp_fn : private _Not_quite_object {
+    class _Clamp_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <class _Ty, class _Pj = identity,
             indirect_strict_weak_order<projected<const _Ty*, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr const _Ty& operator()(
@@ -10611,12 +10437,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Clamp_fn clamp{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Clamp_fn clamp;
 
-    class _Lexicographical_compare_fn : private _Not_quite_object {
+    class _Lexicographical_compare_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pj1 = identity, class _Pj2 = identity,
             indirect_strict_weak_order<projected<_It1, _Pj1>, projected<_It2, _Pj2>> _Pr = ranges::less>
@@ -10689,8 +10513,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Lexicographical_compare_fn lexicographical_compare{
-        _Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Lexicographical_compare_fn lexicographical_compare;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -52,10 +52,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using uninitialized_copy_result = in_out_result<_In, _Out>;
 
-    class _Uninitialized_copy_fn : private _Not_quite_object {
+    class _Uninitialized_copy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, _No_throw_forward_iterator _Out,
             _No_throw_sentinel_for<_Out> _OSe>
             requires constructible_from<iter_value_t<_Out>, iter_reference_t<_It>>
@@ -120,7 +118,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_copy_fn uninitialized_copy{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_copy_fn uninitialized_copy;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -170,10 +168,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using uninitialized_copy_n_result = in_out_result<_In, _Out>;
 
-    class _Uninitialized_copy_n_fn : private _Not_quite_object {
+    class _Uninitialized_copy_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, _No_throw_forward_iterator _Out, _No_throw_sentinel_for<_Out> _OSe>
             requires constructible_from<iter_value_t<_Out>, iter_reference_t<_It>>
         uninitialized_copy_n_result<_It, _Out> operator()(
@@ -214,7 +210,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_copy_n_fn uninitialized_copy_n{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_copy_n_fn uninitialized_copy_n;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -243,10 +239,8 @@ _NoThrowFwdIt uninitialized_move(_ExPo&&, const _FwdIt _First, const _FwdIt _Las
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Uninitialized_move_fn : private _Not_quite_object {
+    class _Uninitialized_move_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, _No_throw_forward_iterator _Out,
             _No_throw_sentinel_for<_Out> _OSe>
             requires constructible_from<iter_value_t<_Out>, iter_rvalue_reference_t<_It>>
@@ -275,7 +269,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_move_fn uninitialized_move{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_move_fn uninitialized_move;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -336,10 +330,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using uninitialized_move_n_result = in_out_result<_In, _Out>;
 
-    class _Uninitialized_move_n_fn : private _Not_quite_object {
+    class _Uninitialized_move_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, _No_throw_forward_iterator _Out, _No_throw_sentinel_for<_Out> _OSe>
             requires constructible_from<iter_value_t<_Out>, iter_rvalue_reference_t<_It>>
         uninitialized_move_n_result<_It, _Out> operator()(
@@ -380,12 +372,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_move_n_fn uninitialized_move_n{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_move_n_fn uninitialized_move_n;
 
-    class _Uninitialized_fill_fn : private _Not_quite_object {
+    class _Uninitialized_fill_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <_No_throw_forward_iterator _It, _No_throw_sentinel_for<_It> _Se, class _Ty>
             requires constructible_from<iter_value_t<_It>, const _Ty&>
         _It operator()(_It _First, _Se _Last, const _Ty& _Val) const {
@@ -434,7 +424,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_fill_fn uninitialized_fill{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_fill_fn uninitialized_fill;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -489,10 +479,8 @@ _NoThrowFwdIt uninitialized_fill_n(
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Uninitialized_fill_n_fn : private _Not_quite_object {
+    class _Uninitialized_fill_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <_No_throw_forward_iterator _It, class _Ty>
             requires constructible_from<iter_value_t<_It>, const _Ty&>
         _It operator()(_It _First, iter_difference_t<_It> _Count, const _Ty& _Val) const {
@@ -525,12 +513,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_fill_n_fn uninitialized_fill_n{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_fill_n_fn uninitialized_fill_n;
 
-    class _Construct_at_fn : private _Not_quite_object {
+    class _Construct_at_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         // clang-format off
         template <class _Ty, class... _Types>
             requires requires(_Ty* _Ptr, _Types&&... _Args) {
@@ -544,16 +530,14 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Construct_at_fn construct_at{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Construct_at_fn construct_at;
 
     template <_No_throw_input_iterator _It, _No_throw_sentinel_for<_It> _Se>
         requires destructible<iter_value_t<_It>>
     _NODISCARD constexpr _It _Destroy_unchecked(_It _First, _Se _Last) noexcept;
 
-    class _Destroy_at_fn : private _Not_quite_object {
+    class _Destroy_at_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <destructible _Ty>
         constexpr void operator()(_Ty* const _Location) const noexcept {
             if constexpr (is_array_v<_Ty>) {
@@ -564,7 +548,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Destroy_at_fn destroy_at{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Destroy_at_fn destroy_at;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -595,10 +579,8 @@ namespace ranges {
         return _First;
     }
 
-    class _Destroy_fn : private _Not_quite_object {
+    class _Destroy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <_No_throw_input_iterator _It, _No_throw_sentinel_for<_It> _Se>
             requires destructible<iter_value_t<_It>>
         constexpr _It operator()(_It _First, _Se _Last) const noexcept {
@@ -618,7 +600,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Destroy_fn destroy{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Destroy_fn destroy;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -648,10 +630,8 @@ _NoThrowFwdIt destroy_n(_ExPo&& _Exec, _NoThrowFwdIt _First, _Diff _Count_raw) n
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Destroy_n_fn : private _Not_quite_object {
+    class _Destroy_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <_No_throw_input_iterator _It>
             requires destructible<iter_value_t<_It>>
         constexpr _It operator()(_It _First, const iter_difference_t<_It> _Count_raw) const noexcept {
@@ -676,7 +656,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Destroy_n_fn destroy_n{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Destroy_n_fn destroy_n;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -701,10 +681,8 @@ void uninitialized_default_construct(_ExPo&& _Exec, _NoThrowFwdIt _First, _NoThr
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Uninitialized_default_construct_fn : private _Not_quite_object {
+    class _Uninitialized_default_construct_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <_No_throw_forward_iterator _It, _No_throw_sentinel_for<_It> _Se>
             requires default_initializable<iter_value_t<_It>>
         _It operator()(_It _First, _Se _Last) const {
@@ -747,8 +725,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_default_construct_fn uninitialized_default_construct{
-        _Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_default_construct_fn uninitialized_default_construct;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -781,10 +758,8 @@ _NoThrowFwdIt uninitialized_default_construct_n(
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Uninitialized_default_construct_n_fn : private _Not_quite_object {
+    class _Uninitialized_default_construct_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <_No_throw_forward_iterator _It>
             requires default_initializable<iter_value_t<_It>>
         _It operator()(_It _First, iter_difference_t<_It> _Count) const {
@@ -808,8 +783,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_default_construct_n_fn uninitialized_default_construct_n{
-        _Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_default_construct_n_fn uninitialized_default_construct_n;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -837,10 +811,8 @@ void uninitialized_value_construct(_ExPo&& _Exec, _NoThrowFwdIt _First, _NoThrow
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Uninitialized_value_construct_fn : private _Not_quite_object {
+    class _Uninitialized_value_construct_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <_No_throw_forward_iterator _It, _No_throw_sentinel_for<_It> _Se>
             requires default_initializable<iter_value_t<_It>>
         _It operator()(_It _First, _Se _Last) const {
@@ -881,8 +853,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_value_construct_fn uninitialized_value_construct{
-        _Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_value_construct_fn uninitialized_value_construct;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -904,10 +875,8 @@ _NoThrowFwdIt uninitialized_value_construct_n(
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Uninitialized_value_construct_n_fn : private _Not_quite_object {
+    class _Uninitialized_value_construct_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <_No_throw_forward_iterator _It>
             requires default_initializable<iter_value_t<_It>>
         _It operator()(_It _First, iter_difference_t<_It> _Count) const {
@@ -931,8 +900,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_value_construct_n_fn uninitialized_value_construct_n{
-        _Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_value_construct_n_fn uninitialized_value_construct_n;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -530,10 +530,8 @@ namespace ranges {
     _EXPORT_STD template <class _Out, class _Ty>
     using iota_result = out_value_result<_Out, _Ty>;
 
-    class _Iota_fn : private _Not_quite_object {
+    class _Iota_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_or_output_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Ty>
             requires indirectly_writable<_It, const _Ty&>
         constexpr iota_result<_It, _Ty> operator()(_It _First, _Se _Last, _Ty _Val) const {
@@ -565,7 +563,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Iota_fn iota{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Iota_fn iota;
 } // namespace ranges
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3644,6 +3644,10 @@ namespace ranges {
         return static_cast<_Ty&>(_Val);
     }
 
+    struct _Construct_tag {
+        explicit _Construct_tag() = default;
+    };
+
     _EXPORT_STD template <input_range _Vw>
         requires view<_Vw> && input_range<range_reference_t<_Vw>>
     class join_view;
@@ -3653,7 +3657,7 @@ namespace ranges {
     private:
         struct _Cache_wrapper {
             template <input_iterator _Iter>
-            constexpr _Cache_wrapper(_Not_quite_object::_Construct_tag, const _Iter& _It) noexcept(
+            constexpr _Cache_wrapper(_Construct_tag, const _Iter& _It) noexcept(
                 noexcept(static_cast<decltype(_Val)>(*_It)))
                 : _Val(*_It) {}
 
@@ -3772,7 +3776,7 @@ namespace ranges {
                 if constexpr (_Deref_is_glvalue) {
                     return *_Get_outer();
                 } else {
-                    return _Parent->_Inner._Emplace(_Not_quite_object::_Construct_tag{}, _Get_outer())._Val;
+                    return _Parent->_Inner._Emplace(_Construct_tag{}, _Get_outer())._Val;
                 }
             }
 
@@ -4091,7 +4095,7 @@ namespace ranges {
     private:
         struct _Cache_wrapper {
             template <input_iterator _Iter>
-            constexpr _Cache_wrapper(_Not_quite_object::_Construct_tag, const _Iter& _It) noexcept(
+            constexpr _Cache_wrapper(_Construct_tag, const _Iter& _It) noexcept(
                 noexcept(static_cast<decltype(_Val)>(*_It)))
                 : _Val(*_It) {}
 
@@ -4224,7 +4228,7 @@ namespace ranges {
                 if constexpr (_Deref_is_glvalue) {
                     return _As_lvalue(*_Get_outer());
                 } else {
-                    return _Parent->_Inner._Emplace(_Not_quite_object::_Construct_tag{}, _Get_outer())._Val;
+                    return _Parent->_Inner._Emplace(_Construct_tag{}, _Get_outer())._Val;
                 }
             }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3217,35 +3217,8 @@ namespace ranges {
         { _RANGES data(__r) } -> same_as<add_pointer_t<range_reference_t<_Rng>>>;
     };
 
-    class _Not_quite_object {
+    class _Advance_fn {
     public:
-        // Some overload sets in the library have the property that their constituent function templates are not visible
-        // to argument-dependent name lookup (ADL) and that they inhibit ADL when found via unqualified name lookup.
-        // This property allows these overload sets to be implemented as function objects. We derive such function
-        // objects from this type to remove some typical object-ish behaviors which helps users avoid depending on their
-        // non-specified object-ness.
-
-        struct _Construct_tag {
-            explicit _Construct_tag() = default;
-        };
-
-        _Not_quite_object() = delete;
-
-        constexpr explicit _Not_quite_object(_Construct_tag) noexcept {}
-
-        _Not_quite_object(const _Not_quite_object&)            = delete;
-        _Not_quite_object& operator=(const _Not_quite_object&) = delete;
-
-        void operator&() const = delete;
-
-    protected:
-        ~_Not_quite_object() = default;
-    };
-
-    class _Advance_fn : private _Not_quite_object {
-    public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_or_output_iterator _It>
         constexpr void operator()(_It& _Where, iter_difference_t<_It> _Off) const {
             if constexpr (random_access_iterator<_It>) {
@@ -3331,12 +3304,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Advance_fn advance{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Advance_fn advance;
 
-    class _Distance_fn : private _Not_quite_object {
+    class _Distance_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <class _It, sentinel_for<_It> _Se>
             requires (!sized_sentinel_for<_Se, _It>)
         _NODISCARD constexpr iter_difference_t<_It> operator()(_It _First, _Se _Last) const
@@ -3384,7 +3355,7 @@ namespace ranges {
         static constexpr bool _Nothrow_size<_Rng> = noexcept(_RANGES size(_STD declval<_Rng&>()));
     };
 
-    _EXPORT_STD inline constexpr _Distance_fn distance{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Distance_fn distance;
 
     class _Ssize_fn {
     public:
@@ -3402,10 +3373,8 @@ namespace ranges {
         _EXPORT_STD inline constexpr _Ssize_fn ssize;
     }
 
-    class _Next_fn : private _Not_quite_object {
+    class _Next_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_or_output_iterator _It>
         _NODISCARD constexpr _It operator()(_It _Where) const {
             ++_Where;
@@ -3431,12 +3400,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Next_fn next{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Next_fn next;
 
-    class _Prev_fn : private _Not_quite_object {
+    class _Prev_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It>
         _NODISCARD constexpr _It operator()(_It _Where) const {
             --_Where;
@@ -3458,7 +3425,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Prev_fn prev{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Prev_fn prev;
 
     template <forward_iterator _It, sentinel_for<_It> _Se>
     _NODISCARD constexpr _It _Find_last_iterator(
@@ -4754,10 +4721,8 @@ namespace ranges {
         return {_STD move(_First), _STD move(_Result)};
     }
 
-    class _Copy_fn : private _Not_quite_object {
+    class _Copy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
             requires indirectly_copyable<_It, _Out>
         constexpr copy_result<_It, _Out> operator()(_It _First, _Se _Last, _Out _Result) const {
@@ -4779,7 +4744,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Copy_fn copy{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Copy_fn copy;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -5127,10 +5092,8 @@ _FwdIt fill_n(_ExPo&&, _FwdIt _Dest, _Diff _Count_raw, const _Ty& _Val) noexcept
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Fill_n_fn : private _Not_quite_object {
+    class _Fill_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <class _Ty, output_iterator<const _Ty&> _It>
         constexpr _It operator()(_It _First, iter_difference_t<_It> _Count, const _Ty& _Value) const {
             if (_Count > 0) {
@@ -5160,7 +5123,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Fill_n_fn fill_n{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Fill_n_fn fill_n;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -5431,10 +5394,8 @@ namespace ranges {
         return {_STD move(_First1), _STD move(_First2)};
     }
 
-    class _Mismatch_fn : private _Not_quite_object {
+    class _Mismatch_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         // clang-format off
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::equal_to, class _Pj1 = identity, class _Pj2 = identity>
@@ -5499,7 +5460,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Mismatch_fn mismatch{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Mismatch_fn mismatch;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -5947,10 +5908,8 @@ namespace ranges {
         return _First;
     }
 
-    class _Find_fn : private _Not_quite_object {
+    class _Find_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         // clang-format off
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity>
             requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
@@ -5977,7 +5936,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Find_fn find{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Find_fn find;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -6370,10 +6329,8 @@ namespace ranges {
         return _First;
     }
 
-    class _Find_if_fn : private _Not_quite_object {
+    class _Find_if_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -6397,12 +6354,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Find_if_fn find_if{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Find_if_fn find_if;
 
-    class _Find_if_not_fn : private _Not_quite_object {
+    class _Find_if_not_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -6444,12 +6399,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Find_if_not_fn find_if_not{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Find_if_not_fn find_if_not;
 
-    class _Adjacent_find_fn : private _Not_quite_object {
+    class _Adjacent_find_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_binary_predicate<projected<_It, _Pj>, projected<_It, _Pj>> _Pr = ranges::equal_to>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -6495,7 +6448,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Adjacent_find_fn adjacent_find{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Adjacent_find_fn adjacent_find;
 
     // clang-format off
     template <class _It1, class _It2, class _Se2, class _Pr, class _Pj1, class _Pj2>
@@ -6537,10 +6490,8 @@ namespace ranges {
         return {true, _STD move(_First1)};
     }
 
-    class _Search_fn : private _Not_quite_object {
+    class _Search_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It1, sentinel_for<_It1> _Se1, forward_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::equal_to, class _Pj1 = identity, class _Pj2 = identity>
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
@@ -6636,7 +6587,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Search_fn search{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Search_fn search;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -6746,10 +6697,8 @@ namespace ranges {
         return _Found;
     }
 
-    class _Max_element_fn : private _Not_quite_object {
+    class _Max_element_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_strict_weak_order<projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -6768,7 +6717,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Max_element_fn max_element{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Max_element_fn max_element;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -6794,10 +6743,8 @@ namespace ranges {
         sizeof(_It) <= 2 * sizeof(iter_value_t<_It>)
         && (is_trivially_copyable_v<_It> || !is_trivially_copyable_v<iter_value_t<_It>>);
 
-    class _Max_fn : private _Not_quite_object {
+    class _Max_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <class _Ty, class _Pj = identity,
             indirect_strict_weak_order<projected<const _Ty*, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr const _Ty& operator()(
@@ -6843,7 +6790,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Max_fn max{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Max_fn max;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -6942,10 +6889,8 @@ namespace ranges {
         return _Found;
     }
 
-    class _Min_element_fn : private _Not_quite_object {
+    class _Min_element_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_strict_weak_order<projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -6964,7 +6909,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Min_element_fn min_element{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Min_element_fn min_element;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -6984,10 +6929,8 @@ _NODISCARD constexpr _Ty(min)(initializer_list<_Ty> _Ilist) {
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Min_fn : private _Not_quite_object {
+    class _Min_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <class _Ty, class _Pj = identity,
             indirect_strict_weak_order<projected<const _Ty*, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr const _Ty& operator()(
@@ -7033,7 +6976,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Min_fn min{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Min_fn min;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 


### PR DESCRIPTION
The core language doesn't seem to be any closer to providing first-class overload sets, and we're starting to get "bug" reports (DevCom-10450794) since the other standard library implementations simply implement these as (semiregular?) function objects.

This change removes the type `std::_Not_quite_object`, promoting its member `_Construct_tag` to namespace scope since it is also used in the implementation of `join_view` and `join_with_view`.

Fixes #4097
