### PR TITLE
Various cleanups: Store properly-typed function pointers in `winapisupp.cpp`

### DIFF
--- a/stl/src/tzdb.cpp
+++ b/stl/src/tzdb.cpp
@@ -378,14 +378,14 @@ _EXTERN_C
 
     _Info->_Num_time_zones = static_cast<size_t>(_Num_time_zones);
     // value-init to ensure __std_tzdb_delete_time_zones() cleanup is valid
-    if (const auto _Names = new (_STD nothrow) const char* [_Info->_Num_time_zones] {}; _Names) {
+    if (const auto _Names = new (_STD nothrow) const char* [_Info->_Num_time_zones] {}) {
         _Info->_Names = _Names;
     } else {
         return nullptr;
     }
 
     // value-init to ensure __std_tzdb_delete_time_zones() cleanup is valid
-    if (const auto _Links = new (_STD nothrow) const char* [_Info->_Num_time_zones] {}; _Links) {
+    if (const auto _Links = new (_STD nothrow) const char* [_Info->_Num_time_zones] {}) {
         _Info->_Links = _Links;
     } else {
         return nullptr;

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -18,29 +18,25 @@
 #if !defined(_ONECORE)
 namespace {
 
-    enum wrapKERNEL32Functions {
+// Use this macro for defining the following function pointers
+#define DEFINEFUNCTIONPOINTER(fn_name) decltype(&fn_name) __KERNEL32Function_##fn_name = nullptr
+
 #if !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
-        eGetCurrentPackageId,
+    DEFINEFUNCTIONPOINTER(GetCurrentPackageId);
 #endif // !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
 
 #if _STL_WIN32_WINNT < _WIN32_WINNT_WIN8
-        eGetSystemTimePreciseAsFileTime,
+    DEFINEFUNCTIONPOINTER(GetSystemTimePreciseAsFileTime);
 #endif // _STL_WIN32_WINNT < _WIN32_WINNT_WIN8
 
-        eGetTempPath2W,
-
-        eMaxKernel32Function
-    };
-
-    PVOID __KERNEL32Functions[eMaxKernel32Function]{};
+    DEFINEFUNCTIONPOINTER(GetTempPath2W);
 
 // Use this macro for caching a function pointer from a DLL
-#define STOREFUNCTIONPOINTER(instance, function_name) \
-    __KERNEL32Functions[e##function_name] = reinterpret_cast<PVOID>(GetProcAddress(instance, #function_name))
+#define STOREFUNCTIONPOINTER(instance, fn_name) \
+    __KERNEL32Function_##fn_name = reinterpret_cast<decltype(&fn_name)>(GetProcAddress(instance, #fn_name))
 
 // Use this macro for retrieving a cached function pointer from a DLL
-#define IFDYNAMICGETCACHEDFUNCTION(name) \
-    if (const auto pf##name = reinterpret_cast<decltype(&name)>(__KERNEL32Functions[e##name]); pf##name)
+#define IFDYNAMICGETCACHEDFUNCTION(fn_name) if (const auto pf##fn_name = __KERNEL32Function_##fn_name; pf##fn_name)
 
 } // unnamed namespace
 #endif // ^^^ !defined(_ONECORE) ^^^

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -36,7 +36,7 @@ namespace {
     __KERNEL32Function_##fn_name = reinterpret_cast<decltype(&fn_name)>(GetProcAddress(instance, #fn_name))
 
 // Use this macro for retrieving a cached function pointer from a DLL
-#define IFDYNAMICGETCACHEDFUNCTION(fn_name) if (const auto pf##fn_name = __KERNEL32Function_##fn_name; pf##fn_name)
+#define IFDYNAMICGETCACHEDFUNCTION(fn_name) if (const auto pf##fn_name = __KERNEL32Function_##fn_name)
 
 } // unnamed namespace
 #endif // ^^^ !defined(_ONECORE) ^^^


### PR DESCRIPTION
`winapisupp.cpp`: Use separate function pointers with proper types, instead of enumerators into an array of `PVOID`.

This is within an unnamed namespace (after #2841 dramatically simplified the code), so we can freely modify this machinery.

Originally, the function pointer table's ordering seemed really important to us, and we were scared about adding/removing/reordering entries. #2841 showed that those fears were unfounded, but it was changing a ton of code so I didn't eliminate the table entirely at that time.

The table wasn't buying us anything - we were able to properly size it via `eMaxKernel32Function`, but we still had to mention every function to manually form the `eMeow` enumerators. By introducing `DEFINEFUNCTIONPOINTER`, we can spend the same number of lines to form separate global variables, which will still consume the same amount of memory as the array (they're just pointers, they pack perfectly either way).

I'm naming these function pointers `__KERNEL32Function_##fn_name` with an underscore in the middle for clarity, e.g. `__KERNEL32Function_GetTempPath2W`. I thought about omitting `Function` but it seems reasonable here. The advantage of this technique is that every function pointer can be given the correct type `decltype(&fn_name)`. We need to adjust how we cast the return value of `GetProcAddress()`, but then we don't need to cast when reading the variable later.

Note that `IFDYNAMICGETCACHEDFUNCTION` still forms `const auto pf##fn_name` to defend against modifying the cache unintentionally, and to provide a nice name `pfMeow` for the code that follows its usage.

Finally, I'm changing all of the macro parameter names to `fn_name` for consistency.

@frederick-vs-ja noticed an opportunity to simplify `if (T meow = init; meow)` to `if (T meow = init)`; I also found a couple of lines in `stl/src/tzdb.cpp` that could benefit.