### PR TITLE
Remove test workarounds for an ASAN bug

### DIFF
--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -1738,7 +1738,6 @@ void test_exceptions() {
             assert(verify_string(append_iterator));
         }
 
-#if 0 // TRANSITION, DevCom-1527920
         str append_iterator_sso{input_sso};
         try {
             assert(verify_string(append_iterator_sso));
@@ -1747,7 +1746,6 @@ void test_exceptions() {
         } catch (...) {
             assert(verify_string(append_iterator_sso));
         }
-#endif
 
         str append_input_iterator{input};
         try {
@@ -1758,14 +1756,12 @@ void test_exceptions() {
             assert(verify_string(append_input_iterator));
         }
 
-#if 0 // TRANSITION, DevCom-1527920
         str append_input_iterator_sso{input_sso};
         try {
             append_input_iterator_sso.append(input_iter_data.begin(), input_iter_data.end());
         } catch (...) {
             assert(verify_string(append_input_iterator_sso));
         }
-#endif
     }
 
     { // assign
@@ -1778,7 +1774,6 @@ void test_exceptions() {
             assert(verify_string(assign_iterator));
         }
 
-#if 0 // TRANSITION, DevCom-1527920
         str assign_iterator_sso{input_sso};
         try {
             assert(verify_string(assign_iterator_sso));
@@ -1786,7 +1781,6 @@ void test_exceptions() {
         } catch (...) {
             assert(verify_string(assign_iterator_sso));
         }
-#endif
 
         str assign_input_iterator{input};
         try {
@@ -1797,7 +1791,6 @@ void test_exceptions() {
             assert(verify_string(assign_input_iterator));
         }
 
-#if 0 // TRANSITION, DevCom-1527920
         str assign_input_iterator_sso{input_sso};
         try {
             assert(verify_string(assign_input_iterator_sso));
@@ -1806,7 +1799,6 @@ void test_exceptions() {
         } catch (...) {
             assert(verify_string(assign_input_iterator_sso));
         }
-#endif
     }
 
     { // insert
@@ -1819,7 +1811,6 @@ void test_exceptions() {
             assert(verify_string(insert_iterator));
         }
 
-#if 0 // TRANSITION, DevCom-1527920
         str insert_iterator_sso{input_sso};
         try {
             assert(verify_string(insert_iterator_sso));
@@ -1828,7 +1819,6 @@ void test_exceptions() {
         } catch (...) {
             assert(verify_string(insert_iterator_sso));
         }
-#endif
 
         str insert_input_iterator{input};
         try {
@@ -1839,7 +1829,6 @@ void test_exceptions() {
             assert(verify_string(insert_input_iterator));
         }
 
-#if 0 // TRANSITION, DevCom-1527920
         str insert_input_iterator_sso{input_sso};
         try {
             assert(verify_string(insert_input_iterator_sso));
@@ -1849,7 +1838,6 @@ void test_exceptions() {
         } catch (...) {
             assert(verify_string(insert_input_iterator_sso));
         }
-#endif
     }
 }
 


### PR DESCRIPTION
I noticed that `GH_002030_asan_annotate_string` had a bunch of workarounds for DevCom-1527920 "\[ASAN\] Exceptions invalidate annotation of stack based buffer", but it no longer appears to repro. Let's see if we can activate this test coverage now. I'm isolating this into a separate PR in case something goes wrong.

The ASAN configurations are passing:

```
D:\GitHub\STL\out\x64>git status
On branch dry-cleaning-2-remove-test-workarounds
Your branch is up to date with 'stephan/dry-cleaning-2-remove-test-workarounds'.

nothing to commit, working tree clean

D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py -o testing_x64.log  %STL%\tests\std\tests\GH_002030_asan_annotate_string
-- Testing: 46 tests, 32 workers --
PASS: std :: tests/GH_002030_asan_annotate_string:00 (1 of 46)
[...]
PASS: std :: tests/GH_002030_asan_annotate_string:45 (46 of 46)

Testing Time: 67.17s
  Passed: 46
```