### PR TITLE
Merge `main` to `feature/flat_set`, fix `__cpp_lib_flat_set` test

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ issue. The [bug tag][] and [enhancement tag][] are being populated.
 
 # Goals
 
-We're implementing the latest C++ Working Draft, currently [N4958][], which will eventually become the next C++
+We're implementing the latest C++ Working Draft, currently [N4964][], which will eventually become the next C++
 International Standard. The terms Working Draft (WD) and Working Paper (WP) are interchangeable; we often
 informally refer to these drafts as "the Standard" while being aware of the difference. (There are other relevant
 Standards; for example, supporting `/std:c++14` and `/std:c++17` involves understanding how the C++14 and C++17
@@ -530,7 +530,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 [LWG issues]: https://cplusplus.github.io/LWG/lwg-toc.html
 [LWG tag]: https://github.com/microsoft/STL/issues?q=is%3Aopen+is%3Aissue+label%3ALWG
 [Microsoft Open Source Code of Conduct]: https://opensource.microsoft.com/codeofconduct/
-[N4958]: https://wg21.link/n4958
+[N4964]: https://wg21.link/n4964
 [NOTICE.txt]: NOTICE.txt
 [Ninja]: https://ninja-build.org
 [STL-CI-badge]: https://dev.azure.com/vclibs/STL/_apis/build/status%2FSTL-CI?branchName=main "STL-CI"

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -54,6 +54,11 @@ _Min_max_element_t __stdcall __std_minmax_element_1(const void* _First, const vo
 _Min_max_element_t __stdcall __std_minmax_element_2(const void* _First, const void* _Last, bool _Signed) noexcept;
 _Min_max_element_t __stdcall __std_minmax_element_4(const void* _First, const void* _Last, bool _Signed) noexcept;
 _Min_max_element_t __stdcall __std_minmax_element_8(const void* _First, const void* _Last, bool _Signed) noexcept;
+
+const void* __stdcall __std_find_last_trivial_1(const void* _First, const void* _Last, uint8_t _Val) noexcept;
+const void* __stdcall __std_find_last_trivial_2(const void* _First, const void* _Last, uint16_t _Val) noexcept;
+const void* __stdcall __std_find_last_trivial_4(const void* _First, const void* _Last, uint32_t _Val) noexcept;
+const void* __stdcall __std_find_last_trivial_8(const void* _First, const void* _Last, uint64_t _Val) noexcept;
 _END_EXTERN_C
 
 template <class _Ty>
@@ -75,6 +80,27 @@ _STD pair<_Ty*, _Ty*> __std_minmax_element(_Ty* _First, _Ty* _Last) noexcept {
     }
 
     return {const_cast<_Ty*>(static_cast<const _Ty*>(_Res._Min)), const_cast<_Ty*>(static_cast<const _Ty*>(_Res._Max))};
+}
+
+template <class _Ty, class _TVal>
+_Ty* __std_find_last_trivial(_Ty* _First, _Ty* _Last, const _TVal _Val) noexcept {
+    if constexpr (_STD is_pointer_v<_TVal> || _STD is_null_pointer_v<_TVal>) {
+        return __std_find_last_trivial(_First, _Last, reinterpret_cast<uintptr_t>(_Val));
+    } else if constexpr (sizeof(_Ty) == 1) {
+        return const_cast<_Ty*>(
+            static_cast<const _Ty*>(__std_find_last_trivial_1(_First, _Last, static_cast<uint8_t>(_Val))));
+    } else if constexpr (sizeof(_Ty) == 2) {
+        return const_cast<_Ty*>(
+            static_cast<const _Ty*>(__std_find_last_trivial_2(_First, _Last, static_cast<uint16_t>(_Val))));
+    } else if constexpr (sizeof(_Ty) == 4) {
+        return const_cast<_Ty*>(
+            static_cast<const _Ty*>(__std_find_last_trivial_4(_First, _Last, static_cast<uint32_t>(_Val))));
+    } else if constexpr (sizeof(_Ty) == 8) {
+        return const_cast<_Ty*>(
+            static_cast<const _Ty*>(__std_find_last_trivial_8(_First, _Last, static_cast<uint64_t>(_Val))));
+    } else {
+        static_assert(_STD _Always_false<_Ty>, "Unexpected size");
+    }
 }
 #endif // _USE_STD_VECTOR_ALGORITHMS
 
@@ -292,10 +318,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Fun>
     using for_each_result = in_fun_result<_In, _Fun>;
 
-    class _For_each_fn : private _Not_quite_object {
+    class _For_each_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirectly_unary_invocable<projected<_It, _Pj>> _Fn>
         constexpr for_each_result<_It, _Fn> operator()(_It _First, _Se _Last, _Fn _Func, _Pj _Proj = {}) const {
@@ -337,15 +361,13 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _For_each_fn for_each{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _For_each_fn for_each;
 
     _EXPORT_STD template <class _In, class _Fun>
     using for_each_n_result = in_fun_result<_In, _Fun>;
 
-    class _For_each_n_fn : private _Not_quite_object {
+    class _For_each_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, class _Pj = identity, indirectly_unary_invocable<projected<_It, _Pj>> _Fn>
         constexpr for_each_n_result<_It, _Fn> operator()(
             _It _First, iter_difference_t<_It> _Count, _Fn _Func, _Pj _Proj = {}) const {
@@ -364,7 +386,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _For_each_n_fn for_each_n{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _For_each_n_fn for_each_n;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -431,10 +453,8 @@ _NODISCARD _FwdIt adjacent_find(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Count_fn : private _Not_quite_object {
+    class _Count_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity>
             requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
         _NODISCARD constexpr iter_difference_t<_It> operator()(
@@ -485,7 +505,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Count_fn count{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Count_fn count;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -512,10 +532,8 @@ _NODISCARD _Iter_diff_t<_FwdIt> count_if(_ExPo&& _Exec, _FwdIt _First, _FwdIt _L
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Count_if_fn : private _Not_quite_object {
+    class _Count_if_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr iter_difference_t<_It> operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -549,7 +567,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Count_if_fn count_if{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Count_if_fn count_if;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -666,7 +684,7 @@ namespace ranges {
         return true;
     }
 
-    class _Equal_fn : private _Not_quite_object {
+    class _Equal_fn {
     private:
         template <class _It1, class _Se1, class _It2, class _Se2, class _Pr, class _Pj1, class _Pj2>
         _NODISCARD static constexpr bool _Equal_4(
@@ -692,8 +710,6 @@ namespace ranges {
         }
 
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::equal_to, class _Pj1 = identity, class _Pj2 = identity>
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
@@ -741,7 +757,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Equal_fn equal{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Equal_fn equal;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -841,10 +857,8 @@ _NODISCARD _CONSTEXPR20 bool is_permutation(_FwdIt1 _First1, _FwdIt1 _Last1, _Fw
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Is_permutation_fn : private _Not_quite_object {
+    class _Is_permutation_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It1, sentinel_for<_It1> _Se1, forward_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pj1 = identity, class _Pj2 = identity,
             indirect_equivalence_relation<projected<_It1, _Pj1>, projected<_It2, _Pj2>> _Pr = ranges::equal_to>
@@ -1109,7 +1123,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Is_permutation_fn is_permutation{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Is_permutation_fn is_permutation;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -1134,10 +1148,8 @@ _NODISCARD bool all_of(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) noexcept
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _All_of_fn : private _Not_quite_object {
+    class _All_of_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -1170,7 +1182,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _All_of_fn all_of{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _All_of_fn all_of;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -1196,10 +1208,8 @@ _NODISCARD bool any_of(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) noexcept
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Any_of_fn : private _Not_quite_object {
+    class _Any_of_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -1232,7 +1242,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Any_of_fn any_of{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Any_of_fn any_of;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -1258,10 +1268,8 @@ _NODISCARD bool none_of(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) noexcep
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _None_of_fn : private _Not_quite_object {
+    class _None_of_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -1294,13 +1302,11 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _None_of_fn none_of{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _None_of_fn none_of;
 
 #if _HAS_CXX23
-    class _Contains_fn : private _Not_quite_object {
+    class _Contains_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity>
             requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, const _Ty& _Val, _Pj _Proj = {}) const {
@@ -1319,12 +1325,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Contains_fn contains{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Contains_fn contains;
 
-    class _Contains_subrange_fn : private _Not_quite_object {
+    class _Contains_subrange_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It1, sentinel_for<_It1> _Se1, forward_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::equal_to, class _Pj1 = identity, class _Pj2 = identity>
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
@@ -1357,16 +1361,14 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Contains_subrange_fn contains_subrange{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Contains_subrange_fn contains_subrange;
 #endif // _HAS_CXX23
 
     _EXPORT_STD template <class _In, class _Out>
     using copy_n_result = in_out_result<_In, _Out>;
 
-    class _Copy_n_fn : private _Not_quite_object {
+    class _Copy_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, weakly_incrementable _Out>
             requires indirectly_copyable<_It, _Out>
         constexpr copy_n_result<_It, _Out> operator()(_It _First, iter_difference_t<_It> _Count, _Out _Result) const {
@@ -1389,15 +1391,13 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Copy_n_fn copy_n{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Copy_n_fn copy_n;
 
     _EXPORT_STD template <class _In, class _Out>
     using copy_backward_result = in_out_result<_In, _Out>;
 
-    class _Copy_backward_fn : private _Not_quite_object {
+    class _Copy_backward_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It1, sentinel_for<_It1> _Se1, bidirectional_iterator _It2>
             requires indirectly_copyable<_It1, _It2>
         constexpr copy_backward_result<_It1, _It2> operator()(_It1 _First, _Se1 _Last, _It2 _Result) const {
@@ -1418,7 +1418,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Copy_backward_fn copy_backward{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Copy_backward_fn copy_backward;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -1455,10 +1455,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using copy_if_result = in_out_result<_In, _Out>;
 
-    class _Copy_if_fn : private _Not_quite_object {
+    class _Copy_if_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
             requires indirectly_copyable<_It, _Out>
@@ -1503,7 +1501,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Copy_if_fn copy_if{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Copy_if_fn copy_if;
 
     _EXPORT_STD template <class _In, class _Out>
     using move_result = in_out_result<_In, _Out>;
@@ -1526,10 +1524,8 @@ namespace ranges {
         return {_STD move(_First), _STD move(_Result)};
     }
 
-    class _Move_fn : private _Not_quite_object {
+    class _Move_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
             requires indirectly_movable<_It, _Out>
         constexpr move_result<_It, _Out> operator()(_It _First, _Se _Last, _Out _Result) const {
@@ -1553,7 +1549,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Move_fn move{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Move_fn move;
 
     _EXPORT_STD template <class _In, class _Out>
     using move_backward_result = in_out_result<_In, _Out>;
@@ -1575,10 +1571,8 @@ namespace ranges {
         return _Result;
     }
 
-    class _Move_backward_fn : private _Not_quite_object {
+    class _Move_backward_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It1, sentinel_for<_It1> _Se1, bidirectional_iterator _It2>
             requires indirectly_movable<_It1, _It2>
         constexpr move_backward_result<_It1, _It2> operator()(_It1 _First, _Se1 _Last, _It2 _Result) const {
@@ -1599,7 +1593,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Move_backward_fn move_backward{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Move_backward_fn move_backward;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -1645,10 +1639,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out1, class _Out2>
     using partition_copy_result = in_out_out_result<_In, _Out1, _Out2>;
 
-    class _Partition_copy_fn : private _Not_quite_object {
+    class _Partition_copy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out1, weakly_incrementable _Out2,
             class _Pj = identity, indirect_unary_predicate<projected<_It, _Pj>> _Pr>
             requires indirectly_copyable<_It, _Out1> && indirectly_copyable<_It, _Out2>
@@ -1704,7 +1696,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Partition_copy_fn partition_copy{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Partition_copy_fn partition_copy;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -1742,10 +1734,8 @@ _NODISCARD bool is_partitioned(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) 
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Is_partitioned_fn : private _Not_quite_object {
+    class _Is_partitioned_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -1788,7 +1778,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Is_partitioned_fn is_partitioned{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Is_partitioned_fn is_partitioned;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -1818,10 +1808,8 @@ _NODISCARD _CONSTEXPR20 _FwdIt partition_point(_FwdIt _First, _FwdIt _Last, _Pr 
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Partition_point_fn : private _Not_quite_object {
+    class _Partition_point_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -1910,7 +1898,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Partition_point_fn partition_point{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Partition_point_fn partition_point;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -2103,10 +2091,8 @@ _NODISCARD _FwdIt search_n(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt _Las
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Search_n_fn : private _Not_quite_object {
+    class _Search_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pr = ranges::equal_to,
             class _Pj = identity>
             requires indirectly_comparable<_It, const _Ty*, _Pr, _Pj>
@@ -2258,13 +2244,11 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Search_n_fn search_n{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Search_n_fn search_n;
 
 #if _HAS_CXX23
-    class _Starts_with_fn : private _Not_quite_object {
+    class _Starts_with_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::equal_to, class _Pj1 = identity, class _Pj2 = identity>
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
@@ -2319,12 +2303,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Starts_with_fn starts_with{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Starts_with_fn starts_with;
 
-    class _Ends_with_fn : private _Not_quite_object {
+    class _Ends_with_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::equal_to, class _Pj1 = identity, class _Pj2 = identity>
             requires (forward_iterator<_It1> || sized_sentinel_for<_Se1, _It1>)
@@ -2542,7 +2524,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Ends_with_fn ends_with{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Ends_with_fn ends_with;
 
     template <class _Fn>
     class _Flipped {
@@ -2577,10 +2559,8 @@ namespace ranges {
     _EXPORT_STD template <class _It, class _Ty>
     using fold_left_first_with_iter_result = in_value_result<_It, _Ty>;
 
-    class _Fold_left_with_iter_fn : private _Not_quite_object {
+    class _Fold_left_with_iter_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, _Indirectly_binary_left_foldable<_Ty, _It> _Fn>
         _NODISCARD constexpr auto operator()(_It _First, _Se _Last, _Ty _Init, _Fn _Func) const {
             _Adl_verify_range(_First, _Last);
@@ -2621,12 +2601,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Fold_left_with_iter_fn fold_left_with_iter{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Fold_left_with_iter_fn fold_left_with_iter;
 
-    class _Fold_left_fn : private _Not_quite_object {
+    class _Fold_left_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, _Indirectly_binary_left_foldable<_Ty, _It> _Fn>
         _NODISCARD constexpr auto operator()(_It _First, _Se _Last, _Ty _Init, _Fn _Func) const {
             return _RANGES fold_left_with_iter(_STD move(_First), _Last, _STD move(_Init), _Pass_fn(_Func)).value;
@@ -2638,12 +2616,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Fold_left_fn fold_left{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Fold_left_fn fold_left;
 
-    class _Fold_left_first_with_iter_fn : private _Not_quite_object {
+    class _Fold_left_first_with_iter_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se,
             _Indirectly_binary_left_foldable<iter_value_t<_It>, _It> _Fn>
             requires constructible_from<iter_value_t<_It>, iter_reference_t<_It>>
@@ -2688,13 +2664,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Fold_left_first_with_iter_fn fold_left_first_with_iter{
-        _Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Fold_left_first_with_iter_fn fold_left_first_with_iter;
 
-    class _Fold_left_first_fn : private _Not_quite_object {
+    class _Fold_left_first_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se,
             _Indirectly_binary_left_foldable<iter_value_t<_It>, _It> _Fn>
             requires constructible_from<iter_value_t<_It>, iter_reference_t<_It>>
@@ -2709,7 +2682,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Fold_left_first_fn fold_left_first{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Fold_left_first_fn fold_left_first;
 
     template <class _It, class _Se, class _Ty, class _Fn>
     _NODISCARD constexpr auto _Fold_right_unchecked(_It _First, _Se _Last, _Ty _Init, _Fn _Func) {
@@ -2730,10 +2703,8 @@ namespace ranges {
         }
     }
 
-    class _Fold_right_fn : private _Not_quite_object {
+    class _Fold_right_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It, sentinel_for<_It> _Se, class _Ty,
             _Indirectly_binary_right_foldable<_Ty, _It> _Fn>
         _NODISCARD constexpr auto operator()(_It _First, _Se _Last, _Ty _Init, _Fn _Func) const {
@@ -2748,12 +2719,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Fold_right_fn fold_right{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Fold_right_fn fold_right;
 
-    class _Fold_right_last_fn : private _Not_quite_object {
+    class _Fold_right_last_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It, sentinel_for<_It> _Se,
             _Indirectly_binary_right_foldable<iter_value_t<_It>, _It> _Fn>
             requires constructible_from<iter_value_t<_It>, iter_reference_t<_It>>
@@ -2789,12 +2758,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Fold_right_last_fn fold_right_last{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Fold_right_last_fn fold_right_last;
 
-    class _Find_last_fn : private _Not_quite_object {
+    class _Find_last_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity>
             requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
         _NODISCARD constexpr subrange<_It> operator()(_It _First, _Se _Last, const _Ty& _Value, _Pj _Proj = {}) const {
@@ -2834,6 +2801,24 @@ namespace ranges {
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se, _It>);
             _STL_INTERNAL_STATIC_ASSERT(indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>);
 
+#if _USE_STD_VECTOR_ALGORITHMS
+            if constexpr (is_same_v<_Pj, identity> && _Vector_alg_in_find_is_safe<_It, _Ty>
+                          && sized_sentinel_for<_Se, _It>) {
+                if (!_STD is_constant_evaluated()) {
+                    const auto _Count     = _Last - _First;
+                    const auto _First_ptr = _To_address(_First);
+                    const auto _Last_ptr  = _First_ptr + _Count;
+
+                    const auto _Result = __std_find_last_trivial(_First_ptr, _Last_ptr, _Value);
+                    if constexpr (is_pointer_v<_It>) {
+                        return {_Result, _Last_ptr};
+                    } else {
+                        return {_First + (_Result - _First_ptr), _First + _Count};
+                    }
+                }
+            }
+#endif // _USE_STD_VECTOR_ALGORITHMS
+
             if constexpr (_Bidi_common<_It, _Se>) {
                 for (auto _Result = _Last; _Result != _First;) {
                     if (_STD invoke(_Proj, *--_Result) == _Value) {
@@ -2870,13 +2855,11 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Find_last_fn find_last{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Find_last_fn find_last;
 
     template <bool _Search_for>
-    class _Find_last_if_fn : private _Not_quite_object {
+    class _Find_last_if_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr subrange<_It> operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -2953,8 +2936,8 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Find_last_if_fn<true> find_last_if{_Not_quite_object::_Construct_tag{}};
-    _EXPORT_STD inline constexpr _Find_last_if_fn<false> find_last_if_not{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Find_last_if_fn<true> find_last_if;
+    _EXPORT_STD inline constexpr _Find_last_if_fn<false> find_last_if_not;
 #endif // _HAS_CXX23
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
@@ -3061,7 +3044,7 @@ _NODISCARD _FwdIt1 find_end(_ExPo&& _Exec, _FwdIt1 _First1, _FwdIt1 _Last1, _Fwd
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Find_end_fn : private _Not_quite_object {
+    class _Find_end_fn {
     private:
         template <class _It1, class _It2, class _Pr, class _Pj1, class _Pj2>
         _NODISCARD static constexpr subrange<_It1> _Random_access_sized_ranges(_It1 _First1,
@@ -3164,8 +3147,6 @@ namespace ranges {
         }
 
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It1, sentinel_for<_It1> _Se1, forward_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::equal_to, class _Pj1 = identity, class _Pj2 = identity>
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
@@ -3218,7 +3199,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Find_end_fn find_end{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Find_end_fn find_end;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -3265,10 +3246,8 @@ _NODISCARD _FwdIt1 find_first_of(_ExPo&& _Exec, const _FwdIt1 _First1, const _Fw
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Find_first_of_fn : private _Not_quite_object {
+    class _Find_first_of_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, forward_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::equal_to, class _Pj1 = identity, class _Pj2 = identity>
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
@@ -3321,15 +3300,13 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Find_first_of_fn find_first_of{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Find_first_of_fn find_first_of;
 
     _EXPORT_STD template <class _In1, class _In2>
     using swap_ranges_result = in_in_result<_In1, _In2>;
 
-    class _Swap_ranges_fn : private _Not_quite_object {
+    class _Swap_ranges_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2>
             requires indirectly_swappable<_It1, _It2>
         constexpr swap_ranges_result<_It1, _It2> operator()(
@@ -3413,7 +3390,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Swap_ranges_fn swap_ranges{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Swap_ranges_fn swap_ranges;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -3498,10 +3475,8 @@ namespace ranges {
     _EXPORT_STD template <class _In1, class _In2, class _Out>
     using binary_transform_result = in_in_out_result<_In1, _In2, _Out>;
 
-    class _Transform_fn : private _Not_quite_object {
+    class _Transform_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out, copy_constructible _Fn,
             class _Pj = identity>
             requires indirectly_writable<_Out, indirect_result_t<_Fn&, projected<_It, _Pj>>>
@@ -3595,7 +3570,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Transform_fn transform{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Transform_fn transform;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -3620,10 +3595,8 @@ void replace(_ExPo&& _Exec, _FwdIt _First, _FwdIt _Last, const _Ty& _Oldval,
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Replace_fn : private _Not_quite_object {
+    class _Replace_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty1, class _Ty2, class _Pj = identity>
             requires indirectly_writable<_It, const _Ty2&>
                   && indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty1*>
@@ -3670,7 +3643,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Replace_fn replace{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Replace_fn replace;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -3694,10 +3667,8 @@ void replace_if(_ExPo&& _Exec, _FwdIt _First, _FwdIt _Last, _Pr _Pred, const _Ty
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Replace_if_fn : private _Not_quite_object {
+    class _Replace_if_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
             requires indirectly_writable<_It, const _Ty&>
@@ -3743,7 +3714,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Replace_if_fn replace_if{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Replace_if_fn replace_if;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -3783,10 +3754,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using replace_copy_result = in_out_result<_In, _Out>;
 
-    class _Replace_copy_fn : private _Not_quite_object {
+    class _Replace_copy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty1, class _Ty2, output_iterator<const _Ty2&> _Out,
             class _Pj = identity>
             requires indirectly_copyable<_It, _Out>
@@ -3837,7 +3806,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Replace_copy_fn replace_copy{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Replace_copy_fn replace_copy;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -3878,10 +3847,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using replace_copy_if_result = in_out_result<_In, _Out>;
 
-    class _Replace_copy_if_fn : private _Not_quite_object {
+    class _Replace_copy_if_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, output_iterator<const _Ty&> _Out,
             class _Pj = identity, indirect_unary_predicate<projected<_It, _Pj>> _Pr>
             requires indirectly_copyable<_It, _Out>
@@ -3931,12 +3898,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Replace_copy_if_fn replace_copy_if{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Replace_copy_if_fn replace_copy_if;
 
-    class _Fill_fn : private _Not_quite_object {
+    class _Fill_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <class _Ty, output_iterator<const _Ty&> _It, sentinel_for<_It> _Se>
         constexpr _It operator()(_It _First, _Se _Last, const _Ty& _Value) const {
             _Adl_verify_range(_First, _Last);
@@ -3976,12 +3941,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Fill_fn fill{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Fill_fn fill;
 
-    class _Generate_fn : private _Not_quite_object {
+    class _Generate_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_or_output_iterator _Out, sentinel_for<_Out> _Se, copy_constructible _Fn>
             requires invocable<_Fn&> && indirectly_writable<_Out, invoke_result_t<_Fn&>>
         constexpr _Out operator()(_Out _First, _Se _Last, _Fn _Gen) const {
@@ -4017,12 +3980,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Generate_fn generate{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Generate_fn generate;
 
-    class _Generate_n_fn : private _Not_quite_object {
+    class _Generate_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_or_output_iterator _Out, copy_constructible _Fn>
             requires invocable<_Fn&> && indirectly_writable<_Out, invoke_result_t<_Fn&>>
         constexpr _Out operator()(_Out _First, iter_difference_t<_Out> _Count, _Fn _Gen) const {
@@ -4040,7 +4001,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Generate_n_fn generate_n{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Generate_n_fn generate_n;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -4158,10 +4119,8 @@ _NODISCARD_REMOVE_ALG _FwdIt remove_if(_ExPo&& _Exec, _FwdIt _First, _FwdIt _Las
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Remove_fn : private _Not_quite_object {
+    class _Remove_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <permutable _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity>
             requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
         _NODISCARD_REMOVE_ALG constexpr subrange<_It> operator()(
@@ -4209,12 +4168,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Remove_fn remove{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Remove_fn remove;
 
-    class _Remove_if_fn : private _Not_quite_object {
+    class _Remove_if_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <permutable _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD_REMOVE_ALG constexpr subrange<_It> operator()(
@@ -4262,15 +4219,13 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Remove_if_fn remove_if{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Remove_if_fn remove_if;
 
     _EXPORT_STD template <class _In, class _Out>
     using remove_copy_result = in_out_result<_In, _Out>;
 
-    class _Remove_copy_fn : private _Not_quite_object {
+    class _Remove_copy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out, class _Ty, class _Pj = identity>
             requires indirectly_copyable<_It, _Out>
                   && indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
@@ -4322,15 +4277,13 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Remove_copy_fn remove_copy{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Remove_copy_fn remove_copy;
 
     _EXPORT_STD template <class _In, class _Out>
     using remove_copy_if_result = in_out_result<_In, _Out>;
 
-    class _Remove_copy_if_fn : private _Not_quite_object {
+    class _Remove_copy_if_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
             requires indirectly_copyable<_It, _Out>
@@ -4382,7 +4335,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Remove_copy_if_fn remove_copy_if{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Remove_copy_if_fn remove_copy_if;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -4436,10 +4389,8 @@ _NODISCARD_UNIQUE_ALG _FwdIt unique(_ExPo&&, _FwdIt _First, _FwdIt _Last) noexce
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Unique_fn : private _Not_quite_object {
+    class _Unique_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <permutable _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_equivalence_relation<projected<_It, _Pj>> _Pr = ranges::equal_to>
         _NODISCARD_UNIQUE_ALG constexpr subrange<_It> operator()(
@@ -4497,7 +4448,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Unique_fn unique{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Unique_fn unique;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -4602,10 +4553,8 @@ namespace ranges {
     concept _Can_reread_or_store = forward_iterator<_It> || _Is_input_with_value_type<_Out, iter_value_t<_It>>
                                 || indirectly_copyable_storable<_It, _Out>;
 
-    class _Unique_copy_fn : private _Not_quite_object {
+    class _Unique_copy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out, class _Pj = identity,
             indirect_equivalence_relation<projected<_It, _Pj>> _Pr = ranges::equal_to>
             requires indirectly_copyable<_It, _Out> && _Can_reread_or_store<_It, _Out>
@@ -4693,7 +4642,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Unique_copy_fn unique_copy{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Unique_copy_fn unique_copy;
 
     // concept-constrained for strict enforcement as it is used by several algorithms
     template <bidirectional_iterator _It>
@@ -4731,10 +4680,8 @@ namespace ranges {
         }
     }
 
-    class _Reverse_fn : private _Not_quite_object {
+    class _Reverse_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It, sentinel_for<_It> _Se>
             requires permutable<_It>
         constexpr _It operator()(_It _First, _Se _Last) const {
@@ -4755,7 +4702,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Reverse_fn reverse{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Reverse_fn reverse;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -4820,10 +4767,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using reverse_copy_result = in_out_result<_In, _Out>;
 
-    class _Reverse_copy_fn : private _Not_quite_object {
+    class _Reverse_copy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
             requires indirectly_copyable<_It, _Out>
         constexpr reverse_copy_result<_It, _Out> operator()(_It _First, _Se _Last, _Out _Result) const {
@@ -4893,7 +4838,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Reverse_copy_fn reverse_copy{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Reverse_copy_fn reverse_copy;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -4977,10 +4922,8 @@ namespace ranges {
         }
     }
 
-    class _Rotate_fn : private _Not_quite_object {
+    class _Rotate_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <permutable _It, sentinel_for<_It> _Se>
         constexpr subrange<_It> operator()(_It _First, _It _Mid, _Se _Last) const {
             _Adl_verify_range(_First, _Mid);
@@ -5003,7 +4946,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Rotate_fn rotate{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Rotate_fn rotate;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -5036,10 +4979,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using rotate_copy_result = in_out_result<_In, _Out>;
 
-    class _Rotate_copy_fn : private _Not_quite_object {
+    class _Rotate_copy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
             requires indirectly_copyable<_It, _Out>
         constexpr rotate_copy_result<_It, _Out> operator()(_It _First, _It _Mid, _Se _Last, _Out _Result) const {
@@ -5080,7 +5021,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Rotate_copy_fn rotate_copy{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Rotate_copy_fn rotate_copy;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -5244,10 +5185,8 @@ concept uniform_random_bit_generator = invocable<_Ty&>
 // clang-format on
 
 namespace ranges {
-    class _Sample_fn : private _Not_quite_object {
+    class _Sample_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out, class _Urng>
             requires (forward_iterator<_It> || random_access_iterator<_Out>)
                   && indirectly_copyable<_It, _Out> && uniform_random_bit_generator<remove_reference_t<_Urng>>
@@ -5342,7 +5281,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Sample_fn sample{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Sample_fn sample;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -5378,10 +5317,8 @@ void shuffle(_RanIt _First, _RanIt _Last, _Urng&& _Func) { // shuffle [_First, _
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Shuffle_fn : private _Not_quite_object {
+    class _Shuffle_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Urng>
             requires permutable<_It> && uniform_random_bit_generator<remove_reference_t<_Urng>>
         _It operator()(_It _First, _Se _Last, _Urng&& _Func) const {
@@ -5430,7 +5367,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Shuffle_fn shuffle{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Shuffle_fn shuffle;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -5592,10 +5529,8 @@ _FwdIt shift_right(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Iter_diff_t<_FwdIt> _P
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 namespace ranges {
-    class _Shift_left_fn : private _Not_quite_object {
+    class _Shift_left_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <permutable _It, sentinel_for<_It> _Se>
         constexpr subrange<_It> operator()(_It _First, const _Se _Last, iter_difference_t<_It> _Pos_to_shift) const {
             _STL_ASSERT(_Pos_to_shift >= 0, "shift count must be non-negative (N4950 [alg.shift]/1)");
@@ -5655,12 +5590,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Shift_left_fn shift_left{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Shift_left_fn shift_left;
 
-    class _Shift_right_fn : private _Not_quite_object {
+    class _Shift_right_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <permutable _It, sentinel_for<_It> _Se>
         constexpr subrange<_It> operator()(_It _First, const _Se _Last, iter_difference_t<_It> _Pos_to_shift) const {
             _Adl_verify_range(_First, _Last);
@@ -5814,7 +5747,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Shift_right_fn shift_right{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Shift_right_fn shift_right;
 } // namespace ranges
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
@@ -5882,10 +5815,8 @@ _FwdIt partition(_ExPo&& _Exec, _FwdIt _First, _FwdIt _Last, _Pr _Pred) noexcept
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Partition_fn : private _Not_quite_object {
+    class _Partition_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <permutable _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         constexpr subrange<_It> operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -5958,7 +5889,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Partition_fn partition{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Partition_fn partition;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -6169,10 +6100,8 @@ namespace ranges {
         return _RANGES _Rotate_unchecked(_STD move(_First), _STD move(_Mid), _STD move(_Last)).begin();
     }
 
-    class _Stable_partition_fn : private _Not_quite_object {
+    class _Stable_partition_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
             requires permutable<_It>
@@ -6328,7 +6257,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Stable_partition_fn stable_partition{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Stable_partition_fn stable_partition;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -6389,10 +6318,8 @@ namespace ranges {
         *(_First + _Hole) = _STD forward<_Ty>(_Val); // drop _Val into final hole
     }
 
-    class _Push_heap_fn : private _Not_quite_object {
+    class _Push_heap_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -6435,7 +6362,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Push_heap_fn push_heap{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Push_heap_fn push_heap;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -6568,10 +6495,8 @@ namespace ranges {
         _RANGES _Pop_heap_hole_unchecked(_STD move(_First), _Last, _Last, _STD move(_Val), _Pred, _Proj, _Proj);
     }
 
-    class _Pop_heap_fn : private _Not_quite_object {
+    class _Pop_heap_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -6597,7 +6522,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Pop_heap_fn pop_heap{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Pop_heap_fn pop_heap;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -6642,10 +6567,8 @@ namespace ranges {
         }
     }
 
-    class _Make_heap_fn : private _Not_quite_object {
+    class _Make_heap_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -6671,7 +6594,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Make_heap_fn make_heap{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Make_heap_fn make_heap;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -6766,10 +6689,8 @@ namespace ranges {
         return _First + _Off;
     }
 
-    class _Is_heap_fn : private _Not_quite_object {
+    class _Is_heap_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_strict_weak_order<projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -6792,12 +6713,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Is_heap_fn is_heap{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Is_heap_fn is_heap;
 
-    class _Is_heap_until_fn : private _Not_quite_object {
+    class _Is_heap_until_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_strict_weak_order<projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -6819,7 +6738,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Is_heap_until_fn is_heap_until{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Is_heap_until_fn is_heap_until;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -6862,10 +6781,8 @@ namespace ranges {
         }
     }
 
-    class _Sort_heap_fn : private _Not_quite_object {
+    class _Sort_heap_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -6891,7 +6808,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Sort_heap_fn sort_heap{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Sort_heap_fn sort_heap;
 
     template <class _It, class _Ty, class _Pr, class _Pj>
     _NODISCARD constexpr _It _Lower_bound_unchecked(
@@ -6916,10 +6833,8 @@ namespace ranges {
         return _First;
     }
 
-    class _Lower_bound_fn : private _Not_quite_object {
+    class _Lower_bound_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity,
             indirect_strict_weak_order<const _Ty*, projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr _It operator()(
@@ -6944,7 +6859,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Lower_bound_fn lower_bound{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Lower_bound_fn lower_bound;
 
     template <class _It, class _Ty, class _Pr, class _Pj>
     _NODISCARD constexpr _It _Upper_bound_unchecked(
@@ -6969,10 +6884,8 @@ namespace ranges {
         return _First;
     }
 
-    class _Upper_bound_fn : private _Not_quite_object {
+    class _Upper_bound_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity,
             indirect_strict_weak_order<const _Ty*, projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr _It operator()(
@@ -6997,7 +6910,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Upper_bound_fn upper_bound{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Upper_bound_fn upper_bound;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -7046,10 +6959,8 @@ _NODISCARD _CONSTEXPR20 pair<_FwdIt, _FwdIt> equal_range(_FwdIt _First, _FwdIt _
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Equal_range_fn : private _Not_quite_object {
+    class _Equal_range_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity,
             indirect_strict_weak_order<const _Ty*, projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr subrange<_It> operator()(
@@ -7103,7 +7014,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Equal_range_fn equal_range{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Equal_range_fn equal_range;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -7125,10 +7036,8 @@ _NODISCARD _CONSTEXPR20 bool binary_search(_FwdIt _First, _FwdIt _Last, const _T
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Binary_search_fn : private _Not_quite_object {
+    class _Binary_search_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity,
             indirect_strict_weak_order<const _Ty*, projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr bool operator()(
@@ -7152,7 +7061,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Binary_search_fn binary_search{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Binary_search_fn binary_search;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -7252,10 +7161,8 @@ namespace ranges {
     _EXPORT_STD template <class _In1, class _In2, class _Out>
     using merge_result = in_in_out_result<_In1, _In2, _Out>;
 
-    class _Merge_fn : private _Not_quite_object {
+    class _Merge_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             weakly_incrementable _Out, class _Pr = ranges::less, class _Pj1 = identity, class _Pj2 = identity>
             requires mergeable<_It1, _It2, _Out, _Pr, _Pj1, _Pj2>
@@ -7322,7 +7229,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Merge_fn merge{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Merge_fn merge;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -7811,10 +7718,8 @@ namespace ranges {
         }
     }
 
-    class _Inplace_merge_fn : private _Not_quite_object {
+    class _Inplace_merge_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         _It operator()(_It _First, _It _Mid, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -7911,7 +7816,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Inplace_merge_fn inplace_merge{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Inplace_merge_fn inplace_merge;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -8242,10 +8147,8 @@ namespace ranges {
         }
     }
 
-    class _Sort_fn : private _Not_quite_object {
+    class _Sort_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -8309,7 +8212,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Sort_fn sort{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Sort_fn sort;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -8508,10 +8411,8 @@ void stable_sort(_ExPo&& _Exec, _BidIt _First, _BidIt _Last) noexcept /* termina
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Stable_sort_fn : private _Not_quite_object {
+    class _Stable_sort_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -8755,7 +8656,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Stable_sort_fn stable_sort{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Stable_sort_fn stable_sort;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -8808,10 +8709,8 @@ void partial_sort(_ExPo&&, _RanIt _First, _RanIt _Mid, _RanIt _Last) noexcept /*
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Partial_sort_fn : private _Not_quite_object {
+    class _Partial_sort_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         constexpr _It operator()(_It _First, _It _Mid, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -8876,7 +8775,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Partial_sort_fn partial_sort{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Partial_sort_fn partial_sort;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -8945,10 +8844,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using partial_sort_copy_result = in_out_result<_In, _Out>;
 
-    class _Partial_sort_copy_fn : private _Not_quite_object {
+    class _Partial_sort_copy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, random_access_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::less, class _Pj1 = identity, class _Pj2 = identity>
             requires indirectly_copyable<_It1, _It2> && sortable<_It2, _Pr, _Pj2>
@@ -9024,7 +8921,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Partial_sort_copy_fn partial_sort_copy{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Partial_sort_copy_fn partial_sort_copy;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -9080,10 +8977,8 @@ void nth_element(_ExPo&&, _RanIt _First, _RanIt _Nth, _RanIt _Last) noexcept /* 
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Nth_element_fn : private _Not_quite_object {
+    class _Nth_element_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         constexpr _It operator()(_It _First, _It _Nth, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -9148,7 +9043,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Nth_element_fn nth_element{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Nth_element_fn nth_element;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -9206,10 +9101,8 @@ _NODISCARD bool includes(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _Firs
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Includes_fn : private _Not_quite_object {
+    class _Includes_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pj1 = identity, class _Pj2 = identity,
             indirect_strict_weak_order<projected<_It1, _Pj1>, projected<_It2, _Pj2>> _Pr = ranges::less>
@@ -9272,7 +9165,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Includes_fn includes{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Includes_fn includes;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -9344,10 +9237,8 @@ namespace ranges {
     _EXPORT_STD template <class _In1, class _In2, class _Out>
     using set_union_result = in_in_out_result<_In1, _In2, _Out>;
 
-    class _Set_union_fn : private _Not_quite_object {
+    class _Set_union_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             weakly_incrementable _Out, class _Pr = ranges::less, class _Pj1 = identity, class _Pj2 = identity>
             requires mergeable<_It1, _It2, _Out, _Pr, _Pj1, _Pj2>
@@ -9411,7 +9302,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Set_union_fn set_union{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Set_union_fn set_union;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -9471,10 +9362,8 @@ namespace ranges {
     _EXPORT_STD template <class _In1, class _In2, class _Out>
     using set_intersection_result = in_in_out_result<_In1, _In2, _Out>;
 
-    class _Set_intersection_fn : private _Not_quite_object {
+    class _Set_intersection_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             weakly_incrementable _Out, class _Pr = ranges::less, class _Pj1 = identity, class _Pj2 = identity>
             requires mergeable<_It1, _It2, _Out, _Pr, _Pj1, _Pj2>
@@ -9544,7 +9433,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Set_intersection_fn set_intersection{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Set_intersection_fn set_intersection;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -9605,10 +9494,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using set_difference_result = in_out_result<_In, _Out>;
 
-    class _Set_difference_fn : private _Not_quite_object {
+    class _Set_difference_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             weakly_incrementable _Out, class _Pr = ranges::less, class _Pj1 = identity, class _Pj2 = identity>
             requires mergeable<_It1, _It2, _Out, _Pr, _Pj1, _Pj2>
@@ -9674,7 +9561,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Set_difference_fn set_difference{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Set_difference_fn set_difference;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -9749,10 +9636,8 @@ namespace ranges {
     _EXPORT_STD template <class _In1, class _In2, class _Out>
     using set_symmetric_difference_result = in_in_out_result<_In1, _In2, _Out>;
 
-    class _Set_symmetric_difference_fn : private _Not_quite_object {
+    class _Set_symmetric_difference_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             weakly_incrementable _Out, class _Pr = ranges::less, class _Pj1 = identity, class _Pj2 = identity>
             requires mergeable<_It1, _It2, _Out, _Pr, _Pj1, _Pj2>
@@ -9826,8 +9711,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Set_symmetric_difference_fn set_symmetric_difference{
-        _Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Set_symmetric_difference_fn set_symmetric_difference;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -9925,10 +9809,8 @@ namespace ranges {
     _EXPORT_STD template <class _Ty>
     using minmax_element_result = min_max_result<_Ty>;
 
-    class _Minmax_element_fn : private _Not_quite_object {
+    class _Minmax_element_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_strict_weak_order<projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr minmax_element_result<_It> operator()(
@@ -10019,7 +9901,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Minmax_element_fn minmax_element{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Minmax_element_fn minmax_element;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -10066,10 +9948,8 @@ namespace ranges {
     _EXPORT_STD template <class _Ty>
     using minmax_result = min_max_result<_Ty>;
 
-    class _Minmax_fn : private _Not_quite_object {
+    class _Minmax_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <class _Ty, class _Pj = identity,
             indirect_strict_weak_order<projected<const _Ty*, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr minmax_result<const _Ty&> operator()(const _Ty& _Left _MSVC_LIFETIMEBOUND,
@@ -10221,7 +10101,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Minmax_fn minmax{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Minmax_fn minmax;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -10267,10 +10147,8 @@ namespace ranges {
     _EXPORT_STD template <class _In>
     using next_permutation_result = in_found_result<_In>;
 
-    class _Next_permutation_fn : private _Not_quite_object {
+    class _Next_permutation_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         constexpr next_permutation_result<_It> operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -10325,7 +10203,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Next_permutation_fn next_permutation{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Next_permutation_fn next_permutation;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -10371,10 +10249,8 @@ namespace ranges {
     _EXPORT_STD template <class _In>
     using prev_permutation_result = in_found_result<_In>;
 
-    class _Prev_permutation_fn : private _Not_quite_object {
+    class _Prev_permutation_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It, sentinel_for<_It> _Se, class _Pr = ranges::less, class _Pj = identity>
             requires sortable<_It, _Pr, _Pj>
         constexpr prev_permutation_result<_It> operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -10429,7 +10305,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Prev_permutation_fn prev_permutation{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Prev_permutation_fn prev_permutation;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -10496,10 +10372,8 @@ _NODISCARD bool is_sorted(_ExPo&& _Exec, _FwdIt _First, _FwdIt _Last) noexcept /
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Is_sorted_fn : private _Not_quite_object {
+    class _Is_sorted_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_strict_weak_order<projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -10520,12 +10394,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Is_sorted_fn is_sorted{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Is_sorted_fn is_sorted;
 
-    class _Is_sorted_until_fn : private _Not_quite_object {
+    class _Is_sorted_until_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_strict_weak_order<projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -10545,7 +10417,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Is_sorted_until_fn is_sorted_until{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Is_sorted_until_fn is_sorted_until;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -10585,10 +10457,8 @@ _NODISCARD constexpr const _Ty& clamp(const _Ty& _Val, const _Ty& _Min_val, cons
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Clamp_fn : private _Not_quite_object {
+    class _Clamp_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <class _Ty, class _Pj = identity,
             indirect_strict_weak_order<projected<const _Ty*, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr const _Ty& operator()(
@@ -10611,12 +10481,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Clamp_fn clamp{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Clamp_fn clamp;
 
-    class _Lexicographical_compare_fn : private _Not_quite_object {
+    class _Lexicographical_compare_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pj1 = identity, class _Pj2 = identity,
             indirect_strict_weak_order<projected<_It1, _Pj1>, projected<_It2, _Pj2>> _Pr = ranges::less>
@@ -10689,8 +10557,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Lexicographical_compare_fn lexicographical_compare{
-        _Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Lexicographical_compare_fn lexicographical_compare;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -52,10 +52,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using uninitialized_copy_result = in_out_result<_In, _Out>;
 
-    class _Uninitialized_copy_fn : private _Not_quite_object {
+    class _Uninitialized_copy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, _No_throw_forward_iterator _Out,
             _No_throw_sentinel_for<_Out> _OSe>
             requires constructible_from<iter_value_t<_Out>, iter_reference_t<_It>>
@@ -120,7 +118,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_copy_fn uninitialized_copy{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_copy_fn uninitialized_copy;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -170,10 +168,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using uninitialized_copy_n_result = in_out_result<_In, _Out>;
 
-    class _Uninitialized_copy_n_fn : private _Not_quite_object {
+    class _Uninitialized_copy_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, _No_throw_forward_iterator _Out, _No_throw_sentinel_for<_Out> _OSe>
             requires constructible_from<iter_value_t<_Out>, iter_reference_t<_It>>
         uninitialized_copy_n_result<_It, _Out> operator()(
@@ -214,7 +210,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_copy_n_fn uninitialized_copy_n{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_copy_n_fn uninitialized_copy_n;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -243,10 +239,8 @@ _NoThrowFwdIt uninitialized_move(_ExPo&&, const _FwdIt _First, const _FwdIt _Las
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Uninitialized_move_fn : private _Not_quite_object {
+    class _Uninitialized_move_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, _No_throw_forward_iterator _Out,
             _No_throw_sentinel_for<_Out> _OSe>
             requires constructible_from<iter_value_t<_Out>, iter_rvalue_reference_t<_It>>
@@ -275,7 +269,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_move_fn uninitialized_move{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_move_fn uninitialized_move;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -336,10 +330,8 @@ namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using uninitialized_move_n_result = in_out_result<_In, _Out>;
 
-    class _Uninitialized_move_n_fn : private _Not_quite_object {
+    class _Uninitialized_move_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, _No_throw_forward_iterator _Out, _No_throw_sentinel_for<_Out> _OSe>
             requires constructible_from<iter_value_t<_Out>, iter_rvalue_reference_t<_It>>
         uninitialized_move_n_result<_It, _Out> operator()(
@@ -380,12 +372,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_move_n_fn uninitialized_move_n{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_move_n_fn uninitialized_move_n;
 
-    class _Uninitialized_fill_fn : private _Not_quite_object {
+    class _Uninitialized_fill_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <_No_throw_forward_iterator _It, _No_throw_sentinel_for<_It> _Se, class _Ty>
             requires constructible_from<iter_value_t<_It>, const _Ty&>
         _It operator()(_It _First, _Se _Last, const _Ty& _Val) const {
@@ -434,7 +424,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_fill_fn uninitialized_fill{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_fill_fn uninitialized_fill;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -489,10 +479,8 @@ _NoThrowFwdIt uninitialized_fill_n(
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Uninitialized_fill_n_fn : private _Not_quite_object {
+    class _Uninitialized_fill_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <_No_throw_forward_iterator _It, class _Ty>
             requires constructible_from<iter_value_t<_It>, const _Ty&>
         _It operator()(_It _First, iter_difference_t<_It> _Count, const _Ty& _Val) const {
@@ -525,12 +513,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_fill_n_fn uninitialized_fill_n{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_fill_n_fn uninitialized_fill_n;
 
-    class _Construct_at_fn : private _Not_quite_object {
+    class _Construct_at_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         // clang-format off
         template <class _Ty, class... _Types>
             requires requires(_Ty* _Ptr, _Types&&... _Args) {
@@ -544,16 +530,14 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Construct_at_fn construct_at{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Construct_at_fn construct_at;
 
     template <_No_throw_input_iterator _It, _No_throw_sentinel_for<_It> _Se>
         requires destructible<iter_value_t<_It>>
     _NODISCARD constexpr _It _Destroy_unchecked(_It _First, _Se _Last) noexcept;
 
-    class _Destroy_at_fn : private _Not_quite_object {
+    class _Destroy_at_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <destructible _Ty>
         constexpr void operator()(_Ty* const _Location) const noexcept {
             if constexpr (is_array_v<_Ty>) {
@@ -564,7 +548,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Destroy_at_fn destroy_at{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Destroy_at_fn destroy_at;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -595,10 +579,8 @@ namespace ranges {
         return _First;
     }
 
-    class _Destroy_fn : private _Not_quite_object {
+    class _Destroy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <_No_throw_input_iterator _It, _No_throw_sentinel_for<_It> _Se>
             requires destructible<iter_value_t<_It>>
         constexpr _It operator()(_It _First, _Se _Last) const noexcept {
@@ -618,7 +600,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Destroy_fn destroy{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Destroy_fn destroy;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -648,10 +630,8 @@ _NoThrowFwdIt destroy_n(_ExPo&& _Exec, _NoThrowFwdIt _First, _Diff _Count_raw) n
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Destroy_n_fn : private _Not_quite_object {
+    class _Destroy_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <_No_throw_input_iterator _It>
             requires destructible<iter_value_t<_It>>
         constexpr _It operator()(_It _First, const iter_difference_t<_It> _Count_raw) const noexcept {
@@ -676,7 +656,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Destroy_n_fn destroy_n{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Destroy_n_fn destroy_n;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -701,10 +681,8 @@ void uninitialized_default_construct(_ExPo&& _Exec, _NoThrowFwdIt _First, _NoThr
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Uninitialized_default_construct_fn : private _Not_quite_object {
+    class _Uninitialized_default_construct_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <_No_throw_forward_iterator _It, _No_throw_sentinel_for<_It> _Se>
             requires default_initializable<iter_value_t<_It>>
         _It operator()(_It _First, _Se _Last) const {
@@ -747,8 +725,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_default_construct_fn uninitialized_default_construct{
-        _Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_default_construct_fn uninitialized_default_construct;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -781,10 +758,8 @@ _NoThrowFwdIt uninitialized_default_construct_n(
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Uninitialized_default_construct_n_fn : private _Not_quite_object {
+    class _Uninitialized_default_construct_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <_No_throw_forward_iterator _It>
             requires default_initializable<iter_value_t<_It>>
         _It operator()(_It _First, iter_difference_t<_It> _Count) const {
@@ -808,8 +783,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_default_construct_n_fn uninitialized_default_construct_n{
-        _Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_default_construct_n_fn uninitialized_default_construct_n;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -837,10 +811,8 @@ void uninitialized_value_construct(_ExPo&& _Exec, _NoThrowFwdIt _First, _NoThrow
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Uninitialized_value_construct_fn : private _Not_quite_object {
+    class _Uninitialized_value_construct_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <_No_throw_forward_iterator _It, _No_throw_sentinel_for<_It> _Se>
             requires default_initializable<iter_value_t<_It>>
         _It operator()(_It _First, _Se _Last) const {
@@ -881,8 +853,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_value_construct_fn uninitialized_value_construct{
-        _Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_value_construct_fn uninitialized_value_construct;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -904,10 +875,8 @@ _NoThrowFwdIt uninitialized_value_construct_n(
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Uninitialized_value_construct_n_fn : private _Not_quite_object {
+    class _Uninitialized_value_construct_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <_No_throw_forward_iterator _It>
             requires default_initializable<iter_value_t<_It>>
         _It operator()(_It _First, iter_difference_t<_It> _Count) const {
@@ -931,8 +900,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Uninitialized_value_construct_n_fn uninitialized_value_construct_n{
-        _Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Uninitialized_value_construct_n_fn uninitialized_value_construct_n;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -530,10 +530,8 @@ namespace ranges {
     _EXPORT_STD template <class _Out, class _Ty>
     using iota_result = out_value_result<_Out, _Ty>;
 
-    class _Iota_fn : private _Not_quite_object {
+    class _Iota_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_or_output_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Ty>
             requires indirectly_writable<_It, const _Ty&>
         constexpr iota_result<_It, _Ty> operator()(_It _First, _Se _Last, _Ty _Val) const {
@@ -565,7 +563,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Iota_fn iota{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Iota_fn iota;
 } // namespace ranges
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3644,6 +3644,10 @@ namespace ranges {
         return static_cast<_Ty&>(_Val);
     }
 
+    struct _Construct_tag {
+        explicit _Construct_tag() = default;
+    };
+
     _EXPORT_STD template <input_range _Vw>
         requires view<_Vw> && input_range<range_reference_t<_Vw>>
     class join_view;
@@ -3653,7 +3657,7 @@ namespace ranges {
     private:
         struct _Cache_wrapper {
             template <input_iterator _Iter>
-            constexpr _Cache_wrapper(_Not_quite_object::_Construct_tag, const _Iter& _It) noexcept(
+            constexpr _Cache_wrapper(_Construct_tag, const _Iter& _It) noexcept(
                 noexcept(static_cast<decltype(_Val)>(*_It)))
                 : _Val(*_It) {}
 
@@ -3772,7 +3776,7 @@ namespace ranges {
                 if constexpr (_Deref_is_glvalue) {
                     return *_Get_outer();
                 } else {
-                    return _Parent->_Inner._Emplace(_Not_quite_object::_Construct_tag{}, _Get_outer())._Val;
+                    return _Parent->_Inner._Emplace(_Construct_tag{}, _Get_outer())._Val;
                 }
             }
 
@@ -4091,7 +4095,7 @@ namespace ranges {
     private:
         struct _Cache_wrapper {
             template <input_iterator _Iter>
-            constexpr _Cache_wrapper(_Not_quite_object::_Construct_tag, const _Iter& _It) noexcept(
+            constexpr _Cache_wrapper(_Construct_tag, const _Iter& _It) noexcept(
                 noexcept(static_cast<decltype(_Val)>(*_It)))
                 : _Val(*_It) {}
 
@@ -4224,7 +4228,7 @@ namespace ranges {
                 if constexpr (_Deref_is_glvalue) {
                     return _As_lvalue(*_Get_outer());
                 } else {
-                    return _Parent->_Inner._Emplace(_Not_quite_object::_Construct_tag{}, _Get_outer())._Val;
+                    return _Parent->_Inner._Emplace(_Construct_tag{}, _Get_outer())._Val;
                 }
             }
 

--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -197,9 +197,16 @@ namespace this_thread {
                 return;
             }
 
-            _timespec64 _Tgt;
-            (void) _To_timespec64_sys_10_day_clamped(_Tgt, _Abs_time - _Now);
-            _Thrd_sleep(&_Tgt);
+            // _Clamp must be less than 2^32 - 1 (INFINITE) milliseconds, but is otherwise arbitrary.
+            constexpr chrono::milliseconds _Clamp{chrono::hours{24}};
+
+            const auto _Rel = _Abs_time - _Now;
+            if (_Rel >= _Clamp) {
+                _Thrd_sleep_for(static_cast<unsigned long>(_Clamp.count()));
+            } else {
+                const auto _Rel_ms = chrono::ceil<chrono::milliseconds>(_Rel);
+                _Thrd_sleep_for(static_cast<unsigned long>(_Rel_ms.count()));
+            }
         }
     }
 

--- a/stl/inc/xthreads.h
+++ b/stl/inc/xthreads.h
@@ -83,10 +83,10 @@ enum class _Thrd_result : int { _Success, _Nomem, _Timedout, _Busy, _Error };
 // threads
 _CRTIMP2_PURE _Thrd_result __cdecl _Thrd_detach(_Thrd_t);
 _CRTIMP2_PURE _Thrd_result __cdecl _Thrd_join(_Thrd_t, int*);
-_CRTIMP2_PURE void __cdecl _Thrd_sleep(const _timespec64*);
 _CRTIMP2_PURE void __cdecl _Thrd_yield();
 _CRTIMP2_PURE unsigned int __cdecl _Thrd_hardware_concurrency();
 _CRTIMP2_PURE _Thrd_id_t __cdecl _Thrd_id();
+void __stdcall _Thrd_sleep_for(unsigned long /*ms*/) noexcept;
 
 // mutexes
 enum { // mutex types

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3217,35 +3217,8 @@ namespace ranges {
         { _RANGES data(__r) } -> same_as<add_pointer_t<range_reference_t<_Rng>>>;
     };
 
-    class _Not_quite_object {
+    class _Advance_fn {
     public:
-        // Some overload sets in the library have the property that their constituent function templates are not visible
-        // to argument-dependent name lookup (ADL) and that they inhibit ADL when found via unqualified name lookup.
-        // This property allows these overload sets to be implemented as function objects. We derive such function
-        // objects from this type to remove some typical object-ish behaviors which helps users avoid depending on their
-        // non-specified object-ness.
-
-        struct _Construct_tag {
-            explicit _Construct_tag() = default;
-        };
-
-        _Not_quite_object() = delete;
-
-        constexpr explicit _Not_quite_object(_Construct_tag) noexcept {}
-
-        _Not_quite_object(const _Not_quite_object&)            = delete;
-        _Not_quite_object& operator=(const _Not_quite_object&) = delete;
-
-        void operator&() const = delete;
-
-    protected:
-        ~_Not_quite_object() = default;
-    };
-
-    class _Advance_fn : private _Not_quite_object {
-    public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_or_output_iterator _It>
         constexpr void operator()(_It& _Where, iter_difference_t<_It> _Off) const {
             if constexpr (random_access_iterator<_It>) {
@@ -3331,12 +3304,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Advance_fn advance{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Advance_fn advance;
 
-    class _Distance_fn : private _Not_quite_object {
+    class _Distance_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <class _It, sentinel_for<_It> _Se>
             requires (!sized_sentinel_for<_Se, _It>)
         _NODISCARD constexpr iter_difference_t<_It> operator()(_It _First, _Se _Last) const
@@ -3384,7 +3355,7 @@ namespace ranges {
         static constexpr bool _Nothrow_size<_Rng> = noexcept(_RANGES size(_STD declval<_Rng&>()));
     };
 
-    _EXPORT_STD inline constexpr _Distance_fn distance{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Distance_fn distance;
 
     class _Ssize_fn {
     public:
@@ -3402,10 +3373,8 @@ namespace ranges {
         _EXPORT_STD inline constexpr _Ssize_fn ssize;
     }
 
-    class _Next_fn : private _Not_quite_object {
+    class _Next_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_or_output_iterator _It>
         _NODISCARD constexpr _It operator()(_It _Where) const {
             ++_Where;
@@ -3431,12 +3400,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Next_fn next{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Next_fn next;
 
-    class _Prev_fn : private _Not_quite_object {
+    class _Prev_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <bidirectional_iterator _It>
         _NODISCARD constexpr _It operator()(_It _Where) const {
             --_Where;
@@ -3458,7 +3425,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Prev_fn prev{_Not_quite_object::_Construct_tag{}};
+    _EXPORT_STD inline constexpr _Prev_fn prev;
 
     template <forward_iterator _It, sentinel_for<_It> _Se>
     _NODISCARD constexpr _It _Find_last_iterator(
@@ -4754,10 +4721,8 @@ namespace ranges {
         return {_STD move(_First), _STD move(_Result)};
     }
 
-    class _Copy_fn : private _Not_quite_object {
+    class _Copy_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
             requires indirectly_copyable<_It, _Out>
         constexpr copy_result<_It, _Out> operator()(_It _First, _Se _Last, _Out _Result) const {
@@ -4779,7 +4744,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Copy_fn copy{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Copy_fn copy;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -5127,10 +5092,8 @@ _FwdIt fill_n(_ExPo&&, _FwdIt _Dest, _Diff _Count_raw, const _Ty& _Val) noexcept
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Fill_n_fn : private _Not_quite_object {
+    class _Fill_n_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <class _Ty, output_iterator<const _Ty&> _It>
         constexpr _It operator()(_It _First, iter_difference_t<_It> _Count, const _Ty& _Value) const {
             if (_Count > 0) {
@@ -5160,7 +5123,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Fill_n_fn fill_n{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Fill_n_fn fill_n;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -5431,10 +5394,8 @@ namespace ranges {
         return {_STD move(_First1), _STD move(_First2)};
     }
 
-    class _Mismatch_fn : private _Not_quite_object {
+    class _Mismatch_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         // clang-format off
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::equal_to, class _Pj1 = identity, class _Pj2 = identity>
@@ -5499,7 +5460,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Mismatch_fn mismatch{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Mismatch_fn mismatch;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -5947,10 +5908,8 @@ namespace ranges {
         return _First;
     }
 
-    class _Find_fn : private _Not_quite_object {
+    class _Find_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         // clang-format off
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity>
             requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
@@ -5977,7 +5936,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Find_fn find{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Find_fn find;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -6370,10 +6329,8 @@ namespace ranges {
         return _First;
     }
 
-    class _Find_if_fn : private _Not_quite_object {
+    class _Find_if_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -6397,12 +6354,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Find_if_fn find_if{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Find_if_fn find_if;
 
-    class _Find_if_not_fn : private _Not_quite_object {
+    class _Find_if_not_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
@@ -6444,12 +6399,10 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Find_if_not_fn find_if_not{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Find_if_not_fn find_if_not;
 
-    class _Adjacent_find_fn : private _Not_quite_object {
+    class _Adjacent_find_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_binary_predicate<projected<_It, _Pj>, projected<_It, _Pj>> _Pr = ranges::equal_to>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -6495,7 +6448,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Adjacent_find_fn adjacent_find{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Adjacent_find_fn adjacent_find;
 
     // clang-format off
     template <class _It1, class _It2, class _Se2, class _Pr, class _Pj1, class _Pj2>
@@ -6537,10 +6490,8 @@ namespace ranges {
         return {true, _STD move(_First1)};
     }
 
-    class _Search_fn : private _Not_quite_object {
+    class _Search_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It1, sentinel_for<_It1> _Se1, forward_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::equal_to, class _Pj1 = identity, class _Pj2 = identity>
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
@@ -6636,7 +6587,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Search_fn search{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Search_fn search;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -6746,10 +6697,8 @@ namespace ranges {
         return _Found;
     }
 
-    class _Max_element_fn : private _Not_quite_object {
+    class _Max_element_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_strict_weak_order<projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -6768,7 +6717,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Max_element_fn max_element{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Max_element_fn max_element;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -6794,10 +6743,8 @@ namespace ranges {
         sizeof(_It) <= 2 * sizeof(iter_value_t<_It>)
         && (is_trivially_copyable_v<_It> || !is_trivially_copyable_v<iter_value_t<_It>>);
 
-    class _Max_fn : private _Not_quite_object {
+    class _Max_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <class _Ty, class _Pj = identity,
             indirect_strict_weak_order<projected<const _Ty*, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr const _Ty& operator()(
@@ -6843,7 +6790,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Max_fn max{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Max_fn max;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 
@@ -6942,10 +6889,8 @@ namespace ranges {
         return _Found;
     }
 
-    class _Min_element_fn : private _Not_quite_object {
+    class _Min_element_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_strict_weak_order<projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
@@ -6964,7 +6909,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Min_element_fn min_element{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Min_element_fn min_element;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
@@ -6984,10 +6929,8 @@ _NODISCARD constexpr _Ty(min)(initializer_list<_Ty> _Ilist) {
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    class _Min_fn : private _Not_quite_object {
+    class _Min_fn {
     public:
-        using _Not_quite_object::_Not_quite_object;
-
         template <class _Ty, class _Pj = identity,
             indirect_strict_weak_order<projected<const _Ty*, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr const _Ty& operator()(
@@ -7033,7 +6976,7 @@ namespace ranges {
         }
     };
 
-    _EXPORT_STD inline constexpr _Min_fn min{_Not_quite_object::_Construct_tag {}};
+    _EXPORT_STD inline constexpr _Min_fn min;
 } // namespace ranges
 #endif // defined(__cpp_lib_concepts)
 

--- a/stl/src/cthread.cpp
+++ b/stl/src/cthread.cpp
@@ -71,6 +71,7 @@ _CRTIMP2_PURE _Thrd_result __cdecl _Thrd_detach(_Thrd_t thr) {
     return CloseHandle(thr._Hnd) ? _Thrd_result::_Success : _Thrd_result::_Error;
 }
 
+// TRANSITION, ABI: _Thrd_sleep() is preserved for binary compatibility
 _CRTIMP2_PURE void __cdecl _Thrd_sleep(const _timespec64* xt) { // suspend thread until time xt
     _timespec64 now;
     _Timespec64_get_sys(&now);

--- a/stl/src/sharedmutex.cpp
+++ b/stl/src/sharedmutex.cpp
@@ -36,4 +36,8 @@ void __cdecl _Smtx_unlock_exclusive(_Smtx_t* smtx) { // unlock exclusive shared 
 void __cdecl _Smtx_unlock_shared(_Smtx_t* smtx) { // unlock non-exclusive shared mutex
     ReleaseSRWLockShared(reinterpret_cast<PSRWLOCK>(smtx));
 }
+
+void __stdcall _Thrd_sleep_for(const unsigned long ms) noexcept { // suspend current thread for `ms` milliseconds
+    Sleep(ms);
+}
 }

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -68,11 +68,21 @@ namespace {
         return static_cast<const unsigned char*>(_Last) - static_cast<const unsigned char*>(_First);
     }
 
-    void _Advance_bytes(void*& _Target, ptrdiff_t _Offset) noexcept {
+    void _Rewind_bytes(void*& _Target, size_t _Offset) noexcept {
+        _Target = static_cast<unsigned char*>(_Target) - _Offset;
+    }
+
+    void _Rewind_bytes(const void*& _Target, size_t _Offset) noexcept {
+        _Target = static_cast<const unsigned char*>(_Target) - _Offset;
+    }
+
+    template <class _Integral>
+    void _Advance_bytes(void*& _Target, _Integral _Offset) noexcept {
         _Target = static_cast<unsigned char*>(_Target) + _Offset;
     }
 
-    void _Advance_bytes(const void*& _Target, ptrdiff_t _Offset) noexcept {
+    template <class _Integral>
+    void _Advance_bytes(const void*& _Target, _Integral _Offset) noexcept {
         _Target = static_cast<const unsigned char*>(_Target) + _Offset;
     }
 } // unnamed namespace
@@ -1144,6 +1154,20 @@ namespace {
     }
 
     template <class _Ty>
+    const void* _Find_trivial_last_tail(const void* _First, const void* _Last, const void* _Real_last, _Ty _Val) {
+        auto _Ptr = static_cast<const _Ty*>(_Last);
+        for (;;) {
+            if (_Ptr == _First) {
+                return _Real_last;
+            }
+            --_Ptr;
+            if (*_Ptr == _Val) {
+                return _Ptr;
+            }
+        }
+    }
+
+    template <class _Ty>
     __declspec(noalias) size_t _Count_trivial_tail(const void* _First, const void* _Last, size_t _Current, _Ty _Val) {
         auto _Ptr = static_cast<const _Ty*>(_First);
         for (; _Ptr != _Last; ++_Ptr) {
@@ -1397,6 +1421,58 @@ namespace {
     }
 
     template <class _Traits, class _Ty>
+    const void* __stdcall __std_find_last_trivial(const void* _First, const void* _Last, _Ty _Val) noexcept {
+        const void* const _Real_last = _Last;
+#ifndef _M_ARM64EC
+        size_t _Size_bytes = _Byte_length(_First, _Last);
+
+        const size_t _Avx_size = _Size_bytes & ~size_t{0x1F};
+        if (_Avx_size != 0 && _Use_avx2()) {
+            _Zeroupper_on_exit _Guard; // TRANSITION, DevCom-10331414
+
+            const __m256i _Comparand = _Traits::_Set_avx(_Val);
+            const void* _Stop_at     = _Last;
+            _Rewind_bytes(_Stop_at, _Avx_size);
+            do {
+                _Rewind_bytes(_Last, 32);
+                const __m256i _Data = _mm256_loadu_si256(static_cast<const __m256i*>(_Last));
+                const int _Bingo    = _mm256_movemask_epi8(_Traits::_Cmp_avx(_Data, _Comparand));
+
+                if (_Bingo != 0) {
+                    const unsigned long _Offset = _lzcnt_u32(_Bingo);
+                    _Advance_bytes(_Last, (31 - _Offset) - (sizeof(_Ty) - 1));
+                    return _Last;
+                }
+
+            } while (_Last != _Stop_at);
+            _Size_bytes &= 0x1F;
+        }
+
+        const size_t _Sse_size = _Size_bytes & ~size_t{0xF};
+        if (_Sse_size != 0 && _Traits::_Sse_available()) {
+            const __m128i _Comparand = _Traits::_Set_sse(_Val);
+            const void* _Stop_at     = _Last;
+            _Rewind_bytes(_Stop_at, _Sse_size);
+            do {
+                _Rewind_bytes(_Last, 16);
+                const __m128i _Data = _mm_loadu_si128(static_cast<const __m128i*>(_Last));
+                const int _Bingo    = _mm_movemask_epi8(_Traits::_Cmp_sse(_Data, _Comparand));
+
+                if (_Bingo != 0) {
+                    unsigned long _Offset;
+                    _BitScanReverse(&_Offset, _Bingo); // lgtm [cpp/conditionallyuninitializedvariable]
+                    _Advance_bytes(_Last, _Offset - (sizeof(_Ty) - 1));
+                    return _Last;
+                }
+
+            } while (_Last != _Stop_at);
+        }
+#endif // !_M_ARM64EC
+
+        return _Find_trivial_last_tail(_First, _Last, _Real_last, _Val);
+    }
+
+    template <class _Traits, class _Ty>
     __declspec(noalias) size_t
         __stdcall __std_count_trivial(const void* _First, const void* const _Last, const _Ty _Val) noexcept {
         size_t _Result = 0;
@@ -1474,6 +1550,26 @@ const void* __stdcall __std_find_trivial_4(
 const void* __stdcall __std_find_trivial_8(
     const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
     return __std_find_trivial<_Find_traits_8>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_last_trivial_1(
+    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
+    return __std_find_last_trivial<_Find_traits_1>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_last_trivial_2(
+    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
+    return __std_find_last_trivial<_Find_traits_2>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_last_trivial_4(
+    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
+    return __std_find_last_trivial<_Find_traits_4>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_last_trivial_8(
+    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
+    return __std_find_last_trivial<_Find_traits_8>(_First, _Last, _Val);
 }
 
 __declspec(noalias) size_t

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -103,6 +103,20 @@ inline auto last_known_good_find(FwdIt first, FwdIt last, T v) {
     return first;
 }
 
+template <class FwdIt, class T>
+inline auto last_known_good_find_last(FwdIt first, FwdIt last, T v) {
+    FwdIt last_save = last;
+    for (;;) {
+        if (last == first) {
+            return last_save;
+        }
+        --last;
+        if (*last == v) {
+            return last;
+        }
+    }
+}
+
 template <class T>
 void test_case_find(const vector<T>& input, T v) {
     auto expected = last_known_good_find(input.begin(), input.end(), v);
@@ -122,6 +136,30 @@ void test_find(mt19937_64& gen) {
         test_case_find(input, static_cast<T>(dis(gen)));
     }
 }
+
+#if _HAS_CXX23 && defined(__cpp_lib_concepts)
+template <class T>
+void test_case_find_last(const vector<T>& input, T v) {
+    auto expected = last_known_good_find_last(input.begin(), input.end(), v);
+    auto range    = ranges::find_last(input.begin(), input.end(), v);
+    auto actual   = range.begin();
+    assert(expected == actual);
+    assert(range.end() == input.end());
+}
+
+template <class T>
+void test_find_last(mt19937_64& gen) {
+    using TD = conditional_t<sizeof(T) == 1, int, T>;
+    binomial_distribution<TD> dis(10);
+    vector<T> input;
+    input.reserve(dataCount);
+    test_case_find_last(input, static_cast<T>(dis(gen)));
+    for (size_t attempts = 0; attempts < dataCount; ++attempts) {
+        input.push_back(static_cast<T>(dis(gen)));
+        test_case_find_last(input, static_cast<T>(dis(gen)));
+    }
+}
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
 template <class T>
 void test_min_max_element(mt19937_64& gen) {
@@ -305,6 +343,18 @@ void test_vector_algorithms(mt19937_64& gen) {
     test_find<long long>(gen);
     test_find<unsigned long long>(gen);
 
+#if _HAS_CXX23 && defined(__cpp_lib_concepts)
+    test_find_last<char>(gen);
+    test_find_last<signed char>(gen);
+    test_find_last<unsigned char>(gen);
+    test_find_last<short>(gen);
+    test_find_last<unsigned short>(gen);
+    test_find_last<int>(gen);
+    test_find_last<unsigned int>(gen);
+    test_find_last<long long>(gen);
+    test_find_last<unsigned long long>(gen);
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+
     test_min_max_element<char>(gen);
     test_min_max_element<signed char>(gen);
     test_min_max_element<unsigned char>(gen);
@@ -399,7 +449,76 @@ void test_various_containers() {
     test_one_container<list<int>>(); // bidi, not vectorizable
 }
 
+#if _HAS_CXX20
+constexpr bool test_constexpr() {
+    const int a[] = {20, 10, 30, 30, 30, 30, 40, 60, 50};
+
+    assert(count(begin(a), end(a), 30) == 4);
+#ifdef __cpp_lib_concepts
+    assert(ranges::count(a, 30) == 4);
+#endif // defined(__cpp_lib_concepts)
+
+    assert(find(begin(a), end(a), 30) == begin(a) + 2);
+#ifdef __cpp_lib_concepts
+    assert(ranges::find(a, 30) == begin(a) + 2);
+#endif // defined(__cpp_lib_concepts)
+
+#if defined(__cpp_lib_concepts) && _HAS_CXX23
+    assert(begin(ranges::find_last(a, 30)) == begin(a) + 5);
+    assert(end(ranges::find_last(a, 30)) == end(a));
+#endif // defined(__cpp_lib_concepts) && _HAS_CXX23
+
+    assert(min_element(begin(a), end(a)) == begin(a) + 1);
+    assert(max_element(begin(a), end(a)) == end(a) - 2);
+    assert(get<0>(minmax_element(begin(a), end(a))) == begin(a) + 1);
+    assert(get<1>(minmax_element(begin(a), end(a))) == end(a) - 2);
+
+#ifdef __cpp_lib_concepts
+    assert(ranges::min_element(a) == begin(a) + 1);
+    assert(ranges::max_element(a) == end(a) - 2);
+    assert(ranges::minmax_element(a).min == begin(a) + 1);
+    assert(ranges::minmax_element(a).max == end(a) - 2);
+#endif // defined(__cpp_lib_concepts)
+
+    int b[size(a)];
+    reverse_copy(begin(a), end(a), begin(b));
+    assert(equal(rbegin(a), rend(a), begin(b), end(b)));
+
+    int c[size(a)];
+#ifdef __cpp_lib_concepts
+    ranges::reverse_copy(a, c);
+    assert(equal(rbegin(a), rend(a), begin(c), end(c)));
+#else // ^^^ defined(__cpp_lib_concepts) / !defined(__cpp_lib_concepts) vvv
+    reverse_copy(begin(a), end(a), begin(c)); // for swap_ranges test below
+#endif // ^^^ !defined(__cpp_lib_concepts) ^^^
+
+    reverse(begin(b), end(b));
+    assert(equal(begin(a), end(a), begin(b), end(b)));
+
+    swap_ranges(begin(b), end(b), begin(c));
+    assert(equal(rbegin(a), rend(a), begin(b), end(b)));
+    assert(equal(begin(a), end(a), begin(c), end(c)));
+
+#ifdef __cpp_lib_concepts
+    ranges::swap_ranges(b, c);
+    assert(equal(begin(a), end(a), begin(b), end(b)));
+    assert(equal(rbegin(a), rend(a), begin(c), end(c)));
+
+    ranges::reverse(c);
+    assert(equal(begin(a), end(a), begin(c), end(c)));
+#endif // defined(__cpp_lib_concepts)
+
+    return true;
+}
+
+static_assert(test_constexpr());
+#endif // _HAS_CXX20
+
 int main() {
+#if _HAS_CXX20
+    assert(test_constexpr());
+#endif // _HAS_CXX20
+
     mt19937_64 gen;
     initialize_randomness(gen);
 

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -5,875 +5,354 @@
 
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
 
-// LIBRARY FEATURE-TEST MACROS
 #if _HAS_CXX23
-#ifndef __cpp_lib_adaptor_iterator_pair_constructor
-#error __cpp_lib_adaptor_iterator_pair_constructor is not defined
-#elif __cpp_lib_adaptor_iterator_pair_constructor != 202106L
-#error __cpp_lib_adaptor_iterator_pair_constructor is not 202106L
-#else
 STATIC_ASSERT(__cpp_lib_adaptor_iterator_pair_constructor == 202106L);
-#endif
-#else
-#ifdef __cpp_lib_adaptor_iterator_pair_constructor
+#elif defined(__cpp_lib_adaptor_iterator_pair_constructor)
 #error __cpp_lib_adaptor_iterator_pair_constructor is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_addressof_constexpr
-#error __cpp_lib_addressof_constexpr is not defined
-#elif __cpp_lib_addressof_constexpr != 201603L
-#error __cpp_lib_addressof_constexpr is not 201603L
-#else
 STATIC_ASSERT(__cpp_lib_addressof_constexpr == 201603L);
-#endif
 
 #if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_algorithm_iterator_requirements
-#error __cpp_lib_algorithm_iterator_requirements is not defined
-#elif __cpp_lib_algorithm_iterator_requirements != 202207L
-#error __cpp_lib_algorithm_iterator_requirements is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_algorithm_iterator_requirements == 202207L);
-#endif
-#else
-#ifdef __cpp_lib_algorithm_iterator_requirements
+#elif defined(__cpp_lib_algorithm_iterator_requirements)
 #error __cpp_lib_algorithm_iterator_requirements is defined
 #endif
-#endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_allocate_at_least
-#error __cpp_lib_allocate_at_least is not defined
-#elif __cpp_lib_allocate_at_least != 202302L
-#error __cpp_lib_allocate_at_least is not 202302L
-#else
 STATIC_ASSERT(__cpp_lib_allocate_at_least == 202302L);
-#endif
-#else
-#ifdef __cpp_lib_allocate_at_least
+#elif defined(__cpp_lib_allocate_at_least)
 #error __cpp_lib_allocate_at_least is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_allocator_traits_is_always_equal
-#error __cpp_lib_allocator_traits_is_always_equal is not defined
-#elif __cpp_lib_allocator_traits_is_always_equal != 201411L
-#error __cpp_lib_allocator_traits_is_always_equal is not 201411L
-#else
 STATIC_ASSERT(__cpp_lib_allocator_traits_is_always_equal == 201411L);
-#endif
 
 #if _HAS_CXX17 && _HAS_STATIC_RTTI
-#ifndef __cpp_lib_any
-#error __cpp_lib_any is not defined
-#elif __cpp_lib_any != 201606L
-#error __cpp_lib_any is not 201606L
-#else
 STATIC_ASSERT(__cpp_lib_any == 201606L);
-#endif
-#else
-#ifdef __cpp_lib_any
+#elif defined(__cpp_lib_any)
 #error __cpp_lib_any is defined
 #endif
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_apply
-#error __cpp_lib_apply is not defined
-#elif __cpp_lib_apply != 201603L
-#error __cpp_lib_apply is not 201603L
-#else
 STATIC_ASSERT(__cpp_lib_apply == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_apply
+#elif defined(__cpp_lib_apply)
 #error __cpp_lib_apply is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_array_constexpr
-#error __cpp_lib_array_constexpr is not defined
-#elif __cpp_lib_array_constexpr != 201811L
-#error __cpp_lib_array_constexpr is not 201811L
-#else
 STATIC_ASSERT(__cpp_lib_array_constexpr == 201811L);
-#endif
 #elif _HAS_CXX17
-#ifndef __cpp_lib_array_constexpr
-#error __cpp_lib_array_constexpr is not defined
-#elif __cpp_lib_array_constexpr != 201803L
-#error __cpp_lib_array_constexpr is not 201803L
-#else
 STATIC_ASSERT(__cpp_lib_array_constexpr == 201803L);
-#endif
-#else
-#ifdef __cpp_lib_array_constexpr
+#elif defined(__cpp_lib_array_constexpr)
 #error __cpp_lib_array_constexpr is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_as_const
-#error __cpp_lib_as_const is not defined
-#elif __cpp_lib_as_const != 201510L
-#error __cpp_lib_as_const is not 201510L
-#else
 STATIC_ASSERT(__cpp_lib_as_const == 201510L);
-#endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_associative_heterogeneous_erasure
-#error __cpp_lib_associative_heterogeneous_erasure is not defined
-#elif __cpp_lib_associative_heterogeneous_erasure != 202110L
-#error __cpp_lib_associative_heterogeneous_erasure is not 202110L
-#else
 STATIC_ASSERT(__cpp_lib_associative_heterogeneous_erasure == 202110L);
-#endif
-#else
-#ifdef __cpp_lib_associative_heterogeneous_erasure
+#elif defined(__cpp_lib_associative_heterogeneous_erasure)
 #error __cpp_lib_associative_heterogeneous_erasure is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_assume_aligned
-#error __cpp_lib_assume_aligned is not defined
-#elif __cpp_lib_assume_aligned != 201811L
-#error __cpp_lib_assume_aligned is not 201811L
-#else
 STATIC_ASSERT(__cpp_lib_assume_aligned == 201811L);
-#endif
-#else
-#ifdef __cpp_lib_assume_aligned
+#elif defined(__cpp_lib_assume_aligned)
 #error __cpp_lib_assume_aligned is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_atomic_flag_test
-#error __cpp_lib_atomic_flag_test is not defined
-#elif __cpp_lib_atomic_flag_test != 201907L
-#error __cpp_lib_atomic_flag_test is not 201907L
-#else
 STATIC_ASSERT(__cpp_lib_atomic_flag_test == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_atomic_flag_test
+#elif defined(__cpp_lib_atomic_flag_test)
 #error __cpp_lib_atomic_flag_test is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_atomic_float
-#error __cpp_lib_atomic_float is not defined
-#elif __cpp_lib_atomic_float != 201711L
-#error __cpp_lib_atomic_float is not 201711L
-#else
 STATIC_ASSERT(__cpp_lib_atomic_float == 201711L);
-#endif
-#else
-#ifdef __cpp_lib_atomic_float
+#elif defined(__cpp_lib_atomic_float)
 #error __cpp_lib_atomic_float is defined
-#endif
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_atomic_is_always_lock_free
-#error __cpp_lib_atomic_is_always_lock_free is not defined
-#elif __cpp_lib_atomic_is_always_lock_free != 201603L
-#error __cpp_lib_atomic_is_always_lock_free is not 201603L
-#else
 STATIC_ASSERT(__cpp_lib_atomic_is_always_lock_free == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_atomic_is_always_lock_free
+#elif defined(__cpp_lib_atomic_is_always_lock_free)
 #error __cpp_lib_atomic_is_always_lock_free is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_atomic_lock_free_type_aliases
-#error __cpp_lib_atomic_lock_free_type_aliases is not defined
-#elif __cpp_lib_atomic_lock_free_type_aliases != 201907L
-#error __cpp_lib_atomic_lock_free_type_aliases is not 201907L
-#else
 STATIC_ASSERT(__cpp_lib_atomic_lock_free_type_aliases == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_atomic_lock_free_type_aliases
+#elif defined(__cpp_lib_atomic_lock_free_type_aliases)
 #error __cpp_lib_atomic_lock_free_type_aliases is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_atomic_ref
-#error __cpp_lib_atomic_ref is not defined
-#elif __cpp_lib_atomic_ref != 201806L
-#error __cpp_lib_atomic_ref is not 201806L
-#else
 STATIC_ASSERT(__cpp_lib_atomic_ref == 201806L);
-#endif
-#else
-#ifdef __cpp_lib_atomic_ref
+#elif defined(__cpp_lib_atomic_ref)
 #error __cpp_lib_atomic_ref is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_atomic_shared_ptr
-#error __cpp_lib_atomic_shared_ptr is not defined
-#elif __cpp_lib_atomic_shared_ptr != 201711L
-#error __cpp_lib_atomic_shared_ptr is not 201711L
-#else
 STATIC_ASSERT(__cpp_lib_atomic_shared_ptr == 201711L);
-#endif
-#else
-#ifdef __cpp_lib_atomic_shared_ptr
+#elif defined(__cpp_lib_atomic_shared_ptr)
 #error __cpp_lib_atomic_shared_ptr is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_atomic_value_initialization
-#error __cpp_lib_atomic_value_initialization is not defined
-#elif __cpp_lib_atomic_value_initialization != 201911L
-#error __cpp_lib_atomic_value_initialization is not 201911L
-#else
 STATIC_ASSERT(__cpp_lib_atomic_value_initialization == 201911L);
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_atomic_wait
-#error __cpp_lib_atomic_wait is not defined
-#elif __cpp_lib_atomic_wait != 201907L
-#error __cpp_lib_atomic_wait is not 201907L
-#else
 STATIC_ASSERT(__cpp_lib_atomic_wait == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_atomic_wait
+#elif defined(__cpp_lib_atomic_wait)
 #error __cpp_lib_atomic_wait is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_barrier
-#error __cpp_lib_barrier is not defined
-#elif __cpp_lib_barrier != 202302L
-#error __cpp_lib_barrier is not 202302L
-#else
 STATIC_ASSERT(__cpp_lib_barrier == 202302L);
-#endif
-#else
-#ifdef __cpp_lib_barrier
+#elif defined(__cpp_lib_barrier)
 #error __cpp_lib_barrier is defined
-#endif
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_bind_back
-#error __cpp_lib_bind_back is not defined
-#elif __cpp_lib_bind_back != 202202L
-#error __cpp_lib_bind_back is not 202202L
-#else
 STATIC_ASSERT(__cpp_lib_bind_back == 202202L);
-#endif
-#else
-#ifdef __cpp_lib_bind_back
+#elif defined(__cpp_lib_bind_back)
 #error __cpp_lib_bind_back is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_bind_front
-#error __cpp_lib_bind_front is not defined
-#elif __cpp_lib_bind_front != 201907L
-#error __cpp_lib_bind_front is not 201907L
-#else
 STATIC_ASSERT(__cpp_lib_bind_front == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_bind_front
+#elif defined(__cpp_lib_bind_front)
 #error __cpp_lib_bind_front is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_bit_cast
-#error __cpp_lib_bit_cast is not defined
-#elif __cpp_lib_bit_cast != 201806L
-#error __cpp_lib_bit_cast is not 201806L
-#else
 STATIC_ASSERT(__cpp_lib_bit_cast == 201806L);
-#endif
-#else
-#ifdef __cpp_lib_bit_cast
+#elif defined(__cpp_lib_bit_cast)
 #error __cpp_lib_bit_cast is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_bitops
-#error __cpp_lib_bitops is not defined
-#elif __cpp_lib_bitops != 201907L
-#error __cpp_lib_bitops is not 201907L
-#else
 STATIC_ASSERT(__cpp_lib_bitops == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_bitops
+#elif defined(__cpp_lib_bitops)
 #error __cpp_lib_bitops is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_bool_constant
-#error __cpp_lib_bool_constant is not defined
-#elif __cpp_lib_bool_constant != 201505L
-#error __cpp_lib_bool_constant is not 201505L
-#else
 STATIC_ASSERT(__cpp_lib_bool_constant == 201505L);
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_bounded_array_traits
-#error __cpp_lib_bounded_array_traits is not defined
-#elif __cpp_lib_bounded_array_traits != 201902L
-#error __cpp_lib_bounded_array_traits is not 201902L
-#else
 STATIC_ASSERT(__cpp_lib_bounded_array_traits == 201902L);
-#endif
-#else
-#ifdef __cpp_lib_bounded_array_traits
+#elif defined(__cpp_lib_bounded_array_traits)
 #error __cpp_lib_bounded_array_traits is defined
-#endif
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_boyer_moore_searcher
-#error __cpp_lib_boyer_moore_searcher is not defined
-#elif __cpp_lib_boyer_moore_searcher != 201603L
-#error __cpp_lib_boyer_moore_searcher is not 201603L
-#else
 STATIC_ASSERT(__cpp_lib_boyer_moore_searcher == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_boyer_moore_searcher
+#elif defined(__cpp_lib_boyer_moore_searcher)
 #error __cpp_lib_boyer_moore_searcher is defined
-#endif
 #endif
 
 #if _HAS_STD_BYTE
-#ifndef __cpp_lib_byte
-#error __cpp_lib_byte is not defined
-#elif __cpp_lib_byte != 201603L
-#error __cpp_lib_byte is not 201603L
-#else
 STATIC_ASSERT(__cpp_lib_byte == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_byte
+#elif defined(__cpp_lib_byte)
 #error __cpp_lib_byte is defined
-#endif
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_byteswap
-#error __cpp_lib_byteswap is not defined
-#elif __cpp_lib_byteswap != 202110L
-#error __cpp_lib_byteswap is not 202110L
-#else
 STATIC_ASSERT(__cpp_lib_byteswap == 202110L);
-#endif
-#else
-#ifdef __cpp_lib_byteswap
+#elif defined(__cpp_lib_byteswap)
 #error __cpp_lib_byteswap is defined
-#endif
 #endif
 
 #if defined(__cpp_char8_t)
-#ifndef __cpp_lib_char8_t
-#error __cpp_lib_char8_t is not defined
-#elif __cpp_lib_char8_t != 201907L
-#error __cpp_lib_char8_t is not 201907L
-#else
 STATIC_ASSERT(__cpp_lib_char8_t == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_char8_t
+#elif defined(__cpp_lib_char8_t)
 #error __cpp_lib_char8_t is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_chrono
-#error __cpp_lib_chrono is not defined
-#elif defined(__cpp_lib_concepts)
-#if __cpp_lib_chrono != 201907L
-#error __cpp_lib_chrono is not 201907L
-#else
+#if defined(__cpp_lib_concepts)
 STATIC_ASSERT(__cpp_lib_chrono == 201907L);
-#endif
 #elif _HAS_CXX17
-#if __cpp_lib_chrono != 201611L
-#error __cpp_lib_chrono is not 201611L
-#else
 STATIC_ASSERT(__cpp_lib_chrono == 201611L);
-#endif
-#else
-#if __cpp_lib_chrono != 201510L
-#error __cpp_lib_chrono is not 201510L
 #else
 STATIC_ASSERT(__cpp_lib_chrono == 201510L);
 #endif
-#endif
 
-#ifndef __cpp_lib_chrono_udls
-#error __cpp_lib_chrono_udls is not defined
-#elif __cpp_lib_chrono_udls != 201304L
-#error __cpp_lib_chrono_udls is not 201304L
-#else
 STATIC_ASSERT(__cpp_lib_chrono_udls == 201304L);
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_clamp
-#error __cpp_lib_clamp is not defined
-#elif __cpp_lib_clamp != 201603L
-#error __cpp_lib_clamp is not 201603L
-#else
 STATIC_ASSERT(__cpp_lib_clamp == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_clamp
+#elif defined(__cpp_lib_clamp)
 #error __cpp_lib_clamp is defined
 #endif
-#endif
 
 #if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_common_reference
-#error __cpp_lib_common_reference is not defined
-#elif __cpp_lib_common_reference != 202302L
-#error __cpp_lib_common_reference is not 202302L
-#else
 STATIC_ASSERT(__cpp_lib_common_reference == 202302L);
-#endif
-#else
-#ifdef __cpp_lib_common_reference
+#elif defined(__cpp_lib_common_reference)
 #error __cpp_lib_common_reference is defined
 #endif
-#endif
 
 #if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_common_reference_wrapper
-#error __cpp_lib_common_reference_wrapper is not defined
-#elif __cpp_lib_common_reference_wrapper != 202302L
-#error __cpp_lib_common_reference_wrapper is not 202302L
-#else
 STATIC_ASSERT(__cpp_lib_common_reference_wrapper == 202302L);
-#endif
-#else
-#ifdef __cpp_lib_common_reference_wrapper
+#elif defined(__cpp_lib_common_reference_wrapper)
 #error __cpp_lib_common_reference_wrapper is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_complex_udls
-#error __cpp_lib_complex_udls is not defined
-#elif __cpp_lib_complex_udls != 201309L
-#error __cpp_lib_complex_udls is not 201309L
-#else
 STATIC_ASSERT(__cpp_lib_complex_udls == 201309L);
-#endif
 
 #if _HAS_CXX23 && !defined(__EDG__) // TRANSITION, GH-395
-#ifndef __cpp_lib_concepts
-#error __cpp_lib_concepts is not defined
-#elif __cpp_lib_concepts != 202207L
-#error __cpp_lib_concepts is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_concepts == 202207L);
-#endif
 #elif _HAS_CXX20 && !defined(__EDG__) // TRANSITION, GH-395
-#ifndef __cpp_lib_concepts
-#error __cpp_lib_concepts is not defined
-#elif __cpp_lib_concepts != 202002L
-#error __cpp_lib_concepts is not 202002L
-#else
 STATIC_ASSERT(__cpp_lib_concepts == 202002L);
-#endif
-#else
-#ifdef __cpp_lib_concepts
+#elif defined(__cpp_lib_concepts)
 #error __cpp_lib_concepts is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_algorithms
-#error __cpp_lib_constexpr_algorithms is not defined
-#elif __cpp_lib_constexpr_algorithms != 201806L
-#error __cpp_lib_constexpr_algorithms is not 201806L
-#else
 STATIC_ASSERT(__cpp_lib_constexpr_algorithms == 201806L);
-#endif
-#else
-#ifdef __cpp_lib_constexpr_algorithms
+#elif defined(__cpp_lib_constexpr_algorithms)
 #error __cpp_lib_constexpr_algorithms is defined
 #endif
-#endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_constexpr_bitset
-#error __cpp_lib_constexpr_bitset is not defined
-#elif __cpp_lib_constexpr_bitset != 202207L
-#error __cpp_lib_constexpr_bitset  is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_constexpr_bitset == 202207L);
-#endif
-#else
-#ifdef __cpp_lib_constexpr_bitset
+#elif defined(__cpp_lib_constexpr_bitset)
 #error __cpp_lib_constexpr_bitset is defined
 #endif
-#endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_constexpr_charconv
-#error __cpp_lib_constexpr_charconv is not defined
-#elif __cpp_lib_constexpr_charconv != 202207L
-#error __cpp_lib_constexpr_charconv  is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_constexpr_charconv == 202207L);
-#endif
-#else
-#ifdef __cpp_lib_constexpr_charconv
+#elif defined(__cpp_lib_constexpr_charconv)
 #error __cpp_lib_constexpr_charconv is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_complex
-#error __cpp_lib_constexpr_complex is not defined
-#elif __cpp_lib_constexpr_complex != 201711L
-#error __cpp_lib_constexpr_complex is not 201711L
-#else
 STATIC_ASSERT(__cpp_lib_constexpr_complex == 201711L);
-#endif
-#else
-#ifdef __cpp_lib_constexpr_complex
+#elif defined(__cpp_lib_constexpr_complex)
 #error __cpp_lib_constexpr_complex is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_dynamic_alloc
-#error __cpp_lib_constexpr_dynamic_alloc is not defined
-#elif __cpp_lib_constexpr_dynamic_alloc != 201907L
-#error __cpp_lib_constexpr_dynamic_alloc is not 201907L
-#else
 STATIC_ASSERT(__cpp_lib_constexpr_dynamic_alloc == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_constexpr_dynamic_alloc
+#elif defined(__cpp_lib_constexpr_dynamic_alloc)
 #error __cpp_lib_constexpr_dynamic_alloc is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_functional
-#error __cpp_lib_constexpr_functional is not defined
-#elif __cpp_lib_constexpr_functional != 201907L
-#error __cpp_lib_constexpr_functional is not 201907L
-#else
 STATIC_ASSERT(__cpp_lib_constexpr_functional == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_constexpr_functional
+#elif defined(__cpp_lib_constexpr_functional)
 #error __cpp_lib_constexpr_functional is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_iterator
-#error __cpp_lib_constexpr_iterator is not defined
-#elif __cpp_lib_constexpr_iterator != 201811L
-#error __cpp_lib_constexpr_iterator is not 201811L
-#else
 STATIC_ASSERT(__cpp_lib_constexpr_iterator == 201811L);
-#endif
-#else
-#ifdef __cpp_lib_constexpr_iterator
+#elif defined(__cpp_lib_constexpr_iterator)
 #error __cpp_lib_constexpr_iterator is defined
 #endif
-#endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_constexpr_memory
-#error __cpp_lib_constexpr_memory is not defined
-#elif __cpp_lib_constexpr_memory != 202202L
-#error __cpp_lib_constexpr_memory is not 202202L
-#else
 STATIC_ASSERT(__cpp_lib_constexpr_memory == 202202L);
-#endif
 #elif _HAS_CXX20
-#ifndef __cpp_lib_constexpr_memory
-#error __cpp_lib_constexpr_memory is not defined
-#elif __cpp_lib_constexpr_memory != 201811L
-#error __cpp_lib_constexpr_memory is not 201811L
-#else
 STATIC_ASSERT(__cpp_lib_constexpr_memory == 201811L);
-#endif
-#else
-#ifdef __cpp_lib_constexpr_memory
+#elif defined(__cpp_lib_constexpr_memory)
 #error __cpp_lib_constexpr_memory is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_numeric
-#error __cpp_lib_constexpr_numeric is not defined
-#elif __cpp_lib_constexpr_numeric != 201911L
-#error __cpp_lib_constexpr_numeric is not 201911L
-#else
 STATIC_ASSERT(__cpp_lib_constexpr_numeric == 201911L);
-#endif
-#else
-#ifdef __cpp_lib_constexpr_numeric
+#elif defined(__cpp_lib_constexpr_numeric)
 #error __cpp_lib_constexpr_numeric is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_string
-#error __cpp_lib_constexpr_string is not defined
-#elif __cpp_lib_constexpr_string != 201907L
-#error __cpp_lib_constexpr_string is not 201907L
-#else
 STATIC_ASSERT(__cpp_lib_constexpr_string == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_constexpr_string
+#elif defined(__cpp_lib_constexpr_string)
 #error __cpp_lib_constexpr_string is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_string_view
-#error __cpp_lib_constexpr_string_view is not defined
-#elif __cpp_lib_constexpr_string_view != 201811L
-#error __cpp_lib_constexpr_string_view is not 201811L
-#else
 STATIC_ASSERT(__cpp_lib_constexpr_string_view == 201811L);
-#endif
-#else
-#ifdef __cpp_lib_constexpr_string_view
+#elif defined(__cpp_lib_constexpr_string_view)
 #error __cpp_lib_constexpr_string_view is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_tuple
-#error __cpp_lib_constexpr_tuple is not defined
-#elif __cpp_lib_constexpr_tuple != 201811L
-#error __cpp_lib_constexpr_tuple is not 201811L
-#else
 STATIC_ASSERT(__cpp_lib_constexpr_tuple == 201811L);
-#endif
-#else
-#ifdef __cpp_lib_constexpr_tuple
+#elif defined(__cpp_lib_constexpr_tuple)
 #error __cpp_lib_constexpr_tuple is defined
-#endif
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_constexpr_typeinfo
-#error __cpp_lib_constexpr_typeinfo is not defined
-#elif __cpp_lib_constexpr_typeinfo != 202106L
-#error __cpp_lib_constexpr_typeinfo is not 202106L
-#else
 STATIC_ASSERT(__cpp_lib_constexpr_typeinfo == 202106L);
-#endif
-#else
-#ifdef __cpp_lib_constexpr_typeinfo
+#elif defined(__cpp_lib_constexpr_typeinfo)
 #error __cpp_lib_constexpr_typeinfo is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_utility
-#error __cpp_lib_constexpr_utility is not defined
-#elif __cpp_lib_constexpr_utility != 201811L
-#error __cpp_lib_constexpr_utility is not 201811L
-#else
 STATIC_ASSERT(__cpp_lib_constexpr_utility == 201811L);
-#endif
-#else
-#ifdef __cpp_lib_constexpr_utility
+#elif defined(__cpp_lib_constexpr_utility)
 #error __cpp_lib_constexpr_utility is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_constexpr_vector
-#error __cpp_lib_constexpr_vector is not defined
-#elif __cpp_lib_constexpr_vector != 201907L
-#error __cpp_lib_constexpr_vector is not 201907L
-#else
 STATIC_ASSERT(__cpp_lib_constexpr_vector == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_constexpr_vector
+#elif defined(__cpp_lib_constexpr_vector)
 #error __cpp_lib_constexpr_vector is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_containers_ranges
-#error __cpp_lib_containers_ranges is not defined
-#elif __cpp_lib_containers_ranges != 202202L
-#error __cpp_lib_containers_ranges is not 202202L
-#else
 STATIC_ASSERT(__cpp_lib_containers_ranges == 202202L);
-#endif
-#else
-#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#elif defined(__cpp_lib_containers_ranges)
 #error __cpp_lib_containers_ranges is defined
-#endif
 #endif
 
 #ifdef __cpp_impl_coroutine
-#ifndef __cpp_lib_coroutine
-#error __cpp_lib_coroutine is not defined
-#elif __cpp_lib_coroutine != 201902L
-#error __cpp_lib_coroutine is not 201902L
-#else
 STATIC_ASSERT(__cpp_lib_coroutine == 201902L);
-#endif
-#else
-#ifdef __cpp_lib_coroutine
+#elif defined(__cpp_lib_coroutine)
 #error __cpp_lib_coroutine is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_destroying_delete
-#error __cpp_lib_destroying_delete is not defined
-#elif __cpp_lib_destroying_delete != 201806L
-#error __cpp_lib_destroying_delete is not 201806L
-#else
 STATIC_ASSERT(__cpp_lib_destroying_delete == 201806L);
-#endif
-#else
-#ifdef __cpp_lib_destroying_delete
+#elif defined(__cpp_lib_destroying_delete)
 #error __cpp_lib_destroying_delete is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_enable_shared_from_this
-#error __cpp_lib_enable_shared_from_this is not defined
-#elif __cpp_lib_enable_shared_from_this != 201603L
-#error __cpp_lib_enable_shared_from_this is not 201603L
-#else
 STATIC_ASSERT(__cpp_lib_enable_shared_from_this == 201603L);
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_endian
-#error __cpp_lib_endian is not defined
-#elif __cpp_lib_endian != 201907L
-#error __cpp_lib_endian is not 201907L
-#else
 STATIC_ASSERT(__cpp_lib_endian == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_endian
+#elif defined(__cpp_lib_endian)
 #error __cpp_lib_endian is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_erase_if
-#error __cpp_lib_erase_if is not defined
-#elif __cpp_lib_erase_if != 202002L
-#error __cpp_lib_erase_if is not 202002L
-#else
 STATIC_ASSERT(__cpp_lib_erase_if == 202002L);
-#endif
-#else
-#ifdef __cpp_lib_erase_if
+#elif defined(__cpp_lib_erase_if)
 #error __cpp_lib_erase_if is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_exchange_function
-#error __cpp_lib_exchange_function is not defined
-#elif __cpp_lib_exchange_function != 201304L
-#error __cpp_lib_exchange_function is not 201304L
-#else
 STATIC_ASSERT(__cpp_lib_exchange_function == 201304L);
-#endif
 
 #if _HAS_CXX20 && !defined(_M_CEE_PURE)
-#ifndef __cpp_lib_execution
-#error __cpp_lib_execution is not defined
-#elif __cpp_lib_execution != 201902L
-#error __cpp_lib_execution is not 201902L
-#else
 STATIC_ASSERT(__cpp_lib_execution == 201902L);
-#endif
 #elif _HAS_CXX17 && !defined(_M_CEE_PURE)
-#ifndef __cpp_lib_execution
-#error __cpp_lib_execution is not defined
-#elif __cpp_lib_execution != 201603L
-#error __cpp_lib_execution is not 201603L
-#else
 STATIC_ASSERT(__cpp_lib_execution == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_execution
+#elif defined(__cpp_lib_execution)
 #error __cpp_lib_execution is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_expected
-#error __cpp_lib_expected is not defined
-#elif __cpp_lib_expected != 202211L
-#error __cpp_lib_expected is not 202211L
-#else
 STATIC_ASSERT(__cpp_lib_expected == 202211L);
-#endif
-#else
-#ifdef __cpp_lib_expected
+#elif defined(__cpp_lib_expected)
 #error __cpp_lib_expected is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_experimental_erase_if
-#error __cpp_lib_experimental_erase_if is not defined
-#elif __cpp_lib_experimental_erase_if != 201411L
-#error __cpp_lib_experimental_erase_if is not 201411L
-#else
 STATIC_ASSERT(__cpp_lib_experimental_erase_if == 201411L);
-#endif
 
-#ifndef __cpp_lib_experimental_filesystem
-#error __cpp_lib_experimental_filesystem is not defined
-#elif __cpp_lib_experimental_filesystem != 201406L
-#error __cpp_lib_experimental_filesystem is not 201406L
-#else
 STATIC_ASSERT(__cpp_lib_experimental_filesystem == 201406L);
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_filesystem
-#error __cpp_lib_filesystem is not defined
-#elif __cpp_lib_filesystem != 201703L
-#error __cpp_lib_filesystem is not 201703L
-#else
 STATIC_ASSERT(__cpp_lib_filesystem == 201703L);
-#endif
-#else
-#ifdef __cpp_lib_filesystem
+#elif defined(__cpp_lib_filesystem)
 #error __cpp_lib_filesystem is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
@@ -891,1637 +370,635 @@ STATIC_ASSERT(__cpp_lib_flat_set == 202207L);
 #endif
 
 #ifdef __cpp_lib_concepts
-#ifndef __cpp_lib_format
-#error __cpp_lib_format is not defined
-#elif __cpp_lib_format != 202207L
-#error __cpp_lib_format is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_format == 202207L);
-#endif
-#else
-#ifdef __cpp_lib_format
+#elif defined(__cpp_lib_format)
 #error __cpp_lib_format is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_formatters
-#error __cpp_lib_formatters is not defined
-#elif __cpp_lib_formatters != 202302L
-#error __cpp_lib_formatters is not 202302L
-#else
 STATIC_ASSERT(__cpp_lib_formatters == 202302L);
-#endif
-#else
-#ifdef __cpp_lib_formatters
+#elif defined(__cpp_lib_formatters)
 #error __cpp_lib_formatters is defined
 #endif
-#endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_forward_like
-#error __cpp_lib_forward_like is not defined
-#elif __cpp_lib_forward_like != 202207L
-#error __cpp_lib_forward_like is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_forward_like == 202207L);
-#endif
-#else
-#ifdef __cpp_lib_forward_like
+#elif defined(__cpp_lib_forward_like)
 #error __cpp_lib_forward_like is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_freestanding_char_traits
-#error __cpp_lib_freestanding_char_traits is not defined
-#elif __cpp_lib_freestanding_char_traits != 202306L
-#error __cpp_lib_freestanding_char_traits is not 202306L
-#else
 STATIC_ASSERT(__cpp_lib_freestanding_char_traits == 202306L);
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_freestanding_charconv
-#error __cpp_lib_freestanding_charconv is not defined
-#elif __cpp_lib_freestanding_charconv != 202306L
-#error __cpp_lib_freestanding_charconv is not 202306L
-#else
 STATIC_ASSERT(__cpp_lib_freestanding_charconv == 202306L);
-#endif
-#else
-#ifdef __cpp_lib_freestanding_charconv
+#elif defined(__cpp_lib_freestanding_charconv)
 #error __cpp_lib_freestanding_charconv is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_freestanding_cstdlib
-#error __cpp_lib_freestanding_cstdlib is not defined
-#elif __cpp_lib_freestanding_cstdlib != 202306L
-#error __cpp_lib_freestanding_cstdlib is not 202306L
-#else
 STATIC_ASSERT(__cpp_lib_freestanding_cstdlib == 202306L);
-#endif
 
-#ifndef __cpp_lib_freestanding_cstring
-#error __cpp_lib_freestanding_cstring is not defined
-#elif __cpp_lib_freestanding_cstring != 202306L
-#error __cpp_lib_freestanding_cstring is not 202306L
-#else
 STATIC_ASSERT(__cpp_lib_freestanding_cstring == 202306L);
-#endif
 
-#ifndef __cpp_lib_freestanding_cwchar
-#error __cpp_lib_freestanding_cwchar is not defined
-#elif __cpp_lib_freestanding_cwchar != 202306L
-#error __cpp_lib_freestanding_cwchar is not 202306L
-#else
 STATIC_ASSERT(__cpp_lib_freestanding_cwchar == 202306L);
-#endif
 
-#ifndef __cpp_lib_freestanding_errc
-#error __cpp_lib_freestanding_errc is not defined
-#elif __cpp_lib_freestanding_errc != 202306L
-#error __cpp_lib_freestanding_errc is not 202306L
-#else
 STATIC_ASSERT(__cpp_lib_freestanding_errc == 202306L);
-#endif
 
-#ifndef __cpp_lib_freestanding_feature_test_macros
-#error __cpp_lib_freestanding_feature_test_macros is not defined
-#elif __cpp_lib_freestanding_feature_test_macros != 202306L
-#error __cpp_lib_freestanding_feature_test_macros is not 202306L
-#else
 STATIC_ASSERT(__cpp_lib_freestanding_feature_test_macros == 202306L);
-#endif
 
-#ifndef __cpp_lib_freestanding_functional
-#error __cpp_lib_freestanding_functional is not defined
-#elif __cpp_lib_freestanding_functional != 202306L
-#error __cpp_lib_freestanding_functional is not 202306L
-#else
 STATIC_ASSERT(__cpp_lib_freestanding_functional == 202306L);
-#endif
 
-#ifndef __cpp_lib_freestanding_iterator
-#error __cpp_lib_freestanding_iterator is not defined
-#elif __cpp_lib_freestanding_iterator != 202306L
-#error __cpp_lib_freestanding_iterator is not 202306L
-#else
 STATIC_ASSERT(__cpp_lib_freestanding_iterator == 202306L);
-#endif
 
-#ifndef __cpp_lib_freestanding_memory
-#error __cpp_lib_freestanding_memory is not defined
-#elif __cpp_lib_freestanding_memory != 202306L
-#error __cpp_lib_freestanding_memory is not 202306L
-#else
 STATIC_ASSERT(__cpp_lib_freestanding_memory == 202306L);
-#endif
 
-#ifndef __cpp_lib_freestanding_operator_new
-#error __cpp_lib_freestanding_operator_new is not defined
-#elif __cpp_lib_freestanding_operator_new != 202306L
-#error __cpp_lib_freestanding_operator_new is not 202306L
-#else
 STATIC_ASSERT(__cpp_lib_freestanding_operator_new == 202306L);
-#endif
 
 #ifdef __cpp_lib_concepts
-#ifndef __cpp_lib_freestanding_ranges
-#error __cpp_lib_freestanding_ranges is not defined
-#elif __cpp_lib_freestanding_ranges != 202306L
-#error __cpp_lib_freestanding_ranges is not 202306L
-#else
 STATIC_ASSERT(__cpp_lib_freestanding_ranges == 202306L);
-#endif
-#else
-#ifdef __cpp_lib_freestanding_ranges
+#elif defined(__cpp_lib_freestanding_ranges)
 #error __cpp_lib_freestanding_ranges is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_freestanding_ratio
-#error __cpp_lib_freestanding_ratio is not defined
-#elif __cpp_lib_freestanding_ratio != 202306L
-#error __cpp_lib_freestanding_ratio is not 202306L
-#else
 STATIC_ASSERT(__cpp_lib_freestanding_ratio == 202306L);
-#endif
 
-#ifndef __cpp_lib_freestanding_tuple
-#error __cpp_lib_freestanding_tuple is not defined
-#elif __cpp_lib_freestanding_tuple != 202306L
-#error __cpp_lib_freestanding_tuple is not 202306L
-#else
 STATIC_ASSERT(__cpp_lib_freestanding_tuple == 202306L);
-#endif
 
-#ifndef __cpp_lib_freestanding_utility
-#error __cpp_lib_freestanding_utility is not defined
-#elif __cpp_lib_freestanding_utility != 202306L
-#error __cpp_lib_freestanding_utility is not 202306L
-#else
 STATIC_ASSERT(__cpp_lib_freestanding_utility == 202306L);
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_gcd_lcm
-#error __cpp_lib_gcd_lcm is not defined
-#elif __cpp_lib_gcd_lcm != 201606L
-#error __cpp_lib_gcd_lcm is not 201606L
-#else
 STATIC_ASSERT(__cpp_lib_gcd_lcm == 201606L);
-#endif
-#else
-#ifdef __cpp_lib_gcd_lcm
+#elif defined(__cpp_lib_gcd_lcm)
 #error __cpp_lib_gcd_lcm is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_generic_associative_lookup
-#error __cpp_lib_generic_associative_lookup is not defined
-#elif __cpp_lib_generic_associative_lookup != 201304L
-#error __cpp_lib_generic_associative_lookup is not 201304L
-#else
 STATIC_ASSERT(__cpp_lib_generic_associative_lookup == 201304L);
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_generic_unordered_lookup
-#error __cpp_lib_generic_unordered_lookup is not defined
-#elif __cpp_lib_generic_unordered_lookup != 201811L
-#error __cpp_lib_generic_unordered_lookup is not 201811L
-#else
 STATIC_ASSERT(__cpp_lib_generic_unordered_lookup == 201811L);
-#endif
-#else
-#ifdef __cpp_lib_generic_unordered_lookup
+#elif defined(__cpp_lib_generic_unordered_lookup)
 #error __cpp_lib_generic_unordered_lookup is defined
 #endif
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_hardware_interference_size
-#error __cpp_lib_hardware_interference_size is not defined
-#elif __cpp_lib_hardware_interference_size != 201703L
-#error __cpp_lib_hardware_interference_size is not 201703L
-#else
 STATIC_ASSERT(__cpp_lib_hardware_interference_size == 201703L);
-#endif
-#else
-#ifdef __cpp_lib_hardware_interference_size
+#elif defined(__cpp_lib_hardware_interference_size)
 #error __cpp_lib_hardware_interference_size is defined
 #endif
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_has_unique_object_representations
-#error __cpp_lib_has_unique_object_representations is not defined
-#elif __cpp_lib_has_unique_object_representations != 201606L
-#error __cpp_lib_has_unique_object_representations is not 201606L
-#else
 STATIC_ASSERT(__cpp_lib_has_unique_object_representations == 201606L);
-#endif
-#else
-#ifdef __cpp_lib_has_unique_object_representations
+#elif defined(__cpp_lib_has_unique_object_representations)
 #error __cpp_lib_has_unique_object_representations is defined
 #endif
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_hypot
-#error __cpp_lib_hypot is not defined
-#elif __cpp_lib_hypot != 201603L
-#error __cpp_lib_hypot is not 201603L
-#else
 STATIC_ASSERT(__cpp_lib_hypot == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_hypot
+#elif defined(__cpp_lib_hypot)
 #error __cpp_lib_hypot is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_incomplete_container_elements
-#error __cpp_lib_incomplete_container_elements is not defined
-#elif __cpp_lib_incomplete_container_elements != 201505L
-#error __cpp_lib_incomplete_container_elements is not 201505L
-#else
 STATIC_ASSERT(__cpp_lib_incomplete_container_elements == 201505L);
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_int_pow2
-#error __cpp_lib_int_pow2 is not defined
-#elif __cpp_lib_int_pow2 != 202002L
-#error __cpp_lib_int_pow2 is not 202002L
-#else
 STATIC_ASSERT(__cpp_lib_int_pow2 == 202002L);
-#endif
-#else
-#ifdef __cpp_lib_int_pow2
+#elif defined(__cpp_lib_int_pow2)
 #error __cpp_lib_int_pow2 is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_integer_comparison_functions
-#error __cpp_lib_integer_comparison_functions is not defined
-#elif __cpp_lib_integer_comparison_functions != 202002L
-#error __cpp_lib_integer_comparison_functions is not 202002L
-#else
 STATIC_ASSERT(__cpp_lib_integer_comparison_functions == 202002L);
-#endif
-#else
-#ifdef __cpp_lib_integer_comparison_functions
+#elif defined(__cpp_lib_integer_comparison_functions)
 #error __cpp_lib_integer_comparison_functions is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_integer_sequence
-#error __cpp_lib_integer_sequence is not defined
-#elif __cpp_lib_integer_sequence != 201304L
-#error __cpp_lib_integer_sequence is not 201304L
-#else
 STATIC_ASSERT(__cpp_lib_integer_sequence == 201304L);
-#endif
 
-#ifndef __cpp_lib_integral_constant_callable
-#error __cpp_lib_integral_constant_callable is not defined
-#elif __cpp_lib_integral_constant_callable != 201304L
-#error __cpp_lib_integral_constant_callable is not 201304L
-#else
 STATIC_ASSERT(__cpp_lib_integral_constant_callable == 201304L);
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_interpolate
-#error __cpp_lib_interpolate is not defined
-#elif __cpp_lib_interpolate != 201902L
-#error __cpp_lib_interpolate is not 201902L
-#else
 STATIC_ASSERT(__cpp_lib_interpolate == 201902L);
-#endif
-#else
-#ifdef __cpp_lib_interpolate
+#elif defined(__cpp_lib_interpolate)
 #error __cpp_lib_interpolate is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_invoke
-#error __cpp_lib_invoke is not defined
-#elif __cpp_lib_invoke != 201411L
-#error __cpp_lib_invoke is not 201411L
-#else
 STATIC_ASSERT(__cpp_lib_invoke == 201411L);
-#endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_invoke_r
-#error __cpp_lib_invoke_r is not defined
-#elif __cpp_lib_invoke_r != 202106L
-#error __cpp_lib_invoke_r is not 202106L
-#else
 STATIC_ASSERT(__cpp_lib_invoke_r == 202106L);
-#endif
-#else
-#ifdef __cpp_lib_invoke_r
+#elif defined(__cpp_lib_invoke_r)
 #error __cpp_lib_invoke_r is defined
 #endif
-#endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_ios_noreplace
-#error __cpp_lib_ios_noreplace is not defined
-#elif __cpp_lib_ios_noreplace != 202207L
-#error __cpp_lib_ios_noreplace is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_ios_noreplace == 202207L);
-#endif
-#else
-#ifdef __cpp_lib_ios_noreplace
+#elif defined(__cpp_lib_ios_noreplace)
 #error __cpp_lib_ios_noreplace is defined
 #endif
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_is_aggregate
-#error __cpp_lib_is_aggregate is not defined
-#elif __cpp_lib_is_aggregate != 201703L
-#error __cpp_lib_is_aggregate is not 201703L
-#else
 STATIC_ASSERT(__cpp_lib_is_aggregate == 201703L);
-#endif
-#else
-#ifdef __cpp_lib_is_aggregate
+#elif defined(__cpp_lib_is_aggregate)
 #error __cpp_lib_is_aggregate is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_is_constant_evaluated
-#error __cpp_lib_is_constant_evaluated is not defined
-#elif __cpp_lib_is_constant_evaluated != 201811L
-#error __cpp_lib_is_constant_evaluated is not 201811L
-#else
 STATIC_ASSERT(__cpp_lib_is_constant_evaluated == 201811L);
-#endif
-#else
-#ifdef __cpp_lib_is_constant_evaluated
+#elif defined(__cpp_lib_is_constant_evaluated)
 #error __cpp_lib_is_constant_evaluated is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_is_final
-#error __cpp_lib_is_final is not defined
-#elif __cpp_lib_is_final != 201402L
-#error __cpp_lib_is_final is not 201402L
-#else
 STATIC_ASSERT(__cpp_lib_is_final == 201402L);
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_is_invocable
-#error __cpp_lib_is_invocable is not defined
-#elif __cpp_lib_is_invocable != 201703L
-#error __cpp_lib_is_invocable is not 201703L
-#else
 STATIC_ASSERT(__cpp_lib_is_invocable == 201703L);
-#endif
-#else
-#ifdef __cpp_lib_is_invocable
+#elif defined(__cpp_lib_is_invocable)
 #error __cpp_lib_is_invocable is defined
 #endif
-#endif
 
-#if _HAS_CXX20
-#ifndef __clang__ // TRANSITION, LLVM-48860
-#ifndef __cpp_lib_is_layout_compatible
-#error __cpp_lib_is_layout_compatible is not defined
-#elif __cpp_lib_is_layout_compatible != 201907L
-#error __cpp_lib_is_layout_compatible is not 201907L
-#else
+#if _HAS_CXX20 && !defined(__clang__) // TRANSITION, LLVM-48860
 STATIC_ASSERT(__cpp_lib_is_layout_compatible == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_is_layout_compatible
+#elif defined(__cpp_lib_is_layout_compatible)
 #error __cpp_lib_is_layout_compatible is defined
 #endif
-#endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_is_nothrow_convertible
-#error __cpp_lib_is_nothrow_convertible is not defined
-#elif __cpp_lib_is_nothrow_convertible != 201806L
-#error __cpp_lib_is_nothrow_convertible is not 201806L
-#else
 STATIC_ASSERT(__cpp_lib_is_nothrow_convertible == 201806L);
-#endif
-#else
-#ifdef __cpp_lib_is_nothrow_convertible
+#elif defined(__cpp_lib_is_nothrow_convertible)
 #error __cpp_lib_is_nothrow_convertible is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_is_null_pointer
-#error __cpp_lib_is_null_pointer is not defined
-#elif __cpp_lib_is_null_pointer != 201309L
-#error __cpp_lib_is_null_pointer is not 201309L
-#else
 STATIC_ASSERT(__cpp_lib_is_null_pointer == 201309L);
-#endif
 
-#if _HAS_CXX20
-#ifndef __clang__ // TRANSITION, LLVM-48860
-#ifndef __cpp_lib_is_pointer_interconvertible
-#error __cpp_lib_is_pointer_interconvertible is not defined
-#elif __cpp_lib_is_pointer_interconvertible != 201907L
-#error __cpp_lib_is_pointer_interconvertible is not 201907L
-#else
+#if _HAS_CXX20 && !defined(__clang__) // TRANSITION, LLVM-48860
 STATIC_ASSERT(__cpp_lib_is_pointer_interconvertible == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_is_pointer_interconvertible
+#elif defined(__cpp_lib_is_pointer_interconvertible)
 #error __cpp_lib_is_pointer_interconvertible is defined
-#endif
-#endif
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_is_scoped_enum
-#error __cpp_lib_is_scoped_enum is not defined
-#elif __cpp_lib_is_scoped_enum != 202011L
-#error __cpp_lib_is_scoped_enum is not 202011L
-#else
 STATIC_ASSERT(__cpp_lib_is_scoped_enum == 202011L);
-#endif
-#else
-#ifdef __cpp_lib_is_scoped_enum
+#elif defined(__cpp_lib_is_scoped_enum)
 #error __cpp_lib_is_scoped_enum is defined
 #endif
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_is_swappable
-#error __cpp_lib_is_swappable is not defined
-#elif __cpp_lib_is_swappable != 201603L
-#error __cpp_lib_is_swappable is not 201603L
-#else
 STATIC_ASSERT(__cpp_lib_is_swappable == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_is_swappable
+#elif defined(__cpp_lib_is_swappable)
 #error __cpp_lib_is_swappable is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_jthread
-#error __cpp_lib_jthread is not defined
-#elif __cpp_lib_jthread != 201911L
-#error __cpp_lib_jthread is not 201911L
-#else
 STATIC_ASSERT(__cpp_lib_jthread == 201911L);
-#endif
-#else
-#ifdef __cpp_lib_jthread
+#elif defined(__cpp_lib_jthread)
 #error __cpp_lib_jthread is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_latch
-#error __cpp_lib_latch is not defined
-#elif __cpp_lib_latch != 201907L
-#error __cpp_lib_latch is not 201907L
-#else
 STATIC_ASSERT(__cpp_lib_latch == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_latch
+#elif defined(__cpp_lib_latch)
 #error __cpp_lib_latch is defined
 #endif
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_launder
-#error __cpp_lib_launder is not defined
-#elif __cpp_lib_launder != 201606L
-#error __cpp_lib_launder is not 201606L
-#else
 STATIC_ASSERT(__cpp_lib_launder == 201606L);
-#endif
-#else
-#ifdef __cpp_lib_launder
+#elif defined(__cpp_lib_launder)
 #error __cpp_lib_launder is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_list_remove_return_type
-#error __cpp_lib_list_remove_return_type is not defined
-#elif __cpp_lib_list_remove_return_type != 201806L
-#error __cpp_lib_list_remove_return_type is not 201806L
-#else
 STATIC_ASSERT(__cpp_lib_list_remove_return_type == 201806L);
-#endif
-#else
-#ifdef __cpp_lib_list_remove_return_type
+#elif defined(__cpp_lib_list_remove_return_type)
 #error __cpp_lib_list_remove_return_type is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_logical_traits
-#error __cpp_lib_logical_traits is not defined
-#elif __cpp_lib_logical_traits != 201510L
-#error __cpp_lib_logical_traits is not 201510L
-#else
 STATIC_ASSERT(__cpp_lib_logical_traits == 201510L);
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_make_from_tuple
-#error __cpp_lib_make_from_tuple is not defined
-#elif __cpp_lib_make_from_tuple != 201606L
-#error __cpp_lib_make_from_tuple is not 201606L
-#else
 STATIC_ASSERT(__cpp_lib_make_from_tuple == 201606L);
-#endif
-#else
-#ifdef __cpp_lib_make_from_tuple
+#elif defined(__cpp_lib_make_from_tuple)
 #error __cpp_lib_make_from_tuple is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_make_reverse_iterator
-#error __cpp_lib_make_reverse_iterator is not defined
-#elif __cpp_lib_make_reverse_iterator != 201402L
-#error __cpp_lib_make_reverse_iterator is not 201402L
-#else
 STATIC_ASSERT(__cpp_lib_make_reverse_iterator == 201402L);
-#endif
 
-#ifndef __cpp_lib_make_unique
-#error __cpp_lib_make_unique is not defined
-#elif __cpp_lib_make_unique != 201304L
-#error __cpp_lib_make_unique is not 201304L
-#else
 STATIC_ASSERT(__cpp_lib_make_unique == 201304L);
-#endif
 
-#ifndef __cpp_lib_map_try_emplace
-#error __cpp_lib_map_try_emplace is not defined
-#elif __cpp_lib_map_try_emplace != 201411L
-#error __cpp_lib_map_try_emplace is not 201411L
-#else
 STATIC_ASSERT(__cpp_lib_map_try_emplace == 201411L);
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_math_constants
-#error __cpp_lib_math_constants is not defined
-#elif __cpp_lib_math_constants != 201907L
-#error __cpp_lib_math_constants is not 201907L
-#else
 STATIC_ASSERT(__cpp_lib_math_constants == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_math_constants
+#elif defined(__cpp_lib_math_constants)
 #error __cpp_lib_math_constants is defined
-#endif
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_math_special_functions
-#error __cpp_lib_math_special_functions is not defined
-#elif __cpp_lib_math_special_functions != 201603L
-#error __cpp_lib_math_special_functions is not 201603L
-#else
 STATIC_ASSERT(__cpp_lib_math_special_functions == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_math_special_functions
+#elif defined(__cpp_lib_math_special_functions)
 #error __cpp_lib_math_special_functions is defined
-#endif
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_mdspan
-#error __cpp_lib_mdspan is not defined
-#elif __cpp_lib_mdspan != 202207L
-#error __cpp_lib_mdspan is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_mdspan == 202207L);
-#endif
-#else
-#ifdef __cpp_lib_mdspan
+#elif defined(__cpp_lib_mdspan)
 #error __cpp_lib_mdspan is defined
-#endif
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_memory_resource
-#error __cpp_lib_memory_resource is not defined
-#elif __cpp_lib_memory_resource != 201603L
-#error __cpp_lib_memory_resource is not 201603L
-#else
 STATIC_ASSERT(__cpp_lib_memory_resource == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_memory_resource
+#elif defined(__cpp_lib_memory_resource)
 #error __cpp_lib_memory_resource is defined
-#endif
 #endif
 
 #if _HAS_CXX20 && !defined(__clang__) && !defined(__EDG__) // TRANSITION, Clang and EDG support for modules
-#ifndef __cpp_lib_modules
-#error __cpp_lib_modules is not defined
-#elif __cpp_lib_modules != 202207L
-#error __cpp_lib_modules is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_modules == 202207L);
-#endif
-#else
-#ifdef __cpp_lib_modules
+#elif defined(__cpp_lib_modules)
 #error __cpp_lib_modules is defined
-#endif
 #endif
 
 #ifdef __cpp_lib_concepts
-#ifndef __cpp_lib_move_iterator_concept
-#error __cpp_lib_move_iterator_concept is not defined
-#elif __cpp_lib_move_iterator_concept != 202207L
-#error __cpp_lib_move_iterator_concept is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_move_iterator_concept == 202207L);
-#endif
-#else
-#ifdef __cpp_lib_move_iterator_concept
+#elif defined(__cpp_lib_move_iterator_concept)
 #error __cpp_lib_move_iterator_concept is defined
-#endif
 #endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_move_only_function
-#error __cpp_lib_move_only_function is not defined
-#elif __cpp_lib_move_only_function != 202110L
-#error __cpp_lib_move_only_function is not 202110L
-#else
 STATIC_ASSERT(__cpp_lib_move_only_function == 202110L);
-#endif
-#else
-#ifdef __cpp_lib_move_only_function
+#elif defined(__cpp_lib_move_only_function)
 #error __cpp_lib_move_only_function is defined
 #endif
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_node_extract
-#error __cpp_lib_node_extract is not defined
-#elif __cpp_lib_node_extract != 201606L
-#error __cpp_lib_node_extract is not 201606L
-#else
 STATIC_ASSERT(__cpp_lib_node_extract == 201606L);
-#endif
-#else
-#ifdef __cpp_lib_node_extract
+#elif defined(__cpp_lib_node_extract)
 #error __cpp_lib_node_extract is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_nonmember_container_access
-#error __cpp_lib_nonmember_container_access is not defined
-#elif __cpp_lib_nonmember_container_access != 201411L
-#error __cpp_lib_nonmember_container_access is not 201411L
-#else
 STATIC_ASSERT(__cpp_lib_nonmember_container_access == 201411L);
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_not_fn
-#error __cpp_lib_not_fn is not defined
-#elif __cpp_lib_not_fn != 201603L
-#error __cpp_lib_not_fn is not 201603L
-#else
 STATIC_ASSERT(__cpp_lib_not_fn == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_not_fn
+#elif defined(__cpp_lib_not_fn)
 #error __cpp_lib_not_fn is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_null_iterators
-#error __cpp_lib_null_iterators is not defined
-#elif __cpp_lib_null_iterators != 201304L
-#error __cpp_lib_null_iterators is not 201304L
-#else
 STATIC_ASSERT(__cpp_lib_null_iterators == 201304L);
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_optional
-#error __cpp_lib_optional is not defined
-#elif __cpp_lib_optional != 202110L
-#error __cpp_lib_optional is not 202110L
-#else
 STATIC_ASSERT(__cpp_lib_optional == 202110L);
-#endif
 #elif _HAS_CXX20
-#ifndef __cpp_lib_optional
-#error __cpp_lib_optional is not defined
-#elif __cpp_lib_optional != 202106L
-#error __cpp_lib_optional is not 202106L
-#else
 STATIC_ASSERT(__cpp_lib_optional == 202106L);
-#endif
 #elif _HAS_CXX17
-#ifndef __cpp_lib_optional
-#error __cpp_lib_optional is not defined
-#elif __cpp_lib_optional != 201606L
-#error __cpp_lib_optional is not 201606L
-#else
 STATIC_ASSERT(__cpp_lib_optional == 201606L);
-#endif
-#else
-#ifdef __cpp_lib_optional
+#elif defined(__cpp_lib_optional)
 #error __cpp_lib_optional is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_out_ptr
-#error __cpp_lib_out_ptr is not defined
-#elif __cpp_lib_out_ptr != 202106L
-#error __cpp_lib_out_ptr is not 202106L
-#else
 STATIC_ASSERT(__cpp_lib_out_ptr == 202106L);
-#endif
-#else
-#ifdef __cpp_lib_out_ptr
+#elif defined(__cpp_lib_out_ptr)
 #error __cpp_lib_out_ptr is defined
-#endif
 #endif
 
 #if _HAS_CXX17 && !defined(_M_CEE_PURE)
-#ifndef __cpp_lib_parallel_algorithm
-#error __cpp_lib_parallel_algorithm is not defined
-#elif __cpp_lib_parallel_algorithm != 201603L
-#error __cpp_lib_parallel_algorithm is not 201603L
-#else
 STATIC_ASSERT(__cpp_lib_parallel_algorithm == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_parallel_algorithm
+#elif defined(__cpp_lib_parallel_algorithm)
 #error __cpp_lib_parallel_algorithm is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_polymorphic_allocator
-#error __cpp_lib_polymorphic_allocator is not defined
-#elif __cpp_lib_polymorphic_allocator != 201902L
-#error __cpp_lib_polymorphic_allocator is not 201902L
-#else
 STATIC_ASSERT(__cpp_lib_polymorphic_allocator == 201902L);
-#endif
-#else
-#ifdef __cpp_lib_polymorphic_allocator
+#elif defined(__cpp_lib_polymorphic_allocator)
 #error __cpp_lib_polymorphic_allocator is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_print
-#error __cpp_lib_print is not defined
-#elif __cpp_lib_print != 202207L
-#error __cpp_lib_print is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_print == 202207L);
-#endif
-#else
-#ifdef __cpp_lib_print
+#elif defined(__cpp_lib_print)
 #error __cpp_lib_print is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_quoted_string_io
-#error __cpp_lib_quoted_string_io is not defined
-#elif __cpp_lib_quoted_string_io != 201304L
-#error __cpp_lib_quoted_string_io is not 201304L
-#else
 STATIC_ASSERT(__cpp_lib_quoted_string_io == 201304L);
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges
-#error __cpp_lib_ranges is not defined
-#elif __cpp_lib_ranges != 202302L
-#error __cpp_lib_ranges is not 202302L
-#else
 STATIC_ASSERT(__cpp_lib_ranges == 202302L);
-#endif
 #elif _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges
-#error __cpp_lib_ranges is not defined
-#elif __cpp_lib_ranges != 202110L
-#error __cpp_lib_ranges is not 202110L
-#else
 STATIC_ASSERT(__cpp_lib_ranges == 202110L);
-#endif
-#else
-#ifdef __cpp_lib_ranges
+#elif defined(__cpp_lib_ranges)
 #error __cpp_lib_ranges is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_as_const
-#error __cpp_lib_ranges_as_const is not defined
-#elif __cpp_lib_ranges_as_const != 202207L
-#error __cpp_lib_ranges_as_const is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_ranges_as_const == 202207L);
-#endif
-#else
-#ifdef __cpp_lib_ranges_as_const
+#elif defined(__cpp_lib_ranges_as_const)
 #error __cpp_lib_ranges_as_const is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_as_rvalue
-#error __cpp_lib_ranges_as_rvalue is not defined
-#elif __cpp_lib_ranges_as_rvalue != 202207L
-#error __cpp_lib_ranges_as_rvalue is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_ranges_as_rvalue == 202207L);
-#endif
-#else
-#ifdef __cpp_lib_ranges_as_rvalue
+#elif defined(__cpp_lib_ranges_as_rvalue)
 #error __cpp_lib_ranges_as_rvalue is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_cartesian_product
-#error __cpp_lib_ranges_cartesian_product is not defined
-#elif __cpp_lib_ranges_cartesian_product != 202207L
-#error __cpp_lib_ranges_cartesian_product is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_ranges_cartesian_product == 202207L);
-#endif
-#else
-#ifdef __cpp_lib_ranges_cartesian_product
+#elif defined(__cpp_lib_ranges_cartesian_product)
 #error __cpp_lib_ranges_cartesian_product is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_chunk
-#error __cpp_lib_ranges_chunk is not defined
-#elif __cpp_lib_ranges_chunk != 202202L
-#error __cpp_lib_ranges_chunk is not 202202L
-#else
 STATIC_ASSERT(__cpp_lib_ranges_chunk == 202202L);
-#endif
-#else
-#ifdef __cpp_lib_ranges_chunk
+#elif defined(__cpp_lib_ranges_chunk)
 #error __cpp_lib_ranges_chunk is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_chunk_by
-#error __cpp_lib_ranges_chunk_by is not defined
-#elif __cpp_lib_ranges_chunk_by != 202202L
-#error __cpp_lib_ranges_chunk_by is not 202202L
-#else
 STATIC_ASSERT(__cpp_lib_ranges_chunk_by == 202202L);
-#endif
-#else
-#ifdef __cpp_lib_ranges_chunk_by
+#elif defined(__cpp_lib_ranges_chunk_by)
 #error __cpp_lib_ranges_chunk_by is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_contains
-#error __cpp_lib_ranges_contains is not defined
-#elif __cpp_lib_ranges_contains != 202207L
-#error __cpp_lib_ranges_contains is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_ranges_contains == 202207L);
-#endif
-#else
-#ifdef __cpp_lib_ranges_contains
+#elif defined(__cpp_lib_ranges_contains)
 #error __cpp_lib_ranges_contains is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_enumerate
-#error __cpp_lib_ranges_enumerate is not defined
-#elif __cpp_lib_ranges_enumerate != 202302L
-#error __cpp_lib_ranges_enumerate is not 202302L
-#else
 STATIC_ASSERT(__cpp_lib_ranges_enumerate == 202302L);
-#endif
-#else
-#ifdef __cpp_lib_ranges_enumerate
+#elif defined(__cpp_lib_ranges_enumerate)
 #error __cpp_lib_ranges_enumerate is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_find_last
-#error __cpp_lib_ranges_find_last is not defined
-#elif __cpp_lib_ranges_find_last != 202207L
-#error __cpp_lib_ranges_find_last is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_ranges_find_last == 202207L);
-#endif
-#else
-#ifdef __cpp_lib_ranges_find_last
+#elif defined(__cpp_lib_ranges_find_last)
 #error __cpp_lib_ranges_find_last is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_fold
-#error __cpp_lib_ranges_fold is not defined
-#elif __cpp_lib_ranges_fold != 202207L
-#error __cpp_lib_ranges_fold is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_ranges_fold == 202207L);
-#endif
-#else
-#ifdef __cpp_lib_ranges_fold
+#elif defined(__cpp_lib_ranges_fold)
 #error __cpp_lib_ranges_fold is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_iota
-#error __cpp_lib_ranges_iota is not defined
-#elif __cpp_lib_ranges_iota != 202202L
-#error __cpp_lib_ranges_iota is not 202202L
-#else
 STATIC_ASSERT(__cpp_lib_ranges_iota == 202202L);
-#endif
-#else
-#ifdef __cpp_lib_ranges_iota
+#elif defined(__cpp_lib_ranges_iota)
 #error __cpp_lib_ranges_iota is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_join_with
-#error __cpp_lib_ranges_join_with is not defined
-#elif __cpp_lib_ranges_join_with != 202202L
-#error __cpp_lib_ranges_join_with is not 202202L
-#else
 STATIC_ASSERT(__cpp_lib_ranges_join_with == 202202L);
-#endif
-#else
-#ifdef __cpp_lib_ranges_join_with
+#elif defined(__cpp_lib_ranges_join_with)
 #error __cpp_lib_ranges_join_with is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_repeat
-#error __cpp_lib_ranges_repeat is not defined
-#elif __cpp_lib_ranges_repeat != 202207L
-#error __cpp_lib_ranges_repeat is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_ranges_repeat == 202207L);
-#endif
-#else
-#ifdef __cpp_lib_ranges_repeat
+#elif defined(__cpp_lib_ranges_repeat)
 #error __cpp_lib_ranges_repeat is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_slide
-#error __cpp_lib_ranges_slide is not defined
-#elif __cpp_lib_ranges_slide != 202202L
-#error __cpp_lib_ranges_slide is not 202202L
-#else
 STATIC_ASSERT(__cpp_lib_ranges_slide == 202202L);
-#endif
-#else
-#ifdef __cpp_lib_ranges_slide
+#elif defined(__cpp_lib_ranges_slide)
 #error __cpp_lib_ranges_slide is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_starts_ends_with
-#error __cpp_lib_ranges_starts_ends_with is not defined
-#elif __cpp_lib_ranges_starts_ends_with != 202106L
-#error __cpp_lib_ranges_starts_ends_with is not 202106L
-#else
 STATIC_ASSERT(__cpp_lib_ranges_starts_ends_with == 202106L);
-#endif
-#else
-#ifdef __cpp_lib_ranges_starts_ends_with
+#elif defined(__cpp_lib_ranges_starts_ends_with)
 #error __cpp_lib_ranges_starts_ends_with is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_stride
-#error __cpp_lib_ranges_stride is not defined
-#elif __cpp_lib_ranges_stride != 202207L
-#error __cpp_lib_ranges_stride is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_ranges_stride == 202207L);
-#endif
-#else
-#ifdef __cpp_lib_ranges_stride
+#elif defined(__cpp_lib_ranges_stride)
 #error __cpp_lib_ranges_stride is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_to_container
-#error __cpp_lib_ranges_to_container is not defined
-#elif __cpp_lib_ranges_to_container != 202202L
-#error __cpp_lib_ranges_to_container is not 202202L
-#else
 STATIC_ASSERT(__cpp_lib_ranges_to_container == 202202L);
-#endif
-#else
-#ifdef __cpp_lib_ranges_to_container
+#elif defined(__cpp_lib_ranges_to_container)
 #error __cpp_lib_ranges_to_container is defined
 #endif
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_zip
-#error __cpp_lib_ranges_zip is not defined
-#elif __cpp_lib_ranges_zip != 202110L
-#error __cpp_lib_ranges_zip is not 202110L
-#else
 STATIC_ASSERT(__cpp_lib_ranges_zip == 202110L);
-#endif
-#else
-#ifdef __cpp_lib_ranges_zip
+#elif defined(__cpp_lib_ranges_zip)
 #error __cpp_lib_ranges_zip is defined
 #endif
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_raw_memory_algorithms
-#error __cpp_lib_raw_memory_algorithms is not defined
-#elif __cpp_lib_raw_memory_algorithms != 201606L
-#error __cpp_lib_raw_memory_algorithms is not 201606L
-#else
 STATIC_ASSERT(__cpp_lib_raw_memory_algorithms == 201606L);
-#endif
-#else
-#ifdef __cpp_lib_raw_memory_algorithms
+#elif defined(__cpp_lib_raw_memory_algorithms)
 #error __cpp_lib_raw_memory_algorithms is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_remove_cvref
-#error __cpp_lib_remove_cvref is not defined
-#elif __cpp_lib_remove_cvref != 201711L
-#error __cpp_lib_remove_cvref is not 201711L
-#else
 STATIC_ASSERT(__cpp_lib_remove_cvref == 201711L);
-#endif
-#else
-#ifdef __cpp_lib_remove_cvref
+#elif defined(__cpp_lib_remove_cvref)
 #error __cpp_lib_remove_cvref is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_result_of_sfinae
-#error __cpp_lib_result_of_sfinae is not defined
-#elif __cpp_lib_result_of_sfinae != 201210L
-#error __cpp_lib_result_of_sfinae is not 201210L
-#else
 STATIC_ASSERT(__cpp_lib_result_of_sfinae == 201210L);
-#endif
 
-#ifndef __cpp_lib_robust_nonmodifying_seq_ops
-#error __cpp_lib_robust_nonmodifying_seq_ops is not defined
-#elif __cpp_lib_robust_nonmodifying_seq_ops != 201304L
-#error __cpp_lib_robust_nonmodifying_seq_ops is not 201304L
-#else
 STATIC_ASSERT(__cpp_lib_robust_nonmodifying_seq_ops == 201304L);
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_sample
-#error __cpp_lib_sample is not defined
-#elif __cpp_lib_sample != 201603L
-#error __cpp_lib_sample is not 201603L
-#else
 STATIC_ASSERT(__cpp_lib_sample == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_sample
+#elif defined(__cpp_lib_sample)
 #error __cpp_lib_sample is defined
 #endif
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_scoped_lock
-#error __cpp_lib_scoped_lock is not defined
-#elif __cpp_lib_scoped_lock != 201703L
-#error __cpp_lib_scoped_lock is not 201703L
-#else
 STATIC_ASSERT(__cpp_lib_scoped_lock == 201703L);
-#endif
-#else
-#ifdef __cpp_lib_scoped_lock
+#elif defined(__cpp_lib_scoped_lock)
 #error __cpp_lib_scoped_lock is defined
-#endif
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_semaphore
-#error __cpp_lib_semaphore is not defined
-#elif __cpp_lib_semaphore != 201907L
-#error __cpp_lib_semaphore is not 201907L
-#else
 STATIC_ASSERT(__cpp_lib_semaphore == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_semaphore
+#elif defined(__cpp_lib_semaphore)
 #error __cpp_lib_semaphore is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_shared_mutex
-#error __cpp_lib_shared_mutex is not defined
-#elif __cpp_lib_shared_mutex != 201505L
-#error __cpp_lib_shared_mutex is not 201505L
-#else
 STATIC_ASSERT(__cpp_lib_shared_mutex == 201505L);
-#endif
 
-#ifndef __cpp_lib_shared_ptr_arrays
-#error __cpp_lib_shared_ptr_arrays is not defined
-#elif _HAS_CXX20
-#if __cpp_lib_shared_ptr_arrays != 201707L
-#error __cpp_lib_shared_ptr_arrays is not 201707L
-#else
+#if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_shared_ptr_arrays == 201707L);
-#endif
-#else
-#if __cpp_lib_shared_ptr_arrays != 201611L
-#error __cpp_lib_shared_ptr_arrays is not 201611L
 #else
 STATIC_ASSERT(__cpp_lib_shared_ptr_arrays == 201611L);
 #endif
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_shared_ptr_weak_type
-#error __cpp_lib_shared_ptr_weak_type is not defined
-#elif __cpp_lib_shared_ptr_weak_type != 201606L
-#error __cpp_lib_shared_ptr_weak_type is not 201606L
-#else
 STATIC_ASSERT(__cpp_lib_shared_ptr_weak_type == 201606L);
-#endif
-#else
-#ifdef __cpp_lib_shared_ptr_weak_type
+#elif defined(__cpp_lib_shared_ptr_weak_type)
 #error __cpp_lib_shared_ptr_weak_type is defined
 #endif
-#endif
 
-#ifdef _M_CEE_PURE
-#ifdef __cpp_lib_shared_timed_mutex
-#error __cpp_lib_shared_timed_mutex is defined
-#endif
-#else
-#ifndef __cpp_lib_shared_timed_mutex
-#error __cpp_lib_shared_timed_mutex is not defined
-#elif __cpp_lib_shared_timed_mutex != 201402L
-#error __cpp_lib_shared_timed_mutex is not 201402L
-#else
+#ifndef _M_CEE_PURE
 STATIC_ASSERT(__cpp_lib_shared_timed_mutex == 201402L);
-#endif
+#elif defined(__cpp_lib_shared_timed_mutex)
+#error __cpp_lib_shared_timed_mutex is defined
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_shift
-#error __cpp_lib_shift is not defined
-#elif __cpp_lib_shift != 202202L
-#if __cpp_lib_shift == 201806L
-#error __cpp_lib_shift is 201806L when it should be 202202L
-#else
-#error __cpp_lib_shift is not 202202L
-#endif
-#else
 STATIC_ASSERT(__cpp_lib_shift == 202202L);
-#endif
 #elif _HAS_CXX20
-#ifndef __cpp_lib_shift
-#error __cpp_lib_shift is not defined
-#elif __cpp_lib_shift != 201806L
-#error __cpp_lib_shift is not 201806L
-#else
 STATIC_ASSERT(__cpp_lib_shift == 201806L);
-#endif
-#else
-#ifdef __cpp_lib_shift
+#elif defined(__cpp_lib_shift)
 #error __cpp_lib_shift is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_smart_ptr_for_overwrite
-#error __cpp_lib_smart_ptr_for_overwrite is not defined
-#elif __cpp_lib_smart_ptr_for_overwrite != 202002L
-#error __cpp_lib_smart_ptr_for_overwrite is not 202002L
-#else
 STATIC_ASSERT(__cpp_lib_smart_ptr_for_overwrite == 202002L);
-#endif
-#else
-#ifdef __cpp_lib_smart_ptr_for_overwrite
+#elif defined(__cpp_lib_smart_ptr_for_overwrite)
 #error __cpp_lib_smart_ptr_for_overwrite is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_source_location
-#error __cpp_lib_source_location is not defined
-#elif __cpp_lib_source_location != 201907L
-#error __cpp_lib_source_location is not 201907L
-#else
 STATIC_ASSERT(__cpp_lib_source_location == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_source_location
+#elif defined(__cpp_lib_source_location)
 #error __cpp_lib_source_location is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_span
-#error __cpp_lib_span is not defined
-#elif __cpp_lib_span != 202002L
-#error __cpp_lib_span is not 202002L
-#else
 STATIC_ASSERT(__cpp_lib_span == 202002L);
-#endif
-#else
-#ifdef __cpp_lib_span
+#elif defined(__cpp_lib_span)
 #error __cpp_lib_span is defined
 #endif
-#endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_spanstream
-#error __cpp_lib_spanstream is not defined
-#elif __cpp_lib_spanstream != 202106L
-#error __cpp_lib_spanstream is not 202106L
-#else
 STATIC_ASSERT(__cpp_lib_spanstream == 202106L);
-#endif
-#else
-#ifdef __cpp_lib_spanstream
+#elif defined(__cpp_lib_spanstream)
 #error __cpp_lib_spanstream is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_ssize
-#error __cpp_lib_ssize is not defined
-#elif __cpp_lib_ssize != 201902L
-#error __cpp_lib_ssize is not 201902L
-#else
 STATIC_ASSERT(__cpp_lib_ssize == 201902L);
-#endif
-#else
-#ifdef __cpp_lib_ssize
+#elif defined(__cpp_lib_ssize)
 #error __cpp_lib_ssize is defined
 #endif
-#endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_stacktrace
-#error __cpp_lib_stacktrace is not defined
-#elif __cpp_lib_stacktrace != 202011L
-#error __cpp_lib_stacktrace is not 202011L
-#else
 STATIC_ASSERT(__cpp_lib_stacktrace == 202011L);
-#endif
-#else
-#ifdef __cpp_lib_stacktrace
+#elif defined(__cpp_lib_stacktrace)
 #error __cpp_lib_stacktrace is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_starts_ends_with
-#error __cpp_lib_starts_ends_with is not defined
-#elif __cpp_lib_starts_ends_with != 201711L
-#error __cpp_lib_starts_ends_with is not 201711L
-#else
 STATIC_ASSERT(__cpp_lib_starts_ends_with == 201711L);
-#endif
-#else
-#ifdef __cpp_lib_starts_ends_with
+#elif defined(__cpp_lib_starts_ends_with)
 #error __cpp_lib_starts_ends_with is defined
 #endif
-#endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_stdatomic_h
-#error __cpp_lib_stdatomic_h is not defined
-#elif __cpp_lib_stdatomic_h != 202011L
-#error __cpp_lib_stdatomic_h is not 202011L
-#else
 STATIC_ASSERT(__cpp_lib_stdatomic_h == 202011L);
-#endif
-#else
-#ifdef __cpp_lib_stdatomic_h
+#elif defined(__cpp_lib_stdatomic_h)
 #error __cpp_lib_stdatomic_h is defined
 #endif
-#endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_string_contains
-#error __cpp_lib_string_contains is not defined
-#elif __cpp_lib_string_contains != 202011L
-#error __cpp_lib_string_contains is not 202011L
-#else
 STATIC_ASSERT(__cpp_lib_string_contains == 202011L);
-#endif
-#else
-#ifdef __cpp_lib_string_contains
+#elif defined(__cpp_lib_string_contains)
 #error __cpp_lib_string_contains is defined
 #endif
-#endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_string_resize_and_overwrite
-#error __cpp_lib_string_resize_and_overwrite is not defined
-#elif __cpp_lib_string_resize_and_overwrite != 202110L
-#error __cpp_lib_string_resize_and_overwrite is not 202110L
-#else
 STATIC_ASSERT(__cpp_lib_string_resize_and_overwrite == 202110L);
-#endif
-#else
-#ifdef __cpp_lib_string_resize_and_overwrite
+#elif defined(__cpp_lib_string_resize_and_overwrite)
 #error __cpp_lib_string_resize_and_overwrite is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_string_udls
-#error __cpp_lib_string_udls is not defined
-#elif __cpp_lib_string_udls != 201304L
-#error __cpp_lib_string_udls is not 201304L
-#else
 STATIC_ASSERT(__cpp_lib_string_udls == 201304L);
-#endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_string_view
-#error __cpp_lib_string_view is not defined
-#elif __cpp_lib_string_view != 201803L
-#error __cpp_lib_string_view is not 201803L
-#else
 STATIC_ASSERT(__cpp_lib_string_view == 201803L);
-#endif
-#else
-#ifdef __cpp_lib_string_view
+#elif defined(__cpp_lib_string_view)
 #error __cpp_lib_string_view is defined
-#endif
 #endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_syncbuf
-#error __cpp_lib_syncbuf is not defined
-#elif __cpp_lib_syncbuf != 201803L
-#error __cpp_lib_syncbuf is not 201803L
-#else
 STATIC_ASSERT(__cpp_lib_syncbuf == 201803L);
-#endif
-#else
-#ifdef __cpp_lib_syncbuf
+#elif defined(__cpp_lib_syncbuf)
 #error __cpp_lib_syncbuf is defined
-#endif
 #endif
 
 #ifdef __cpp_lib_concepts
-#ifndef __cpp_lib_three_way_comparison
-#error __cpp_lib_three_way_comparison is not defined
-#elif __cpp_lib_three_way_comparison != 201907L
-#error __cpp_lib_three_way_comparison is not 201907L
-#else
 STATIC_ASSERT(__cpp_lib_three_way_comparison == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_three_way_comparison
+#elif defined(__cpp_lib_three_way_comparison)
 #error __cpp_lib_three_way_comparison is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_to_address
-#error __cpp_lib_to_address is not defined
-#elif __cpp_lib_to_address != 201711L
-#error __cpp_lib_to_address is not 201711L
-#else
 STATIC_ASSERT(__cpp_lib_to_address == 201711L);
-#endif
-#else
-#ifdef __cpp_lib_to_address
+#elif defined(__cpp_lib_to_address)
 #error __cpp_lib_to_address is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_to_array
-#error __cpp_lib_to_array is not defined
-#elif __cpp_lib_to_array != 201907L
-#error __cpp_lib_to_array is not 201907L
-#else
 STATIC_ASSERT(__cpp_lib_to_array == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_to_array
+#elif defined(__cpp_lib_to_array)
 #error __cpp_lib_to_array is defined
-#endif
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_lib_to_chars
-#error __cpp_lib_to_chars is not defined
-#elif __cpp_lib_to_chars != 201611L
-#error __cpp_lib_to_chars is not 201611L
-#else
 STATIC_ASSERT(__cpp_lib_to_chars == 201611L);
-#endif
-#else
-#ifdef __cpp_lib_to_chars
+#elif defined(__cpp_lib_to_chars)
 #error __cpp_lib_to_chars is defined
 #endif
-#endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_to_underlying
-#error __cpp_lib_to_underlying is not defined
-#elif __cpp_lib_to_underlying != 202102L
-#error __cpp_lib_to_underlying is not 202102L
-#else
 STATIC_ASSERT(__cpp_lib_to_underlying == 202102L);
-#endif
-#else
-#ifdef __cpp_lib_to_underlying
+#elif defined(__cpp_lib_to_underlying)
 #error __cpp_lib_to_underlying is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_transformation_trait_aliases
-#error __cpp_lib_transformation_trait_aliases is not defined
-#elif __cpp_lib_transformation_trait_aliases != 201304L
-#error __cpp_lib_transformation_trait_aliases is not 201304L
-#else
 STATIC_ASSERT(__cpp_lib_transformation_trait_aliases == 201304L);
-#endif
 
-#ifndef __cpp_lib_transparent_operators
-#error __cpp_lib_transparent_operators is not defined
-#elif __cpp_lib_transparent_operators != 201510L
-#error __cpp_lib_transparent_operators is not 201510L
-#else
 STATIC_ASSERT(__cpp_lib_transparent_operators == 201510L);
-#endif
 
-#ifndef __cpp_lib_tuple_element_t
-#error __cpp_lib_tuple_element_t is not defined
-#elif __cpp_lib_tuple_element_t != 201402L
-#error __cpp_lib_tuple_element_t is not 201402L
-#else
 STATIC_ASSERT(__cpp_lib_tuple_element_t == 201402L);
-#endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_tuple_like
-#error __cpp_lib_tuple_like is not defined
-#elif __cpp_lib_tuple_like != 202207L
-#error __cpp_lib_tuple_like is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_tuple_like == 202207L);
-#endif
-#else
-#ifdef __cpp_lib_tuple_like
+#elif defined(__cpp_lib_tuple_like)
 #error __cpp_lib_tuple_like is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_tuples_by_type
-#error __cpp_lib_tuples_by_type is not defined
-#elif __cpp_lib_tuples_by_type != 201304L
-#error __cpp_lib_tuples_by_type is not 201304L
-#else
 STATIC_ASSERT(__cpp_lib_tuples_by_type == 201304L);
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_type_identity
-#error __cpp_lib_type_identity is not defined
-#elif __cpp_lib_type_identity != 201806L
-#error __cpp_lib_type_identity is not 201806L
-#else
 STATIC_ASSERT(__cpp_lib_type_identity == 201806L);
-#endif
-#else
-#ifdef __cpp_lib_type_identity
+#elif defined(__cpp_lib_type_identity)
 #error __cpp_lib_type_identity is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_type_trait_variable_templates
-#error __cpp_lib_type_trait_variable_templates is not defined
-#elif __cpp_lib_type_trait_variable_templates != 201510L
-#error __cpp_lib_type_trait_variable_templates is not 201510L
-#else
 STATIC_ASSERT(__cpp_lib_type_trait_variable_templates == 201510L);
-#endif
 
-#ifndef __cpp_lib_uncaught_exceptions
-#error __cpp_lib_uncaught_exceptions is not defined
-#elif __cpp_lib_uncaught_exceptions != 201411L
-#error __cpp_lib_uncaught_exceptions is not 201411L
-#else
 STATIC_ASSERT(__cpp_lib_uncaught_exceptions == 201411L);
-#endif
 
-#ifndef __cpp_lib_unordered_map_try_emplace
-#error __cpp_lib_unordered_map_try_emplace is not defined
-#elif __cpp_lib_unordered_map_try_emplace != 201411L
-#error __cpp_lib_unordered_map_try_emplace is not 201411L
-#else
 STATIC_ASSERT(__cpp_lib_unordered_map_try_emplace == 201411L);
-#endif
 
 #if _HAS_CXX23
-#ifndef __cpp_lib_unreachable
-#error __cpp_lib_unreachable is not defined
-#elif __cpp_lib_unreachable != 202202L
-#error __cpp_lib_unreachable is not 202202L
-#else
 STATIC_ASSERT(__cpp_lib_unreachable == 202202L);
-#endif
-#else
-#ifdef __cpp_lib_unreachable
+#elif defined(__cpp_lib_unreachable)
 #error __cpp_lib_unreachable is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_unwrap_ref
-#error __cpp_lib_unwrap_ref is not defined
-#elif __cpp_lib_unwrap_ref != 201811L
-#error __cpp_lib_unwrap_ref is not 201811L
-#else
 STATIC_ASSERT(__cpp_lib_unwrap_ref == 201811L);
-#endif
-#else
-#ifdef __cpp_lib_unwrap_ref
+#elif defined(__cpp_lib_unwrap_ref)
 #error __cpp_lib_unwrap_ref is defined
 #endif
-#endif
 
 #if _HAS_CXX20
-#ifndef __cpp_lib_variant
-#error __cpp_lib_variant is not defined
-#elif __cpp_lib_variant != 202106L
-#error __cpp_lib_variant is not 202106L
-#else
 STATIC_ASSERT(__cpp_lib_variant == 202106L);
-#endif
 #elif _HAS_CXX17
-#ifndef __cpp_lib_variant
-#error __cpp_lib_variant is not defined
-#elif __cpp_lib_variant != 202102L
-#error __cpp_lib_variant is not 202102L
-#else
 STATIC_ASSERT(__cpp_lib_variant == 202102L);
-#endif
-#else
-#ifdef __cpp_lib_variant
+#elif defined(__cpp_lib_variant)
 #error __cpp_lib_variant is defined
 #endif
-#endif
 
-#ifndef __cpp_lib_void_t
-#error __cpp_lib_void_t is not defined
-#elif __cpp_lib_void_t != 201411L
-#error __cpp_lib_void_t is not 201411L
-#else
 STATIC_ASSERT(__cpp_lib_void_t == 201411L);
-#endif

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -356,17 +356,9 @@ STATIC_ASSERT(__cpp_lib_filesystem == 201703L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_flat_set
-#error __cpp_lib_flat_set is not defined
-#elif __cpp_lib_flat_set != 202207L
-#error __cpp_lib_flat_set is not 202207L
-#else
 STATIC_ASSERT(__cpp_lib_flat_set == 202207L);
-#endif
-#else
-#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#elif defined(__cpp_lib_flat_set)
 #error __cpp_lib_flat_set is defined
-#endif
 #endif
 
 #ifdef __cpp_lib_concepts


### PR DESCRIPTION
:warning: Commit as a merge, not as a squash!

This merges `main` to pick up #4103, then contains an additional commit to update the `__cpp_lib_flat_set` test accordingly. Note that it was damaged like `__cpp_lib_containers_ranges` previously was.