### PR TITLE
Fix and simplify the feature-test macro test

### DIFF
--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -5,7 +5,6 @@
 
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
 
-// LIBRARY FEATURE-TEST MACROS
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_adaptor_iterator_pair_constructor == 202106L);
 #elif defined(__cpp_lib_adaptor_iterator_pair_constructor)

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -7,12 +7,10 @@
 
 // LIBRARY FEATURE-TEST MACROS
 #if _HAS_CXX23
-#ifndef __cpp_lib_adaptor_iterator_pair_constructor
-#error __cpp_lib_adaptor_iterator_pair_constructor is not defined
-#elif __cpp_lib_adaptor_iterator_pair_constructor != 202106L
-#error __cpp_lib_adaptor_iterator_pair_constructor is not 202106L
-#else
+#ifdef __cpp_lib_adaptor_iterator_pair_constructor
 STATIC_ASSERT(__cpp_lib_adaptor_iterator_pair_constructor == 202106L);
+#else
+#error __cpp_lib_adaptor_iterator_pair_constructor is not defined
 #endif
 #else
 #ifdef __cpp_lib_adaptor_iterator_pair_constructor
@@ -20,21 +18,17 @@ STATIC_ASSERT(__cpp_lib_adaptor_iterator_pair_constructor == 202106L);
 #endif
 #endif
 
-#ifndef __cpp_lib_addressof_constexpr
-#error __cpp_lib_addressof_constexpr is not defined
-#elif __cpp_lib_addressof_constexpr != 201603L
-#error __cpp_lib_addressof_constexpr is not 201603L
-#else
+#ifdef __cpp_lib_addressof_constexpr
 STATIC_ASSERT(__cpp_lib_addressof_constexpr == 201603L);
+#else
+#error __cpp_lib_addressof_constexpr is not defined
 #endif
 
 #if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_algorithm_iterator_requirements
-#error __cpp_lib_algorithm_iterator_requirements is not defined
-#elif __cpp_lib_algorithm_iterator_requirements != 202207L
-#error __cpp_lib_algorithm_iterator_requirements is not 202207L
-#else
+#ifdef __cpp_lib_algorithm_iterator_requirements
 STATIC_ASSERT(__cpp_lib_algorithm_iterator_requirements == 202207L);
+#else
+#error __cpp_lib_algorithm_iterator_requirements is not defined
 #endif
 #else
 #ifdef __cpp_lib_algorithm_iterator_requirements
@@ -43,12 +37,10 @@ STATIC_ASSERT(__cpp_lib_algorithm_iterator_requirements == 202207L);
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_allocate_at_least
-#error __cpp_lib_allocate_at_least is not defined
-#elif __cpp_lib_allocate_at_least != 202302L
-#error __cpp_lib_allocate_at_least is not 202302L
-#else
+#ifdef __cpp_lib_allocate_at_least
 STATIC_ASSERT(__cpp_lib_allocate_at_least == 202302L);
+#else
+#error __cpp_lib_allocate_at_least is not defined
 #endif
 #else
 #ifdef __cpp_lib_allocate_at_least
@@ -56,21 +48,17 @@ STATIC_ASSERT(__cpp_lib_allocate_at_least == 202302L);
 #endif
 #endif
 
-#ifndef __cpp_lib_allocator_traits_is_always_equal
-#error __cpp_lib_allocator_traits_is_always_equal is not defined
-#elif __cpp_lib_allocator_traits_is_always_equal != 201411L
-#error __cpp_lib_allocator_traits_is_always_equal is not 201411L
-#else
+#ifdef __cpp_lib_allocator_traits_is_always_equal
 STATIC_ASSERT(__cpp_lib_allocator_traits_is_always_equal == 201411L);
+#else
+#error __cpp_lib_allocator_traits_is_always_equal is not defined
 #endif
 
 #if _HAS_CXX17 && _HAS_STATIC_RTTI
-#ifndef __cpp_lib_any
-#error __cpp_lib_any is not defined
-#elif __cpp_lib_any != 201606L
-#error __cpp_lib_any is not 201606L
-#else
+#ifdef __cpp_lib_any
 STATIC_ASSERT(__cpp_lib_any == 201606L);
+#else
+#error __cpp_lib_any is not defined
 #endif
 #else
 #ifdef __cpp_lib_any
@@ -79,12 +67,10 @@ STATIC_ASSERT(__cpp_lib_any == 201606L);
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_apply
-#error __cpp_lib_apply is not defined
-#elif __cpp_lib_apply != 201603L
-#error __cpp_lib_apply is not 201603L
-#else
+#ifdef __cpp_lib_apply
 STATIC_ASSERT(__cpp_lib_apply == 201603L);
+#else
+#error __cpp_lib_apply is not defined
 #endif
 #else
 #ifdef __cpp_lib_apply
