### PR TITLE
Make invoke constexpr available in all modes

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1724,13 +1724,13 @@ template <class _Callable, class _Ty1, class _Removed_cvref>
 struct _Invoker1<_Callable, _Ty1, _Removed_cvref, false, false> : _Invoker_functor {};
 
 _EXPORT_STD template <class _Callable>
-_CONSTEXPR17 auto invoke(_Callable&& _Obj) noexcept(noexcept(static_cast<_Callable&&>(_Obj)()))
+constexpr auto invoke(_Callable&& _Obj) noexcept(noexcept(static_cast<_Callable&&>(_Obj)()))
     -> decltype(static_cast<_Callable&&>(_Obj)()) {
     return static_cast<_Callable&&>(_Obj)();
 }
 
 _EXPORT_STD template <class _Callable, class _Ty1, class... _Types2>
-_CONSTEXPR17 auto invoke(_Callable&& _Obj, _Ty1&& _Arg1, _Types2&&... _Args2) noexcept(
+constexpr auto invoke(_Callable&& _Obj, _Ty1&& _Arg1, _Types2&&... _Args2) noexcept(
     noexcept(_Invoker1<_Callable, _Ty1>::_Call(
         static_cast<_Callable&&>(_Obj), static_cast<_Ty1&&>(_Arg1), static_cast<_Types2&&>(_Args2)...)))
     -> decltype(_Invoker1<_Callable, _Ty1>::_Call(

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -68,6 +68,8 @@
 // P0935R0 Eradicating Unnecessarily Explicit Default Constructors
 // P0941R2 Feature-Test Macros
 // P0972R0 noexcept For <chrono> zero(), min(), max()
+// P1065R2 constexpr INVOKE
+//     (the std::invoke function only; other components like bind and reference_wrapper are C++20 only)
 // P1164R1 Making create_directory() Intuitive
 // P1165R1 Consistently Propagating Stateful Allocators In basic_string's operator+()
 // P1902R1 Missing Feature-Test Macros 2017-2019
@@ -126,8 +128,6 @@
 // P0682R1 Repairing Elementary String Conversions
 // P0739R0 Improving Class Template Argument Deduction For The STL
 // P0858R0 Constexpr Iterator Requirements
-// P1065R2 constexpr INVOKE
-//     (the std::invoke function only; other components like bind and reference_wrapper are C++20 only)
 // P1169R4 static operator()
 // P1518R2 Stop Overconstraining Allocators In Container Deduction Guides
 // P2162R2 Inheriting From variant
@@ -224,7 +224,7 @@
 // P1032R1 Miscellaneous constexpr
 // P1035R7 Input Range Adaptors
 // P1065R2 constexpr INVOKE
-//     (except the std::invoke function which is implemented in C++17)
+//     (except the std::invoke function which is implemented unconditionally)
 // P1085R2 Removing span Comparisons
 // P1115R3 erase()/erase_if() Return size_type
 // P1123R0 Atomic Compare-And-Exchange With Padding Bits For atomic_ref

--- a/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
+++ b/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
@@ -1049,8 +1049,7 @@ void test_reference_wrapper_invocation() {
 }
 
 
-// Test C++17 invoke().
-#if _HAS_CXX17
+// Test invoke().
 constexpr bool test_invoke_constexpr() {
     // MSVC implements LWG-2894 in C++17 and later
     Thing thing;
@@ -1076,13 +1075,10 @@ constexpr bool test_invoke_constexpr() {
     assert(invoke(&cube_constexpr, 7) == 343);
     return true;
 }
-#endif // _HAS_CXX17
 
 void test_invoke() {
-#if _HAS_CXX17
     assert(test_invoke_constexpr());
     STATIC_ASSERT(test_invoke_constexpr());
-#endif // _HAS_CXX17
 
     auto sp = make_shared<Thing>();
 

--- a/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
+++ b/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
@@ -1051,7 +1051,7 @@ void test_reference_wrapper_invocation() {
 
 // Test invoke().
 constexpr bool test_invoke_constexpr() {
-    // MSVC implements LWG-2894 in C++17 and later
+    // MSVC implements LWG-2894 unconditionally
     Thing thing;
     auto p = &thing;
 


### PR DESCRIPTION
Resolves #4080 by replacing the _CONSTEXPR17 with constexpr for std::invoke.
