### PR TITLE
Various cleanups: Use unnamed namespaces

### DIFF
--- a/stl/src/stdhndlr.cpp
+++ b/stl/src/stdhndlr.cpp
@@ -3,19 +3,19 @@
 
 // set_new_handler
 
+#include <new.h>
 #include <new>
 
-using new_hand = int(__cdecl*)(size_t);
+namespace {
+    _STD new_handler _New_handler;
 
-extern "C" new_hand __cdecl _set_new_handler(new_hand);
+    int __cdecl _New_handler_interface(size_t) { // interface to existing Microsoft _callnewh mechanism
+        _New_handler();
+        return 1;
+    }
+} // namespace
 
 _STD_BEGIN
-static new_handler _New_handler;
-
-int __cdecl _New_handler_interface(size_t) { // interface to existing Microsoft _callnewh mechanism
-    _New_handler();
-    return 1;
-}
 
 _CRTIMP2 new_handler __cdecl set_new_handler(_In_opt_ new_handler pnew) noexcept { // remove current handler
     _BEGIN_LOCK(_LOCK_MALLOC) // lock thread to ensure atomicity

--- a/stl/src/xtime.cpp
+++ b/stl/src/xtime.cpp
@@ -42,12 +42,11 @@ static _timespec64 _timespec64_diff(const _timespec64* xt, const _timespec64* no
     return diff;
 }
 
-constexpr long long _Epoch      = 0x19DB1DED53E8000LL;
-constexpr long _Nsec100_per_sec = _Nsec_per_sec / 100;
-
 _EXTERN_C
 
 _CRTIMP2_PURE long long __cdecl _Xtime_get_ticks() { // get system time in 100-nanosecond intervals since the epoch
+    constexpr long long _Epoch = 0x19DB1DED53E8000LL;
+
     FILETIME ft;
     __crtGetSystemTimePreciseAsFileTime(&ft);
     return ((static_cast<long long>(ft.dwHighDateTime)) << 32) + static_cast<long long>(ft.dwLowDateTime) - _Epoch;
@@ -55,6 +54,8 @@ _CRTIMP2_PURE long long __cdecl _Xtime_get_ticks() { // get system time in 100-n
 
 // Used by several src files, but not dllexported.
 void _Timespec64_get_sys(_timespec64* xt) { // get system time with nanosecond resolution
+    constexpr long _Nsec100_per_sec = _Nsec_per_sec / 100;
+
     unsigned long long now = _Xtime_get_ticks();
     xt->tv_sec             = static_cast<__time64_t>(now / _Nsec100_per_sec);
     xt->tv_nsec            = static_cast<long>(now % _Nsec100_per_sec) * 100;


### PR DESCRIPTION
(I recommend "ignore whitespace" while reviewing this.)

Over time, we've developed a convention of using unnamed namespaces in `stl/src` for internal machinery. This clearly separates TU-local code from functions that are accessed from other `stl/src` TUs, injected into the import lib, or dllexported. I noticed a couple of older TUs that could benefit from being cleaned up.

* `xtime.cpp`: The `_Epoch` and `_Nsec100_per_sec` constants can be function-local.
* `xtime.cpp`: Use an unnamed namespace, following our modern convention.
  + The `constexpr` variables and `static` functions had internal linkage, so this is unobservable to other TUs. We can drop `static` now.
* `stdhndlr.cpp`: Use an unnamed namespace, following our modern convention.
  + UCRT `<new.h>` declares `_set_new_handler`, which is better than trying to declare it ourselves. We can then drop the `new_hand` typedef which was being used for that declaration.
  + The `_New_handler` variable was `static`, so we can clearly move it into an unnamed namespace and drop the `static`. We do need to qualify the `_STD new_handler` type now.
  + The `_New_handler_interface` helper function was never dllexported nor referred to by other `stl/src` TUs. We can move it out of `namespace std` and into the unnamed namespace.
  + The resulting code has our desired distinction between TU-local and dllexported machinery.