### PR TITLE
`<random>`: Fix minor conformance issues

### DIFF
--- a/stl/inc/random
+++ b/stl/inc/random
@@ -1362,6 +1362,8 @@ public:
 
     explicit discard_block(const _Engine& _Ex) : _Eng(_Ex), _Nx(0) {}
 
+    explicit discard_block(_Engine&& _Ex) : _Eng(_STD move(_Ex)), _Nx(0) {}
+
     explicit discard_block(result_type _Seed) : _Eng(_Seed), _Nx(0) {}
 
     template <class _Seed_seq, _Enable_if_seed_seq_t<_Seed_seq, discard_block, _Engine> = 0>
@@ -1448,6 +1450,8 @@ public:
     _Discard_block_base() : _Eng(), _Nx(0) {}
 
     explicit _Discard_block_base(const _Engine& _Ex) : _Eng(_Ex), _Nx(0) {}
+
+    explicit _Discard_block_base(_Engine&& _Ex) : _Eng(_STD move(_Ex)), _Nx(0) {}
 
     explicit _Discard_block_base(result_type _Seed) : _Eng(_Seed), _Nx(0) {}
 

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -1349,7 +1349,10 @@ public:
 template <class _Engine, int _Px, int _Rx>
 class discard_block { // discard_block compound engine
 public:
-    using base_type   = _Engine;
+#if _HAS_TR1_NAMESPACE
+    using base_type _DEPRECATE_TR1_NAMESPACE = _Engine; // TR1-only typedef
+#endif // _HAS_TR1_NAMESPACE
+
     using result_type = typename _Engine::result_type;
 
     static constexpr int block_size = _Px;
@@ -1380,7 +1383,7 @@ public:
         _Nx = 0;
     }
 
-    _NODISCARD const base_type& base() const noexcept {
+    _NODISCARD const _Engine& base() const noexcept {
         return _Eng;
     }
 
@@ -1433,14 +1436,13 @@ public:
     }
 
 private:
-    base_type _Eng;
+    _Engine _Eng;
     int _Nx;
 };
 
 template <class _Engine, size_t _Px, size_t _Rx>
 class _Discard_block_base { // TRANSITION, ABI, should be merged into discard_block_engine
 public:
-    using base_type   = _Engine;
     using result_type = typename _Engine::result_type;
 
     _Discard_block_base() : _Eng(), _Nx(0) {}
@@ -1468,7 +1470,7 @@ public:
         _Nx = 0;
     }
 
-    _NODISCARD const base_type& base() const noexcept {
+    _NODISCARD const _Engine& base() const noexcept {
         return _Eng;
     }
 
@@ -1513,7 +1515,7 @@ public:
     }
 
 private:
-    base_type _Eng;
+    _Engine _Eng;
     size_t _Nx;
 };
 
@@ -1559,7 +1561,6 @@ public:
     static_assert(
         0 < _Wx && _Wx <= numeric_limits<_UIntType>::digits, "invalid template argument for independent_bits_engine");
 
-    using base_type   = _Engine;
     using result_type = _UIntType;
     using _Eres       = typename _Engine::result_type;
 
@@ -1707,7 +1708,6 @@ class shuffle_order_engine { // shuffle_order_engine compound engine
 public:
     static_assert(0 < _Kx, "invalid template argument for shuffle_order_engine");
 
-    using base_type   = _Engine;
     using result_type = typename _Engine::result_type;
 
     static constexpr size_t table_size = _Kx;

--- a/tests/tr1/tests/random1/test.cpp
+++ b/tests/tr1/tests/random1/test.cpp
@@ -466,9 +466,11 @@ static void tdiscard() {
     typedef STD discard_block<rng_base_t, 223, 24> rng_t;
     CHECK_INT(rng_t::block_size, 223);
     CHECK_INT(rng_t::used_block, 24);
+#if _HAS_TR1_NAMESPACE
     CHECK_INT(rng_t::base_type::modulus, 1 << 24);
     CHECK_INT(rng_t::base_type::long_lag, 24);
     CHECK_INT(rng_t::base_type::short_lag, 10);
+#endif // _HAS_TR1_NAMESPACE
     bool st = STD is_same<rng_t::result_type, Uint32>::value;
     CHECK(st);
 


### PR DESCRIPTION
* Conformance: `base_type` in `<random>` is a non-Standard typedef.
  + Remove it outright for Standard `discard_block_engine` (via the new base class `_Discard_block_base` introduced by #4066), `independent_bits_engine`, and `shuffle_order_engine`.
  + For `discard_block`, which is usually the base class for Standard `discard_block_engine`, we can guard the typedef with TR1's availability, and deprecate it. We should then avoid using it ourselves.
* Conformance: Add `_Engine&&` constructors to `discard_block` and `_Discard_block_base`.
  + `discard_block_engine` had an `_Engine&&` constructor but its base classes didn't, so it was always copying.
