### PR TITLE
Various cleanups: Simplify product code

### DIFF
--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -361,8 +361,7 @@ _EXPORT_STD template <class _Ty>
 
     if constexpr (is_class_v<_Uty> && !is_base_of_v<nested_exception, _Uty> && !is_final_v<_Uty>) {
         // throw user exception glued to nested_exception
-        using _Glued = _With_nested_v2<_Uty>;
-        _THROW(_Glued(_STD forward<_Ty>(_Arg)));
+        _THROW(_With_nested_v2<_Uty>(_STD forward<_Ty>(_Arg)));
     } else {
         // throw user exception by itself
         _THROW(_STD forward<_Ty>(_Arg));

--- a/stl/inc/ios
+++ b/stl/inc/ios
@@ -37,7 +37,7 @@ public:
 
     void __CLR_OR_THIS_CALL clear(iostate _State = goodbit, bool _Reraise = false) {
         // set state, possibly reraise exception
-        ios_base::clear(_State | (_Mystrbuf ? ios_base::_Iostate{} : ios_base::badbit), _Reraise);
+        ios_base::clear(_State | (_Mystrbuf ? ios_base::goodbit : ios_base::badbit), _Reraise);
     }
 
 #if _HAS_OLD_IOSTREAMS_MEMBERS

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -1542,11 +1542,11 @@ public:
     template <class _Seed_seq, _Enable_if_seed_seq_t<_Seed_seq, discard_block_engine, _Engine> = 0>
     explicit discard_block_engine(_Seed_seq& _Seq) : _Mybase(_Seq) {}
 
-    _NODISCARD static constexpr typename _Engine::result_type(min)() noexcept /* strengthened */ {
+    _NODISCARD static constexpr result_type(min)() noexcept /* strengthened */ {
         return (_Engine::min)();
     }
 
-    _NODISCARD static constexpr typename _Engine::result_type(max)() noexcept /* strengthened */ {
+    _NODISCARD static constexpr result_type(max)() noexcept /* strengthened */ {
         return (_Engine::max)();
     }
 };

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -4856,7 +4856,8 @@ private:
 
     _CONSTEXPR20 void _Eos(const size_type _New_size) noexcept { // set new length and null terminator
         _ASAN_STRING_MODIFY(*this, _Mypair._Myval2._Mysize, _New_size);
-        _Traits::assign(_Mypair._Myval2._Myptr()[_Mypair._Myval2._Mysize = _New_size], _Elem());
+        _Mypair._Myval2._Mysize = _New_size;
+        _Traits::assign(_Mypair._Myval2._Myptr()[_New_size], _Elem());
     }
 
     _CONSTEXPR20 void _Tidy_deallocate() noexcept { // initialize buffer, deallocating any storage

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4562,16 +4562,13 @@ _CONSTEXPR20 _OutIt _Copy_unchecked(_InIt _First, _Sent _Last, _OutIt _Dest) {
 #endif // _HAS_CXX20
             {
 #ifdef __cpp_lib_concepts
-                if constexpr (is_same_v<_InIt, _Sent>)
+                if constexpr (!is_same_v<_InIt, _Sent>) {
+                    return _Copy_memmove_n(_First, static_cast<size_t>(_Last - _First), _Dest);
+                } else
 #endif // defined(__cpp_lib_concepts)
                 {
                     return _Copy_memmove(_First, _Last, _Dest);
                 }
-#ifdef __cpp_lib_concepts
-                else {
-                    return _Copy_memmove_n(_First, static_cast<size_t>(_Last - _First), _Dest);
-                }
-#endif // defined(__cpp_lib_concepts)
             }
         }
 


### PR DESCRIPTION
* `<exception>`: `throw_with_nested()` no longer needs `_Glued` to defend against the preprocessor.
  + After #3973, `_With_nested_v2<_Uty>` doesn't contain commas.
* Simplify: `ios_base::_Iostate{}` => `ios_base::goodbit`
  + It's just zero.
* Simplify `_Copy_unchecked()`'s `#ifdef __cpp_lib_concepts` logic.
  + Here's a case where a negative test allows us to considerably simplify the code by avoiding the need for two `#ifdef __cpp_lib_concepts` regions (which was hard to follow). Now the code reads much more naturally - in concepts mode, we need to handle different iterator/sentinel types.
* `<random>`: `discard_block_engine` can use its `result_type` typedef for `min` and `max`.
  + A constructor above is already using this typedef.
* Style: Avoid using an assignment expression as an index in `basic_string::_Eos()`.
  + We prefer to avoid expressions with lots of side effects, so we should update `_Mysize` before indexing. I'm using `_New_size` for the index since it's shorter.