### PR TITLE
Various cleanups: `<chrono>`

### DIFF
--- a/stl/inc/__msvc_tzdb.hpp
+++ b/stl/inc/__msvc_tzdb.hpp
@@ -151,6 +151,11 @@ public:
     void deallocate(_Ty* const _Ptr, size_t) noexcept {
         __std_free_crt(_Ptr);
     }
+
+    template <class _Other>
+    _NODISCARD bool operator==(const _Crt_allocator<_Other>&) const noexcept {
+        return true;
+    }
 };
 
 _STD_END

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -1712,7 +1712,7 @@ namespace chrono {
 
     template <class _Duration>
     [[noreturn]] void _Throw_nonexistent_local_time(const local_time<_Duration>& _Tp, const local_info& _Info) {
-        _THROW((nonexistent_local_time{_Tp, _Info}));
+        _THROW(nonexistent_local_time{_Tp, _Info});
     }
 
     _EXPORT_STD class ambiguous_local_time : public runtime_error {
@@ -1735,7 +1735,7 @@ namespace chrono {
 
     template <class _Duration>
     [[noreturn]] void _Throw_ambiguous_local_time(const local_time<_Duration>& _Tp, const local_info& _Info) {
-        _THROW((ambiguous_local_time{_Tp, _Info}));
+        _THROW(ambiguous_local_time{_Tp, _Info});
     }
 
     // [time.zone.timezone]

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -2094,7 +2094,7 @@ namespace chrono {
         }
     };
 
-    _NODISCARD inline tuple<string, decltype(tzdb::zones), decltype(tzdb::links)> _Tzdb_generate_time_zones() {
+    _NODISCARD inline tuple<string, vector<time_zone>, vector<time_zone_link>> _Tzdb_generate_time_zones() {
         unique_ptr<__std_tzdb_time_zones_info, _Tzdb_deleter<__std_tzdb_time_zones_info>> _Info{
             __std_tzdb_get_time_zones()};
         if (_Info == nullptr) {
@@ -2105,8 +2105,8 @@ namespace chrono {
             _Xruntime_error("Internal error loading IANA database information");
         }
 
-        decltype(tzdb::zones) _Time_zones;
-        decltype(tzdb::links) _Time_zone_links;
+        vector<time_zone> _Time_zones;
+        vector<time_zone_link> _Time_zone_links;
         for (size_t _Idx = 0; _Idx < _Info->_Num_time_zones; ++_Idx) {
             const string_view _Name{_Info->_Names[_Idx]};
             if (_Info->_Links[_Idx] == nullptr) {

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -3174,7 +3174,7 @@ namespace chrono {
                 _Val = _New;
                 return true;
             } else {
-                return _STD exchange(_Val, _New) == _New;
+                return _STD exchange(*_Val, _New) == _New;
             }
         }
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -4389,7 +4389,7 @@ namespace chrono {
                     }
                 }
 
-                _CATCH_IO_(_Myis, _Istr)
+                _CATCH_IO_(ios_base, _Istr)
             }
 
             if (!_Is_complete()) {

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -1740,6 +1740,25 @@ namespace chrono {
 
     // [time.zone.timezone]
 
+    template <auto& _Get_tzdb_info, class... _Types>
+    _NODISCARD auto _Make_unique_tzdb_info(_Types&&... _Args) {
+        const auto _Raw_ptr = _Get_tzdb_info(_STD forward<_Types>(_Args)...);
+
+        using _Tzdb_info = remove_pointer_t<decltype(_Raw_ptr)>;
+
+        unique_ptr<_Tzdb_info, _Tzdb_deleter<_Tzdb_info>> _Info{_Raw_ptr};
+
+        if (_Info == nullptr) {
+            _Xbad_alloc();
+        } else if (_Info->_Err == __std_tzdb_error::_Win_error) {
+            _XGetLastError();
+        } else if (_Info->_Err == __std_tzdb_error::_Icu_error) {
+            _Xruntime_error("Internal error loading IANA database information");
+        }
+
+        return _Info;
+    }
+
     _EXPORT_STD enum class choose { earliest, latest };
 
     struct _Secret_time_zone_construct_tag {
@@ -1815,16 +1834,8 @@ namespace chrono {
 
             const auto _Tz_len = _Name.length();
 
-            const unique_ptr<__std_tzdb_sys_info, _Tzdb_deleter<__std_tzdb_sys_info>> _Info{
-                __std_tzdb_get_sys_info(_Tz_arg.c_str(), _Tz_len, _Internal_dur.count())};
-
-            if (_Info == nullptr) {
-                _Xbad_alloc();
-            } else if (_Info->_Err == __std_tzdb_error::_Win_error) {
-                _XGetLastError();
-            } else if (_Info->_Err == __std_tzdb_error::_Icu_error) {
-                _Xruntime_error("Internal error loading IANA database information");
-            }
+            const auto _Info =
+                _Make_unique_tzdb_info<__std_tzdb_get_sys_info>(_Tz_arg.c_str(), _Tz_len, _Internal_dur.count());
 
             constexpr auto _Min_internal =
                 _CHRONO duration_cast<_Internal_duration>(_Min_seconds.time_since_epoch()).count();
@@ -2055,15 +2066,7 @@ namespace chrono {
     // [time.zone.db]
 
     _NODISCARD inline string _Tzdb_generate_current_zone() {
-        unique_ptr<__std_tzdb_current_zone_info, _Tzdb_deleter<__std_tzdb_current_zone_info>> _Info{
-            __std_tzdb_get_current_zone()};
-        if (_Info == nullptr) {
-            _Xbad_alloc();
-        } else if (_Info->_Err == __std_tzdb_error::_Win_error) {
-            _XGetLastError();
-        } else if (_Info->_Err == __std_tzdb_error::_Icu_error) {
-            _Xruntime_error("Internal error loading IANA database information");
-        }
+        auto _Info = _Make_unique_tzdb_info<__std_tzdb_get_current_zone>();
 
         return _Info->_Tz_name;
     }
@@ -2104,15 +2107,7 @@ namespace chrono {
     };
 
     _NODISCARD inline tuple<string, vector<time_zone>, vector<time_zone_link>> _Tzdb_generate_time_zones() {
-        unique_ptr<__std_tzdb_time_zones_info, _Tzdb_deleter<__std_tzdb_time_zones_info>> _Info{
-            __std_tzdb_get_time_zones()};
-        if (_Info == nullptr) {
-            _Xbad_alloc();
-        } else if (_Info->_Err == __std_tzdb_error::_Win_error) {
-            _XGetLastError();
-        } else if (_Info->_Err == __std_tzdb_error::_Icu_error) {
-            _Xruntime_error("Internal error loading IANA database information");
-        }
+        auto _Info = _Make_unique_tzdb_info<__std_tzdb_get_time_zones>();
 
         vector<time_zone> _Time_zones;
         vector<time_zone_link> _Time_zone_links;

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -3728,15 +3728,14 @@ namespace chrono {
             }
         }
 
-        template <class _InIt>
-        _NODISCARD _InIt _Parse_time_field(_InIt _First, ios_base& _Iosbase, ios_base::iostate& _State,
-            const char _Flag, const char _Modifier, const unsigned int _Width,
-            const unsigned int _Subsecond_precision) {
-            using _CharT = _InIt::value_type;
+        template <class _CharT, class _Traits>
+        _NODISCARD istreambuf_iterator<_CharT, _Traits> _Parse_time_field(istreambuf_iterator<_CharT, _Traits> _First,
+            ios_base& _Iosbase, ios_base::iostate& _State, const char _Flag, const char _Modifier,
+            const unsigned int _Width, const unsigned int _Subsecond_precision) {
 
             const auto& _Ctype_fac = _STD use_facet<ctype<_CharT>>(_Iosbase.getloc());
             const auto& _Time_fac  = _STD use_facet<time_get<_CharT>>(_Iosbase.getloc());
-            constexpr _InIt _Last{};
+            constexpr istreambuf_iterator<_CharT, _Traits> _Last{};
 
             int _Val{0};
             switch (_Flag) {
@@ -4054,10 +4053,11 @@ namespace chrono {
             return _First;
         }
 
-        template <class _InIt>
-        _NODISCARD _InIt _Parse_time_field_restricted(_InIt _First, ios_base& _Iosbase, ios_base::iostate& _State,
+        template <class _CharT, class _Traits>
+        _NODISCARD istreambuf_iterator<_CharT, _Traits> _Parse_time_field_restricted(
+            istreambuf_iterator<_CharT, _Traits> _First, ios_base& _Iosbase, ios_base::iostate& _State,
             const char* _Fmt, const unsigned int _Subsecond_precision = 0) {
-            using _Ctype = ctype<typename _InIt::value_type>;
+            using _Ctype = ctype<_CharT>;
             // Parses a restricted format string. It generally doesn't handle anything parsed outside of
             // _Parse_time_field:
             //   (a) any whitespace (' ', %n, %t)
@@ -4066,7 +4066,7 @@ namespace chrono {
             //   (d) width parameter
             // It also assumes a valid format string, specifically that '%' is always followed by a flag.
             const _Ctype& _Ctype_fac{_STD use_facet<_Ctype>(_Iosbase.getloc())};
-            constexpr _InIt _Last{};
+            constexpr istreambuf_iterator<_CharT, _Traits> _Last{};
 
             while (*_Fmt != '\0' && (_State & ~ios_base::eofbit) == ios_base::goodbit) {
                 if (_First == _Last) {
@@ -4082,11 +4082,10 @@ namespace chrono {
             return _First;
         }
 
-        template <class _InIt>
-        _NODISCARD ios_base::iostate _Get_fixed(_InIt& _First, unsigned int _Width,
-            const ctype<typename _InIt::value_type>& _Ctype_fac,
-            const numpunct<typename _InIt::value_type>& _Numpunct_fac) {
-            constexpr _InIt _Last{};
+        template <class _CharT, class _Traits>
+        _NODISCARD ios_base::iostate _Get_fixed(istreambuf_iterator<_CharT, _Traits>& _First, unsigned int _Width,
+            const ctype<_CharT>& _Ctype_fac, const numpunct<_CharT>& _Numpunct_fac) {
+            constexpr istreambuf_iterator<_CharT, _Traits> _Last{};
 
             while (_First != _Last && _Ctype_fac.is(ctype_base::space, *_First) && _Width > 0) {
                 ++_First;
@@ -4135,10 +4134,10 @@ namespace chrono {
             return _State;
         }
 
-        template <class _InIt>
-        _NODISCARD ios_base::iostate _Get_int(
-            _InIt& _First, unsigned int _Width, int& _Val, const ctype<typename _InIt::value_type>& _Ctype_fac) {
-            constexpr _InIt _Last{};
+        template <class _CharT, class _Traits>
+        _NODISCARD ios_base::iostate _Get_int(istreambuf_iterator<_CharT, _Traits>& _First, unsigned int _Width,
+            int& _Val, const ctype<_CharT>& _Ctype_fac) {
+            constexpr istreambuf_iterator<_CharT, _Traits> _Last{};
 
             while (_First != _Last && _Ctype_fac.is(ctype_base::space, *_First) && _Width > 0) {
                 ++_First;
@@ -4197,10 +4196,10 @@ namespace chrono {
             return _State;
         }
 
-        template <class _InIt>
-        _NODISCARD ios_base::iostate _Get_tz_offset(
-            _InIt& _First, const ctype<typename _InIt::value_type>& _Ctype_fac, const bool _Is_modified, int& _Offset) {
-            constexpr _InIt _Last{};
+        template <class _CharT, class _Traits>
+        _NODISCARD ios_base::iostate _Get_tz_offset(istreambuf_iterator<_CharT, _Traits>& _First,
+            const ctype<_CharT>& _Ctype_fac, const bool _Is_modified, int& _Offset) {
+            constexpr istreambuf_iterator<_CharT, _Traits> _Last{};
             if (_First == _Last) {
                 return ios_base::eofbit;
             }
@@ -4270,10 +4269,10 @@ namespace chrono {
             return ios_base::goodbit;
         }
 
-        template <class _InIt>
+        template <class _CharT, class _Traits>
         _NODISCARD ios_base::iostate _Get_tz_name(
-            _InIt& _First, const ctype<typename _InIt::value_type>& _Ctype_fac, string& _Tz_name) {
-            constexpr _InIt _Last{};
+            istreambuf_iterator<_CharT, _Traits>& _First, const ctype<_CharT>& _Ctype_fac, string& _Tz_name) {
+            constexpr istreambuf_iterator<_CharT, _Traits> _Last{};
             _Tz_name.clear();
             while (_First != _Last) {
                 const char _Ch{_Ctype_fac.narrow(*_First)};

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -3585,7 +3585,6 @@ namespace chrono {
 
         template <class _DurationType>
         _NODISCARD bool _Make_time_point(_DurationType& _Dur, _Leap_second_rep _Leap) {
-
             const bool _Consistent{_Calculate_hour24() && _Calculate_year_fields() && _Calculate_ymd()};
             if (!_Consistent || !_Apply_duration_fields<_Parse_tp_or_duration::_Time_point>(_Dur)) {
                 return false;

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -4787,7 +4787,6 @@ public:
     }
 
     constexpr void _On_conversion_spec(char _Modifier, _CharT _Type) {
-        // NOTE: same performance note from _Basic_format_specs also applies here
         if (_Modifier != '\0' && _Modifier != 'E' && _Modifier != 'O') {
             _Throw_format_error("Invalid modifier specification.");
         }

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5721,7 +5721,7 @@ namespace chrono {
                 case 'Y':
                     if constexpr (is_same_v<_Ty, year>) {
                         return _Val.ok();
-                    } else if constexpr (_Is_any_of_v<_Ty, year_month> || _Is_ymd) {
+                    } else if constexpr (is_same_v<_Ty, year_month> || _Is_ymd) {
                         return _Val.year().ok();
                     }
                     break;

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -1742,9 +1742,13 @@ namespace chrono {
 
     _EXPORT_STD enum class choose { earliest, latest };
 
+    struct _Secret_time_zone_construct_tag {
+        explicit _Secret_time_zone_construct_tag() = default;
+    };
+
     _EXPORT_STD class time_zone {
     public:
-        explicit time_zone(string_view _Name_) : _Name(_Name_) {}
+        explicit time_zone(_Secret_time_zone_construct_tag, string_view _Name_) : _Name(_Name_) {}
 
         time_zone(time_zone&&)            = default;
         time_zone& operator=(time_zone&&) = default;
@@ -2012,9 +2016,14 @@ namespace chrono {
 
     // [time.zone.link]
 
+    struct _Secret_time_zone_link_construct_tag {
+        explicit _Secret_time_zone_link_construct_tag() = default;
+    };
+
     _EXPORT_STD class time_zone_link {
     public:
-        explicit time_zone_link(string_view _Name_, string_view _Target_) : _Name(_Name_), _Target(_Target_) {}
+        explicit time_zone_link(_Secret_time_zone_link_construct_tag, string_view _Name_, string_view _Target_)
+            : _Name(_Name_), _Target(_Target_) {}
 
         time_zone_link(time_zone_link&&)            = default;
         time_zone_link& operator=(time_zone_link&&) = default;
@@ -2110,10 +2119,10 @@ namespace chrono {
         for (size_t _Idx = 0; _Idx < _Info->_Num_time_zones; ++_Idx) {
             const string_view _Name{_Info->_Names[_Idx]};
             if (_Info->_Links[_Idx] == nullptr) {
-                _Time_zones.emplace_back(_Name);
+                _Time_zones.emplace_back(_Secret_time_zone_construct_tag{}, _Name);
             } else {
                 const string_view _Target{_Info->_Links[_Idx]};
-                _Time_zone_links.emplace_back(_Name, _Target);
+                _Time_zone_links.emplace_back(_Secret_time_zone_link_construct_tag{}, _Name, _Target);
             }
         }
 
@@ -2259,13 +2268,13 @@ namespace chrono {
                 vector<time_zone> _Zones;
                 _Zones.reserve(_Tzdb.zones.size());
                 for (const auto& _Tz : _Tzdb.zones) {
-                    _Zones.emplace_back(_Tz.name());
+                    _Zones.emplace_back(_Secret_time_zone_construct_tag{}, _Tz.name());
                 }
 
                 vector<time_zone_link> _Links;
                 _Links.reserve(_Tzdb.links.size());
                 for (const auto& _Link : _Tzdb.links) {
-                    _Links.emplace_back(_Link.name(), _Link.target());
+                    _Links.emplace_back(_Secret_time_zone_link_construct_tag{}, _Link.name(), _Link.target());
                 }
 
                 auto _Version = _Tzdb_update_version(_Tzdb.version, _Leap_sec.size());

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5525,9 +5525,9 @@ namespace chrono {
                     _CharT _Fmt_str[4];
                     _Os << _STD put_time(&_Time, _Fmt_string({._Type = _Gregorian_type}, _Fmt_str));
                     return true;
+                } else {
+                    return false;
                 }
-
-                return false;
             case 'r':
                 // put_time uses _Strftime in order to bypass reference-counting that locale uses. This function
                 // takes the locale information by pointer, but the pointer (from _Gettnames) returns a copy.
@@ -5545,8 +5545,9 @@ namespace chrono {
                 if constexpr (_Is_specialization_v<_Ty, duration>) {
                     _Os << _STD abs(_Duration_cast_underflow_to_zero<days>(_Val).count());
                     return true;
+                } else {
+                    return false;
                 }
-                return false;
             case 'q':
                 if constexpr (_Is_specialization_v<_Ty, duration>) {
                     _Write_unit_suffix<typename _Ty::period>(_Os);

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -3612,7 +3612,7 @@ namespace chrono {
                     return false;
                 } else {
                     // It's possible that the parsed time doesn't exist because (a) _Seconds == 60 and there *isn't* a
-                    // leap second insertion or (b) _Seconds >= 59 and there *is* a leap second subtraction.
+                    // leap second insertion or (b) _Seconds >= 59 and there *is* a leap second deletion.
                     const auto& _Tzdb{_CHRONO get_tzdb()};
 
                     const bool _Possible_insertion{_Second == 60};

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5550,11 +5550,15 @@ namespace chrono {
             case 'q':
                 if constexpr (_Is_specialization_v<_Ty, duration>) {
                     _Write_unit_suffix<typename _Ty::period>(_Os);
+                } else {
+                    _STL_INTERNAL_CHECK(false);
                 }
                 return true;
             case 'Q':
                 if constexpr (_Is_specialization_v<_Ty, duration>) {
                     _Os << _STD abs(_Val.count());
+                } else {
+                    _STL_INTERNAL_CHECK(false);
                 }
                 return true;
             case 'm': // Print months as a decimal, even if invalid.

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -2065,7 +2065,7 @@ namespace chrono {
             _Xruntime_error("Internal error loading IANA database information");
         }
 
-        return {_Info->_Tz_name};
+        return _Info->_Tz_name;
     }
 
     template <class _Ty>

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -4057,7 +4057,6 @@ namespace chrono {
         _NODISCARD istreambuf_iterator<_CharT, _Traits> _Parse_time_field_restricted(
             istreambuf_iterator<_CharT, _Traits> _First, ios_base& _Iosbase, ios_base::iostate& _State,
             const char* _Fmt, const unsigned int _Subsecond_precision = 0) {
-            using _Ctype = ctype<_CharT>;
             // Parses a restricted format string. It generally doesn't handle anything parsed outside of
             // _Parse_time_field:
             //   (a) any whitespace (' ', %n, %t)
@@ -4065,7 +4064,7 @@ namespace chrono {
             //   (c) E or O modifiers
             //   (d) width parameter
             // It also assumes a valid format string, specifically that '%' is always followed by a flag.
-            const _Ctype& _Ctype_fac{_STD use_facet<_Ctype>(_Iosbase.getloc())};
+            const auto& _Ctype_fac{_STD use_facet<ctype<_CharT>>(_Iosbase.getloc())};
             constexpr istreambuf_iterator<_CharT, _Traits> _Last{};
 
             while (*_Fmt != '\0' && (_State & ~ios_base::eofbit) == ios_base::goodbit) {

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -3170,12 +3170,12 @@ namespace chrono {
                 }
             }
 
-            if (!_Val.has_value()) {
-                _Val = _New;
-                return true;
-            } else {
+            if (_Val.has_value()) {
                 return _STD exchange(*_Val, _New) == _New;
             }
+
+            _Val = _New;
+            return true;
         }
 
         _NODISCARD static pair<int, int> _Decompose_year(const int _Year) {

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -4880,6 +4880,8 @@ _NODISCARD constexpr const _CharT* _Parse_chrono_format_specs(
 
     // chrono-spec
     while (_Begin != _End && *_Begin != '}') {
+        // Note that in this loop, ++_Begin is safe (and we don't need _Fmt_codec)
+        // because '%' isn't used as a non-lead-byte in any supported multibyte encoding.
         if (*_Begin == '%') { // conversion-spec
             if (++_Begin == _End) {
                 _Throw_format_error("Invalid format string - missing type after %");

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -451,8 +451,8 @@ private:
     catch (...) {
 #define _CATCH_END }
 
-#define _RERAISE  throw
-#define _THROW(x) throw x
+#define _RERAISE    throw
+#define _THROW(...) throw __VA_ARGS__
 
 #else // ^^^ _HAS_EXCEPTIONS / !_HAS_EXCEPTIONS vvv
 #define _TRY_BEGIN \
@@ -475,7 +475,7 @@ private:
 #endif
 
 #define _RERAISE
-#define _THROW(x) x._Raise()
+#define _THROW(...) __VA_ARGS__._Raise()
 #endif // ^^^ !_HAS_EXCEPTIONS ^^^
 _STD_END
 

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_clocks/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_clocks/test.cpp
@@ -385,10 +385,11 @@ tzdb copy_tzdb() {
     const auto& my_tzdb = get_tzdb_list().front();
     vector<time_zone> zones;
     vector<time_zone_link> links;
-    transform(my_tzdb.zones.begin(), my_tzdb.zones.end(), back_inserter(zones),
-        [](const auto& tz) { return time_zone{tz.name()}; });
+    transform(my_tzdb.zones.begin(), my_tzdb.zones.end(), back_inserter(zones), [](const auto& tz) {
+        return time_zone{_Secret_time_zone_construct_tag{}, tz.name()};
+    });
     transform(my_tzdb.links.begin(), my_tzdb.links.end(), back_inserter(links), [](const auto& link) {
-        return time_zone_link{link.name(), link.target()};
+        return time_zone_link{_Secret_time_zone_link_construct_tag{}, link.name(), link.target()};
     });
 
     return {my_tzdb.version, move(zones), move(links), my_tzdb.leap_seconds, my_tzdb._All_ls_positive};

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -469,7 +469,7 @@ void test_year_formatter() {
 
 template <typename CharT>
 void test_weekday_formatter() {
-    weekday invalid{10};
+    constexpr weekday invalid{10};
     empty_braces_helper(weekday{3}, STR("Wed"));
     empty_braces_helper(invalid, STR("10 is not a valid weekday"));
 
@@ -607,7 +607,7 @@ void test_year_month_formatter() {
 
 template <typename CharT>
 void test_year_month_day_formatter() {
-    year_month_day invalid{year{1234}, month{0}, day{31}};
+    constexpr year_month_day invalid{year{1234}, month{0}, day{31}};
     empty_braces_helper(year_month_day{year{1900}, month{2}, day{1}}, STR("1900-02-01"));
     empty_braces_helper(invalid, STR("1234-00-31 is not a valid date"));
 

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -385,51 +385,36 @@ void test_day_formatter() {
 
     // 2 digits
     day d0{27};
-    auto res = format(s0, d0);
-    assert(res == a0);
-    res = format(s1, d0);
-    assert(res == a0);
+    assert(format(s0, d0) == a0);
+    assert(format(s1, d0) == a0);
 
     // 1 digit
     day d1{5};
-    res = format(s0, d1);
-    assert(res == a1);
-    res = format(s1, d1);
-    assert(res == a2);
+    assert(format(s0, d1) == a1);
+    assert(format(s1, d1) == a2);
 
     // O modifier
-    res = format(s2, d0);
-    assert(res == a0);
-    res = format(s3, d0);
-    assert(res == a0);
-    res = format(s2, d1);
-    assert(res == a1);
-    res = format(s3, d1);
-    assert(res == a2);
+    assert(format(s2, d0) == a0);
+    assert(format(s3, d0) == a0);
+    assert(format(s2, d1) == a1);
+    assert(format(s3, d1) == a2);
 
     // [time.format]/6
     day d2{50};
-    res = format(s4, d0);
-    assert(res == a0);
-    res = format(s4, d2);
-    assert(res == a3);
+    assert(format(s4, d0) == a0);
+    assert(format(s4, d2) == a3);
 
     // width/align
-    res = format(s5, d0);
-    assert(res == a4);
-    res = format(s5, d1);
-    assert(res == a5);
-    res = format(s5, d2);
-    assert(res == a3);
+    assert(format(s5, d0) == a4);
+    assert(format(s5, d1) == a5);
+    assert(format(s5, d2) == a3);
 
     // chrono-spec must begin with conversion-spec
     throw_helper(s6, d0);
 
     // lit chars
-    res = format(s7, d0);
-    assert(res == a7);
-    res = format(s8, d0);
-    assert(res == a8);
+    assert(format(s7, d0) == a7);
+    assert(format(s8, d0) == a8);
 
     assert(format(STR("{:%d %d %d}"), day{27}) == STR("27 27 27"));
     assert(format(STR("{:%d}"), day{200}) == STR("200"));

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_io/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_io/test.cpp
@@ -921,10 +921,11 @@ tzdb copy_tzdb() {
     const auto& my_tzdb = get_tzdb_list().front();
     vector<time_zone> zones;
     vector<time_zone_link> links;
-    transform(my_tzdb.zones.begin(), my_tzdb.zones.end(), back_inserter(zones),
-        [](const auto& tz) { return time_zone{tz.name()}; });
+    transform(my_tzdb.zones.begin(), my_tzdb.zones.end(), back_inserter(zones), [](const auto& tz) {
+        return time_zone{_Secret_time_zone_construct_tag{}, tz.name()};
+    });
     transform(my_tzdb.links.begin(), my_tzdb.links.end(), back_inserter(links), [](const auto& link) {
-        return time_zone_link{link.name(), link.target()};
+        return time_zone_link{_Secret_time_zone_link_construct_tag{}, link.name(), link.target()};
     });
 
     return {my_tzdb.version, move(zones), move(links), my_tzdb.leap_seconds, my_tzdb._All_ls_positive};

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_time_zones/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_time_zones/test.cpp
@@ -109,9 +109,9 @@ void timezone_names_test() {
     try_locate_invalid_zone(my_tzdb, "AEST");
 
     // Comparison operators
-    const time_zone tz1{"Earlier"};
-    const time_zone tz2{"Earlier"};
-    const time_zone tz3{"Later"};
+    const time_zone tz1{_Secret_time_zone_construct_tag{}, "Earlier"};
+    const time_zone tz2{_Secret_time_zone_construct_tag{}, "Earlier"};
+    const time_zone tz3{_Secret_time_zone_construct_tag{}, "Later"};
     assert(tz1 == tz2);
     assert(tz1 != tz3);
 #ifdef __cpp_lib_concepts
@@ -120,9 +120,9 @@ void timezone_names_test() {
     assert(tz3 <=> tz1 == strong_ordering::greater);
 #endif // __cpp_lib_concepts
 
-    const time_zone_link link1{"Earlier", "Target"};
-    const time_zone_link link2{"Earlier", "Is"};
-    const time_zone_link link3{"Later", "Ignored"};
+    const time_zone_link link1{_Secret_time_zone_link_construct_tag{}, "Earlier", "Target"};
+    const time_zone_link link2{_Secret_time_zone_link_construct_tag{}, "Earlier", "Is"};
+    const time_zone_link link3{_Secret_time_zone_link_construct_tag{}, "Later", "Ignored"};
     assert(link1 == link2);
     assert(link1 != link3);
 #ifdef __cpp_lib_concepts


### PR DESCRIPTION
Fixes #1805 after 2.5 years. It's about time!

This is inherently a grab-bag PR (sorry) of various cleanups we identified during the rush to complete C++20. I've structured it into a series of fine-grained commits addressing each comment. Most are for the product code, with only a few changes to the test code. (We generally refrain from large-scale cleanups of test code, as it's low-value work and has the potential to disrupt what the tests were trying to do, but these changes are quite simple.) There are also a few cleanups I noticed myself along the way; I've included them here since they're pretty small.

* Make `_THROW` a variadic macro so we never need extra parens.
  + Something I noticed myself.
* Replace `decltype(tzdb::zones)` and `decltype(tzdb::links)` with their actual types.
  + These were relics of an early attempt to use special allocators, which was foiled by the Standard's insistence on `std::allocator`.
* `_Crt_allocator` should provide equality.
* `time_zone` and `time_zone_link`'s internal constructors should be tagged.
  + We also need to update some test code that was using these internal constructors.
* Return `const char*` as `string` without braces.
* Extract `_Make_unique_tzdb_info()`.
* `exchange()` the contained value instead of the entire `optional`.
  + We know `_Val.has_value()` here, so we can directly reach into the `optional`.
* Use positive test and early `return`.
  + Something I noticed myself. The negative test wasn't providing any value here. Additionally, the two cases are different enough that there's no symmetry advantage to keeping the `else`, so I believe this is clearer with an early `return`.
* Drop empty line at the top of `_Make_time_point()`.
* Consistently say "leap second deletion" in comments.
* `_InIt` is always `istreambuf_iterator`, not an arbitrary input iterator.
  + I decided that making the code specific to `istreambuf_iterator` was better than just renaming the parameters to `_Iter`. Accordingly, we can simplify the code because we know that the `value_type` will be `_CharT`.
* Use `const auto&` to avoid `_Ctype` typedef.
  + Something I noticed myself. Now that `ctype<_CharT>` is so short, we can just mention it in-place.
* `'q'` and `'Q'` should always be given `duration`s, otherwise there's a logic error in `_Is_valid_type`.
* Avoid dead `return`s after `if constexpr`.
  + Something I noticed myself. Unlike runtime `if`-statements where early `return`s are often desirable, `if constexpr` should avoid emitting dead code.
* `_Is_any_of_v` => `is_same_v` for one type.
* Test cleanup: Drop separate `res` variable used during debugging.
* Test cleanup: Consistently make `invalid` variables `constexpr`.
* Drop performance note.
  + I don't believe that this comment is worth keeping.
* Comment why `++_Begin` is safe.
* Use `ios_base` with `_CATCH_IO_`.
  + Something I noticed myself. The first parameter of `_CATCH_IO_` is used to qualify `badbit`. It's usually `ios_base`, but is allowed to vary for headers that are only dragging in `<iosfwd>`. `chrono` has the full definition, so it should just say `ios_base` here. This was the only affected line.

