### PR TITLE
Various cleanups: Comments and strings

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -4137,7 +4137,6 @@ struct _Pointer_of_or_helper<_Ty, _Uty> {
 template <class _Ty, class _Uty>
 using _Pointer_of_or = _Pointer_of_or_helper<_Ty, _Uty>::type;
 
-// TRANSITION, requires expression support
 template <class _SmartPtr, class _Sp, class _Pointer, class... _ArgsT>
 concept _Resettable_pointer = requires(_SmartPtr& _Smart_ptr, _Pointer _Ptr, _ArgsT&&... _Args) {
     _Smart_ptr.reset(static_cast<_Sp>(_Ptr), _STD forward<_ArgsT>(_Args)...);

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -676,7 +676,7 @@ _NODISCARD const _Ty& _Immortalize_memcpy_image() noexcept {
     static _Constexpr_immortalize_impl<_Ty> _Static;
     return _Static._Storage;
 }
-#else // ^^^ !defined(_M_CEE) / defined(_M_CEE), TRANSITION, VSO-1153256  vvv
+#else // ^^^ !defined(_M_CEE) / defined(_M_CEE), TRANSITION, VSO-1153256 vvv
 template <class _Ty>
 _NODISCARD const _Ty& _Immortalize_memcpy_image() noexcept {
     // return reference to a memcpy'd default-initialized _Ty

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1856,8 +1856,8 @@ public:
 #if _ITERATOR_DEBUG_LEVEL >= 1
         _STL_VERIFY(_Ptr, "cannot dereference value-initialized string iterator");
         const auto _Mycont = static_cast<const _Mystr*>(this->_Getcont());
-        _STL_VERIFY(_Mycont, "cannot dereference string iterator because the iterator was"
-                             " invalidated (e.g. reallocation occurred, or the string was destroyed)");
+        _STL_VERIFY(_Mycont, "cannot dereference string iterator because the iterator was "
+                             "invalidated (e.g. reallocation occurred, or the string was destroyed)");
         const auto _Contptr = _Mycont->_Myptr();
         const auto _Rawptr  = _Unfancy(_Ptr);
         _STL_VERIFY(_Contptr <= _Rawptr && _Rawptr < _Contptr + _Mycont->_Mysize,
@@ -1876,8 +1876,8 @@ public:
 #if _ITERATOR_DEBUG_LEVEL >= 1
         _STL_VERIFY(_Ptr, "cannot increment value-initialized string iterator");
         const auto _Mycont = static_cast<const _Mystr*>(this->_Getcont());
-        _STL_VERIFY(_Mycont, "cannot increment string iterator because the iterator was"
-                             " invalidated (e.g. reallocation occurred, or the string was destroyed)");
+        _STL_VERIFY(_Mycont, "cannot increment string iterator because the iterator was "
+                             "invalidated (e.g. reallocation occurred, or the string was destroyed)");
         _STL_VERIFY(_Unfancy(_Ptr) < _Mycont->_Myptr() + _Mycont->_Mysize, "cannot increment string iterator past end");
 #endif // _ITERATOR_DEBUG_LEVEL >= 1
 
@@ -1895,8 +1895,8 @@ public:
 #if _ITERATOR_DEBUG_LEVEL >= 1
         _STL_VERIFY(_Ptr, "cannot decrement value-initialized string iterator");
         const auto _Mycont = static_cast<const _Mystr*>(this->_Getcont());
-        _STL_VERIFY(_Mycont, "cannot decrement string iterator because the iterator was"
-                             " invalidated (e.g. reallocation occurred, or the string was destroyed)");
+        _STL_VERIFY(_Mycont, "cannot decrement string iterator because the iterator was "
+                             "invalidated (e.g. reallocation occurred, or the string was destroyed)");
         _STL_VERIFY(_Mycont->_Myptr() < _Unfancy(_Ptr), "cannot decrement string iterator before begin");
 #endif // _ITERATOR_DEBUG_LEVEL >= 1
 
@@ -1918,8 +1918,8 @@ public:
 
         _STL_ASSERT(_Ptr, "cannot seek value-initialized string iterator");
         const auto _Mycont = static_cast<const _Mystr*>(this->_Getcont());
-        _STL_ASSERT(_Mycont, "cannot seek string iterator because the iterator was"
-                             " invalidated (e.g. reallocation occurred, or the string was destroyed)");
+        _STL_ASSERT(_Mycont, "cannot seek string iterator because the iterator was "
+                             "invalidated (e.g. reallocation occurred, or the string was destroyed)");
         const auto _Contptr = _Mycont->_Myptr();
         const auto _Rawptr  = _Unfancy(_Ptr);
 

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2012,8 +2012,8 @@ public:
     _CONSTEXPR20 void _Compat(const _String_const_iterator& _Right) const noexcept {
         // test for compatible iterator pair
 #if _ITERATOR_DEBUG_LEVEL >= 1
-        _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "string iterators incompatible (e.g."
-                                                           " point to different string instances)");
+        _STL_VERIFY(this->_Getcont() == _Right._Getcont(),
+            "string iterators incompatible (e.g. point to different string instances)");
 #else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         (void) _Right;
 #endif // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5848,8 +5848,8 @@ namespace ranges {
                     if constexpr (_Is_sized) {
                         return _RANGES next(_STD move(_First), _Last);
                     } else {
-                        _STL_ASSERT(false, "Tried to find a value in a range with unreachable sentinel"
-                                           " that cannot be represented by the range's value type");
+                        _STL_ASSERT(false, "Tried to find a value in a range with unreachable sentinel "
+                                           "that cannot be represented by the range's value type");
                     }
                 }
 

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -56,7 +56,7 @@ namespace Concurrency {
             /// </summary>
             _CRTIMP2 size_t __cdecl CaptureCallstack(void** stackData, size_t skipFrames, size_t captureFrames) {
                 size_t capturedFrames = 0;
-                // RtlCaptureSTackBackTrace is not available in MSDK, so we only call it under Desktop or _DEBUG MSDK.
+                // RtlCaptureStackBackTrace is not available in MSDK, so we only call it under Desktop or _DEBUG MSDK.
                 //  For MSDK unsupported version, we will return zero frame number.
 #if !defined(_CRT_APP) || defined(_DEBUG)
                 capturedFrames = RtlCaptureStackBackTrace(

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -21,7 +21,7 @@
 #include <windows.foundation.diagnostics.h>
 #endif
 
-// This IID is exported by ole32.dll; we cannot depend on ole32.dll on OneCore.
+// This IID is exported by ole32.dll; we cannot depend on ole32.dll.
 static GUID const Local_IID_ICallbackWithNoReentrancyToApplicationSTA = {
     0x0A299774, 0x3E4E, 0xFC42, {0x1D, 0x9D, 0x72, 0xCE, 0xE1, 0x05, 0xCA, 0x57}};
 

--- a/stl/src/stdthrow.cpp
+++ b/stl/src/stdthrow.cpp
@@ -18,5 +18,5 @@ _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Debug_message(
     const unsigned short* message, const unsigned short* file, unsigned int line) { // report error and die
     _Debug_message(reinterpret_cast<const wchar_t*>(message), reinterpret_cast<const wchar_t*>(file), line);
 }
-#endif
+#endif // ^^^ defined(_DEBUG) ^^^
 _STD_END

--- a/stl/src/xgetwctype.cpp
+++ b/stl/src/xgetwctype.cpp
@@ -36,6 +36,6 @@ _CRTIMP2_PURE const unsigned short* __CLRCALL_PURE_OR_CDECL _Getwctypes(
     return reinterpret_cast<const unsigned short*>(
         _Getwctypes(reinterpret_cast<const wchar_t*>(_First), reinterpret_cast<const wchar_t*>(_Last), _Dest, _Ctype));
 }
-#endif
+#endif // ^^^ defined(MRTDLL) ^^^
 
 _END_EXTERN_C_UNLESS_PURE

--- a/stl/src/xlock.cpp
+++ b/stl/src/xlock.cpp
@@ -39,7 +39,7 @@ __thiscall _Init_locks::~_Init_locks() noexcept { // clean up locks
     }
 }
 
-#endif
+#endif // ^^^ !defined(MRTDLL) ^^^
 
 void __cdecl _Init_locks::_Init_locks_ctor(_Init_locks*) noexcept { // initialize locks
     if (InterlockedIncrement(&init) == 0) {
@@ -85,7 +85,7 @@ __thiscall _Lockit::~_Lockit() noexcept { // unlock the mutex
     }
 }
 
-#endif
+#endif // ^^^ !defined(MRTDLL) ^^^
 
 void __cdecl _Lockit::_Lockit_ctor(_Lockit*) noexcept { // lock default mutex
     _Mtxlock(&mtx[0]);


### PR DESCRIPTION
* Comments: Drop extra space.
* Comments: Add them to `#endif`.
* Comments: Drop "TRANSITION, requires expression support".
  + We use `_Resettable_pointer` twice; *requires-expression*s would be more verbose.
* Comments: Fix capitalization typo.
* Comments: Strengthen comment about `ole32.dll`.
  + See #3607 - we can't depend on `ole32.dll` anywhere.
* String literals: Space before wrapping.
  + There were only a few places that weren't following our usual convention.
* String literals: Unwrap.
  + This one was easier to read on a single line.