### PR TITLE
Various cleanups: Test code

### DIFF
--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -20,7 +20,7 @@ template <class>
 inline constexpr bool always_false = false;
 
 namespace detail {
-    static constexpr bool permissive() {
+    constexpr bool permissive() {
         return false;
     }
 

--- a/tests/std/include/test_mdspan_support.hpp
+++ b/tests/std/include/test_mdspan_support.hpp
@@ -235,7 +235,7 @@ constexpr void check_members_with_various_extents(Fn&& fn) {
 }
 
 namespace details {
-    static constexpr bool permissive() {
+    constexpr bool permissive() {
         return false;
     }
 

--- a/tests/std/tests/Dev09_174589_tr1_function_storing_pmf_called_with_reference_or_pointer/test.cpp
+++ b/tests/std/tests/Dev09_174589_tr1_function_storing_pmf_called_with_reference_or_pointer/test.cpp
@@ -69,7 +69,7 @@ struct B {
 
 struct X : public B {};
 
-void test_294051() {
+void test_DevDiv_294051() {
     shared_ptr<B> b(new B);
     shared_ptr<X> x(new X);
 
@@ -121,5 +121,5 @@ void test_294051() {
 int main() {
     test_orig();
 
-    test_294051();
+    test_DevDiv_294051();
 }

--- a/tests/std/tests/Dev10_646244_bad_alloc_message/test.cpp
+++ b/tests/std/tests/Dev10_646244_bad_alloc_message/test.cpp
@@ -8,5 +8,5 @@
 using namespace std;
 
 int main() {
-    assert(strcmp(std::bad_alloc().what(), "bad allocation") == 0);
+    assert(strcmp(bad_alloc().what(), "bad allocation") == 0);
 }

--- a/tests/std/tests/Dev10_722102_shared_ptr_nullptr/test.cpp
+++ b/tests/std/tests/Dev10_722102_shared_ptr_nullptr/test.cpp
@@ -74,12 +74,12 @@ void test_exception() {
     try {
         shared_ptr<int>{nullptr, NullptrDeleter{}};
         abort();
-    } catch (bad_alloc&) {
+    } catch (const bad_alloc&) {
     }
     try {
         shared_ptr<int>{nullptr, NullptrDeleter{}, allocator<int>{}};
         abort();
-    } catch (bad_alloc&) {
+    } catch (const bad_alloc&) {
     }
     g_throw_on_alloc = false;
 }
@@ -286,7 +286,7 @@ namespace unique_ptr_ {
         try {
             shared_ptr<int>{move(up)};
             abort();
-        } catch (bad_alloc&) {
+        } catch (const bad_alloc&) {
         }
         g_throw_on_alloc = false;
         assert(up.get() == rawptr);

--- a/tests/std/tests/Dev10_860421_deque_push_back_pop_front/test.cpp
+++ b/tests/std/tests/Dev10_860421_deque_push_back_pop_front/test.cpp
@@ -36,7 +36,7 @@ void test_push_back_pop_front() {
 
 // Also test Dev10-391805 "STL: Prefast error in deque".
 
-void test_391805() {
+void test_Dev10_391805() {
     deque<int> d;
 
     d.push_back(10);
@@ -262,7 +262,7 @@ void test_exception_safety_for_throwing_movable() {
 int main() {
     test_push_back_pop_front();
 
-    test_391805();
+    test_Dev10_391805();
 
     test_exception_safety_for_nonswappable_movable();
     test_exception_safety_for_throwing_movable();

--- a/tests/std/tests/Dev11_0485243_condition_variable_crash/test.cpp
+++ b/tests/std/tests/Dev11_0485243_condition_variable_crash/test.cpp
@@ -24,7 +24,7 @@ void assert_no_leaks() {
 #endif
 }
 
-void test_484720();
+void test_DevDiv_484720();
 
 int main() {
     // DevDiv-452211 "<thread>: init_at_thread_exit_mutex() creates a spurious memory leak"
@@ -80,7 +80,7 @@ int main() {
 
     assert_no_leaks();
 
-    test_484720();
+    test_DevDiv_484720();
 
     assert_no_leaks();
 
@@ -183,7 +183,7 @@ void f2(locked_list<elt<int>>& lst) {
     assert(i == lst.end());
 }
 
-void test_484720() {
+void test_DevDiv_484720() {
     locked_list<elt<int>> lst;
     lst.emplace_back(1);
 

--- a/tests/std/tests/Dev11_0836436_get_time/test.cpp
+++ b/tests/std/tests/Dev11_0836436_get_time/test.cpp
@@ -101,8 +101,8 @@ tuple<int, int, int> read_time(const char* const s) {
     return make_tuple(t.tm_hour, t.tm_min, t.tm_sec);
 }
 
-void test_640278();
-void test_990695();
+void test_DevDiv_640278();
+void test_DevDiv_990695();
 void test_locale_russian();
 void test_locale_german();
 void test_locale_chinese();
@@ -148,8 +148,8 @@ int main() {
 
     assert(read_time("15 : 47 : 60") == make_tuple(15, 47, 60));
 
-    test_640278();
-    test_990695();
+    test_DevDiv_640278();
+    test_DevDiv_990695();
     test_locale_russian();
     test_locale_german();
     test_locale_chinese();
@@ -171,7 +171,7 @@ void test_year(const string& str, const ios_base::iostate expected_err, const in
     assert(t.tm_year == expected_tm_year);
 }
 
-void test_640278() {
+void test_DevDiv_640278() {
     test_year("", ios_base::eofbit | ios_base::failbit, 0);
 
     test_year("xyz", ios_base::failbit, 0);
@@ -197,7 +197,7 @@ void test_640278() {
 }
 
 // DevDiv-990695 "<locale>: time_get should ignore ios_base::iostate's initial value"
-void test_990695() {
+void test_DevDiv_990695() {
     for (int k = 0; k < 2; ++k) {
         const auto Bit = k == 0 ? ios_base::goodbit : ios_base::failbit;
 

--- a/tests/std/tests/Dev11_0920385_list_sort_allocator/test.cpp
+++ b/tests/std/tests/Dev11_0920385_list_sort_allocator/test.cpp
@@ -81,8 +81,8 @@ struct MyAlloc {
     }
 };
 
-void test_1119194();
-void test_1184701();
+void test_DevDiv_1119194();
+void test_DevDiv_1184701();
 void test_LWG_2455();
 void test_allocator_construct_const();
 
@@ -279,8 +279,8 @@ int main() {
 #endif // _HAS_FUNCTION_ALLOCATOR_SUPPORT
 #endif // _M_CEE_PURE
 
-    test_1119194();
-    test_1184701();
+    test_DevDiv_1119194();
+    test_DevDiv_1184701();
     test_LWG_2455();
 #if !_HAS_CXX20 // support removed in C++20 by P0619R4
     test_allocator_construct_const();
@@ -328,7 +328,7 @@ void test_swap_copy_move() {
     a = move(b);
 }
 
-void test_1119194() {
+void test_DevDiv_1119194() {
     using AB = NoProp<bool>;
     using AC = NoProp<char>;
     using AI = NoProp<int>;
@@ -395,7 +395,7 @@ struct NonVoid {
     }
 };
 
-void test_1184701() {
+void test_DevDiv_1184701() {
     const vector<int, NonVoid<int>> v = {11, 22, 33};
 
     assert(v[1] == 22);

--- a/tests/std/tests/P0024R2_parallel_algorithms_find_first_of/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_find_first_of/test.cpp
@@ -26,7 +26,7 @@ void test_case_find_first_of_parallel(const size_t testSize) {
     iota(candidates.begin(), candidates.end(), 0);
     auto expected        = tmp.begin();
     auto candidatesBegin = candidates.begin();
-    const auto limit     = std::min(testSize, quadratic_complexity_case_limit);
+    const auto limit     = min(testSize, quadratic_complexity_case_limit);
     for (size_t idx = 0; idx < limit; ++idx) {
         assert(expected == find_first_of(par, tmp.begin(), tmp.end(), candidatesBegin, candidates.end()));
         ++candidatesBegin;

--- a/tests/std/tests/P0024R2_parallel_algorithms_is_heap/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_is_heap/test.cpp
@@ -35,7 +35,7 @@ void test_case_is_heap_parallel(const size_t testSize) {
     v[0] = 0;
 
     // (0, testSize - 1]
-    const auto limit = std::min(testSize, quadratic_complexity_case_limit);
+    const auto limit = min(testSize, quadratic_complexity_case_limit);
     for (auto i = 1U; i < limit; ++i) {
         v[i] = 1;
         assert(!is_heap(par, v.begin(), v.end()));

--- a/tests/std/tests/P0083R3_splicing_maps_and_sets/test.cpp
+++ b/tests/std/tests/P0083R3_splicing_maps_and_sets/test.cpp
@@ -154,10 +154,10 @@ void test_node_handle(NodeHandle& nh1, NodeHandle& nh2, Validator1 v1, Validator
     static_assert(std::is_nothrow_default_constructible_v<NodeHandle>);
     CHECK_EMPTY(NodeHandle{});
 #ifndef _M_CEE // TRANSITION, VSO-1664382
-#ifdef __cpp_constinit
+#if _HAS_CXX20
 #pragma warning(suppress : 4640) // C4640 emitted by MSVC because 'NodeHandle' type has non-trivial dtor
     { static constinit NodeHandle static_handle{}; }
-#endif // ^^^ __cpp_constinit ^^^
+#endif // ^^^ _HAS_CXX20 ^^^
 #endif // _M_CEE
 
     // No copies!

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -7227,17 +7227,17 @@ namespace msvc {
                 try {
                     std::visit(very_useful_visitor, v);
                     abort();
-                } catch (std::bad_variant_access&) {
+                } catch (const std::bad_variant_access&) {
                 }
                 try {
                     std::visit(very_useful_visitor, my_variant{42}, v);
                     abort();
-                } catch (std::bad_variant_access&) {
+                } catch (const std::bad_variant_access&) {
                 }
                 try {
                     std::visit(very_useful_visitor, v, my_variant{42});
                     abort();
-                } catch (std::bad_variant_access&) {
+                } catch (const std::bad_variant_access&) {
                 }
             }
         }

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -2258,7 +2258,7 @@ void test_copy_directory_as_symlink() {
     try {
         copy(dirpath, L"./symlink"sv, copy_options::create_symlinks);
         EXPECT(false);
-    } catch (filesystem_error& e) {
+    } catch (const filesystem_error& e) {
         EXPECT(e.code().value() == static_cast<int>(errc::is_a_directory));
     }
     {

--- a/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
+++ b/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
@@ -399,7 +399,7 @@ namespace {
                             try {
                                 (void) nmr.allocate(size, align);
                                 CHECK(false);
-                            } catch (std::bad_alloc&) {
+                            } catch (const std::bad_alloc&) {
                             }
                         }
                     }
@@ -617,7 +617,7 @@ namespace {
                     try {
                         (void) alloc.allocate(size_max / sizeof(T) + 1);
                         CHECK(false);
-                    } catch (std::bad_alloc&) {
+                    } catch (const std::bad_alloc&) {
                     }
                 }
 
@@ -1114,7 +1114,7 @@ namespace {
                     try {
                         (void) mbr.allocate(1, 1);
                         CHECK(false);
-                    } catch (std::bad_alloc&) {
+                    } catch (const std::bad_alloc&) {
                         // nothing to do
                     }
                 }
@@ -1150,7 +1150,7 @@ namespace {
                         do {
                             (void) mbr.allocate(1, 1);
                         } while (rr.allocations_.size() < N);
-                    } catch (std::bad_alloc&) {
+                    } catch (const std::bad_alloc&) {
                     }
 
                     std::vector<std::size_t> sizes;
@@ -1324,7 +1324,7 @@ namespace {
                     do {
                         (void) upr.allocate(block_size, block_size);
                     } while (rr.allocations_.size() < N + idl);
-                } catch (std::bad_alloc&) {
+                } catch (const std::bad_alloc&) {
                 }
 
                 auto const n = rr.allocations_.size() - idl;

--- a/tests/std/tests/P0288R9_move_only_function/test.cpp
+++ b/tests/std/tests/P0288R9_move_only_function/test.cpp
@@ -532,14 +532,14 @@ void test_except() {
     try {
         move_only_function<void()> f{throwing{}};
         assert(false); // unreachable
-    } catch (runtime_error&) {
+    } catch (const runtime_error&) {
     }
 
     try {
         fail_allocations = true;
         move_only_function<void()> f{not_throwing{}};
         assert(false); // unreachable
-    } catch (bad_alloc&) {
+    } catch (const bad_alloc&) {
         fail_allocations = false;
     }
 }

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -1283,7 +1283,7 @@ namespace test_expected {
         constexpr payload_swap(payload_swap&& other) noexcept(IsYes(nothrowMoveConstructible))
             : _val(other._val + 42) {}
         // Note: cannot declare friends of function local structs
-        constexpr friend void swap(payload_swap& left, payload_swap& right) noexcept(IsYes(nothrowSwappable)) {
+        friend constexpr void swap(payload_swap& left, payload_swap& right) noexcept(IsYes(nothrowSwappable)) {
             left._val = exchange(right._val, left._val);
         }
 

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -75,7 +75,7 @@ namespace test_unexpected {
 
             int _val = 0;
         };
-        using Unexpect = std::unexpected<test_error>;
+        using Unexpect = unexpected<test_error>;
 
         // [expected.un.ctor]
         const int& input = 1;
@@ -113,7 +113,7 @@ namespace test_unexpected {
         static_assert(noexcept(in_place_lvalue_constructed == in_place_lvalue_constructed) == compare_is_noexcept);
         static_assert(noexcept(in_place_lvalue_constructed != in_place_lvalue_constructed) == compare_is_noexcept);
 
-        const auto converted = std::unexpected<convertible>{convertible{3}};
+        const auto converted = unexpected<convertible>{convertible{3}};
         assert(base_error_constructed == converted);
         assert(conversion_error_constructed != converted);
         static_assert(noexcept(base_error_constructed == converted) == compare_is_noexcept);
@@ -148,7 +148,7 @@ namespace test_unexpected {
         static_assert(is_same_v<decltype(const_rvalue_error), const test_error&&>);
 
         // deduction guide
-        std::unexpected deduced(test_error{42});
+        unexpected deduced(test_error{42});
         static_assert(same_as<decltype(deduced), Unexpect>);
     }
 
@@ -182,7 +182,7 @@ namespace test_expected {
             using Expected = expected<value_tag, error_tag>;
             static_assert(same_as<typename Expected::value_type, value_tag>);
             static_assert(same_as<typename Expected::error_type, error_tag>);
-            static_assert(same_as<typename Expected::unexpected_type, std::unexpected<error_tag>>);
+            static_assert(same_as<typename Expected::unexpected_type, unexpected<error_tag>>);
 
             static_assert(same_as<typename Expected::rebind<int>, expected<int, error_tag>>);
         }
@@ -191,7 +191,7 @@ namespace test_expected {
             using Expected = expected<void, error_tag>;
             static_assert(same_as<typename Expected::value_type, void>);
             static_assert(same_as<typename Expected::error_type, error_tag>);
-            static_assert(same_as<typename Expected::unexpected_type, std::unexpected<error_tag>>);
+            static_assert(same_as<typename Expected::unexpected_type, unexpected<error_tag>>);
 
             static_assert(same_as<typename Expected::rebind<int>, expected<int, error_tag>>);
         }
@@ -535,7 +535,7 @@ namespace test_expected {
         }
 
         { // converting from unexpected
-            using Input    = std::unexpected<convertible>;
+            using Input    = unexpected<convertible>;
             using Expected = expected<int, payload_constructors>;
 
             const Input const_input{in_place};
@@ -616,7 +616,7 @@ namespace test_expected {
         }
 
         { // expected<void, E>: converting from unexpected
-            using Input    = std::unexpected<convertible>;
+            using Input    = unexpected<convertible>;
             using Expected = expected<void, payload_constructors>;
 
             const Input const_input{in_place};
@@ -668,8 +668,8 @@ namespace test_expected {
         struct BaseError {};
         struct DerivedError : BaseError {};
 
-        std::expected<bool, DerivedError> e1(false);
-        std::expected<bool, BaseError> e2(e1);
+        expected<bool, DerivedError> e1(false);
+        expected<bool, BaseError> e2(e1);
         assert(!e2.value());
     }
 
@@ -980,7 +980,7 @@ namespace test_expected {
         { // assign error type const ref
             constexpr bool should_be_noexcept = nothrow_copy_constructible && nothrow_copy_assignable;
             using Expected                    = expected<int, payload_assign>;
-            using Unexpected                  = std::unexpected<payload_assign>;
+            using Unexpected                  = unexpected<payload_assign>;
             const Unexpected input_error{42};
 
             Expected assign_error_to_value{in_place, 1};
@@ -999,7 +999,7 @@ namespace test_expected {
         { // assign expected<void> error type const ref
             constexpr bool should_be_noexcept = nothrow_copy_constructible && nothrow_copy_assignable;
             using Expected                    = expected<void, payload_assign>;
-            using Unexpected                  = std::unexpected<payload_assign>;
+            using Unexpected                  = unexpected<payload_assign>;
             const Unexpected input_error{42};
 
             Expected assign_error_to_value{in_place};
@@ -1018,7 +1018,7 @@ namespace test_expected {
         { // assign error type rvalue
             constexpr bool should_be_noexcept = nothrow_move_constructible && nothrow_move_assignable;
             using Expected                    = expected<int, payload_assign>;
-            using Unexpected                  = std::unexpected<payload_assign>;
+            using Unexpected                  = unexpected<payload_assign>;
 
             Expected assign_error_to_value{in_place, 1};
             assign_error_to_value = Unexpected{42};
@@ -1036,7 +1036,7 @@ namespace test_expected {
         { // assign expected<void> error type rvalue
             constexpr bool should_be_noexcept = nothrow_move_constructible && nothrow_move_assignable;
             using Expected                    = expected<void, payload_assign>;
-            using Unexpected                  = std::unexpected<payload_assign>;
+            using Unexpected                  = unexpected<payload_assign>;
 
             Expected assign_error_to_value{in_place};
             assign_error_to_value = Unexpected{42};
@@ -1054,7 +1054,7 @@ namespace test_expected {
         { // assign convertible error const ref
             constexpr bool should_be_noexcept = nothrow_copy_constructible && nothrow_copy_assignable;
             using Expected                    = expected<int, payload_assign>;
-            using Unexpected                  = std::unexpected<convertible>;
+            using Unexpected                  = unexpected<convertible>;
             const Unexpected input_error{42};
 
             Expected assign_error_to_value{in_place, 1};
@@ -1073,7 +1073,7 @@ namespace test_expected {
         { // assign expected<void> convertible error const ref
             constexpr bool should_be_noexcept = nothrow_copy_constructible && nothrow_copy_assignable;
             using Expected                    = expected<void, payload_assign>;
-            using Unexpected                  = std::unexpected<convertible>;
+            using Unexpected                  = unexpected<convertible>;
             const Unexpected input_error{42};
 
             Expected assign_error_to_value{in_place};
@@ -1092,7 +1092,7 @@ namespace test_expected {
         { // assign convertible error rvalue
             constexpr bool should_be_noexcept = nothrow_move_constructible && nothrow_move_assignable;
             using Expected                    = expected<int, payload_assign>;
-            using Unexpected                  = std::unexpected<convertible>;
+            using Unexpected                  = unexpected<convertible>;
 
             Expected assign_error_to_value{in_place, 1};
             assign_error_to_value = Unexpected{42};
@@ -1110,7 +1110,7 @@ namespace test_expected {
         { // assign expected<void> convertible error rvalue
             constexpr bool should_be_noexcept = nothrow_move_constructible && nothrow_move_assignable;
             using Expected                    = expected<void, payload_assign>;
-            using Unexpected                  = std::unexpected<convertible>;
+            using Unexpected                  = unexpected<convertible>;
 
             Expected assign_error_to_value{in_place};
             assign_error_to_value = Unexpected{42};
@@ -1941,7 +1941,7 @@ namespace test_expected {
 
         { // compare against unexpected with same base
             using Base       = payload_equality;
-            using Unexpected = std::unexpected<Base>;
+            using Unexpected = unexpected<Base>;
             using Expected   = expected<int, Base>;
 
             const Expected with_value{in_place, 42};
@@ -1960,7 +1960,7 @@ namespace test_expected {
 
         { // expected<void> compare against unexpected with same base
             using Base       = payload_equality;
-            using Unexpected = std::unexpected<Base>;
+            using Unexpected = unexpected<Base>;
             using Expected   = expected<void, Base>;
 
             const Expected with_value{in_place};
@@ -1976,7 +1976,7 @@ namespace test_expected {
 
         { // compare against unexpected with different base
             using Base       = payload_equality;
-            using Unexpected = std::unexpected<int>;
+            using Unexpected = unexpected<int>;
             using Expected   = expected<int, Base>;
 
             const Expected with_value{in_place, 42};
@@ -1995,7 +1995,7 @@ namespace test_expected {
 
         { // expected<void> compare against unexpected with different base
             using Base       = payload_equality;
-            using Unexpected = std::unexpected<int>;
+            using Unexpected = unexpected<int>;
             using Expected   = expected<void, Base>;
 
             const Expected with_value{in_place};

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_zoned_time/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_zoned_time/test.cpp
@@ -171,24 +171,24 @@ void zonedtime_exception_tests() {
     try {
         (void) zoned_time<seconds>{ZT::locate_zone(Sydney::Tz_name), ambiguous_local};
         assert(false);
-    } catch (nonexistent_local_time&) {
-    } catch (ambiguous_local_time&) {
+    } catch (const nonexistent_local_time&) {
+    } catch (const ambiguous_local_time&) {
     }
 
     try {
         (void) zoned_time<seconds>{Sydney::Tz_name, ambiguous_local};
         assert(false);
-    } catch (nonexistent_local_time&) {
-    } catch (ambiguous_local_time&) {
+    } catch (const nonexistent_local_time&) {
+    } catch (const ambiguous_local_time&) {
     }
 
     // safe constructors
     try {
         (void) zoned_time<seconds>{ZT::locate_zone(Sydney::Tz_name), ambiguous_local, choose::earliest};
         (void) zoned_time<seconds>{Sydney::Tz_name, ambiguous_local, choose::earliest};
-    } catch (nonexistent_local_time&) {
+    } catch (const nonexistent_local_time&) {
         assert(false);
-    } catch (ambiguous_local_time&) {
+    } catch (const ambiguous_local_time&) {
         assert(false);
     }
 
@@ -198,8 +198,8 @@ void zonedtime_exception_tests() {
         zone = ambiguous_local;
         (void) zone;
         assert(false);
-    } catch (nonexistent_local_time&) {
-    } catch (ambiguous_local_time&) {
+    } catch (const nonexistent_local_time&) {
+    } catch (const ambiguous_local_time&) {
     }
 }
 

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_zoned_time/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_zoned_time/test.cpp
@@ -224,7 +224,7 @@ struct Always_zero {
     }
 
     template <class Duration>
-    [[nodiscard]] sys_time<common_type_t<Duration, seconds>> to_sys(const local_time<Duration>&, const choose) const {
+    [[nodiscard]] sys_time<common_type_t<Duration, seconds>> to_sys(const local_time<Duration>&, choose) const {
         return sys_time<common_type_t<Duration, seconds>>{};
     }
 

--- a/tests/std/tests/P0811R3_midpoint_lerp/test.cpp
+++ b/tests/std/tests/P0811R3_midpoint_lerp/test.cpp
@@ -624,7 +624,7 @@ struct LerpNaNTestCase {
 
 template <typename Ty>
 struct LerpCases { // TRANSITION, VSO-934633
-    static inline constexpr LerpTestCase<Ty> lerpTestCases[] = {
+    static constexpr LerpTestCase<Ty> lerpTestCases[] = {
         {Ty(-1.0), Ty(1.0), Ty(2.0), Ty(3.0)},
         {Ty(0.0), Ty(1.0), Ty(2.0), Ty(2.0)},
         {Ty(-1.0), Ty(0.0), Ty(2.0), Ty(1.0)},
@@ -794,12 +794,12 @@ struct LerpCases { // TRANSITION, VSO-934633
         {Ty(1.0), -limits<Ty>::infinity(), limits<Ty>::infinity(), -limits<Ty>::infinity()},
     };
 
-    static inline constexpr LerpTestCase<Ty> lerpOverflowTestCases[] = {
+    static constexpr LerpTestCase<Ty> lerpOverflowTestCases[] = {
         {limits<Ty>::lowest(), limits<Ty>::max(), Ty(2.0), limits<Ty>::infinity()},
         {limits<Ty>::max(), limits<Ty>::lowest(), Ty(2.0), -limits<Ty>::infinity()},
     };
 
-    static inline constexpr LerpNaNTestCase<Ty> lerpInvalidTestCases[] = {
+    static constexpr LerpNaNTestCase<Ty> lerpInvalidTestCases[] = {
         // if the values are equal and T is an infinity, NaN
         {Ty(0), Ty(0), limits<Ty>::infinity()},
         {Ty(0), Ty(0), -limits<Ty>::infinity()},
@@ -855,7 +855,7 @@ struct LerpCases { // TRANSITION, VSO-934633
         {Ty(1.0), -limits<Ty>::infinity(), -Ty(0.0)},
     };
 
-    static inline constexpr LerpNaNTestCase<Ty> lerpNaNTestCases[] = {
+    static constexpr LerpNaNTestCase<Ty> lerpNaNTestCases[] = {
         {mint_nan<Ty>(0, 42), mint_nan<Ty>(1, 42), mint_nan<Ty>(0, 1729),
             {mint_nan<Ty>(0, 42), mint_nan<Ty>(1, 42), mint_nan<Ty>(0, 1729)}},
         {Ty(1.0), mint_nan<Ty>(1, 42), mint_nan<Ty>(0, 1729), {mint_nan<Ty>(1, 42), mint_nan<Ty>(0, 1729)}},

--- a/tests/std/tests/P0896R4_ranges_alg_find_end/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_end/test.cpp
@@ -98,9 +98,9 @@ constexpr void test_devcom_1559808() {
     // Regression test for DevCom-1559808, an interaction between vector and the
     // use of structured bindings in the constexpr evaluator.
 
-    std::vector<int> haystack(33, 42); // No particular significance to any numbers in this function
-    std::vector<int> needle(8, 42);
-    using size_type = std::vector<int>::size_type;
+    vector<int> haystack(33, 42); // No particular significance to any numbers in this function
+    vector<int> needle(8, 42);
+    using size_type = vector<int>::size_type;
 
     auto result = ranges::find_end(haystack, needle);
     assert(static_cast<size_type>(result.begin() - haystack.begin()) == haystack.size() - needle.size());

--- a/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
@@ -308,12 +308,12 @@ constexpr void mm_element_constexpr_tests() {
     mm_element::call<range<fwd, E, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>>();
     mm_element::call<range<fwd, E, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>>();
 
-    mm_element::call<range<std::bidirectional_iterator_tag, E, Sized::no, CanDifference::no, Common::yes,
-        CanCompare::yes, ProxyRef::yes>>();
-    mm_element::call<range<std::random_access_iterator_tag, E, Sized::yes, CanDifference::yes, Common::yes,
-        CanCompare::yes, ProxyRef::yes>>();
-    mm_element::call<range<std::contiguous_iterator_tag, E, Sized::yes, CanDifference::yes, Common::yes,
-        CanCompare::yes, ProxyRef::no>>();
+    mm_element::call<range<bidirectional_iterator_tag, E, Sized::no, CanDifference::no, Common::yes, CanCompare::yes,
+        ProxyRef::yes>>();
+    mm_element::call<range<random_access_iterator_tag, E, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+        ProxyRef::yes>>();
+    mm_element::call<range<contiguous_iterator_tag, E, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+        ProxyRef::no>>();
 }
 
 constexpr void mm_constexpr_tests() {
@@ -331,11 +331,11 @@ constexpr void mm_constexpr_tests() {
     mm::call<range<fwd, E, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>>();
     mm::call<range<fwd, E, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>>();
 
-    mm::call<range<std::bidirectional_iterator_tag, E, Sized::no, CanDifference::no, Common::yes, CanCompare::yes,
+    mm::call<range<bidirectional_iterator_tag, E, Sized::no, CanDifference::no, Common::yes, CanCompare::yes,
         ProxyRef::yes>>();
-    mm::call<range<std::random_access_iterator_tag, E, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+    mm::call<range<random_access_iterator_tag, E, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
         ProxyRef::yes>>();
-    mm::call<range<std::contiguous_iterator_tag, E, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+    mm::call<range<contiguous_iterator_tag, E, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
         ProxyRef::no>>();
 }
 

--- a/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.compile.pass.cpp
+++ b/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.compile.pass.cpp
@@ -18,7 +18,7 @@
 namespace ranges = std::ranges;
 
 namespace detail {
-    static constexpr bool permissive() {
+    constexpr bool permissive() {
         return false;
     }
 

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -33,7 +33,7 @@ template <class>
 constexpr bool always_false = false;
 
 namespace detail {
-    static constexpr bool permissive() {
+    constexpr bool permissive() {
         return false;
     }
 

--- a/tests/std/tests/P2136R3_invoke_r/test.cpp
+++ b/tests/std/tests/P2136R3_invoke_r/test.cpp
@@ -12,7 +12,7 @@ using namespace std;
 
 // TRANSITION, DevCom-1457457
 namespace detail {
-    static constexpr bool permissive() {
+    constexpr bool permissive() {
         return false;
     }
 

--- a/tests/std/tests/P2441R2_views_join_with/test.cpp
+++ b/tests/std/tests/P2441R2_views_join_with/test.cpp
@@ -535,28 +535,28 @@ void test_valueless_iterator() {
     try {
         it2 = it;
         assert(false);
-    } catch (throwing_iterator::tag&) {
+    } catch (const throwing_iterator::tag&) {
     }
 
     try {
         (void) *it2;
         assert(false);
-    } catch (bad_variant_access&) {
+    } catch (const bad_variant_access&) {
     }
     try {
         (void) ++it2;
         assert(false);
-    } catch (bad_variant_access&) {
+    } catch (const bad_variant_access&) {
     }
     try {
         (void) --it2;
         assert(false);
-    } catch (bad_variant_access&) {
+    } catch (const bad_variant_access&) {
     }
     try {
         (void) ranges::iter_move(it2);
         assert(false);
-    } catch (bad_variant_access&) {
+    } catch (const bad_variant_access&) {
     }
 }
 

--- a/tests/std/tests/VSO_0000000_type_traits/test.cpp
+++ b/tests/std/tests/VSO_0000000_type_traits/test.cpp
@@ -1271,7 +1271,7 @@ namespace {
     constexpr bool is_trait<T, void_t<typename T::type>> = true;
 
     namespace detail {
-        static constexpr bool permissive() {
+        constexpr bool permissive() {
             return false;
         }
 

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -64,7 +64,7 @@ void disable_instructions(ISA_AVAILABILITY isa) {
 constexpr size_t dataCount = 1024;
 
 template <class FwdIt, class T>
-inline ptrdiff_t last_known_good_count(FwdIt first, FwdIt last, T v) {
+ptrdiff_t last_known_good_count(FwdIt first, FwdIt last, T v) {
     ptrdiff_t result = 0;
     for (; first != last; ++first) {
         result += (*first == v);
@@ -94,7 +94,7 @@ void test_count(mt19937_64& gen) {
 }
 
 template <class FwdIt, class T>
-inline auto last_known_good_find(FwdIt first, FwdIt last, T v) {
+auto last_known_good_find(FwdIt first, FwdIt last, T v) {
     for (; first != last; ++first) {
         if (*first == v) {
             break;
@@ -104,7 +104,7 @@ inline auto last_known_good_find(FwdIt first, FwdIt last, T v) {
 }
 
 template <class FwdIt, class T>
-inline auto last_known_good_find_last(FwdIt first, FwdIt last, T v) {
+auto last_known_good_find_last(FwdIt first, FwdIt last, T v) {
     FwdIt last_save = last;
     for (;;) {
         if (last == first) {
@@ -239,7 +239,7 @@ void test_min_max_element_special_cases() {
 }
 
 template <class BidIt>
-inline void last_known_good_reverse(BidIt first, BidIt last) {
+void last_known_good_reverse(BidIt first, BidIt last) {
     for (; first != last && first != --last; ++first) {
         iter_swap(first, last);
     }
@@ -287,7 +287,7 @@ void test_reverse_copy(mt19937_64& gen) {
 }
 
 template <class FwdIt1, class FwdIt2>
-inline FwdIt2 last_known_good_swap_ranges(FwdIt1 first1, const FwdIt1 last1, FwdIt2 dest) {
+FwdIt2 last_known_good_swap_ranges(FwdIt1 first1, const FwdIt1 last1, FwdIt2 dest) {
     for (; first1 != last1; ++first1, ++dest) {
         iter_swap(first1, dest);
     }

--- a/tests/std/tests/VSO_0095837_current_exception_dtor/test.cpp
+++ b/tests/std/tests/VSO_0095837_current_exception_dtor/test.cpp
@@ -45,7 +45,7 @@ struct B {
             assert(uncaught_exceptions() == 1);
             A aa;
             throw runtime_error("oh no!");
-        } catch (exception&) {
+        } catch (const exception&) {
             assert(uncaught_exceptions() == 1);
             auto c = current_exception();
             try {

--- a/tests/utils/stl/test/format.py
+++ b/tests/utils/stl/test/format.py
@@ -9,7 +9,6 @@
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
-import copy
 import itertools
 import os
 import re


### PR DESCRIPTION
Usual disclaimer about how we dislike grab-bag PRs as a general rule, *and* how we avoid large-scale cleanups of test code (low value, potentially disrupts the weird subtle things that the tests were trying to cover). The existence of this PR means that I think these cases are worth it for codebase consistency and that they're low-risk.

* `format.py`: `import copy` was unused.
  + Thanks to Pylance for finding this.
* Style: `constexpr friend` => `friend constexpr`
  + This was the only place that wasn't following our convention.
* Style: Nameless value parameter `const choose` => `choose`
* Drop unnecessary `static` for namespace-scope `permissive()`.
  + This one was easy to miss, because it's followed by a `static` member function.
* Test cleanup: Catch by const ref, even when unnamed.
  + Catching by modifiable reference is weird; there are a couple of places elsewhere where we're intentionally doing so, but here we certainly don't need to. As usual, following the normal pattern in most places helps to draw attention to the weird occurrences.
* Test cleanup: Catch by const ref.
  + Here we're just observing the `filesystem_error`.
* `P0811R3_midpoint_lerp`: `static inline constexpr` => `static constexpr`
  + I suspect that the `inline` was accumulated before a compiler bug workaround was added.
* `VSO_0000000_vector_algorithms`: Drop `inline` after `template`.
  + We conventionally never say `inline` here.
* Tests: Add bug databases to function names.
  + It's very important to cite bug databases and not just plain numbers (as we've gone through so many databases over the years). These occurrences were at least properly commented, but we conventionally name functions with bug databases too.
  + Example internal URLs (one must be VPNed to access these): [Dev10-391805](https://vstfdevdiv.redmond.corp.microsoft.com/DevDiv/Dev10/_workitems/edit/391805) and [DevDiv-1184701](https://vstfdevdiv.redmond.corp.microsoft.com/DevDiv2/DevDiv/_workitems/edit/1184701).
* Tests: Drop unnecessary `std::` qualification.
  + I consider these to be "slam dunks". On the other hand, we accumulated a bunch of `std::move` and `std::forward` during an annoying era where Clang was warning about unqualified calls before we silenced that; I don't think it's worth the effort to go clean them up.
* `P0083R3_splicing_maps_and_sets`: `#ifdef __cpp_constinit` => `#if _HAS_CXX20`
  + Once compiler divergence has subsided and there are no escape hatches, we prefer to use the coarse-grained modes to guard things.