@@ -93,20 +79,16 @@ STATIC_ASSERT(__cpp_lib_apply == 201603L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_array_constexpr
-#error __cpp_lib_array_constexpr is not defined
-#elif __cpp_lib_array_constexpr != 201811L
-#error __cpp_lib_array_constexpr is not 201811L
-#else
+#ifdef __cpp_lib_array_constexpr
 STATIC_ASSERT(__cpp_lib_array_constexpr == 201811L);
+#else
+#error __cpp_lib_array_constexpr is not defined
 #endif
 #elif _HAS_CXX17
-#ifndef __cpp_lib_array_constexpr
-#error __cpp_lib_array_constexpr is not defined
-#elif __cpp_lib_array_constexpr != 201803L
-#error __cpp_lib_array_constexpr is not 201803L
-#else
+#ifdef __cpp_lib_array_constexpr
 STATIC_ASSERT(__cpp_lib_array_constexpr == 201803L);
+#else
+#error __cpp_lib_array_constexpr is not defined
 #endif
 #else
 #ifdef __cpp_lib_array_constexpr
@@ -114,21 +96,17 @@ STATIC_ASSERT(__cpp_lib_array_constexpr == 201803L);
 #endif
 #endif
 
-#ifndef __cpp_lib_as_const
-#error __cpp_lib_as_const is not defined
-#elif __cpp_lib_as_const != 201510L
-#error __cpp_lib_as_const is not 201510L
-#else
+#ifdef __cpp_lib_as_const
 STATIC_ASSERT(__cpp_lib_as_const == 201510L);
+#else
+#error __cpp_lib_as_const is not defined
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_associative_heterogeneous_erasure
-#error __cpp_lib_associative_heterogeneous_erasure is not defined
-#elif __cpp_lib_associative_heterogeneous_erasure != 202110L
-#error __cpp_lib_associative_heterogeneous_erasure is not 202110L
-#else
+#ifdef __cpp_lib_associative_heterogeneous_erasure
 STATIC_ASSERT(__cpp_lib_associative_heterogeneous_erasure == 202110L);
+#else
+#error __cpp_lib_associative_heterogeneous_erasure is not defined
 #endif
 #else
 #ifdef __cpp_lib_associative_heterogeneous_erasure
@@ -137,12 +115,10 @@ STATIC_ASSERT(__cpp_lib_associative_heterogeneous_erasure == 202110L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_assume_aligned
-#error __cpp_lib_assume_aligned is not defined
-#elif __cpp_lib_assume_aligned != 201811L
-#error __cpp_lib_assume_aligned is not 201811L
-#else
+#ifdef __cpp_lib_assume_aligned
 STATIC_ASSERT(__cpp_lib_assume_aligned == 201811L);
+#else
+#error __cpp_lib_assume_aligned is not defined
 #endif
 #else
 #ifdef __cpp_lib_assume_aligned
@@ -151,12 +127,10 @@ STATIC_ASSERT(__cpp_lib_assume_aligned == 201811L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_atomic_flag_test
-#error __cpp_lib_atomic_flag_test is not defined
-#elif __cpp_lib_atomic_flag_test != 201907L
-#error __cpp_lib_atomic_flag_test is not 201907L
-#else
+#ifdef __cpp_lib_atomic_flag_test
 STATIC_ASSERT(__cpp_lib_atomic_flag_test == 201907L);
+#else
+#error __cpp_lib_atomic_flag_test is not defined
 #endif
 #else
 #ifdef __cpp_lib_atomic_flag_test
@@ -165,12 +139,10 @@ STATIC_ASSERT(__cpp_lib_atomic_flag_test == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_atomic_float
-#error __cpp_lib_atomic_float is not defined
-#elif __cpp_lib_atomic_float != 201711L
-#error __cpp_lib_atomic_float is not 201711L
-#else
+#ifdef __cpp_lib_atomic_float
 STATIC_ASSERT(__cpp_lib_atomic_float == 201711L);
+#else
+#error __cpp_lib_atomic_float is not defined
 #endif
 #else
 #ifdef __cpp_lib_atomic_float
@@ -179,12 +151,10 @@ STATIC_ASSERT(__cpp_lib_atomic_float == 201711L);
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_atomic_is_always_lock_free
-#error __cpp_lib_atomic_is_always_lock_free is not defined
-#elif __cpp_lib_atomic_is_always_lock_free != 201603L
-#error __cpp_lib_atomic_is_always_lock_free is not 201603L
-#else
+#ifdef __cpp_lib_atomic_is_always_lock_free
 STATIC_ASSERT(__cpp_lib_atomic_is_always_lock_free == 201603L);
+#else
+#error __cpp_lib_atomic_is_always_lock_free is not defined
 #endif
 #else
 #ifdef __cpp_lib_atomic_is_always_lock_free
@@ -193,12 +163,10 @@ STATIC_ASSERT(__cpp_lib_atomic_is_always_lock_free == 201603L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_atomic_lock_free_type_aliases
-#error __cpp_lib_atomic_lock_free_type_aliases is not defined
-#elif __cpp_lib_atomic_lock_free_type_aliases != 201907L
-#error __cpp_lib_atomic_lock_free_type_aliases is not 201907L
-#else
+#ifdef __cpp_lib_atomic_lock_free_type_aliases
 STATIC_ASSERT(__cpp_lib_atomic_lock_free_type_aliases == 201907L);
+#else
+#error __cpp_lib_atomic_lock_free_type_aliases is not defined
 #endif
 #else
 #ifdef __cpp_lib_atomic_lock_free_type_aliases
@@ -207,12 +175,10 @@ STATIC_ASSERT(__cpp_lib_atomic_lock_free_type_aliases == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_atomic_ref
-#error __cpp_lib_atomic_ref is not defined
-#elif __cpp_lib_atomic_ref != 201806L
-#error __cpp_lib_atomic_ref is not 201806L
-#else
+#ifdef __cpp_lib_atomic_ref
 STATIC_ASSERT(__cpp_lib_atomic_ref == 201806L);
+#else
+#error __cpp_lib_atomic_ref is not defined
 #endif
 #else
 #ifdef __cpp_lib_atomic_ref
@@ -221,12 +187,10 @@ STATIC_ASSERT(__cpp_lib_atomic_ref == 201806L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_atomic_shared_ptr
-#error __cpp_lib_atomic_shared_ptr is not defined
-#elif __cpp_lib_atomic_shared_ptr != 201711L
-#error __cpp_lib_atomic_shared_ptr is not 201711L
-#else
+#ifdef __cpp_lib_atomic_shared_ptr
 STATIC_ASSERT(__cpp_lib_atomic_shared_ptr == 201711L);
+#else
+#error __cpp_lib_atomic_shared_ptr is not defined
 #endif
 #else
 #ifdef __cpp_lib_atomic_shared_ptr
@@ -234,21 +198,17 @@ STATIC_ASSERT(__cpp_lib_atomic_shared_ptr == 201711L);
 #endif
 #endif
 
-#ifndef __cpp_lib_atomic_value_initialization
-#error __cpp_lib_atomic_value_initialization is not defined
-#elif __cpp_lib_atomic_value_initialization != 201911L
-#error __cpp_lib_atomic_value_initialization is not 201911L
-#else
+#ifdef __cpp_lib_atomic_value_initialization
 STATIC_ASSERT(__cpp_lib_atomic_value_initialization == 201911L);
+#else
+#error __cpp_lib_atomic_value_initialization is not defined
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_atomic_wait
-#error __cpp_lib_atomic_wait is not defined
-#elif __cpp_lib_atomic_wait != 201907L
-#error __cpp_lib_atomic_wait is not 201907L
-#else
+#ifdef __cpp_lib_atomic_wait
 STATIC_ASSERT(__cpp_lib_atomic_wait == 201907L);
+#else
+#error __cpp_lib_atomic_wait is not defined
 #endif
 #else
 #ifdef __cpp_lib_atomic_wait
@@ -257,12 +217,10 @@ STATIC_ASSERT(__cpp_lib_atomic_wait == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_barrier
-#error __cpp_lib_barrier is not defined
-#elif __cpp_lib_barrier != 202302L
-#error __cpp_lib_barrier is not 202302L
-#else
+#ifdef __cpp_lib_barrier
 STATIC_ASSERT(__cpp_lib_barrier == 202302L);
+#else
+#error __cpp_lib_barrier is not defined
 #endif
 #else
 #ifdef __cpp_lib_barrier
@@ -271,12 +229,10 @@ STATIC_ASSERT(__cpp_lib_barrier == 202302L);
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_bind_back
-#error __cpp_lib_bind_back is not defined
-#elif __cpp_lib_bind_back != 202202L
-#error __cpp_lib_bind_back is not 202202L
-#else
+#ifdef __cpp_lib_bind_back
 STATIC_ASSERT(__cpp_lib_bind_back == 202202L);
+#else
+#error __cpp_lib_bind_back is not defined
 #endif
 #else
 #ifdef __cpp_lib_bind_back
@@ -285,12 +241,10 @@ STATIC_ASSERT(__cpp_lib_bind_back == 202202L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_bind_front
-#error __cpp_lib_bind_front is not defined
-#elif __cpp_lib_bind_front != 201907L
-#error __cpp_lib_bind_front is not 201907L
-#else
+#ifdef __cpp_lib_bind_front
 STATIC_ASSERT(__cpp_lib_bind_front == 201907L);
+#else
+#error __cpp_lib_bind_front is not defined
 #endif
 #else
 #ifdef __cpp_lib_bind_front
@@ -299,12 +253,10 @@ STATIC_ASSERT(__cpp_lib_bind_front == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_bit_cast
-#error __cpp_lib_bit_cast is not defined
-#elif __cpp_lib_bit_cast != 201806L
-#error __cpp_lib_bit_cast is not 201806L
-#else
+#ifdef __cpp_lib_bit_cast
 STATIC_ASSERT(__cpp_lib_bit_cast == 201806L);
+#else
+#error __cpp_lib_bit_cast is not defined
 #endif
 #else
 #ifdef __cpp_lib_bit_cast
@@ -313,12 +265,10 @@ STATIC_ASSERT(__cpp_lib_bit_cast == 201806L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_bitops
-#error __cpp_lib_bitops is not defined
-#elif __cpp_lib_bitops != 201907L
-#error __cpp_lib_bitops is not 201907L
-#else
+#ifdef __cpp_lib_bitops
 STATIC_ASSERT(__cpp_lib_bitops == 201907L);
+#else
+#error __cpp_lib_bitops is not defined
 #endif
 #else
 #ifdef __cpp_lib_bitops
@@ -326,21 +276,17 @@ STATIC_ASSERT(__cpp_lib_bitops == 201907L);
 #endif
 #endif
 
-#ifndef __cpp_lib_bool_constant
-#error __cpp_lib_bool_constant is not defined
-#elif __cpp_lib_bool_constant != 201505L
-#error __cpp_lib_bool_constant is not 201505L
-#else
+#ifdef __cpp_lib_bool_constant
 STATIC_ASSERT(__cpp_lib_bool_constant == 201505L);
+#else
+#error __cpp_lib_bool_constant is not defined
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_bounded_array_traits
-#error __cpp_lib_bounded_array_traits is not defined
-#elif __cpp_lib_bounded_array_traits != 201902L
-#error __cpp_lib_bounded_array_traits is not 201902L
-#else
+#ifdef __cpp_lib_bounded_array_traits
 STATIC_ASSERT(__cpp_lib_bounded_array_traits == 201902L);
+#else
+#error __cpp_lib_bounded_array_traits is not defined
 #endif
 #else
 #ifdef __cpp_lib_bounded_array_traits
@@ -349,12 +295,10 @@ STATIC_ASSERT(__cpp_lib_bounded_array_traits == 201902L);
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_boyer_moore_searcher
-#error __cpp_lib_boyer_moore_searcher is not defined
-#elif __cpp_lib_boyer_moore_searcher != 201603L
-#error __cpp_lib_boyer_moore_searcher is not 201603L
-#else
+#ifdef __cpp_lib_boyer_moore_searcher
 STATIC_ASSERT(__cpp_lib_boyer_moore_searcher == 201603L);
+#else
+#error __cpp_lib_boyer_moore_searcher is not defined
 #endif
 #else
 #ifdef __cpp_lib_boyer_moore_searcher
@@ -363,12 +307,10 @@ STATIC_ASSERT(__cpp_lib_boyer_moore_searcher == 201603L);
 #endif
 
 #if _HAS_STD_BYTE
-#ifndef __cpp_lib_byte
-#error __cpp_lib_byte is not defined
-#elif __cpp_lib_byte != 201603L
-#error __cpp_lib_byte is not 201603L
-#else
+#ifdef __cpp_lib_byte
 STATIC_ASSERT(__cpp_lib_byte == 201603L);
+#else
+#error __cpp_lib_byte is not defined
 #endif
 #else
 #ifdef __cpp_lib_byte
@@ -377,12 +319,10 @@ STATIC_ASSERT(__cpp_lib_byte == 201603L);
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_byteswap
-#error __cpp_lib_byteswap is not defined
-#elif __cpp_lib_byteswap != 202110L
-#error __cpp_lib_byteswap is not 202110L
-#else
+#ifdef __cpp_lib_byteswap
 STATIC_ASSERT(__cpp_lib_byteswap == 202110L);
+#else
+#error __cpp_lib_byteswap is not defined
 #endif
 #else
 #ifdef __cpp_lib_byteswap
@@ -391,12 +331,10 @@ STATIC_ASSERT(__cpp_lib_byteswap == 202110L);
 #endif
 
 #if defined(__cpp_char8_t)
-#ifndef __cpp_lib_char8_t
-#error __cpp_lib_char8_t is not defined
-#elif __cpp_lib_char8_t != 201907L
-#error __cpp_lib_char8_t is not 201907L
-#else
+#ifdef __cpp_lib_char8_t
 STATIC_ASSERT(__cpp_lib_char8_t == 201907L);
+#else
+#error __cpp_lib_char8_t is not defined
 #endif
 #else
 #ifdef __cpp_lib_char8_t
@@ -426,21 +364,17 @@ STATIC_ASSERT(__cpp_lib_chrono == 201510L);
 #endif
 #endif
 
-#ifndef __cpp_lib_chrono_udls
-#error __cpp_lib_chrono_udls is not defined
-#elif __cpp_lib_chrono_udls != 201304L
-#error __cpp_lib_chrono_udls is not 201304L
-#else
+#ifdef __cpp_lib_chrono_udls
 STATIC_ASSERT(__cpp_lib_chrono_udls == 201304L);
+#else
+#error __cpp_lib_chrono_udls is not defined
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_clamp
-#error __cpp_lib_clamp is not defined
-#elif __cpp_lib_clamp != 201603L
-#error __cpp_lib_clamp is not 201603L
-#else
+#ifdef __cpp_lib_clamp
 STATIC_ASSERT(__cpp_lib_clamp == 201603L);
+#else
+#error __cpp_lib_clamp is not defined
 #endif
 #else
 #ifdef __cpp_lib_clamp
@@ -449,12 +383,10 @@ STATIC_ASSERT(__cpp_lib_clamp == 201603L);
 #endif
 
 #if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_common_reference
-#error __cpp_lib_common_reference is not defined
-#elif __cpp_lib_common_reference != 202302L
-#error __cpp_lib_common_reference is not 202302L
-#else
+#ifdef __cpp_lib_common_reference
 STATIC_ASSERT(__cpp_lib_common_reference == 202302L);
+#else
+#error __cpp_lib_common_reference is not defined
 #endif
 #else
 #ifdef __cpp_lib_common_reference
@@ -463,12 +395,10 @@ STATIC_ASSERT(__cpp_lib_common_reference == 202302L);
 #endif
 
 #if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_common_reference_wrapper
-#error __cpp_lib_common_reference_wrapper is not defined
-#elif __cpp_lib_common_reference_wrapper != 202302L
-#error __cpp_lib_common_reference_wrapper is not 202302L
-#else
+#ifdef __cpp_lib_common_reference_wrapper
 STATIC_ASSERT(__cpp_lib_common_reference_wrapper == 202302L);
+#else
+#error __cpp_lib_common_reference_wrapper is not defined
 #endif
 #else
 #ifdef __cpp_lib_common_reference_wrapper
@@ -476,29 +406,23 @@ STATIC_ASSERT(__cpp_lib_common_reference_wrapper == 202302L);
 #endif
 #endif
 
-#ifndef __cpp_lib_complex_udls
-#error __cpp_lib_complex_udls is not defined
-#elif __cpp_lib_complex_udls != 201309L
-#error __cpp_lib_complex_udls is not 201309L
-#else
+#ifdef __cpp_lib_complex_udls
 STATIC_ASSERT(__cpp_lib_complex_udls == 201309L);
+#else
+#error __cpp_lib_complex_udls is not defined
 #endif
 
 #if _HAS_CXX23 && !defined(__EDG__) // TRANSITION, GH-395
-#ifndef __cpp_lib_concepts
-#error __cpp_lib_concepts is not defined
-#elif __cpp_lib_concepts != 202207L
-#error __cpp_lib_concepts is not 202207L
-#else
+#ifdef __cpp_lib_concepts
 STATIC_ASSERT(__cpp_lib_concepts == 202207L);
+#else
+#error __cpp_lib_concepts is not defined
 #endif
 #elif _HAS_CXX20 && !defined(__EDG__) // TRANSITION, GH-395
-#ifndef __cpp_lib_concepts
-#error __cpp_lib_concepts is not defined
-#elif __cpp_lib_concepts != 202002L
-#error __cpp_lib_concepts is not 202002L
-#else
+#ifdef __cpp_lib_concepts
 STATIC_ASSERT(__cpp_lib_concepts == 202002L);
+#else
+#error __cpp_lib_concepts is not defined
 #endif
 #else
 #ifdef __cpp_lib_concepts
@@ -507,12 +431,10 @@ STATIC_ASSERT(__cpp_lib_concepts == 202002L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_algorithms
-#error __cpp_lib_constexpr_algorithms is not defined
-#elif __cpp_lib_constexpr_algorithms != 201806L
-#error __cpp_lib_constexpr_algorithms is not 201806L
-#else
+#ifdef __cpp_lib_constexpr_algorithms
 STATIC_ASSERT(__cpp_lib_constexpr_algorithms == 201806L);
+#else
+#error __cpp_lib_constexpr_algorithms is not defined
 #endif
 #else
 #ifdef __cpp_lib_constexpr_algorithms
@@ -521,12 +443,10 @@ STATIC_ASSERT(__cpp_lib_constexpr_algorithms == 201806L);
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_constexpr_bitset
-#error __cpp_lib_constexpr_bitset is not defined
-#elif __cpp_lib_constexpr_bitset != 202207L
-#error __cpp_lib_constexpr_bitset is not 202207L
-#else
+#ifdef __cpp_lib_constexpr_bitset
 STATIC_ASSERT(__cpp_lib_constexpr_bitset == 202207L);
+#else
+#error __cpp_lib_constexpr_bitset is not defined
 #endif
 #else
 #ifdef __cpp_lib_constexpr_bitset
@@ -535,12 +455,10 @@ STATIC_ASSERT(__cpp_lib_constexpr_bitset == 202207L);
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_constexpr_charconv
-#error __cpp_lib_constexpr_charconv is not defined
-#elif __cpp_lib_constexpr_charconv != 202207L
-#error __cpp_lib_constexpr_charconv is not 202207L
-#else
+#ifdef __cpp_lib_constexpr_charconv
 STATIC_ASSERT(__cpp_lib_constexpr_charconv == 202207L);
+#else
+#error __cpp_lib_constexpr_charconv is not defined
 #endif
 #else
 #ifdef __cpp_lib_constexpr_charconv
@@ -549,12 +467,10 @@ STATIC_ASSERT(__cpp_lib_constexpr_charconv == 202207L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_complex
-#error __cpp_lib_constexpr_complex is not defined
-#elif __cpp_lib_constexpr_complex != 201711L
-#error __cpp_lib_constexpr_complex is not 201711L
-#else
+#ifdef __cpp_lib_constexpr_complex
 STATIC_ASSERT(__cpp_lib_constexpr_complex == 201711L);
+#else
+#error __cpp_lib_constexpr_complex is not defined
 #endif
 #else
 #ifdef __cpp_lib_constexpr_complex
@@ -563,12 +479,10 @@ STATIC_ASSERT(__cpp_lib_constexpr_complex == 201711L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_dynamic_alloc
-#error __cpp_lib_constexpr_dynamic_alloc is not defined
-#elif __cpp_lib_constexpr_dynamic_alloc != 201907L
-#error __cpp_lib_constexpr_dynamic_alloc is not 201907L
-#else
+#ifdef __cpp_lib_constexpr_dynamic_alloc
 STATIC_ASSERT(__cpp_lib_constexpr_dynamic_alloc == 201907L);
+#else
+#error __cpp_lib_constexpr_dynamic_alloc is not defined
 #endif
 #else
 #ifdef __cpp_lib_constexpr_dynamic_alloc
@@ -577,12 +491,10 @@ STATIC_ASSERT(__cpp_lib_constexpr_dynamic_alloc == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_functional
-#error __cpp_lib_constexpr_functional is not defined
-#elif __cpp_lib_constexpr_functional != 201907L
-#error __cpp_lib_constexpr_functional is not 201907L
-#else
+#ifdef __cpp_lib_constexpr_functional
 STATIC_ASSERT(__cpp_lib_constexpr_functional == 201907L);
+#else
+#error __cpp_lib_constexpr_functional is not defined
 #endif
 #else
 #ifdef __cpp_lib_constexpr_functional
@@ -591,12 +503,10 @@ STATIC_ASSERT(__cpp_lib_constexpr_functional == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_iterator
-#error __cpp_lib_constexpr_iterator is not defined
-#elif __cpp_lib_constexpr_iterator != 201811L
-#error __cpp_lib_constexpr_iterator is not 201811L
-#else
+#ifdef __cpp_lib_constexpr_iterator
 STATIC_ASSERT(__cpp_lib_constexpr_iterator == 201811L);
+#else
+#error __cpp_lib_constexpr_iterator is not defined
 #endif
 #else
 #ifdef __cpp_lib_constexpr_iterator
@@ -605,20 +515,16 @@ STATIC_ASSERT(__cpp_lib_constexpr_iterator == 201811L);
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_constexpr_memory
-#error __cpp_lib_constexpr_memory is not defined
-#elif __cpp_lib_constexpr_memory != 202202L
-#error __cpp_lib_constexpr_memory is not 202202L
-#else
+#ifdef __cpp_lib_constexpr_memory
 STATIC_ASSERT(__cpp_lib_constexpr_memory == 202202L);
+#else
+#error __cpp_lib_constexpr_memory is not defined
 #endif
 #elif _HAS_CXX20
-#ifndef __cpp_lib_constexpr_memory
-#error __cpp_lib_constexpr_memory is not defined
-#elif __cpp_lib_constexpr_memory != 201811L
-#error __cpp_lib_constexpr_memory is not 201811L
-#else
+#ifdef __cpp_lib_constexpr_memory
 STATIC_ASSERT(__cpp_lib_constexpr_memory == 201811L);
+#else
+#error __cpp_lib_constexpr_memory is not defined
 #endif
 #else
 #ifdef __cpp_lib_constexpr_memory
@@ -627,12 +533,10 @@ STATIC_ASSERT(__cpp_lib_constexpr_memory == 201811L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_numeric
-#error __cpp_lib_constexpr_numeric is not defined
-#elif __cpp_lib_constexpr_numeric != 201911L
-#error __cpp_lib_constexpr_numeric is not 201911L
-#else
+#ifdef __cpp_lib_constexpr_numeric
 STATIC_ASSERT(__cpp_lib_constexpr_numeric == 201911L);
+#else
+#error __cpp_lib_constexpr_numeric is not defined
 #endif
 #else
 #ifdef __cpp_lib_constexpr_numeric
@@ -641,12 +545,10 @@ STATIC_ASSERT(__cpp_lib_constexpr_numeric == 201911L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_string
-#error __cpp_lib_constexpr_string is not defined
-#elif __cpp_lib_constexpr_string != 201907L
-#error __cpp_lib_constexpr_string is not 201907L
-#else
+#ifdef __cpp_lib_constexpr_string
 STATIC_ASSERT(__cpp_lib_constexpr_string == 201907L);
+#else
+#error __cpp_lib_constexpr_string is not defined
 #endif
 #else
 #ifdef __cpp_lib_constexpr_string
@@ -655,12 +557,10 @@ STATIC_ASSERT(__cpp_lib_constexpr_string == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_string_view
-#error __cpp_lib_constexpr_string_view is not defined
-#elif __cpp_lib_constexpr_string_view != 201811L
-#error __cpp_lib_constexpr_string_view is not 201811L
-#else
+#ifdef __cpp_lib_constexpr_string_view
 STATIC_ASSERT(__cpp_lib_constexpr_string_view == 201811L);
+#else
+#error __cpp_lib_constexpr_string_view is not defined
 #endif
 #else
 #ifdef __cpp_lib_constexpr_string_view
@@ -669,12 +569,10 @@ STATIC_ASSERT(__cpp_lib_constexpr_string_view == 201811L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_tuple
-#error __cpp_lib_constexpr_tuple is not defined
-#elif __cpp_lib_constexpr_tuple != 201811L
-#error __cpp_lib_constexpr_tuple is not 201811L
-#else
+#ifdef __cpp_lib_constexpr_tuple
 STATIC_ASSERT(__cpp_lib_constexpr_tuple == 201811L);
+#else
+#error __cpp_lib_constexpr_tuple is not defined
 #endif
 #else
 #ifdef __cpp_lib_constexpr_tuple
@@ -683,12 +581,10 @@ STATIC_ASSERT(__cpp_lib_constexpr_tuple == 201811L);
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_constexpr_typeinfo
-#error __cpp_lib_constexpr_typeinfo is not defined
-#elif __cpp_lib_constexpr_typeinfo != 202106L
-#error __cpp_lib_constexpr_typeinfo is not 202106L
-#else
+#ifdef __cpp_lib_constexpr_typeinfo
 STATIC_ASSERT(__cpp_lib_constexpr_typeinfo == 202106L);
+#else
+#error __cpp_lib_constexpr_typeinfo is not defined
 #endif
 #else
 #ifdef __cpp_lib_constexpr_typeinfo
@@ -697,12 +593,10 @@ STATIC_ASSERT(__cpp_lib_constexpr_typeinfo == 202106L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_utility
-#error __cpp_lib_constexpr_utility is not defined
-#elif __cpp_lib_constexpr_utility != 201811L
-#error __cpp_lib_constexpr_utility is not 201811L
-#else
+#ifdef __cpp_lib_constexpr_utility
 STATIC_ASSERT(__cpp_lib_constexpr_utility == 201811L);
+#else
+#error __cpp_lib_constexpr_utility is not defined
 #endif
 #else
 #ifdef __cpp_lib_constexpr_utility
@@ -711,12 +605,10 @@ STATIC_ASSERT(__cpp_lib_constexpr_utility == 201811L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_vector
-#error __cpp_lib_constexpr_vector is not defined
-#elif __cpp_lib_constexpr_vector != 201907L
-#error __cpp_lib_constexpr_vector is not 201907L
-#else
+#ifdef __cpp_lib_constexpr_vector
 STATIC_ASSERT(__cpp_lib_constexpr_vector == 201907L);
+#else
+#error __cpp_lib_constexpr_vector is not defined
 #endif
 #else
 #ifdef __cpp_lib_constexpr_vector
@@ -725,12 +617,10 @@ STATIC_ASSERT(__cpp_lib_constexpr_vector == 201907L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_containers_ranges
-#error __cpp_lib_containers_ranges is not defined
-#elif __cpp_lib_containers_ranges != 202202L
-#error __cpp_lib_containers_ranges is not 202202L
-#else
+#ifdef __cpp_lib_containers_ranges
 STATIC_ASSERT(__cpp_lib_containers_ranges == 202202L);
+#else
+#error __cpp_lib_containers_ranges is not defined
 #endif
 #else
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
@@ -739,12 +629,10 @@ STATIC_ASSERT(__cpp_lib_containers_ranges == 202202L);
 #endif
 
 #ifdef __cpp_impl_coroutine
-#ifndef __cpp_lib_coroutine
-#error __cpp_lib_coroutine is not defined
-#elif __cpp_lib_coroutine != 201902L
-#error __cpp_lib_coroutine is not 201902L
-#else
+#ifdef __cpp_lib_coroutine
 STATIC_ASSERT(__cpp_lib_coroutine == 201902L);
+#else
+#error __cpp_lib_coroutine is not defined
 #endif
 #else
 #ifdef __cpp_lib_coroutine
@@ -753,12 +641,10 @@ STATIC_ASSERT(__cpp_lib_coroutine == 201902L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_destroying_delete
-#error __cpp_lib_destroying_delete is not defined
-#elif __cpp_lib_destroying_delete != 201806L
-#error __cpp_lib_destroying_delete is not 201806L
-#else
+#ifdef __cpp_lib_destroying_delete
 STATIC_ASSERT(__cpp_lib_destroying_delete == 201806L);
+#else
+#error __cpp_lib_destroying_delete is not defined
 #endif
 #else
 #ifdef __cpp_lib_destroying_delete
@@ -766,21 +652,17 @@ STATIC_ASSERT(__cpp_lib_destroying_delete == 201806L);
 #endif
 #endif
 
-#ifndef __cpp_lib_enable_shared_from_this
-#error __cpp_lib_enable_shared_from_this is not defined
-#elif __cpp_lib_enable_shared_from_this != 201603L
-#error __cpp_lib_enable_shared_from_this is not 201603L
-#else
+#ifdef __cpp_lib_enable_shared_from_this
 STATIC_ASSERT(__cpp_lib_enable_shared_from_this == 201603L);
+#else
+#error __cpp_lib_enable_shared_from_this is not defined
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_endian
-#error __cpp_lib_endian is not defined
-#elif __cpp_lib_endian != 201907L
-#error __cpp_lib_endian is not 201907L
-#else
+#ifdef __cpp_lib_endian
 STATIC_ASSERT(__cpp_lib_endian == 201907L);
+#else
+#error __cpp_lib_endian is not defined
 #endif
 #else
 #ifdef __cpp_lib_endian
@@ -789,12 +671,10 @@ STATIC_ASSERT(__cpp_lib_endian == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_erase_if
-#error __cpp_lib_erase_if is not defined
-#elif __cpp_lib_erase_if != 202002L
-#error __cpp_lib_erase_if is not 202002L
-#else
+#ifdef __cpp_lib_erase_if
 STATIC_ASSERT(__cpp_lib_erase_if == 202002L);
+#else
+#error __cpp_lib_erase_if is not defined
 #endif
 #else
 #ifdef __cpp_lib_erase_if
@@ -802,29 +682,23 @@ STATIC_ASSERT(__cpp_lib_erase_if == 202002L);
 #endif
 #endif
 
-#ifndef __cpp_lib_exchange_function
-#error __cpp_lib_exchange_function is not defined
-#elif __cpp_lib_exchange_function != 201304L
-#error __cpp_lib_exchange_function is not 201304L
-#else
+#ifdef __cpp_lib_exchange_function
 STATIC_ASSERT(__cpp_lib_exchange_function == 201304L);
+#else
+#error __cpp_lib_exchange_function is not defined
 #endif
 
 #if _HAS_CXX20 && !defined(_M_CEE_PURE)
-#ifndef __cpp_lib_execution
-#error __cpp_lib_execution is not defined
-#elif __cpp_lib_execution != 201902L
-#error __cpp_lib_execution is not 201902L
-#else
+#ifdef __cpp_lib_execution
 STATIC_ASSERT(__cpp_lib_execution == 201902L);
+#else
+#error __cpp_lib_execution is not defined
 #endif
 #elif _HAS_CXX17 && !defined(_M_CEE_PURE)
-#ifndef __cpp_lib_execution
-#error __cpp_lib_execution is not defined
-#elif __cpp_lib_execution != 201603L
-#error __cpp_lib_execution is not 201603L
-#else
+#ifdef __cpp_lib_execution
 STATIC_ASSERT(__cpp_lib_execution == 201603L);
+#else
+#error __cpp_lib_execution is not defined
 #endif
 #else
 #ifdef __cpp_lib_execution
@@ -833,12 +707,10 @@ STATIC_ASSERT(__cpp_lib_execution == 201603L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_expected
-#error __cpp_lib_expected is not defined
-#elif __cpp_lib_expected != 202211L
-#error __cpp_lib_expected is not 202211L
-#else
+#ifdef __cpp_lib_expected
 STATIC_ASSERT(__cpp_lib_expected == 202211L);
+#else
+#error __cpp_lib_expected is not defined
 #endif
 #else
 #ifdef __cpp_lib_expected
@@ -846,29 +718,23 @@ STATIC_ASSERT(__cpp_lib_expected == 202211L);
 #endif
 #endif
 
-#ifndef __cpp_lib_experimental_erase_if
-#error __cpp_lib_experimental_erase_if is not defined
-#elif __cpp_lib_experimental_erase_if != 201411L
-#error __cpp_lib_experimental_erase_if is not 201411L
-#else
+#ifdef __cpp_lib_experimental_erase_if
 STATIC_ASSERT(__cpp_lib_experimental_erase_if == 201411L);
+#else
+#error __cpp_lib_experimental_erase_if is not defined
 #endif
 
-#ifndef __cpp_lib_experimental_filesystem
-#error __cpp_lib_experimental_filesystem is not defined
-#elif __cpp_lib_experimental_filesystem != 201406L
-#error __cpp_lib_experimental_filesystem is not 201406L
-#else
+#ifdef __cpp_lib_experimental_filesystem
 STATIC_ASSERT(__cpp_lib_experimental_filesystem == 201406L);
+#else
+#error __cpp_lib_experimental_filesystem is not defined
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_filesystem
-#error __cpp_lib_filesystem is not defined
-#elif __cpp_lib_filesystem != 201703L
-#error __cpp_lib_filesystem is not 201703L
-#else
+#ifdef __cpp_lib_filesystem
 STATIC_ASSERT(__cpp_lib_filesystem == 201703L);
+#else
+#error __cpp_lib_filesystem is not defined
 #endif
 #else
 #ifdef __cpp_lib_filesystem
@@ -877,12 +743,10 @@ STATIC_ASSERT(__cpp_lib_filesystem == 201703L);
 #endif
 
 #ifdef __cpp_lib_concepts
-#ifndef __cpp_lib_format
-#error __cpp_lib_format is not defined
-#elif __cpp_lib_format != 202207L
-#error __cpp_lib_format is not 202207L
-#else
+#ifdef __cpp_lib_format
 STATIC_ASSERT(__cpp_lib_format == 202207L);
+#else
+#error __cpp_lib_format is not defined
 #endif
 #else
 #ifdef __cpp_lib_format
@@ -891,12 +755,10 @@ STATIC_ASSERT(__cpp_lib_format == 202207L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_formatters
-#error __cpp_lib_formatters is not defined
-#elif __cpp_lib_formatters != 202302L
-#error __cpp_lib_formatters is not 202302L
-#else
+#ifdef __cpp_lib_formatters
 STATIC_ASSERT(__cpp_lib_formatters == 202302L);
+#else
+#error __cpp_lib_formatters is not defined
 #endif
 #else
 #ifdef __cpp_lib_formatters
@@ -905,12 +767,10 @@ STATIC_ASSERT(__cpp_lib_formatters == 202302L);
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_forward_like
-#error __cpp_lib_forward_like is not defined
-#elif __cpp_lib_forward_like != 202207L
-#error __cpp_lib_forward_like is not 202207L
-#else
+#ifdef __cpp_lib_forward_like
 STATIC_ASSERT(__cpp_lib_forward_like == 202207L);
+#else
+#error __cpp_lib_forward_like is not defined
 #endif
 #else
 #ifdef __cpp_lib_forward_like
@@ -918,21 +778,17 @@ STATIC_ASSERT(__cpp_lib_forward_like == 202207L);
 #endif
 #endif
 
-#ifndef __cpp_lib_freestanding_char_traits
-#error __cpp_lib_freestanding_char_traits is not defined
-#elif __cpp_lib_freestanding_char_traits != 202306L
-#error __cpp_lib_freestanding_char_traits is not 202306L
-#else
+#ifdef __cpp_lib_freestanding_char_traits
 STATIC_ASSERT(__cpp_lib_freestanding_char_traits == 202306L);
+#else
+#error __cpp_lib_freestanding_char_traits is not defined
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_freestanding_charconv
-#error __cpp_lib_freestanding_charconv is not defined
-#elif __cpp_lib_freestanding_charconv != 202306L
-#error __cpp_lib_freestanding_charconv is not 202306L
-#else
+#ifdef __cpp_lib_freestanding_charconv
 STATIC_ASSERT(__cpp_lib_freestanding_charconv == 202306L);
+#else
+#error __cpp_lib_freestanding_charconv is not defined
 #endif
 #else
 #ifdef __cpp_lib_freestanding_charconv
@@ -940,85 +796,65 @@ STATIC_ASSERT(__cpp_lib_freestanding_charconv == 202306L);
 #endif
 #endif
 
-#ifndef __cpp_lib_freestanding_cstdlib
-#error __cpp_lib_freestanding_cstdlib is not defined
-#elif __cpp_lib_freestanding_cstdlib != 202306L
-#error __cpp_lib_freestanding_cstdlib is not 202306L
-#else
+#ifdef __cpp_lib_freestanding_cstdlib
 STATIC_ASSERT(__cpp_lib_freestanding_cstdlib == 202306L);
+#else
+#error __cpp_lib_freestanding_cstdlib is not defined
 #endif
 
-#ifndef __cpp_lib_freestanding_cstring
-#error __cpp_lib_freestanding_cstring is not defined
-#elif __cpp_lib_freestanding_cstring != 202306L
-#error __cpp_lib_freestanding_cstring is not 202306L
-#else
+#ifdef __cpp_lib_freestanding_cstring
 STATIC_ASSERT(__cpp_lib_freestanding_cstring == 202306L);
+#else
+#error __cpp_lib_freestanding_cstring is not defined
 #endif
 
-#ifndef __cpp_lib_freestanding_cwchar
-#error __cpp_lib_freestanding_cwchar is not defined
-#elif __cpp_lib_freestanding_cwchar != 202306L
-#error __cpp_lib_freestanding_cwchar is not 202306L
-#else
+#ifdef __cpp_lib_freestanding_cwchar
 STATIC_ASSERT(__cpp_lib_freestanding_cwchar == 202306L);
+#else
+#error __cpp_lib_freestanding_cwchar is not defined
 #endif
 
-#ifndef __cpp_lib_freestanding_errc
-#error __cpp_lib_freestanding_errc is not defined
-#elif __cpp_lib_freestanding_errc != 202306L
-#error __cpp_lib_freestanding_errc is not 202306L
-#else
+#ifdef __cpp_lib_freestanding_errc
 STATIC_ASSERT(__cpp_lib_freestanding_errc == 202306L);
+#else
+#error __cpp_lib_freestanding_errc is not defined
 #endif
 
-#ifndef __cpp_lib_freestanding_feature_test_macros
-#error __cpp_lib_freestanding_feature_test_macros is not defined
-#elif __cpp_lib_freestanding_feature_test_macros != 202306L
-#error __cpp_lib_freestanding_feature_test_macros is not 202306L
-#else
+#ifdef __cpp_lib_freestanding_feature_test_macros
 STATIC_ASSERT(__cpp_lib_freestanding_feature_test_macros == 202306L);
+#else
+#error __cpp_lib_freestanding_feature_test_macros is not defined
 #endif
 
-#ifndef __cpp_lib_freestanding_functional
-#error __cpp_lib_freestanding_functional is not defined
-#elif __cpp_lib_freestanding_functional != 202306L
-#error __cpp_lib_freestanding_functional is not 202306L
-#else
+#ifdef __cpp_lib_freestanding_functional
 STATIC_ASSERT(__cpp_lib_freestanding_functional == 202306L);
+#else
+#error __cpp_lib_freestanding_functional is not defined
 #endif
 
-#ifndef __cpp_lib_freestanding_iterator
-#error __cpp_lib_freestanding_iterator is not defined
-#elif __cpp_lib_freestanding_iterator != 202306L
-#error __cpp_lib_freestanding_iterator is not 202306L
-#else
+#ifdef __cpp_lib_freestanding_iterator
 STATIC_ASSERT(__cpp_lib_freestanding_iterator == 202306L);
+#else
+#error __cpp_lib_freestanding_iterator is not defined
 #endif
 
-#ifndef __cpp_lib_freestanding_memory
-#error __cpp_lib_freestanding_memory is not defined
-#elif __cpp_lib_freestanding_memory != 202306L
-#error __cpp_lib_freestanding_memory is not 202306L
-#else
+#ifdef __cpp_lib_freestanding_memory
 STATIC_ASSERT(__cpp_lib_freestanding_memory == 202306L);
+#else
+#error __cpp_lib_freestanding_memory is not defined
 #endif
 
-#ifndef __cpp_lib_freestanding_operator_new
-#error __cpp_lib_freestanding_operator_new is not defined
-#elif __cpp_lib_freestanding_operator_new != 202306L
-#error __cpp_lib_freestanding_operator_new is not 202306L
-#else
+#ifdef __cpp_lib_freestanding_operator_new
 STATIC_ASSERT(__cpp_lib_freestanding_operator_new == 202306L);
+#else
+#error __cpp_lib_freestanding_operator_new is not defined
 #endif
 
 #ifdef __cpp_lib_concepts
-#ifndef __cpp_lib_freestanding_ranges
-#error __cpp_lib_freestanding_ranges is not defined
-#elif __cpp_lib_freestanding_ranges != 202306L
-#error __cpp_lib_freestanding_ranges is not 202306L
-#else
+#ifdef __cpp_lib_freestanding_ranges
 STATIC_ASSERT(__cpp_lib_freestanding_ranges == 202306L);
+#else
+#error __cpp_lib_freestanding_ranges is not defined
 #endif
 #else
 #ifdef __cpp_lib_freestanding_ranges
@@ -1026,37 +862,29 @@ STATIC_ASSERT(__cpp_lib_freestanding_ranges == 202306L);
 #endif
 #endif
 
-#ifndef __cpp_lib_freestanding_ratio
-#error __cpp_lib_freestanding_ratio is not defined
-#elif __cpp_lib_freestanding_ratio != 202306L
-#error __cpp_lib_freestanding_ratio is not 202306L
-#else
+#ifdef __cpp_lib_freestanding_ratio
 STATIC_ASSERT(__cpp_lib_freestanding_ratio == 202306L);
+#else
+#error __cpp_lib_freestanding_ratio is not defined
 #endif
 
-#ifndef __cpp_lib_freestanding_tuple
-#error __cpp_lib_freestanding_tuple is not defined
-#elif __cpp_lib_freestanding_tuple != 202306L
-#error __cpp_lib_freestanding_tuple is not 202306L
-#else
+#ifdef __cpp_lib_freestanding_tuple
 STATIC_ASSERT(__cpp_lib_freestanding_tuple == 202306L);
+#else
+#error __cpp_lib_freestanding_tuple is not defined
 #endif
 
-#ifndef __cpp_lib_freestanding_utility
-#error __cpp_lib_freestanding_utility is not defined
-#elif __cpp_lib_freestanding_utility != 202306L
-#error __cpp_lib_freestanding_utility is not 202306L
-#else
+#ifdef __cpp_lib_freestanding_utility
 STATIC_ASSERT(__cpp_lib_freestanding_utility == 202306L);
+#else
+#error __cpp_lib_freestanding_utility is not defined
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_gcd_lcm
-#error __cpp_lib_gcd_lcm is not defined
-#elif __cpp_lib_gcd_lcm != 201606L
-#error __cpp_lib_gcd_lcm is not 201606L
-#else
+#ifdef __cpp_lib_gcd_lcm
 STATIC_ASSERT(__cpp_lib_gcd_lcm == 201606L);
+#else
+#error __cpp_lib_gcd_lcm is not defined
 #endif
 #else
 #ifdef __cpp_lib_gcd_lcm
@@ -1064,21 +892,17 @@ STATIC_ASSERT(__cpp_lib_gcd_lcm == 201606L);
 #endif
 #endif
 
-#ifndef __cpp_lib_generic_associative_lookup
-#error __cpp_lib_generic_associative_lookup is not defined
-#elif __cpp_lib_generic_associative_lookup != 201304L
-#error __cpp_lib_generic_associative_lookup is not 201304L
-#else
+#ifdef __cpp_lib_generic_associative_lookup
 STATIC_ASSERT(__cpp_lib_generic_associative_lookup == 201304L);
+#else
+#error __cpp_lib_generic_associative_lookup is not defined
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_generic_unordered_lookup
-#error __cpp_lib_generic_unordered_lookup is not defined
-#elif __cpp_lib_generic_unordered_lookup != 201811L
-#error __cpp_lib_generic_unordered_lookup is not 201811L
-#else
+#ifdef __cpp_lib_generic_unordered_lookup
 STATIC_ASSERT(__cpp_lib_generic_unordered_lookup == 201811L);
+#else
+#error __cpp_lib_generic_unordered_lookup is not defined
 #endif
 #else
 #ifdef __cpp_lib_generic_unordered_lookup
@@ -1087,12 +911,10 @@ STATIC_ASSERT(__cpp_lib_generic_unordered_lookup == 201811L);
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_hardware_interference_size
-#error __cpp_lib_hardware_interference_size is not defined
-#elif __cpp_lib_hardware_interference_size != 201703L
-#error __cpp_lib_hardware_interference_size is not 201703L
-#else
+#ifdef __cpp_lib_hardware_interference_size
 STATIC_ASSERT(__cpp_lib_hardware_interference_size == 201703L);
+#else
+#error __cpp_lib_hardware_interference_size is not defined
 #endif
 #else
 #ifdef __cpp_lib_hardware_interference_size
@@ -1101,12 +923,10 @@ STATIC_ASSERT(__cpp_lib_hardware_interference_size == 201703L);
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_has_unique_object_representations
-#error __cpp_lib_has_unique_object_representations is not defined
-#elif __cpp_lib_has_unique_object_representations != 201606L
-#error __cpp_lib_has_unique_object_representations is not 201606L
-#else
+#ifdef __cpp_lib_has_unique_object_representations
 STATIC_ASSERT(__cpp_lib_has_unique_object_representations == 201606L);
+#else
+#error __cpp_lib_has_unique_object_representations is not defined
 #endif
 #else
 #ifdef __cpp_lib_has_unique_object_representations
@@ -1115,12 +935,10 @@ STATIC_ASSERT(__cpp_lib_has_unique_object_representations == 201606L);
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_hypot
-#error __cpp_lib_hypot is not defined
-#elif __cpp_lib_hypot != 201603L
-#error __cpp_lib_hypot is not 201603L
-#else
+#ifdef __cpp_lib_hypot
 STATIC_ASSERT(__cpp_lib_hypot == 201603L);
+#else
+#error __cpp_lib_hypot is not defined
 #endif
 #else
 #ifdef __cpp_lib_hypot
@@ -1128,21 +946,17 @@ STATIC_ASSERT(__cpp_lib_hypot == 201603L);
 #endif
 #endif
 
-#ifndef __cpp_lib_incomplete_container_elements
-#error __cpp_lib_incomplete_container_elements is not defined
-#elif __cpp_lib_incomplete_container_elements != 201505L
-#error __cpp_lib_incomplete_container_elements is not 201505L
-#else
+#ifdef __cpp_lib_incomplete_container_elements
 STATIC_ASSERT(__cpp_lib_incomplete_container_elements == 201505L);
+#else
+#error __cpp_lib_incomplete_container_elements is not defined
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_int_pow2
-#error __cpp_lib_int_pow2 is not defined
-#elif __cpp_lib_int_pow2 != 202002L
-#error __cpp_lib_int_pow2 is not 202002L
-#else
+#ifdef __cpp_lib_int_pow2
 STATIC_ASSERT(__cpp_lib_int_pow2 == 202002L);
+#else
+#error __cpp_lib_int_pow2 is not defined
 #endif
 #else
 #ifdef __cpp_lib_int_pow2
@@ -1151,12 +965,10 @@ STATIC_ASSERT(__cpp_lib_int_pow2 == 202002L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_integer_comparison_functions
-#error __cpp_lib_integer_comparison_functions is not defined
-#elif __cpp_lib_integer_comparison_functions != 202002L
-#error __cpp_lib_integer_comparison_functions is not 202002L
-#else
+#ifdef __cpp_lib_integer_comparison_functions
 STATIC_ASSERT(__cpp_lib_integer_comparison_functions == 202002L);
+#else
+#error __cpp_lib_integer_comparison_functions is not defined
 #endif
 #else
 #ifdef __cpp_lib_integer_comparison_functions
@@ -1164,29 +976,23 @@ STATIC_ASSERT(__cpp_lib_integer_comparison_functions == 202002L);
 #endif
 #endif
 
-#ifndef __cpp_lib_integer_sequence
-#error __cpp_lib_integer_sequence is not defined
-#elif __cpp_lib_integer_sequence != 201304L
-#error __cpp_lib_integer_sequence is not 201304L
-#else
+#ifdef __cpp_lib_integer_sequence
 STATIC_ASSERT(__cpp_lib_integer_sequence == 201304L);
+#else
+#error __cpp_lib_integer_sequence is not defined
 #endif
 
-#ifndef __cpp_lib_integral_constant_callable
-#error __cpp_lib_integral_constant_callable is not defined
-#elif __cpp_lib_integral_constant_callable != 201304L
-#error __cpp_lib_integral_constant_callable is not 201304L
-#else
+#ifdef __cpp_lib_integral_constant_callable
 STATIC_ASSERT(__cpp_lib_integral_constant_callable == 201304L);
+#else
+#error __cpp_lib_integral_constant_callable is not defined
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_interpolate
-#error __cpp_lib_interpolate is not defined
-#elif __cpp_lib_interpolate != 201902L
-#error __cpp_lib_interpolate is not 201902L
-#else
+#ifdef __cpp_lib_interpolate
 STATIC_ASSERT(__cpp_lib_interpolate == 201902L);
+#else
+#error __cpp_lib_interpolate is not defined
 #endif
 #else
 #ifdef __cpp_lib_interpolate
@@ -1194,21 +1000,17 @@ STATIC_ASSERT(__cpp_lib_interpolate == 201902L);
 #endif
 #endif
 
-#ifndef __cpp_lib_invoke
-#error __cpp_lib_invoke is not defined
-#elif __cpp_lib_invoke != 201411L
-#error __cpp_lib_invoke is not 201411L
-#else
+#ifdef __cpp_lib_invoke
 STATIC_ASSERT(__cpp_lib_invoke == 201411L);
+#else
+#error __cpp_lib_invoke is not defined
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_invoke_r
-#error __cpp_lib_invoke_r is not defined
-#elif __cpp_lib_invoke_r != 202106L
-#error __cpp_lib_invoke_r is not 202106L
-#else
+#ifdef __cpp_lib_invoke_r
 STATIC_ASSERT(__cpp_lib_invoke_r == 202106L);
+#else
+#error __cpp_lib_invoke_r is not defined
 #endif
 #else
 #ifdef __cpp_lib_invoke_r
@@ -1217,12 +1019,10 @@ STATIC_ASSERT(__cpp_lib_invoke_r == 202106L);
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_ios_noreplace
-#error __cpp_lib_ios_noreplace is not defined
-#elif __cpp_lib_ios_noreplace != 202207L
-#error __cpp_lib_ios_noreplace is not 202207L
-#else
+#ifdef __cpp_lib_ios_noreplace
 STATIC_ASSERT(__cpp_lib_ios_noreplace == 202207L);
+#else
+#error __cpp_lib_ios_noreplace is not defined
 #endif
 #else
 #ifdef __cpp_lib_ios_noreplace
@@ -1231,12 +1031,10 @@ STATIC_ASSERT(__cpp_lib_ios_noreplace == 202207L);
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_is_aggregate
-#error __cpp_lib_is_aggregate is not defined
-#elif __cpp_lib_is_aggregate != 201703L
-#error __cpp_lib_is_aggregate is not 201703L
-#else
+#ifdef __cpp_lib_is_aggregate
 STATIC_ASSERT(__cpp_lib_is_aggregate == 201703L);
+#else
+#error __cpp_lib_is_aggregate is not defined
 #endif
 #else
 #ifdef __cpp_lib_is_aggregate
@@ -1245,12 +1043,10 @@ STATIC_ASSERT(__cpp_lib_is_aggregate == 201703L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_is_constant_evaluated
-#error __cpp_lib_is_constant_evaluated is not defined
-#elif __cpp_lib_is_constant_evaluated != 201811L
-#error __cpp_lib_is_constant_evaluated is not 201811L
-#else
+#ifdef __cpp_lib_is_constant_evaluated
 STATIC_ASSERT(__cpp_lib_is_constant_evaluated == 201811L);
+#else
+#error __cpp_lib_is_constant_evaluated is not defined
 #endif
 #else
 #ifdef __cpp_lib_is_constant_evaluated
@@ -1258,21 +1054,17 @@ STATIC_ASSERT(__cpp_lib_is_constant_evaluated == 201811L);
 #endif
 #endif
 
-#ifndef __cpp_lib_is_final
-#error __cpp_lib_is_final is not defined
-#elif __cpp_lib_is_final != 201402L
-#error __cpp_lib_is_final is not 201402L
-#else
+#ifdef __cpp_lib_is_final
 STATIC_ASSERT(__cpp_lib_is_final == 201402L);
+#else
+#error __cpp_lib_is_final is not defined
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_is_invocable
-#error __cpp_lib_is_invocable is not defined
-#elif __cpp_lib_is_invocable != 201703L
-#error __cpp_lib_is_invocable is not 201703L
-#else
+#ifdef __cpp_lib_is_invocable
 STATIC_ASSERT(__cpp_lib_is_invocable == 201703L);
+#else
+#error __cpp_lib_is_invocable is not defined
 #endif
 #else
 #ifdef __cpp_lib_is_invocable
@@ -1282,12 +1074,10 @@ STATIC_ASSERT(__cpp_lib_is_invocable == 201703L);
 
 #if _HAS_CXX20
 #ifndef __clang__ // TRANSITION, LLVM-48860
-#ifndef __cpp_lib_is_layout_compatible
-#error __cpp_lib_is_layout_compatible is not defined
-#elif __cpp_lib_is_layout_compatible != 201907L
-#error __cpp_lib_is_layout_compatible is not 201907L
-#else
+#ifdef __cpp_lib_is_layout_compatible
 STATIC_ASSERT(__cpp_lib_is_layout_compatible == 201907L);
+#else
+#error __cpp_lib_is_layout_compatible is not defined
 #endif
 #else
 #ifdef __cpp_lib_is_layout_compatible
@@ -1297,12 +1087,10 @@ STATIC_ASSERT(__cpp_lib_is_layout_compatible == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_is_nothrow_convertible
-#error __cpp_lib_is_nothrow_convertible is not defined
-#elif __cpp_lib_is_nothrow_convertible != 201806L
-#error __cpp_lib_is_nothrow_convertible is not 201806L
-#else
+#ifdef __cpp_lib_is_nothrow_convertible
 STATIC_ASSERT(__cpp_lib_is_nothrow_convertible == 201806L);
+#else
+#error __cpp_lib_is_nothrow_convertible is not defined
 #endif
 #else
 #ifdef __cpp_lib_is_nothrow_convertible
@@ -1310,22 +1098,18 @@ STATIC_ASSERT(__cpp_lib_is_nothrow_convertible == 201806L);
 #endif
 #endif
 
-#ifndef __cpp_lib_is_null_pointer
-#error __cpp_lib_is_null_pointer is not defined
-#elif __cpp_lib_is_null_pointer != 201309L
-#error __cpp_lib_is_null_pointer is not 201309L
-#else
+#ifdef __cpp_lib_is_null_pointer
 STATIC_ASSERT(__cpp_lib_is_null_pointer == 201309L);
+#else
+#error __cpp_lib_is_null_pointer is not defined
 #endif
 
 #if _HAS_CXX20
 #ifndef __clang__ // TRANSITION, LLVM-48860
-#ifndef __cpp_lib_is_pointer_interconvertible
-#error __cpp_lib_is_pointer_interconvertible is not defined
-#elif __cpp_lib_is_pointer_interconvertible != 201907L
-#error __cpp_lib_is_pointer_interconvertible is not 201907L
-#else
+#ifdef __cpp_lib_is_pointer_interconvertible
 STATIC_ASSERT(__cpp_lib_is_pointer_interconvertible == 201907L);
+#else
+#error __cpp_lib_is_pointer_interconvertible is not defined
 #endif
 #else
 #ifdef __cpp_lib_is_pointer_interconvertible
@@ -1335,12 +1119,10 @@ STATIC_ASSERT(__cpp_lib_is_pointer_interconvertible == 201907L);
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_is_scoped_enum
-#error __cpp_lib_is_scoped_enum is not defined
-#elif __cpp_lib_is_scoped_enum != 202011L
-#error __cpp_lib_is_scoped_enum is not 202011L
-#else
+#ifdef __cpp_lib_is_scoped_enum
 STATIC_ASSERT(__cpp_lib_is_scoped_enum == 202011L);
+#else
+#error __cpp_lib_is_scoped_enum is not defined
 #endif
 #else
 #ifdef __cpp_lib_is_scoped_enum
@@ -1349,12 +1131,10 @@ STATIC_ASSERT(__cpp_lib_is_scoped_enum == 202011L);
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_is_swappable
-#error __cpp_lib_is_swappable is not defined
-#elif __cpp_lib_is_swappable != 201603L
-#error __cpp_lib_is_swappable is not 201603L
-#else
+#ifdef __cpp_lib_is_swappable
 STATIC_ASSERT(__cpp_lib_is_swappable == 201603L);
+#else
+#error __cpp_lib_is_swappable is not defined
 #endif
 #else
 #ifdef __cpp_lib_is_swappable
@@ -1363,12 +1143,10 @@ STATIC_ASSERT(__cpp_lib_is_swappable == 201603L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_jthread
-#error __cpp_lib_jthread is not defined
-#elif __cpp_lib_jthread != 201911L
-#error __cpp_lib_jthread is not 201911L
-#else
+#ifdef __cpp_lib_jthread
 STATIC_ASSERT(__cpp_lib_jthread == 201911L);
+#else
+#error __cpp_lib_jthread is not defined
 #endif
 #else
 #ifdef __cpp_lib_jthread
@@ -1377,12 +1155,10 @@ STATIC_ASSERT(__cpp_lib_jthread == 201911L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_latch
-#error __cpp_lib_latch is not defined
-#elif __cpp_lib_latch != 201907L
-#error __cpp_lib_latch is not 201907L
-#else
+#ifdef __cpp_lib_latch
 STATIC_ASSERT(__cpp_lib_latch == 201907L);
+#else
+#error __cpp_lib_latch is not defined
 #endif
 #else
 #ifdef __cpp_lib_latch
@@ -1391,12 +1167,10 @@ STATIC_ASSERT(__cpp_lib_latch == 201907L);
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_launder
-#error __cpp_lib_launder is not defined
-#elif __cpp_lib_launder != 201606L
-#error __cpp_lib_launder is not 201606L
-#else
+#ifdef __cpp_lib_launder
 STATIC_ASSERT(__cpp_lib_launder == 201606L);
+#else
+#error __cpp_lib_launder is not defined
 #endif
 #else
 #ifdef __cpp_lib_launder
@@ -1405,12 +1179,10 @@ STATIC_ASSERT(__cpp_lib_launder == 201606L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_list_remove_return_type
-#error __cpp_lib_list_remove_return_type is not defined
-#elif __cpp_lib_list_remove_return_type != 201806L
-#error __cpp_lib_list_remove_return_type is not 201806L
-#else
+#ifdef __cpp_lib_list_remove_return_type
 STATIC_ASSERT(__cpp_lib_list_remove_return_type == 201806L);
+#else
+#error __cpp_lib_list_remove_return_type is not defined
 #endif
 #else
 #ifdef __cpp_lib_list_remove_return_type
@@ -1418,21 +1190,17 @@ STATIC_ASSERT(__cpp_lib_list_remove_return_type == 201806L);
 #endif
 #endif
 
-#ifndef __cpp_lib_logical_traits
-#error __cpp_lib_logical_traits is not defined
-#elif __cpp_lib_logical_traits != 201510L
-#error __cpp_lib_logical_traits is not 201510L
-#else
+#ifdef __cpp_lib_logical_traits
 STATIC_ASSERT(__cpp_lib_logical_traits == 201510L);
+#else
+#error __cpp_lib_logical_traits is not defined
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_make_from_tuple
-#error __cpp_lib_make_from_tuple is not defined
-#elif __cpp_lib_make_from_tuple != 201606L
-#error __cpp_lib_make_from_tuple is not 201606L
-#else
+#ifdef __cpp_lib_make_from_tuple
 STATIC_ASSERT(__cpp_lib_make_from_tuple == 201606L);
+#else
+#error __cpp_lib_make_from_tuple is not defined
 #endif
 #else
 #ifdef __cpp_lib_make_from_tuple
@@ -1440,37 +1208,29 @@ STATIC_ASSERT(__cpp_lib_make_from_tuple == 201606L);
 #endif
 #endif
 
-#ifndef __cpp_lib_make_reverse_iterator
-#error __cpp_lib_make_reverse_iterator is not defined
-#elif __cpp_lib_make_reverse_iterator != 201402L
-#error __cpp_lib_make_reverse_iterator is not 201402L
-#else
+#ifdef __cpp_lib_make_reverse_iterator
 STATIC_ASSERT(__cpp_lib_make_reverse_iterator == 201402L);
+#else
+#error __cpp_lib_make_reverse_iterator is not defined
 #endif
 
-#ifndef __cpp_lib_make_unique
-#error __cpp_lib_make_unique is not defined
-#elif __cpp_lib_make_unique != 201304L
-#error __cpp_lib_make_unique is not 201304L
-#else
+#ifdef __cpp_lib_make_unique
 STATIC_ASSERT(__cpp_lib_make_unique == 201304L);
+#else
+#error __cpp_lib_make_unique is not defined
 #endif
 
-#ifndef __cpp_lib_map_try_emplace
-#error __cpp_lib_map_try_emplace is not defined
-#elif __cpp_lib_map_try_emplace != 201411L
-#error __cpp_lib_map_try_emplace is not 201411L
-#else
+#ifdef __cpp_lib_map_try_emplace
 STATIC_ASSERT(__cpp_lib_map_try_emplace == 201411L);
+#else
+#error __cpp_lib_map_try_emplace is not defined
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_math_constants
-#error __cpp_lib_math_constants is not defined
-#elif __cpp_lib_math_constants != 201907L
-#error __cpp_lib_math_constants is not 201907L
-#else
+#ifdef __cpp_lib_math_constants
 STATIC_ASSERT(__cpp_lib_math_constants == 201907L);
+#else
+#error __cpp_lib_math_constants is not defined
 #endif
 #else
 #ifdef __cpp_lib_math_constants
@@ -1479,12 +1239,10 @@ STATIC_ASSERT(__cpp_lib_math_constants == 201907L);
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_math_special_functions
-#error __cpp_lib_math_special_functions is not defined
-#elif __cpp_lib_math_special_functions != 201603L
-#error __cpp_lib_math_special_functions is not 201603L
-#else
+#ifdef __cpp_lib_math_special_functions
 STATIC_ASSERT(__cpp_lib_math_special_functions == 201603L);
+#else
+#error __cpp_lib_math_special_functions is not defined
 #endif
 #else
 #ifdef __cpp_lib_math_special_functions
@@ -1493,12 +1251,10 @@ STATIC_ASSERT(__cpp_lib_math_special_functions == 201603L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_mdspan
-#error __cpp_lib_mdspan is not defined
-#elif __cpp_lib_mdspan != 202207L
-#error __cpp_lib_mdspan is not 202207L
-#else
+#ifdef __cpp_lib_mdspan
 STATIC_ASSERT(__cpp_lib_mdspan == 202207L);
+#else
+#error __cpp_lib_mdspan is not defined
 #endif
 #else
 #ifdef __cpp_lib_mdspan
@@ -1507,12 +1263,10 @@ STATIC_ASSERT(__cpp_lib_mdspan == 202207L);
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_memory_resource
-#error __cpp_lib_memory_resource is not defined
-#elif __cpp_lib_memory_resource != 201603L
-#error __cpp_lib_memory_resource is not 201603L
-#else
+#ifdef __cpp_lib_memory_resource
 STATIC_ASSERT(__cpp_lib_memory_resource == 201603L);
+#else
+#error __cpp_lib_memory_resource is not defined
 #endif
 #else
 #ifdef __cpp_lib_memory_resource
@@ -1521,12 +1275,10 @@ STATIC_ASSERT(__cpp_lib_memory_resource == 201603L);
 #endif
 
 #if _HAS_CXX20 && !defined(__clang__) && !defined(__EDG__) // TRANSITION, Clang and EDG support for modules
-#ifndef __cpp_lib_modules
-#error __cpp_lib_modules is not defined
-#elif __cpp_lib_modules != 202207L
-#error __cpp_lib_modules is not 202207L
-#else
+#ifdef __cpp_lib_modules
 STATIC_ASSERT(__cpp_lib_modules == 202207L);
+#else
+#error __cpp_lib_modules is not defined
 #endif
 #else
 #ifdef __cpp_lib_modules
@@ -1535,12 +1287,10 @@ STATIC_ASSERT(__cpp_lib_modules == 202207L);
 #endif
 
 #ifdef __cpp_lib_concepts
-#ifndef __cpp_lib_move_iterator_concept
-#error __cpp_lib_move_iterator_concept is not defined
-#elif __cpp_lib_move_iterator_concept != 202207L
-#error __cpp_lib_move_iterator_concept is not 202207L
-#else
+#ifdef __cpp_lib_move_iterator_concept
 STATIC_ASSERT(__cpp_lib_move_iterator_concept == 202207L);
+#else
+#error __cpp_lib_move_iterator_concept is not defined
 #endif
 #else
 #ifdef __cpp_lib_move_iterator_concept
@@ -1549,12 +1299,10 @@ STATIC_ASSERT(__cpp_lib_move_iterator_concept == 202207L);
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_move_only_function
-#error __cpp_lib_move_only_function is not defined
-#elif __cpp_lib_move_only_function != 202110L
-#error __cpp_lib_move_only_function is not 202110L
-#else
+#ifdef __cpp_lib_move_only_function
 STATIC_ASSERT(__cpp_lib_move_only_function == 202110L);
+#else
+#error __cpp_lib_move_only_function is not defined
 #endif
 #else
 #ifdef __cpp_lib_move_only_function
@@ -1563,12 +1311,10 @@ STATIC_ASSERT(__cpp_lib_move_only_function == 202110L);
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_node_extract
-#error __cpp_lib_node_extract is not defined
-#elif __cpp_lib_node_extract != 201606L
-#error __cpp_lib_node_extract is not 201606L
-#else
+#ifdef __cpp_lib_node_extract
 STATIC_ASSERT(__cpp_lib_node_extract == 201606L);
+#else
+#error __cpp_lib_node_extract is not defined
 #endif
 #else
 #ifdef __cpp_lib_node_extract
@@ -1576,21 +1322,17 @@ STATIC_ASSERT(__cpp_lib_node_extract == 201606L);
 #endif
 #endif
 
-#ifndef __cpp_lib_nonmember_container_access
-#error __cpp_lib_nonmember_container_access is not defined
-#elif __cpp_lib_nonmember_container_access != 201411L
-#error __cpp_lib_nonmember_container_access is not 201411L
-#else
+#ifdef __cpp_lib_nonmember_container_access
 STATIC_ASSERT(__cpp_lib_nonmember_container_access == 201411L);
+#else
+#error __cpp_lib_nonmember_container_access is not defined
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_not_fn
-#error __cpp_lib_not_fn is not defined
-#elif __cpp_lib_not_fn != 201603L
-#error __cpp_lib_not_fn is not 201603L
-#else
+#ifdef __cpp_lib_not_fn
 STATIC_ASSERT(__cpp_lib_not_fn == 201603L);
+#else
+#error __cpp_lib_not_fn is not defined
 #endif
 #else
 #ifdef __cpp_lib_not_fn
@@ -1598,37 +1340,29 @@ STATIC_ASSERT(__cpp_lib_not_fn == 201603L);
 #endif
 #endif
 
-#ifndef __cpp_lib_null_iterators
-#error __cpp_lib_null_iterators is not defined
-#elif __cpp_lib_null_iterators != 201304L
-#error __cpp_lib_null_iterators is not 201304L
-#else
+#ifdef __cpp_lib_null_iterators
 STATIC_ASSERT(__cpp_lib_null_iterators == 201304L);
+#else
+#error __cpp_lib_null_iterators is not defined
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_optional
-#error __cpp_lib_optional is not defined
-#elif __cpp_lib_optional != 202110L
-#error __cpp_lib_optional is not 202110L
-#else
+#ifdef __cpp_lib_optional
 STATIC_ASSERT(__cpp_lib_optional == 202110L);
+#else
+#error __cpp_lib_optional is not defined
 #endif
 #elif _HAS_CXX20
-#ifndef __cpp_lib_optional
-#error __cpp_lib_optional is not defined
-#elif __cpp_lib_optional != 202106L
-#error __cpp_lib_optional is not 202106L
-#else
+#ifdef __cpp_lib_optional
 STATIC_ASSERT(__cpp_lib_optional == 202106L);
+#else
+#error __cpp_lib_optional is not defined
 #endif
 #elif _HAS_CXX17
-#ifndef __cpp_lib_optional
-#error __cpp_lib_optional is not defined
-#elif __cpp_lib_optional != 201606L
-#error __cpp_lib_optional is not 201606L
-#else
+#ifdef __cpp_lib_optional
 STATIC_ASSERT(__cpp_lib_optional == 201606L);
+#else
+#error __cpp_lib_optional is not defined
 #endif
 #else
 #ifdef __cpp_lib_optional
@@ -1637,12 +1371,10 @@ STATIC_ASSERT(__cpp_lib_optional == 201606L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_out_ptr
-#error __cpp_lib_out_ptr is not defined
-#elif __cpp_lib_out_ptr != 202106L
-#error __cpp_lib_out_ptr is not 202106L
-#else
+#ifdef __cpp_lib_out_ptr
 STATIC_ASSERT(__cpp_lib_out_ptr == 202106L);
+#else
+#error __cpp_lib_out_ptr is not defined
 #endif
 #else
 #ifdef __cpp_lib_out_ptr
@@ -1651,12 +1383,10 @@ STATIC_ASSERT(__cpp_lib_out_ptr == 202106L);
 #endif
 
 #if _HAS_CXX17 && !defined(_M_CEE_PURE)
-#ifndef __cpp_lib_parallel_algorithm
-#error __cpp_lib_parallel_algorithm is not defined
-#elif __cpp_lib_parallel_algorithm != 201603L
-#error __cpp_lib_parallel_algorithm is not 201603L
-#else
+#ifdef __cpp_lib_parallel_algorithm
 STATIC_ASSERT(__cpp_lib_parallel_algorithm == 201603L);
+#else
+#error __cpp_lib_parallel_algorithm is not defined
 #endif
 #else
 #ifdef __cpp_lib_parallel_algorithm
@@ -1665,12 +1395,10 @@ STATIC_ASSERT(__cpp_lib_parallel_algorithm == 201603L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_polymorphic_allocator
-#error __cpp_lib_polymorphic_allocator is not defined
-#elif __cpp_lib_polymorphic_allocator != 201902L
-#error __cpp_lib_polymorphic_allocator is not 201902L
-#else
+#ifdef __cpp_lib_polymorphic_allocator
 STATIC_ASSERT(__cpp_lib_polymorphic_allocator == 201902L);
+#else
+#error __cpp_lib_polymorphic_allocator is not defined
 #endif
 #else
 #ifdef __cpp_lib_polymorphic_allocator
@@ -1679,12 +1407,10 @@ STATIC_ASSERT(__cpp_lib_polymorphic_allocator == 201902L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_print
-#error __cpp_lib_print is not defined
-#elif __cpp_lib_print != 202207L
-#error __cpp_lib_print is not 202207L
-#else
+#ifdef __cpp_lib_print
 STATIC_ASSERT(__cpp_lib_print == 202207L);
+#else
+#error __cpp_lib_print is not defined
 #endif
 #else
 #ifdef __cpp_lib_print
@@ -1692,29 +1418,23 @@ STATIC_ASSERT(__cpp_lib_print == 202207L);
 #endif
 #endif
 
-#ifndef __cpp_lib_quoted_string_io
-#error __cpp_lib_quoted_string_io is not defined
-#elif __cpp_lib_quoted_string_io != 201304L
-#error __cpp_lib_quoted_string_io is not 201304L
-#else
+#ifdef __cpp_lib_quoted_string_io
 STATIC_ASSERT(__cpp_lib_quoted_string_io == 201304L);
+#else
+#error __cpp_lib_quoted_string_io is not defined
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges
-#error __cpp_lib_ranges is not defined
-#elif __cpp_lib_ranges != 202302L
-#error __cpp_lib_ranges is not 202302L
-#else
+#ifdef __cpp_lib_ranges
 STATIC_ASSERT(__cpp_lib_ranges == 202302L);
+#else
+#error __cpp_lib_ranges is not defined
 #endif
 #elif _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges
-#error __cpp_lib_ranges is not defined
-#elif __cpp_lib_ranges != 202110L
-#error __cpp_lib_ranges is not 202110L
-#else
+#ifdef __cpp_lib_ranges
 STATIC_ASSERT(__cpp_lib_ranges == 202110L);
+#else
+#error __cpp_lib_ranges is not defined
 #endif
 #else
 #ifdef __cpp_lib_ranges
@@ -1723,12 +1443,10 @@ STATIC_ASSERT(__cpp_lib_ranges == 202110L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_as_const
-#error __cpp_lib_ranges_as_const is not defined
-#elif __cpp_lib_ranges_as_const != 202207L
-#error __cpp_lib_ranges_as_const is not 202207L
-#else
+#ifdef __cpp_lib_ranges_as_const
 STATIC_ASSERT(__cpp_lib_ranges_as_const == 202207L);
+#else
+#error __cpp_lib_ranges_as_const is not defined
 #endif
 #else
 #ifdef __cpp_lib_ranges_as_const
@@ -1737,12 +1455,10 @@ STATIC_ASSERT(__cpp_lib_ranges_as_const == 202207L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_as_rvalue
-#error __cpp_lib_ranges_as_rvalue is not defined
-#elif __cpp_lib_ranges_as_rvalue != 202207L
-#error __cpp_lib_ranges_as_rvalue is not 202207L
-#else
+#ifdef __cpp_lib_ranges_as_rvalue
 STATIC_ASSERT(__cpp_lib_ranges_as_rvalue == 202207L);
+#else
+#error __cpp_lib_ranges_as_rvalue is not defined
 #endif
 #else
 #ifdef __cpp_lib_ranges_as_rvalue
@@ -1751,12 +1467,10 @@ STATIC_ASSERT(__cpp_lib_ranges_as_rvalue == 202207L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_cartesian_product
-#error __cpp_lib_ranges_cartesian_product is not defined
-#elif __cpp_lib_ranges_cartesian_product != 202207L
-#error __cpp_lib_ranges_cartesian_product is not 202207L
-#else
+#ifdef __cpp_lib_ranges_cartesian_product
 STATIC_ASSERT(__cpp_lib_ranges_cartesian_product == 202207L);
+#else
+#error __cpp_lib_ranges_cartesian_product is not defined
 #endif
 #else
 #ifdef __cpp_lib_ranges_cartesian_product
@@ -1765,12 +1479,10 @@ STATIC_ASSERT(__cpp_lib_ranges_cartesian_product == 202207L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_chunk
-#error __cpp_lib_ranges_chunk is not defined
-#elif __cpp_lib_ranges_chunk != 202202L
-#error __cpp_lib_ranges_chunk is not 202202L
-#else
+#ifdef __cpp_lib_ranges_chunk
 STATIC_ASSERT(__cpp_lib_ranges_chunk == 202202L);
+#else
+#error __cpp_lib_ranges_chunk is not defined
 #endif
 #else
 #ifdef __cpp_lib_ranges_chunk
@@ -1779,12 +1491,10 @@ STATIC_ASSERT(__cpp_lib_ranges_chunk == 202202L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_chunk_by
-#error __cpp_lib_ranges_chunk_by is not defined
-#elif __cpp_lib_ranges_chunk_by != 202202L
-#error __cpp_lib_ranges_chunk_by is not 202202L
-#else
+#ifdef __cpp_lib_ranges_chunk_by
 STATIC_ASSERT(__cpp_lib_ranges_chunk_by == 202202L);
+#else
+#error __cpp_lib_ranges_chunk_by is not defined
 #endif
 #else
 #ifdef __cpp_lib_ranges_chunk_by
@@ -1793,12 +1503,10 @@ STATIC_ASSERT(__cpp_lib_ranges_chunk_by == 202202L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_contains
-#error __cpp_lib_ranges_contains is not defined
-#elif __cpp_lib_ranges_contains != 202207L
-#error __cpp_lib_ranges_contains is not 202207L
-#else
+#ifdef __cpp_lib_ranges_contains
 STATIC_ASSERT(__cpp_lib_ranges_contains == 202207L);
+#else
+#error __cpp_lib_ranges_contains is not defined
 #endif
 #else
 #ifdef __cpp_lib_ranges_contains
@@ -1807,12 +1515,10 @@ STATIC_ASSERT(__cpp_lib_ranges_contains == 202207L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_enumerate
-#error __cpp_lib_ranges_enumerate is not defined
-#elif __cpp_lib_ranges_enumerate != 202302L
-#error __cpp_lib_ranges_enumerate is not 202302L
-#else
+#ifdef __cpp_lib_ranges_enumerate
 STATIC_ASSERT(__cpp_lib_ranges_enumerate == 202302L);
+#else
+#error __cpp_lib_ranges_enumerate is not defined
 #endif
 #else
 #ifdef __cpp_lib_ranges_enumerate
@@ -1821,12 +1527,10 @@ STATIC_ASSERT(__cpp_lib_ranges_enumerate == 202302L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_find_last
-#error __cpp_lib_ranges_find_last is not defined
-#elif __cpp_lib_ranges_find_last != 202207L
-#error __cpp_lib_ranges_find_last is not 202207L
-#else
+#ifdef __cpp_lib_ranges_find_last
 STATIC_ASSERT(__cpp_lib_ranges_find_last == 202207L);
+#else
+#error __cpp_lib_ranges_find_last is not defined
 #endif
 #else
 #ifdef __cpp_lib_ranges_find_last
@@ -1835,12 +1539,10 @@ STATIC_ASSERT(__cpp_lib_ranges_find_last == 202207L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_fold
-#error __cpp_lib_ranges_fold is not defined
-#elif __cpp_lib_ranges_fold != 202207L
-#error __cpp_lib_ranges_fold is not 202207L
-#else
+#ifdef __cpp_lib_ranges_fold
 STATIC_ASSERT(__cpp_lib_ranges_fold == 202207L);
+#else
+#error __cpp_lib_ranges_fold is not defined
 #endif
 #else
 #ifdef __cpp_lib_ranges_fold
@@ -1849,12 +1551,10 @@ STATIC_ASSERT(__cpp_lib_ranges_fold == 202207L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_iota
-#error __cpp_lib_ranges_iota is not defined
-#elif __cpp_lib_ranges_iota != 202202L
-#error __cpp_lib_ranges_iota is not 202202L
-#else
+#ifdef __cpp_lib_ranges_iota
 STATIC_ASSERT(__cpp_lib_ranges_iota == 202202L);
+#else
+#error __cpp_lib_ranges_iota is not defined
 #endif
 #else
 #ifdef __cpp_lib_ranges_iota
@@ -1863,12 +1563,10 @@ STATIC_ASSERT(__cpp_lib_ranges_iota == 202202L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_join_with
-#error __cpp_lib_ranges_join_with is not defined
-#elif __cpp_lib_ranges_join_with != 202202L
-#error __cpp_lib_ranges_join_with is not 202202L
-#else
+#ifdef __cpp_lib_ranges_join_with
 STATIC_ASSERT(__cpp_lib_ranges_join_with == 202202L);
+#else
+#error __cpp_lib_ranges_join_with is not defined
 #endif
 #else
 #ifdef __cpp_lib_ranges_join_with
@@ -1877,12 +1575,10 @@ STATIC_ASSERT(__cpp_lib_ranges_join_with == 202202L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_repeat
-#error __cpp_lib_ranges_repeat is not defined
-#elif __cpp_lib_ranges_repeat != 202207L
-#error __cpp_lib_ranges_repeat is not 202207L
-#else
+#ifdef __cpp_lib_ranges_repeat
 STATIC_ASSERT(__cpp_lib_ranges_repeat == 202207L);
+#else
+#error __cpp_lib_ranges_repeat is not defined
 #endif
 #else
 #ifdef __cpp_lib_ranges_repeat
@@ -1891,12 +1587,10 @@ STATIC_ASSERT(__cpp_lib_ranges_repeat == 202207L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_slide
-#error __cpp_lib_ranges_slide is not defined
-#elif __cpp_lib_ranges_slide != 202202L
-#error __cpp_lib_ranges_slide is not 202202L
-#else
+#ifdef __cpp_lib_ranges_slide
 STATIC_ASSERT(__cpp_lib_ranges_slide == 202202L);
+#else
+#error __cpp_lib_ranges_slide is not defined
 #endif
 #else
 #ifdef __cpp_lib_ranges_slide
@@ -1905,12 +1599,10 @@ STATIC_ASSERT(__cpp_lib_ranges_slide == 202202L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_starts_ends_with
-#error __cpp_lib_ranges_starts_ends_with is not defined
-#elif __cpp_lib_ranges_starts_ends_with != 202106L
-#error __cpp_lib_ranges_starts_ends_with is not 202106L
-#else
+#ifdef __cpp_lib_ranges_starts_ends_with
 STATIC_ASSERT(__cpp_lib_ranges_starts_ends_with == 202106L);
+#else
+#error __cpp_lib_ranges_starts_ends_with is not defined
 #endif
 #else
 #ifdef __cpp_lib_ranges_starts_ends_with
@@ -1919,12 +1611,10 @@ STATIC_ASSERT(__cpp_lib_ranges_starts_ends_with == 202106L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_stride
-#error __cpp_lib_ranges_stride is not defined
-#elif __cpp_lib_ranges_stride != 202207L
-#error __cpp_lib_ranges_stride is not 202207L
-#else
+#ifdef __cpp_lib_ranges_stride
 STATIC_ASSERT(__cpp_lib_ranges_stride == 202207L);
+#else
+#error __cpp_lib_ranges_stride is not defined
 #endif
 #else
 #ifdef __cpp_lib_ranges_stride
@@ -1933,12 +1623,10 @@ STATIC_ASSERT(__cpp_lib_ranges_stride == 202207L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_to_container
-#error __cpp_lib_ranges_to_container is not defined
-#elif __cpp_lib_ranges_to_container != 202202L
-#error __cpp_lib_ranges_to_container is not 202202L
-#else
+#ifdef __cpp_lib_ranges_to_container
 STATIC_ASSERT(__cpp_lib_ranges_to_container == 202202L);
+#else
+#error __cpp_lib_ranges_to_container is not defined
 #endif
 #else
 #ifdef __cpp_lib_ranges_to_container
@@ -1947,12 +1635,10 @@ STATIC_ASSERT(__cpp_lib_ranges_to_container == 202202L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_zip
-#error __cpp_lib_ranges_zip is not defined
-#elif __cpp_lib_ranges_zip != 202110L
-#error __cpp_lib_ranges_zip is not 202110L
-#else
+#ifdef __cpp_lib_ranges_zip
 STATIC_ASSERT(__cpp_lib_ranges_zip == 202110L);
+#else
+#error __cpp_lib_ranges_zip is not defined
 #endif
 #else
 #ifdef __cpp_lib_ranges_zip
@@ -1961,12 +1647,10 @@ STATIC_ASSERT(__cpp_lib_ranges_zip == 202110L);
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_raw_memory_algorithms
-#error __cpp_lib_raw_memory_algorithms is not defined
-#elif __cpp_lib_raw_memory_algorithms != 201606L
-#error __cpp_lib_raw_memory_algorithms is not 201606L
-#else
+#ifdef __cpp_lib_raw_memory_algorithms
 STATIC_ASSERT(__cpp_lib_raw_memory_algorithms == 201606L);
+#else
+#error __cpp_lib_raw_memory_algorithms is not defined
 #endif
 #else
 #ifdef __cpp_lib_raw_memory_algorithms
@@ -1975,12 +1659,10 @@ STATIC_ASSERT(__cpp_lib_raw_memory_algorithms == 201606L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_remove_cvref
-#error __cpp_lib_remove_cvref is not defined
-#elif __cpp_lib_remove_cvref != 201711L
-#error __cpp_lib_remove_cvref is not 201711L
-#else
+#ifdef __cpp_lib_remove_cvref
 STATIC_ASSERT(__cpp_lib_remove_cvref == 201711L);
+#else
+#error __cpp_lib_remove_cvref is not defined
 #endif
 #else
 #ifdef __cpp_lib_remove_cvref
@@ -1988,29 +1670,23 @@ STATIC_ASSERT(__cpp_lib_remove_cvref == 201711L);
 #endif
 #endif
 
-#ifndef __cpp_lib_result_of_sfinae
-#error __cpp_lib_result_of_sfinae is not defined
-#elif __cpp_lib_result_of_sfinae != 201210L
-#error __cpp_lib_result_of_sfinae is not 201210L
-#else
+#ifdef __cpp_lib_result_of_sfinae
 STATIC_ASSERT(__cpp_lib_result_of_sfinae == 201210L);
+#else
+#error __cpp_lib_result_of_sfinae is not defined
 #endif
 
-#ifndef __cpp_lib_robust_nonmodifying_seq_ops
-#error __cpp_lib_robust_nonmodifying_seq_ops is not defined
-#elif __cpp_lib_robust_nonmodifying_seq_ops != 201304L
-#error __cpp_lib_robust_nonmodifying_seq_ops is not 201304L
-#else
+#ifdef __cpp_lib_robust_nonmodifying_seq_ops
 STATIC_ASSERT(__cpp_lib_robust_nonmodifying_seq_ops == 201304L);
+#else
+#error __cpp_lib_robust_nonmodifying_seq_ops is not defined
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_sample
-#error __cpp_lib_sample is not defined
-#elif __cpp_lib_sample != 201603L
-#error __cpp_lib_sample is not 201603L
-#else
+#ifdef __cpp_lib_sample
 STATIC_ASSERT(__cpp_lib_sample == 201603L);
+#else
+#error __cpp_lib_sample is not defined
 #endif
 #else
 #ifdef __cpp_lib_sample
@@ -2019,12 +1695,10 @@ STATIC_ASSERT(__cpp_lib_sample == 201603L);
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_scoped_lock
-#error __cpp_lib_scoped_lock is not defined
-#elif __cpp_lib_scoped_lock != 201703L
-#error __cpp_lib_scoped_lock is not 201703L
-#else
+#ifdef __cpp_lib_scoped_lock
 STATIC_ASSERT(__cpp_lib_scoped_lock == 201703L);
+#else
+#error __cpp_lib_scoped_lock is not defined
 #endif
 #else
 #ifdef __cpp_lib_scoped_lock
@@ -2033,12 +1707,10 @@ STATIC_ASSERT(__cpp_lib_scoped_lock == 201703L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_semaphore
-#error __cpp_lib_semaphore is not defined
-#elif __cpp_lib_semaphore != 201907L
-#error __cpp_lib_semaphore is not 201907L
-#else
+#ifdef __cpp_lib_semaphore
 STATIC_ASSERT(__cpp_lib_semaphore == 201907L);
+#else
+#error __cpp_lib_semaphore is not defined
 #endif
 #else
 #ifdef __cpp_lib_semaphore
@@ -2046,12 +1718,10 @@ STATIC_ASSERT(__cpp_lib_semaphore == 201907L);
 #endif
 #endif
 
-#ifndef __cpp_lib_shared_mutex
-#error __cpp_lib_shared_mutex is not defined
-#elif __cpp_lib_shared_mutex != 201505L
-#error __cpp_lib_shared_mutex is not 201505L
-#else
+#ifdef __cpp_lib_shared_mutex
 STATIC_ASSERT(__cpp_lib_shared_mutex == 201505L);
+#else
+#error __cpp_lib_shared_mutex is not defined
 #endif
 
 #ifndef __cpp_lib_shared_ptr_arrays
@@ -2071,12 +1741,10 @@ STATIC_ASSERT(__cpp_lib_shared_ptr_arrays == 201611L);
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_shared_ptr_weak_type
-#error __cpp_lib_shared_ptr_weak_type is not defined
-#elif __cpp_lib_shared_ptr_weak_type != 201606L
-#error __cpp_lib_shared_ptr_weak_type is not 201606L
-#else
+#ifdef __cpp_lib_shared_ptr_weak_type
 STATIC_ASSERT(__cpp_lib_shared_ptr_weak_type == 201606L);
+#else
+#error __cpp_lib_shared_ptr_weak_type is not defined
 #endif
 #else
 #ifdef __cpp_lib_shared_ptr_weak_type
@@ -2089,12 +1757,10 @@ STATIC_ASSERT(__cpp_lib_shared_ptr_weak_type == 201606L);
 #error __cpp_lib_shared_timed_mutex is defined
 #endif
 #else
-#ifndef __cpp_lib_shared_timed_mutex
-#error __cpp_lib_shared_timed_mutex is not defined
-#elif __cpp_lib_shared_timed_mutex != 201402L
-#error __cpp_lib_shared_timed_mutex is not 201402L
-#else
+#ifdef __cpp_lib_shared_timed_mutex
 STATIC_ASSERT(__cpp_lib_shared_timed_mutex == 201402L);
+#else
+#error __cpp_lib_shared_timed_mutex is not defined
 #endif
 #endif
 
@@ -2111,12 +1777,10 @@ STATIC_ASSERT(__cpp_lib_shared_timed_mutex == 201402L);
 STATIC_ASSERT(__cpp_lib_shift == 202202L);
 #endif
 #elif _HAS_CXX20
-#ifndef __cpp_lib_shift
-#error __cpp_lib_shift is not defined
-#elif __cpp_lib_shift != 201806L
-#error __cpp_lib_shift is not 201806L
-#else
+#ifdef __cpp_lib_shift
 STATIC_ASSERT(__cpp_lib_shift == 201806L);
+#else
+#error __cpp_lib_shift is not defined
 #endif
 #else
 #ifdef __cpp_lib_shift
@@ -2125,12 +1789,10 @@ STATIC_ASSERT(__cpp_lib_shift == 201806L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_smart_ptr_for_overwrite
-#error __cpp_lib_smart_ptr_for_overwrite is not defined
-#elif __cpp_lib_smart_ptr_for_overwrite != 202002L
-#error __cpp_lib_smart_ptr_for_overwrite is not 202002L
-#else
+#ifdef __cpp_lib_smart_ptr_for_overwrite
 STATIC_ASSERT(__cpp_lib_smart_ptr_for_overwrite == 202002L);
+#else
+#error __cpp_lib_smart_ptr_for_overwrite is not defined
 #endif
 #else
 #ifdef __cpp_lib_smart_ptr_for_overwrite
@@ -2139,12 +1801,10 @@ STATIC_ASSERT(__cpp_lib_smart_ptr_for_overwrite == 202002L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_source_location
-#error __cpp_lib_source_location is not defined
-#elif __cpp_lib_source_location != 201907L
-#error __cpp_lib_source_location is not 201907L
-#else
+#ifdef __cpp_lib_source_location
 STATIC_ASSERT(__cpp_lib_source_location == 201907L);
+#else
+#error __cpp_lib_source_location is not defined
 #endif
 #else
 #ifdef __cpp_lib_source_location
@@ -2153,12 +1813,10 @@ STATIC_ASSERT(__cpp_lib_source_location == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_span
-#error __cpp_lib_span is not defined
-#elif __cpp_lib_span != 202002L
-#error __cpp_lib_span is not 202002L
-#else
+#ifdef __cpp_lib_span
 STATIC_ASSERT(__cpp_lib_span == 202002L);
+#else
+#error __cpp_lib_span is not defined
 #endif
 #else
 #ifdef __cpp_lib_span
@@ -2167,12 +1825,10 @@ STATIC_ASSERT(__cpp_lib_span == 202002L);
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_spanstream
-#error __cpp_lib_spanstream is not defined
-#elif __cpp_lib_spanstream != 202106L
-#error __cpp_lib_spanstream is not 202106L
-#else
+#ifdef __cpp_lib_spanstream
 STATIC_ASSERT(__cpp_lib_spanstream == 202106L);
+#else
+#error __cpp_lib_spanstream is not defined
 #endif
 #else
 #ifdef __cpp_lib_spanstream
@@ -2181,12 +1837,10 @@ STATIC_ASSERT(__cpp_lib_spanstream == 202106L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_ssize
-#error __cpp_lib_ssize is not defined
-#elif __cpp_lib_ssize != 201902L
-#error __cpp_lib_ssize is not 201902L
-#else
+#ifdef __cpp_lib_ssize
 STATIC_ASSERT(__cpp_lib_ssize == 201902L);
+#else
+#error __cpp_lib_ssize is not defined
 #endif
 #else
 #ifdef __cpp_lib_ssize
@@ -2195,12 +1849,10 @@ STATIC_ASSERT(__cpp_lib_ssize == 201902L);
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_stacktrace
-#error __cpp_lib_stacktrace is not defined
-#elif __cpp_lib_stacktrace != 202011L
-#error __cpp_lib_stacktrace is not 202011L
-#else
+#ifdef __cpp_lib_stacktrace
 STATIC_ASSERT(__cpp_lib_stacktrace == 202011L);
+#else
+#error __cpp_lib_stacktrace is not defined
 #endif
 #else
 #ifdef __cpp_lib_stacktrace
@@ -2209,12 +1861,10 @@ STATIC_ASSERT(__cpp_lib_stacktrace == 202011L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_starts_ends_with
-#error __cpp_lib_starts_ends_with is not defined
-#elif __cpp_lib_starts_ends_with != 201711L
-#error __cpp_lib_starts_ends_with is not 201711L
-#else
+#ifdef __cpp_lib_starts_ends_with
 STATIC_ASSERT(__cpp_lib_starts_ends_with == 201711L);
+#else
+#error __cpp_lib_starts_ends_with is not defined
 #endif
 #else
 #ifdef __cpp_lib_starts_ends_with
@@ -2223,12 +1873,10 @@ STATIC_ASSERT(__cpp_lib_starts_ends_with == 201711L);
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_stdatomic_h
-#error __cpp_lib_stdatomic_h is not defined
-#elif __cpp_lib_stdatomic_h != 202011L
-#error __cpp_lib_stdatomic_h is not 202011L
-#else
+#ifdef __cpp_lib_stdatomic_h
 STATIC_ASSERT(__cpp_lib_stdatomic_h == 202011L);
+#else
+#error __cpp_lib_stdatomic_h is not defined
 #endif
 #else
 #ifdef __cpp_lib_stdatomic_h
@@ -2237,12 +1885,10 @@ STATIC_ASSERT(__cpp_lib_stdatomic_h == 202011L);
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_string_contains
-#error __cpp_lib_string_contains is not defined
-#elif __cpp_lib_string_contains != 202011L
-#error __cpp_lib_string_contains is not 202011L
-#else
+#ifdef __cpp_lib_string_contains
 STATIC_ASSERT(__cpp_lib_string_contains == 202011L);
+#else
+#error __cpp_lib_string_contains is not defined
 #endif
 #else
 #ifdef __cpp_lib_string_contains
@@ -2251,12 +1897,10 @@ STATIC_ASSERT(__cpp_lib_string_contains == 202011L);
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_string_resize_and_overwrite
-#error __cpp_lib_string_resize_and_overwrite is not defined
-#elif __cpp_lib_string_resize_and_overwrite != 202110L
-#error __cpp_lib_string_resize_and_overwrite is not 202110L
-#else
+#ifdef __cpp_lib_string_resize_and_overwrite
 STATIC_ASSERT(__cpp_lib_string_resize_and_overwrite == 202110L);
+#else
+#error __cpp_lib_string_resize_and_overwrite is not defined
 #endif
 #else
 #ifdef __cpp_lib_string_resize_and_overwrite
@@ -2264,21 +1908,17 @@ STATIC_ASSERT(__cpp_lib_string_resize_and_overwrite == 202110L);
 #endif
 #endif
 
-#ifndef __cpp_lib_string_udls
-#error __cpp_lib_string_udls is not defined
-#elif __cpp_lib_string_udls != 201304L
-#error __cpp_lib_string_udls is not 201304L
-#else
+#ifdef __cpp_lib_string_udls
 STATIC_ASSERT(__cpp_lib_string_udls == 201304L);
+#else
+#error __cpp_lib_string_udls is not defined
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_string_view
-#error __cpp_lib_string_view is not defined
-#elif __cpp_lib_string_view != 201803L
-#error __cpp_lib_string_view is not 201803L
-#else
+#ifdef __cpp_lib_string_view
 STATIC_ASSERT(__cpp_lib_string_view == 201803L);
+#else
+#error __cpp_lib_string_view is not defined
 #endif
 #else
 #ifdef __cpp_lib_string_view
@@ -2287,12 +1927,10 @@ STATIC_ASSERT(__cpp_lib_string_view == 201803L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_syncbuf
-#error __cpp_lib_syncbuf is not defined
-#elif __cpp_lib_syncbuf != 201803L
-#error __cpp_lib_syncbuf is not 201803L
-#else
+#ifdef __cpp_lib_syncbuf
 STATIC_ASSERT(__cpp_lib_syncbuf == 201803L);
+#else
+#error __cpp_lib_syncbuf is not defined
 #endif
 #else
 #ifdef __cpp_lib_syncbuf
@@ -2301,12 +1939,10 @@ STATIC_ASSERT(__cpp_lib_syncbuf == 201803L);
 #endif
 
 #ifdef __cpp_lib_concepts
-#ifndef __cpp_lib_three_way_comparison
-#error __cpp_lib_three_way_comparison is not defined
-#elif __cpp_lib_three_way_comparison != 201907L
-#error __cpp_lib_three_way_comparison is not 201907L
-#else
+#ifdef __cpp_lib_three_way_comparison
 STATIC_ASSERT(__cpp_lib_three_way_comparison == 201907L);
+#else
+#error __cpp_lib_three_way_comparison is not defined
 #endif
 #else
 #ifdef __cpp_lib_three_way_comparison
@@ -2315,12 +1951,10 @@ STATIC_ASSERT(__cpp_lib_three_way_comparison == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_to_address
-#error __cpp_lib_to_address is not defined
-#elif __cpp_lib_to_address != 201711L
-#error __cpp_lib_to_address is not 201711L
-#else
+#ifdef __cpp_lib_to_address
 STATIC_ASSERT(__cpp_lib_to_address == 201711L);
+#else
+#error __cpp_lib_to_address is not defined
 #endif
 #else
 #ifdef __cpp_lib_to_address
@@ -2329,12 +1963,10 @@ STATIC_ASSERT(__cpp_lib_to_address == 201711L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_to_array
-#error __cpp_lib_to_array is not defined
-#elif __cpp_lib_to_array != 201907L
-#error __cpp_lib_to_array is not 201907L
-#else
+#ifdef __cpp_lib_to_array
 STATIC_ASSERT(__cpp_lib_to_array == 201907L);
+#else
+#error __cpp_lib_to_array is not defined
 #endif
 #else
 #ifdef __cpp_lib_to_array
@@ -2343,12 +1975,10 @@ STATIC_ASSERT(__cpp_lib_to_array == 201907L);
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_to_chars
-#error __cpp_lib_to_chars is not defined
-#elif __cpp_lib_to_chars != 201611L
-#error __cpp_lib_to_chars is not 201611L
-#else
+#ifdef __cpp_lib_to_chars
 STATIC_ASSERT(__cpp_lib_to_chars == 201611L);
+#else
+#error __cpp_lib_to_chars is not defined
 #endif
 #else
 #ifdef __cpp_lib_to_chars
@@ -2357,12 +1987,10 @@ STATIC_ASSERT(__cpp_lib_to_chars == 201611L);
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_to_underlying
-#error __cpp_lib_to_underlying is not defined
-#elif __cpp_lib_to_underlying != 202102L
-#error __cpp_lib_to_underlying is not 202102L
-#else
+#ifdef __cpp_lib_to_underlying
 STATIC_ASSERT(__cpp_lib_to_underlying == 202102L);
+#else
+#error __cpp_lib_to_underlying is not defined
 #endif
 #else
 #ifdef __cpp_lib_to_underlying
@@ -2370,37 +1998,29 @@ STATIC_ASSERT(__cpp_lib_to_underlying == 202102L);
 #endif
 #endif
 
-#ifndef __cpp_lib_transformation_trait_aliases
-#error __cpp_lib_transformation_trait_aliases is not defined
-#elif __cpp_lib_transformation_trait_aliases != 201304L
-#error __cpp_lib_transformation_trait_aliases is not 201304L
-#else
+#ifdef __cpp_lib_transformation_trait_aliases
 STATIC_ASSERT(__cpp_lib_transformation_trait_aliases == 201304L);
+#else
+#error __cpp_lib_transformation_trait_aliases is not defined
 #endif
 
-#ifndef __cpp_lib_transparent_operators
-#error __cpp_lib_transparent_operators is not defined
-#elif __cpp_lib_transparent_operators != 201510L
-#error __cpp_lib_transparent_operators is not 201510L
-#else
+#ifdef __cpp_lib_transparent_operators
 STATIC_ASSERT(__cpp_lib_transparent_operators == 201510L);
+#else
+#error __cpp_lib_transparent_operators is not defined
 #endif
 
-#ifndef __cpp_lib_tuple_element_t
-#error __cpp_lib_tuple_element_t is not defined
-#elif __cpp_lib_tuple_element_t != 201402L
-#error __cpp_lib_tuple_element_t is not 201402L
-#else
+#ifdef __cpp_lib_tuple_element_t
 STATIC_ASSERT(__cpp_lib_tuple_element_t == 201402L);
+#else
+#error __cpp_lib_tuple_element_t is not defined
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_tuple_like
-#error __cpp_lib_tuple_like is not defined
-#elif __cpp_lib_tuple_like != 202207L
-#error __cpp_lib_tuple_like is not 202207L
-#else
+#ifdef __cpp_lib_tuple_like
 STATIC_ASSERT(__cpp_lib_tuple_like == 202207L);
+#else
+#error __cpp_lib_tuple_like is not defined
 #endif
 #else
 #ifdef __cpp_lib_tuple_like
@@ -2408,21 +2028,17 @@ STATIC_ASSERT(__cpp_lib_tuple_like == 202207L);
 #endif
 #endif
 
-#ifndef __cpp_lib_tuples_by_type
-#error __cpp_lib_tuples_by_type is not defined
-#elif __cpp_lib_tuples_by_type != 201304L
-#error __cpp_lib_tuples_by_type is not 201304L
-#else
+#ifdef __cpp_lib_tuples_by_type
 STATIC_ASSERT(__cpp_lib_tuples_by_type == 201304L);
+#else
+#error __cpp_lib_tuples_by_type is not defined
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_type_identity
-#error __cpp_lib_type_identity is not defined
-#elif __cpp_lib_type_identity != 201806L
-#error __cpp_lib_type_identity is not 201806L
-#else
+#ifdef __cpp_lib_type_identity
 STATIC_ASSERT(__cpp_lib_type_identity == 201806L);
+#else
+#error __cpp_lib_type_identity is not defined
 #endif
 #else
 #ifdef __cpp_lib_type_identity
@@ -2430,37 +2046,29 @@ STATIC_ASSERT(__cpp_lib_type_identity == 201806L);
 #endif
 #endif
 
-#ifndef __cpp_lib_type_trait_variable_templates
-#error __cpp_lib_type_trait_variable_templates is not defined
-#elif __cpp_lib_type_trait_variable_templates != 201510L
-#error __cpp_lib_type_trait_variable_templates is not 201510L
-#else
+#ifdef __cpp_lib_type_trait_variable_templates
 STATIC_ASSERT(__cpp_lib_type_trait_variable_templates == 201510L);
+#else
+#error __cpp_lib_type_trait_variable_templates is not defined
 #endif
 
-#ifndef __cpp_lib_uncaught_exceptions
-#error __cpp_lib_uncaught_exceptions is not defined
-#elif __cpp_lib_uncaught_exceptions != 201411L
-#error __cpp_lib_uncaught_exceptions is not 201411L
-#else
+#ifdef __cpp_lib_uncaught_exceptions
 STATIC_ASSERT(__cpp_lib_uncaught_exceptions == 201411L);
+#else
+#error __cpp_lib_uncaught_exceptions is not defined
 #endif
 
-#ifndef __cpp_lib_unordered_map_try_emplace
-#error __cpp_lib_unordered_map_try_emplace is not defined
-#elif __cpp_lib_unordered_map_try_emplace != 201411L
-#error __cpp_lib_unordered_map_try_emplace is not 201411L
-#else
+#ifdef __cpp_lib_unordered_map_try_emplace
 STATIC_ASSERT(__cpp_lib_unordered_map_try_emplace == 201411L);
+#else
+#error __cpp_lib_unordered_map_try_emplace is not defined
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_unreachable
-#error __cpp_lib_unreachable is not defined
-#elif __cpp_lib_unreachable != 202202L
-#error __cpp_lib_unreachable is not 202202L
-#else
+#ifdef __cpp_lib_unreachable
 STATIC_ASSERT(__cpp_lib_unreachable == 202202L);
+#else
+#error __cpp_lib_unreachable is not defined
 #endif
 #else
 #ifdef __cpp_lib_unreachable
@@ -2469,12 +2077,10 @@ STATIC_ASSERT(__cpp_lib_unreachable == 202202L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_unwrap_ref
-#error __cpp_lib_unwrap_ref is not defined
-#elif __cpp_lib_unwrap_ref != 201811L
-#error __cpp_lib_unwrap_ref is not 201811L
-#else
+#ifdef __cpp_lib_unwrap_ref
 STATIC_ASSERT(__cpp_lib_unwrap_ref == 201811L);
+#else
+#error __cpp_lib_unwrap_ref is not defined
 #endif
 #else
 #ifdef __cpp_lib_unwrap_ref
@@ -2483,20 +2089,16 @@ STATIC_ASSERT(__cpp_lib_unwrap_ref == 201811L);
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_variant
-#error __cpp_lib_variant is not defined
-#elif __cpp_lib_variant != 202106L
-#error __cpp_lib_variant is not 202106L
-#else
+#ifdef __cpp_lib_variant
 STATIC_ASSERT(__cpp_lib_variant == 202106L);
+#else
+#error __cpp_lib_variant is not defined
 #endif
 #elif _HAS_CXX17
-#ifndef __cpp_lib_variant
-#error __cpp_lib_variant is not defined
-#elif __cpp_lib_variant != 202102L
-#error __cpp_lib_variant is not 202102L
-#else
+#ifdef __cpp_lib_variant
 STATIC_ASSERT(__cpp_lib_variant == 202102L);
+#else
+#error __cpp_lib_variant is not defined
 #endif
 #else
 #ifdef __cpp_lib_variant
@@ -2504,10 +2106,8 @@ STATIC_ASSERT(__cpp_lib_variant == 202102L);
 #endif
 #endif
 
-#ifndef __cpp_lib_void_t
-#error __cpp_lib_void_t is not defined
-#elif __cpp_lib_void_t != 201411L
-#error __cpp_lib_void_t is not 201411L
-#else
+#ifdef __cpp_lib_void_t
 STATIC_ASSERT(__cpp_lib_void_t == 201411L);
+#else
+#error __cpp_lib_void_t is not defined
 #endif

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -611,7 +611,7 @@ STATIC_ASSERT(__cpp_lib_containers_ranges == 202202L);
 #error __cpp_lib_containers_ranges is not defined
 #endif
 #else
-#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#ifdef __cpp_lib_containers_ranges
 #error __cpp_lib_containers_ranges is defined
 #endif
 #endif

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -345,23 +345,11 @@ STATIC_ASSERT(__cpp_lib_char8_t == 201907L);
 #ifndef __cpp_lib_chrono
 #error __cpp_lib_chrono is not defined
 #elif defined(__cpp_lib_concepts)
-#if __cpp_lib_chrono != 201907L
-#error __cpp_lib_chrono is not 201907L
-#else
 STATIC_ASSERT(__cpp_lib_chrono == 201907L);
-#endif
 #elif _HAS_CXX17
-#if __cpp_lib_chrono != 201611L
-#error __cpp_lib_chrono is not 201611L
-#else
 STATIC_ASSERT(__cpp_lib_chrono == 201611L);
-#endif
-#else
-#if __cpp_lib_chrono != 201510L
-#error __cpp_lib_chrono is not 201510L
 #else
 STATIC_ASSERT(__cpp_lib_chrono == 201510L);
-#endif
 #endif
 
 #ifdef __cpp_lib_chrono_udls
@@ -1727,17 +1715,9 @@ STATIC_ASSERT(__cpp_lib_shared_mutex == 201505L);
 #ifndef __cpp_lib_shared_ptr_arrays
 #error __cpp_lib_shared_ptr_arrays is not defined
 #elif _HAS_CXX20
-#if __cpp_lib_shared_ptr_arrays != 201707L
-#error __cpp_lib_shared_ptr_arrays is not 201707L
-#else
 STATIC_ASSERT(__cpp_lib_shared_ptr_arrays == 201707L);
-#endif
-#else
-#if __cpp_lib_shared_ptr_arrays != 201611L
-#error __cpp_lib_shared_ptr_arrays is not 201611L
 #else
 STATIC_ASSERT(__cpp_lib_shared_ptr_arrays == 201611L);
-#endif
 #endif
 
 #if _HAS_CXX17

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -7,29 +7,17 @@
 
 // LIBRARY FEATURE-TEST MACROS
 #if _HAS_CXX23
-#ifdef __cpp_lib_adaptor_iterator_pair_constructor
 STATIC_ASSERT(__cpp_lib_adaptor_iterator_pair_constructor == 202106L);
-#else
-#error __cpp_lib_adaptor_iterator_pair_constructor is not defined
-#endif
 #else
 #ifdef __cpp_lib_adaptor_iterator_pair_constructor
 #error __cpp_lib_adaptor_iterator_pair_constructor is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_addressof_constexpr
 STATIC_ASSERT(__cpp_lib_addressof_constexpr == 201603L);
-#else
-#error __cpp_lib_addressof_constexpr is not defined
-#endif
 
 #if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_algorithm_iterator_requirements
 STATIC_ASSERT(__cpp_lib_algorithm_iterator_requirements == 202207L);
-#else
-#error __cpp_lib_algorithm_iterator_requirements is not defined
-#endif
 #else
 #ifdef __cpp_lib_algorithm_iterator_requirements
 #error __cpp_lib_algorithm_iterator_requirements is defined
@@ -37,29 +25,17 @@ STATIC_ASSERT(__cpp_lib_algorithm_iterator_requirements == 202207L);
 #endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_allocate_at_least
 STATIC_ASSERT(__cpp_lib_allocate_at_least == 202302L);
-#else
-#error __cpp_lib_allocate_at_least is not defined
-#endif
 #else
 #ifdef __cpp_lib_allocate_at_least
 #error __cpp_lib_allocate_at_least is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_allocator_traits_is_always_equal
 STATIC_ASSERT(__cpp_lib_allocator_traits_is_always_equal == 201411L);
-#else
-#error __cpp_lib_allocator_traits_is_always_equal is not defined
-#endif
 
 #if _HAS_CXX17 && _HAS_STATIC_RTTI
-#ifdef __cpp_lib_any
 STATIC_ASSERT(__cpp_lib_any == 201606L);
-#else
-#error __cpp_lib_any is not defined
-#endif
 #else
 #ifdef __cpp_lib_any
 #error __cpp_lib_any is defined
@@ -67,11 +43,7 @@ STATIC_ASSERT(__cpp_lib_any == 201606L);
 #endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_apply
 STATIC_ASSERT(__cpp_lib_apply == 201603L);
-#else
-#error __cpp_lib_apply is not defined
-#endif
 #else
 #ifdef __cpp_lib_apply
 #error __cpp_lib_apply is defined
@@ -79,35 +51,19 @@ STATIC_ASSERT(__cpp_lib_apply == 201603L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_array_constexpr
 STATIC_ASSERT(__cpp_lib_array_constexpr == 201811L);
-#else
-#error __cpp_lib_array_constexpr is not defined
-#endif
 #elif _HAS_CXX17
-#ifdef __cpp_lib_array_constexpr
 STATIC_ASSERT(__cpp_lib_array_constexpr == 201803L);
-#else
-#error __cpp_lib_array_constexpr is not defined
-#endif
 #else
 #ifdef __cpp_lib_array_constexpr
 #error __cpp_lib_array_constexpr is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_as_const
 STATIC_ASSERT(__cpp_lib_as_const == 201510L);
-#else
-#error __cpp_lib_as_const is not defined
-#endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_associative_heterogeneous_erasure
 STATIC_ASSERT(__cpp_lib_associative_heterogeneous_erasure == 202110L);
-#else
-#error __cpp_lib_associative_heterogeneous_erasure is not defined
-#endif
 #else
 #ifdef __cpp_lib_associative_heterogeneous_erasure
 #error __cpp_lib_associative_heterogeneous_erasure is defined
@@ -115,11 +71,7 @@ STATIC_ASSERT(__cpp_lib_associative_heterogeneous_erasure == 202110L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_assume_aligned
 STATIC_ASSERT(__cpp_lib_assume_aligned == 201811L);
-#else
-#error __cpp_lib_assume_aligned is not defined
-#endif
 #else
 #ifdef __cpp_lib_assume_aligned
 #error __cpp_lib_assume_aligned is defined
@@ -127,11 +79,7 @@ STATIC_ASSERT(__cpp_lib_assume_aligned == 201811L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_atomic_flag_test
 STATIC_ASSERT(__cpp_lib_atomic_flag_test == 201907L);
-#else
-#error __cpp_lib_atomic_flag_test is not defined
-#endif
 #else
 #ifdef __cpp_lib_atomic_flag_test
 #error __cpp_lib_atomic_flag_test is defined
@@ -139,11 +87,7 @@ STATIC_ASSERT(__cpp_lib_atomic_flag_test == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_atomic_float
 STATIC_ASSERT(__cpp_lib_atomic_float == 201711L);
-#else
-#error __cpp_lib_atomic_float is not defined
-#endif
 #else
 #ifdef __cpp_lib_atomic_float
 #error __cpp_lib_atomic_float is defined
@@ -151,11 +95,7 @@ STATIC_ASSERT(__cpp_lib_atomic_float == 201711L);
 #endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_atomic_is_always_lock_free
 STATIC_ASSERT(__cpp_lib_atomic_is_always_lock_free == 201603L);
-#else
-#error __cpp_lib_atomic_is_always_lock_free is not defined
-#endif
 #else
 #ifdef __cpp_lib_atomic_is_always_lock_free
 #error __cpp_lib_atomic_is_always_lock_free is defined
@@ -163,11 +103,7 @@ STATIC_ASSERT(__cpp_lib_atomic_is_always_lock_free == 201603L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_atomic_lock_free_type_aliases
 STATIC_ASSERT(__cpp_lib_atomic_lock_free_type_aliases == 201907L);
-#else
-#error __cpp_lib_atomic_lock_free_type_aliases is not defined
-#endif
 #else
 #ifdef __cpp_lib_atomic_lock_free_type_aliases
 #error __cpp_lib_atomic_lock_free_type_aliases is defined
@@ -175,11 +111,7 @@ STATIC_ASSERT(__cpp_lib_atomic_lock_free_type_aliases == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_atomic_ref
 STATIC_ASSERT(__cpp_lib_atomic_ref == 201806L);
-#else
-#error __cpp_lib_atomic_ref is not defined
-#endif
 #else
 #ifdef __cpp_lib_atomic_ref
 #error __cpp_lib_atomic_ref is defined
@@ -187,29 +119,17 @@ STATIC_ASSERT(__cpp_lib_atomic_ref == 201806L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_atomic_shared_ptr
 STATIC_ASSERT(__cpp_lib_atomic_shared_ptr == 201711L);
-#else
-#error __cpp_lib_atomic_shared_ptr is not defined
-#endif
 #else
 #ifdef __cpp_lib_atomic_shared_ptr
 #error __cpp_lib_atomic_shared_ptr is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_atomic_value_initialization
 STATIC_ASSERT(__cpp_lib_atomic_value_initialization == 201911L);
-#else
-#error __cpp_lib_atomic_value_initialization is not defined
-#endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_atomic_wait
 STATIC_ASSERT(__cpp_lib_atomic_wait == 201907L);
-#else
-#error __cpp_lib_atomic_wait is not defined
-#endif
 #else
 #ifdef __cpp_lib_atomic_wait
 #error __cpp_lib_atomic_wait is defined
@@ -217,11 +137,7 @@ STATIC_ASSERT(__cpp_lib_atomic_wait == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_barrier
 STATIC_ASSERT(__cpp_lib_barrier == 202302L);
-#else
-#error __cpp_lib_barrier is not defined
-#endif
 #else
 #ifdef __cpp_lib_barrier
 #error __cpp_lib_barrier is defined
@@ -229,11 +145,7 @@ STATIC_ASSERT(__cpp_lib_barrier == 202302L);
 #endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_bind_back
 STATIC_ASSERT(__cpp_lib_bind_back == 202202L);
-#else
-#error __cpp_lib_bind_back is not defined
-#endif
 #else
 #ifdef __cpp_lib_bind_back
 #error __cpp_lib_bind_back is defined
@@ -241,11 +153,7 @@ STATIC_ASSERT(__cpp_lib_bind_back == 202202L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_bind_front
 STATIC_ASSERT(__cpp_lib_bind_front == 201907L);
-#else
-#error __cpp_lib_bind_front is not defined
-#endif
 #else
 #ifdef __cpp_lib_bind_front
 #error __cpp_lib_bind_front is defined
@@ -253,11 +161,7 @@ STATIC_ASSERT(__cpp_lib_bind_front == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_bit_cast
 STATIC_ASSERT(__cpp_lib_bit_cast == 201806L);
-#else
-#error __cpp_lib_bit_cast is not defined
-#endif
 #else
 #ifdef __cpp_lib_bit_cast
 #error __cpp_lib_bit_cast is defined
@@ -265,29 +169,17 @@ STATIC_ASSERT(__cpp_lib_bit_cast == 201806L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_bitops
 STATIC_ASSERT(__cpp_lib_bitops == 201907L);
-#else
-#error __cpp_lib_bitops is not defined
-#endif
 #else
 #ifdef __cpp_lib_bitops
 #error __cpp_lib_bitops is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_bool_constant
 STATIC_ASSERT(__cpp_lib_bool_constant == 201505L);
-#else
-#error __cpp_lib_bool_constant is not defined
-#endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_bounded_array_traits
 STATIC_ASSERT(__cpp_lib_bounded_array_traits == 201902L);
-#else
-#error __cpp_lib_bounded_array_traits is not defined
-#endif
 #else
 #ifdef __cpp_lib_bounded_array_traits
 #error __cpp_lib_bounded_array_traits is defined
@@ -295,11 +187,7 @@ STATIC_ASSERT(__cpp_lib_bounded_array_traits == 201902L);
 #endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_boyer_moore_searcher
 STATIC_ASSERT(__cpp_lib_boyer_moore_searcher == 201603L);
-#else
-#error __cpp_lib_boyer_moore_searcher is not defined
-#endif
 #else
 #ifdef __cpp_lib_boyer_moore_searcher
 #error __cpp_lib_boyer_moore_searcher is defined
@@ -307,11 +195,7 @@ STATIC_ASSERT(__cpp_lib_boyer_moore_searcher == 201603L);
 #endif
 
 #if _HAS_STD_BYTE
-#ifdef __cpp_lib_byte
 STATIC_ASSERT(__cpp_lib_byte == 201603L);
-#else
-#error __cpp_lib_byte is not defined
-#endif
 #else
 #ifdef __cpp_lib_byte
 #error __cpp_lib_byte is defined
@@ -319,11 +203,7 @@ STATIC_ASSERT(__cpp_lib_byte == 201603L);
 #endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_byteswap
 STATIC_ASSERT(__cpp_lib_byteswap == 202110L);
-#else
-#error __cpp_lib_byteswap is not defined
-#endif
 #else
 #ifdef __cpp_lib_byteswap
 #error __cpp_lib_byteswap is defined
@@ -331,11 +211,7 @@ STATIC_ASSERT(__cpp_lib_byteswap == 202110L);
 #endif
 
 #if defined(__cpp_char8_t)
-#ifdef __cpp_lib_char8_t
 STATIC_ASSERT(__cpp_lib_char8_t == 201907L);
-#else
-#error __cpp_lib_char8_t is not defined
-#endif
 #else
 #ifdef __cpp_lib_char8_t
 #error __cpp_lib_char8_t is defined
@@ -352,18 +228,10 @@ STATIC_ASSERT(__cpp_lib_chrono == 201611L);
 STATIC_ASSERT(__cpp_lib_chrono == 201510L);
 #endif
 
-#ifdef __cpp_lib_chrono_udls
 STATIC_ASSERT(__cpp_lib_chrono_udls == 201304L);
-#else
-#error __cpp_lib_chrono_udls is not defined
-#endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_clamp
 STATIC_ASSERT(__cpp_lib_clamp == 201603L);
-#else
-#error __cpp_lib_clamp is not defined
-#endif
 #else
 #ifdef __cpp_lib_clamp
 #error __cpp_lib_clamp is defined
@@ -371,11 +239,7 @@ STATIC_ASSERT(__cpp_lib_clamp == 201603L);
 #endif
 
 #if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_common_reference
 STATIC_ASSERT(__cpp_lib_common_reference == 202302L);
-#else
-#error __cpp_lib_common_reference is not defined
-#endif
 #else
 #ifdef __cpp_lib_common_reference
 #error __cpp_lib_common_reference is defined
@@ -383,35 +247,19 @@ STATIC_ASSERT(__cpp_lib_common_reference == 202302L);
 #endif
 
 #if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_common_reference_wrapper
 STATIC_ASSERT(__cpp_lib_common_reference_wrapper == 202302L);
-#else
-#error __cpp_lib_common_reference_wrapper is not defined
-#endif
 #else
 #ifdef __cpp_lib_common_reference_wrapper
 #error __cpp_lib_common_reference_wrapper is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_complex_udls
 STATIC_ASSERT(__cpp_lib_complex_udls == 201309L);
-#else
-#error __cpp_lib_complex_udls is not defined
-#endif
 
 #if _HAS_CXX23 && !defined(__EDG__) // TRANSITION, GH-395
-#ifdef __cpp_lib_concepts
 STATIC_ASSERT(__cpp_lib_concepts == 202207L);
-#else
-#error __cpp_lib_concepts is not defined
-#endif
 #elif _HAS_CXX20 && !defined(__EDG__) // TRANSITION, GH-395
-#ifdef __cpp_lib_concepts
 STATIC_ASSERT(__cpp_lib_concepts == 202002L);
-#else
-#error __cpp_lib_concepts is not defined
-#endif
 #else
 #ifdef __cpp_lib_concepts
 #error __cpp_lib_concepts is defined
@@ -419,11 +267,7 @@ STATIC_ASSERT(__cpp_lib_concepts == 202002L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_constexpr_algorithms
 STATIC_ASSERT(__cpp_lib_constexpr_algorithms == 201806L);
-#else
-#error __cpp_lib_constexpr_algorithms is not defined
-#endif
 #else
 #ifdef __cpp_lib_constexpr_algorithms
 #error __cpp_lib_constexpr_algorithms is defined
@@ -431,11 +275,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_algorithms == 201806L);
 #endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_constexpr_bitset
 STATIC_ASSERT(__cpp_lib_constexpr_bitset == 202207L);
-#else
-#error __cpp_lib_constexpr_bitset is not defined
-#endif
 #else
 #ifdef __cpp_lib_constexpr_bitset
 #error __cpp_lib_constexpr_bitset is defined
@@ -443,11 +283,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_bitset == 202207L);
 #endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_constexpr_charconv
 STATIC_ASSERT(__cpp_lib_constexpr_charconv == 202207L);
-#else
-#error __cpp_lib_constexpr_charconv is not defined
-#endif
 #else
 #ifdef __cpp_lib_constexpr_charconv
 #error __cpp_lib_constexpr_charconv is defined
@@ -455,11 +291,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_charconv == 202207L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_constexpr_complex
 STATIC_ASSERT(__cpp_lib_constexpr_complex == 201711L);
-#else
-#error __cpp_lib_constexpr_complex is not defined
-#endif
 #else
 #ifdef __cpp_lib_constexpr_complex
 #error __cpp_lib_constexpr_complex is defined
@@ -467,11 +299,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_complex == 201711L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_constexpr_dynamic_alloc
 STATIC_ASSERT(__cpp_lib_constexpr_dynamic_alloc == 201907L);
-#else
-#error __cpp_lib_constexpr_dynamic_alloc is not defined
-#endif
 #else
 #ifdef __cpp_lib_constexpr_dynamic_alloc
 #error __cpp_lib_constexpr_dynamic_alloc is defined
@@ -479,11 +307,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_dynamic_alloc == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_constexpr_functional
 STATIC_ASSERT(__cpp_lib_constexpr_functional == 201907L);
-#else
-#error __cpp_lib_constexpr_functional is not defined
-#endif
 #else
 #ifdef __cpp_lib_constexpr_functional
 #error __cpp_lib_constexpr_functional is defined
@@ -491,11 +315,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_functional == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_constexpr_iterator
 STATIC_ASSERT(__cpp_lib_constexpr_iterator == 201811L);
-#else
-#error __cpp_lib_constexpr_iterator is not defined
-#endif
 #else
 #ifdef __cpp_lib_constexpr_iterator
 #error __cpp_lib_constexpr_iterator is defined
@@ -503,17 +323,9 @@ STATIC_ASSERT(__cpp_lib_constexpr_iterator == 201811L);
 #endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_constexpr_memory
 STATIC_ASSERT(__cpp_lib_constexpr_memory == 202202L);
-#else
-#error __cpp_lib_constexpr_memory is not defined
-#endif
 #elif _HAS_CXX20
-#ifdef __cpp_lib_constexpr_memory
 STATIC_ASSERT(__cpp_lib_constexpr_memory == 201811L);
-#else
-#error __cpp_lib_constexpr_memory is not defined
-#endif
 #else
 #ifdef __cpp_lib_constexpr_memory
 #error __cpp_lib_constexpr_memory is defined
@@ -521,11 +333,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_memory == 201811L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_constexpr_numeric
 STATIC_ASSERT(__cpp_lib_constexpr_numeric == 201911L);
-#else
-#error __cpp_lib_constexpr_numeric is not defined
-#endif
 #else
 #ifdef __cpp_lib_constexpr_numeric
 #error __cpp_lib_constexpr_numeric is defined
@@ -533,11 +341,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_numeric == 201911L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_constexpr_string
 STATIC_ASSERT(__cpp_lib_constexpr_string == 201907L);
-#else
-#error __cpp_lib_constexpr_string is not defined
-#endif
 #else
 #ifdef __cpp_lib_constexpr_string
 #error __cpp_lib_constexpr_string is defined
@@ -545,11 +349,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_string == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_constexpr_string_view
 STATIC_ASSERT(__cpp_lib_constexpr_string_view == 201811L);
-#else
-#error __cpp_lib_constexpr_string_view is not defined
-#endif
 #else
 #ifdef __cpp_lib_constexpr_string_view
 #error __cpp_lib_constexpr_string_view is defined
@@ -557,11 +357,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_string_view == 201811L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_constexpr_tuple
 STATIC_ASSERT(__cpp_lib_constexpr_tuple == 201811L);
-#else
-#error __cpp_lib_constexpr_tuple is not defined
-#endif
 #else
 #ifdef __cpp_lib_constexpr_tuple
 #error __cpp_lib_constexpr_tuple is defined
@@ -569,11 +365,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_tuple == 201811L);
 #endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_constexpr_typeinfo
 STATIC_ASSERT(__cpp_lib_constexpr_typeinfo == 202106L);
-#else
-#error __cpp_lib_constexpr_typeinfo is not defined
-#endif
 #else
 #ifdef __cpp_lib_constexpr_typeinfo
 #error __cpp_lib_constexpr_typeinfo is defined
@@ -581,11 +373,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_typeinfo == 202106L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_constexpr_utility
 STATIC_ASSERT(__cpp_lib_constexpr_utility == 201811L);
-#else
-#error __cpp_lib_constexpr_utility is not defined
-#endif
 #else
 #ifdef __cpp_lib_constexpr_utility
 #error __cpp_lib_constexpr_utility is defined
@@ -593,11 +381,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_utility == 201811L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_constexpr_vector
 STATIC_ASSERT(__cpp_lib_constexpr_vector == 201907L);
-#else
-#error __cpp_lib_constexpr_vector is not defined
-#endif
 #else
 #ifdef __cpp_lib_constexpr_vector
 #error __cpp_lib_constexpr_vector is defined
@@ -605,11 +389,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_vector == 201907L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_containers_ranges
 STATIC_ASSERT(__cpp_lib_containers_ranges == 202202L);
-#else
-#error __cpp_lib_containers_ranges is not defined
-#endif
 #else
 #ifdef __cpp_lib_containers_ranges
 #error __cpp_lib_containers_ranges is defined
@@ -617,11 +397,7 @@ STATIC_ASSERT(__cpp_lib_containers_ranges == 202202L);
 #endif
 
 #ifdef __cpp_impl_coroutine
-#ifdef __cpp_lib_coroutine
 STATIC_ASSERT(__cpp_lib_coroutine == 201902L);
-#else
-#error __cpp_lib_coroutine is not defined
-#endif
 #else
 #ifdef __cpp_lib_coroutine
 #error __cpp_lib_coroutine is defined
@@ -629,29 +405,17 @@ STATIC_ASSERT(__cpp_lib_coroutine == 201902L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_destroying_delete
 STATIC_ASSERT(__cpp_lib_destroying_delete == 201806L);
-#else
-#error __cpp_lib_destroying_delete is not defined
-#endif
 #else
 #ifdef __cpp_lib_destroying_delete
 #error __cpp_lib_destroying_delete is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_enable_shared_from_this
 STATIC_ASSERT(__cpp_lib_enable_shared_from_this == 201603L);
-#else
-#error __cpp_lib_enable_shared_from_this is not defined
-#endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_endian
 STATIC_ASSERT(__cpp_lib_endian == 201907L);
-#else
-#error __cpp_lib_endian is not defined
-#endif
 #else
 #ifdef __cpp_lib_endian
 #error __cpp_lib_endian is defined
@@ -659,35 +423,19 @@ STATIC_ASSERT(__cpp_lib_endian == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_erase_if
 STATIC_ASSERT(__cpp_lib_erase_if == 202002L);
-#else
-#error __cpp_lib_erase_if is not defined
-#endif
 #else
 #ifdef __cpp_lib_erase_if
 #error __cpp_lib_erase_if is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_exchange_function
 STATIC_ASSERT(__cpp_lib_exchange_function == 201304L);
-#else
-#error __cpp_lib_exchange_function is not defined
-#endif
 
 #if _HAS_CXX20 && !defined(_M_CEE_PURE)
-#ifdef __cpp_lib_execution
 STATIC_ASSERT(__cpp_lib_execution == 201902L);
-#else
-#error __cpp_lib_execution is not defined
-#endif
 #elif _HAS_CXX17 && !defined(_M_CEE_PURE)
-#ifdef __cpp_lib_execution
 STATIC_ASSERT(__cpp_lib_execution == 201603L);
-#else
-#error __cpp_lib_execution is not defined
-#endif
 #else
 #ifdef __cpp_lib_execution
 #error __cpp_lib_execution is defined
@@ -695,35 +443,19 @@ STATIC_ASSERT(__cpp_lib_execution == 201603L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_expected
 STATIC_ASSERT(__cpp_lib_expected == 202211L);
-#else
-#error __cpp_lib_expected is not defined
-#endif
 #else
 #ifdef __cpp_lib_expected
 #error __cpp_lib_expected is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_experimental_erase_if
 STATIC_ASSERT(__cpp_lib_experimental_erase_if == 201411L);
-#else
-#error __cpp_lib_experimental_erase_if is not defined
-#endif
 
-#ifdef __cpp_lib_experimental_filesystem
 STATIC_ASSERT(__cpp_lib_experimental_filesystem == 201406L);
-#else
-#error __cpp_lib_experimental_filesystem is not defined
-#endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_filesystem
 STATIC_ASSERT(__cpp_lib_filesystem == 201703L);
-#else
-#error __cpp_lib_filesystem is not defined
-#endif
 #else
 #ifdef __cpp_lib_filesystem
 #error __cpp_lib_filesystem is defined
@@ -731,11 +463,7 @@ STATIC_ASSERT(__cpp_lib_filesystem == 201703L);
 #endif
 
 #ifdef __cpp_lib_concepts
-#ifdef __cpp_lib_format
 STATIC_ASSERT(__cpp_lib_format == 202207L);
-#else
-#error __cpp_lib_format is not defined
-#endif
 #else
 #ifdef __cpp_lib_format
 #error __cpp_lib_format is defined
@@ -743,11 +471,7 @@ STATIC_ASSERT(__cpp_lib_format == 202207L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_formatters
 STATIC_ASSERT(__cpp_lib_formatters == 202302L);
-#else
-#error __cpp_lib_formatters is not defined
-#endif
 #else
 #ifdef __cpp_lib_formatters
 #error __cpp_lib_formatters is defined
@@ -755,143 +479,67 @@ STATIC_ASSERT(__cpp_lib_formatters == 202302L);
 #endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_forward_like
 STATIC_ASSERT(__cpp_lib_forward_like == 202207L);
-#else
-#error __cpp_lib_forward_like is not defined
-#endif
 #else
 #ifdef __cpp_lib_forward_like
 #error __cpp_lib_forward_like is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_freestanding_char_traits
 STATIC_ASSERT(__cpp_lib_freestanding_char_traits == 202306L);
-#else
-#error __cpp_lib_freestanding_char_traits is not defined
-#endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_freestanding_charconv
 STATIC_ASSERT(__cpp_lib_freestanding_charconv == 202306L);
-#else
-#error __cpp_lib_freestanding_charconv is not defined
-#endif
 #else
 #ifdef __cpp_lib_freestanding_charconv
 #error __cpp_lib_freestanding_charconv is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_freestanding_cstdlib
 STATIC_ASSERT(__cpp_lib_freestanding_cstdlib == 202306L);
-#else
-#error __cpp_lib_freestanding_cstdlib is not defined
-#endif
 
-#ifdef __cpp_lib_freestanding_cstring
 STATIC_ASSERT(__cpp_lib_freestanding_cstring == 202306L);
-#else
-#error __cpp_lib_freestanding_cstring is not defined
-#endif
 
-#ifdef __cpp_lib_freestanding_cwchar
 STATIC_ASSERT(__cpp_lib_freestanding_cwchar == 202306L);
-#else
-#error __cpp_lib_freestanding_cwchar is not defined
-#endif
 
-#ifdef __cpp_lib_freestanding_errc
 STATIC_ASSERT(__cpp_lib_freestanding_errc == 202306L);
-#else
-#error __cpp_lib_freestanding_errc is not defined
-#endif
 
-#ifdef __cpp_lib_freestanding_feature_test_macros
 STATIC_ASSERT(__cpp_lib_freestanding_feature_test_macros == 202306L);
-#else
-#error __cpp_lib_freestanding_feature_test_macros is not defined
-#endif
 
-#ifdef __cpp_lib_freestanding_functional
 STATIC_ASSERT(__cpp_lib_freestanding_functional == 202306L);
-#else
-#error __cpp_lib_freestanding_functional is not defined
-#endif
 
-#ifdef __cpp_lib_freestanding_iterator
 STATIC_ASSERT(__cpp_lib_freestanding_iterator == 202306L);
-#else
-#error __cpp_lib_freestanding_iterator is not defined
-#endif
 
-#ifdef __cpp_lib_freestanding_memory
 STATIC_ASSERT(__cpp_lib_freestanding_memory == 202306L);
-#else
-#error __cpp_lib_freestanding_memory is not defined
-#endif
 
-#ifdef __cpp_lib_freestanding_operator_new
 STATIC_ASSERT(__cpp_lib_freestanding_operator_new == 202306L);
-#else
-#error __cpp_lib_freestanding_operator_new is not defined
-#endif
 
 #ifdef __cpp_lib_concepts
-#ifdef __cpp_lib_freestanding_ranges
 STATIC_ASSERT(__cpp_lib_freestanding_ranges == 202306L);
-#else
-#error __cpp_lib_freestanding_ranges is not defined
-#endif
 #else
 #ifdef __cpp_lib_freestanding_ranges
 #error __cpp_lib_freestanding_ranges is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_freestanding_ratio
 STATIC_ASSERT(__cpp_lib_freestanding_ratio == 202306L);
-#else
-#error __cpp_lib_freestanding_ratio is not defined
-#endif
 
-#ifdef __cpp_lib_freestanding_tuple
 STATIC_ASSERT(__cpp_lib_freestanding_tuple == 202306L);
-#else
-#error __cpp_lib_freestanding_tuple is not defined
-#endif
 
-#ifdef __cpp_lib_freestanding_utility
 STATIC_ASSERT(__cpp_lib_freestanding_utility == 202306L);
-#else
-#error __cpp_lib_freestanding_utility is not defined
-#endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_gcd_lcm
 STATIC_ASSERT(__cpp_lib_gcd_lcm == 201606L);
-#else
-#error __cpp_lib_gcd_lcm is not defined
-#endif
 #else
 #ifdef __cpp_lib_gcd_lcm
 #error __cpp_lib_gcd_lcm is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_generic_associative_lookup
 STATIC_ASSERT(__cpp_lib_generic_associative_lookup == 201304L);
-#else
-#error __cpp_lib_generic_associative_lookup is not defined
-#endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_generic_unordered_lookup
 STATIC_ASSERT(__cpp_lib_generic_unordered_lookup == 201811L);
-#else
-#error __cpp_lib_generic_unordered_lookup is not defined
-#endif
 #else
 #ifdef __cpp_lib_generic_unordered_lookup
 #error __cpp_lib_generic_unordered_lookup is defined
@@ -899,11 +547,7 @@ STATIC_ASSERT(__cpp_lib_generic_unordered_lookup == 201811L);
 #endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_hardware_interference_size
 STATIC_ASSERT(__cpp_lib_hardware_interference_size == 201703L);
-#else
-#error __cpp_lib_hardware_interference_size is not defined
-#endif
 #else
 #ifdef __cpp_lib_hardware_interference_size
 #error __cpp_lib_hardware_interference_size is defined
@@ -911,11 +555,7 @@ STATIC_ASSERT(__cpp_lib_hardware_interference_size == 201703L);
 #endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_has_unique_object_representations
 STATIC_ASSERT(__cpp_lib_has_unique_object_representations == 201606L);
-#else
-#error __cpp_lib_has_unique_object_representations is not defined
-#endif
 #else
 #ifdef __cpp_lib_has_unique_object_representations
 #error __cpp_lib_has_unique_object_representations is defined
@@ -923,29 +563,17 @@ STATIC_ASSERT(__cpp_lib_has_unique_object_representations == 201606L);
 #endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_hypot
 STATIC_ASSERT(__cpp_lib_hypot == 201603L);
-#else
-#error __cpp_lib_hypot is not defined
-#endif
 #else
 #ifdef __cpp_lib_hypot
 #error __cpp_lib_hypot is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_incomplete_container_elements
 STATIC_ASSERT(__cpp_lib_incomplete_container_elements == 201505L);
-#else
-#error __cpp_lib_incomplete_container_elements is not defined
-#endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_int_pow2
 STATIC_ASSERT(__cpp_lib_int_pow2 == 202002L);
-#else
-#error __cpp_lib_int_pow2 is not defined
-#endif
 #else
 #ifdef __cpp_lib_int_pow2
 #error __cpp_lib_int_pow2 is defined
@@ -953,53 +581,29 @@ STATIC_ASSERT(__cpp_lib_int_pow2 == 202002L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_integer_comparison_functions
 STATIC_ASSERT(__cpp_lib_integer_comparison_functions == 202002L);
-#else
-#error __cpp_lib_integer_comparison_functions is not defined
-#endif
 #else
 #ifdef __cpp_lib_integer_comparison_functions
 #error __cpp_lib_integer_comparison_functions is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_integer_sequence
 STATIC_ASSERT(__cpp_lib_integer_sequence == 201304L);
-#else
-#error __cpp_lib_integer_sequence is not defined
-#endif
 
-#ifdef __cpp_lib_integral_constant_callable
 STATIC_ASSERT(__cpp_lib_integral_constant_callable == 201304L);
-#else
-#error __cpp_lib_integral_constant_callable is not defined
-#endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_interpolate
 STATIC_ASSERT(__cpp_lib_interpolate == 201902L);
-#else
-#error __cpp_lib_interpolate is not defined
-#endif
 #else
 #ifdef __cpp_lib_interpolate
 #error __cpp_lib_interpolate is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_invoke
 STATIC_ASSERT(__cpp_lib_invoke == 201411L);
-#else
-#error __cpp_lib_invoke is not defined
-#endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_invoke_r
 STATIC_ASSERT(__cpp_lib_invoke_r == 202106L);
-#else
-#error __cpp_lib_invoke_r is not defined
-#endif
 #else
 #ifdef __cpp_lib_invoke_r
 #error __cpp_lib_invoke_r is defined
@@ -1007,11 +611,7 @@ STATIC_ASSERT(__cpp_lib_invoke_r == 202106L);
 #endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_ios_noreplace
 STATIC_ASSERT(__cpp_lib_ios_noreplace == 202207L);
-#else
-#error __cpp_lib_ios_noreplace is not defined
-#endif
 #else
 #ifdef __cpp_lib_ios_noreplace
 #error __cpp_lib_ios_noreplace is defined
@@ -1019,11 +619,7 @@ STATIC_ASSERT(__cpp_lib_ios_noreplace == 202207L);
 #endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_is_aggregate
 STATIC_ASSERT(__cpp_lib_is_aggregate == 201703L);
-#else
-#error __cpp_lib_is_aggregate is not defined
-#endif
 #else
 #ifdef __cpp_lib_is_aggregate
 #error __cpp_lib_is_aggregate is defined
@@ -1031,29 +627,17 @@ STATIC_ASSERT(__cpp_lib_is_aggregate == 201703L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_is_constant_evaluated
 STATIC_ASSERT(__cpp_lib_is_constant_evaluated == 201811L);
-#else
-#error __cpp_lib_is_constant_evaluated is not defined
-#endif
 #else
 #ifdef __cpp_lib_is_constant_evaluated
 #error __cpp_lib_is_constant_evaluated is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_is_final
 STATIC_ASSERT(__cpp_lib_is_final == 201402L);
-#else
-#error __cpp_lib_is_final is not defined
-#endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_is_invocable
 STATIC_ASSERT(__cpp_lib_is_invocable == 201703L);
-#else
-#error __cpp_lib_is_invocable is not defined
-#endif
 #else
 #ifdef __cpp_lib_is_invocable
 #error __cpp_lib_is_invocable is defined
@@ -1062,11 +646,7 @@ STATIC_ASSERT(__cpp_lib_is_invocable == 201703L);
 
 #if _HAS_CXX20
 #ifndef __clang__ // TRANSITION, LLVM-48860
-#ifdef __cpp_lib_is_layout_compatible
 STATIC_ASSERT(__cpp_lib_is_layout_compatible == 201907L);
-#else
-#error __cpp_lib_is_layout_compatible is not defined
-#endif
 #else
 #ifdef __cpp_lib_is_layout_compatible
 #error __cpp_lib_is_layout_compatible is defined
@@ -1075,30 +655,18 @@ STATIC_ASSERT(__cpp_lib_is_layout_compatible == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_is_nothrow_convertible
 STATIC_ASSERT(__cpp_lib_is_nothrow_convertible == 201806L);
-#else
-#error __cpp_lib_is_nothrow_convertible is not defined
-#endif
 #else
 #ifdef __cpp_lib_is_nothrow_convertible
 #error __cpp_lib_is_nothrow_convertible is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_is_null_pointer
 STATIC_ASSERT(__cpp_lib_is_null_pointer == 201309L);
-#else
-#error __cpp_lib_is_null_pointer is not defined
-#endif
 
 #if _HAS_CXX20
 #ifndef __clang__ // TRANSITION, LLVM-48860
-#ifdef __cpp_lib_is_pointer_interconvertible
 STATIC_ASSERT(__cpp_lib_is_pointer_interconvertible == 201907L);
-#else
-#error __cpp_lib_is_pointer_interconvertible is not defined
-#endif
 #else
 #ifdef __cpp_lib_is_pointer_interconvertible
 #error __cpp_lib_is_pointer_interconvertible is defined
@@ -1107,11 +675,7 @@ STATIC_ASSERT(__cpp_lib_is_pointer_interconvertible == 201907L);
 #endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_is_scoped_enum
 STATIC_ASSERT(__cpp_lib_is_scoped_enum == 202011L);
-#else
-#error __cpp_lib_is_scoped_enum is not defined
-#endif
 #else
 #ifdef __cpp_lib_is_scoped_enum
 #error __cpp_lib_is_scoped_enum is defined
@@ -1119,11 +683,7 @@ STATIC_ASSERT(__cpp_lib_is_scoped_enum == 202011L);
 #endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_is_swappable
 STATIC_ASSERT(__cpp_lib_is_swappable == 201603L);
-#else
-#error __cpp_lib_is_swappable is not defined
-#endif
 #else
 #ifdef __cpp_lib_is_swappable
 #error __cpp_lib_is_swappable is defined
@@ -1131,11 +691,7 @@ STATIC_ASSERT(__cpp_lib_is_swappable == 201603L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_jthread
 STATIC_ASSERT(__cpp_lib_jthread == 201911L);
-#else
-#error __cpp_lib_jthread is not defined
-#endif
 #else
 #ifdef __cpp_lib_jthread
 #error __cpp_lib_jthread is defined
@@ -1143,11 +699,7 @@ STATIC_ASSERT(__cpp_lib_jthread == 201911L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_latch
 STATIC_ASSERT(__cpp_lib_latch == 201907L);
-#else
-#error __cpp_lib_latch is not defined
-#endif
 #else
 #ifdef __cpp_lib_latch
 #error __cpp_lib_latch is defined
@@ -1155,11 +707,7 @@ STATIC_ASSERT(__cpp_lib_latch == 201907L);
 #endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_launder
 STATIC_ASSERT(__cpp_lib_launder == 201606L);
-#else
-#error __cpp_lib_launder is not defined
-#endif
 #else
 #ifdef __cpp_lib_launder
 #error __cpp_lib_launder is defined
@@ -1167,59 +715,31 @@ STATIC_ASSERT(__cpp_lib_launder == 201606L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_list_remove_return_type
 STATIC_ASSERT(__cpp_lib_list_remove_return_type == 201806L);
-#else
-#error __cpp_lib_list_remove_return_type is not defined
-#endif
 #else
 #ifdef __cpp_lib_list_remove_return_type
 #error __cpp_lib_list_remove_return_type is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_logical_traits
 STATIC_ASSERT(__cpp_lib_logical_traits == 201510L);
-#else
-#error __cpp_lib_logical_traits is not defined
-#endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_make_from_tuple
 STATIC_ASSERT(__cpp_lib_make_from_tuple == 201606L);
-#else
-#error __cpp_lib_make_from_tuple is not defined
-#endif
 #else
 #ifdef __cpp_lib_make_from_tuple
 #error __cpp_lib_make_from_tuple is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_make_reverse_iterator
 STATIC_ASSERT(__cpp_lib_make_reverse_iterator == 201402L);
-#else
-#error __cpp_lib_make_reverse_iterator is not defined
-#endif
 
-#ifdef __cpp_lib_make_unique
 STATIC_ASSERT(__cpp_lib_make_unique == 201304L);
-#else
-#error __cpp_lib_make_unique is not defined
-#endif
 
-#ifdef __cpp_lib_map_try_emplace
 STATIC_ASSERT(__cpp_lib_map_try_emplace == 201411L);
-#else
-#error __cpp_lib_map_try_emplace is not defined
-#endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_math_constants
 STATIC_ASSERT(__cpp_lib_math_constants == 201907L);
-#else
-#error __cpp_lib_math_constants is not defined
-#endif
 #else
 #ifdef __cpp_lib_math_constants
 #error __cpp_lib_math_constants is defined
@@ -1227,11 +747,7 @@ STATIC_ASSERT(__cpp_lib_math_constants == 201907L);
 #endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_math_special_functions
 STATIC_ASSERT(__cpp_lib_math_special_functions == 201603L);
-#else
-#error __cpp_lib_math_special_functions is not defined
-#endif
 #else
 #ifdef __cpp_lib_math_special_functions
 #error __cpp_lib_math_special_functions is defined
@@ -1239,11 +755,7 @@ STATIC_ASSERT(__cpp_lib_math_special_functions == 201603L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_mdspan
 STATIC_ASSERT(__cpp_lib_mdspan == 202207L);
-#else
-#error __cpp_lib_mdspan is not defined
-#endif
 #else
 #ifdef __cpp_lib_mdspan
 #error __cpp_lib_mdspan is defined
@@ -1251,11 +763,7 @@ STATIC_ASSERT(__cpp_lib_mdspan == 202207L);
 #endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_memory_resource
 STATIC_ASSERT(__cpp_lib_memory_resource == 201603L);
-#else
-#error __cpp_lib_memory_resource is not defined
-#endif
 #else
 #ifdef __cpp_lib_memory_resource
 #error __cpp_lib_memory_resource is defined
@@ -1263,11 +771,7 @@ STATIC_ASSERT(__cpp_lib_memory_resource == 201603L);
 #endif
 
 #if _HAS_CXX20 && !defined(__clang__) && !defined(__EDG__) // TRANSITION, Clang and EDG support for modules
-#ifdef __cpp_lib_modules
 STATIC_ASSERT(__cpp_lib_modules == 202207L);
-#else
-#error __cpp_lib_modules is not defined
-#endif
 #else
 #ifdef __cpp_lib_modules
 #error __cpp_lib_modules is defined
@@ -1275,11 +779,7 @@ STATIC_ASSERT(__cpp_lib_modules == 202207L);
 #endif
 
 #ifdef __cpp_lib_concepts
-#ifdef __cpp_lib_move_iterator_concept
 STATIC_ASSERT(__cpp_lib_move_iterator_concept == 202207L);
-#else
-#error __cpp_lib_move_iterator_concept is not defined
-#endif
 #else
 #ifdef __cpp_lib_move_iterator_concept
 #error __cpp_lib_move_iterator_concept is defined
@@ -1287,11 +787,7 @@ STATIC_ASSERT(__cpp_lib_move_iterator_concept == 202207L);
 #endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_move_only_function
 STATIC_ASSERT(__cpp_lib_move_only_function == 202110L);
-#else
-#error __cpp_lib_move_only_function is not defined
-#endif
 #else
 #ifdef __cpp_lib_move_only_function
 #error __cpp_lib_move_only_function is defined
@@ -1299,59 +795,31 @@ STATIC_ASSERT(__cpp_lib_move_only_function == 202110L);
 #endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_node_extract
 STATIC_ASSERT(__cpp_lib_node_extract == 201606L);
-#else
-#error __cpp_lib_node_extract is not defined
-#endif
 #else
 #ifdef __cpp_lib_node_extract
 #error __cpp_lib_node_extract is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_nonmember_container_access
 STATIC_ASSERT(__cpp_lib_nonmember_container_access == 201411L);
-#else
-#error __cpp_lib_nonmember_container_access is not defined
-#endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_not_fn
 STATIC_ASSERT(__cpp_lib_not_fn == 201603L);
-#else
-#error __cpp_lib_not_fn is not defined
-#endif
 #else
 #ifdef __cpp_lib_not_fn
 #error __cpp_lib_not_fn is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_null_iterators
 STATIC_ASSERT(__cpp_lib_null_iterators == 201304L);
-#else
-#error __cpp_lib_null_iterators is not defined
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_optional
 STATIC_ASSERT(__cpp_lib_optional == 202110L);
-#else
-#error __cpp_lib_optional is not defined
-#endif
 #elif _HAS_CXX20
-#ifdef __cpp_lib_optional
 STATIC_ASSERT(__cpp_lib_optional == 202106L);
-#else
-#error __cpp_lib_optional is not defined
-#endif
 #elif _HAS_CXX17
-#ifdef __cpp_lib_optional
 STATIC_ASSERT(__cpp_lib_optional == 201606L);
-#else
-#error __cpp_lib_optional is not defined
-#endif
 #else
 #ifdef __cpp_lib_optional
 #error __cpp_lib_optional is defined
@@ -1359,11 +827,7 @@ STATIC_ASSERT(__cpp_lib_optional == 201606L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_out_ptr
 STATIC_ASSERT(__cpp_lib_out_ptr == 202106L);
-#else
-#error __cpp_lib_out_ptr is not defined
-#endif
 #else
 #ifdef __cpp_lib_out_ptr
 #error __cpp_lib_out_ptr is defined
@@ -1371,11 +835,7 @@ STATIC_ASSERT(__cpp_lib_out_ptr == 202106L);
 #endif
 
 #if _HAS_CXX17 && !defined(_M_CEE_PURE)
-#ifdef __cpp_lib_parallel_algorithm
 STATIC_ASSERT(__cpp_lib_parallel_algorithm == 201603L);
-#else
-#error __cpp_lib_parallel_algorithm is not defined
-#endif
 #else
 #ifdef __cpp_lib_parallel_algorithm
 #error __cpp_lib_parallel_algorithm is defined
@@ -1383,11 +843,7 @@ STATIC_ASSERT(__cpp_lib_parallel_algorithm == 201603L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_polymorphic_allocator
 STATIC_ASSERT(__cpp_lib_polymorphic_allocator == 201902L);
-#else
-#error __cpp_lib_polymorphic_allocator is not defined
-#endif
 #else
 #ifdef __cpp_lib_polymorphic_allocator
 #error __cpp_lib_polymorphic_allocator is defined
@@ -1395,35 +851,19 @@ STATIC_ASSERT(__cpp_lib_polymorphic_allocator == 201902L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_print
 STATIC_ASSERT(__cpp_lib_print == 202207L);
-#else
-#error __cpp_lib_print is not defined
-#endif
 #else
 #ifdef __cpp_lib_print
 #error __cpp_lib_print is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_quoted_string_io
 STATIC_ASSERT(__cpp_lib_quoted_string_io == 201304L);
-#else
-#error __cpp_lib_quoted_string_io is not defined
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_ranges
 STATIC_ASSERT(__cpp_lib_ranges == 202302L);
-#else
-#error __cpp_lib_ranges is not defined
-#endif
 #elif _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_ranges
 STATIC_ASSERT(__cpp_lib_ranges == 202110L);
-#else
-#error __cpp_lib_ranges is not defined
-#endif
 #else
 #ifdef __cpp_lib_ranges
 #error __cpp_lib_ranges is defined
@@ -1431,11 +871,7 @@ STATIC_ASSERT(__cpp_lib_ranges == 202110L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_ranges_as_const
 STATIC_ASSERT(__cpp_lib_ranges_as_const == 202207L);
-#else
-#error __cpp_lib_ranges_as_const is not defined
-#endif
 #else
 #ifdef __cpp_lib_ranges_as_const
 #error __cpp_lib_ranges_as_const is defined
@@ -1443,11 +879,7 @@ STATIC_ASSERT(__cpp_lib_ranges_as_const == 202207L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_ranges_as_rvalue
 STATIC_ASSERT(__cpp_lib_ranges_as_rvalue == 202207L);
-#else
-#error __cpp_lib_ranges_as_rvalue is not defined
-#endif
 #else
 #ifdef __cpp_lib_ranges_as_rvalue
 #error __cpp_lib_ranges_as_rvalue is defined
@@ -1455,11 +887,7 @@ STATIC_ASSERT(__cpp_lib_ranges_as_rvalue == 202207L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_ranges_cartesian_product
 STATIC_ASSERT(__cpp_lib_ranges_cartesian_product == 202207L);
-#else
-#error __cpp_lib_ranges_cartesian_product is not defined
-#endif
 #else
 #ifdef __cpp_lib_ranges_cartesian_product
 #error __cpp_lib_ranges_cartesian_product is defined
@@ -1467,11 +895,7 @@ STATIC_ASSERT(__cpp_lib_ranges_cartesian_product == 202207L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_ranges_chunk
 STATIC_ASSERT(__cpp_lib_ranges_chunk == 202202L);
-#else
-#error __cpp_lib_ranges_chunk is not defined
-#endif
 #else
 #ifdef __cpp_lib_ranges_chunk
 #error __cpp_lib_ranges_chunk is defined
@@ -1479,11 +903,7 @@ STATIC_ASSERT(__cpp_lib_ranges_chunk == 202202L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_ranges_chunk_by
 STATIC_ASSERT(__cpp_lib_ranges_chunk_by == 202202L);
-#else
-#error __cpp_lib_ranges_chunk_by is not defined
-#endif
 #else
 #ifdef __cpp_lib_ranges_chunk_by
 #error __cpp_lib_ranges_chunk_by is defined
@@ -1491,11 +911,7 @@ STATIC_ASSERT(__cpp_lib_ranges_chunk_by == 202202L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_ranges_contains
 STATIC_ASSERT(__cpp_lib_ranges_contains == 202207L);
-#else
-#error __cpp_lib_ranges_contains is not defined
-#endif
 #else
 #ifdef __cpp_lib_ranges_contains
 #error __cpp_lib_ranges_contains is defined
@@ -1503,11 +919,7 @@ STATIC_ASSERT(__cpp_lib_ranges_contains == 202207L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_ranges_enumerate
 STATIC_ASSERT(__cpp_lib_ranges_enumerate == 202302L);
-#else
-#error __cpp_lib_ranges_enumerate is not defined
-#endif
 #else
 #ifdef __cpp_lib_ranges_enumerate
 #error __cpp_lib_ranges_enumerate is defined
@@ -1515,11 +927,7 @@ STATIC_ASSERT(__cpp_lib_ranges_enumerate == 202302L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_ranges_find_last
 STATIC_ASSERT(__cpp_lib_ranges_find_last == 202207L);
-#else
-#error __cpp_lib_ranges_find_last is not defined
-#endif
 #else
 #ifdef __cpp_lib_ranges_find_last
 #error __cpp_lib_ranges_find_last is defined
@@ -1527,11 +935,7 @@ STATIC_ASSERT(__cpp_lib_ranges_find_last == 202207L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_ranges_fold
 STATIC_ASSERT(__cpp_lib_ranges_fold == 202207L);
-#else
-#error __cpp_lib_ranges_fold is not defined
-#endif
 #else
 #ifdef __cpp_lib_ranges_fold
 #error __cpp_lib_ranges_fold is defined
@@ -1539,11 +943,7 @@ STATIC_ASSERT(__cpp_lib_ranges_fold == 202207L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_ranges_iota
 STATIC_ASSERT(__cpp_lib_ranges_iota == 202202L);
-#else
-#error __cpp_lib_ranges_iota is not defined
-#endif
 #else
 #ifdef __cpp_lib_ranges_iota
 #error __cpp_lib_ranges_iota is defined
@@ -1551,11 +951,7 @@ STATIC_ASSERT(__cpp_lib_ranges_iota == 202202L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_ranges_join_with
 STATIC_ASSERT(__cpp_lib_ranges_join_with == 202202L);
-#else
-#error __cpp_lib_ranges_join_with is not defined
-#endif
 #else
 #ifdef __cpp_lib_ranges_join_with
 #error __cpp_lib_ranges_join_with is defined
@@ -1563,11 +959,7 @@ STATIC_ASSERT(__cpp_lib_ranges_join_with == 202202L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_ranges_repeat
 STATIC_ASSERT(__cpp_lib_ranges_repeat == 202207L);
-#else
-#error __cpp_lib_ranges_repeat is not defined
-#endif
 #else
 #ifdef __cpp_lib_ranges_repeat
 #error __cpp_lib_ranges_repeat is defined
@@ -1575,11 +967,7 @@ STATIC_ASSERT(__cpp_lib_ranges_repeat == 202207L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_ranges_slide
 STATIC_ASSERT(__cpp_lib_ranges_slide == 202202L);
-#else
-#error __cpp_lib_ranges_slide is not defined
-#endif
 #else
 #ifdef __cpp_lib_ranges_slide
 #error __cpp_lib_ranges_slide is defined
@@ -1587,11 +975,7 @@ STATIC_ASSERT(__cpp_lib_ranges_slide == 202202L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_ranges_starts_ends_with
 STATIC_ASSERT(__cpp_lib_ranges_starts_ends_with == 202106L);
-#else
-#error __cpp_lib_ranges_starts_ends_with is not defined
-#endif
 #else
 #ifdef __cpp_lib_ranges_starts_ends_with
 #error __cpp_lib_ranges_starts_ends_with is defined
@@ -1599,11 +983,7 @@ STATIC_ASSERT(__cpp_lib_ranges_starts_ends_with == 202106L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_ranges_stride
 STATIC_ASSERT(__cpp_lib_ranges_stride == 202207L);
-#else
-#error __cpp_lib_ranges_stride is not defined
-#endif
 #else
 #ifdef __cpp_lib_ranges_stride
 #error __cpp_lib_ranges_stride is defined
@@ -1611,11 +991,7 @@ STATIC_ASSERT(__cpp_lib_ranges_stride == 202207L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_ranges_to_container
 STATIC_ASSERT(__cpp_lib_ranges_to_container == 202202L);
-#else
-#error __cpp_lib_ranges_to_container is not defined
-#endif
 #else
 #ifdef __cpp_lib_ranges_to_container
 #error __cpp_lib_ranges_to_container is defined
@@ -1623,11 +999,7 @@ STATIC_ASSERT(__cpp_lib_ranges_to_container == 202202L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_ranges_zip
 STATIC_ASSERT(__cpp_lib_ranges_zip == 202110L);
-#else
-#error __cpp_lib_ranges_zip is not defined
-#endif
 #else
 #ifdef __cpp_lib_ranges_zip
 #error __cpp_lib_ranges_zip is defined
@@ -1635,11 +1007,7 @@ STATIC_ASSERT(__cpp_lib_ranges_zip == 202110L);
 #endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_raw_memory_algorithms
 STATIC_ASSERT(__cpp_lib_raw_memory_algorithms == 201606L);
-#else
-#error __cpp_lib_raw_memory_algorithms is not defined
-#endif
 #else
 #ifdef __cpp_lib_raw_memory_algorithms
 #error __cpp_lib_raw_memory_algorithms is defined
@@ -1647,35 +1015,19 @@ STATIC_ASSERT(__cpp_lib_raw_memory_algorithms == 201606L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_remove_cvref
 STATIC_ASSERT(__cpp_lib_remove_cvref == 201711L);
-#else
-#error __cpp_lib_remove_cvref is not defined
-#endif
 #else
 #ifdef __cpp_lib_remove_cvref
 #error __cpp_lib_remove_cvref is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_result_of_sfinae
 STATIC_ASSERT(__cpp_lib_result_of_sfinae == 201210L);
-#else
-#error __cpp_lib_result_of_sfinae is not defined
-#endif
 
-#ifdef __cpp_lib_robust_nonmodifying_seq_ops
 STATIC_ASSERT(__cpp_lib_robust_nonmodifying_seq_ops == 201304L);
-#else
-#error __cpp_lib_robust_nonmodifying_seq_ops is not defined
-#endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_sample
 STATIC_ASSERT(__cpp_lib_sample == 201603L);
-#else
-#error __cpp_lib_sample is not defined
-#endif
 #else
 #ifdef __cpp_lib_sample
 #error __cpp_lib_sample is defined
@@ -1683,11 +1035,7 @@ STATIC_ASSERT(__cpp_lib_sample == 201603L);
 #endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_scoped_lock
 STATIC_ASSERT(__cpp_lib_scoped_lock == 201703L);
-#else
-#error __cpp_lib_scoped_lock is not defined
-#endif
 #else
 #ifdef __cpp_lib_scoped_lock
 #error __cpp_lib_scoped_lock is defined
@@ -1695,22 +1043,14 @@ STATIC_ASSERT(__cpp_lib_scoped_lock == 201703L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_semaphore
 STATIC_ASSERT(__cpp_lib_semaphore == 201907L);
-#else
-#error __cpp_lib_semaphore is not defined
-#endif
 #else
 #ifdef __cpp_lib_semaphore
 #error __cpp_lib_semaphore is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_shared_mutex
 STATIC_ASSERT(__cpp_lib_shared_mutex == 201505L);
-#else
-#error __cpp_lib_shared_mutex is not defined
-#endif
 
 #ifndef __cpp_lib_shared_ptr_arrays
 #error __cpp_lib_shared_ptr_arrays is not defined
@@ -1721,11 +1061,7 @@ STATIC_ASSERT(__cpp_lib_shared_ptr_arrays == 201611L);
 #endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_shared_ptr_weak_type
 STATIC_ASSERT(__cpp_lib_shared_ptr_weak_type == 201606L);
-#else
-#error __cpp_lib_shared_ptr_weak_type is not defined
-#endif
 #else
 #ifdef __cpp_lib_shared_ptr_weak_type
 #error __cpp_lib_shared_ptr_weak_type is defined
@@ -1737,25 +1073,13 @@ STATIC_ASSERT(__cpp_lib_shared_ptr_weak_type == 201606L);
 #error __cpp_lib_shared_timed_mutex is defined
 #endif
 #else
-#ifdef __cpp_lib_shared_timed_mutex
 STATIC_ASSERT(__cpp_lib_shared_timed_mutex == 201402L);
-#else
-#error __cpp_lib_shared_timed_mutex is not defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_shift
 STATIC_ASSERT(__cpp_lib_shift == 202202L);
-#else
-#error __cpp_lib_shift is not defined
-#endif
 #elif _HAS_CXX20
-#ifdef __cpp_lib_shift
 STATIC_ASSERT(__cpp_lib_shift == 201806L);
-#else
-#error __cpp_lib_shift is not defined
-#endif
 #else
 #ifdef __cpp_lib_shift
 #error __cpp_lib_shift is defined
@@ -1763,11 +1087,7 @@ STATIC_ASSERT(__cpp_lib_shift == 201806L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_smart_ptr_for_overwrite
 STATIC_ASSERT(__cpp_lib_smart_ptr_for_overwrite == 202002L);
-#else
-#error __cpp_lib_smart_ptr_for_overwrite is not defined
-#endif
 #else
 #ifdef __cpp_lib_smart_ptr_for_overwrite
 #error __cpp_lib_smart_ptr_for_overwrite is defined
@@ -1775,11 +1095,7 @@ STATIC_ASSERT(__cpp_lib_smart_ptr_for_overwrite == 202002L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_source_location
 STATIC_ASSERT(__cpp_lib_source_location == 201907L);
-#else
-#error __cpp_lib_source_location is not defined
-#endif
 #else
 #ifdef __cpp_lib_source_location
 #error __cpp_lib_source_location is defined
@@ -1787,11 +1103,7 @@ STATIC_ASSERT(__cpp_lib_source_location == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_span
 STATIC_ASSERT(__cpp_lib_span == 202002L);
-#else
-#error __cpp_lib_span is not defined
-#endif
 #else
 #ifdef __cpp_lib_span
 #error __cpp_lib_span is defined
@@ -1799,11 +1111,7 @@ STATIC_ASSERT(__cpp_lib_span == 202002L);
 #endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_spanstream
 STATIC_ASSERT(__cpp_lib_spanstream == 202106L);
-#else
-#error __cpp_lib_spanstream is not defined
-#endif
 #else
 #ifdef __cpp_lib_spanstream
 #error __cpp_lib_spanstream is defined
@@ -1811,11 +1119,7 @@ STATIC_ASSERT(__cpp_lib_spanstream == 202106L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_ssize
 STATIC_ASSERT(__cpp_lib_ssize == 201902L);
-#else
-#error __cpp_lib_ssize is not defined
-#endif
 #else
 #ifdef __cpp_lib_ssize
 #error __cpp_lib_ssize is defined
@@ -1823,11 +1127,7 @@ STATIC_ASSERT(__cpp_lib_ssize == 201902L);
 #endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_stacktrace
 STATIC_ASSERT(__cpp_lib_stacktrace == 202011L);
-#else
-#error __cpp_lib_stacktrace is not defined
-#endif
 #else
 #ifdef __cpp_lib_stacktrace
 #error __cpp_lib_stacktrace is defined
@@ -1835,11 +1135,7 @@ STATIC_ASSERT(__cpp_lib_stacktrace == 202011L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_starts_ends_with
 STATIC_ASSERT(__cpp_lib_starts_ends_with == 201711L);
-#else
-#error __cpp_lib_starts_ends_with is not defined
-#endif
 #else
 #ifdef __cpp_lib_starts_ends_with
 #error __cpp_lib_starts_ends_with is defined
@@ -1847,11 +1143,7 @@ STATIC_ASSERT(__cpp_lib_starts_ends_with == 201711L);
 #endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_stdatomic_h
 STATIC_ASSERT(__cpp_lib_stdatomic_h == 202011L);
-#else
-#error __cpp_lib_stdatomic_h is not defined
-#endif
 #else
 #ifdef __cpp_lib_stdatomic_h
 #error __cpp_lib_stdatomic_h is defined
@@ -1859,11 +1151,7 @@ STATIC_ASSERT(__cpp_lib_stdatomic_h == 202011L);
 #endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_string_contains
 STATIC_ASSERT(__cpp_lib_string_contains == 202011L);
-#else
-#error __cpp_lib_string_contains is not defined
-#endif
 #else
 #ifdef __cpp_lib_string_contains
 #error __cpp_lib_string_contains is defined
@@ -1871,29 +1159,17 @@ STATIC_ASSERT(__cpp_lib_string_contains == 202011L);
 #endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_string_resize_and_overwrite
 STATIC_ASSERT(__cpp_lib_string_resize_and_overwrite == 202110L);
-#else
-#error __cpp_lib_string_resize_and_overwrite is not defined
-#endif
 #else
 #ifdef __cpp_lib_string_resize_and_overwrite
 #error __cpp_lib_string_resize_and_overwrite is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_string_udls
 STATIC_ASSERT(__cpp_lib_string_udls == 201304L);
-#else
-#error __cpp_lib_string_udls is not defined
-#endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_string_view
 STATIC_ASSERT(__cpp_lib_string_view == 201803L);
-#else
-#error __cpp_lib_string_view is not defined
-#endif
 #else
 #ifdef __cpp_lib_string_view
 #error __cpp_lib_string_view is defined
@@ -1901,11 +1177,7 @@ STATIC_ASSERT(__cpp_lib_string_view == 201803L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_syncbuf
 STATIC_ASSERT(__cpp_lib_syncbuf == 201803L);
-#else
-#error __cpp_lib_syncbuf is not defined
-#endif
 #else
 #ifdef __cpp_lib_syncbuf
 #error __cpp_lib_syncbuf is defined
@@ -1913,11 +1185,7 @@ STATIC_ASSERT(__cpp_lib_syncbuf == 201803L);
 #endif
 
 #ifdef __cpp_lib_concepts
-#ifdef __cpp_lib_three_way_comparison
 STATIC_ASSERT(__cpp_lib_three_way_comparison == 201907L);
-#else
-#error __cpp_lib_three_way_comparison is not defined
-#endif
 #else
 #ifdef __cpp_lib_three_way_comparison
 #error __cpp_lib_three_way_comparison is defined
@@ -1925,11 +1193,7 @@ STATIC_ASSERT(__cpp_lib_three_way_comparison == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_to_address
 STATIC_ASSERT(__cpp_lib_to_address == 201711L);
-#else
-#error __cpp_lib_to_address is not defined
-#endif
 #else
 #ifdef __cpp_lib_to_address
 #error __cpp_lib_to_address is defined
@@ -1937,11 +1201,7 @@ STATIC_ASSERT(__cpp_lib_to_address == 201711L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_to_array
 STATIC_ASSERT(__cpp_lib_to_array == 201907L);
-#else
-#error __cpp_lib_to_array is not defined
-#endif
 #else
 #ifdef __cpp_lib_to_array
 #error __cpp_lib_to_array is defined
@@ -1949,11 +1209,7 @@ STATIC_ASSERT(__cpp_lib_to_array == 201907L);
 #endif
 
 #if _HAS_CXX17
-#ifdef __cpp_lib_to_chars
 STATIC_ASSERT(__cpp_lib_to_chars == 201611L);
-#else
-#error __cpp_lib_to_chars is not defined
-#endif
 #else
 #ifdef __cpp_lib_to_chars
 #error __cpp_lib_to_chars is defined
@@ -1961,89 +1217,45 @@ STATIC_ASSERT(__cpp_lib_to_chars == 201611L);
 #endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_to_underlying
 STATIC_ASSERT(__cpp_lib_to_underlying == 202102L);
-#else
-#error __cpp_lib_to_underlying is not defined
-#endif
 #else
 #ifdef __cpp_lib_to_underlying
 #error __cpp_lib_to_underlying is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_transformation_trait_aliases
 STATIC_ASSERT(__cpp_lib_transformation_trait_aliases == 201304L);
-#else
-#error __cpp_lib_transformation_trait_aliases is not defined
-#endif
 
-#ifdef __cpp_lib_transparent_operators
 STATIC_ASSERT(__cpp_lib_transparent_operators == 201510L);
-#else
-#error __cpp_lib_transparent_operators is not defined
-#endif
 
-#ifdef __cpp_lib_tuple_element_t
 STATIC_ASSERT(__cpp_lib_tuple_element_t == 201402L);
-#else
-#error __cpp_lib_tuple_element_t is not defined
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifdef __cpp_lib_tuple_like
 STATIC_ASSERT(__cpp_lib_tuple_like == 202207L);
-#else
-#error __cpp_lib_tuple_like is not defined
-#endif
 #else
 #ifdef __cpp_lib_tuple_like
 #error __cpp_lib_tuple_like is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_tuples_by_type
 STATIC_ASSERT(__cpp_lib_tuples_by_type == 201304L);
-#else
-#error __cpp_lib_tuples_by_type is not defined
-#endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_type_identity
 STATIC_ASSERT(__cpp_lib_type_identity == 201806L);
-#else
-#error __cpp_lib_type_identity is not defined
-#endif
 #else
 #ifdef __cpp_lib_type_identity
 #error __cpp_lib_type_identity is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_type_trait_variable_templates
 STATIC_ASSERT(__cpp_lib_type_trait_variable_templates == 201510L);
-#else
-#error __cpp_lib_type_trait_variable_templates is not defined
-#endif
 
-#ifdef __cpp_lib_uncaught_exceptions
 STATIC_ASSERT(__cpp_lib_uncaught_exceptions == 201411L);
-#else
-#error __cpp_lib_uncaught_exceptions is not defined
-#endif
 
-#ifdef __cpp_lib_unordered_map_try_emplace
 STATIC_ASSERT(__cpp_lib_unordered_map_try_emplace == 201411L);
-#else
-#error __cpp_lib_unordered_map_try_emplace is not defined
-#endif
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_unreachable
 STATIC_ASSERT(__cpp_lib_unreachable == 202202L);
-#else
-#error __cpp_lib_unreachable is not defined
-#endif
 #else
 #ifdef __cpp_lib_unreachable
 #error __cpp_lib_unreachable is defined
@@ -2051,11 +1263,7 @@ STATIC_ASSERT(__cpp_lib_unreachable == 202202L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_unwrap_ref
 STATIC_ASSERT(__cpp_lib_unwrap_ref == 201811L);
-#else
-#error __cpp_lib_unwrap_ref is not defined
-#endif
 #else
 #ifdef __cpp_lib_unwrap_ref
 #error __cpp_lib_unwrap_ref is defined
@@ -2063,25 +1271,13 @@ STATIC_ASSERT(__cpp_lib_unwrap_ref == 201811L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __cpp_lib_variant
 STATIC_ASSERT(__cpp_lib_variant == 202106L);
-#else
-#error __cpp_lib_variant is not defined
-#endif
 #elif _HAS_CXX17
-#ifdef __cpp_lib_variant
 STATIC_ASSERT(__cpp_lib_variant == 202102L);
-#else
-#error __cpp_lib_variant is not defined
-#endif
 #else
 #ifdef __cpp_lib_variant
 #error __cpp_lib_variant is defined
 #endif
 #endif
 
-#ifdef __cpp_lib_void_t
 STATIC_ASSERT(__cpp_lib_void_t == 201411L);
-#else
-#error __cpp_lib_void_t is not defined
-#endif

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -524,7 +524,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_algorithms == 201806L);
 #ifndef __cpp_lib_constexpr_bitset
 #error __cpp_lib_constexpr_bitset is not defined
 #elif __cpp_lib_constexpr_bitset != 202207L
-#error __cpp_lib_constexpr_bitset  is not 202207L
+#error __cpp_lib_constexpr_bitset is not 202207L
 #else
 STATIC_ASSERT(__cpp_lib_constexpr_bitset == 202207L);
 #endif
@@ -538,7 +538,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_bitset == 202207L);
 #ifndef __cpp_lib_constexpr_charconv
 #error __cpp_lib_constexpr_charconv is not defined
 #elif __cpp_lib_constexpr_charconv != 202207L
-#error __cpp_lib_constexpr_charconv  is not 202207L
+#error __cpp_lib_constexpr_charconv is not 202207L
 #else
 STATIC_ASSERT(__cpp_lib_constexpr_charconv == 202207L);
 #endif

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -502,12 +502,10 @@ STATIC_ASSERT(__cpp_lib_is_invocable == 201703L);
 #error __cpp_lib_is_invocable is defined
 #endif
 
-#if _HAS_CXX20
-#ifndef __clang__ // TRANSITION, LLVM-48860
+#if _HAS_CXX20 && !defined(__clang__) // TRANSITION, LLVM-48860
 STATIC_ASSERT(__cpp_lib_is_layout_compatible == 201907L);
 #elif defined(__cpp_lib_is_layout_compatible)
 #error __cpp_lib_is_layout_compatible is defined
-#endif
 #endif
 
 #if _HAS_CXX20
@@ -518,12 +516,10 @@ STATIC_ASSERT(__cpp_lib_is_nothrow_convertible == 201806L);
 
 STATIC_ASSERT(__cpp_lib_is_null_pointer == 201309L);
 
-#if _HAS_CXX20
-#ifndef __clang__ // TRANSITION, LLVM-48860
+#if _HAS_CXX20 && !defined(__clang__) // TRANSITION, LLVM-48860
 STATIC_ASSERT(__cpp_lib_is_pointer_interconvertible == 201907L);
 #elif defined(__cpp_lib_is_pointer_interconvertible)
 #error __cpp_lib_is_pointer_interconvertible is defined
-#endif
 #endif
 
 #if _HAS_CXX23

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -8,214 +8,164 @@
 // LIBRARY FEATURE-TEST MACROS
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_adaptor_iterator_pair_constructor == 202106L);
-#else
-#ifdef __cpp_lib_adaptor_iterator_pair_constructor
+#elif defined(__cpp_lib_adaptor_iterator_pair_constructor)
 #error __cpp_lib_adaptor_iterator_pair_constructor is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_addressof_constexpr == 201603L);
 
 #if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_algorithm_iterator_requirements == 202207L);
-#else
-#ifdef __cpp_lib_algorithm_iterator_requirements
+#elif defined(__cpp_lib_algorithm_iterator_requirements)
 #error __cpp_lib_algorithm_iterator_requirements is defined
-#endif
 #endif
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_allocate_at_least == 202302L);
-#else
-#ifdef __cpp_lib_allocate_at_least
+#elif defined(__cpp_lib_allocate_at_least)
 #error __cpp_lib_allocate_at_least is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_allocator_traits_is_always_equal == 201411L);
 
 #if _HAS_CXX17 && _HAS_STATIC_RTTI
 STATIC_ASSERT(__cpp_lib_any == 201606L);
-#else
-#ifdef __cpp_lib_any
+#elif defined(__cpp_lib_any)
 #error __cpp_lib_any is defined
-#endif
 #endif
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_apply == 201603L);
-#else
-#ifdef __cpp_lib_apply
+#elif defined(__cpp_lib_apply)
 #error __cpp_lib_apply is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_array_constexpr == 201811L);
 #elif _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_array_constexpr == 201803L);
-#else
-#ifdef __cpp_lib_array_constexpr
+#elif defined(__cpp_lib_array_constexpr)
 #error __cpp_lib_array_constexpr is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_as_const == 201510L);
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_associative_heterogeneous_erasure == 202110L);
-#else
-#ifdef __cpp_lib_associative_heterogeneous_erasure
+#elif defined(__cpp_lib_associative_heterogeneous_erasure)
 #error __cpp_lib_associative_heterogeneous_erasure is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_assume_aligned == 201811L);
-#else
-#ifdef __cpp_lib_assume_aligned
+#elif defined(__cpp_lib_assume_aligned)
 #error __cpp_lib_assume_aligned is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_atomic_flag_test == 201907L);
-#else
-#ifdef __cpp_lib_atomic_flag_test
+#elif defined(__cpp_lib_atomic_flag_test)
 #error __cpp_lib_atomic_flag_test is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_atomic_float == 201711L);
-#else
-#ifdef __cpp_lib_atomic_float
+#elif defined(__cpp_lib_atomic_float)
 #error __cpp_lib_atomic_float is defined
-#endif
 #endif
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_atomic_is_always_lock_free == 201603L);
-#else
-#ifdef __cpp_lib_atomic_is_always_lock_free
+#elif defined(__cpp_lib_atomic_is_always_lock_free)
 #error __cpp_lib_atomic_is_always_lock_free is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_atomic_lock_free_type_aliases == 201907L);
-#else
-#ifdef __cpp_lib_atomic_lock_free_type_aliases
+#elif defined(__cpp_lib_atomic_lock_free_type_aliases)
 #error __cpp_lib_atomic_lock_free_type_aliases is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_atomic_ref == 201806L);
-#else
-#ifdef __cpp_lib_atomic_ref
+#elif defined(__cpp_lib_atomic_ref)
 #error __cpp_lib_atomic_ref is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_atomic_shared_ptr == 201711L);
-#else
-#ifdef __cpp_lib_atomic_shared_ptr
+#elif defined(__cpp_lib_atomic_shared_ptr)
 #error __cpp_lib_atomic_shared_ptr is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_atomic_value_initialization == 201911L);
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_atomic_wait == 201907L);
-#else
-#ifdef __cpp_lib_atomic_wait
+#elif defined(__cpp_lib_atomic_wait)
 #error __cpp_lib_atomic_wait is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_barrier == 202302L);
-#else
-#ifdef __cpp_lib_barrier
+#elif defined(__cpp_lib_barrier)
 #error __cpp_lib_barrier is defined
-#endif
 #endif
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_bind_back == 202202L);
-#else
-#ifdef __cpp_lib_bind_back
+#elif defined(__cpp_lib_bind_back)
 #error __cpp_lib_bind_back is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_bind_front == 201907L);
-#else
-#ifdef __cpp_lib_bind_front
+#elif defined(__cpp_lib_bind_front)
 #error __cpp_lib_bind_front is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_bit_cast == 201806L);
-#else
-#ifdef __cpp_lib_bit_cast
+#elif defined(__cpp_lib_bit_cast)
 #error __cpp_lib_bit_cast is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_bitops == 201907L);
-#else
-#ifdef __cpp_lib_bitops
+#elif defined(__cpp_lib_bitops)
 #error __cpp_lib_bitops is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_bool_constant == 201505L);
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_bounded_array_traits == 201902L);
-#else
-#ifdef __cpp_lib_bounded_array_traits
+#elif defined(__cpp_lib_bounded_array_traits)
 #error __cpp_lib_bounded_array_traits is defined
-#endif
 #endif
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_boyer_moore_searcher == 201603L);
-#else
-#ifdef __cpp_lib_boyer_moore_searcher
+#elif defined(__cpp_lib_boyer_moore_searcher)
 #error __cpp_lib_boyer_moore_searcher is defined
-#endif
 #endif
 
 #if _HAS_STD_BYTE
 STATIC_ASSERT(__cpp_lib_byte == 201603L);
-#else
-#ifdef __cpp_lib_byte
+#elif defined(__cpp_lib_byte)
 #error __cpp_lib_byte is defined
-#endif
 #endif
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_byteswap == 202110L);
-#else
-#ifdef __cpp_lib_byteswap
+#elif defined(__cpp_lib_byteswap)
 #error __cpp_lib_byteswap is defined
-#endif
 #endif
 
 #if defined(__cpp_char8_t)
 STATIC_ASSERT(__cpp_lib_char8_t == 201907L);
-#else
-#ifdef __cpp_lib_char8_t
+#elif defined(__cpp_lib_char8_t)
 #error __cpp_lib_char8_t is defined
-#endif
 #endif
 
 #if defined(__cpp_lib_concepts)
@@ -230,26 +180,20 @@ STATIC_ASSERT(__cpp_lib_chrono_udls == 201304L);
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_clamp == 201603L);
-#else
-#ifdef __cpp_lib_clamp
+#elif defined(__cpp_lib_clamp)
 #error __cpp_lib_clamp is defined
-#endif
 #endif
 
 #if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_common_reference == 202302L);
-#else
-#ifdef __cpp_lib_common_reference
+#elif defined(__cpp_lib_common_reference)
 #error __cpp_lib_common_reference is defined
-#endif
 #endif
 
 #if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_common_reference_wrapper == 202302L);
-#else
-#ifdef __cpp_lib_common_reference_wrapper
+#elif defined(__cpp_lib_common_reference_wrapper)
 #error __cpp_lib_common_reference_wrapper is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_complex_udls == 201309L);
@@ -258,174 +202,132 @@ STATIC_ASSERT(__cpp_lib_complex_udls == 201309L);
 STATIC_ASSERT(__cpp_lib_concepts == 202207L);
 #elif _HAS_CXX20 && !defined(__EDG__) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_concepts == 202002L);
-#else
-#ifdef __cpp_lib_concepts
+#elif defined(__cpp_lib_concepts)
 #error __cpp_lib_concepts is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_constexpr_algorithms == 201806L);
-#else
-#ifdef __cpp_lib_constexpr_algorithms
+#elif defined(__cpp_lib_constexpr_algorithms)
 #error __cpp_lib_constexpr_algorithms is defined
-#endif
 #endif
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_constexpr_bitset == 202207L);
-#else
-#ifdef __cpp_lib_constexpr_bitset
+#elif defined(__cpp_lib_constexpr_bitset)
 #error __cpp_lib_constexpr_bitset is defined
-#endif
 #endif
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_constexpr_charconv == 202207L);
-#else
-#ifdef __cpp_lib_constexpr_charconv
+#elif defined(__cpp_lib_constexpr_charconv)
 #error __cpp_lib_constexpr_charconv is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_constexpr_complex == 201711L);
-#else
-#ifdef __cpp_lib_constexpr_complex
+#elif defined(__cpp_lib_constexpr_complex)
 #error __cpp_lib_constexpr_complex is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_constexpr_dynamic_alloc == 201907L);
-#else
-#ifdef __cpp_lib_constexpr_dynamic_alloc
+#elif defined(__cpp_lib_constexpr_dynamic_alloc)
 #error __cpp_lib_constexpr_dynamic_alloc is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_constexpr_functional == 201907L);
-#else
-#ifdef __cpp_lib_constexpr_functional
+#elif defined(__cpp_lib_constexpr_functional)
 #error __cpp_lib_constexpr_functional is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_constexpr_iterator == 201811L);
-#else
-#ifdef __cpp_lib_constexpr_iterator
+#elif defined(__cpp_lib_constexpr_iterator)
 #error __cpp_lib_constexpr_iterator is defined
-#endif
 #endif
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_constexpr_memory == 202202L);
 #elif _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_constexpr_memory == 201811L);
-#else
-#ifdef __cpp_lib_constexpr_memory
+#elif defined(__cpp_lib_constexpr_memory)
 #error __cpp_lib_constexpr_memory is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_constexpr_numeric == 201911L);
-#else
-#ifdef __cpp_lib_constexpr_numeric
+#elif defined(__cpp_lib_constexpr_numeric)
 #error __cpp_lib_constexpr_numeric is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_constexpr_string == 201907L);
-#else
-#ifdef __cpp_lib_constexpr_string
+#elif defined(__cpp_lib_constexpr_string)
 #error __cpp_lib_constexpr_string is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_constexpr_string_view == 201811L);
-#else
-#ifdef __cpp_lib_constexpr_string_view
+#elif defined(__cpp_lib_constexpr_string_view)
 #error __cpp_lib_constexpr_string_view is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_constexpr_tuple == 201811L);
-#else
-#ifdef __cpp_lib_constexpr_tuple
+#elif defined(__cpp_lib_constexpr_tuple)
 #error __cpp_lib_constexpr_tuple is defined
-#endif
 #endif
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_constexpr_typeinfo == 202106L);
-#else
-#ifdef __cpp_lib_constexpr_typeinfo
+#elif defined(__cpp_lib_constexpr_typeinfo)
 #error __cpp_lib_constexpr_typeinfo is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_constexpr_utility == 201811L);
-#else
-#ifdef __cpp_lib_constexpr_utility
+#elif defined(__cpp_lib_constexpr_utility)
 #error __cpp_lib_constexpr_utility is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_constexpr_vector == 201907L);
-#else
-#ifdef __cpp_lib_constexpr_vector
+#elif defined(__cpp_lib_constexpr_vector)
 #error __cpp_lib_constexpr_vector is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_containers_ranges == 202202L);
-#else
-#ifdef __cpp_lib_containers_ranges
+#elif defined(__cpp_lib_containers_ranges)
 #error __cpp_lib_containers_ranges is defined
-#endif
 #endif
 
 #ifdef __cpp_impl_coroutine
 STATIC_ASSERT(__cpp_lib_coroutine == 201902L);
-#else
-#ifdef __cpp_lib_coroutine
+#elif defined(__cpp_lib_coroutine)
 #error __cpp_lib_coroutine is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_destroying_delete == 201806L);
-#else
-#ifdef __cpp_lib_destroying_delete
+#elif defined(__cpp_lib_destroying_delete)
 #error __cpp_lib_destroying_delete is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_enable_shared_from_this == 201603L);
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_endian == 201907L);
-#else
-#ifdef __cpp_lib_endian
+#elif defined(__cpp_lib_endian)
 #error __cpp_lib_endian is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_erase_if == 202002L);
-#else
-#ifdef __cpp_lib_erase_if
+#elif defined(__cpp_lib_erase_if)
 #error __cpp_lib_erase_if is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_exchange_function == 201304L);
@@ -434,18 +336,14 @@ STATIC_ASSERT(__cpp_lib_exchange_function == 201304L);
 STATIC_ASSERT(__cpp_lib_execution == 201902L);
 #elif _HAS_CXX17 && !defined(_M_CEE_PURE)
 STATIC_ASSERT(__cpp_lib_execution == 201603L);
-#else
-#ifdef __cpp_lib_execution
+#elif defined(__cpp_lib_execution)
 #error __cpp_lib_execution is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_expected == 202211L);
-#else
-#ifdef __cpp_lib_expected
+#elif defined(__cpp_lib_expected)
 #error __cpp_lib_expected is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_experimental_erase_if == 201411L);
@@ -454,44 +352,34 @@ STATIC_ASSERT(__cpp_lib_experimental_filesystem == 201406L);
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_filesystem == 201703L);
-#else
-#ifdef __cpp_lib_filesystem
+#elif defined(__cpp_lib_filesystem)
 #error __cpp_lib_filesystem is defined
-#endif
 #endif
 
 #ifdef __cpp_lib_concepts
 STATIC_ASSERT(__cpp_lib_format == 202207L);
-#else
-#ifdef __cpp_lib_format
+#elif defined(__cpp_lib_format)
 #error __cpp_lib_format is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_formatters == 202302L);
-#else
-#ifdef __cpp_lib_formatters
+#elif defined(__cpp_lib_formatters)
 #error __cpp_lib_formatters is defined
-#endif
 #endif
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_forward_like == 202207L);
-#else
-#ifdef __cpp_lib_forward_like
+#elif defined(__cpp_lib_forward_like)
 #error __cpp_lib_forward_like is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_freestanding_char_traits == 202306L);
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_freestanding_charconv == 202306L);
-#else
-#ifdef __cpp_lib_freestanding_charconv
+#elif defined(__cpp_lib_freestanding_charconv)
 #error __cpp_lib_freestanding_charconv is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_freestanding_cstdlib == 202306L);
@@ -514,10 +402,8 @@ STATIC_ASSERT(__cpp_lib_freestanding_operator_new == 202306L);
 
 #ifdef __cpp_lib_concepts
 STATIC_ASSERT(__cpp_lib_freestanding_ranges == 202306L);
-#else
-#ifdef __cpp_lib_freestanding_ranges
+#elif defined(__cpp_lib_freestanding_ranges)
 #error __cpp_lib_freestanding_ranges is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_freestanding_ratio == 202306L);
@@ -528,62 +414,48 @@ STATIC_ASSERT(__cpp_lib_freestanding_utility == 202306L);
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_gcd_lcm == 201606L);
-#else
-#ifdef __cpp_lib_gcd_lcm
+#elif defined(__cpp_lib_gcd_lcm)
 #error __cpp_lib_gcd_lcm is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_generic_associative_lookup == 201304L);
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_generic_unordered_lookup == 201811L);
-#else
-#ifdef __cpp_lib_generic_unordered_lookup
+#elif defined(__cpp_lib_generic_unordered_lookup)
 #error __cpp_lib_generic_unordered_lookup is defined
-#endif
 #endif
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_hardware_interference_size == 201703L);
-#else
-#ifdef __cpp_lib_hardware_interference_size
+#elif defined(__cpp_lib_hardware_interference_size)
 #error __cpp_lib_hardware_interference_size is defined
-#endif
 #endif
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_has_unique_object_representations == 201606L);
-#else
-#ifdef __cpp_lib_has_unique_object_representations
+#elif defined(__cpp_lib_has_unique_object_representations)
 #error __cpp_lib_has_unique_object_representations is defined
-#endif
 #endif
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_hypot == 201603L);
-#else
-#ifdef __cpp_lib_hypot
+#elif defined(__cpp_lib_hypot)
 #error __cpp_lib_hypot is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_incomplete_container_elements == 201505L);
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_int_pow2 == 202002L);
-#else
-#ifdef __cpp_lib_int_pow2
+#elif defined(__cpp_lib_int_pow2)
 #error __cpp_lib_int_pow2 is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_integer_comparison_functions == 202002L);
-#else
-#ifdef __cpp_lib_integer_comparison_functions
+#elif defined(__cpp_lib_integer_comparison_functions)
 #error __cpp_lib_integer_comparison_functions is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_integer_sequence == 201304L);
@@ -592,72 +464,56 @@ STATIC_ASSERT(__cpp_lib_integral_constant_callable == 201304L);
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_interpolate == 201902L);
-#else
-#ifdef __cpp_lib_interpolate
+#elif defined(__cpp_lib_interpolate)
 #error __cpp_lib_interpolate is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_invoke == 201411L);
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_invoke_r == 202106L);
-#else
-#ifdef __cpp_lib_invoke_r
+#elif defined(__cpp_lib_invoke_r)
 #error __cpp_lib_invoke_r is defined
-#endif
 #endif
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_ios_noreplace == 202207L);
-#else
-#ifdef __cpp_lib_ios_noreplace
+#elif defined(__cpp_lib_ios_noreplace)
 #error __cpp_lib_ios_noreplace is defined
-#endif
 #endif
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_is_aggregate == 201703L);
-#else
-#ifdef __cpp_lib_is_aggregate
+#elif defined(__cpp_lib_is_aggregate)
 #error __cpp_lib_is_aggregate is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_is_constant_evaluated == 201811L);
-#else
-#ifdef __cpp_lib_is_constant_evaluated
+#elif defined(__cpp_lib_is_constant_evaluated)
 #error __cpp_lib_is_constant_evaluated is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_is_final == 201402L);
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_is_invocable == 201703L);
-#else
-#ifdef __cpp_lib_is_invocable
+#elif defined(__cpp_lib_is_invocable)
 #error __cpp_lib_is_invocable is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __clang__ // TRANSITION, LLVM-48860
 STATIC_ASSERT(__cpp_lib_is_layout_compatible == 201907L);
-#else
-#ifdef __cpp_lib_is_layout_compatible
+#elif defined(__cpp_lib_is_layout_compatible)
 #error __cpp_lib_is_layout_compatible is defined
-#endif
 #endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_is_nothrow_convertible == 201806L);
-#else
-#ifdef __cpp_lib_is_nothrow_convertible
+#elif defined(__cpp_lib_is_nothrow_convertible)
 #error __cpp_lib_is_nothrow_convertible is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_is_null_pointer == 201309L);
@@ -665,69 +521,53 @@ STATIC_ASSERT(__cpp_lib_is_null_pointer == 201309L);
 #if _HAS_CXX20
 #ifndef __clang__ // TRANSITION, LLVM-48860
 STATIC_ASSERT(__cpp_lib_is_pointer_interconvertible == 201907L);
-#else
-#ifdef __cpp_lib_is_pointer_interconvertible
+#elif defined(__cpp_lib_is_pointer_interconvertible)
 #error __cpp_lib_is_pointer_interconvertible is defined
-#endif
 #endif
 #endif
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_is_scoped_enum == 202011L);
-#else
-#ifdef __cpp_lib_is_scoped_enum
+#elif defined(__cpp_lib_is_scoped_enum)
 #error __cpp_lib_is_scoped_enum is defined
-#endif
 #endif
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_is_swappable == 201603L);
-#else
-#ifdef __cpp_lib_is_swappable
+#elif defined(__cpp_lib_is_swappable)
 #error __cpp_lib_is_swappable is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_jthread == 201911L);
-#else
-#ifdef __cpp_lib_jthread
+#elif defined(__cpp_lib_jthread)
 #error __cpp_lib_jthread is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_latch == 201907L);
-#else
-#ifdef __cpp_lib_latch
+#elif defined(__cpp_lib_latch)
 #error __cpp_lib_latch is defined
-#endif
 #endif
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_launder == 201606L);
-#else
-#ifdef __cpp_lib_launder
+#elif defined(__cpp_lib_launder)
 #error __cpp_lib_launder is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_list_remove_return_type == 201806L);
-#else
-#ifdef __cpp_lib_list_remove_return_type
+#elif defined(__cpp_lib_list_remove_return_type)
 #error __cpp_lib_list_remove_return_type is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_logical_traits == 201510L);
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_make_from_tuple == 201606L);
-#else
-#ifdef __cpp_lib_make_from_tuple
+#elif defined(__cpp_lib_make_from_tuple)
 #error __cpp_lib_make_from_tuple is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_make_reverse_iterator == 201402L);
@@ -738,76 +578,58 @@ STATIC_ASSERT(__cpp_lib_map_try_emplace == 201411L);
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_math_constants == 201907L);
-#else
-#ifdef __cpp_lib_math_constants
+#elif defined(__cpp_lib_math_constants)
 #error __cpp_lib_math_constants is defined
-#endif
 #endif
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_math_special_functions == 201603L);
-#else
-#ifdef __cpp_lib_math_special_functions
+#elif defined(__cpp_lib_math_special_functions)
 #error __cpp_lib_math_special_functions is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_mdspan == 202207L);
-#else
-#ifdef __cpp_lib_mdspan
+#elif defined(__cpp_lib_mdspan)
 #error __cpp_lib_mdspan is defined
-#endif
 #endif
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_memory_resource == 201603L);
-#else
-#ifdef __cpp_lib_memory_resource
+#elif defined(__cpp_lib_memory_resource)
 #error __cpp_lib_memory_resource is defined
-#endif
 #endif
 
 #if _HAS_CXX20 && !defined(__clang__) && !defined(__EDG__) // TRANSITION, Clang and EDG support for modules
 STATIC_ASSERT(__cpp_lib_modules == 202207L);
-#else
-#ifdef __cpp_lib_modules
+#elif defined(__cpp_lib_modules)
 #error __cpp_lib_modules is defined
-#endif
 #endif
 
 #ifdef __cpp_lib_concepts
 STATIC_ASSERT(__cpp_lib_move_iterator_concept == 202207L);
-#else
-#ifdef __cpp_lib_move_iterator_concept
+#elif defined(__cpp_lib_move_iterator_concept)
 #error __cpp_lib_move_iterator_concept is defined
-#endif
 #endif
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_move_only_function == 202110L);
-#else
-#ifdef __cpp_lib_move_only_function
+#elif defined(__cpp_lib_move_only_function)
 #error __cpp_lib_move_only_function is defined
-#endif
 #endif
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_node_extract == 201606L);
-#else
-#ifdef __cpp_lib_node_extract
+#elif defined(__cpp_lib_node_extract)
 #error __cpp_lib_node_extract is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_nonmember_container_access == 201411L);
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_not_fn == 201603L);
-#else
-#ifdef __cpp_lib_not_fn
+#elif defined(__cpp_lib_not_fn)
 #error __cpp_lib_not_fn is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_null_iterators == 201304L);
@@ -818,42 +640,32 @@ STATIC_ASSERT(__cpp_lib_optional == 202110L);
 STATIC_ASSERT(__cpp_lib_optional == 202106L);
 #elif _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_optional == 201606L);
-#else
-#ifdef __cpp_lib_optional
+#elif defined(__cpp_lib_optional)
 #error __cpp_lib_optional is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_out_ptr == 202106L);
-#else
-#ifdef __cpp_lib_out_ptr
+#elif defined(__cpp_lib_out_ptr)
 #error __cpp_lib_out_ptr is defined
-#endif
 #endif
 
 #if _HAS_CXX17 && !defined(_M_CEE_PURE)
 STATIC_ASSERT(__cpp_lib_parallel_algorithm == 201603L);
-#else
-#ifdef __cpp_lib_parallel_algorithm
+#elif defined(__cpp_lib_parallel_algorithm)
 #error __cpp_lib_parallel_algorithm is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_polymorphic_allocator == 201902L);
-#else
-#ifdef __cpp_lib_polymorphic_allocator
+#elif defined(__cpp_lib_polymorphic_allocator)
 #error __cpp_lib_polymorphic_allocator is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_print == 202207L);
-#else
-#ifdef __cpp_lib_print
+#elif defined(__cpp_lib_print)
 #error __cpp_lib_print is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_quoted_string_io == 201304L);
@@ -862,162 +674,122 @@ STATIC_ASSERT(__cpp_lib_quoted_string_io == 201304L);
 STATIC_ASSERT(__cpp_lib_ranges == 202302L);
 #elif _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_ranges == 202110L);
-#else
-#ifdef __cpp_lib_ranges
+#elif defined(__cpp_lib_ranges)
 #error __cpp_lib_ranges is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_ranges_as_const == 202207L);
-#else
-#ifdef __cpp_lib_ranges_as_const
+#elif defined(__cpp_lib_ranges_as_const)
 #error __cpp_lib_ranges_as_const is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_ranges_as_rvalue == 202207L);
-#else
-#ifdef __cpp_lib_ranges_as_rvalue
+#elif defined(__cpp_lib_ranges_as_rvalue)
 #error __cpp_lib_ranges_as_rvalue is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_ranges_cartesian_product == 202207L);
-#else
-#ifdef __cpp_lib_ranges_cartesian_product
+#elif defined(__cpp_lib_ranges_cartesian_product)
 #error __cpp_lib_ranges_cartesian_product is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_ranges_chunk == 202202L);
-#else
-#ifdef __cpp_lib_ranges_chunk
+#elif defined(__cpp_lib_ranges_chunk)
 #error __cpp_lib_ranges_chunk is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_ranges_chunk_by == 202202L);
-#else
-#ifdef __cpp_lib_ranges_chunk_by
+#elif defined(__cpp_lib_ranges_chunk_by)
 #error __cpp_lib_ranges_chunk_by is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_ranges_contains == 202207L);
-#else
-#ifdef __cpp_lib_ranges_contains
+#elif defined(__cpp_lib_ranges_contains)
 #error __cpp_lib_ranges_contains is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_ranges_enumerate == 202302L);
-#else
-#ifdef __cpp_lib_ranges_enumerate
+#elif defined(__cpp_lib_ranges_enumerate)
 #error __cpp_lib_ranges_enumerate is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_ranges_find_last == 202207L);
-#else
-#ifdef __cpp_lib_ranges_find_last
+#elif defined(__cpp_lib_ranges_find_last)
 #error __cpp_lib_ranges_find_last is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_ranges_fold == 202207L);
-#else
-#ifdef __cpp_lib_ranges_fold
+#elif defined(__cpp_lib_ranges_fold)
 #error __cpp_lib_ranges_fold is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_ranges_iota == 202202L);
-#else
-#ifdef __cpp_lib_ranges_iota
+#elif defined(__cpp_lib_ranges_iota)
 #error __cpp_lib_ranges_iota is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_ranges_join_with == 202202L);
-#else
-#ifdef __cpp_lib_ranges_join_with
+#elif defined(__cpp_lib_ranges_join_with)
 #error __cpp_lib_ranges_join_with is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_ranges_repeat == 202207L);
-#else
-#ifdef __cpp_lib_ranges_repeat
+#elif defined(__cpp_lib_ranges_repeat)
 #error __cpp_lib_ranges_repeat is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_ranges_slide == 202202L);
-#else
-#ifdef __cpp_lib_ranges_slide
+#elif defined(__cpp_lib_ranges_slide)
 #error __cpp_lib_ranges_slide is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_ranges_starts_ends_with == 202106L);
-#else
-#ifdef __cpp_lib_ranges_starts_ends_with
+#elif defined(__cpp_lib_ranges_starts_ends_with)
 #error __cpp_lib_ranges_starts_ends_with is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_ranges_stride == 202207L);
-#else
-#ifdef __cpp_lib_ranges_stride
+#elif defined(__cpp_lib_ranges_stride)
 #error __cpp_lib_ranges_stride is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_ranges_to_container == 202202L);
-#else
-#ifdef __cpp_lib_ranges_to_container
+#elif defined(__cpp_lib_ranges_to_container)
 #error __cpp_lib_ranges_to_container is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_ranges_zip == 202110L);
-#else
-#ifdef __cpp_lib_ranges_zip
+#elif defined(__cpp_lib_ranges_zip)
 #error __cpp_lib_ranges_zip is defined
-#endif
 #endif
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_raw_memory_algorithms == 201606L);
-#else
-#ifdef __cpp_lib_raw_memory_algorithms
+#elif defined(__cpp_lib_raw_memory_algorithms)
 #error __cpp_lib_raw_memory_algorithms is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_remove_cvref == 201711L);
-#else
-#ifdef __cpp_lib_remove_cvref
+#elif defined(__cpp_lib_remove_cvref)
 #error __cpp_lib_remove_cvref is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_result_of_sfinae == 201210L);
@@ -1026,26 +798,20 @@ STATIC_ASSERT(__cpp_lib_robust_nonmodifying_seq_ops == 201304L);
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_sample == 201603L);
-#else
-#ifdef __cpp_lib_sample
+#elif defined(__cpp_lib_sample)
 #error __cpp_lib_sample is defined
-#endif
 #endif
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_scoped_lock == 201703L);
-#else
-#ifdef __cpp_lib_scoped_lock
+#elif defined(__cpp_lib_scoped_lock)
 #error __cpp_lib_scoped_lock is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_semaphore == 201907L);
-#else
-#ifdef __cpp_lib_semaphore
+#elif defined(__cpp_lib_semaphore)
 #error __cpp_lib_semaphore is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_shared_mutex == 201505L);
@@ -1058,10 +824,8 @@ STATIC_ASSERT(__cpp_lib_shared_ptr_arrays == 201611L);
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_shared_ptr_weak_type == 201606L);
-#else
-#ifdef __cpp_lib_shared_ptr_weak_type
+#elif defined(__cpp_lib_shared_ptr_weak_type)
 #error __cpp_lib_shared_ptr_weak_type is defined
-#endif
 #endif
 
 #ifdef _M_CEE_PURE
@@ -1076,148 +840,112 @@ STATIC_ASSERT(__cpp_lib_shared_timed_mutex == 201402L);
 STATIC_ASSERT(__cpp_lib_shift == 202202L);
 #elif _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_shift == 201806L);
-#else
-#ifdef __cpp_lib_shift
+#elif defined(__cpp_lib_shift)
 #error __cpp_lib_shift is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_smart_ptr_for_overwrite == 202002L);
-#else
-#ifdef __cpp_lib_smart_ptr_for_overwrite
+#elif defined(__cpp_lib_smart_ptr_for_overwrite)
 #error __cpp_lib_smart_ptr_for_overwrite is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_source_location == 201907L);
-#else
-#ifdef __cpp_lib_source_location
+#elif defined(__cpp_lib_source_location)
 #error __cpp_lib_source_location is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_span == 202002L);
-#else
-#ifdef __cpp_lib_span
+#elif defined(__cpp_lib_span)
 #error __cpp_lib_span is defined
-#endif
 #endif
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_spanstream == 202106L);
-#else
-#ifdef __cpp_lib_spanstream
+#elif defined(__cpp_lib_spanstream)
 #error __cpp_lib_spanstream is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_ssize == 201902L);
-#else
-#ifdef __cpp_lib_ssize
+#elif defined(__cpp_lib_ssize)
 #error __cpp_lib_ssize is defined
-#endif
 #endif
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_stacktrace == 202011L);
-#else
-#ifdef __cpp_lib_stacktrace
+#elif defined(__cpp_lib_stacktrace)
 #error __cpp_lib_stacktrace is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_starts_ends_with == 201711L);
-#else
-#ifdef __cpp_lib_starts_ends_with
+#elif defined(__cpp_lib_starts_ends_with)
 #error __cpp_lib_starts_ends_with is defined
-#endif
 #endif
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_stdatomic_h == 202011L);
-#else
-#ifdef __cpp_lib_stdatomic_h
+#elif defined(__cpp_lib_stdatomic_h)
 #error __cpp_lib_stdatomic_h is defined
-#endif
 #endif
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_string_contains == 202011L);
-#else
-#ifdef __cpp_lib_string_contains
+#elif defined(__cpp_lib_string_contains)
 #error __cpp_lib_string_contains is defined
-#endif
 #endif
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_string_resize_and_overwrite == 202110L);
-#else
-#ifdef __cpp_lib_string_resize_and_overwrite
+#elif defined(__cpp_lib_string_resize_and_overwrite)
 #error __cpp_lib_string_resize_and_overwrite is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_string_udls == 201304L);
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_string_view == 201803L);
-#else
-#ifdef __cpp_lib_string_view
+#elif defined(__cpp_lib_string_view)
 #error __cpp_lib_string_view is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_syncbuf == 201803L);
-#else
-#ifdef __cpp_lib_syncbuf
+#elif defined(__cpp_lib_syncbuf)
 #error __cpp_lib_syncbuf is defined
-#endif
 #endif
 
 #ifdef __cpp_lib_concepts
 STATIC_ASSERT(__cpp_lib_three_way_comparison == 201907L);
-#else
-#ifdef __cpp_lib_three_way_comparison
+#elif defined(__cpp_lib_three_way_comparison)
 #error __cpp_lib_three_way_comparison is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_to_address == 201711L);
-#else
-#ifdef __cpp_lib_to_address
+#elif defined(__cpp_lib_to_address)
 #error __cpp_lib_to_address is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_to_array == 201907L);
-#else
-#ifdef __cpp_lib_to_array
+#elif defined(__cpp_lib_to_array)
 #error __cpp_lib_to_array is defined
-#endif
 #endif
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_to_chars == 201611L);
-#else
-#ifdef __cpp_lib_to_chars
+#elif defined(__cpp_lib_to_chars)
 #error __cpp_lib_to_chars is defined
-#endif
 #endif
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_to_underlying == 202102L);
-#else
-#ifdef __cpp_lib_to_underlying
+#elif defined(__cpp_lib_to_underlying)
 #error __cpp_lib_to_underlying is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_transformation_trait_aliases == 201304L);
@@ -1228,20 +956,16 @@ STATIC_ASSERT(__cpp_lib_tuple_element_t == 201402L);
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 STATIC_ASSERT(__cpp_lib_tuple_like == 202207L);
-#else
-#ifdef __cpp_lib_tuple_like
+#elif defined(__cpp_lib_tuple_like)
 #error __cpp_lib_tuple_like is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_tuples_by_type == 201304L);
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_type_identity == 201806L);
-#else
-#ifdef __cpp_lib_type_identity
+#elif defined(__cpp_lib_type_identity)
 #error __cpp_lib_type_identity is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_type_trait_variable_templates == 201510L);
@@ -1252,28 +976,22 @@ STATIC_ASSERT(__cpp_lib_unordered_map_try_emplace == 201411L);
 
 #if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_unreachable == 202202L);
-#else
-#ifdef __cpp_lib_unreachable
+#elif defined(__cpp_lib_unreachable)
 #error __cpp_lib_unreachable is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_unwrap_ref == 201811L);
-#else
-#ifdef __cpp_lib_unwrap_ref
+#elif defined(__cpp_lib_unwrap_ref)
 #error __cpp_lib_unwrap_ref is defined
-#endif
 #endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_variant == 202106L);
 #elif _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_variant == 202102L);
-#else
-#ifdef __cpp_lib_variant
+#elif defined(__cpp_lib_variant)
 #error __cpp_lib_variant is defined
-#endif
 #endif
 
 STATIC_ASSERT(__cpp_lib_void_t == 201411L);

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -828,12 +828,10 @@ STATIC_ASSERT(__cpp_lib_shared_ptr_weak_type == 201606L);
 #error __cpp_lib_shared_ptr_weak_type is defined
 #endif
 
-#ifdef _M_CEE_PURE
-#ifdef __cpp_lib_shared_timed_mutex
-#error __cpp_lib_shared_timed_mutex is defined
-#endif
-#else
+#ifndef _M_CEE_PURE
 STATIC_ASSERT(__cpp_lib_shared_timed_mutex == 201402L);
+#elif defined(__cpp_lib_shared_timed_mutex)
+#error __cpp_lib_shared_timed_mutex is defined
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -218,9 +218,7 @@ STATIC_ASSERT(__cpp_lib_char8_t == 201907L);
 #endif
 #endif
 
-#ifndef __cpp_lib_chrono
-#error __cpp_lib_chrono is not defined
-#elif defined(__cpp_lib_concepts)
+#if defined(__cpp_lib_concepts)
 STATIC_ASSERT(__cpp_lib_chrono == 201907L);
 #elif _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_chrono == 201611L);
@@ -1052,9 +1050,7 @@ STATIC_ASSERT(__cpp_lib_semaphore == 201907L);
 
 STATIC_ASSERT(__cpp_lib_shared_mutex == 201505L);
 
-#ifndef __cpp_lib_shared_ptr_arrays
-#error __cpp_lib_shared_ptr_arrays is not defined
-#elif _HAS_CXX20
+#if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_shared_ptr_arrays == 201707L);
 #else
 STATIC_ASSERT(__cpp_lib_shared_ptr_arrays == 201611L);

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -1745,16 +1745,10 @@ STATIC_ASSERT(__cpp_lib_shared_timed_mutex == 201402L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_shift
-#error __cpp_lib_shift is not defined
-#elif __cpp_lib_shift != 202202L
-#if __cpp_lib_shift == 201806L
-#error __cpp_lib_shift is 201806L when it should be 202202L
-#else
-#error __cpp_lib_shift is not 202202L
-#endif
-#else
+#ifdef __cpp_lib_shift
 STATIC_ASSERT(__cpp_lib_shift == 202202L);
+#else
+#error __cpp_lib_shift is not defined
 #endif
 #elif _HAS_CXX20
 #ifdef __cpp_lib_shift


### PR DESCRIPTION
* Drop extra spaces in `#error` messages.
* Mechanically simplify.
  + This test originally covered both the compiler and library feature-test macros, and was therefore extremely paranoid about checking the behavior of the preprocessor. We gave the compiler test coverage to the compiler team a long time ago, so we can simplify the library test coverage now. This commit is a 100% regex search-and-replace, from:
    ```cpp
    #ifndef (__cpp_lib_\w+)
    #error \1 is not defined
    #elif \1 != (\d{6}L)
    #error \1 is not \2
    #else
    STATIC_ASSERT\(\1 == \2\);
    #endif
    ```
    to:
    ```cpp
    #ifdef $1
    STATIC_ASSERT($1 == $2);
    #else
    #error $1 is not defined
    #endif
    ```
    except with `\n` between each line of the "from" and "to" (presented here on separate lines for clarity).
* Simplify `__cpp_lib_chrono` and `__cpp_lib_shared_ptr_arrays`.
  + These are always defined, but to varying values, so they use a slightly different pattern.
* Simplify `__cpp_lib_shift`.
  + This was trying to be extra helpful with a message saying "is OLD_VALUE when it should be NEW_VALUE", but that made the code verbose and unsystematic. This test is passing, so we don't need elaborate error messages in case of failure.
* Fix damaged `__cpp_lib_containers_ranges` test.
  + This would never have detected `__cpp_lib_containers_ranges` being defined outside of the relevant mode.
* Mechanically simplify again (100% regex).
  + From:
    ```cpp
    #ifdef (__cpp_lib_\w+)
    (STATIC_ASSERT\(\1 == \d{6}L\);)
    #else
    #error \1 is not defined
    #endif
    ```
    to:
    ```
    $2
    ```
* Manually simplify `__cpp_lib_chrono` and `__cpp_lib_shared_ptr_arrays` again.
  + This removes all occurrences of "is not defined".
* Mechanically simplify yet again (100% regex).
  + From:
    ```cpp
    #else
    #ifdef (__cpp_lib_\w+)
    #error \1 is defined
    #endif
    #endif
    ```
    to:
    ```cpp
    #elif defined($1)
    #error $1 is defined
    #endif
    ```
* Manually simplify `__cpp_lib_shared_timed_mutex`.
  + Testing for non-`/clr:pure` mode allows this to follow the consistent pattern.
* Fix damaged `__cpp_lib_is_layout_compatible` and `__cpp_lib_is_pointer_interconvertible` tests.
  + These tests weren't doing anything for C++14/17 mode. Now they'll detect the macros being present when they shouldn't be.
* DROP SHOUTY COMMENT.
