### PR TITLE
`<flat_set>`: `flat_(multi)set`'s `iterator` type should be constant iterator

### DIFF
--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -56,8 +56,8 @@ public:
     using const_reference        = const value_type&;
     using size_type              = _Container::size_type;
     using difference_type        = _Container::difference_type;
-    using iterator               = _Container::iterator;
     using const_iterator         = _Container::const_iterator;
+    using iterator               = const_iterator;
     using reverse_iterator       = _STD reverse_iterator<iterator>;
     using const_reverse_iterator = _STD reverse_iterator<const_iterator>;
     using container_type         = _Container;
@@ -324,7 +324,9 @@ public:
         _Guard._Target = nullptr;
     }
 
-    iterator erase(iterator _Where) {
+    iterator erase(iterator _Where)
+        requires (!is_same_v<iterator, const_iterator>)
+    {
         return _Mycont.erase(_Where);
     }
     iterator erase(const_iterator _Where) {
@@ -357,6 +359,10 @@ public:
     }
     _NODISCARD value_compare value_comp() const {
         return _Mycomp;
+    }
+
+    _NODISCARD const container_type& _Get_container() const {
+        return _Mycont;
     }
 
     // set operations
@@ -666,16 +672,16 @@ private:
             const auto _Equivalent = [this](const _Kty& _Lhs, const _Kty& _Rhs) {
                 return !_Compare(_Lhs, _Rhs) && !_Compare(_Rhs, _Lhs);
             };
-            const iterator _End = end();
-            _Mycont.erase(_STD unique(begin(), _End, _Equivalent), _End);
+            const auto _End = _Mycont.end();
+            _Mycont.erase(_STD unique(_Mycont.begin(), _End, _Equivalent), _End);
         }
     }
 
     template <bool _Presorted>
     void _Restore_invariants_after_insert(const size_type _Old_size) {
-        const iterator _Begin   = begin();
-        const iterator _Old_end = _Begin + static_cast<difference_type>(_Old_size);
-        const iterator _End     = end();
+        const auto _Begin   = _Mycont.begin();
+        const auto _Old_end = _Begin + static_cast<difference_type>(_Old_size);
+        const auto _End     = _Mycont.end();
 
         if constexpr (!_Presorted) {
             _STD sort(_Old_end, _End, _Pass_comp());
@@ -690,15 +696,15 @@ private:
     }
 
     void _Make_invariants_fulfilled() {
-        const iterator _Begin = begin();
-        const iterator _End   = end();
+        const auto _Begin = _Mycont.begin();
+        const auto _End   = _Mycont.end();
 
         if (_Begin == _End) {
             return;
         }
 
         // O(N) if already sorted.
-        const iterator _Begin_unsorted = _STD is_sorted_until(_Begin, _End, _Pass_comp());
+        const auto _Begin_unsorted = _STD is_sorted_until(_Begin, _End, _Pass_comp());
 
         _STD sort(_Begin_unsorted, _End, _Pass_comp());
         _STD inplace_merge(_Begin, _Begin_unsorted, _End, _Pass_comp());
@@ -769,8 +775,9 @@ _EXPORT_STD template <class _Kty, class _Keylt, class _Container, class _Pred>
 _Container::size_type erase_if(flat_set<_Kty, _Keylt, _Container>& _Val, _Pred _Predicate) {
     // clears the container to maintain the invariants when an exception is thrown (N4950 [flat.set.erasure]/5)
     _Clear_guard<flat_set<_Kty, _Keylt, _Container>> _Guard{_STD addressof(_Val)};
-    const auto _Erased_count = _STD _Erase_remove_if(_Val, _STD _Pass_fn(_Predicate));
-    _Guard._Target           = nullptr;
+    const auto _Erased_count =
+        _STD _Erase_remove_if(const_cast<_Container&>(_Val._Get_container()), _STD _Pass_fn(_Predicate));
+    _Guard._Target = nullptr;
     return _Erased_count;
 }
 
@@ -778,8 +785,9 @@ _EXPORT_STD template <class _Kty, class _Keylt, class _Container, class _Pred>
 _Container::size_type erase_if(flat_multiset<_Kty, _Keylt, _Container>& _Val, _Pred _Predicate) {
     // clears the container to maintain the invariants when an exception is thrown (N4950 [flat.multiset.erasure]/5)
     _Clear_guard<flat_multiset<_Kty, _Keylt, _Container>> _Guard{_STD addressof(_Val)};
-    const auto _Erased_count = _STD _Erase_remove_if(_Val, _STD _Pass_fn(_Predicate));
-    _Guard._Target           = nullptr;
+    const auto _Erased_count =
+        _STD _Erase_remove_if(const_cast<_Container&>(_Val._Get_container()), _STD _Pass_fn(_Predicate));
+    _Guard._Target = nullptr;
     return _Erased_count;
 }
 

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -345,7 +345,7 @@ public:
         return _Mycomp;
     }
 
-    _NODISCARD const container_type& _Get_container() const {
+    _NODISCARD container_type& _Get_container_for_erase_if() noexcept {
         return _Mycont;
     }
 
@@ -708,7 +708,7 @@ public:
 _EXPORT_STD template <class _Kty, class _Keylt, class _Container, class _Pred>
 _Container::size_type erase_if(flat_set<_Kty, _Keylt, _Container>& _Val, _Pred _Predicate) {
     // clears the container to maintain the invariants when an exception is thrown (N4950 [flat.set.erasure]/5)
-    _Container& _Cont = const_cast<_Container&>(_Val._Get_container());
+    _Container& _Cont = _Val._Get_container_for_erase_if();
     _Clear_guard<_Container> _Guard{_STD addressof(_Cont)};
     const auto _Erased_count = _STD _Erase_remove_if(_Cont, _STD _Pass_fn(_Predicate));
     _Guard._Target           = nullptr;
@@ -718,7 +718,7 @@ _Container::size_type erase_if(flat_set<_Kty, _Keylt, _Container>& _Val, _Pred _
 _EXPORT_STD template <class _Kty, class _Keylt, class _Container, class _Pred>
 _Container::size_type erase_if(flat_multiset<_Kty, _Keylt, _Container>& _Val, _Pred _Predicate) {
     // clears the container to maintain the invariants when an exception is thrown (N4950 [flat.multiset.erasure]/5)
-    _Container& _Cont = const_cast<_Container&>(_Val._Get_container());
+    _Container& _Cont = _Val._Get_container_for_erase_if();
     _Clear_guard<_Container> _Guard{_STD addressof(_Cont)};
     const auto _Erased_count = _STD _Erase_remove_if(_Cont, _STD _Pass_fn(_Predicate));
     _Guard._Target           = nullptr;

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -189,16 +189,16 @@ public:
 
     // iterators
     _NODISCARD iterator begin() noexcept {
-        return cbegin();
+        return _Mycont.cbegin();
     }
     _NODISCARD const_iterator begin() const noexcept {
-        return cbegin();
+        return _Mycont.cbegin();
     }
     _NODISCARD iterator end() noexcept {
-        return cend();
+        return _Mycont.cend();
     }
     _NODISCARD const_iterator end() const noexcept {
-        return cend();
+        return _Mycont.cend();
     }
 
     _NODISCARD reverse_iterator rbegin() noexcept {
@@ -529,7 +529,6 @@ private:
     _NODISCARD pair<iterator, bool> _Emplace(_Ty&& _Val) {
         const const_iterator _Where = lower_bound(_Val);
         if (_Where != cend() && !_Compare(_Val, *_Where)) {
-            // *_Where is equivalent to _Val.
             return pair{_Where, false};
         }
 

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -160,7 +160,7 @@ public:
     {}
 
     _Base_flat_set& operator=(const _Base_flat_set& _Other) {
-        _Clear_guard<_Base_flat_set> _Guard{this};
+        _Clear_guard<container_type> _Guard{_STD addressof(_Mycont)};
         _Mycont        = _Other._Mycont;
         _Mycomp        = _Other._Mycomp;
         _Guard._Target = nullptr;
@@ -170,8 +170,8 @@ public:
         is_nothrow_move_assignable_v<container_type>&& is_nothrow_copy_assignable_v<key_compare>) // strengthened
     {
         if (this != _STD addressof(_Other)) {
-            _Clear_guard<_Base_flat_set> _Guard{this};
-            _Clear_guard<_Base_flat_set> _Always_clear{_STD addressof(_Other)};
+            _Clear_guard<container_type> _Guard{_STD addressof(_Mycont)};
+            _Clear_guard<container_type> _Always_clear{_STD addressof(_Other._Mycont)};
             _Mycont        = _STD move(_Other._Mycont);
             _Mycomp        = _Other._Mycomp; // intentionally copy comparator, see LWG-2227
             _Guard._Target = nullptr;
@@ -180,7 +180,7 @@ public:
     }
 
     _Deriv& operator=(initializer_list<_Kty> _Ilist) {
-        _Clear_guard<_Base_flat_set> _Guard{this};
+        _Clear_guard<container_type> _Guard{_STD addressof(_Mycont)};
         _Mycont.assign(_Ilist);
         _Make_invariants_fulfilled();
         _Guard._Target = nullptr;
@@ -188,17 +188,19 @@ public:
     }
 
     // iterators
+    // for flat_meow, `const_iterator` is required to be convertible to `iterator` (per N4958
+    // [associative.reqmts.general]/6)
     _NODISCARD iterator begin() noexcept {
-        return _Mycont.begin();
+        return cbegin();
     }
     _NODISCARD const_iterator begin() const noexcept {
-        return _Mycont.begin();
+        return cbegin();
     }
     _NODISCARD iterator end() noexcept {
-        return _Mycont.end();
+        return cend();
     }
     _NODISCARD const_iterator end() const noexcept {
-        return _Mycont.end();
+        return cend();
     }
 
     _NODISCARD reverse_iterator rbegin() noexcept {
@@ -314,12 +316,12 @@ public:
     _NODISCARD container_type extract() && noexcept(
         is_nothrow_move_constructible_v<container_type>) /* strengthened */ {
         // always clears the container (N4950 [flat.set.modifiers]/14 and [flat.multiset.modifiers]/10)
-        _Clear_guard<_Base_flat_set> _Always_clear{this};
+        _Clear_guard<container_type> _Always_clear{_STD addressof(_Mycont)};
         return _STD move(_Mycont);
     }
     void replace(container_type&& _Cont) {
         _STL_ASSERT(_Is_sorted(_Cont), _Msg_not_sorted);
-        _Clear_guard<_Base_flat_set> _Guard{this};
+        _Clear_guard<container_type> _Guard{_STD addressof(_Mycont)};
         _Mycont        = _STD move(_Cont);
         _Guard._Target = nullptr;
     }
@@ -527,8 +529,8 @@ private:
     template <class _Ty>
         requires (!_Multi) // flat_set
     _NODISCARD pair<iterator, bool> _Emplace(_Ty&& _Val) {
-        const iterator _Where = lower_bound(_Val);
-        if (_Where != end() && !_Compare(_Val, *_Where)) {
+        const const_iterator _Where = lower_bound(_Val);
+        if (_Where != cend() && !_Compare(_Val, *_Where)) {
             // *_Where is equivalent to _Val.
             return pair{_Where, false};
         }
@@ -595,8 +597,9 @@ private:
         }
 
         if (_Where != _End && !_Compare(_Val, *_Where)) {
-            // *_Where is equivalent to _Val; convert _Where to iterator type.
-            return _Mycont.begin() + (_Where - _Begin);
+            // *_Where is equivalent to _Val.
+            // for flat_meow, _Where should be convertible to iterator type.
+            return _Where;
         }
 
         if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
@@ -626,8 +629,8 @@ private:
         _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent || is_same_v<_Ty, _Kty>);
 
         if constexpr (!_Multi && is_same_v<_Ty, _Kty>) {
-            const iterator _Where = lower_bound(_Val);
-            if (_Where != end() && !_Compare(_Val, *_Where)) {
+            const const_iterator _Where = lower_bound(_Val);
+            if (_Where != cend() && !_Compare(_Val, *_Where)) {
                 _Mycont.erase(_Where);
                 return 1;
             }
@@ -638,19 +641,6 @@ private:
             const auto _Removed = static_cast<size_type>(_Last - _First);
             _Mycont.erase(_First, _Last);
             return _Removed;
-        }
-    }
-
-    template <class _Ty>
-    _NODISCARD iterator _Find(const _Ty& _Val) {
-        _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent || is_same_v<_Ty, _Kty>);
-
-        const iterator _End   = end();
-        const iterator _Where = lower_bound(_Val);
-        if (_Where != _End && !_Compare(_Val, *_Where)) {
-            return _Where;
-        } else {
-            return _End;
         }
     }
 
@@ -774,20 +764,20 @@ public:
 _EXPORT_STD template <class _Kty, class _Keylt, class _Container, class _Pred>
 _Container::size_type erase_if(flat_set<_Kty, _Keylt, _Container>& _Val, _Pred _Predicate) {
     // clears the container to maintain the invariants when an exception is thrown (N4950 [flat.set.erasure]/5)
-    _Clear_guard<flat_set<_Kty, _Keylt, _Container>> _Guard{_STD addressof(_Val)};
-    const auto _Erased_count =
-        _STD _Erase_remove_if(const_cast<_Container&>(_Val._Get_container()), _STD _Pass_fn(_Predicate));
-    _Guard._Target = nullptr;
+    _Container& _Cont = const_cast<_Container&>(_Val._Get_container());
+    _Clear_guard<_Container> _Guard{_STD addressof(_Cont)};
+    const auto _Erased_count = _STD _Erase_remove_if(_Cont, _STD _Pass_fn(_Predicate));
+    _Guard._Target           = nullptr;
     return _Erased_count;
 }
 
 _EXPORT_STD template <class _Kty, class _Keylt, class _Container, class _Pred>
 _Container::size_type erase_if(flat_multiset<_Kty, _Keylt, _Container>& _Val, _Pred _Predicate) {
     // clears the container to maintain the invariants when an exception is thrown (N4950 [flat.multiset.erasure]/5)
-    _Clear_guard<flat_multiset<_Kty, _Keylt, _Container>> _Guard{_STD addressof(_Val)};
-    const auto _Erased_count =
-        _STD _Erase_remove_if(const_cast<_Container&>(_Val._Get_container()), _STD _Pass_fn(_Predicate));
-    _Guard._Target = nullptr;
+    _Container& _Cont = const_cast<_Container&>(_Val._Get_container());
+    _Clear_guard<_Container> _Guard{_STD addressof(_Cont)};
+    const auto _Erased_count = _STD _Erase_remove_if(_Cont, _STD _Pass_fn(_Predicate));
+    _Guard._Target           = nullptr;
     return _Erased_count;
 }
 

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -188,27 +188,16 @@ public:
     }
 
     // iterators
-    _NODISCARD iterator begin() noexcept {
-        return _Mycont.cbegin();
-    }
+    // NB: The non-const overloads are intentionally removed for brevity. This will not result in behavioral changes.
     _NODISCARD const_iterator begin() const noexcept {
-        return _Mycont.cbegin();
-    }
-    _NODISCARD iterator end() noexcept {
-        return _Mycont.cend();
+        return _Mycont.begin();
     }
     _NODISCARD const_iterator end() const noexcept {
-        return _Mycont.cend();
+        return _Mycont.end();
     }
 
-    _NODISCARD reverse_iterator rbegin() noexcept {
-        return reverse_iterator(end());
-    }
     _NODISCARD const_reverse_iterator rbegin() const noexcept {
         return const_reverse_iterator(end());
-    }
-    _NODISCARD reverse_iterator rend() noexcept {
-        return reverse_iterator(begin());
     }
     _NODISCARD const_reverse_iterator rend() const noexcept {
         return const_reverse_iterator(begin());
@@ -324,11 +313,7 @@ public:
         _Guard._Target = nullptr;
     }
 
-    iterator erase(iterator _Where)
-        requires (!is_same_v<iterator, const_iterator>)
-    {
-        return _Mycont.erase(_Where);
-    }
+    // NB: `erase(iterator)` is identical to `erase(const_iterator)`
     iterator erase(const_iterator _Where) {
         return _Mycont.erase(_Where);
     }
@@ -336,8 +321,7 @@ public:
         return _Erase(_Val);
     }
     template <_Different_from<_Kty> _Other>
-        requires (
-            _Keylt_transparent && !is_convertible_v<_Other, iterator> && !is_convertible_v<_Other, const_iterator>)
+        requires (_Keylt_transparent && !is_convertible_v<_Other, const_iterator>)
     size_type erase(_Other&& _Val) {
         return _Erase(_Val);
     }
@@ -366,16 +350,8 @@ public:
     }
 
     // set operations
-    _NODISCARD iterator find(const _Kty& _Val) {
-        return _Find(_Val);
-    }
+    // NB: The non-const overloads are intentionally removed for brevity. This will not result in behavioral changes.
     _NODISCARD const_iterator find(const _Kty& _Val) const {
-        return _Find(_Val);
-    }
-
-    template <class _Other>
-        requires _Keylt_transparent
-    _NODISCARD iterator find(const _Other& _Val) {
         return _Find(_Val);
     }
     template <class _Other>
@@ -408,17 +384,8 @@ public:
         return _STD binary_search(cbegin(), cend(), _Val, _Pass_comp());
     }
 
-    _NODISCARD iterator lower_bound(const _Kty& _Val) {
-        return _STD lower_bound(begin(), end(), _Val, _Pass_comp());
-    }
     _NODISCARD const_iterator lower_bound(const _Kty& _Val) const {
         return _STD lower_bound(cbegin(), cend(), _Val, _Pass_comp());
-    }
-
-    template <class _Other>
-        requires _Keylt_transparent
-    _NODISCARD iterator lower_bound(const _Other& _Val) {
-        return _STD lower_bound(begin(), end(), _Val, _Pass_comp());
     }
     template <class _Other>
         requires _Keylt_transparent
@@ -426,17 +393,8 @@ public:
         return _STD lower_bound(cbegin(), cend(), _Val, _Pass_comp());
     }
 
-    _NODISCARD iterator upper_bound(const _Kty& _Val) {
-        return _STD upper_bound(begin(), end(), _Val, _Pass_comp());
-    }
     _NODISCARD const_iterator upper_bound(const _Kty& _Val) const {
         return _STD upper_bound(cbegin(), cend(), _Val, _Pass_comp());
-    }
-
-    template <class _Other>
-        requires _Keylt_transparent
-    _NODISCARD iterator upper_bound(const _Other& _Val) {
-        return _STD upper_bound(begin(), end(), _Val, _Pass_comp());
     }
     template <class _Other>
         requires _Keylt_transparent
@@ -444,17 +402,8 @@ public:
         return _STD upper_bound(cbegin(), cend(), _Val, _Pass_comp());
     }
 
-    _NODISCARD pair<iterator, iterator> equal_range(const _Kty& _Val) {
-        return _STD equal_range(begin(), end(), _Val, _Pass_comp());
-    }
     _NODISCARD pair<const_iterator, const_iterator> equal_range(const _Kty& _Val) const {
         return _STD equal_range(cbegin(), cend(), _Val, _Pass_comp());
-    }
-
-    template <class _Other>
-        requires _Keylt_transparent
-    _NODISCARD pair<iterator, iterator> equal_range(const _Other& _Val) {
-        return _STD equal_range(begin(), end(), _Val, _Pass_comp());
     }
     template <class _Other>
         requires _Keylt_transparent

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -58,8 +58,8 @@ public:
     using difference_type        = _Container::difference_type;
     using const_iterator         = _Container::const_iterator;
     using iterator               = const_iterator;
-    using reverse_iterator       = _STD reverse_iterator<iterator>;
     using const_reverse_iterator = _STD reverse_iterator<const_iterator>;
+    using reverse_iterator       = const_reverse_iterator;
     using container_type         = _Container;
 
     static_assert(random_access_iterator<iterator>, "The C++ Standard forbids containers without random "
@@ -188,8 +188,6 @@ public:
     }
 
     // iterators
-    // for flat_meow, `const_iterator` is required to be convertible to `iterator` (per N4958
-    // [associative.reqmts.general]/6)
     _NODISCARD iterator begin() noexcept {
         return cbegin();
     }
@@ -597,8 +595,6 @@ private:
         }
 
         if (_Where != _End && !_Compare(_Val, *_Where)) {
-            // *_Where is equivalent to _Val.
-            // for flat_meow, _Where should be convertible to iterator type.
             return _Where;
         }
 

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -80,7 +80,7 @@ void assert_set_requirements() {
     using key_type       = T::key_type;
     using value_type     = T::value_type;
 
-    static_assert(_Constant_iterator<const_iterator>);
+    static_assert(same_as<std::const_iterator<const_iterator>, const_iterator>);
     static_assert(is_convertible_v<iterator, const_iterator>);
 
     // additionally:

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -85,7 +85,7 @@ void assert_set_requirements() {
 
     // additionally:
     static_assert(is_same_v<key_type, value_type>);
-    static_assert(_Constant_iterator<iterator>);
+    static_assert(same_as<std::const_iterator<iterator>, iterator>);
     static_assert(is_convertible_v<const_iterator, iterator>);
 }
 

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -33,7 +33,7 @@ void assert_container_requirements(const T& s) {
     static_assert(is_same_v<decltype(m.begin() <=> m.end()), strong_ordering>);
     static_assert(is_same_v<decltype(s.size()), typename T::size_type>);
     static_assert(is_same_v<decltype(s.max_size()), typename T::size_type>);
-    static_assert(is_same_v<decltype(*m.begin()), typename T::value_type&>);
+    static_assert(is_same_v<decltype(*m.begin()), const typename T::value_type&>);
     static_assert(is_same_v<decltype(*m.cbegin()), const typename T::value_type&>);
 
     T my_moved = std::move(m);
@@ -74,6 +74,22 @@ void assert_reversible_container_requirements(const T& s) {
 }
 
 template <class T>
+void assert_set_requirements() {
+    using iterator       = T::iterator;
+    using const_iterator = T::const_iterator;
+    using key_type       = T::key_type;
+    using value_type     = T::value_type;
+
+    static_assert(_Constant_iterator<const_iterator>);
+    static_assert(is_convertible_v<iterator, const_iterator>);
+
+    // additionally:
+    static_assert(is_same_v<key_type, value_type>);
+    static_assert(_Constant_iterator<iterator>);
+    static_assert(is_convertible_v<const_iterator, iterator>);
+}
+
+template <class T>
 void assert_noexcept_requirements(T& s) {
     static_assert(noexcept(s.begin()));
     static_assert(noexcept(s.end()));
@@ -99,6 +115,7 @@ template <class T>
 void assert_all_requirements(const T& s) {
     assert_container_requirements(s);
     assert_reversible_container_requirements(s);
+    assert_set_requirements<T>();
 
     assert_noexcept_requirements(s);
     assert_noexcept_requirements(const_cast<T&>(s));


### PR DESCRIPTION
Citation:
>For associative containers where the value type is the same as the key type, both iterator and const_iterator are constant iterators[.](https://eel.is/c++draft/container.requirements#associative.reqmts.general-6.sentence-2) It is unspecified whether or not iterator and const_iterator are the same type[.](https://eel.is/c++draft/container.requirements#associative.reqmts.general-6.sentence-3)

This pr makes `flat_(multi)set`'s `iterator` an alias for `const_iterator`.