### PR TITLE
Add a Standard mode check to `<__msvc_print.hpp>`

### DIFF
--- a/stl/inc/__msvc_print.hpp
+++ b/stl/inc/__msvc_print.hpp
@@ -8,9 +8,8 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 
-#ifndef __cpp_lib_concepts
-#error The contents of <format> are available only with C++20 or later, and the contents of <print> \
-are available only with C++23 or later. (Also, you should not include this internal header.)
+#ifndef __cpp_lib_concepts // note: <format> includes this header in C++20 mode
+#error The contents of <print> are available only with C++23. (Also, you should not include this internal header.)
 #endif // ^^^ !defined(__cpp_lib_concepts) ^^^
 
 #include <cstdio>

--- a/stl/inc/__msvc_print.hpp
+++ b/stl/inc/__msvc_print.hpp
@@ -8,6 +8,11 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 
+#ifndef __cpp_lib_concepts
+#error The contents of <format> are available only with C++20 or later, and the contents of <print> \
+are available only with C++23 or later. (Also, you should not include this internal header.)
+#endif // ^^^ !defined(__cpp_lib_concepts) ^^^
+
 #include <cstdio>
 #include <xfilesystem_abi.h>
 

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -9,11 +9,11 @@
 #if _STL_COMPILER_PREPROCESSOR
 #include <ios>
 
-#if _HAS_CXX23
+#ifdef __cpp_lib_print
 #include <__msvc_filebuf.hpp>
 #include <__msvc_print.hpp>
 #include <format>
-#endif // _HAS_CXX23
+#endif // ^^^ defined(__cpp_lib_print) ^^^
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)

--- a/stl/inc/xcharconv.h
+++ b/stl/inc/xcharconv.h
@@ -8,13 +8,13 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 
-#include <cstdint>
-#include <type_traits>
-#include <xerrc.h>
-
 #if !_HAS_CXX17
 #error The contents of <charconv> are only available with C++17. (Also, you should not include this internal header.)
 #endif // !_HAS_CXX17
+
+#include <cstdint>
+#include <type_traits>
+#include <xerrc.h>
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)

--- a/stl/inc/xcharconv_ryu.h
+++ b/stl/inc/xcharconv_ryu.h
@@ -37,6 +37,10 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 
+#if !_HAS_CXX17
+#error The contents of <charconv> are only available with C++17. (Also, you should not include this internal header.)
+#endif // !_HAS_CXX17
+
 #include <cstring>
 #include <type_traits>
 #include <utility>
@@ -53,10 +57,6 @@
 #if _HAS_CHARCONV_INTRINSICS
 #include _STL_INTRIN_HEADER // for _umul128() and __shiftright128()
 #endif // ^^^ intrinsics available ^^^
-
-#if !_HAS_CXX17
-#error The contents of <charconv> are only available with C++17. (Also, you should not include this internal header.)
-#endif // !_HAS_CXX17
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)

--- a/stl/inc/xcharconv_ryu_tables.h
+++ b/stl/inc/xcharconv_ryu_tables.h
@@ -37,11 +37,11 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 
-#include <cstdint>
-
 #if !_HAS_CXX17
 #error The contents of <charconv> are only available with C++17. (Also, you should not include this internal header.)
 #endif // !_HAS_CXX17
+
+#include <cstdint>
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)

--- a/stl/inc/xnode_handle.h
+++ b/stl/inc/xnode_handle.h
@@ -7,11 +7,12 @@
 #define _XNODE_HANDLE_H
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
-#include <xmemory>
 
 #if !_HAS_CXX17
 #error Node handles are only available with C++17. (Also, you should not include this internal header.)
 #endif // _HAS_CXX17
+
+#include <xmemory>
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)

--- a/tests/std/tests/GH_001411_core_headers/test.cpp
+++ b/tests/std/tests/GH_001411_core_headers/test.cpp
@@ -19,9 +19,9 @@
 #include <xfilesystem_abi.h>
 #endif // _HAS_CXX17
 
-#if _HAS_CXX23
+#ifdef __cpp_lib_concepts
 #include <__msvc_print.hpp>
-#endif // _HAS_CXX23
+#endif // ^^^ defined(__cpp_lib_concepts) ^^^
 
 // <__msvc_bit_utils.hpp> is included by <bit> and <limits>
 // <__msvc_iter_core.hpp> is included by <tuple>


### PR DESCRIPTION
`<__msvc_print.hpp>` was missing the Standard mode check that the rest of our internal headers perform. This one's a little special because it's included by `<format>` in C++20 Concepts mode, and by `<print>` in C++23 Concepts mode.

Without this check, the header is still rejected in C++14/17 mode, but with a less clear error about the usage of `consteval`:

https://github.com/microsoft/STL/blob/1c59a205787f4fdcd9c20decc8fa6dfa9096d394/stl/inc/__msvc_print.hpp#L58

Also, this moves the other Standard mode checks in `<xmeow.h>` as early as possible. The mode is available after including `<yvals_core.h>`, and if we're doomed, we should diagnose doom immediately. `<xcharconv_tables.h>` was already doing this.

Next, `<ostream>` was guarding its inclusion of `<__msvc_print.hpp>` with `#if _HAS_CXX23`, even though its usage was guarded with `#ifdef __cpp_lib_print`:

https://github.com/microsoft/STL/blob/adea8d5ae280cafb91ae69b8dfaecd1c37a847d9/stl/inc/ostream#L1085

This meant that in our test suite, EDG in C++23 non-concepts mode had `<ostream>` including `<__msvc_print.hpp>` and then doing nothing with it. That was previously harmless but is now an error, so we need to make the guards consistent. (I don't think `<ostream>`'s dependency needs to be mentioned in the `<__msvc_print.hpp>` error message, that would just be confusing and it wouldn't be why users were trying to include the thing.)

Finally, `GH_001411_core_headers` was guarding with `#if _HAS_CXX23`, which was both too restrictive (the header is used by `<format>` in C++20) and too permissive (the header is used only in Concepts mode). We need to change this to `#ifdef __cpp_lib_concepts`.

Thanks to @ThomasFWise for the report!