### PR TITLE
ADL-proof implementation of algorithms in [alg.nonmodifying]

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -85,19 +85,19 @@ _STD pair<_Ty*, _Ty*> __std_minmax_element(_Ty* _First, _Ty* _Last) noexcept {
 template <class _Ty, class _TVal>
 _Ty* __std_find_last_trivial(_Ty* _First, _Ty* _Last, const _TVal _Val) noexcept {
     if constexpr (_STD is_pointer_v<_TVal> || _STD is_null_pointer_v<_TVal>) {
-        return __std_find_last_trivial(_First, _Last, reinterpret_cast<uintptr_t>(_Val));
+        return ::__std_find_last_trivial(_First, _Last, reinterpret_cast<uintptr_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 1) {
         return const_cast<_Ty*>(
-            static_cast<const _Ty*>(__std_find_last_trivial_1(_First, _Last, static_cast<uint8_t>(_Val))));
+            static_cast<const _Ty*>(::__std_find_last_trivial_1(_First, _Last, static_cast<uint8_t>(_Val))));
     } else if constexpr (sizeof(_Ty) == 2) {
         return const_cast<_Ty*>(
-            static_cast<const _Ty*>(__std_find_last_trivial_2(_First, _Last, static_cast<uint16_t>(_Val))));
+            static_cast<const _Ty*>(::__std_find_last_trivial_2(_First, _Last, static_cast<uint16_t>(_Val))));
     } else if constexpr (sizeof(_Ty) == 4) {
         return const_cast<_Ty*>(
-            static_cast<const _Ty*>(__std_find_last_trivial_4(_First, _Last, static_cast<uint32_t>(_Val))));
+            static_cast<const _Ty*>(::__std_find_last_trivial_4(_First, _Last, static_cast<uint32_t>(_Val))));
     } else if constexpr (sizeof(_Ty) == 8) {
         return const_cast<_Ty*>(
-            static_cast<const _Ty*>(__std_find_last_trivial_8(_First, _Last, static_cast<uint64_t>(_Val))));
+            static_cast<const _Ty*>(::__std_find_last_trivial_8(_First, _Last, static_cast<uint64_t>(_Val))));
     } else {
         static_assert(_STD _Always_false<_Ty>, "Unexpected size");
     }
@@ -277,9 +277,9 @@ namespace ranges {
 
 _EXPORT_STD template <class _InIt, class _Fn>
 _CONSTEXPR20 _Fn for_each(_InIt _First, _InIt _Last, _Fn _Func) { // perform function for each element [_First, _Last)
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     for (; _UFirst != _ULast; ++_UFirst) {
         _Func(*_UFirst);
     }
@@ -296,14 +296,14 @@ _CONSTEXPR20 _InIt for_each_n(_InIt _First, const _Diff _Count_raw, _Fn _Func) {
     // perform function for each element [_First, _First + _Count)
     _Algorithm_int_t<_Diff> _Count = _Count_raw;
     if (0 < _Count) {
-        auto _UFirst = _Get_unwrapped_n(_First, _Count);
+        auto _UFirst = _STD _Get_unwrapped_n(_First, _Count);
         do {
             _Func(*_UFirst);
             --_Count;
             ++_UFirst;
         } while (0 < _Count);
 
-        _Seek_wrapped(_First, _UFirst);
+        _STD _Seek_wrapped(_First, _UFirst);
     }
 
     return _First;
@@ -323,12 +323,12 @@ namespace ranges {
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirectly_unary_invocable<projected<_It, _Pj>> _Fn>
         constexpr for_each_result<_It, _Fn> operator()(_It _First, _Se _Last, _Fn _Func, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
 
-            auto _UResult = _For_each_unchecked(_Unwrap_iter<_Se>(_STD move(_First)),
-                _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Func), _Pass_fn(_Proj));
+            auto _UResult = _For_each_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Func), _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.fun)};
         }
 
@@ -339,9 +339,9 @@ namespace ranges {
             auto _First = _RANGES begin(_Range);
 
             auto _UResult = _For_each_unchecked(
-                _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD move(_Func), _Pass_fn(_Proj));
+                _RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD move(_Func), _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.fun)};
         }
 
@@ -372,14 +372,14 @@ namespace ranges {
         constexpr for_each_n_result<_It, _Fn> operator()(
             _It _First, iter_difference_t<_It> _Count, _Fn _Func, _Pj _Proj = {}) const {
             if (0 < _Count) {
-                auto _UFirst = _Get_unwrapped_n(_STD move(_First), _Count);
+                auto _UFirst = _STD _Get_unwrapped_n(_STD move(_First), _Count);
                 do {
                     _STD invoke(_Func, _STD invoke(_Proj, *_UFirst));
                     --_Count;
                     ++_UFirst;
                 } while (0 < _Count);
 
-                _Seek_wrapped(_First, _STD move(_UFirst));
+                _STD _Seek_wrapped(_First, _STD move(_UFirst));
             }
 
             return {_STD move(_First), _STD move(_Func)};
@@ -398,16 +398,16 @@ _NODISCARD _FwdIt find_if(_ExPo&& _Exec, _FwdIt _First, _FwdIt _Last, _Pr _Pred)
 _EXPORT_STD template <class _InIt, class _Pr>
 _NODISCARD _CONSTEXPR20 _InIt find_if_not(_InIt _First, const _InIt _Last, _Pr _Pred) {
     // find first element that satisfies !_Pred
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     for (; _UFirst != _ULast; ++_UFirst) {
         if (!_Pred(*_UFirst)) {
             break;
         }
     }
 
-    _Seek_wrapped(_First, _UFirst);
+    _STD _Seek_wrapped(_First, _UFirst);
     return _First;
 }
 
@@ -419,9 +419,9 @@ _NODISCARD _FwdIt find_if_not(_ExPo&& _Exec, _FwdIt _First, _FwdIt _Last, _Pr _P
 _EXPORT_STD template <class _FwdIt, class _Pr>
 _NODISCARD _CONSTEXPR20 _FwdIt adjacent_find(const _FwdIt _First, _FwdIt _Last, _Pr _Pred) {
     // find first satisfying _Pred with successor
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst = _Get_unwrapped(_First);
-    auto _ULast  = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst = _STD _Get_unwrapped(_First);
+    auto _ULast  = _STD _Get_unwrapped(_Last);
     if (_UFirst != _ULast) {
         for (auto _UNext = _UFirst; ++_UNext != _ULast; _UFirst = _UNext) {
             if (_Pred(*_UFirst, *_UNext)) {
@@ -431,7 +431,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt adjacent_find(const _FwdIt _First, _FwdIt _Last, 
         }
     }
 
-    _Seek_wrapped(_Last, _ULast);
+    _STD _Seek_wrapped(_Last, _ULast);
     return _Last;
 }
 
@@ -459,15 +459,15 @@ namespace ranges {
             requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
         _NODISCARD constexpr iter_difference_t<_It> operator()(
             _It _First, _Se _Last, const _Ty& _Val, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
             return _Count_unchecked(
-                _Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)), _Val, _Pass_fn(_Proj));
+                _RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _Val, _STD _Pass_fn(_Proj));
         }
 
         template <input_range _Rng, class _Ty, class _Pj = identity>
             requires indirect_binary_predicate<ranges::equal_to, projected<iterator_t<_Rng>, _Pj>, const _Ty*>
         _NODISCARD constexpr range_difference_t<_Rng> operator()(_Rng&& _Range, const _Ty& _Val, _Pj _Proj = {}) const {
-            return _Count_unchecked(_Ubegin(_Range), _Uend(_Range), _Val, _Pass_fn(_Proj));
+            return _Count_unchecked(_Ubegin(_Range), _Uend(_Range), _Val, _STD _Pass_fn(_Proj));
         }
 
     private:
@@ -486,10 +486,10 @@ namespace ranges {
                         return 0;
                     }
 
-                    const auto _First_ptr = _To_address(_First);
+                    const auto _First_ptr = _STD _To_address(_First);
                     const auto _Last_ptr  = _First_ptr + (_Last - _First);
 
-                    return static_cast<iter_difference_t<_It>>(__std_count_trivial(_First_ptr, _Last_ptr, _Val));
+                    return static_cast<iter_difference_t<_It>>(::__std_count_trivial(_First_ptr, _Last_ptr, _Val));
                 }
             }
 #endif // _USE_STD_VECTOR_ALGORITHMS
@@ -512,9 +512,9 @@ namespace ranges {
 _EXPORT_STD template <class _InIt, class _Pr>
 _NODISCARD _CONSTEXPR20 _Iter_diff_t<_InIt> count_if(_InIt _First, _InIt _Last, _Pr _Pred) {
     // count elements satisfying _Pred
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst               = _Get_unwrapped(_First);
-    const auto _ULast          = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst               = _STD _Get_unwrapped(_First);
+    const auto _ULast          = _STD _Get_unwrapped(_Last);
     _Iter_diff_t<_InIt> _Count = 0;
     for (; _UFirst != _ULast; ++_UFirst) {
         if (_Pred(*_UFirst)) {
@@ -537,15 +537,15 @@ namespace ranges {
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr iter_difference_t<_It> operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
-            return _Count_if_unchecked(_Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)),
-                _Pass_fn(_Pred), _Pass_fn(_Proj));
+            _STD _Adl_verify_range(_First, _Last);
+            return _Count_if_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)),
+                _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
         }
 
         template <input_range _Rng, class _Pj = identity,
             indirect_unary_predicate<projected<iterator_t<_Rng>, _Pj>> _Pr>
         _NODISCARD constexpr range_difference_t<_Rng> operator()(_Rng&& _Range, _Pr _Pred, _Pj _Proj = {}) const {
-            return _Count_if_unchecked(_Ubegin(_Range), _Uend(_Range), _Pass_fn(_Pred), _Pass_fn(_Proj));
+            return _Count_if_unchecked(_Ubegin(_Range), _Uend(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
         }
 
     private:
@@ -574,17 +574,17 @@ namespace ranges {
 _EXPORT_STD template <class _InIt1, class _InIt2, class _Pr>
 _NODISCARD _CONSTEXPR20 pair<_InIt1, _InIt2> mismatch(_InIt1 _First1, const _InIt1 _Last1, _InIt2 _First2, _Pr _Pred) {
     // return [_First1, _Last1)/[_First2, ...) mismatch
-    _Adl_verify_range(_First1, _Last1);
-    auto _UFirst1      = _Get_unwrapped(_First1);
-    const auto _ULast1 = _Get_unwrapped(_Last1);
-    auto _UFirst2      = _Get_unwrapped_n(_First2, _Idl_distance<_InIt1>(_UFirst1, _ULast1));
+    _STD _Adl_verify_range(_First1, _Last1);
+    auto _UFirst1      = _STD _Get_unwrapped(_First1);
+    const auto _ULast1 = _STD _Get_unwrapped(_Last1);
+    auto _UFirst2      = _STD _Get_unwrapped_n(_First2, _STD _Idl_distance<_InIt1>(_UFirst1, _ULast1));
     while (_UFirst1 != _ULast1 && _Pred(*_UFirst1, *_UFirst2)) {
         ++_UFirst1;
         ++_UFirst2;
     }
 
-    _Seek_wrapped(_First2, _UFirst2);
-    _Seek_wrapped(_First1, _UFirst1);
+    _STD _Seek_wrapped(_First2, _UFirst2);
+    _STD _Seek_wrapped(_First1, _UFirst1);
     return {_First1, _First2};
 }
 
@@ -613,12 +613,12 @@ _EXPORT_STD template <class _InIt1, class _InIt2, class _Pr>
 _NODISCARD _CONSTEXPR20 pair<_InIt1, _InIt2> mismatch(
     _InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _Pr _Pred) {
     // return [_First1, _Last1)/[_First2, _Last2) mismatch
-    _Adl_verify_range(_First1, _Last1);
-    _Adl_verify_range(_First2, _Last2);
-    auto _UFirst1      = _Get_unwrapped(_First1);
-    auto _ULast1       = _Get_unwrapped(_Last1);
-    auto _UFirst2      = _Get_unwrapped(_First2);
-    const auto _ULast2 = _Get_unwrapped(_Last2);
+    _STD _Adl_verify_range(_First1, _Last1);
+    _STD _Adl_verify_range(_First2, _Last2);
+    auto _UFirst1      = _STD _Get_unwrapped(_First1);
+    auto _ULast1       = _STD _Get_unwrapped(_Last1);
+    auto _UFirst2      = _STD _Get_unwrapped(_First2);
+    const auto _ULast2 = _STD _Get_unwrapped(_Last2);
     if constexpr (_Is_ranges_random_iter_v<_InIt1> && _Is_ranges_random_iter_v<_InIt2>) {
         using _CT         = _Common_diff_t<_InIt1, _InIt2>;
         const _CT _Count1 = _ULast1 - _UFirst1;
@@ -636,8 +636,8 @@ _NODISCARD _CONSTEXPR20 pair<_InIt1, _InIt2> mismatch(
         }
     }
 
-    _Seek_wrapped(_First2, _UFirst2);
-    _Seek_wrapped(_First1, _UFirst1);
+    _STD _Seek_wrapped(_First2, _UFirst2);
+    _STD _Seek_wrapped(_First1, _UFirst1);
     return {_First1, _First2};
 }
 
@@ -671,7 +671,7 @@ namespace ranges {
         _STL_INTERNAL_CHECK(_Count >= 0);
         if constexpr (_Equal_memcmp_is_safe<_It1, _It2, _Pr> && same_as<_Pj1, identity> && same_as<_Pj2, identity>) {
             if (!_STD is_constant_evaluated()) {
-                return _Memcmp_count(_First1, _First2, static_cast<size_t>(_Count)) == 0;
+                return _STD _Memcmp_count(_First1, _First2, static_cast<size_t>(_Count)) == 0;
             }
         }
 
@@ -715,12 +715,12 @@ namespace ranges {
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
         _NODISCARD constexpr bool operator()(_It1 _First1, _Se1 _Last1, _It2 _First2, _Se2 _Last2, _Pr _Pred = {},
             _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
-            _Adl_verify_range(_First1, _Last1);
-            _Adl_verify_range(_First2, _Last2);
-            auto _UFirst1 = _Unwrap_iter<_Se1>(_STD move(_First1));
-            auto _ULast1  = _Unwrap_sent<_It1>(_STD move(_Last1));
-            auto _UFirst2 = _Unwrap_iter<_Se2>(_STD move(_First2));
-            auto _ULast2  = _Unwrap_sent<_It2>(_STD move(_Last2));
+            _STD _Adl_verify_range(_First1, _Last1);
+            _STD _Adl_verify_range(_First2, _Last2);
+            auto _UFirst1 = _RANGES _Unwrap_iter<_Se1>(_STD move(_First1));
+            auto _ULast1  = _RANGES _Unwrap_sent<_It1>(_STD move(_Last1));
+            auto _UFirst2 = _RANGES _Unwrap_iter<_Se2>(_STD move(_First2));
+            auto _ULast2  = _RANGES _Unwrap_sent<_It2>(_STD move(_Last2));
 
             if constexpr (sized_sentinel_for<_Se1, _It1> && sized_sentinel_for<_Se2, _It2>) {
                 const auto _Count = _ULast1 - _UFirst1;
@@ -728,11 +728,11 @@ namespace ranges {
                     return false;
                 }
 
-                return _RANGES _Equal_count(_STD move(_UFirst1), _STD move(_UFirst2), _Count, _Pass_fn(_Pred),
-                    _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+                return _RANGES _Equal_count(_STD move(_UFirst1), _STD move(_UFirst2), _Count, _STD _Pass_fn(_Pred),
+                    _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             } else {
                 return _Equal_4(_STD move(_UFirst1), _STD move(_ULast1), _STD move(_UFirst2), _STD move(_ULast2),
-                    _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+                    _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             }
         }
 
@@ -749,10 +749,10 @@ namespace ranges {
                     return false;
                 }
                 return _RANGES _Equal_count(
-                    _Ubegin(_Range1), _Ubegin(_Range2), _Count, _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+                    _Ubegin(_Range1), _Ubegin(_Range2), _Count, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             } else {
-                return _Equal_4(_Ubegin(_Range1), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2), _Pass_fn(_Pred),
-                    _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+                return _Equal_4(_Ubegin(_Range1), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2), _STD _Pass_fn(_Pred),
+                    _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             }
         }
     };
@@ -764,10 +764,10 @@ namespace ranges {
 _EXPORT_STD template <class _FwdIt1, class _FwdIt2, class _Pr>
 _NODISCARD _CONSTEXPR20 bool is_permutation(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _Pr _Pred) {
     // test if [_First1, _Last1) == permuted [_First2, ...)
-    _Adl_verify_range(_First1, _Last1);
-    auto _UFirst1      = _Get_unwrapped(_First1);
-    const auto _ULast1 = _Get_unwrapped(_Last1);
-    auto _UFirst2      = _Get_unwrapped_n(_First2, _Idl_distance<_FwdIt1>(_UFirst1, _ULast1));
+    _STD _Adl_verify_range(_First1, _Last1);
+    auto _UFirst1      = _STD _Get_unwrapped(_First1);
+    const auto _ULast1 = _STD _Get_unwrapped(_Last1);
+    auto _UFirst2      = _STD _Get_unwrapped_n(_First2, _STD _Idl_distance<_FwdIt1>(_UFirst1, _ULast1));
 
     for (;; ++_UFirst1, (void) ++_UFirst2) { // trim matching prefix
         if (_UFirst1 == _ULast1) { // everything matched
@@ -782,7 +782,7 @@ _NODISCARD _CONSTEXPR20 bool is_permutation(_FwdIt1 _First1, _FwdIt1 _Last1, _Fw
     // Narrowing _Iter_diff_t<_FwdIt1> to _Iter_diff_t<_FwdIt2> is OK because the second range must be at least as long
     // as the first.
     const auto _Dist2 = static_cast<_Iter_diff_t<_FwdIt2>>(_STD distance(_UFirst1, _ULast1));
-    return _Check_match_counts(_UFirst1, _ULast1, _UFirst2, _STD next(_UFirst2, _Dist2), _Pass_fn(_Pred));
+    return _STD _Check_match_counts(_UFirst1, _ULast1, _UFirst2, _STD next(_UFirst2, _Dist2), _STD _Pass_fn(_Pred));
 }
 
 _EXPORT_STD template <class _FwdIt1, class _FwdIt2>
@@ -795,12 +795,12 @@ _EXPORT_STD template <class _FwdIt1, class _FwdIt2, class _Pr>
 _NODISCARD _CONSTEXPR20 bool is_permutation(
     _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _Pr _Pred) {
     // test if [_First1, _Last1) == permuted [_First2, _Last2)
-    _Adl_verify_range(_First1, _Last1);
-    _Adl_verify_range(_First2, _Last2);
-    auto _UFirst1 = _Get_unwrapped(_First1);
-    auto _ULast1  = _Get_unwrapped(_Last1);
-    auto _UFirst2 = _Get_unwrapped(_First2);
-    auto _ULast2  = _Get_unwrapped(_Last2);
+    _STD _Adl_verify_range(_First1, _Last1);
+    _STD _Adl_verify_range(_First2, _Last2);
+    auto _UFirst1 = _STD _Get_unwrapped(_First1);
+    auto _ULast1  = _STD _Get_unwrapped(_Last1);
+    auto _UFirst2 = _STD _Get_unwrapped(_First2);
+    auto _ULast2  = _STD _Get_unwrapped(_Last2);
     if constexpr (_Is_ranges_random_iter_v<_FwdIt1> && _Is_ranges_random_iter_v<_FwdIt2>) {
         if (_ULast1 - _UFirst1 != _ULast2 - _UFirst2) {
             return false;
@@ -809,7 +809,7 @@ _NODISCARD _CONSTEXPR20 bool is_permutation(
         for (; _UFirst1 != _ULast1; ++_UFirst1, (void) ++_UFirst2) { // trim matching prefix
             if (!_Pred(*_UFirst1, *_UFirst2)) {
                 // found first inequality, check match counts in suffix
-                return _Check_match_counts(_UFirst1, _ULast1, _UFirst2, _ULast2, _Pass_fn(_Pred));
+                return _STD _Check_match_counts(_UFirst1, _ULast1, _UFirst2, _ULast2, _STD _Pass_fn(_Pred));
             }
         }
 
@@ -836,7 +836,7 @@ _NODISCARD _CONSTEXPR20 bool is_permutation(
         for (;; ++_Next1, (void) ++_Next2) { // check for same lengths
             if (_Next1 == _ULast1) {
                 if (_Next2 == _ULast2) {
-                    return _Check_match_counts(_UFirst1, _ULast1, _UFirst2, _ULast2, _Pass_fn(_Pred));
+                    return _STD _Check_match_counts(_UFirst1, _ULast1, _UFirst2, _ULast2, _STD _Pass_fn(_Pred));
                 }
 
                 return false; // sequence 1 is shorter than sequence 2, not a permutation
@@ -864,12 +864,12 @@ namespace ranges {
             indirect_equivalence_relation<projected<_It1, _Pj1>, projected<_It2, _Pj2>> _Pr = ranges::equal_to>
         _NODISCARD constexpr bool operator()(_It1 _First1, _Se1 _Last1, _It2 _First2, _Se2 _Last2, _Pr _Pred = {},
             _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
-            _Adl_verify_range(_First1, _Last1);
-            _Adl_verify_range(_First2, _Last2);
-            auto _UFirst1 = _Unwrap_iter<_Se1>(_STD move(_First1));
-            auto _ULast1  = _Unwrap_sent<_It1>(_STD move(_Last1));
-            auto _UFirst2 = _Unwrap_iter<_Se2>(_STD move(_First2));
-            auto _ULast2  = _Unwrap_sent<_It2>(_STD move(_Last2));
+            _STD _Adl_verify_range(_First1, _Last1);
+            _STD _Adl_verify_range(_First2, _Last2);
+            auto _UFirst1 = _RANGES _Unwrap_iter<_Se1>(_STD move(_First1));
+            auto _ULast1  = _RANGES _Unwrap_sent<_It1>(_STD move(_Last1));
+            auto _UFirst2 = _RANGES _Unwrap_iter<_Se2>(_STD move(_First2));
+            auto _ULast2  = _RANGES _Unwrap_sent<_It2>(_STD move(_Last2));
 
             if constexpr (sized_sentinel_for<_Se1, _It1> && sized_sentinel_for<_Se2, _It2>) {
                 const auto _Count = _ULast1 - _UFirst1;
@@ -878,10 +878,10 @@ namespace ranges {
                 }
 
                 return _Is_permutation_sized(_STD move(_UFirst1), _STD move(_ULast1), _STD move(_UFirst2),
-                    _STD move(_ULast2), _Count, _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+                    _STD move(_ULast2), _Count, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             } else {
                 return _Is_permutation_unsized(_STD move(_UFirst1), _STD move(_ULast1), _STD move(_UFirst2),
-                    _STD move(_ULast2), _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+                    _STD move(_ULast2), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             }
         }
 
@@ -897,10 +897,10 @@ namespace ranges {
                 }
 
                 return _Is_permutation_sized(_Ubegin(_Range1), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2), _Count,
-                    _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+                    _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             } else {
                 return _Is_permutation_unsized(_Ubegin(_Range1), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2),
-                    _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+                    _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             }
         }
 
@@ -934,8 +934,8 @@ namespace ranges {
 
             if constexpr (bidirectional_iterator<_It1> && bidirectional_iterator<_It2>) {
                 // determine final iterator values
-                auto _Final1 = _Find_last_iterator(_First1, _Last1, _Count);
-                auto _Final2 = _Find_last_iterator(_First2, _Last2, _Count);
+                auto _Final1 = _RANGES _Find_last_iterator(_First1, _Last1, _Count);
+                auto _Final2 = _RANGES _Find_last_iterator(_First2, _Last2, _Count);
 
                 for (;;) { // trim matching suffixes
                     --_Final1;
@@ -958,7 +958,7 @@ namespace ranges {
                         _STD invoke(_Proj2, _STD forward<_Ty2>(_Right)));
                 };
 
-                const _TrimResult _Res = _Trim_completely(_First1, _Final1, _First2, _Final2, _ProjectedPred);
+                const _TrimResult _Res = _STD _Trim_completely(_First1, _Final1, _First2, _Final2, _ProjectedPred);
 
                 if (_Res != _TrimResult::_HaveWorkAfterTrimming) {
                     return _Res == _TrimResult::_ReturnTrue;
@@ -1047,7 +1047,7 @@ namespace ranges {
                         _STD invoke(_Proj2, _STD forward<_Ty2>(_Right)));
                 };
 
-                const _TrimResult _Res = _Trim_completely(_First1, _Final1, _First2, _Final2, _ProjectedPred);
+                const _TrimResult _Res = _STD _Trim_completely(_First1, _Final1, _First2, _Final2, _ProjectedPred);
 
                 if (_Res != _TrimResult::_HaveWorkAfterTrimming) {
                     return _Res == _TrimResult::_ReturnTrue;
@@ -1129,9 +1129,9 @@ namespace ranges {
 
 _EXPORT_STD template <class _InIt, class _Pr>
 _NODISCARD _CONSTEXPR20 bool all_of(_InIt _First, _InIt _Last, _Pr _Pred) { // test if all elements satisfy _Pred
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     for (; _UFirst != _ULast; ++_UFirst) {
         if (!_Pred(*_UFirst)) {
             return false;
@@ -1153,16 +1153,16 @@ namespace ranges {
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
 
-            return _All_of_unchecked(_Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)),
-                _Pass_fn(_Pred), _Pass_fn(_Proj));
+            return _All_of_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)),
+                _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
         }
 
         template <input_range _Rng, class _Pj = identity,
             indirect_unary_predicate<projected<iterator_t<_Rng>, _Pj>> _Pr>
         _NODISCARD constexpr bool operator()(_Rng&& _Range, _Pr _Pred, _Pj _Proj = {}) const {
-            return _All_of_unchecked(_Ubegin(_Range), _Uend(_Range), _Pass_fn(_Pred), _Pass_fn(_Proj));
+            return _All_of_unchecked(_Ubegin(_Range), _Uend(_Range), _STD _Pass_fn(_Pred), _Proj);
         }
 
     private:
@@ -1189,9 +1189,9 @@ namespace ranges {
 _EXPORT_STD template <class _InIt, class _Pr>
 _NODISCARD _CONSTEXPR20 bool any_of(const _InIt _First, const _InIt _Last, _Pr _Pred) {
     // test if any element satisfies _Pred
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     for (; _UFirst != _ULast; ++_UFirst) {
         if (_Pred(*_UFirst)) {
             return true;
@@ -1213,16 +1213,16 @@ namespace ranges {
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
 
-            return _Any_of_unchecked(_Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)),
-                _Pass_fn(_Pred), _Pass_fn(_Proj));
+            return _Any_of_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)),
+                _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
         }
 
         template <input_range _Rng, class _Pj = identity,
             indirect_unary_predicate<projected<iterator_t<_Rng>, _Pj>> _Pr>
         _NODISCARD constexpr bool operator()(_Rng&& _Range, _Pr _Pred, _Pj _Proj = {}) const {
-            return _Any_of_unchecked(_Ubegin(_Range), _Uend(_Range), _Pass_fn(_Pred), _Pass_fn(_Proj));
+            return _Any_of_unchecked(_Ubegin(_Range), _Uend(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
         }
 
     private:
@@ -1249,9 +1249,9 @@ namespace ranges {
 _EXPORT_STD template <class _InIt, class _Pr>
 _NODISCARD _CONSTEXPR20 bool none_of(const _InIt _First, const _InIt _Last, _Pr _Pred) {
     // test if no elements satisfy _Pred
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     for (; _UFirst != _ULast; ++_UFirst) {
         if (_Pred(*_UFirst)) {
             return false;
@@ -1273,16 +1273,16 @@ namespace ranges {
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
 
-            return _None_of_unchecked(_Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)),
-                _Pass_fn(_Pred), _Pass_fn(_Proj));
+            return _None_of_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)),
+                _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
         }
 
         template <input_range _Rng, class _Pj = identity,
             indirect_unary_predicate<projected<iterator_t<_Rng>, _Pj>> _Pr>
         _NODISCARD constexpr bool operator()(_Rng&& _Range, _Pr _Pred, _Pj _Proj = {}) const {
-            return _None_of_unchecked(_Ubegin(_Range), _Uend(_Range), _Pass_fn(_Pred), _Pass_fn(_Proj));
+            return _None_of_unchecked(_Ubegin(_Range), _Uend(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
         }
 
     private:
@@ -1310,17 +1310,17 @@ namespace ranges {
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity>
             requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, const _Ty& _Val, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
-            const auto _ULast = _Unwrap_sent<_It>(_STD move(_Last));
+            _STD _Adl_verify_range(_First, _Last);
+            const auto _ULast = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
             const auto _UResult =
-                _RANGES _Find_unchecked(_Unwrap_iter<_Se>(_STD move(_First)), _ULast, _Val, _Pass_fn(_Proj));
+                _RANGES _Find_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _ULast, _Val, _STD _Pass_fn(_Proj));
             return _UResult != _ULast;
         }
 
         template <input_range _Rng, class _Ty, class _Pj = identity>
             requires indirect_binary_predicate<ranges::equal_to, projected<iterator_t<_Rng>, _Pj>, const _Ty*>
         _NODISCARD constexpr bool operator()(_Rng&& _Range, const _Ty& _Val, _Pj _Proj = {}) const {
-            const auto _UResult = _RANGES _Find_unchecked(_Ubegin(_Range), _Uend(_Range), _Val, _Pass_fn(_Proj));
+            const auto _UResult = _RANGES _Find_unchecked(_Ubegin(_Range), _Uend(_Range), _Val, _STD _Pass_fn(_Proj));
             return _UResult != _Uend(_Range);
         }
     };
@@ -1334,16 +1334,16 @@ namespace ranges {
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
         _NODISCARD constexpr bool operator()(_It1 _First1, _Se1 _Last1, _It2 _First2, _Se2 _Last2, _Pr _Pred = {},
             _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
-            _Adl_verify_range(_First2, _Last2);
-            auto _UFirst2 = _Unwrap_iter<_Se2>(_STD move(_First2));
-            auto _ULast2  = _Unwrap_sent<_It2>(_STD move(_Last2));
+            _STD _Adl_verify_range(_First2, _Last2);
+            auto _UFirst2 = _RANGES _Unwrap_iter<_Se2>(_STD move(_First2));
+            auto _ULast2  = _RANGES _Unwrap_sent<_It2>(_STD move(_Last2));
 
             if (_UFirst2 == _ULast2) {
                 return true;
             }
 
             const auto _Match = _RANGES search(_STD move(_First1), _STD move(_Last1), _STD move(_UFirst2),
-                _STD move(_ULast2), _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+                _STD move(_ULast2), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             return !_Match.empty();
         }
 
@@ -1356,7 +1356,7 @@ namespace ranges {
                 return true;
             }
 
-            const auto _Match = _RANGES search(_Range1, _Range2, _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+            const auto _Match = _RANGES search(_Range1, _Range2, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             return !_Match.empty();
         }
     };
@@ -1910,7 +1910,7 @@ _NODISCARD _CONSTEXPR20 bool _Equal_rev_pred_unchecked(_InIt1 _First1, _InIt2 _F
         if (!_STD is_constant_evaluated())
 #endif // _HAS_CXX20
         {
-            return _Memcmp_ranges(_First2, _Last2, _First1) == 0;
+            return _STD _Memcmp_ranges(_First2, _Last2, _First1) == 0;
         }
     }
 
@@ -1926,19 +1926,19 @@ _NODISCARD _CONSTEXPR20 bool _Equal_rev_pred_unchecked(_InIt1 _First1, _InIt2 _F
 _EXPORT_STD template <class _FwdItHaystack, class _FwdItPat, class _Pr>
 _NODISCARD _CONSTEXPR20 _FwdItHaystack search(_FwdItHaystack _First1, _FwdItHaystack _Last1, const _FwdItPat _First2,
     const _FwdItPat _Last2, _Pr _Pred) { // find first [_First2, _Last2) satisfying _Pred
-    _Adl_verify_range(_First1, _Last1);
-    _Adl_verify_range(_First2, _Last2);
-    auto _UFirst1       = _Get_unwrapped(_First1);
-    const auto _ULast1  = _Get_unwrapped(_Last1);
-    const auto _UFirst2 = _Get_unwrapped(_First2);
-    const auto _ULast2  = _Get_unwrapped(_Last2);
+    _STD _Adl_verify_range(_First1, _Last1);
+    _STD _Adl_verify_range(_First2, _Last2);
+    auto _UFirst1       = _STD _Get_unwrapped(_First1);
+    const auto _ULast1  = _STD _Get_unwrapped(_Last1);
+    const auto _UFirst2 = _STD _Get_unwrapped(_First2);
+    const auto _ULast2  = _STD _Get_unwrapped(_Last2);
     if constexpr (_Is_ranges_random_iter_v<_FwdItHaystack> && _Is_ranges_random_iter_v<_FwdItPat>) {
         const _Iter_diff_t<_FwdItPat> _Count2 = _ULast2 - _UFirst2;
         if (_ULast1 - _UFirst1 >= _Count2) {
             const auto _Last_possible = _ULast1 - static_cast<_Iter_diff_t<_FwdItHaystack>>(_Count2);
             for (;; ++_UFirst1) {
-                if (_Equal_rev_pred_unchecked(_UFirst1, _UFirst2, _ULast2, _Pass_fn(_Pred))) {
-                    _Seek_wrapped(_Last1, _UFirst1);
+                if (_STD _Equal_rev_pred_unchecked(_UFirst1, _UFirst2, _ULast2, _STD _Pass_fn(_Pred))) {
+                    _STD _Seek_wrapped(_Last1, _UFirst1);
                     break;
                 }
 
@@ -1952,7 +1952,7 @@ _NODISCARD _CONSTEXPR20 _FwdItHaystack search(_FwdItHaystack _First1, _FwdItHays
             auto _UMid1 = _UFirst1;
             for (auto _UMid2 = _UFirst2;; ++_UMid1, (void) ++_UMid2) {
                 if (_UMid2 == _ULast2) {
-                    _Seek_wrapped(_Last1, _UFirst1);
+                    _STD _Seek_wrapped(_Last1, _UFirst1);
                     return _Last1;
                 } else if (_UMid1 == _ULast1) {
                     return _Last1;
@@ -2010,9 +2010,9 @@ _NODISCARD _CONSTEXPR20 _FwdIt search_n(
         return _Last;
     }
 
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     if constexpr (_Is_ranges_random_iter_v<_FwdIt>) {
         const auto _Count_diff = static_cast<_Iter_diff_t<_FwdIt>>(_Count);
         auto _UOld_first       = _UFirst;
@@ -2022,7 +2022,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt search_n(
                 _Iter_diff_t<_FwdIt> _Count1 = _Count_diff;
                 auto _UMid                   = _UFirst;
 
-                while (_UOld_first != _UFirst && _Pred(*_Prev_iter(_UFirst), _Val)) { // back up over any skipped prefix
+                while (_UOld_first != _UFirst && _Pred(*_STD _Prev_iter(_UFirst), _Val)) { // back up over any skipped prefix
                     --_Count1;
                     --_UFirst;
                 }
@@ -2030,7 +2030,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt search_n(
                 if (_Count1 <= _ULast - _UMid) {
                     for (;;) { // enough left, test suffix
                         if (--_Count1 == 0) {
-                            _Seek_wrapped(_Last, _UFirst); // found rest of match, report it
+                            _STD _Seek_wrapped(_Last, _UFirst); // found rest of match, report it
                             return _Last;
                         } else if (!_Pred(*++_UMid, _Val)) { // short match not at end
                             break;
@@ -2040,7 +2040,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt search_n(
                 _UOld_first = ++_UMid; // failed match, take small jump
                 _Inc        = 0;
             } else { // no match, take big jump and back up as needed
-                _UOld_first = _Next_iter(_UFirst);
+                _UOld_first = _STD _Next_iter(_UFirst);
                 _Inc        = _Count_diff - 1;
             }
         }
@@ -2051,7 +2051,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt search_n(
 
                 for (_Algorithm_int_t<_Diff> _Count1 = _Count;;) {
                     if (--_Count1 == 0) {
-                        _Seek_wrapped(_Last, _UFirst); // found rest of match, report it
+                        _STD _Seek_wrapped(_Last, _UFirst); // found rest of match, report it
                         return _Last;
                     } else if (++_UMid == _ULast) {
                         return _Last; // short match at end
@@ -2098,24 +2098,24 @@ namespace ranges {
             requires indirectly_comparable<_It, const _Ty*, _Pr, _Pj>
         _NODISCARD constexpr subrange<_It> operator()(_It _First, _Se _Last, const iter_difference_t<_It> _Count,
             const _Ty& _Val, _Pr _Pred = {}, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
 
             if (_Count <= 0) {
                 return {_First, _First};
             }
 
-            auto _UFirst = _Unwrap_iter<_Se>(_STD move(_First));
-            auto _ULast  = _Unwrap_sent<_It>(_STD move(_Last));
+            auto _UFirst = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
+            auto _ULast  = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
 
             if constexpr (sized_sentinel_for<_Se, _It>) {
                 const auto _Dist = _ULast - _UFirst;
                 auto _UResult =
-                    _Search_n_sized(_STD move(_UFirst), _Dist, _Val, _Count, _Pass_fn(_Pred), _Pass_fn(_Proj));
-                return _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
+                    _Search_n_sized(_STD move(_UFirst), _Dist, _Val, _Count, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                return _RANGES _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
             } else {
                 auto _UResult = _Search_n_unsized(
-                    _STD move(_UFirst), _STD move(_ULast), _Val, _Count, _Pass_fn(_Pred), _Pass_fn(_Proj));
-                return _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
+                    _STD move(_UFirst), _STD move(_ULast), _Val, _Count, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                return _RANGES _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
             }
         }
 
@@ -2133,12 +2133,12 @@ namespace ranges {
                 const auto _Dist = _RANGES distance(_Range);
 
                 auto _UResult =
-                    _Search_n_sized(_Get_unwrapped(_First), _Dist, _Val, _Count, _Pass_fn(_Pred), _Pass_fn(_Proj));
-                return _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_First, _STD move(_UResult));
+                    _Search_n_sized(_STD _Get_unwrapped(_First), _Dist, _Val, _Count, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_First, _STD move(_UResult));
             } else {
                 auto _UResult = _Search_n_unsized(
-                    _Unwrap_range_iter<_Rng>(_First), _Uend(_Range), _Val, _Count, _Pass_fn(_Pred), _Pass_fn(_Proj));
-                return _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_First, _STD move(_UResult));
+                    _RANGES _Unwrap_range_iter<_Rng>(_First), _Uend(_Range), _Val, _Count, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_First, _STD move(_UResult));
             }
         }
 
@@ -2254,13 +2254,13 @@ namespace ranges {
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
         _NODISCARD constexpr bool operator()(_It1 _First1, _Se1 _Last1, _It2 _First2, _Se2 _Last2, _Pr _Pred = {},
             _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
-            _Adl_verify_range(_First1, _Last1);
-            _Adl_verify_range(_First2, _Last2);
+            _STD _Adl_verify_range(_First1, _Last1);
+            _STD _Adl_verify_range(_First2, _Last2);
 
-            auto _UFirst1      = _Unwrap_iter<_Se1>(_STD move(_First1));
-            auto _ULast1       = _Unwrap_sent<_It1>(_STD move(_Last1));
-            auto _UFirst2      = _Unwrap_iter<_Se2>(_STD move(_First2));
-            const auto _ULast2 = _Unwrap_sent<_It2>(_STD move(_Last2));
+            auto _UFirst1      = _RANGES _Unwrap_iter<_Se1>(_STD move(_First1));
+            auto _ULast1       = _RANGES _Unwrap_sent<_It1>(_STD move(_Last1));
+            auto _UFirst2      = _RANGES _Unwrap_iter<_Se2>(_STD move(_First2));
+            const auto _ULast2 = _RANGES _Unwrap_sent<_It2>(_STD move(_Last2));
             if constexpr (_Sized_or_unreachable_sentinel_for<_Se1, _It1> && sized_sentinel_for<_Se2, _It2>) {
                 const iter_difference_t<_It2> _Count2 = _ULast2 - _UFirst2;
                 if constexpr (sized_sentinel_for<_Se1, _It1>) {
@@ -2270,10 +2270,10 @@ namespace ranges {
                 }
 
                 return _RANGES _Equal_count(_STD move(_UFirst1), _STD move(_UFirst2),
-                    static_cast<iter_difference_t<_It1>>(_Count2), _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+                    static_cast<iter_difference_t<_It1>>(_Count2), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             } else {
                 const auto _Result = _RANGES _Mismatch_4(_STD move(_UFirst1), _STD move(_ULast1), _STD move(_UFirst2),
-                    _ULast2, _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+                    _ULast2, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
                 return _Result.in2 == _ULast2;
             }
         }
@@ -2292,12 +2292,12 @@ namespace ranges {
                 }
 
                 return _RANGES _Equal_count(_Ubegin(_Range1), _Ubegin(_Range2),
-                    static_cast<range_difference_t<_Rng1>>(_Count2), _Pass_fn(_Pred), _Pass_fn(_Proj1),
-                    _Pass_fn(_Proj2));
+                    static_cast<range_difference_t<_Rng1>>(_Count2), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1),
+                    _STD _Pass_fn(_Proj2));
             } else {
                 const auto _ULast2 = _Uend(_Range2);
                 const auto _Result = _RANGES _Mismatch_4(_Ubegin(_Range1), _Uend(_Range1), _Ubegin(_Range2), _ULast2,
-                    _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+                    _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
                 return _Result.in2 == _ULast2;
             }
         }
@@ -2314,18 +2314,18 @@ namespace ranges {
                   && indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
         _NODISCARD constexpr bool operator()(_It1 _First1, _Se1 _Last1, _It2 _First2, _Se2 _Last2, _Pr _Pred = {},
             _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
-            _Adl_verify_range(_First1, _Last1);
-            _Adl_verify_range(_First2, _Last2);
-            auto _UFirst1 = _Unwrap_iter<_Se1>(_STD move(_First1));
-            auto _ULast1  = _Unwrap_sent<_It1>(_STD move(_Last1));
-            auto _UFirst2 = _Unwrap_iter<_Se2>(_STD move(_First2));
-            auto _ULast2  = _Unwrap_sent<_It2>(_STD move(_Last2));
+            _STD _Adl_verify_range(_First1, _Last1);
+            _STD _Adl_verify_range(_First2, _Last2);
+            auto _UFirst1 = _RANGES _Unwrap_iter<_Se1>(_STD move(_First1));
+            auto _ULast1  = _RANGES _Unwrap_sent<_It1>(_STD move(_Last1));
+            auto _UFirst2 = _RANGES _Unwrap_iter<_Se2>(_STD move(_First2));
+            auto _ULast2  = _RANGES _Unwrap_sent<_It2>(_STD move(_Last2));
 
             const auto _Count1 = _Distance_helper(_UFirst1, _ULast1);
             const auto _Count2 = _Distance_helper(_UFirst2, _ULast2);
 
             return _Ends_with_impl(_STD move(_UFirst1), _STD move(_ULast1), _Count1, _STD move(_UFirst2),
-                _STD move(_ULast2), _Count2, _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+                _STD move(_ULast2), _Count2, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
         }
 
         template <input_range _Rng1, input_range _Rng2, class _Pr = ranges::equal_to, class _Pj1 = identity,
@@ -2338,7 +2338,7 @@ namespace ranges {
             const auto _Count2 = _Distance_helper(_Range2);
 
             return _Ends_with_impl(_Ubegin(_Range1), _Uend(_Range1), _Count1, _Ubegin(_Range2), _Uend(_Range2), _Count2,
-                _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+                _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
         }
 
     private:
@@ -2563,15 +2563,15 @@ namespace ranges {
     public:
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, _Indirectly_binary_left_foldable<_Ty, _It> _Fn>
         _NODISCARD constexpr auto operator()(_It _First, _Se _Last, _Ty _Init, _Fn _Func) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
             return _Fold_left_with_iter_impl<_It>(
-                _STD move(_First), _STD move(_Last), _STD move(_Init), _Pass_fn(_Func));
+                _STD move(_First), _STD move(_Last), _STD move(_Init), _STD _Pass_fn(_Func));
         }
 
         template <input_range _Rng, class _Ty, _Indirectly_binary_left_foldable<_Ty, iterator_t<_Rng>> _Fn>
         _NODISCARD constexpr auto operator()(_Rng&& _Range, _Ty _Init, _Fn _Func) const {
             return _Fold_left_with_iter_impl<borrowed_iterator_t<_Rng>>(
-                _RANGES begin(_Range), _RANGES end(_Range), _STD move(_Init), _Pass_fn(_Func));
+                _RANGES begin(_Range), _RANGES end(_Range), _STD move(_Init), _STD _Pass_fn(_Func));
         }
 
     private:
@@ -2587,15 +2587,15 @@ namespace ranges {
             if (_First == _Last) {
                 return _Return_type{_STD move(_First), static_cast<_Uty>(_STD move(_Init))};
             } else {
-                auto _UFirst = _Unwrap_iter<_Se>(_STD move(_First));
-                auto _ULast  = _Unwrap_sent<_It>(_STD move(_Last));
+                auto _UFirst = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
+                auto _ULast  = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
 
                 _Uty _Accum = _STD invoke(_Func, _STD move(_Init), *_UFirst);
                 for (++_UFirst; _UFirst != _ULast; ++_UFirst) {
                     _Accum = _STD invoke(_Func, _STD move(_Accum), *_UFirst);
                 }
 
-                _Seek_wrapped(_First, _STD move(_UFirst));
+                _STD _Seek_wrapped(_First, _STD move(_UFirst));
                 return _Return_type{_STD move(_First), _STD move(_Accum)};
             }
         }
@@ -2607,12 +2607,12 @@ namespace ranges {
     public:
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, _Indirectly_binary_left_foldable<_Ty, _It> _Fn>
         _NODISCARD constexpr auto operator()(_It _First, _Se _Last, _Ty _Init, _Fn _Func) const {
-            return _RANGES fold_left_with_iter(_STD move(_First), _Last, _STD move(_Init), _Pass_fn(_Func)).value;
+            return _RANGES fold_left_with_iter(_STD move(_First), _Last, _STD move(_Init), _STD _Pass_fn(_Func)).value;
         }
 
         template <input_range _Rng, class _Ty, _Indirectly_binary_left_foldable<_Ty, iterator_t<_Rng>> _Fn>
         _NODISCARD constexpr auto operator()(_Rng&& _Range, _Ty _Init, _Fn _Func) const {
-            return _RANGES fold_left_with_iter(_STD forward<_Rng>(_Range), _STD move(_Init), _Pass_fn(_Func)).value;
+            return _RANGES fold_left_with_iter(_STD forward<_Rng>(_Range), _STD move(_Init), _STD _Pass_fn(_Func)).value;
         }
     };
 
@@ -2624,15 +2624,15 @@ namespace ranges {
             _Indirectly_binary_left_foldable<iter_value_t<_It>, _It> _Fn>
             requires constructible_from<iter_value_t<_It>, iter_reference_t<_It>>
         _NODISCARD constexpr auto operator()(_It _First, _Se _Last, _Fn _Func) const {
-            _Adl_verify_range(_First, _Last);
-            return _Fold_left_first_with_iter_impl<_It>(_STD move(_First), _STD move(_Last), _Pass_fn(_Func));
+            _STD _Adl_verify_range(_First, _Last);
+            return _Fold_left_first_with_iter_impl<_It>(_STD move(_First), _STD move(_Last), _STD _Pass_fn(_Func));
         }
 
         template <input_range _Rng, _Indirectly_binary_left_foldable<range_value_t<_Rng>, iterator_t<_Rng>> _Fn>
             requires constructible_from<range_value_t<_Rng>, range_reference_t<_Rng>>
         _NODISCARD constexpr auto operator()(_Rng&& _Range, _Fn _Func) const {
             return _Fold_left_first_with_iter_impl<borrowed_iterator_t<_Rng>>(
-                _RANGES begin(_Range), _RANGES end(_Range), _Pass_fn(_Func));
+                _RANGES begin(_Range), _RANGES end(_Range), _STD _Pass_fn(_Func));
         }
 
     private:
@@ -2649,8 +2649,8 @@ namespace ranges {
             if (_First == _Last) {
                 return _Return_type{_STD move(_First), optional<_Uty>{}};
             } else {
-                auto _UFirst = _Unwrap_iter<_Se>(_STD move(_First));
-                auto _ULast  = _Unwrap_sent<_It>(_STD move(_Last));
+                auto _UFirst = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
+                auto _ULast  = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
 
                 optional<_Uty> _Init{in_place, *_UFirst};
                 _Uty& _Init_ref = *_Init;
@@ -2658,7 +2658,7 @@ namespace ranges {
                     _Init_ref = _STD invoke(_Func, _STD move(_Init_ref), *_UFirst);
                 }
 
-                _Seek_wrapped(_First, _STD move(_UFirst));
+                _STD _Seek_wrapped(_First, _STD move(_UFirst));
                 return _Return_type{_STD move(_First), _STD move(_Init)};
             }
         }
@@ -2672,13 +2672,13 @@ namespace ranges {
             _Indirectly_binary_left_foldable<iter_value_t<_It>, _It> _Fn>
             requires constructible_from<iter_value_t<_It>, iter_reference_t<_It>>
         _NODISCARD constexpr auto operator()(_It _First, _Se _Last, _Fn _Func) const {
-            return _RANGES fold_left_first_with_iter(_STD move(_First), _STD move(_Last), _Pass_fn(_Func)).value;
+            return _RANGES fold_left_first_with_iter(_STD move(_First), _STD move(_Last), _STD _Pass_fn(_Func)).value;
         }
 
         template <input_range _Rng, _Indirectly_binary_left_foldable<range_value_t<_Rng>, iterator_t<_Rng>> _Fn>
             requires constructible_from<range_value_t<_Rng>, range_reference_t<_Rng>>
         _NODISCARD constexpr auto operator()(_Rng&& _Range, _Fn _Func) const {
-            return _RANGES fold_left_first_with_iter(_STD forward<_Rng>(_Range), _Pass_fn(_Func)).value;
+            return _RANGES fold_left_first_with_iter(_STD forward<_Rng>(_Range), _STD _Pass_fn(_Func)).value;
         }
     };
 
@@ -2708,14 +2708,14 @@ namespace ranges {
         template <bidirectional_iterator _It, sentinel_for<_It> _Se, class _Ty,
             _Indirectly_binary_right_foldable<_Ty, _It> _Fn>
         _NODISCARD constexpr auto operator()(_It _First, _Se _Last, _Ty _Init, _Fn _Func) const {
-            _Adl_verify_range(_First, _Last);
-            return _RANGES _Fold_right_unchecked(_Unwrap_iter<_Se>(_STD move(_First)),
-                _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Init), _Pass_fn(_Func));
+            _STD _Adl_verify_range(_First, _Last);
+            return _RANGES _Fold_right_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Init), _STD _Pass_fn(_Func));
         }
 
         template <bidirectional_range _Rng, class _Ty, _Indirectly_binary_right_foldable<_Ty, iterator_t<_Rng>> _Fn>
         _NODISCARD constexpr auto operator()(_Rng&& _Range, _Ty _Init, _Fn _Func) const {
-            return _RANGES _Fold_right_unchecked(_Ubegin(_Range), _Uend(_Range), _STD move(_Init), _Pass_fn(_Func));
+            return _RANGES _Fold_right_unchecked(_Ubegin(_Range), _Uend(_Range), _STD move(_Init), _STD _Pass_fn(_Func));
         }
     };
 
@@ -2727,16 +2727,16 @@ namespace ranges {
             _Indirectly_binary_right_foldable<iter_value_t<_It>, _It> _Fn>
             requires constructible_from<iter_value_t<_It>, iter_reference_t<_It>>
         _NODISCARD constexpr auto operator()(_It _First, _Se _Last, _Fn _Func) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
             return _Fold_right_last_unchecked(
-                _Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)), _Pass_fn(_Func));
+                _RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Pass_fn(_Func));
         }
 
         template <bidirectional_range _Rng,
             _Indirectly_binary_right_foldable<range_value_t<_Rng>, iterator_t<_Rng>> _Fn>
             requires constructible_from<range_value_t<_Rng>, range_reference_t<_Rng>>
         _NODISCARD constexpr auto operator()(_Rng&& _Range, _Fn _Func) const {
-            return _Fold_right_last_unchecked(_Ubegin(_Range), _Uend(_Range), _Pass_fn(_Func));
+            return _Fold_right_last_unchecked(_Ubegin(_Range), _Uend(_Range), _STD _Pass_fn(_Func));
         }
 
     private:
@@ -2765,17 +2765,17 @@ namespace ranges {
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity>
             requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
         _NODISCARD constexpr subrange<_It> operator()(_It _First, _Se _Last, const _Ty& _Value, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
 
-            auto _UFirst = _Unwrap_iter<_Se>(_STD move(_First));
+            auto _UFirst = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
             if constexpr (bidirectional_iterator<_It>) {
-                auto _ULast   = _Get_final_iterator_unwrapped<_It>(_UFirst, _STD move(_Last));
-                auto _UResult = _Find_last_unchecked(_STD move(_UFirst), _STD move(_ULast), _Value, _Pass_fn(_Proj));
-                return _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
+                auto _ULast   = _RANGES _Get_final_iterator_unwrapped<_It>(_UFirst, _STD move(_Last));
+                auto _UResult = _Find_last_unchecked(_STD move(_UFirst), _STD move(_ULast), _Value, _STD _Pass_fn(_Proj));
+                return _RANGES _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
             } else {
-                auto _ULast   = _Unwrap_sent<_It>(_STD move(_Last));
-                auto _UResult = _Find_last_unchecked(_STD move(_UFirst), _STD move(_ULast), _Value, _Pass_fn(_Proj));
-                return _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
+                auto _ULast   = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
+                auto _UResult = _Find_last_unchecked(_STD move(_UFirst), _STD move(_ULast), _Value, _STD _Pass_fn(_Proj));
+                return _RANGES _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
             }
         }
 
@@ -2785,11 +2785,11 @@ namespace ranges {
             _Rng&& _Range, const _Ty& _Value, _Pj _Proj = {}) const {
             if constexpr (bidirectional_range<_Rng>) {
                 auto _UResult = _Find_last_unchecked(
-                    _Ubegin(_Range), _Get_final_iterator_unwrapped(_Range), _Value, _Pass_fn(_Proj));
-                return _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Range, _STD move(_UResult));
+                    _Ubegin(_Range), _RANGES _Get_final_iterator_unwrapped(_Range), _Value, _STD _Pass_fn(_Proj));
+                return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Range, _STD move(_UResult));
             } else {
-                auto _UResult = _Find_last_unchecked(_Ubegin(_Range), _Uend(_Range), _Value, _Pass_fn(_Proj));
-                return _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Range, _STD move(_UResult));
+                auto _UResult = _Find_last_unchecked(_Ubegin(_Range), _Uend(_Range), _Value, _STD _Pass_fn(_Proj));
+                return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Range, _STD move(_UResult));
             }
         }
 
@@ -2806,10 +2806,10 @@ namespace ranges {
                           && sized_sentinel_for<_Se, _It>) {
                 if (!_STD is_constant_evaluated()) {
                     const auto _Count     = _Last - _First;
-                    const auto _First_ptr = _To_address(_First);
+                    const auto _First_ptr = _STD _To_address(_First);
                     const auto _Last_ptr  = _First_ptr + _Count;
 
-                    const auto _Result = __std_find_last_trivial(_First_ptr, _Last_ptr, _Value);
+                    const auto _Result = ::__std_find_last_trivial(_First_ptr, _Last_ptr, _Value);
                     if constexpr (is_pointer_v<_It>) {
                         return {_Result, _Last_ptr};
                     } else {
@@ -2863,19 +2863,19 @@ namespace ranges {
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr subrange<_It> operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
 
-            auto _UFirst = _Unwrap_iter<_Se>(_STD move(_First));
+            auto _UFirst = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
             if constexpr (bidirectional_iterator<_It>) {
-                auto _ULast = _Get_final_iterator_unwrapped<_It>(_UFirst, _STD move(_Last));
+                auto _ULast = _RANGES _Get_final_iterator_unwrapped<_It>(_UFirst, _STD move(_Last));
                 auto _UResult =
-                    _Find_last_if_unchecked(_STD move(_UFirst), _STD move(_ULast), _Pass_fn(_Pred), _Pass_fn(_Proj));
-                return _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
+                    _Find_last_if_unchecked(_STD move(_UFirst), _STD move(_ULast), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                return _RANGES _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
             } else {
-                auto _ULast = _Unwrap_sent<_It>(_STD move(_Last));
+                auto _ULast = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
                 auto _UResult =
-                    _Find_last_if_unchecked(_STD move(_UFirst), _STD move(_ULast), _Pass_fn(_Pred), _Pass_fn(_Proj));
-                return _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
+                    _Find_last_if_unchecked(_STD move(_UFirst), _STD move(_ULast), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                return _RANGES _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
             }
         }
 
@@ -2884,12 +2884,12 @@ namespace ranges {
         _NODISCARD constexpr borrowed_subrange_t<_Rng> operator()(_Rng&& _Range, _Pr _Pred, _Pj _Proj = {}) const {
             if constexpr (bidirectional_range<_Rng>) {
                 auto _UResult = _Find_last_if_unchecked(
-                    _Ubegin(_Range), _Get_final_iterator_unwrapped(_Range), _Pass_fn(_Pred), _Pass_fn(_Proj));
-                return _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Range, _STD move(_UResult));
+                    _Ubegin(_Range), _RANGES _Get_final_iterator_unwrapped(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Range, _STD move(_UResult));
             } else {
                 auto _UResult =
-                    _Find_last_if_unchecked(_Ubegin(_Range), _Uend(_Range), _Pass_fn(_Pred), _Pass_fn(_Proj));
-                return _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Range, _STD move(_UResult));
+                    _Find_last_if_unchecked(_Ubegin(_Range), _Uend(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Range, _STD move(_UResult));
             }
         }
 
@@ -2946,18 +2946,18 @@ _EXPORT_STD template <class _FwdIt1, class _FwdIt2, class _Pr>
 _NODISCARD _CONSTEXPR20 _FwdIt1 find_end(
     _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2, const _FwdIt2 _Last2, _Pr _Pred) {
     // find last [_First2, _Last2) satisfying _Pred
-    _Adl_verify_range(_First1, _Last1);
-    _Adl_verify_range(_First2, _Last2);
-    auto _UFirst1       = _Get_unwrapped(_First1);
-    const auto _ULast1  = _Get_unwrapped(_Last1);
-    const auto _UFirst2 = _Get_unwrapped(_First2);
-    const auto _ULast2  = _Get_unwrapped(_Last2);
+    _STD _Adl_verify_range(_First1, _Last1);
+    _STD _Adl_verify_range(_First2, _Last2);
+    auto _UFirst1       = _STD _Get_unwrapped(_First1);
+    const auto _ULast1  = _STD _Get_unwrapped(_Last1);
+    const auto _UFirst2 = _STD _Get_unwrapped(_First2);
+    const auto _ULast2  = _STD _Get_unwrapped(_Last2);
     if constexpr (_Is_ranges_random_iter_v<_FwdIt1> && _Is_ranges_random_iter_v<_FwdIt2>) {
         const _Iter_diff_t<_FwdIt2> _Count2 = _ULast2 - _UFirst2;
         if (_Count2 > 0 && _Count2 <= _ULast1 - _UFirst1) {
             for (auto _UCandidate = _ULast1 - static_cast<_Iter_diff_t<_FwdIt1>>(_Count2);; --_UCandidate) {
-                if (_Equal_rev_pred_unchecked(_UCandidate, _UFirst2, _ULast2, _Pass_fn(_Pred))) {
-                    _Seek_wrapped(_First1, _UCandidate);
+                if (_STD _Equal_rev_pred_unchecked(_UCandidate, _UFirst2, _ULast2, _STD _Pass_fn(_Pred))) {
+                    _STD _Seek_wrapped(_First1, _UCandidate);
                     return _First1;
                 }
 
@@ -2974,7 +2974,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt1 find_end(
             auto _UNext2 = _ULast2;
             for (;;) { // test if [_UFirst2, _ULast2) is a suffix of [_UFirst1, _UCandidate)
                 if (_UFirst2 == _UNext2) { // match found
-                    _Seek_wrapped(_First1, _UNext1);
+                    _STD _Seek_wrapped(_First1, _UNext1);
                     return _First1;
                 }
 
@@ -3003,7 +3003,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt1 find_end(
 
                 if (_UNext1 == _ULast1) {
                     // trying the next candidate would make [_UFirst1, _ULast1) shorter than [_UFirst2, _ULast2), done
-                    _Seek_wrapped(_First1, _UResult);
+                    _STD _Seek_wrapped(_First1, _UResult);
                     return _First1;
                 }
 
@@ -3018,7 +3018,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt1 find_end(
             ++_UFirst1;
         }
 
-        _Seek_wrapped(_First1, _UResult);
+        _STD _Seek_wrapped(_First1, _UResult);
         return _First1;
     }
 }
@@ -3152,28 +3152,28 @@ namespace ranges {
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
         _NODISCARD constexpr subrange<_It1> operator()(_It1 _First1, _Se1 _Last1, _It2 _First2, _Se2 _Last2,
             _Pr _Pred = {}, _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
-            _Adl_verify_range(_First1, _Last1);
-            _Adl_verify_range(_First2, _Last2);
-            auto _UFirst1 = _Unwrap_iter<_Se1>(_First1);
-            auto _ULast1  = _Unwrap_sent<_It1>(_Last1);
-            auto _UFirst2 = _Unwrap_iter<_Se2>(_First2);
-            auto _ULast2  = _Unwrap_sent<_It2>(_Last2);
+            _STD _Adl_verify_range(_First1, _Last1);
+            _STD _Adl_verify_range(_First2, _Last2);
+            auto _UFirst1 = _RANGES _Unwrap_iter<_Se1>(_First1);
+            auto _ULast1  = _RANGES _Unwrap_sent<_It1>(_Last1);
+            auto _UFirst2 = _RANGES _Unwrap_iter<_Se2>(_First2);
+            auto _ULast2  = _RANGES _Unwrap_sent<_It2>(_Last2);
 
             if constexpr (random_access_iterator<_It1> && sized_sentinel_for<_Se1, _It1> && random_access_iterator<_It2>
                           && sized_sentinel_for<_Se2, _It2>) {
                 const auto _Count1 = _ULast1 - _UFirst1;
                 const auto _Count2 = _ULast2 - _UFirst2;
                 auto _UResult = _Random_access_sized_ranges(_STD move(_UFirst1), _Count1, _STD move(_UFirst2), _Count2,
-                    _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
-                return _Rewrap_subrange<subrange<_It1>>(_First1, _STD move(_UResult));
+                    _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                return _RANGES _Rewrap_subrange<subrange<_It1>>(_First1, _STD move(_UResult));
             } else if constexpr (_Bidi_common<_It1, _Se1> && _Bidi_common<_It2, _Se2>) {
                 auto _UResult = _Bidi_common_ranges(_STD move(_UFirst1), _STD move(_ULast1), _STD move(_UFirst2),
-                    _STD move(_ULast2), _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
-                return _Rewrap_subrange<subrange<_It1>>(_First1, _STD move(_UResult));
+                    _STD move(_ULast2), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                return _RANGES _Rewrap_subrange<subrange<_It1>>(_First1, _STD move(_UResult));
             } else {
                 auto _UResult = _Forward_ranges(_STD move(_UFirst1), _STD move(_ULast1), _STD move(_UFirst2),
-                    _STD move(_ULast2), _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
-                return _Rewrap_subrange<subrange<_It1>>(_First1, _STD move(_UResult));
+                    _STD move(_ULast2), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                return _RANGES _Rewrap_subrange<subrange<_It1>>(_First1, _STD move(_UResult));
             }
         }
 
@@ -3185,16 +3185,16 @@ namespace ranges {
             if constexpr (random_access_range<_Rng1> && sized_range<_Rng1> && random_access_range<_Rng2>
                           && sized_range<_Rng2>) {
                 auto _UResult = _Random_access_sized_ranges(_Ubegin(_Range1), _RANGES distance(_Range1),
-                    _Ubegin(_Range2), _RANGES distance(_Range2), _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
-                return _Rewrap_subrange<borrowed_subrange_t<_Rng1>>(_Range1, _STD move(_UResult));
+                    _Ubegin(_Range2), _RANGES distance(_Range2), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng1>>(_Range1, _STD move(_UResult));
             } else if constexpr (_Bidi_common_range<_Rng1> && _Bidi_common_range<_Rng2>) {
                 auto _UResult = _Bidi_common_ranges(_Ubegin(_Range1), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2),
-                    _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
-                return _Rewrap_subrange<borrowed_subrange_t<_Rng1>>(_Range1, _STD move(_UResult));
+                    _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng1>>(_Range1, _STD move(_UResult));
             } else {
                 auto _UResult = _Forward_ranges(_Ubegin(_Range1), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2),
-                    _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
-                return _Rewrap_subrange<borrowed_subrange_t<_Rng1>>(_Range1, _STD move(_UResult));
+                    _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng1>>(_Range1, _STD move(_UResult));
             }
         }
     };
@@ -3207,22 +3207,22 @@ _EXPORT_STD template <class _FwdIt1, class _FwdIt2, class _Pr>
 _NODISCARD _CONSTEXPR20 _FwdIt1 find_first_of(
     _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2, const _FwdIt2 _Last2, _Pr _Pred) {
     // look for one of [_First2, _Last2) satisfying _Pred with element
-    _Adl_verify_range(_First1, _Last1);
-    _Adl_verify_range(_First2, _Last2);
-    auto _UFirst1       = _Get_unwrapped(_First1);
-    const auto _ULast1  = _Get_unwrapped(_Last1);
-    const auto _UFirst2 = _Get_unwrapped(_First2);
-    const auto _ULast2  = _Get_unwrapped(_Last2);
+    _STD _Adl_verify_range(_First1, _Last1);
+    _STD _Adl_verify_range(_First2, _Last2);
+    auto _UFirst1       = _STD _Get_unwrapped(_First1);
+    const auto _ULast1  = _STD _Get_unwrapped(_Last1);
+    const auto _UFirst2 = _STD _Get_unwrapped(_First2);
+    const auto _ULast2  = _STD _Get_unwrapped(_Last2);
     for (; _UFirst1 != _ULast1; ++_UFirst1) {
         for (auto _UMid2 = _UFirst2; _UMid2 != _ULast2; ++_UMid2) {
             if (_Pred(*_UFirst1, *_UMid2)) {
-                _Seek_wrapped(_First1, _UFirst1);
+                _STD _Seek_wrapped(_First1, _UFirst1);
                 return _First1;
             }
         }
     }
 
-    _Seek_wrapped(_First1, _UFirst1);
+    _STD _Seek_wrapped(_First1, _UFirst1);
     return _First1;
 }
 
@@ -3253,14 +3253,14 @@ namespace ranges {
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
         _NODISCARD constexpr _It1 operator()(_It1 _First1, _Se1 _Last1, _It2 _First2, _Se2 _Last2, _Pr _Pred = {},
             _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
-            _Adl_verify_range(_First1, _Last1);
-            _Adl_verify_range(_First2, _Last2);
+            _STD _Adl_verify_range(_First1, _Last1);
+            _STD _Adl_verify_range(_First2, _Last2);
 
-            auto _UResult = _Find_first_of_unchecked(_Unwrap_iter<_Se1>(_STD move(_First1)),
-                _Unwrap_sent<_It1>(_STD move(_Last1)), _Unwrap_iter<_Se2>(_STD move(_First2)),
-                _Unwrap_sent<_It2>(_STD move(_Last2)), _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+            auto _UResult = _Find_first_of_unchecked(_RANGES _Unwrap_iter<_Se1>(_STD move(_First1)),
+                _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)), _RANGES _Unwrap_iter<_Se2>(_STD move(_First2)),
+                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
 
-            _Seek_wrapped(_First1, _STD move(_UResult));
+            _STD _Seek_wrapped(_First1, _STD move(_UResult));
             return _First1;
         }
 
@@ -3271,10 +3271,10 @@ namespace ranges {
             _Rng1&& _Range1, _Rng2&& _Range2, _Pr _Pred = {}, _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
             auto _First1 = _RANGES begin(_Range1);
 
-            auto _UResult = _Find_first_of_unchecked(_Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1),
-                _Ubegin(_Range2), _Uend(_Range2), _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+            auto _UResult = _Find_first_of_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1),
+                _Ubegin(_Range2), _Uend(_Range2), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
 
-            _Seek_wrapped(_First1, _STD move(_UResult));
+            _STD _Seek_wrapped(_First1, _STD move(_UResult));
             return _First1;
         }
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -86,7 +86,7 @@ _STD pair<_Ty*, _Ty*> __std_minmax_element(_Ty* _First, _Ty* _Last) noexcept {
 template <class _Ty, class _TVal>
 _Ty* __std_find_last_trivial(_Ty* _First, _Ty* _Last, const _TVal _Val) noexcept {
     if constexpr (_STD is_pointer_v<_TVal> || _STD is_null_pointer_v<_TVal>) {
-        return ::__std_find_last_trivial(_First, _Last, reinterpret_cast<uintptr_t>(_Val));
+        return _STD __std_find_last_trivial(_First, _Last, reinterpret_cast<uintptr_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 1) {
         return const_cast<_Ty*>(
             static_cast<const _Ty*>(::__std_find_last_trivial_1(_First, _Last, static_cast<uint8_t>(_Val))));
@@ -491,7 +491,7 @@ namespace ranges {
                     const auto _First_ptr = _STD _To_address(_First);
                     const auto _Last_ptr  = _First_ptr + (_Last - _First);
 
-                    return static_cast<iter_difference_t<_It>>(::__std_count_trivial(_First_ptr, _Last_ptr, _Val));
+                    return static_cast<iter_difference_t<_It>>(_STD __std_count_trivial(_First_ptr, _Last_ptr, _Val));
                 }
             }
 #endif // _USE_STD_VECTOR_ALGORITHMS
@@ -2818,7 +2818,7 @@ namespace ranges {
                     const auto _First_ptr = _STD _To_address(_First);
                     const auto _Last_ptr  = _First_ptr + _Count;
 
-                    const auto _Result = ::__std_find_last_trivial(_First_ptr, _Last_ptr, _Value);
+                    const auto _Result = _STD __std_find_last_trivial(_First_ptr, _Last_ptr, _Value);
                     if constexpr (is_pointer_v<_It>) {
                         return {_Result, _Last_ptr};
                     } else {
@@ -9734,7 +9734,7 @@ constexpr pair<_FwdIt, _FwdIt> _Minmax_element_unchecked(_FwdIt _First, _FwdIt _
     if constexpr (_Is_min_max_optimization_safe<_FwdIt, _Pr>) {
         if (!_Is_constant_evaluated()) {
             const auto _First_ptr = _To_address(_First);
-            const auto _Result    = __std_minmax_element(_First_ptr, _To_address(_Last));
+            const auto _Result    = _STD __std_minmax_element(_First_ptr, _To_address(_Last));
             if constexpr (is_pointer_v<_FwdIt>) {
                 return _Result;
             } else {

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1164,7 +1164,7 @@ namespace ranges {
         template <input_range _Rng, class _Pj = identity,
             indirect_unary_predicate<projected<iterator_t<_Rng>, _Pj>> _Pr>
         _NODISCARD constexpr bool operator()(_Rng&& _Range, _Pr _Pred, _Pj _Proj = {}) const {
-            return _All_of_unchecked(_Ubegin(_Range), _Uend(_Range), _STD _Pass_fn(_Pred), _Proj);
+            return _All_of_unchecked(_Ubegin(_Range), _Uend(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
         }
 
     private:

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -3060,10 +3060,10 @@ namespace ranges {
                 const auto _Count2_as1 = static_cast<iter_difference_t<_It1>>(_Count2);
 
                 for (auto _Candidate = _First1 + (_Count1 - _Count2_as1);; --_Candidate) {
-                    auto [_Match, _Mid1] =
+                    auto _Match_and_mid1 =
                         _RANGES _Equal_rev_pred(_Candidate, _First2, _First2 + _Count2, _Pred, _Proj1, _Proj2);
-                    if (_Match) {
-                        return {_STD move(_Candidate), _STD move(_Mid1)};
+                    if (_Match_and_mid1.first) {
+                        return {_STD move(_Candidate), _STD move(_Match_and_mid1.second)};
                     }
 
                     if (_Candidate == _First1) {

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -2653,7 +2653,7 @@ namespace ranges {
                 auto _ULast  = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
 
                 optional<_Uty> _Init{in_place, *_UFirst};
-                _Uty& _Init_ref = *_Init;
+                _Uty& _Init_ref = _Init.operator*(); // per LWG-3969
                 for (++_UFirst; _UFirst != _ULast; ++_UFirst) {
                     _Init_ref = _STD invoke(_Func, _STD move(_Init_ref), *_UFirst);
                 }

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -338,8 +338,8 @@ namespace ranges {
             _Rng&& _Range, _Fn _Func, _Pj _Proj = {}) const {
             auto _First = _RANGES begin(_Range);
 
-            auto _UResult = _For_each_unchecked(
-                _RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD move(_Func), _STD _Pass_fn(_Proj));
+            auto _UResult = _For_each_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
+                _STD move(_Func), _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.fun)};
@@ -460,8 +460,8 @@ namespace ranges {
         _NODISCARD constexpr iter_difference_t<_It> operator()(
             _It _First, _Se _Last, const _Ty& _Val, _Pj _Proj = {}) const {
             _STD _Adl_verify_range(_First, _Last);
-            return _Count_unchecked(
-                _RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _Val, _STD _Pass_fn(_Proj));
+            return _Count_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _Val, _STD _Pass_fn(_Proj));
         }
 
         template <input_range _Rng, class _Ty, class _Pj = identity>
@@ -538,8 +538,8 @@ namespace ranges {
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr iter_difference_t<_It> operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
             _STD _Adl_verify_range(_First, _Last);
-            return _Count_if_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)),
-                _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+            return _Count_if_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
         }
 
         template <input_range _Rng, class _Pj = identity,
@@ -748,11 +748,11 @@ namespace ranges {
                 if (_Count != static_cast<_Size2>(_RANGES size(_Range2))) {
                     return false;
                 }
-                return _RANGES _Equal_count(
-                    _Ubegin(_Range1), _Ubegin(_Range2), _Count, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
-            } else {
-                return _Equal_4(_Ubegin(_Range1), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2), _STD _Pass_fn(_Pred),
+                return _RANGES _Equal_count(_Ubegin(_Range1), _Ubegin(_Range2), _Count, _STD _Pass_fn(_Pred),
                     _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+            } else {
+                return _Equal_4(_Ubegin(_Range1), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2),
+                    _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             }
         }
     };
@@ -1155,8 +1155,8 @@ namespace ranges {
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
             _STD _Adl_verify_range(_First, _Last);
 
-            return _All_of_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)),
-                _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+            return _All_of_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
         }
 
         template <input_range _Rng, class _Pj = identity,
@@ -1215,8 +1215,8 @@ namespace ranges {
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
             _STD _Adl_verify_range(_First, _Last);
 
-            return _Any_of_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)),
-                _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+            return _Any_of_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
         }
 
         template <input_range _Rng, class _Pj = identity,
@@ -1275,8 +1275,8 @@ namespace ranges {
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
             _STD _Adl_verify_range(_First, _Last);
 
-            return _None_of_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)),
-                _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+            return _None_of_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
         }
 
         template <input_range _Rng, class _Pj = identity,
@@ -1311,9 +1311,9 @@ namespace ranges {
             requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, const _Ty& _Val, _Pj _Proj = {}) const {
             _STD _Adl_verify_range(_First, _Last);
-            const auto _ULast = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
-            const auto _UResult =
-                _RANGES _Find_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _ULast, _Val, _STD _Pass_fn(_Proj));
+            const auto _ULast   = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
+            const auto _UResult = _RANGES _Find_unchecked(
+                _RANGES _Unwrap_iter<_Se>(_STD move(_First)), _ULast, _Val, _STD _Pass_fn(_Proj));
             return _UResult != _ULast;
         }
 
@@ -1356,7 +1356,8 @@ namespace ranges {
                 return true;
             }
 
-            const auto _Match = _RANGES search(_Range1, _Range2, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+            const auto _Match =
+                _RANGES search(_Range1, _Range2, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             return !_Match.empty();
         }
     };
@@ -2022,7 +2023,8 @@ _NODISCARD _CONSTEXPR20 _FwdIt search_n(
                 _Iter_diff_t<_FwdIt> _Count1 = _Count_diff;
                 auto _UMid                   = _UFirst;
 
-                while (_UOld_first != _UFirst && _Pred(*_STD _Prev_iter(_UFirst), _Val)) { // back up over any skipped prefix
+                while (_UOld_first != _UFirst
+                       && _Pred(*_STD _Prev_iter(_UFirst), _Val)) { // back up over any skipped prefix
                     --_Count1;
                     --_UFirst;
                 }
@@ -2109,8 +2111,8 @@ namespace ranges {
 
             if constexpr (sized_sentinel_for<_Se, _It>) {
                 const auto _Dist = _ULast - _UFirst;
-                auto _UResult =
-                    _Search_n_sized(_STD move(_UFirst), _Dist, _Val, _Count, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                auto _UResult    = _Search_n_sized(
+                    _STD move(_UFirst), _Dist, _Val, _Count, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
                 return _RANGES _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
             } else {
                 auto _UResult = _Search_n_unsized(
@@ -2132,12 +2134,12 @@ namespace ranges {
             if constexpr (sized_range<_Rng>) {
                 const auto _Dist = _RANGES distance(_Range);
 
-                auto _UResult =
-                    _Search_n_sized(_STD _Get_unwrapped(_First), _Dist, _Val, _Count, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                auto _UResult = _Search_n_sized(
+                    _STD _Get_unwrapped(_First), _Dist, _Val, _Count, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
                 return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_First, _STD move(_UResult));
             } else {
-                auto _UResult = _Search_n_unsized(
-                    _RANGES _Unwrap_range_iter<_Rng>(_First), _Uend(_Range), _Val, _Count, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                auto _UResult = _Search_n_unsized(_RANGES _Unwrap_range_iter<_Rng>(_First), _Uend(_Range), _Val, _Count,
+                    _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
                 return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_First, _STD move(_UResult));
             }
         }
@@ -2270,7 +2272,8 @@ namespace ranges {
                 }
 
                 return _RANGES _Equal_count(_STD move(_UFirst1), _STD move(_UFirst2),
-                    static_cast<iter_difference_t<_It1>>(_Count2), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                    static_cast<iter_difference_t<_It1>>(_Count2), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1),
+                    _STD _Pass_fn(_Proj2));
             } else {
                 const auto _Result = _RANGES _Mismatch_4(_STD move(_UFirst1), _STD move(_ULast1), _STD move(_UFirst2),
                     _ULast2, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
@@ -2612,7 +2615,8 @@ namespace ranges {
 
         template <input_range _Rng, class _Ty, _Indirectly_binary_left_foldable<_Ty, iterator_t<_Rng>> _Fn>
         _NODISCARD constexpr auto operator()(_Rng&& _Range, _Ty _Init, _Fn _Func) const {
-            return _RANGES fold_left_with_iter(_STD forward<_Rng>(_Range), _STD move(_Init), _STD _Pass_fn(_Func)).value;
+            return _RANGES fold_left_with_iter(_STD forward<_Rng>(_Range), _STD move(_Init), _STD _Pass_fn(_Func))
+                .value;
         }
     };
 
@@ -2715,7 +2719,8 @@ namespace ranges {
 
         template <bidirectional_range _Rng, class _Ty, _Indirectly_binary_right_foldable<_Ty, iterator_t<_Rng>> _Fn>
         _NODISCARD constexpr auto operator()(_Rng&& _Range, _Ty _Init, _Fn _Func) const {
-            return _RANGES _Fold_right_unchecked(_Ubegin(_Range), _Uend(_Range), _STD move(_Init), _STD _Pass_fn(_Func));
+            return _RANGES _Fold_right_unchecked(
+                _Ubegin(_Range), _Uend(_Range), _STD move(_Init), _STD _Pass_fn(_Func));
         }
     };
 
@@ -2728,8 +2733,8 @@ namespace ranges {
             requires constructible_from<iter_value_t<_It>, iter_reference_t<_It>>
         _NODISCARD constexpr auto operator()(_It _First, _Se _Last, _Fn _Func) const {
             _STD _Adl_verify_range(_First, _Last);
-            return _Fold_right_last_unchecked(
-                _RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Pass_fn(_Func));
+            return _Fold_right_last_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Pass_fn(_Func));
         }
 
         template <bidirectional_range _Rng,
@@ -2769,12 +2774,14 @@ namespace ranges {
 
             auto _UFirst = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
             if constexpr (bidirectional_iterator<_It>) {
-                auto _ULast   = _RANGES _Get_final_iterator_unwrapped<_It>(_UFirst, _STD move(_Last));
-                auto _UResult = _Find_last_unchecked(_STD move(_UFirst), _STD move(_ULast), _Value, _STD _Pass_fn(_Proj));
+                auto _ULast = _RANGES _Get_final_iterator_unwrapped<_It>(_UFirst, _STD move(_Last));
+                auto _UResult =
+                    _Find_last_unchecked(_STD move(_UFirst), _STD move(_ULast), _Value, _STD _Pass_fn(_Proj));
                 return _RANGES _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
             } else {
-                auto _ULast   = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
-                auto _UResult = _Find_last_unchecked(_STD move(_UFirst), _STD move(_ULast), _Value, _STD _Pass_fn(_Proj));
+                auto _ULast = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
+                auto _UResult =
+                    _Find_last_unchecked(_STD move(_UFirst), _STD move(_ULast), _Value, _STD _Pass_fn(_Proj));
                 return _RANGES _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
             }
         }
@@ -2867,14 +2874,14 @@ namespace ranges {
 
             auto _UFirst = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
             if constexpr (bidirectional_iterator<_It>) {
-                auto _ULast = _RANGES _Get_final_iterator_unwrapped<_It>(_UFirst, _STD move(_Last));
-                auto _UResult =
-                    _Find_last_if_unchecked(_STD move(_UFirst), _STD move(_ULast), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                auto _ULast   = _RANGES _Get_final_iterator_unwrapped<_It>(_UFirst, _STD move(_Last));
+                auto _UResult = _Find_last_if_unchecked(
+                    _STD move(_UFirst), _STD move(_ULast), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
                 return _RANGES _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
             } else {
-                auto _ULast = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
-                auto _UResult =
-                    _Find_last_if_unchecked(_STD move(_UFirst), _STD move(_ULast), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                auto _ULast   = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
+                auto _UResult = _Find_last_if_unchecked(
+                    _STD move(_UFirst), _STD move(_ULast), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
                 return _RANGES _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
             }
         }
@@ -2883,8 +2890,8 @@ namespace ranges {
             indirect_unary_predicate<projected<iterator_t<_Rng>, _Pj>> _Pr>
         _NODISCARD constexpr borrowed_subrange_t<_Rng> operator()(_Rng&& _Range, _Pr _Pred, _Pj _Proj = {}) const {
             if constexpr (bidirectional_range<_Rng>) {
-                auto _UResult = _Find_last_if_unchecked(
-                    _Ubegin(_Range), _RANGES _Get_final_iterator_unwrapped(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                auto _UResult = _Find_last_if_unchecked(_Ubegin(_Range), _RANGES _Get_final_iterator_unwrapped(_Range),
+                    _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
                 return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Range, _STD move(_UResult));
             } else {
                 auto _UResult =
@@ -3184,8 +3191,9 @@ namespace ranges {
             _Rng1&& _Range1, _Rng2&& _Range2, _Pr _Pred = {}, _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
             if constexpr (random_access_range<_Rng1> && sized_range<_Rng1> && random_access_range<_Rng2>
                           && sized_range<_Rng2>) {
-                auto _UResult = _Random_access_sized_ranges(_Ubegin(_Range1), _RANGES distance(_Range1),
-                    _Ubegin(_Range2), _RANGES distance(_Range2), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                auto _UResult =
+                    _Random_access_sized_ranges(_Ubegin(_Range1), _RANGES distance(_Range1), _Ubegin(_Range2),
+                        _RANGES distance(_Range2), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
                 return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng1>>(_Range1, _STD move(_UResult));
             } else if constexpr (_Bidi_common_range<_Rng1> && _Bidi_common_range<_Rng2>) {
                 auto _UResult = _Bidi_common_ranges(_Ubegin(_Range1), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2),
@@ -3258,7 +3266,8 @@ namespace ranges {
 
             auto _UResult = _Find_first_of_unchecked(_RANGES _Unwrap_iter<_Se1>(_STD move(_First1)),
                 _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)), _RANGES _Unwrap_iter<_Se2>(_STD move(_First2)),
-                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1),
+                _STD _Pass_fn(_Proj2));
 
             _STD _Seek_wrapped(_First1, _STD move(_UResult));
             return _First1;
@@ -3271,8 +3280,9 @@ namespace ranges {
             _Rng1&& _Range1, _Rng2&& _Range2, _Pr _Pred = {}, _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
             auto _First1 = _RANGES begin(_Range1);
 
-            auto _UResult = _Find_first_of_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1),
-                _Ubegin(_Range2), _Uend(_Range2), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+            auto _UResult = _Find_first_of_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)),
+                _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1),
+                _STD _Pass_fn(_Proj2));
 
             _STD _Seek_wrapped(_First1, _STD move(_UResult));
             return _First1;

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -1172,7 +1172,8 @@ struct _Atomic_storage<_Ty, 8> { // lock-free using 8-byte intrinsics
         }
 #endif // _CMPXCHG_MASK_OUT_PADDING_BITS
         _ATOMIC_CHOOSE_INTRINSIC(static_cast<unsigned int>(_Order), _Prev_bytes, _InterlockedCompareExchange64,
-            _STD _Atomic_address_as<long long>(_Storage), _STD _Atomic_reinterpret_as<long long>(_Desired), _Expected_bytes);
+            _STD _Atomic_address_as<long long>(_Storage), _STD _Atomic_reinterpret_as<long long>(_Desired),
+            _Expected_bytes);
         if (_Prev_bytes == _Expected_bytes) {
             return true;
         }

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -998,7 +998,7 @@ struct _Atomic_storage<_Ty, 4> { // lock-free using 4-byte intrinsics
     }
 
     _NODISCARD _TVal load(const memory_order _Order) const noexcept { // load with given memory order
-        const auto _Mem = _Atomic_address_as<int>(_Storage);
+        const auto _Mem = _STD _Atomic_address_as<int>(_Storage);
         int _As_bytes;
 #if _STD_ATOMIC_USE_ARM64_LDAR_STLR == 1
         _ATOMIC_LOAD_ARM64(_As_bytes, 32, _Mem, static_cast<unsigned int>(_Order))
@@ -1019,16 +1019,17 @@ struct _Atomic_storage<_Ty, 4> { // lock-free using 4-byte intrinsics
 
     bool compare_exchange_strong(_TVal& _Expected, const _TVal _Desired,
         const memory_order _Order = memory_order_seq_cst) noexcept { // CAS with given memory order
-        long _Expected_bytes = _Atomic_reinterpret_as<long>(_Expected); // read before atomic operation
+        long _Expected_bytes = _STD _Atomic_reinterpret_as<long>(_Expected); // read before atomic operation
         long _Prev_bytes;
 #if _CMPXCHG_MASK_OUT_PADDING_BITS
         if constexpr (_Might_have_non_value_bits<_TVal>) {
             _Storage_for<_TVal> _Mask{_Form_mask};
-            const long _Mask_val = _Atomic_reinterpret_as<long>(_Mask);
+            const long _Mask_val = _STD _Atomic_reinterpret_as<long>(_Mask);
 
             for (;;) {
                 _ATOMIC_CHOOSE_INTRINSIC(static_cast<unsigned int>(_Order), _Prev_bytes, _InterlockedCompareExchange,
-                    _Atomic_address_as<long>(_Storage), _Atomic_reinterpret_as<long>(_Desired), _Expected_bytes);
+                    _STD _Atomic_address_as<long>(_Storage), _STD _Atomic_reinterpret_as<long>(_Desired),
+                    _Expected_bytes);
                 if (_Prev_bytes == _Expected_bytes) {
                     return true;
                 }
@@ -1042,7 +1043,7 @@ struct _Atomic_storage<_Ty, 4> { // lock-free using 4-byte intrinsics
         }
 #endif // _CMPXCHG_MASK_OUT_PADDING_BITS
         _ATOMIC_CHOOSE_INTRINSIC(static_cast<unsigned int>(_Order), _Prev_bytes, _InterlockedCompareExchange,
-            _Atomic_address_as<long>(_Storage), _Atomic_reinterpret_as<long>(_Desired), _Expected_bytes);
+            _STD _Atomic_address_as<long>(_Storage), _STD _Atomic_reinterpret_as<long>(_Desired), _Expected_bytes);
         if (_Prev_bytes == _Expected_bytes) {
             return true;
         }

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -1109,7 +1109,7 @@ struct _Atomic_storage<_Ty, 8> { // lock-free using 8-byte intrinsics
     }
 
     _NODISCARD _TVal load(const memory_order _Order) const noexcept { // load with given memory order
-        const auto _Mem = _Atomic_address_as<long long>(_Storage);
+        const auto _Mem = _STD _Atomic_address_as<long long>(_Storage);
         long long _As_bytes;
 #if _STD_ATOMIC_USE_ARM64_LDAR_STLR == 1
         _ATOMIC_LOAD_ARM64(_As_bytes, 64, _Mem, static_cast<unsigned int>(_Order))
@@ -1147,17 +1147,17 @@ struct _Atomic_storage<_Ty, 8> { // lock-free using 8-byte intrinsics
 
     bool compare_exchange_strong(_TVal& _Expected, const _TVal _Desired,
         const memory_order _Order = memory_order_seq_cst) noexcept { // CAS with given memory order
-        long long _Expected_bytes = _Atomic_reinterpret_as<long long>(_Expected); // read before atomic operation
+        long long _Expected_bytes = _STD _Atomic_reinterpret_as<long long>(_Expected); // read before atomic operation
         long long _Prev_bytes;
 
 #if _CMPXCHG_MASK_OUT_PADDING_BITS
         if constexpr (_Might_have_non_value_bits<_TVal>) {
             _Storage_for<_TVal> _Mask{_Form_mask};
-            const long long _Mask_val = _Atomic_reinterpret_as<long long>(_Mask);
+            const long long _Mask_val = _STD _Atomic_reinterpret_as<long long>(_Mask);
 
             for (;;) {
                 _ATOMIC_CHOOSE_INTRINSIC(static_cast<unsigned int>(_Order), _Prev_bytes, _InterlockedCompareExchange64,
-                    _Atomic_address_as<long long>(_Storage), _Atomic_reinterpret_as<long long>(_Desired),
+                    _STD _Atomic_address_as<long long>(_Storage), _STD _Atomic_reinterpret_as<long long>(_Desired),
                     _Expected_bytes);
                 if (_Prev_bytes == _Expected_bytes) {
                     return true;
@@ -1172,7 +1172,7 @@ struct _Atomic_storage<_Ty, 8> { // lock-free using 8-byte intrinsics
         }
 #endif // _CMPXCHG_MASK_OUT_PADDING_BITS
         _ATOMIC_CHOOSE_INTRINSIC(static_cast<unsigned int>(_Order), _Prev_bytes, _InterlockedCompareExchange64,
-            _Atomic_address_as<long long>(_Storage), _Atomic_reinterpret_as<long long>(_Desired), _Expected_bytes);
+            _STD _Atomic_address_as<long long>(_Storage), _STD _Atomic_reinterpret_as<long long>(_Desired), _Expected_bytes);
         if (_Prev_bytes == _Expected_bytes) {
             return true;
         }

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -181,7 +181,7 @@ class _Work_ptr {
 public:
     template <class _Work, enable_if_t<!is_same_v<remove_cv_t<_Work>, _Work_ptr>, int> = 0>
     explicit _Work_ptr(_Work& _Operation)
-        : _Ptp_work(__std_create_threadpool_work(&_Work::_Threadpool_callback, _STD addressof(_Operation), nullptr)) {
+        : _Ptp_work(::__std_create_threadpool_work(&_Work::_Threadpool_callback, _STD addressof(_Operation), nullptr)) {
         // register work with the thread pool
         // usually, after _Work_ptr is constructed, a parallel algorithm runs to completion or terminates
         static_assert(noexcept(_Work::_Threadpool_callback(_STD declval<__std_PTP_CALLBACK_INSTANCE>(),
@@ -229,7 +229,7 @@ void _Run_chunked_parallel_work(const size_t _Hw_threads, _Work& _Operation) {
     const _Work_ptr _Work_op{_Operation};
     // setup complete, hereafter nothrow or terminate
     _Work_op._Submit_for_chunks(_Hw_threads, _Operation._Team._Chunks);
-    _Run_available_chunked_work(_Operation);
+    _STD _Run_available_chunked_work(_Operation);
 }
 
 // The parallel algorithms library below assumes that distance(first, last) fits into a size_t;
@@ -840,15 +840,15 @@ struct _Static_partition_range<_RanIt, _Diff, true> {
         // statically partition a random-access iterator range and return next(_First, _Team._Count)
         // pre: _Populate hasn't yet been called on this instance
         auto _Result = _First + static_cast<_Target_diff>(_Team._Count); // does verification
-        _Start_at    = _Get_unwrapped(_First);
+        _Start_at    = _STD _Get_unwrapped(_First);
         return _Result;
     }
 
     bool _Populate(const _Static_partition_team<_Diff>& _Team, _RanIt _First, _RanIt _Last) {
         // statically partition a random-access iterator range and check if the range ends at _Last
         // pre: _Populate hasn't yet been called on this instance
-        _Adl_verify_range(_First, _Last);
-        _Start_at = _Get_unwrapped(_First);
+        _STD _Adl_verify_range(_First, _Last);
+        _Start_at = _STD _Get_unwrapped(_First);
         return _Team._Count == _Last - _First;
     }
 
@@ -883,16 +883,16 @@ struct _Static_partition_range<_FwdIt, _Diff, false> {
         const auto _Chunk_size      = static_cast<_Target_diff>(_Team._Chunk_size);
         const auto _Unchunked_items = _Team._Unchunked_items;
         auto _Result                = _Division_points.begin();
-        *_Result                    = _Get_unwrapped(_First);
+        *_Result                    = _STD _Get_unwrapped(_First);
         for (_Diff _Idx{}; _Idx < _Unchunked_items; ++_Idx) { // record bounds of chunks with an extra item
             _STD advance(_First, static_cast<_Target_diff>(_Chunk_size + 1));
-            *++_Result = _Get_unwrapped(_First);
+            *++_Result = _STD _Get_unwrapped(_First);
         }
 
         const auto _Diff_chunks = static_cast<_Diff>(_Chunks);
         for (_Diff _Idx = _Unchunked_items; _Idx < _Diff_chunks; ++_Idx) { // record bounds of chunks with no extra item
             _STD advance(_First, _Chunk_size);
-            *++_Result = _Get_unwrapped(_First);
+            *++_Result = _STD _Get_unwrapped(_First);
         }
 
         return _First;
@@ -906,7 +906,7 @@ struct _Static_partition_range<_FwdIt, _Diff, false> {
         const auto _Chunk_size      = _Team._Chunk_size;
         const auto _Unchunked_items = _Team._Unchunked_items;
         auto _Result                = _Division_points.begin();
-        *_Result                    = _Get_unwrapped(_First);
+        *_Result                    = _STD _Get_unwrapped(_First);
         for (_Diff _Idx{}; _Idx < _Unchunked_items; ++_Idx) { // record bounds of chunks with an extra item
             for (_Diff _This_chunk_size = _Chunk_size + 1; 0 < _This_chunk_size--;) {
                 if (_First == _Last) {
@@ -916,7 +916,7 @@ struct _Static_partition_range<_FwdIt, _Diff, false> {
                 ++_First;
             }
 
-            *++_Result = _Get_unwrapped(_First);
+            *++_Result = _STD _Get_unwrapped(_First);
         }
 
         const auto _Diff_chunks = static_cast<_Diff>(_Chunks);
@@ -929,7 +929,7 @@ struct _Static_partition_range<_FwdIt, _Diff, false> {
                 ++_First;
             }
 
-            *++_Result = _Get_unwrapped(_First);
+            *++_Result = _STD _Get_unwrapped(_First);
         }
 
         return _First == _Last;
@@ -960,7 +960,7 @@ struct _Static_partition_range_backward<_RanIt, _Diff, true> {
     void _Populate(const _Static_partition_team<_Diff>& _Team, _RanIt _Last) {
         // statically partition a random-access iterator range ending at _Last
         // pre: _Populate hasn't yet been called on this instance
-        _Start_at = _Get_unwrapped_n(_Last, -static_cast<_Target_diff>(_Team._Count));
+        _Start_at = _STD _Get_unwrapped_n(_Last, -static_cast<_Target_diff>(_Team._Count));
     }
 
     _Chunk_type _Get_chunk(const _Static_partition_key<_Diff> _Key) const {
@@ -986,10 +986,10 @@ struct _Static_partition_range_backward<_BidIt, _Diff, false> {
         const auto _Neg_chunk_size  = static_cast<_Target_diff>(-_Team._Chunk_size);
         const auto _Unchunked_items = _Team._Unchunked_items;
         auto _Result = _Division_points.begin(); // does range checking by incrementing in the checked domain
-        *_Result     = _Get_unwrapped(_Last);
+        *_Result     = _STD _Get_unwrapped(_Last);
         for (_Diff _Idx{}; _Idx < _Unchunked_items; ++_Idx) {
             _STD advance(_Last, static_cast<_Target_diff>(_Neg_chunk_size - 1));
-            *++_Result = _Get_unwrapped(_Last);
+            *++_Result = _STD _Get_unwrapped(_Last);
         }
 
         const auto _Diff_chunks = static_cast<_Diff>(_Chunks);
@@ -1085,7 +1085,7 @@ struct _Static_partitioned_all_of_family2 { // all_of/any_of/none_of task schedu
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_all_of_family2*>(_Context));
+        _STD _Run_available_chunked_work(*static_cast<_Static_partitioned_all_of_family2*>(_Context));
     }
 };
 
@@ -1098,7 +1098,7 @@ bool _All_of_family_parallel(_FwdIt _First, const _FwdIt _Last, _Pr _Pred) {
         if (_Count >= 2) { // ... with at least 2 elements
             _TRY_BEGIN
             _Static_partitioned_all_of_family2<_Invert, _FwdIt, _Pr> _Operation{_First, _Hw_threads, _Count, _Pred};
-            _Run_chunked_parallel_work(_Hw_threads, _Operation);
+            _STD _Run_chunked_parallel_work(_Hw_threads, _Operation);
             return !_Operation._Cancel_token._Is_canceled_relaxed();
             _CATCH(const _Parallelism_resources_exhausted&)
             // fall through to serial case below
@@ -1119,13 +1119,13 @@ _EXPORT_STD template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution
 _NODISCARD bool all_of(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // test if all elements in [_First, _Last) satisfy _Pred with the indicated execution policy
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     if constexpr (remove_reference_t<_ExPo>::_Parallelize) {
-        return _All_of_family_parallel<false>(_UFirst, _ULast, _Pass_fn(_Pred));
+        return _STD _All_of_family_parallel<false>(_UFirst, _ULast, _STD _Pass_fn(_Pred));
     } else {
-        return _STD all_of(_UFirst, _ULast, _Pass_fn(_Pred));
+        return _STD all_of(_UFirst, _ULast, _STD _Pass_fn(_Pred));
     }
 }
 
@@ -1133,13 +1133,13 @@ _EXPORT_STD template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution
 _NODISCARD bool any_of(_ExPo&&, const _FwdIt _First, const _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // test if any element in [_First, _Last) satisfies _Pred with the indicated execution policy
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     if constexpr (remove_reference_t<_ExPo>::_Parallelize) {
-        return !_All_of_family_parallel<true>(_UFirst, _ULast, _Pass_fn(_Pred));
+        return !_STD _All_of_family_parallel<true>(_UFirst, _ULast, _STD _Pass_fn(_Pred));
     } else {
-        return _STD any_of(_UFirst, _ULast, _Pass_fn(_Pred));
+        return _STD any_of(_UFirst, _ULast, _STD _Pass_fn(_Pred));
     }
 }
 
@@ -1147,13 +1147,13 @@ _EXPORT_STD template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution
 _NODISCARD bool none_of(_ExPo&&, const _FwdIt _First, const _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // test if no element in [_First, _Last) satisfies _Pred with the indicated execution policy
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     if constexpr (remove_reference_t<_ExPo>::_Parallelize) {
-        return _All_of_family_parallel<true>(_UFirst, _ULast, _Pass_fn(_Pred));
+        return _STD _All_of_family_parallel<true>(_UFirst, _ULast, _STD _Pass_fn(_Pred));
     } else {
-        return _STD none_of(_UFirst, _ULast, _Pass_fn(_Pred));
+        return _STD none_of(_UFirst, _ULast, _STD _Pass_fn(_Pred));
     }
 }
 
@@ -1179,7 +1179,7 @@ struct _Static_partitioned_for_each2 { // for_each task scheduled on the system 
         const auto _Key = _Team._Get_next_key();
         if (_Key) {
             const auto _Chunk = _Basis._Get_chunk(_Key);
-            _For_each_ivdep(_Chunk._First, _Chunk._Last, _Func);
+            _STD _For_each_ivdep(_Chunk._First, _Chunk._Last, _Func);
             return _Cancellation_status::_Running;
         }
 
@@ -1188,7 +1188,7 @@ struct _Static_partitioned_for_each2 { // for_each task scheduled on the system 
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_for_each2*>(_Context));
+        _STD _Run_available_chunked_work(*static_cast<_Static_partitioned_for_each2*>(_Context));
     }
 };
 
@@ -1196,20 +1196,20 @@ _EXPORT_STD template <class _ExPo, class _FwdIt, class _Fn, _Enable_if_execution
 void for_each(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Fn _Func) noexcept /* terminates */ {
     // perform function for each element [_First, _Last) with the indicated execution policy
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     if constexpr (remove_reference_t<_ExPo>::_Parallelize) {
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
         if (_Hw_threads > 1) { // parallelize on multiprocessor machines...
             auto _Count = _STD distance(_UFirst, _ULast);
             if (_Count >= 2) { // ... with at least 2 elements
                 _TRY_BEGIN
-                auto _Passed_fn = _Pass_fn(_Func);
+                auto _Passed_fn = _STD _Pass_fn(_Func);
                 _Static_partitioned_for_each2<decltype(_UFirst), decltype(_Count), decltype(_Passed_fn)> _Operation{
                     _Hw_threads, _Count, _Passed_fn};
                 _Operation._Basis._Populate(_Operation._Team, _UFirst);
-                _Run_chunked_parallel_work(_Hw_threads, _Operation);
+                _STD _Run_chunked_parallel_work(_Hw_threads, _Operation);
                 return;
                 _CATCH(const _Parallelism_resources_exhausted&)
                 // fall through to serial case below
@@ -1217,9 +1217,9 @@ void for_each(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Fn _Func) noexcept /* termi
             }
         }
 
-        _For_each_ivdep(_UFirst, _ULast, _Pass_fn(_Func));
+        _STD _For_each_ivdep(_UFirst, _ULast, _STD _Pass_fn(_Func));
     } else if constexpr (remove_reference_t<_ExPo>::_Ivdep) {
-        _For_each_ivdep(_UFirst, _ULast, _Pass_fn(_Func));
+        _STD _For_each_ivdep(_UFirst, _ULast, _STD _Pass_fn(_Func));
     } else {
         for (; _UFirst != _ULast; ++_UFirst) {
             _Func(*_UFirst);
@@ -1244,31 +1244,31 @@ _FwdIt for_each_n(_ExPo&&, _FwdIt _First, const _Diff _Count_raw, _Fn _Func) noe
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     _Algorithm_int_t<_Diff> _Count = _Count_raw;
     if (0 < _Count) {
-        auto _UFirst = _Get_unwrapped_n(_First, _Count);
+        auto _UFirst = _STD _Get_unwrapped_n(_First, _Count);
         if constexpr (remove_reference_t<_ExPo>::_Parallelize) {
             const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
             if (_Hw_threads > 1 && _Count >= 2) { // parallelize on multiprocessor machines with at least 2 elements
                 _TRY_BEGIN
-                auto _Passed_fn = _Pass_fn(_Func);
+                auto _Passed_fn = _STD _Pass_fn(_Func);
                 _Static_partitioned_for_each2<decltype(_UFirst), decltype(_Count), decltype(_Passed_fn)> _Operation{
                     _Hw_threads, _Count, _Passed_fn};
-                _Seek_wrapped(_First, _Operation._Basis._Populate(_Operation._Team, _UFirst));
-                _Run_chunked_parallel_work(_Hw_threads, _Operation);
+                _STD _Seek_wrapped(_First, _Operation._Basis._Populate(_Operation._Team, _UFirst));
+                _STD _Run_chunked_parallel_work(_Hw_threads, _Operation);
                 return _First;
                 _CATCH(const _Parallelism_resources_exhausted&)
                 // fall through to serial case below
                 _CATCH_END
             }
 
-            _Seek_wrapped(_First, _For_each_n_ivdep(_UFirst, _Count, _Pass_fn(_Func)));
+            _STD _Seek_wrapped(_First, _STD _For_each_n_ivdep(_UFirst, _Count, _STD _Pass_fn(_Func)));
         } else if constexpr (remove_reference_t<_ExPo>::_Ivdep) {
-            _Seek_wrapped(_First, _For_each_n_ivdep(_UFirst, _Count, _Pass_fn(_Func)));
+            _STD _Seek_wrapped(_First, _STD _For_each_n_ivdep(_UFirst, _Count, _STD _Pass_fn(_Func)));
         } else {
             for (; 0 < _Count; --_Count, (void) ++_UFirst) {
                 _Func(*_UFirst);
             }
 
-            _Seek_wrapped(_First, _UFirst);
+            _STD _Seek_wrapped(_First, _UFirst);
         }
     }
 
@@ -1313,7 +1313,7 @@ struct _Static_partitioned_find3 {
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_find3*>(_Context));
+        _STD _Run_available_chunked_work(*static_cast<_Static_partitioned_find3*>(_Context));
     }
 };
 
@@ -1328,7 +1328,7 @@ _FwdIt _Find_parallel_unchecked(_ExPo&&, const _FwdIt _First, const _FwdIt _Last
                 _TRY_BEGIN
                 _Static_partitioned_find3 _Operation{_Hw_threads, _Count, _Last, _Fx};
                 _Operation._Basis._Populate(_Operation._Team, _First);
-                _Run_chunked_parallel_work(_Hw_threads, _Operation);
+                _STD _Run_chunked_parallel_work(_Hw_threads, _Operation);
                 return _Operation._Results._Get_result();
                 _CATCH(const _Parallelism_resources_exhausted&)
                 // fall through to _Fx below
@@ -1345,9 +1345,9 @@ _NODISCARD _FwdIt find(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, const _
     // find first matching _Val
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     using _UFwdIt = _Unwrapped_t<const _FwdIt&>;
-    _Adl_verify_range(_First, _Last);
-    _Seek_wrapped(_First,
-        _Find_parallel_unchecked(_STD forward<_ExPo>(_Exec), _Get_unwrapped(_First), _Get_unwrapped(_Last),
+    _STD _Adl_verify_range(_First, _Last);
+    _STD _Seek_wrapped(_First,
+        _STD _Find_parallel_unchecked(_STD forward<_ExPo>(_Exec), _STD _Get_unwrapped(_First), _STD _Get_unwrapped(_Last),
             [&](const _UFwdIt _LFirst, const _UFwdIt _LLast) { return _STD _Find_unchecked(_LFirst, _LLast, _Val); }));
     return _First;
 }
@@ -1357,10 +1357,10 @@ _NODISCARD _FwdIt find_if(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, _Pr 
     // find first satisfying _Pred
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     using _UFwdIt = _Unwrapped_t<const _FwdIt&>;
-    _Adl_verify_range(_First, _Last);
-    auto _Pass_pred = _Pass_fn(_Pred);
-    _Seek_wrapped(_First,
-        _Find_parallel_unchecked(_STD forward<_ExPo>(_Exec), _Get_unwrapped(_First), _Get_unwrapped(_Last),
+    _STD _Adl_verify_range(_First, _Last);
+    auto _Pass_pred = _STD _Pass_fn(_Pred);
+    _STD _Seek_wrapped(_First,
+        _STD _Find_parallel_unchecked(_STD forward<_ExPo>(_Exec), _STD _Get_unwrapped(_First), _STD _Get_unwrapped(_Last),
             [=](const _UFwdIt _LFirst, const _UFwdIt _LLast) { return _STD find_if(_LFirst, _LLast, _Pass_pred); }));
     return _First;
 }
@@ -1370,10 +1370,10 @@ _NODISCARD _FwdIt find_if_not(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, 
     // find first satisfying !_Pred
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     using _UFwdIt = _Unwrapped_t<const _FwdIt&>;
-    _Adl_verify_range(_First, _Last);
-    auto _Pass_pred = _Pass_fn(_Pred);
-    _Seek_wrapped(_First, _Find_parallel_unchecked(_STD forward<_ExPo>(_Exec), _Get_unwrapped(_First),
-                              _Get_unwrapped(_Last), [=](const _UFwdIt _LFirst, const _UFwdIt _LLast) {
+    _STD _Adl_verify_range(_First, _Last);
+    auto _Pass_pred = _STD _Pass_fn(_Pred);
+    _STD _Seek_wrapped(_First, _STD _Find_parallel_unchecked(_STD forward<_ExPo>(_Exec), _STD _Get_unwrapped(_First),
+                              _STD _Get_unwrapped(_Last), [=](const _UFwdIt _LFirst, const _UFwdIt _LLast) {
                                   return _STD find_if_not(_LFirst, _LLast, _Pass_pred);
                               }));
     return _First;
@@ -1508,7 +1508,7 @@ struct _Static_partitioned_find_end_backward3 {
         auto _Last1              = _Range._Last;
         do {
             --_Last1;
-            if (_Equal_rev_pred_unchecked(_Last1, _Range2._First, _Range2._Last, _Pred)) {
+            if (_STD _Equal_rev_pred_unchecked(_Last1, _Range2._First, _Range2._Last, _Pred)) {
                 _Results._Imbue(_Chunk_number, _Last1);
                 return _Cancellation_status::_Canceled;
             }
@@ -1518,7 +1518,7 @@ struct _Static_partitioned_find_end_backward3 {
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_find_end_backward3*>(_Context));
+        _STD _Run_available_chunked_work(*static_cast<_Static_partitioned_find_end_backward3*>(_Context));
     }
 };
 
@@ -1529,20 +1529,20 @@ _NODISCARD _FwdIt1 find_end(_ExPo&&, _FwdIt1 _First1, const _FwdIt1 _Last1, cons
     // find last [_First2, _Last2) satisfying _Pred
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
-    _Adl_verify_range(_First1, _Last1);
-    _Adl_verify_range(_First2, _Last2);
-    const auto _UFirst1 = _Get_unwrapped(_First1);
-    const auto _ULast1  = _Get_unwrapped(_Last1);
-    const auto _UFirst2 = _Get_unwrapped(_First2);
-    const auto _ULast2  = _Get_unwrapped(_Last2);
+    _STD _Adl_verify_range(_First1, _Last1);
+    _STD _Adl_verify_range(_First2, _Last2);
+    const auto _UFirst1 = _STD _Get_unwrapped(_First1);
+    const auto _ULast1  = _STD _Get_unwrapped(_Last1);
+    const auto _UFirst2 = _STD _Get_unwrapped(_First2);
+    const auto _ULast2  = _STD _Get_unwrapped(_Last2);
     if constexpr (remove_reference_t<_ExPo>::_Parallelize) {
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
         if (_Hw_threads > 1) {
             if constexpr (_Is_ranges_bidi_iter_v<_FwdIt1>) {
                 const auto _Partition_start =
-                    _Get_find_end_backward_partition_start(_UFirst1, _ULast1, _UFirst2, _ULast2);
+                    _STD _Get_find_end_backward_partition_start(_UFirst1, _ULast1, _UFirst2, _ULast2);
                 if (_UFirst1 == _Partition_start) {
-                    _Seek_wrapped(_First1, _ULast1);
+                    _STD _Seek_wrapped(_First1, _ULast1);
                     return _First1;
                 }
 
@@ -1550,24 +1550,24 @@ _NODISCARD _FwdIt1 find_end(_ExPo&&, _FwdIt1 _First1, const _FwdIt1 _Last1, cons
                 if (_Count >= 2) {
                     _TRY_BEGIN
                     _Static_partitioned_find_end_backward3 _Operation{
-                        _Hw_threads, _Count, _ULast1, _UFirst2, _ULast2, _Pass_fn(_Pred)};
+                        _Hw_threads, _Count, _ULast1, _UFirst2, _ULast2, _STD _Pass_fn(_Pred)};
                     _Operation._Basis._Populate(_Operation._Team, _Partition_start);
-                    _Run_chunked_parallel_work(_Hw_threads, _Operation);
-                    _Seek_wrapped(_First1, _Operation._Results._Get_result());
+                    _STD _Run_chunked_parallel_work(_Hw_threads, _Operation);
+                    _STD _Seek_wrapped(_First1, _Operation._Results._Get_result());
                     return _First1;
                     _CATCH(const _Parallelism_resources_exhausted&)
                     // fall through to serial case below
                     _CATCH_END
                 }
             } else {
-                const auto _Count = _Get_find_end_forward_partition_size(_UFirst1, _ULast1, _UFirst2, _ULast2);
+                const auto _Count = _STD _Get_find_end_forward_partition_size(_UFirst1, _ULast1, _UFirst2, _ULast2);
                 if (_Count >= 2) {
                     _TRY_BEGIN
                     _Static_partitioned_find_end_forward2 _Operation{
-                        _Hw_threads, _Count, _ULast1, _UFirst2, _ULast2, _Pass_fn(_Pred)};
+                        _Hw_threads, _Count, _ULast1, _UFirst2, _ULast2, _STD _Pass_fn(_Pred)};
                     _Operation._Basis._Populate(_Operation._Team, _UFirst1);
-                    _Run_chunked_parallel_work(_Hw_threads, _Operation);
-                    _Seek_wrapped(_First1, _Operation._Results._Get_result());
+                    _STD _Run_chunked_parallel_work(_Hw_threads, _Operation);
+                    _STD _Seek_wrapped(_First1, _Operation._Results._Get_result());
                     return _First1;
                     _CATCH(const _Parallelism_resources_exhausted&)
                     // fall through to serial case below
@@ -1577,7 +1577,7 @@ _NODISCARD _FwdIt1 find_end(_ExPo&&, _FwdIt1 _First1, const _FwdIt1 _Last1, cons
         }
     }
 
-    _Seek_wrapped(_First1, _STD find_end(_UFirst1, _ULast1, _UFirst2, _ULast2, _Pass_fn(_Pred)));
+    _STD _Seek_wrapped(_First1, _STD find_end(_UFirst1, _ULast1, _UFirst2, _ULast2, _STD _Pass_fn(_Pred)));
     return _First1;
 }
 
@@ -1589,17 +1589,17 @@ _NODISCARD _FwdIt1 find_first_of(_ExPo&& _Exec, const _FwdIt1 _First1, _FwdIt1 _
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     using _UFwdIt1 = _Unwrapped_t<const _FwdIt1&>;
-    _Adl_verify_range(_First1, _Last1);
-    _Adl_verify_range(_First2, _Last2);
-    const auto _UFirst2 = _Get_unwrapped(_First2);
-    const auto _ULast2  = _Get_unwrapped(_Last2);
+    _STD _Adl_verify_range(_First1, _Last1);
+    _STD _Adl_verify_range(_First2, _Last2);
+    const auto _UFirst2 = _STD _Get_unwrapped(_First2);
+    const auto _ULast2  = _STD _Get_unwrapped(_Last2);
     if (_UFirst2 == _ULast2) {
         return _Last1;
     }
 
-    auto _Pass_pred = _Pass_fn(_Pred);
-    _Seek_wrapped(_Last1, _Find_parallel_unchecked(_STD forward<_ExPo>(_Exec), _Get_unwrapped(_First1),
-                              _Get_unwrapped(_Last1), [=](const _UFwdIt1 _LFirst1, const _UFwdIt1 _LLast1) {
+    auto _Pass_pred = _STD _Pass_fn(_Pred);
+    _STD _Seek_wrapped(_Last1, _STD _Find_parallel_unchecked(_STD forward<_ExPo>(_Exec), _STD _Get_unwrapped(_First1),
+                              _STD _Get_unwrapped(_Last1), [=](const _UFwdIt1 _LFirst1, const _UFwdIt1 _LLast1) {
                                   return _STD find_first_of(_LFirst1, _LLast1, _UFirst2, _ULast2, _Pass_pred);
                               }));
     return _Last1;
@@ -1645,7 +1645,7 @@ struct _Static_partitioned_adjacent_find3 {
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_adjacent_find3*>(_Context));
+        _STD _Run_available_chunked_work(*static_cast<_Static_partitioned_adjacent_find3*>(_Context));
     }
 };
 
@@ -1653,19 +1653,19 @@ _EXPORT_STD template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution
 _NODISCARD _FwdIt adjacent_find(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // find first satisfying _Pred with successor
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     if constexpr (remove_reference_t<_ExPo>::_Parallelize) {
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
         if (_Hw_threads > 1) {
             const auto _Count = static_cast<_Iter_diff_t<_FwdIt>>(_STD distance(_UFirst, _ULast) - 1);
             if (_Count >= 2) {
                 _TRY_BEGIN
-                _Static_partitioned_adjacent_find3 _Operation{_Hw_threads, _Count, _ULast, _Pass_fn(_Pred)};
+                _Static_partitioned_adjacent_find3 _Operation{_Hw_threads, _Count, _ULast, _STD _Pass_fn(_Pred)};
                 _Operation._Basis._Populate(_Operation._Team, _UFirst);
-                _Run_chunked_parallel_work(_Hw_threads, _Operation);
-                _Seek_wrapped(_Last, _Operation._Results._Get_result());
+                _STD _Run_chunked_parallel_work(_Hw_threads, _Operation);
+                _STD _Seek_wrapped(_Last, _Operation._Results._Get_result());
                 return _Last;
                 _CATCH(const _Parallelism_resources_exhausted&)
                 // fall through to adjacent_find below
@@ -1674,7 +1674,7 @@ _NODISCARD _FwdIt adjacent_find(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred)
         }
     }
 
-    _Seek_wrapped(_Last, _STD adjacent_find(_UFirst, _ULast, _Pass_fn(_Pred)));
+    _STD _Seek_wrapped(_Last, _STD adjacent_find(_UFirst, _ULast, _STD _Pass_fn(_Pred)));
     return _Last;
 }
 
@@ -1713,9 +1713,9 @@ _NODISCARD _Iter_diff_t<_FwdIt> count_if(_ExPo&&, const _FwdIt _First, const _Fw
 /* terminates */ {
     // count elements satisfying _Pred
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     if constexpr (remove_reference_t<_ExPo>::_Parallelize) {
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
         if (_Hw_threads > 1) {
@@ -1723,7 +1723,7 @@ _NODISCARD _Iter_diff_t<_FwdIt> count_if(_ExPo&&, const _FwdIt _First, const _Fw
             if (_Count >= 2) {
                 const auto _Chunks = _Get_chunked_work_chunk_count(_Hw_threads, _Count);
                 _TRY_BEGIN
-                _Static_partitioned_count_if2 _Operation{_Count, _Chunks, _UFirst, _Pass_fn(_Pred)};
+                _Static_partitioned_count_if2 _Operation{_Count, _Chunks, _UFirst, _STD _Pass_fn(_Pred)};
                 _Iter_diff_t<_FwdIt> _Foreground_count;
                 {
                     const _Work_ptr _Work{_Operation};
@@ -1740,7 +1740,7 @@ _NODISCARD _Iter_diff_t<_FwdIt> count_if(_ExPo&&, const _FwdIt _First, const _Fw
         }
     }
 
-    return _STD count_if(_UFirst, _ULast, _Pass_fn(_Pred));
+    return _STD count_if(_UFirst, _ULast, _STD _Pass_fn(_Pred));
 }
 
 _EXPORT_STD template <class _ExPo, class _FwdIt, class _Ty, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
@@ -1748,8 +1748,8 @@ _NODISCARD _Iter_diff_t<_FwdIt> count(_ExPo&& _Exec, const _FwdIt _First, const 
 /* terminates */ {
     // count elements that match _Val
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
-    _Adl_verify_range(_First, _Last);
-    return _STD count_if(_STD forward<_ExPo>(_Exec), _Get_unwrapped(_First), _Get_unwrapped(_Last),
+    _STD _Adl_verify_range(_First, _Last);
+    return _STD count_if(_STD forward<_ExPo>(_Exec), _STD _Get_unwrapped(_First), _STD _Get_unwrapped(_Last),
         [&_Val](auto&& _Iter_val) { return _STD forward<decltype(_Iter_val)>(_Iter_val) == _Val; });
 }
 
@@ -1809,8 +1809,8 @@ struct _Static_partitioned_mismatch_results<_FwdIt1, _FwdIt2, false, false> {
 
     pair<_FwdIt1, _FwdIt2> _Get_result(_FwdIt1 _First1, _FwdIt2 _First2) const {
         const auto _Result = _Storage._Get_result();
-        _Seek_wrapped(_First2, _Result.second);
-        _Seek_wrapped(_First1, _Result.first);
+        _STD _Seek_wrapped(_First2, _Result.second);
+        _STD _Seek_wrapped(_First1, _Result.first);
         return {_First1, _First2};
     }
 };
@@ -1828,7 +1828,7 @@ struct _Static_partitioned_mismatch3 {
         const size_t _Hw_threads, const _Diff _Count, const _FwdIt1 _First1, const _FwdIt2 _First2, const _Pr _Pred_)
         : _Team{_Count, _Get_chunked_work_chunk_count(_Hw_threads, _Count)}, _Basis1{}, _Basis2{},
           _Results(
-              _Get_unwrapped(_Basis1._Populate(_Team, _First1)), _Get_unwrapped(_Basis2._Populate(_Team, _First2))),
+              _STD _Get_unwrapped(_Basis1._Populate(_Team, _First1)), _STD _Get_unwrapped(_Basis2._Populate(_Team, _First2))),
           _Pred(_Pred_) {}
 
     _Cancellation_status _Process_chunk() {
@@ -1863,7 +1863,7 @@ struct _Static_partitioned_mismatch3 {
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_mismatch3*>(_Context));
+        _STD _Run_available_chunked_work(*static_cast<_Static_partitioned_mismatch3*>(_Context));
     }
 };
 
@@ -1874,38 +1874,38 @@ _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
     // return [_First1, _Last1)/[_First2, ...) mismatch
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
-    _Adl_verify_range(_First1, _Last1);
-    const auto _UFirst1 = _Get_unwrapped(_First1);
-    const auto _ULast1  = _Get_unwrapped(_Last1);
+    _STD _Adl_verify_range(_First1, _Last1);
+    const auto _UFirst1 = _STD _Get_unwrapped(_First1);
+    const auto _ULast1  = _STD _Get_unwrapped(_Last1);
     if constexpr (remove_reference_t<_ExPo>::_Parallelize) {
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
         if (_Hw_threads > 1) {
             const auto _Count   = _STD distance(_UFirst1, _ULast1);
-            const auto _UFirst2 = _Get_unwrapped_n(_First2, _Count);
+            const auto _UFirst2 = _STD _Get_unwrapped_n(_First2, _Count);
             if (_Count >= 2) {
                 _TRY_BEGIN
-                _Static_partitioned_mismatch3 _Operation{_Hw_threads, _Count, _UFirst1, _UFirst2, _Pass_fn(_Pred)};
-                _Run_chunked_parallel_work(_Hw_threads, _Operation);
+                _Static_partitioned_mismatch3 _Operation{_Hw_threads, _Count, _UFirst1, _UFirst2, _STD _Pass_fn(_Pred)};
+                _STD _Run_chunked_parallel_work(_Hw_threads, _Operation);
                 const auto _Result = _Operation._Results._Get_result(_UFirst1, _UFirst2);
-                _Seek_wrapped(_First2, _Result.second);
-                _Seek_wrapped(_First1, _Result.first);
+                _STD _Seek_wrapped(_First2, _Result.second);
+                _STD _Seek_wrapped(_First1, _Result.first);
                 return {_First1, _First2};
                 _CATCH(const _Parallelism_resources_exhausted&)
                 // fall through to serial case below
                 _CATCH_END
             }
 
-            const auto _Result = _STD mismatch(_UFirst1, _ULast1, _UFirst2, _Pass_fn(_Pred));
-            _Seek_wrapped(_First2, _Result.second);
-            _Seek_wrapped(_First1, _Result.first);
+            const auto _Result = _STD mismatch(_UFirst1, _ULast1, _UFirst2, _STD _Pass_fn(_Pred));
+            _STD _Seek_wrapped(_First2, _Result.second);
+            _STD _Seek_wrapped(_First1, _Result.first);
             return {_First1, _First2};
         }
     }
 
     const auto _Result = _STD mismatch(
-        _UFirst1, _ULast1, _Get_unwrapped_n(_First2, _Idl_distance<_FwdIt1>(_UFirst1, _ULast1)), _Pass_fn(_Pred));
-    _Seek_wrapped(_First2, _Result.second);
-    _Seek_wrapped(_First1, _Result.first);
+        _UFirst1, _ULast1, _STD _Get_unwrapped_n(_First2, _STD _Idl_distance<_FwdIt1>(_UFirst1, _ULast1)), _STD _Pass_fn(_Pred));
+    _STD _Seek_wrapped(_First2, _Result.second);
+    _STD _Seek_wrapped(_First1, _Result.first);
     return {_First1, _First2};
 }
 
@@ -1916,23 +1916,23 @@ _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
     // return [_First1, _Last1)/[_First2, _Last2) mismatch
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
-    _Adl_verify_range(_First1, _Last1);
-    _Adl_verify_range(_First2, _Last2);
-    const auto _UFirst1 = _Get_unwrapped(_First1);
-    const auto _ULast1  = _Get_unwrapped(_Last1);
-    const auto _UFirst2 = _Get_unwrapped(_First2);
-    const auto _ULast2  = _Get_unwrapped(_Last2);
+    _STD _Adl_verify_range(_First1, _Last1);
+    _STD _Adl_verify_range(_First2, _Last2);
+    const auto _UFirst1 = _STD _Get_unwrapped(_First1);
+    const auto _ULast1  = _STD _Get_unwrapped(_Last1);
+    const auto _UFirst2 = _STD _Get_unwrapped(_First2);
+    const auto _ULast2  = _STD _Get_unwrapped(_Last2);
     if constexpr (remove_reference_t<_ExPo>::_Parallelize) {
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
         if (_Hw_threads > 1) {
-            const auto _Count = static_cast<_Iter_diff_t<_FwdIt1>>(_Distance_min(_UFirst1, _ULast1, _UFirst2, _ULast2));
+            const auto _Count = static_cast<_Iter_diff_t<_FwdIt1>>(_STD _Distance_min(_UFirst1, _ULast1, _UFirst2, _ULast2));
             if (_Count >= 2) {
                 _TRY_BEGIN
-                _Static_partitioned_mismatch3 _Operation{_Hw_threads, _Count, _UFirst1, _UFirst2, _Pass_fn(_Pred)};
-                _Run_chunked_parallel_work(_Hw_threads, _Operation);
+                _Static_partitioned_mismatch3 _Operation{_Hw_threads, _Count, _UFirst1, _UFirst2, _STD _Pass_fn(_Pred)};
+                _STD _Run_chunked_parallel_work(_Hw_threads, _Operation);
                 const auto _Result = _Operation._Results._Get_result(_UFirst1, _UFirst2);
-                _Seek_wrapped(_First2, _Result.second);
-                _Seek_wrapped(_First1, _Result.first);
+                _STD _Seek_wrapped(_First2, _Result.second);
+                _STD _Seek_wrapped(_First1, _Result.first);
                 return {_First1, _First2};
                 _CATCH(const _Parallelism_resources_exhausted&)
                 // fall through to serial below
@@ -1941,9 +1941,9 @@ _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
         }
     }
 
-    const auto _Result = _STD mismatch(_UFirst1, _ULast1, _UFirst2, _ULast2, _Pass_fn(_Pred));
-    _Seek_wrapped(_First2, _Result.second);
-    _Seek_wrapped(_First1, _Result.first);
+    const auto _Result = _STD mismatch(_UFirst1, _ULast1, _UFirst2, _ULast2, _STD _Pass_fn(_Pred));
+    _STD _Seek_wrapped(_First2, _Result.second);
+    _STD _Seek_wrapped(_First1, _Result.first);
     return {_First1, _First2};
 }
 
@@ -1983,7 +1983,7 @@ struct _Static_partitioned_equal2 {
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_equal2*>(_Context));
+        _STD _Run_available_chunked_work(*static_cast<_Static_partitioned_equal2*>(_Context));
     }
 };
 
@@ -1994,31 +1994,31 @@ _NODISCARD bool equal(_ExPo&&, const _FwdIt1 _First1, const _FwdIt1 _Last1, cons
     // compare [_First1, _Last1) to [_First2, ...)
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
-    _Adl_verify_range(_First1, _Last1);
-    const auto _UFirst1 = _Get_unwrapped(_First1);
-    const auto _ULast1  = _Get_unwrapped(_Last1);
+    _STD _Adl_verify_range(_First1, _Last1);
+    const auto _UFirst1 = _STD _Get_unwrapped(_First1);
+    const auto _ULast1  = _STD _Get_unwrapped(_Last1);
     if constexpr (remove_reference_t<_ExPo>::_Parallelize) {
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
         if (_Hw_threads > 1) {
             const auto _Count   = _STD distance(_UFirst1, _ULast1);
-            const auto _UFirst2 = _Get_unwrapped_n(_First2, _Count);
+            const auto _UFirst2 = _STD _Get_unwrapped_n(_First2, _Count);
             if (_Count >= 2) {
                 _TRY_BEGIN
-                _Static_partitioned_equal2 _Operation{_Hw_threads, _Count, _Pass_fn(_Pred), _UFirst1, _UFirst2};
+                _Static_partitioned_equal2 _Operation{_Hw_threads, _Count, _STD _Pass_fn(_Pred), _UFirst1, _UFirst2};
                 _Operation._Basis1._Populate(_Operation._Team, _UFirst1);
                 _Operation._Basis2._Populate(_Operation._Team, _UFirst2);
-                _Run_chunked_parallel_work(_Hw_threads, _Operation);
+                _STD _Run_chunked_parallel_work(_Hw_threads, _Operation);
                 return !_Operation._Cancel_token._Is_canceled_relaxed();
                 _CATCH(const _Parallelism_resources_exhausted&)
                 // fall through to serial case below
                 _CATCH_END
             }
 
-            return _STD equal(_UFirst1, _ULast1, _UFirst2, _Pass_fn(_Pred));
+            return _STD equal(_UFirst1, _ULast1, _UFirst2, _STD _Pass_fn(_Pred));
         }
     }
 
-    return _STD equal(_UFirst1, _ULast1, _First2, _Pass_fn(_Pred));
+    return _STD equal(_UFirst1, _ULast1, _First2, _STD _Pass_fn(_Pred));
 }
 
 _EXPORT_STD template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr,
@@ -2028,19 +2028,19 @@ _NODISCARD bool equal(_ExPo&&, const _FwdIt1 _First1, const _FwdIt1 _Last1, cons
     // compare [_First1, _Last1) to [_First2, _Last2)
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
-    _Adl_verify_range(_First1, _Last1);
-    _Adl_verify_range(_First2, _Last2);
-    const auto _UFirst1 = _Get_unwrapped(_First1);
-    const auto _ULast1  = _Get_unwrapped(_Last1);
-    const auto _UFirst2 = _Get_unwrapped(_First2);
-    const auto _ULast2  = _Get_unwrapped(_Last2);
+    _STD _Adl_verify_range(_First1, _Last1);
+    _STD _Adl_verify_range(_First2, _Last2);
+    const auto _UFirst1 = _STD _Get_unwrapped(_First1);
+    const auto _ULast1  = _STD _Get_unwrapped(_Last1);
+    const auto _UFirst2 = _STD _Get_unwrapped(_First2);
+    const auto _ULast2  = _STD _Get_unwrapped(_Last2);
     if constexpr (remove_reference_t<_ExPo>::_Parallelize) {
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
         if (_Hw_threads > 1) {
-            const auto _Count = _Distance_any(_UFirst1, _ULast1, _UFirst2, _ULast2);
+            const auto _Count = _STD _Distance_any(_UFirst1, _ULast1, _UFirst2, _ULast2);
             if (_Count >= 2) {
                 _TRY_BEGIN
-                _Static_partitioned_equal2 _Operation{_Hw_threads, _Count, _Pass_fn(_Pred), _UFirst1, _UFirst2};
+                _Static_partitioned_equal2 _Operation{_Hw_threads, _Count, _STD _Pass_fn(_Pred), _UFirst1, _UFirst2};
                 if (!_Operation._Basis1._Populate(_Operation._Team, _UFirst1, _ULast1)) {
                     // left sequence didn't have length _Count
                     return false;
@@ -2051,7 +2051,7 @@ _NODISCARD bool equal(_ExPo&&, const _FwdIt1 _First1, const _FwdIt1 _Last1, cons
                     return false;
                 }
 
-                _Run_chunked_parallel_work(_Hw_threads, _Operation);
+                _STD _Run_chunked_parallel_work(_Hw_threads, _Operation);
                 return !_Operation._Cancel_token._Is_canceled_relaxed();
                 _CATCH(const _Parallelism_resources_exhausted&)
                 // fall through to equal below
@@ -2060,7 +2060,7 @@ _NODISCARD bool equal(_ExPo&&, const _FwdIt1 _First1, const _FwdIt1 _Last1, cons
         }
     }
 
-    return _STD equal(_UFirst1, _ULast1, _UFirst2, _ULast2, _Pass_fn(_Pred));
+    return _STD equal(_UFirst1, _ULast1, _UFirst2, _ULast2, _STD _Pass_fn(_Pred));
 }
 
 template <class _FwdItHaystack, class _FwdItPat, class _Pr>
@@ -2093,7 +2093,7 @@ struct _Static_partitioned_search3 {
 
         const auto _Range = _Basis._Get_chunk(_Key);
         for (auto _Candidate = _Range._First; _Candidate != _Range._Last; ++_Candidate) {
-            if (_Equal_rev_pred_unchecked(_Candidate, _First2, _Last2, _Pred)) {
+            if (_STD _Equal_rev_pred_unchecked(_Candidate, _First2, _Last2, _Pred)) {
                 _Results._Imbue(_Key._Chunk_number, _Candidate);
                 return _Cancellation_status::_Canceled;
             }
@@ -2104,7 +2104,7 @@ struct _Static_partitioned_search3 {
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_search3*>(_Context));
+        _STD _Run_available_chunked_work(*static_cast<_Static_partitioned_search3*>(_Context));
     }
 };
 
@@ -2115,16 +2115,16 @@ _NODISCARD _FwdItHaystack search(_ExPo&&, const _FwdItHaystack _First1, _FwdItHa
     // find first [_First2, _Last2) match
     _REQUIRE_PARALLEL_ITERATOR(_FwdItHaystack);
     _REQUIRE_PARALLEL_ITERATOR(_FwdItPat);
-    _Adl_verify_range(_First2, _Last2);
-    const auto _UFirst2 = _Get_unwrapped(_First2);
-    const auto _ULast2  = _Get_unwrapped(_Last2);
+    _STD _Adl_verify_range(_First2, _Last2);
+    const auto _UFirst2 = _STD _Get_unwrapped(_First2);
+    const auto _ULast2  = _STD _Get_unwrapped(_Last2);
     if (_UFirst2 == _ULast2) {
         return _First1;
     }
 
-    _Adl_verify_range(_First1, _Last1);
-    const auto _UFirst1 = _Get_unwrapped(_First1);
-    const auto _ULast1  = _Get_unwrapped(_Last1);
+    _STD _Adl_verify_range(_First1, _Last1);
+    const auto _UFirst1 = _STD _Get_unwrapped(_First1);
+    const auto _ULast1  = _STD _Get_unwrapped(_Last1);
 
     if constexpr (remove_reference_t<_ExPo>::_Parallelize) {
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
@@ -2162,7 +2162,7 @@ _NODISCARD _FwdItHaystack search(_ExPo&&, const _FwdItHaystack _First1, _FwdItHa
             if (_Count == 1) {
                 // 1 match possible == ranges are of equal length -- do better than serial search because we've done the
                 // work to calculate distance() of the inputs
-                if (_Equal_rev_pred_unchecked(_UFirst1, _UFirst2, _ULast2, _Pass_fn(_Pred))) {
+                if (_STD _Equal_rev_pred_unchecked(_UFirst1, _UFirst2, _ULast2, _STD _Pass_fn(_Pred))) {
                     return _First1;
                 }
 
@@ -2171,9 +2171,9 @@ _NODISCARD _FwdItHaystack search(_ExPo&&, const _FwdItHaystack _First1, _FwdItHa
 
             _TRY_BEGIN
             _Static_partitioned_search3 _Operation{
-                _Hw_threads, _Count, _UFirst1, _ULast1, _UFirst2, _ULast2, _Pass_fn(_Pred)};
-            _Run_chunked_parallel_work(_Hw_threads, _Operation);
-            _Seek_wrapped(_Last1, _Operation._Results._Get_result());
+                _Hw_threads, _Count, _UFirst1, _ULast1, _UFirst2, _ULast2, _STD _Pass_fn(_Pred)};
+            _STD _Run_chunked_parallel_work(_Hw_threads, _Operation);
+            _STD _Seek_wrapped(_Last1, _Operation._Results._Get_result());
             return _Last1;
             _CATCH(const _Parallelism_resources_exhausted&)
             // fall through to search, below
@@ -2181,7 +2181,7 @@ _NODISCARD _FwdItHaystack search(_ExPo&&, const _FwdItHaystack _First1, _FwdItHa
         }
     }
 
-    _Seek_wrapped(_Last1, _STD search(_UFirst1, _ULast1, _UFirst2, _ULast2, _Pass_fn(_Pred)));
+    _STD _Seek_wrapped(_Last1, _STD search(_UFirst1, _ULast1, _UFirst2, _ULast2, _STD _Pass_fn(_Pred)));
     return _Last1;
 }
 
@@ -2234,7 +2234,7 @@ struct _Static_partitioned_search_n3 {
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_search_n3*>(_Context));
+        _STD _Run_available_chunked_work(*static_cast<_Static_partitioned_search_n3*>(_Context));
     }
 };
 
@@ -2255,9 +2255,9 @@ _NODISCARD _FwdIt search_n(_ExPo&&, const _FwdIt _First, _FwdIt _Last, const _Di
         return _Last;
     }
 
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     if constexpr (remove_reference_t<_ExPo>::_Parallelize) {
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
         if (_Hw_threads > 1) {
@@ -2270,9 +2270,9 @@ _NODISCARD _FwdIt search_n(_ExPo&&, const _FwdIt _First, _FwdIt _Last, const _Di
             const auto _Candidates = static_cast<_Iter_diff_t<_FwdIt>>(_Haystack_count - _Count + 1);
             _TRY_BEGIN
             _Static_partitioned_search_n3 _Operation{_Hw_threads, _Candidates, _UFirst, _ULast,
-                static_cast<_Iter_diff_t<_FwdIt>>(_Count), _Val, _Pass_fn(_Pred)};
-            _Run_chunked_parallel_work(_Hw_threads, _Operation);
-            _Seek_wrapped(_Last, _Operation._Results._Get_result());
+                static_cast<_Iter_diff_t<_FwdIt>>(_Count), _Val, _STD _Pass_fn(_Pred)};
+            _STD _Run_chunked_parallel_work(_Hw_threads, _Operation);
+            _STD _Seek_wrapped(_Last, _Operation._Results._Get_result());
             return _Last;
             _CATCH(const _Parallelism_resources_exhausted&)
             // fall through to search_n, below
@@ -2280,7 +2280,7 @@ _NODISCARD _FwdIt search_n(_ExPo&&, const _FwdIt _First, _FwdIt _Last, const _Di
         }
     }
 
-    _Seek_wrapped(_Last, _STD search_n(_UFirst, _ULast, _Count, _Val, _Pass_fn(_Pred)));
+    _STD _Seek_wrapped(_Last, _STD search_n(_UFirst, _ULast, _Count, _Val, _STD _Pass_fn(_Pred)));
     return _Last;
 }
 

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -1346,9 +1346,10 @@ _NODISCARD _FwdIt find(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, const _
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     using _UFwdIt = _Unwrapped_t<const _FwdIt&>;
     _STD _Adl_verify_range(_First, _Last);
-    _STD _Seek_wrapped(_First,
-        _STD _Find_parallel_unchecked(_STD forward<_ExPo>(_Exec), _STD _Get_unwrapped(_First), _STD _Get_unwrapped(_Last),
-            [&](const _UFwdIt _LFirst, const _UFwdIt _LLast) { return _STD _Find_unchecked(_LFirst, _LLast, _Val); }));
+    _STD _Seek_wrapped(_First, _STD _Find_parallel_unchecked(_STD forward<_ExPo>(_Exec), _STD _Get_unwrapped(_First),
+                                   _STD _Get_unwrapped(_Last), [&](const _UFwdIt _LFirst, const _UFwdIt _LLast) {
+                                       return _STD _Find_unchecked(_LFirst, _LLast, _Val);
+                                   }));
     return _First;
 }
 
@@ -1359,9 +1360,10 @@ _NODISCARD _FwdIt find_if(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, _Pr 
     using _UFwdIt = _Unwrapped_t<const _FwdIt&>;
     _STD _Adl_verify_range(_First, _Last);
     auto _Pass_pred = _STD _Pass_fn(_Pred);
-    _STD _Seek_wrapped(_First,
-        _STD _Find_parallel_unchecked(_STD forward<_ExPo>(_Exec), _STD _Get_unwrapped(_First), _STD _Get_unwrapped(_Last),
-            [=](const _UFwdIt _LFirst, const _UFwdIt _LLast) { return _STD find_if(_LFirst, _LLast, _Pass_pred); }));
+    _STD _Seek_wrapped(_First, _STD _Find_parallel_unchecked(_STD forward<_ExPo>(_Exec), _STD _Get_unwrapped(_First),
+                                   _STD _Get_unwrapped(_Last), [=](const _UFwdIt _LFirst, const _UFwdIt _LLast) {
+                                       return _STD find_if(_LFirst, _LLast, _Pass_pred);
+                                   }));
     return _First;
 }
 
@@ -1373,9 +1375,9 @@ _NODISCARD _FwdIt find_if_not(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, 
     _STD _Adl_verify_range(_First, _Last);
     auto _Pass_pred = _STD _Pass_fn(_Pred);
     _STD _Seek_wrapped(_First, _STD _Find_parallel_unchecked(_STD forward<_ExPo>(_Exec), _STD _Get_unwrapped(_First),
-                              _STD _Get_unwrapped(_Last), [=](const _UFwdIt _LFirst, const _UFwdIt _LLast) {
-                                  return _STD find_if_not(_LFirst, _LLast, _Pass_pred);
-                              }));
+                                   _STD _Get_unwrapped(_Last), [=](const _UFwdIt _LFirst, const _UFwdIt _LLast) {
+                                       return _STD find_if_not(_LFirst, _LLast, _Pass_pred);
+                                   }));
     return _First;
 }
 
@@ -1599,9 +1601,9 @@ _NODISCARD _FwdIt1 find_first_of(_ExPo&& _Exec, const _FwdIt1 _First1, _FwdIt1 _
 
     auto _Pass_pred = _STD _Pass_fn(_Pred);
     _STD _Seek_wrapped(_Last1, _STD _Find_parallel_unchecked(_STD forward<_ExPo>(_Exec), _STD _Get_unwrapped(_First1),
-                              _STD _Get_unwrapped(_Last1), [=](const _UFwdIt1 _LFirst1, const _UFwdIt1 _LLast1) {
-                                  return _STD find_first_of(_LFirst1, _LLast1, _UFirst2, _ULast2, _Pass_pred);
-                              }));
+                                   _STD _Get_unwrapped(_Last1), [=](const _UFwdIt1 _LFirst1, const _UFwdIt1 _LLast1) {
+                                       return _STD find_first_of(_LFirst1, _LLast1, _UFirst2, _ULast2, _Pass_pred);
+                                   }));
     return _Last1;
 }
 
@@ -1827,8 +1829,8 @@ struct _Static_partitioned_mismatch3 {
     _Static_partitioned_mismatch3(
         const size_t _Hw_threads, const _Diff _Count, const _FwdIt1 _First1, const _FwdIt2 _First2, const _Pr _Pred_)
         : _Team{_Count, _Get_chunked_work_chunk_count(_Hw_threads, _Count)}, _Basis1{}, _Basis2{},
-          _Results(
-              _STD _Get_unwrapped(_Basis1._Populate(_Team, _First1)), _STD _Get_unwrapped(_Basis2._Populate(_Team, _First2))),
+          _Results(_STD _Get_unwrapped(_Basis1._Populate(_Team, _First1)),
+              _STD _Get_unwrapped(_Basis2._Populate(_Team, _First2))),
           _Pred(_Pred_) {}
 
     _Cancellation_status _Process_chunk() {
@@ -1902,8 +1904,8 @@ _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
         }
     }
 
-    const auto _Result = _STD mismatch(
-        _UFirst1, _ULast1, _STD _Get_unwrapped_n(_First2, _STD _Idl_distance<_FwdIt1>(_UFirst1, _ULast1)), _STD _Pass_fn(_Pred));
+    const auto _Result = _STD mismatch(_UFirst1, _ULast1,
+        _STD _Get_unwrapped_n(_First2, _STD _Idl_distance<_FwdIt1>(_UFirst1, _ULast1)), _STD _Pass_fn(_Pred));
     _STD _Seek_wrapped(_First2, _Result.second);
     _STD _Seek_wrapped(_First1, _Result.first);
     return {_First1, _First2};
@@ -1925,7 +1927,8 @@ _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
     if constexpr (remove_reference_t<_ExPo>::_Parallelize) {
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
         if (_Hw_threads > 1) {
-            const auto _Count = static_cast<_Iter_diff_t<_FwdIt1>>(_STD _Distance_min(_UFirst1, _ULast1, _UFirst2, _ULast2));
+            const auto _Count =
+                static_cast<_Iter_diff_t<_FwdIt1>>(_STD _Distance_min(_UFirst1, _ULast1, _UFirst2, _ULast2));
             if (_Count >= 2) {
                 _TRY_BEGIN
                 _Static_partitioned_mismatch3 _Operation{_Hw_threads, _Count, _UFirst1, _UFirst2, _STD _Pass_fn(_Pred)};

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -98,7 +98,7 @@ _STD_BEGIN
 template <class _Ty, class _TVal>
 __declspec(noalias) size_t __std_count_trivial(_Ty* _First, _Ty* _Last, const _TVal _Val) noexcept {
     if constexpr (_STD is_pointer_v<_TVal> || _STD is_null_pointer_v<_TVal>) {
-        return ::__std_count_trivial(_First, _Last, reinterpret_cast<uintptr_t>(_Val));
+        return _STD __std_count_trivial(_First, _Last, reinterpret_cast<uintptr_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 1) {
         return ::__std_count_trivial_1(_First, _Last, static_cast<uint8_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 2) {
@@ -115,7 +115,7 @@ __declspec(noalias) size_t __std_count_trivial(_Ty* _First, _Ty* _Last, const _T
 template <class _Ty, class _TVal>
 _Ty* __std_find_trivial(_Ty* _First, _Ty* _Last, const _TVal _Val) noexcept {
     if constexpr (_STD is_pointer_v<_TVal> || _STD is_null_pointer_v<_TVal>) {
-        return ::__std_find_trivial(_First, _Last, reinterpret_cast<uintptr_t>(_Val));
+        return _STD __std_find_trivial(_First, _Last, reinterpret_cast<uintptr_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 1) {
         return const_cast<_Ty*>(
             static_cast<const _Ty*>(::__std_find_trivial_1(_First, _Last, static_cast<uint8_t>(_Val))));
@@ -136,7 +136,7 @@ _Ty* __std_find_trivial(_Ty* _First, _Ty* _Last, const _TVal _Val) noexcept {
 template <class _Ty, class _TVal>
 _Ty* __std_find_trivial_unsized(_Ty* _First, const _TVal _Val) noexcept {
     if constexpr (_STD is_pointer_v<_TVal> || _STD is_null_pointer_v<_TVal>) {
-        return ::__std_find_trivial_unsized(_First, reinterpret_cast<uintptr_t>(_Val));
+        return _STD __std_find_trivial_unsized(_First, reinterpret_cast<uintptr_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 1) {
         return const_cast<_Ty*>(
             static_cast<const _Ty*>(::__std_find_trivial_unsized_1(_First, static_cast<uint8_t>(_Val))));
@@ -5786,7 +5786,7 @@ _NODISCARD _CONSTEXPR20 _InIt _Find_unchecked(_InIt _First, const _InIt _Last, c
             }
 #if _USE_STD_VECTOR_ALGORITHMS
             const auto _First_ptr = _STD _To_address(_First);
-            const auto _Result    = ::__std_find_trivial(_First_ptr, _STD _To_address(_Last), _Val);
+            const auto _Result    = _STD __std_find_trivial(_First_ptr, _STD _To_address(_Last), _Val);
             if constexpr (is_pointer_v<_InIt>) {
                 return _Result;
             } else {
@@ -5868,9 +5868,9 @@ namespace ranges {
                 if constexpr (_Is_sized) {
                     const auto _Last_ptr = _First_ptr + (_Last - _First);
 
-                    _Result = ::__std_find_trivial(_First_ptr, _Last_ptr, _Val);
+                    _Result = _STD __std_find_trivial(_First_ptr, _Last_ptr, _Val);
                 } else {
-                    _Result = ::__std_find_trivial_unsized(_First_ptr, _Val);
+                    _Result = _STD __std_find_trivial_unsized(_First_ptr, _Val);
                 }
 
                 if constexpr (is_pointer_v<_It>) {
@@ -5967,7 +5967,7 @@ _NODISCARD _CONSTEXPR20 _Iter_diff_t<_InIt> count(const _InIt _First, const _InI
                 }
 
                 return static_cast<_Iter_diff_t<_InIt>>(
-                    ::__std_count_trivial(_STD _To_address(_UFirst), _STD _To_address(_ULast), _Val));
+                    _STD __std_count_trivial(_STD _To_address(_UFirst), _STD _To_address(_ULast), _Val));
             }
         }
 #endif // _USE_STD_VECTOR_ALGORITHMS
@@ -6615,7 +6615,7 @@ constexpr _FwdIt _Max_element_unchecked(_FwdIt _First, _FwdIt _Last, _Pr _Pred) 
     if constexpr (_Is_min_max_optimization_safe<_FwdIt, _Pr>) {
         if (!_Is_constant_evaluated()) {
             const auto _First_ptr = _To_address(_First);
-            const auto _Result    = __std_max_element(_First_ptr, _To_address(_Last));
+            const auto _Result    = _STD __std_max_element(_First_ptr, _To_address(_Last));
             if constexpr (is_pointer_v<_FwdIt>) {
                 return _Result;
             } else {
@@ -6680,7 +6680,7 @@ namespace ranges {
             if (!_STD is_constant_evaluated()) {
                 const auto _First_ptr = _STD to_address(_First);
                 const auto _Last_ptr  = _First_ptr + (_Last - _First);
-                const auto _Result    = __std_max_element(_First_ptr, _Last_ptr);
+                const auto _Result    = _STD __std_max_element(_First_ptr, _Last_ptr);
                 if constexpr (is_pointer_v<_It>) {
                     return _Result;
                 } else {
@@ -6807,7 +6807,7 @@ constexpr _FwdIt _Min_element_unchecked(_FwdIt _First, _FwdIt _Last, _Pr _Pred) 
     if constexpr (_Is_min_max_optimization_safe<_FwdIt, _Pr>) {
         if (!_Is_constant_evaluated()) {
             const auto _First_ptr = _To_address(_First);
-            const auto _Result    = __std_min_element(_First_ptr, _To_address(_Last));
+            const auto _Result    = _STD __std_min_element(_First_ptr, _To_address(_Last));
             if constexpr (is_pointer_v<_FwdIt>) {
                 return _Result;
             } else {
@@ -6872,7 +6872,7 @@ namespace ranges {
             if (!_STD is_constant_evaluated()) {
                 const auto _First_ptr = _STD to_address(_First);
                 const auto _Last_ptr  = _First_ptr + (_Last - _First);
-                const auto _Result    = __std_min_element(_First_ptr, _Last_ptr);
+                const auto _Result    = _STD __std_min_element(_First_ptr, _Last_ptr);
                 if constexpr (is_pointer_v<_It>) {
                     return _Result;
                 } else {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -97,15 +97,15 @@ _END_EXTERN_C
 template <class _Ty, class _TVal>
 __declspec(noalias) size_t __std_count_trivial(_Ty* _First, _Ty* _Last, const _TVal _Val) noexcept {
     if constexpr (_STD is_pointer_v<_TVal> || _STD is_null_pointer_v<_TVal>) {
-        return __std_count_trivial(_First, _Last, reinterpret_cast<uintptr_t>(_Val));
+        return ::__std_count_trivial(_First, _Last, reinterpret_cast<uintptr_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 1) {
-        return __std_count_trivial_1(_First, _Last, static_cast<uint8_t>(_Val));
+        return ::__std_count_trivial_1(_First, _Last, static_cast<uint8_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 2) {
-        return __std_count_trivial_2(_First, _Last, static_cast<uint16_t>(_Val));
+        return ::__std_count_trivial_2(_First, _Last, static_cast<uint16_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 4) {
-        return __std_count_trivial_4(_First, _Last, static_cast<uint32_t>(_Val));
+        return ::__std_count_trivial_4(_First, _Last, static_cast<uint32_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 8) {
-        return __std_count_trivial_8(_First, _Last, static_cast<uint64_t>(_Val));
+        return ::__std_count_trivial_8(_First, _Last, static_cast<uint64_t>(_Val));
     } else {
         static_assert(_STD _Always_false<_Ty>, "Unexpected size");
     }
@@ -114,19 +114,19 @@ __declspec(noalias) size_t __std_count_trivial(_Ty* _First, _Ty* _Last, const _T
 template <class _Ty, class _TVal>
 _Ty* __std_find_trivial(_Ty* _First, _Ty* _Last, const _TVal _Val) noexcept {
     if constexpr (_STD is_pointer_v<_TVal> || _STD is_null_pointer_v<_TVal>) {
-        return __std_find_trivial(_First, _Last, reinterpret_cast<uintptr_t>(_Val));
+        return ::__std_find_trivial(_First, _Last, reinterpret_cast<uintptr_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 1) {
         return const_cast<_Ty*>(
-            static_cast<const _Ty*>(__std_find_trivial_1(_First, _Last, static_cast<uint8_t>(_Val))));
+            static_cast<const _Ty*>(::__std_find_trivial_1(_First, _Last, static_cast<uint8_t>(_Val))));
     } else if constexpr (sizeof(_Ty) == 2) {
         return const_cast<_Ty*>(
-            static_cast<const _Ty*>(__std_find_trivial_2(_First, _Last, static_cast<uint16_t>(_Val))));
+            static_cast<const _Ty*>(::__std_find_trivial_2(_First, _Last, static_cast<uint16_t>(_Val))));
     } else if constexpr (sizeof(_Ty) == 4) {
         return const_cast<_Ty*>(
-            static_cast<const _Ty*>(__std_find_trivial_4(_First, _Last, static_cast<uint32_t>(_Val))));
+            static_cast<const _Ty*>(::__std_find_trivial_4(_First, _Last, static_cast<uint32_t>(_Val))));
     } else if constexpr (sizeof(_Ty) == 8) {
         return const_cast<_Ty*>(
-            static_cast<const _Ty*>(__std_find_trivial_8(_First, _Last, static_cast<uint64_t>(_Val))));
+            static_cast<const _Ty*>(::__std_find_trivial_8(_First, _Last, static_cast<uint64_t>(_Val))));
     } else {
         static_assert(_STD _Always_false<_Ty>, "Unexpected size");
     }
@@ -135,19 +135,19 @@ _Ty* __std_find_trivial(_Ty* _First, _Ty* _Last, const _TVal _Val) noexcept {
 template <class _Ty, class _TVal>
 _Ty* __std_find_trivial_unsized(_Ty* _First, const _TVal _Val) noexcept {
     if constexpr (_STD is_pointer_v<_TVal> || _STD is_null_pointer_v<_TVal>) {
-        return __std_find_trivial_unsized(_First, reinterpret_cast<uintptr_t>(_Val));
+        return ::__std_find_trivial_unsized(_First, reinterpret_cast<uintptr_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 1) {
         return const_cast<_Ty*>(
-            static_cast<const _Ty*>(__std_find_trivial_unsized_1(_First, static_cast<uint8_t>(_Val))));
+            static_cast<const _Ty*>(::__std_find_trivial_unsized_1(_First, static_cast<uint8_t>(_Val))));
     } else if constexpr (sizeof(_Ty) == 2) {
         return const_cast<_Ty*>(
-            static_cast<const _Ty*>(__std_find_trivial_unsized_2(_First, static_cast<uint16_t>(_Val))));
+            static_cast<const _Ty*>(::__std_find_trivial_unsized_2(_First, static_cast<uint16_t>(_Val))));
     } else if constexpr (sizeof(_Ty) == 4) {
         return const_cast<_Ty*>(
-            static_cast<const _Ty*>(__std_find_trivial_unsized_4(_First, static_cast<uint32_t>(_Val))));
+            static_cast<const _Ty*>(::__std_find_trivial_unsized_4(_First, static_cast<uint32_t>(_Val))));
     } else if constexpr (sizeof(_Ty) == 8) {
         return const_cast<_Ty*>(
-            static_cast<const _Ty*>(__std_find_trivial_unsized_8(_First, static_cast<uint64_t>(_Val))));
+            static_cast<const _Ty*>(::__std_find_trivial_unsized_8(_First, static_cast<uint64_t>(_Val))));
     } else {
         static_assert(_STD _Always_false<_Ty>, "Unexpected size");
     }
@@ -1198,7 +1198,7 @@ _NODISCARD constexpr decltype(auto) _Get_unwrapped(_Iter&& _It) noexcept(
 }
 
 template <class _Iter>
-using _Unwrapped_t = _Remove_cvref_t<decltype(_Get_unwrapped(_STD declval<_Iter>()))>;
+using _Unwrapped_t = _Remove_cvref_t<decltype(_STD _Get_unwrapped(_STD declval<_Iter>()))>;
 
 template <class _Iter, class = bool>
 _INLINE_VAR constexpr bool _Do_unwrap_when_unverified_v = false;
@@ -2538,22 +2538,22 @@ namespace ranges {
 
     template <range _Rng, class _Iter>
     _NODISCARD constexpr decltype(auto) _Unwrap_range_iter(_Iter&& _It) noexcept(
-        noexcept(_Unwrap_iter<sentinel_t<_Rng>>(static_cast<_Iter&&>(_It)))) {
+        noexcept(_RANGES _Unwrap_iter<sentinel_t<_Rng>>(static_cast<_Iter&&>(_It)))) {
         _STL_INTERNAL_STATIC_ASSERT(same_as<remove_cvref_t<_Iter>, iterator_t<_Rng>>);
-        return _Unwrap_iter<sentinel_t<_Rng>>(static_cast<_Iter&&>(_It));
+        return _RANGES _Unwrap_iter<sentinel_t<_Rng>>(static_cast<_Iter&&>(_It));
     }
 
     template <range _Rng, class _Sent>
     _NODISCARD constexpr decltype(auto) _Unwrap_range_sent(_Sent&& _Se) noexcept(
-        noexcept(_Unwrap_sent<iterator_t<_Rng>>(static_cast<_Sent&&>(_Se)))) {
+        noexcept(_RANGES _Unwrap_sent<iterator_t<_Rng>>(static_cast<_Sent&&>(_Se)))) {
         _STL_INTERNAL_STATIC_ASSERT(same_as<remove_cvref_t<_Sent>, sentinel_t<_Rng>>);
-        return _Unwrap_sent<iterator_t<_Rng>>(static_cast<_Sent&&>(_Se));
+        return _RANGES _Unwrap_sent<iterator_t<_Rng>>(static_cast<_Sent&&>(_Se));
     }
 
     template <class _Iter, class _Sent>
-    using _Unwrap_iter_t = remove_cvref_t<decltype(_Unwrap_iter<_Sent>(_STD declval<_Iter>()))>;
+    using _Unwrap_iter_t = remove_cvref_t<decltype(_RANGES _Unwrap_iter<_Sent>(_STD declval<_Iter>()))>;
     template <class _Sent, class _Iter>
-    using _Unwrap_sent_t = remove_cvref_t<decltype(_Unwrap_sent<_Iter>(_STD declval<_Sent>()))>;
+    using _Unwrap_sent_t = remove_cvref_t<decltype(_RANGES _Unwrap_sent<_Iter>(_STD declval<_Sent>()))>;
 
     template <range _Rng>
     using _Unwrapped_iterator_t = _Unwrap_iter_t<iterator_t<_Rng>, sentinel_t<_Rng>>;
@@ -2567,7 +2567,7 @@ namespace ranges {
         };
 
         template <class _Ty>
-        concept _Can_begin = requires(_Ty& __t) { _Unwrap_range_iter<_Ty>(_RANGES begin(__t)); };
+        concept _Can_begin = requires(_Ty& __t) { _RANGES _Unwrap_range_iter<_Ty>(_RANGES begin(__t)); };
 
         class _Cpo {
         private:
@@ -2579,10 +2579,10 @@ namespace ranges {
                 if constexpr (_Has_member<_Ty>) {
                     _STL_INTERNAL_STATIC_ASSERT(
                         same_as<decltype(_STD declval<_Ty>()._Unchecked_begin()), _Unwrapped_iterator_t<_Ty>>);
-                    return {_St::_Member, noexcept(_Fake_copy_init(_STD declval<_Ty>()._Unchecked_begin()))};
+                    return {_St::_Member, noexcept(_STD _Fake_copy_init(_STD declval<_Ty>()._Unchecked_begin()))};
                 } else if constexpr (_Can_begin<_Ty>) {
                     return {_St::_Unwrap,
-                        noexcept(_Fake_copy_init(_Unwrap_range_iter<_Ty>(_RANGES begin(_STD declval<_Ty>()))))};
+                        noexcept(_STD _Fake_copy_init(_RANGES _Unwrap_range_iter<_Ty>(_RANGES begin(_STD declval<_Ty>()))))};
                 } else {
                     return {_St::_None};
                 }
@@ -2600,7 +2600,7 @@ namespace ranges {
                 if constexpr (_Strat == _St::_Member) {
                     return _Val._Unchecked_begin();
                 } else if constexpr (_Strat == _St::_Unwrap) {
-                    return _Unwrap_range_iter<_Ty>(_RANGES begin(_Val));
+                    return _RANGES _Unwrap_range_iter<_Ty>(_RANGES begin(_Val));
                 } else {
                     static_assert(_Always_false<_Ty>, "Should be unreachable");
                 }
@@ -2620,7 +2620,7 @@ namespace ranges {
         };
 
         template <class _Ty>
-        concept _Can_end = requires(_Ty& __t) { _Unwrap_range_sent<_Ty>(_RANGES end(__t)); };
+        concept _Can_end = requires(_Ty& __t) { _RANGES _Unwrap_range_sent<_Ty>(_RANGES end(__t)); };
 
         class _Cpo {
         private:
@@ -2632,7 +2632,7 @@ namespace ranges {
                 if constexpr (_Has_member<_Ty>) {
                     return {_St::_Member, noexcept(_STD declval<_Ty>()._Unchecked_end())};
                 } else if constexpr (_Can_end<_Ty>) {
-                    return {_St::_Unwrap, noexcept(_Unwrap_range_sent<_Ty>(_RANGES end(_STD declval<_Ty>())))};
+                    return {_St::_Unwrap, noexcept(_RANGES _Unwrap_range_sent<_Ty>(_RANGES end(_STD declval<_Ty>())))};
                 } else {
                     return {_St::_None};
                 }
@@ -2650,7 +2650,7 @@ namespace ranges {
                 if constexpr (_Strat == _St::_Member) {
                     return _Val._Unchecked_end();
                 } else if constexpr (_Strat == _St::_Unwrap) {
-                    return _Unwrap_range_sent<_Ty>(_RANGES end(_Val));
+                    return _RANGES _Unwrap_range_sent<_Ty>(_RANGES end(_Val));
                 } else {
                     static_assert(_Always_false<_Ty>, "Should be unreachable");
                 }
@@ -4633,9 +4633,9 @@ namespace ranges {
         // find the iterator in [_UFirst, _Unwrap_sent<_It>(_Last)) which equals _Unwrap_sent<_It>(_Last)
         // [possibly O(N)]
         if constexpr (is_same_v<_Unwrap_iter_t<_It, _Se>, _Unwrap_sent_t<_Se, _It>>) {
-            return _Unwrap_sent<_It>(_STD forward<_Se>(_Last));
+            return _RANGES _Unwrap_sent<_It>(_STD forward<_Se>(_Last));
         } else {
-            return _RANGES next(_UFirst, _Unwrap_sent<_It>(_STD forward<_Se>(_Last)));
+            return _RANGES next(_UFirst, _RANGES _Unwrap_sent<_It>(_STD forward<_Se>(_Last)));
         }
     }
 
@@ -4646,7 +4646,7 @@ namespace ranges {
             if constexpr (same_as<decltype(_Uend(_Range)), _Unwrapped_iterator_t<_Rng>>) {
                 return _Uend(_Range);
             } else {
-                return _Unwrap_range_sent<_Rng>(_RANGES end(_Range));
+                return _RANGES _Unwrap_range_sent<_Rng>(_RANGES end(_Range));
             }
         } else if constexpr (sized_range<_Rng>) {
             return _RANGES next(_Ubegin(_Range), _RANGES distance(_Range));
@@ -5212,33 +5212,33 @@ _INLINE_VAR constexpr bool _Equal_memcmp_is_safe =
 template <class _CtgIt1, class _CtgIt2>
 _NODISCARD int _Memcmp_ranges(_CtgIt1 _First1, _CtgIt1 _Last1, _CtgIt2 _First2) {
     _STL_INTERNAL_STATIC_ASSERT(sizeof(_Iter_value_t<_CtgIt1>) == sizeof(_Iter_value_t<_CtgIt2>));
-    const auto _First1_ch = reinterpret_cast<const char*>(_To_address(_First1));
-    const auto _Last1_ch  = reinterpret_cast<const char*>(_To_address(_Last1));
-    const auto _First2_ch = reinterpret_cast<const char*>(_To_address(_First2));
+    const auto _First1_ch = reinterpret_cast<const char*>(_STD _To_address(_First1));
+    const auto _Last1_ch  = reinterpret_cast<const char*>(_STD _To_address(_Last1));
+    const auto _First2_ch = reinterpret_cast<const char*>(_STD _To_address(_First2));
     return _CSTD memcmp(_First1_ch, _First2_ch, static_cast<size_t>(_Last1_ch - _First1_ch));
 }
 
 template <class _CtgIt1, class _CtgIt2>
 _NODISCARD int _Memcmp_count(_CtgIt1 _First1, _CtgIt2 _First2, const size_t _Count) {
     _STL_INTERNAL_STATIC_ASSERT(sizeof(_Iter_value_t<_CtgIt1>) == sizeof(_Iter_value_t<_CtgIt2>));
-    const auto _First1_ch = reinterpret_cast<const char*>(_To_address(_First1));
-    const auto _First2_ch = reinterpret_cast<const char*>(_To_address(_First2));
+    const auto _First1_ch = reinterpret_cast<const char*>(_STD _To_address(_First1));
+    const auto _First2_ch = reinterpret_cast<const char*>(_STD _To_address(_First2));
     return _CSTD memcmp(_First1_ch, _First2_ch, _Count * sizeof(_Iter_value_t<_CtgIt1>));
 }
 
 _EXPORT_STD template <class _InIt1, class _InIt2, class _Pr>
 _NODISCARD _CONSTEXPR20 bool equal(const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _First2, _Pr _Pred) {
     // compare [_First1, _Last1) to [_First2, ...)
-    _Adl_verify_range(_First1, _Last1);
-    auto _UFirst1      = _Get_unwrapped(_First1);
-    const auto _ULast1 = _Get_unwrapped(_Last1);
-    auto _UFirst2      = _Get_unwrapped_n(_First2, _Idl_distance<_InIt1>(_UFirst1, _ULast1));
+    _STD _Adl_verify_range(_First1, _Last1);
+    auto _UFirst1      = _STD _Get_unwrapped(_First1);
+    const auto _ULast1 = _STD _Get_unwrapped(_Last1);
+    auto _UFirst2      = _STD _Get_unwrapped_n(_First2, _STD _Idl_distance<_InIt1>(_UFirst1, _ULast1));
     if constexpr (_Equal_memcmp_is_safe<decltype(_UFirst1), decltype(_UFirst2), _Pr>) {
 #if _HAS_CXX20
         if (!_STD is_constant_evaluated())
 #endif // _HAS_CXX20
         {
-            return _Memcmp_ranges(_UFirst1, _ULast1, _UFirst2) == 0;
+            return _STD _Memcmp_ranges(_UFirst1, _ULast1, _UFirst2) == 0;
         }
     }
 
@@ -5276,18 +5276,18 @@ _EXPORT_STD template <class _InIt1, class _InIt2, class _Pr>
 _NODISCARD _CONSTEXPR20 bool equal(
     const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _First2, const _InIt2 _Last2, _Pr _Pred) {
     // compare [_First1, _Last1) to [_First2, _Last2)
-    _Adl_verify_range(_First1, _Last1);
-    _Adl_verify_range(_First2, _Last2);
-    auto _UFirst1      = _Get_unwrapped(_First1);
-    const auto _ULast1 = _Get_unwrapped(_Last1);
-    auto _UFirst2      = _Get_unwrapped(_First2);
-    const auto _ULast2 = _Get_unwrapped(_Last2);
+    _STD _Adl_verify_range(_First1, _Last1);
+    _STD _Adl_verify_range(_First2, _Last2);
+    auto _UFirst1      = _STD _Get_unwrapped(_First1);
+    const auto _ULast1 = _STD _Get_unwrapped(_Last1);
+    auto _UFirst2      = _STD _Get_unwrapped(_First2);
+    const auto _ULast2 = _STD _Get_unwrapped(_Last2);
     if constexpr (_Is_ranges_random_iter_v<_InIt1> && _Is_ranges_random_iter_v<_InIt2>) {
         if (_ULast1 - _UFirst1 != _ULast2 - _UFirst2) {
             return false;
         }
 
-        return _STD equal(_UFirst1, _ULast1, _UFirst2, _Pass_fn(_Pred));
+        return _STD equal(_UFirst1, _ULast1, _UFirst2, _STD _Pass_fn(_Pred));
     } else {
         for (;;) {
             if (_UFirst1 == _ULast1) {
@@ -5404,8 +5404,8 @@ namespace ranges {
         _NODISCARD constexpr mismatch_result<_It1, _It2> operator()(_It1 _First1, _Se1 _Last1,
             _It2 _First2, _Se2 _Last2, _Pr _Pred = {}, _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
             // clang-format on
-            _Adl_verify_range(_First1, _Last1);
-            _Adl_verify_range(_First2, _Last2);
+            _STD _Adl_verify_range(_First1, _Last1);
+            _STD _Adl_verify_range(_First2, _Last2);
 
             if constexpr (sized_sentinel_for<_Se1, _It1> && sized_sentinel_for<_Se2, _It2>) {
                 iter_difference_t<_It1> _Count1       = _Last1 - _First1;
@@ -5414,17 +5414,17 @@ namespace ranges {
                     _Count1 = static_cast<decltype(_Count1)>(_Count2);
                 }
 
-                auto _Result = _RANGES _Mismatch_n(_Get_unwrapped(_STD move(_First1)),
-                    _Get_unwrapped(_STD move(_First2)), _Count1, _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
-                _Seek_wrapped(_First1, _STD move(_Result.in1));
-                _Seek_wrapped(_First2, _STD move(_Result.in2));
+                auto _Result = _RANGES _Mismatch_n(_STD _Get_unwrapped(_STD move(_First1)),
+                    _STD _Get_unwrapped(_STD move(_First2)), _Count1, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                _STD _Seek_wrapped(_First1, _STD move(_Result.in1));
+                _STD _Seek_wrapped(_First2, _STD move(_Result.in2));
                 return {_STD move(_First1), _STD move(_First2)};
             } else {
-                auto _Result = _RANGES _Mismatch_4(_Unwrap_iter<_Se1>(_STD move(_First1)),
-                    _Unwrap_sent<_It1>(_STD move(_Last1)), _Unwrap_iter<_Se2>(_STD move(_First2)),
-                    _Unwrap_sent<_It2>(_STD move(_Last2)), _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
-                _Seek_wrapped(_First1, _STD move(_Result.in1));
-                _Seek_wrapped(_First2, _STD move(_Result.in2));
+                auto _Result = _RANGES _Mismatch_4(_RANGES _Unwrap_iter<_Se1>(_STD move(_First1)),
+                    _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)), _RANGES _Unwrap_iter<_Se2>(_STD move(_First2)),
+                    _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                _STD _Seek_wrapped(_First1, _STD move(_Result.in1));
+                _STD _Seek_wrapped(_First2, _STD move(_Result.in2));
                 return {_STD move(_First1), _STD move(_First2)};
             }
         }
@@ -5443,19 +5443,19 @@ namespace ranges {
 
                 auto _First1 = _RANGES begin(_Range1);
                 auto _First2 = _RANGES begin(_Range2);
-                auto _Result = _RANGES _Mismatch_n(_Get_unwrapped(_STD move(_First1)),
-                    _Get_unwrapped(_STD move(_First2)), _Count1, _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
-                _Seek_wrapped(_First1, _STD move(_Result.in1));
-                _Seek_wrapped(_First2, _STD move(_Result.in2));
+                auto _Result = _RANGES _Mismatch_n(_STD _Get_unwrapped(_STD move(_First1)),
+                    _STD _Get_unwrapped(_STD move(_First2)), _Count1, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                _STD _Seek_wrapped(_First1, _STD move(_Result.in1));
+                _STD _Seek_wrapped(_First2, _STD move(_Result.in2));
                 return {_STD move(_First1), _STD move(_First2)};
             } else {
                 auto _First1 = _RANGES begin(_Range1);
                 auto _First2 = _RANGES begin(_Range2);
-                auto _Result = _RANGES _Mismatch_4(_Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1),
-                    _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2), _Pass_fn(_Pred), _Pass_fn(_Proj1),
-                    _Pass_fn(_Proj2));
-                _Seek_wrapped(_First1, _STD move(_Result.in1));
-                _Seek_wrapped(_First2, _STD move(_Result.in2));
+                auto _Result = _RANGES _Mismatch_4(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1),
+                    _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1),
+                    _STD _Pass_fn(_Proj2));
+                _STD _Seek_wrapped(_First1, _STD move(_Result.in1));
+                _STD _Seek_wrapped(_First2, _STD move(_Result.in2));
                 return {_STD move(_First1), _STD move(_First2)};
             }
         }
@@ -5780,8 +5780,8 @@ _NODISCARD _CONSTEXPR20 _InIt _Find_unchecked(_InIt _First, const _InIt _Last, c
                 return _Last;
             }
 #if _USE_STD_VECTOR_ALGORITHMS
-            const auto _First_ptr = _To_address(_First);
-            const auto _Result    = __std_find_trivial(_First_ptr, _To_address(_Last), _Val);
+            const auto _First_ptr = _STD _To_address(_First);
+            const auto _Result    = ::__std_find_trivial(_First_ptr, _STD _To_address(_Last), _Val);
             if constexpr (is_pointer_v<_InIt>) {
                 return _Result;
             } else {
@@ -5789,7 +5789,7 @@ _NODISCARD _CONSTEXPR20 _InIt _Find_unchecked(_InIt _First, const _InIt _Last, c
             }
 #else // ^^^ _USE_STD_VECTOR_ALGORITHMS / !_USE_STD_VECTOR_ALGORITHMS vvv
             if constexpr (sizeof(_Iter_value_t<_InIt>) == 1) {
-                const auto _First_ptr = _To_address(_First);
+                const auto _First_ptr = _STD _To_address(_First);
                 const auto _Result    = static_cast<remove_reference_t<_Iter_ref_t<_InIt>>*>(
                     _CSTD memchr(_First_ptr, static_cast<unsigned char>(_Val), static_cast<size_t>(_Last - _First)));
                 if constexpr (is_pointer_v<_InIt>) {
@@ -5814,11 +5814,11 @@ _NODISCARD _CONSTEXPR20 _InIt _Find_unchecked(_InIt _First, const _InIt _Last, c
 
 _EXPORT_STD template <class _InIt, class _Ty>
 _NODISCARD _CONSTEXPR20 _InIt find(_InIt _First, const _InIt _Last, const _Ty& _Val) { // find first matching _Val
-    _Adl_verify_range(_First, _Last);
+    _STD _Adl_verify_range(_First, _Last);
     if constexpr (_Is_vb_iterator<_InIt> && is_same_v<_Ty, bool>) {
         return _Find_vbool(_First, _Last, _Val);
     } else {
-        _Seek_wrapped(_First, _STD _Find_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Val));
+        _STD _Seek_wrapped(_First, _STD _Find_unchecked(_STD _Get_unwrapped(_First), _STD _Get_unwrapped(_Last), _Val));
         return _First;
     }
 }
@@ -5856,16 +5856,16 @@ namespace ranges {
 
                 using _Ptr_t = remove_reference_t<_Iter_ref_t<_It>>*;
 #if _USE_STD_VECTOR_ALGORITHMS
-                const auto _First_ptr = _To_address(_First);
+                const auto _First_ptr = _STD _To_address(_First);
 
                 _Ptr_t _Result;
 
                 if constexpr (_Is_sized) {
                     const auto _Last_ptr = _First_ptr + (_Last - _First);
 
-                    _Result = __std_find_trivial(_First_ptr, _Last_ptr, _Val);
+                    _Result = ::__std_find_trivial(_First_ptr, _Last_ptr, _Val);
                 } else {
-                    _Result = __std_find_trivial_unsized(_First_ptr, _Val);
+                    _Result = ::__std_find_trivial_unsized(_First_ptr, _Val);
                 }
 
                 if constexpr (is_pointer_v<_It>) {
@@ -5916,11 +5916,11 @@ namespace ranges {
             requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, const _Ty& _Val, _Pj _Proj = {}) const {
             // clang-format on
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _RANGES _Find_unchecked(
-                _Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)), _Val, _Pass_fn(_Proj));
+                _RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _Val, _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult));
+            _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
         }
 
@@ -5930,9 +5930,9 @@ namespace ranges {
             _Rng&& _Range, const _Ty& _Val, _Pj _Proj = {}) const {
             auto _First   = _RANGES begin(_Range);
             auto _UResult = _RANGES _Find_unchecked(
-                _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _Val, _Pass_fn(_Proj));
+                _RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _Val, _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult));
+            _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
         }
     };
@@ -5944,12 +5944,12 @@ namespace ranges {
 _EXPORT_STD template <class _InIt, class _Ty>
 _NODISCARD _CONSTEXPR20 _Iter_diff_t<_InIt> count(const _InIt _First, const _InIt _Last, const _Ty& _Val) {
     // count elements that match _Val
-    _Adl_verify_range(_First, _Last);
+    _STD _Adl_verify_range(_First, _Last);
     if constexpr (_Is_vb_iterator<_InIt> && is_same_v<_Ty, bool>) {
         return _Count_vbool(_First, _Last, _Val);
     } else {
-        auto _UFirst      = _Get_unwrapped(_First);
-        const auto _ULast = _Get_unwrapped(_Last);
+        auto _UFirst      = _STD _Get_unwrapped(_First);
+        const auto _ULast = _STD _Get_unwrapped(_Last);
 
 #if _USE_STD_VECTOR_ALGORITHMS
         if constexpr (_Vector_alg_in_find_is_safe<decltype(_UFirst), _Ty>) {
@@ -5962,7 +5962,7 @@ _NODISCARD _CONSTEXPR20 _Iter_diff_t<_InIt> count(const _InIt _First, const _InI
                 }
 
                 return static_cast<_Iter_diff_t<_InIt>>(
-                    __std_count_trivial(_To_address(_UFirst), _To_address(_ULast), _Val));
+                    ::__std_count_trivial(_STD _To_address(_UFirst), _STD _To_address(_ULast), _Val));
             }
         }
 #endif // _USE_STD_VECTOR_ALGORITHMS
@@ -6097,9 +6097,9 @@ _NODISCARD _CONSTEXPR20 _TrimResult _Trim_completely(
 
     for (bool _Check_reversed = true; _Res == _TrimResult::_KeepTrimming; _Check_reversed = !_Check_reversed) {
         if (_Check_reversed) {
-            _Res = _Trim_reversed(_First1, _Back1, _First2, _Back2, _Pred);
+            _Res = _STD _Trim_reversed(_First1, _Back1, _First2, _Back2, _Pred);
         } else {
-            _Res = _Trim_equal(_First1, _Back1, _First2, _Back2, _Pred);
+            _Res = _STD _Trim_equal(_First1, _Back1, _First2, _Back2, _Pred);
         }
     }
 
@@ -6122,7 +6122,7 @@ _NODISCARD _CONSTEXPR20 bool _Check_match_counts(
             return false;
         }
 
-        const _TrimResult _Res = _Trim_completely(_First1, _Last1, _First2, _Last2, _Pred);
+        const _TrimResult _Res = _STD _Trim_completely(_First1, _Last1, _First2, _Last2, _Pred);
 
         if (_Res != _TrimResult::_HaveWorkAfterTrimming) {
             return _Res == _TrimResult::_ReturnTrue;
@@ -6133,14 +6133,14 @@ _NODISCARD _CONSTEXPR20 bool _Check_match_counts(
     }
 
     for (_FwdIt1 _Next1 = _First1; _Next1 != _Last1; ++_Next1) {
-        if (_Next1 == _Find_pr(_First1, _Next1, *_Next1, _Pred)) { // new value, compare match counts
-            _Iter_diff_t<_FwdIt2> _Count2 = _Count_pr(_First2, _Last2, *_Next1, _Pred);
+        if (_Next1 == _STD _Find_pr(_First1, _Next1, *_Next1, _Pred)) { // new value, compare match counts
+            _Iter_diff_t<_FwdIt2> _Count2 = _STD _Count_pr(_First2, _Last2, *_Next1, _Pred);
             if (_Count2 == 0) {
                 return false; // second range lacks value, not a permutation
             }
 
-            _FwdIt1 _Skip1                = _Next_iter(_Next1);
-            _Iter_diff_t<_FwdIt1> _Count1 = _Count_pr(_Skip1, _Last1, *_Next1, _Pred) + 1;
+            _FwdIt1 _Skip1                = _STD _Next_iter(_Next1);
+            _Iter_diff_t<_FwdIt1> _Count1 = _STD _Count_pr(_Skip1, _Last1, *_Next1, _Pred) + 1;
             if (_Count2 != _Count1) {
                 return false; // match counts differ, not a permutation
             }
@@ -6275,16 +6275,16 @@ _FwdIt rotate(_ExPo&&, _FwdIt _First, _FwdIt _Mid, _FwdIt _Last) noexcept /* ter
 
 _EXPORT_STD template <class _InIt, class _Pr>
 _NODISCARD _CONSTEXPR20 _InIt find_if(_InIt _First, const _InIt _Last, _Pr _Pred) { // find first satisfying _Pred
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     for (; _UFirst != _ULast; ++_UFirst) {
         if (_Pred(*_UFirst)) {
             break;
         }
     }
 
-    _Seek_wrapped(_First, _UFirst);
+    _STD _Seek_wrapped(_First, _UFirst);
     return _First;
 }
 
@@ -6335,11 +6335,11 @@ namespace ranges {
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
-            auto _UResult = _RANGES _Find_if_unchecked(_Unwrap_iter<_Se>(_STD move(_First)),
-                _Unwrap_sent<_It>(_STD move(_Last)), _Pass_fn(_Pred), _Pass_fn(_Proj));
+            _STD _Adl_verify_range(_First, _Last);
+            auto _UResult = _RANGES _Find_if_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult));
+            _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
         }
 
@@ -6348,9 +6348,9 @@ namespace ranges {
         _NODISCARD constexpr borrowed_iterator_t<_Rng> operator()(_Rng&& _Range, _Pr _Pred, _Pj _Proj = {}) const {
             auto _First   = _RANGES begin(_Range);
             auto _UResult = _RANGES _Find_if_unchecked(
-                _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _Pass_fn(_Pred), _Pass_fn(_Proj));
+                _RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult));
+            _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
         }
     };
@@ -6362,12 +6362,12 @@ namespace ranges {
         template <input_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
 
-            auto _UResult = _Find_if_not_unchecked(_Unwrap_iter<_Se>(_STD move(_First)),
-                _Unwrap_sent<_It>(_STD move(_Last)), _Pass_fn(_Pred), _Pass_fn(_Proj));
+            auto _UResult = _Find_if_not_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult));
+            _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
         }
 
@@ -6377,9 +6377,9 @@ namespace ranges {
             auto _First = _RANGES begin(_Range);
 
             auto _UResult = _Find_if_not_unchecked(
-                _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _Pass_fn(_Pred), _Pass_fn(_Proj));
+                _RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult));
+            _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
         }
 
@@ -6407,12 +6407,12 @@ namespace ranges {
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_binary_predicate<projected<_It, _Pj>, projected<_It, _Pj>> _Pr = ranges::equal_to>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
 
-            auto _UResult = _Adjacent_find_unchecked(_Unwrap_iter<_Se>(_STD move(_First)),
-                _Unwrap_sent<_It>(_STD move(_Last)), _Pass_fn(_Pred), _Pass_fn(_Proj));
+            auto _UResult = _Adjacent_find_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult));
+            _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
         }
 
@@ -6420,9 +6420,9 @@ namespace ranges {
             indirect_binary_predicate<projected<iterator_t<_Rng>, _Pj>, projected<iterator_t<_Rng>, _Pj>> _Pr =
                 ranges::equal_to>
         _NODISCARD constexpr borrowed_iterator_t<_Rng> operator()(_Rng&& _Range, _Pr _Pred = {}, _Pj _Proj = {}) const {
-            auto _UResult = _Adjacent_find_unchecked(_Ubegin(_Range), _Uend(_Range), _Pass_fn(_Pred), _Pass_fn(_Proj));
+            auto _UResult = _Adjacent_find_unchecked(_Ubegin(_Range), _Uend(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
-            return _Rewrap_iterator(_Range, _STD move(_UResult));
+            return _RANGES _Rewrap_iterator(_Range, _STD move(_UResult));
         }
 
     private:
@@ -6468,9 +6468,9 @@ namespace ranges {
             if (!_STD is_constant_evaluated()) {
                 bool _Ans;
                 if constexpr (same_as<_It2, _Se2>) {
-                    _Ans = _Memcmp_ranges(_First2, _Last2, _First1) == 0;
+                    _Ans = _STD _Memcmp_ranges(_First2, _Last2, _First1) == 0;
                 } else {
-                    _Ans = _Memcmp_count(_First1, _First2, static_cast<size_t>(_Last2 - _First2)) == 0;
+                    _Ans = _STD _Memcmp_count(_First1, _First2, static_cast<size_t>(_Last2 - _First2)) == 0;
                 }
 
                 if (_Ans) {
@@ -6498,23 +6498,23 @@ namespace ranges {
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
         _NODISCARD constexpr subrange<_It1> operator()(_It1 _First1, _Se1 _Last1, _It2 _First2, _Se2 _Last2,
             _Pr _Pred = {}, _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
-            _Adl_verify_range(_First1, _Last1);
-            _Adl_verify_range(_First2, _Last2);
-            auto _UFirst1 = _Unwrap_iter<_Se1>(_STD move(_First1));
-            auto _ULast1  = _Unwrap_sent<_It1>(_STD move(_Last1));
-            auto _UFirst2 = _Unwrap_iter<_Se2>(_STD move(_First2));
-            auto _ULast2  = _Unwrap_sent<_It2>(_STD move(_Last2));
+            _STD _Adl_verify_range(_First1, _Last1);
+            _STD _Adl_verify_range(_First2, _Last2);
+            auto _UFirst1 = _RANGES _Unwrap_iter<_Se1>(_STD move(_First1));
+            auto _ULast1  = _RANGES _Unwrap_sent<_It1>(_STD move(_Last1));
+            auto _UFirst2 = _RANGES _Unwrap_iter<_Se2>(_STD move(_First2));
+            auto _ULast2  = _RANGES _Unwrap_sent<_It2>(_STD move(_Last2));
 
             if constexpr (sized_sentinel_for<_Se1, _It1> && sized_sentinel_for<_Se2, _It2>) {
                 const auto _Count1 = _ULast1 - _UFirst1;
                 const auto _Count2 = _ULast2 - _UFirst2;
                 auto _UResult = _Search_sized(_STD move(_UFirst1), _STD move(_ULast1), _Count1, _STD move(_UFirst2),
-                    _STD move(_ULast2), _Count2, _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
-                return _Rewrap_subrange<subrange<_It1>>(_First1, _STD move(_UResult));
+                    _STD move(_ULast2), _Count2, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                return _RANGES _Rewrap_subrange<subrange<_It1>>(_First1, _STD move(_UResult));
             } else {
                 auto _UResult = _Search_unsized(_STD move(_UFirst1), _STD move(_ULast1), _STD move(_UFirst2),
-                    _STD move(_ULast2), _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
-                return _Rewrap_subrange<subrange<_It1>>(_First1, _STD move(_UResult));
+                    _STD move(_ULast2), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                return _RANGES _Rewrap_subrange<subrange<_It1>>(_First1, _STD move(_UResult));
             }
         }
 
@@ -6527,12 +6527,12 @@ namespace ranges {
                 const auto _Count1 = _RANGES distance(_Range1);
                 const auto _Count2 = _RANGES distance(_Range2);
                 auto _UResult      = _Search_sized(_Ubegin(_Range1), _Uend(_Range1), _Count1, _Ubegin(_Range2),
-                         _Uend(_Range2), _Count2, _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
-                return _Rewrap_subrange<borrowed_subrange_t<_Rng1>>(_Range1, _STD move(_UResult));
+                         _Uend(_Range2), _Count2, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng1>>(_Range1, _STD move(_UResult));
             } else {
                 auto _UResult = _Search_unsized(_Ubegin(_Range1), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2),
-                    _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
-                return _Rewrap_subrange<borrowed_subrange_t<_Rng1>>(_Range1, _STD move(_UResult));
+                    _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng1>>(_Range1, _STD move(_UResult));
             }
         }
 
@@ -6556,7 +6556,7 @@ namespace ranges {
                 }
             }
 
-            _First1 = _Find_last_iterator(_First1, _Last1, _Count1);
+            _First1 = _RANGES _Find_last_iterator(_First1, _Last1, _Count1);
             return {_First1, _First1};
         }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6550,9 +6550,9 @@ namespace ranges {
             _STL_INTERNAL_CHECK(_RANGES distance(_First2, _Last2) == _Count2);
 
             for (; _Count1 >= _Count2; ++_First1, (void) --_Count1) {
-                auto [_Match, _Mid1] = _RANGES _Equal_rev_pred(_First1, _First2, _Last2, _Pred, _Proj1, _Proj2);
-                if (_Match) {
-                    return {_STD move(_First1), _STD move(_Mid1)};
+                auto _Match_and_mid1 = _RANGES _Equal_rev_pred(_First1, _First2, _Last2, _Pred, _Proj1, _Proj2);
+                if (_Match_and_mid1.first) {
+                    return {_STD move(_First1), _STD move(_Match_and_mid1.second)};
                 }
             }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1161,7 +1161,11 @@ _INLINE_VAR constexpr bool _Range_verifiable_v<_Iter, _Sentinel,
 template <class _Iter, class _Sentinel>
 constexpr void _Adl_verify_range(const _Iter& _First, const _Sentinel& _Last) {
     // check that [_First, _Last) forms an iterator range
-    if constexpr (_Range_verifiable_v<_Iter, _Sentinel>) {
+    if constexpr (is_pointer_v<_Iter> && is_pointer_v<_Sentinel>) {
+#if _ITERATOR_DEBUG_LEVEL != 0
+        _STL_VERIFY(_First <= _Last, "transposed pointer range");
+#endif // _ITERATOR_DEBUG_LEVEL != 0
+    } else if constexpr (_Range_verifiable_v<_Iter, _Sentinel>) {
         _Verify_range(_First, _Last);
     }
 }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2581,8 +2581,8 @@ namespace ranges {
                         same_as<decltype(_STD declval<_Ty>()._Unchecked_begin()), _Unwrapped_iterator_t<_Ty>>);
                     return {_St::_Member, noexcept(_STD _Fake_copy_init(_STD declval<_Ty>()._Unchecked_begin()))};
                 } else if constexpr (_Can_begin<_Ty>) {
-                    return {_St::_Unwrap,
-                        noexcept(_STD _Fake_copy_init(_RANGES _Unwrap_range_iter<_Ty>(_RANGES begin(_STD declval<_Ty>()))))};
+                    return {_St::_Unwrap, noexcept(_STD _Fake_copy_init(
+                                              _RANGES _Unwrap_range_iter<_Ty>(_RANGES begin(_STD declval<_Ty>()))))};
                 } else {
                     return {_St::_None};
                 }
@@ -5415,14 +5415,16 @@ namespace ranges {
                 }
 
                 auto _Result = _RANGES _Mismatch_n(_STD _Get_unwrapped(_STD move(_First1)),
-                    _STD _Get_unwrapped(_STD move(_First2)), _Count1, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                    _STD _Get_unwrapped(_STD move(_First2)), _Count1, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1),
+                    _STD _Pass_fn(_Proj2));
                 _STD _Seek_wrapped(_First1, _STD move(_Result.in1));
                 _STD _Seek_wrapped(_First2, _STD move(_Result.in2));
                 return {_STD move(_First1), _STD move(_First2)};
             } else {
                 auto _Result = _RANGES _Mismatch_4(_RANGES _Unwrap_iter<_Se1>(_STD move(_First1)),
                     _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)), _RANGES _Unwrap_iter<_Se2>(_STD move(_First2)),
-                    _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                    _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1),
+                    _STD _Pass_fn(_Proj2));
                 _STD _Seek_wrapped(_First1, _STD move(_Result.in1));
                 _STD _Seek_wrapped(_First2, _STD move(_Result.in2));
                 return {_STD move(_First1), _STD move(_First2)};
@@ -5444,16 +5446,17 @@ namespace ranges {
                 auto _First1 = _RANGES begin(_Range1);
                 auto _First2 = _RANGES begin(_Range2);
                 auto _Result = _RANGES _Mismatch_n(_STD _Get_unwrapped(_STD move(_First1)),
-                    _STD _Get_unwrapped(_STD move(_First2)), _Count1, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                    _STD _Get_unwrapped(_STD move(_First2)), _Count1, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1),
+                    _STD _Pass_fn(_Proj2));
                 _STD _Seek_wrapped(_First1, _STD move(_Result.in1));
                 _STD _Seek_wrapped(_First2, _STD move(_Result.in2));
                 return {_STD move(_First1), _STD move(_First2)};
             } else {
                 auto _First1 = _RANGES begin(_Range1);
                 auto _First2 = _RANGES begin(_Range2);
-                auto _Result = _RANGES _Mismatch_4(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1),
-                    _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1),
-                    _STD _Pass_fn(_Proj2));
+                auto _Result = _RANGES _Mismatch_4(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)),
+                    _Uend(_Range1), _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2),
+                    _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
                 _STD _Seek_wrapped(_First1, _STD move(_Result.in1));
                 _STD _Seek_wrapped(_First2, _STD move(_Result.in2));
                 return {_STD move(_First1), _STD move(_First2)};
@@ -5917,8 +5920,8 @@ namespace ranges {
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, const _Ty& _Val, _Pj _Proj = {}) const {
             // clang-format on
             _STD _Adl_verify_range(_First, _Last);
-            auto _UResult = _RANGES _Find_unchecked(
-                _RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _Val, _STD _Pass_fn(_Proj));
+            auto _UResult = _RANGES _Find_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _Val, _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
@@ -6347,8 +6350,8 @@ namespace ranges {
             indirect_unary_predicate<projected<iterator_t<_Rng>, _Pj>> _Pr>
         _NODISCARD constexpr borrowed_iterator_t<_Rng> operator()(_Rng&& _Range, _Pr _Pred, _Pj _Proj = {}) const {
             auto _First   = _RANGES begin(_Range);
-            auto _UResult = _RANGES _Find_if_unchecked(
-                _RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+            auto _UResult = _RANGES _Find_if_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)),
+                _Uend(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
@@ -6376,8 +6379,8 @@ namespace ranges {
         _NODISCARD constexpr borrowed_iterator_t<_Rng> operator()(_Rng&& _Range, _Pr _Pred, _Pj _Proj = {}) const {
             auto _First = _RANGES begin(_Range);
 
-            auto _UResult = _Find_if_not_unchecked(
-                _RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+            auto _UResult = _Find_if_not_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
+                _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
@@ -6420,7 +6423,8 @@ namespace ranges {
             indirect_binary_predicate<projected<iterator_t<_Rng>, _Pj>, projected<iterator_t<_Rng>, _Pj>> _Pr =
                 ranges::equal_to>
         _NODISCARD constexpr borrowed_iterator_t<_Rng> operator()(_Rng&& _Range, _Pr _Pred = {}, _Pj _Proj = {}) const {
-            auto _UResult = _Adjacent_find_unchecked(_Ubegin(_Range), _Uend(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+            auto _UResult =
+                _Adjacent_find_unchecked(_Ubegin(_Range), _Uend(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
             return _RANGES _Rewrap_iterator(_Range, _STD move(_UResult));
         }

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -189,6 +189,7 @@ tests\GH_001277_num_get_bad_grouping
 tests\GH_001411_core_headers
 tests\GH_001530_binomial_accuracy
 tests\GH_001541_case_sensitive_boolalpha
+tests\GH_001596_adl_proof_algorithms
 tests\GH_001638_dllexport_derived_classes
 tests\GH_001850_clog_tied_to_cout
 tests\GH_001858_iostream_exception

--- a/tests/std/tests/GH_001596_adl_proof_algorithms/env.lst
+++ b/tests/std/tests/GH_001596_adl_proof_algorithms/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/GH_001596_adl_proof_algorithms/test.compile.pass.cpp
+++ b/tests/std/tests/GH_001596_adl_proof_algorithms/test.compile.pass.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#ifndef _M_CEE // TRANSITION, VSO-1659496
 #include <algorithm>
 #include <cstddef>
 #if _HAS_CXX17
@@ -196,7 +197,7 @@ void test_parallel_algorithms() {
 }
 #endif // _HAS_CXX17
 
-#if _HAS_CXX23 && defined(__cpp_lib_concepts) && !defined(_M_CEE) // TRANSITION, GH-395, VSO-1659496
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 void test_ranges_non_projected_algorithms() {
     using namespace std::ranges;
 
@@ -233,4 +234,5 @@ void test_ranges_non_projected_algorithms() {
     (void) fold_left_first_with_iter(iarr, iarr, validating_left_selector{});
     (void) fold_left_first_with_iter(iarr, validating_left_selector{});
 }
-#endif // _HAS_CXX23 && defined(__cpp_lib_concepts) && !defined(_M_CEE)
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+#endif // _M_CEE

--- a/tests/std/tests/GH_001596_adl_proof_algorithms/test.compile.pass.cpp
+++ b/tests/std/tests/GH_001596_adl_proof_algorithms/test.compile.pass.cpp
@@ -1,0 +1,236 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <algorithm>
+#include <cstddef>
+#if _HAS_CXX17
+#include <execution>
+#endif // _HAS_CXX17
+#include <type_traits>
+#include <utility>
+
+template <class Tag>
+struct tagged_truth {
+    template <class T>
+    constexpr bool operator()(T&&) const noexcept {
+        return true;
+    }
+};
+
+template <class Tag>
+struct tagged_equal {
+    template <class T, class U>
+    constexpr auto operator()(T&& t, U&& u) const -> decltype(std::forward<T>(t) == std::forward<U>(u)) {
+        return std::forward<T>(t) == std::forward<U>(u);
+    }
+};
+
+template <class T>
+struct holder {
+    T t;
+};
+
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+template <class Tag>
+struct tagged_left_selector {
+    template <class T>
+    constexpr T operator()(T lhs, T) const noexcept {
+        return lhs;
+    }
+};
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+
+struct incomplete;
+
+using simple_truth = tagged_truth<void>;
+
+using validator        = holder<incomplete>*;
+using validating_truth = tagged_truth<holder<incomplete>>;
+using validating_equal = tagged_equal<holder<incomplete>>;
+
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+using simple_left_selector = tagged_left_selector<void>;
+
+using validating_left_selector = tagged_left_selector<holder<incomplete>>;
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+
+void test_algorithms() {
+    int iarr[1]{};
+    validator varr[1]{};
+
+    (void) std::all_of(varr, varr, simple_truth{});
+    (void) std::all_of(iarr, iarr, validating_truth{});
+
+    (void) std::any_of(varr, varr, simple_truth{});
+    (void) std::any_of(iarr, iarr, validating_truth{});
+
+    (void) std::none_of(varr, varr, simple_truth{});
+    (void) std::none_of(iarr, iarr, validating_truth{});
+
+    (void) std::for_each(varr, varr, simple_truth{});
+    (void) std::for_each(varr, varr, validating_truth{});
+    (void) std::for_each(iarr, iarr, validating_truth{});
+
+#if _HAS_CXX17
+    (void) std::for_each_n(varr, 0, simple_truth{});
+    (void) std::for_each_n(varr, 0, validating_truth{});
+    (void) std::for_each_n(iarr, 0, validating_truth{});
+#endif // _HAS_CXX17
+
+    (void) std::find(varr, varr, validator{});
+
+    (void) std::find_if(varr, varr, simple_truth{});
+    (void) std::find_if(iarr, iarr, validating_truth{});
+
+    (void) std::find_if_not(varr, varr, simple_truth{});
+    (void) std::find_if_not(iarr, iarr, validating_truth{});
+
+    (void) std::find_end(varr, varr, varr, varr);
+    (void) std::find_end(varr, varr, varr, varr, validating_equal{});
+    (void) std::find_end(iarr, iarr, iarr, iarr, validating_equal{});
+
+    (void) std::find_first_of(varr, varr, varr, varr);
+    (void) std::find_first_of(varr, varr, varr, varr, validating_equal{});
+    (void) std::find_first_of(iarr, iarr, iarr, iarr, validating_equal{});
+
+    (void) std::adjacent_find(varr, varr);
+    (void) std::adjacent_find(iarr, iarr, validating_equal{});
+
+    (void) std::count(varr, varr, validator{});
+
+    (void) std::count_if(varr, varr, simple_truth{});
+    (void) std::count_if(iarr, iarr, validating_truth{});
+
+    (void) std::mismatch(varr, varr, varr);
+    (void) std::mismatch(varr, varr, varr, varr);
+    (void) std::mismatch(iarr, iarr, iarr, validating_equal{});
+    (void) std::mismatch(iarr, iarr, iarr, iarr, validating_equal{});
+
+    (void) std::equal(varr, varr, varr);
+    (void) std::equal(varr, varr, varr, varr);
+    (void) std::equal(iarr, iarr, iarr, validating_equal{});
+    (void) std::equal(iarr, iarr, iarr, iarr, validating_equal{});
+
+    (void) std::is_permutation(varr, varr, varr);
+    (void) std::is_permutation(varr, varr, varr, validating_equal{});
+    (void) std::is_permutation(varr, varr, varr, varr);
+    (void) std::is_permutation(varr, varr, varr, varr, validating_equal{});
+    (void) std::is_permutation(iarr, iarr, iarr, validating_equal{});
+    (void) std::is_permutation(iarr, iarr, iarr, iarr, validating_equal{});
+
+    (void) std::search(varr, varr, varr, varr);
+    (void) std::search(iarr, iarr, iarr, iarr, validating_equal{});
+}
+
+#if _HAS_CXX17
+template <auto& ExecutionPolicy>
+void test_per_execution_policy() {
+    int iarr[1]{};
+    validator varr[1]{};
+
+    (void) std::all_of(ExecutionPolicy, varr, varr, simple_truth{});
+    (void) std::all_of(ExecutionPolicy, iarr, iarr, validating_truth{});
+
+    (void) std::any_of(ExecutionPolicy, varr, varr, simple_truth{});
+    (void) std::any_of(ExecutionPolicy, iarr, iarr, validating_truth{});
+
+    (void) std::none_of(ExecutionPolicy, varr, varr, simple_truth{});
+    (void) std::none_of(ExecutionPolicy, iarr, iarr, validating_truth{});
+
+    std::for_each(ExecutionPolicy, varr, varr, simple_truth{});
+    std::for_each(ExecutionPolicy, varr, varr, validating_truth{});
+    std::for_each(ExecutionPolicy, iarr, iarr, validating_truth{});
+
+    (void) std::for_each_n(ExecutionPolicy, varr, 0, simple_truth{});
+    (void) std::for_each_n(ExecutionPolicy, varr, 0, validating_truth{});
+    (void) std::for_each_n(ExecutionPolicy, iarr, 0, validating_truth{});
+
+    (void) std::find(ExecutionPolicy, varr, varr, validator{});
+
+    (void) std::find_if(ExecutionPolicy, varr, varr, simple_truth{});
+    (void) std::find_if(ExecutionPolicy, iarr, iarr, validating_truth{});
+
+    (void) std::find_if_not(ExecutionPolicy, varr, varr, simple_truth{});
+    (void) std::find_if_not(ExecutionPolicy, iarr, iarr, validating_truth{});
+
+    (void) std::find_end(ExecutionPolicy, varr, varr, varr, varr);
+    (void) std::find_end(ExecutionPolicy, varr, varr, varr, varr, validating_equal{});
+    (void) std::find_end(ExecutionPolicy, iarr, iarr, iarr, iarr, validating_equal{});
+
+    (void) std::find_first_of(ExecutionPolicy, varr, varr, varr, varr);
+    (void) std::find_first_of(ExecutionPolicy, varr, varr, varr, varr, validating_equal{});
+    (void) std::find_first_of(ExecutionPolicy, iarr, iarr, iarr, iarr, validating_equal{});
+
+    (void) std::adjacent_find(ExecutionPolicy, varr, varr);
+    (void) std::adjacent_find(ExecutionPolicy, iarr, iarr, validating_equal{});
+
+    (void) std::count(ExecutionPolicy, varr, varr, validator{});
+
+    (void) std::count_if(ExecutionPolicy, varr, varr, simple_truth{});
+    (void) std::count_if(ExecutionPolicy, iarr, iarr, validating_truth{});
+
+    (void) std::mismatch(ExecutionPolicy, varr, varr, varr);
+    (void) std::mismatch(ExecutionPolicy, varr, varr, varr, varr);
+    (void) std::mismatch(ExecutionPolicy, iarr, iarr, iarr, validating_equal{});
+    (void) std::mismatch(ExecutionPolicy, iarr, iarr, iarr, iarr, validating_equal{});
+
+    (void) std::equal(ExecutionPolicy, varr, varr, varr);
+    (void) std::equal(ExecutionPolicy, varr, varr, varr, varr);
+    (void) std::equal(ExecutionPolicy, iarr, iarr, iarr, validating_equal{});
+    (void) std::equal(ExecutionPolicy, iarr, iarr, iarr, iarr, validating_equal{});
+
+    (void) std::search(ExecutionPolicy, varr, varr, varr, varr);
+    (void) std::search(ExecutionPolicy, iarr, iarr, iarr, iarr, validating_equal{});
+
+    (void) std::search_n(ExecutionPolicy, varr, varr, 0, validator{});
+    (void) std::search_n(ExecutionPolicy, iarr, iarr, 0, 0, validating_equal{});
+}
+
+void test_parallel_algorithms() {
+    test_per_execution_policy<std::execution::seq>();
+    test_per_execution_policy<std::execution::par>();
+    test_per_execution_policy<std::execution::par_unseq>();
+#if _HAS_CXX20
+    test_per_execution_policy<std::execution::unseq>();
+#endif // _HAS_CXX20
+}
+#endif // _HAS_CXX17
+
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) && !defined(_M_CEE) // TRANSITION, GH-395, VSO-1659496
+void test_ranges_non_projected_algorithms() {
+    using namespace std::ranges;
+
+    int iarr[1]{};
+    validator varr[1]{};
+
+    (void) fold_left(varr, varr, validator{}, simple_left_selector{});
+    (void) fold_left(varr, validator{}, simple_left_selector{});
+    (void) fold_left(iarr, iarr, 0, validating_left_selector{});
+    (void) fold_left(iarr, 0, validating_left_selector{});
+
+    (void) fold_left_first(varr, varr + 1, simple_left_selector{});
+    (void) fold_left_first(varr, simple_left_selector{});
+    (void) fold_left_first(iarr, iarr + 1, validating_left_selector{});
+    (void) fold_left_first(iarr, validating_left_selector{});
+
+    (void) fold_right(varr, varr, validator{}, simple_left_selector{});
+    (void) fold_right(varr, validator{}, simple_left_selector{});
+    (void) fold_right(iarr, iarr, 0, validating_left_selector{});
+    (void) fold_right(iarr, 0, validating_left_selector{});
+
+    (void) fold_right_last(varr, varr + 1, simple_left_selector{});
+    (void) fold_right_last(varr, simple_left_selector{});
+    (void) fold_right_last(iarr, iarr + 1, validating_left_selector{});
+    (void) fold_right_last(iarr, validating_left_selector{});
+
+    (void) fold_left_with_iter(varr, varr, validator{}, simple_left_selector{});
+    (void) fold_left_with_iter(varr, validator{}, simple_left_selector{});
+    (void) fold_left_with_iter(iarr, iarr, 0, validating_left_selector{});
+    (void) fold_left_with_iter(iarr, 0, validating_left_selector{});
+
+    (void) fold_left_first_with_iter(varr, varr, simple_left_selector{});
+    (void) fold_left_first_with_iter(varr, simple_left_selector{});
+    (void) fold_left_first_with_iter(iarr, iarr, validating_left_selector{});
+    (void) fold_left_first_with_iter(iarr, validating_left_selector{});
+}
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts) && !defined(_M_CEE)

--- a/tests/std/tests/P2538R1_adl_proof_std_projected/test.compile.pass.cpp
+++ b/tests/std/tests/P2538R1_adl_proof_std_projected/test.compile.pass.cpp
@@ -2,53 +2,218 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #ifndef _M_CEE // TRANSITION, VSO-1659496
+#include <algorithm>
 #include <cassert>
 #include <functional>
 #include <iterator>
 #include <ranges>
 #include <utility>
 
-using namespace std;
-
-// TRANSITION, GH-1596, should use ranges::count
-struct my_count_fn {
-    template <input_iterator I, sentinel_for<I> S, class T, class Proj = identity>
-        requires indirect_binary_predicate<ranges::equal_to, projected<I, Proj>, const T*>
-    constexpr iter_difference_t<I> operator()(I first, S last, const T& value, Proj proj = {}) const {
-        iter_difference_t<I> counter = 0;
-        for (; first != last; ++first) {
-            if (std::invoke(proj, *first) == value) { // intentionally qualified to avoid ADL
-                ++counter;
-            }
-        }
-        return counter;
-    }
-
-    template <ranges::input_range R, class T, class Proj = identity>
-        requires indirect_binary_predicate<ranges::equal_to, projected<ranges::iterator_t<R>, Proj>, const T*>
-    constexpr ranges::range_difference_t<R> operator()(R&& r, const T& value, Proj proj = {}) const {
-        return (*this)(ranges::begin(r), ranges::end(r), value, ref(proj));
+template <class Tag>
+struct tagged_truth {
+    template <class T>
+    constexpr bool operator()(T&&) const noexcept {
+        return true;
     }
 };
 
-inline constexpr my_count_fn my_count;
+template <class Tag>
+struct tagged_equal {
+    template <class T, class U>
+    constexpr auto operator()(T&& t, U&& u) const -> decltype(std::forward<T>(t) == std::forward<U>(u)) {
+        return std::forward<T>(t) == std::forward<U>(u);
+    }
+};
+
+template <class Tag>
+struct tagged_identity {
+    template <class T>
+    constexpr T&& operator()(T&& t) const noexcept {
+        return std::forward<T>(t);
+    }
+};
+
+template <class Tag>
+struct tagged_left_selector {
+    template <class T>
+    constexpr T operator()(T lhs, T) const noexcept {
+        return lhs;
+    }
+};
 
 template <class T>
-struct Holder {
+struct holder {
     T t;
 };
-struct Incomplete;
 
-static_assert(equality_comparable<Holder<Incomplete>*>);
-static_assert(indirectly_comparable<Holder<Incomplete>**, Holder<Incomplete>**, equal_to<>>);
-static_assert(sortable<Holder<Incomplete>**>);
+struct incomplete;
 
-constexpr bool test() {
-    Holder<Incomplete>* a[10] = {};
-    assert(my_count(a, a + 10, nullptr) == 10);
-    assert(my_count(a, nullptr) == 10);
-    return true;
+using simple_truth    = tagged_truth<void>;
+using simple_identity = tagged_identity<void>;
+
+using validator           = holder<incomplete>*;
+using validating_truth    = tagged_truth<holder<incomplete>>;
+using validating_equal    = tagged_equal<holder<incomplete>>;
+using validating_identity = tagged_identity<holder<incomplete>>;
+
+void test_ranges_algorithms() {
+    using namespace std::ranges;
+
+    int iarr[1]{};
+    validator varr[1]{};
+
+    (void) all_of(varr, varr, simple_truth{});
+    (void) all_of(varr, simple_truth{});
+    (void) all_of(iarr, iarr, validating_truth{});
+    (void) all_of(iarr, validating_truth{});
+
+    (void) any_of(varr, varr, simple_truth{});
+    (void) any_of(varr, simple_truth{});
+    (void) any_of(iarr, iarr, validating_truth{});
+    (void) any_of(iarr, validating_truth{});
+
+    (void) none_of(varr, varr, simple_truth{});
+    (void) none_of(varr, simple_truth{});
+    (void) none_of(iarr, iarr, validating_truth{});
+    (void) none_of(iarr, validating_truth{});
+
+#if _HAS_CXX23
+    (void) contains(varr, varr, validator{});
+    (void) contains(varr, validator{});
+    (void) contains(iarr, iarr, 0, validating_identity{});
+    (void) contains(iarr, 0, validating_identity{});
+
+    (void) contains_subrange(varr, varr, varr, varr);
+    (void) contains_subrange(varr, varr);
+    (void) contains_subrange(iarr, iarr, iarr, iarr, validating_equal{});
+    // (void) contains_subrange(iarr, iarr, validating_equal{}); // needs to check ADL-found operator*
+    (void) contains_subrange(iarr, iarr, {}, validating_identity{});
+#endif // _HAS_CXX23
+
+    (void) for_each(varr, varr, simple_truth{});
+    (void) for_each(varr, simple_truth{});
+    (void) for_each(varr, varr, validating_truth{});
+    (void) for_each(varr, validating_truth{});
+    (void) for_each(iarr, iarr, validating_truth{});
+    (void) for_each(iarr, validating_truth{});
+
+    (void) for_each_n(varr, 0, simple_truth{});
+    (void) for_each_n(varr, 0, validating_truth{});
+    (void) for_each_n(iarr, 0, validating_truth{});
+
+    (void) find(varr, varr, validator{});
+    (void) find(varr, validator{});
+
+    (void) find_if(varr, varr, simple_truth{});
+    (void) find_if(varr, simple_truth{});
+    (void) find_if(iarr, iarr, validating_truth{});
+    (void) find_if(iarr, validating_truth{});
+
+    (void) find_if_not(varr, varr, simple_truth{});
+    (void) find_if_not(varr, simple_truth{});
+    (void) find_if_not(iarr, iarr, validating_truth{});
+    (void) find_if_not(iarr, validating_truth{});
+
+#if _HAS_CXX23
+    (void) find_last(varr, varr, validator{});
+    (void) find_last(varr, validator{});
+
+    (void) find_last_if(varr, varr, simple_truth{});
+    (void) find_last_if(varr, simple_truth{});
+    (void) find_last_if(iarr, iarr, validating_truth{});
+    (void) find_last_if(iarr, validating_truth{});
+
+    (void) find_last_if_not(varr, varr, simple_truth{});
+    (void) find_last_if_not(varr, simple_truth{});
+    (void) find_last_if_not(iarr, iarr, validating_truth{});
+    (void) find_last_if_not(iarr, validating_truth{});
+#endif // _HAS_CXX23
+
+    (void) find_end(varr, varr, varr, varr);
+    (void) find_end(varr, varr);
+    (void) find_end(varr, varr, varr, varr, validating_equal{});
+    (void) find_end(varr, varr, validating_equal{});
+    (void) find_end(iarr, iarr, iarr, iarr, validating_equal{});
+    (void) find_end(iarr, iarr, validating_equal{});
+
+    (void) find_first_of(varr, varr, varr, varr);
+    (void) find_first_of(varr, varr);
+    (void) find_first_of(varr, varr, varr, varr, validating_equal{});
+    (void) find_first_of(varr, varr, validating_equal{});
+    (void) find_first_of(iarr, iarr, iarr, iarr, validating_equal{});
+    (void) find_first_of(iarr, iarr, validating_equal{});
+
+    (void) adjacent_find(varr, varr);
+    (void) adjacent_find(varr);
+    (void) adjacent_find(iarr, iarr, validating_equal{});
+    (void) adjacent_find(iarr, iarr, {}, validating_identity{});
+    // (void) adjacent_find(iarr, validating_equal{}); // needs to check ADL-found swap
+    (void) adjacent_find(iarr, {}, validating_identity{});
+
+    (void) count(varr, varr, validator{});
+    (void) count(varr, validator{});
+    (void) count(iarr, iarr, 0, validating_identity{});
+    (void) count(iarr, 0, validating_identity{});
+
+    (void) count_if(varr, varr, simple_truth{});
+    (void) count_if(varr, simple_truth{});
+    (void) count_if(iarr, iarr, validating_truth{});
+    (void) count_if(iarr, validating_truth{});
+
+    (void) mismatch(varr, varr, varr, varr);
+    (void) mismatch(varr, varr);
+    (void) mismatch(iarr, iarr, iarr, iarr, validating_equal{});
+    (void) mismatch(iarr, iarr, validating_equal{});
+
+    (void) equal(varr, varr, varr, varr);
+    (void) equal(varr, varr);
+    (void) equal(iarr, iarr, iarr, iarr, validating_equal{});
+    (void) equal(iarr, iarr, validating_equal{});
+
+    (void) is_permutation(varr, varr, varr, varr);
+    (void) is_permutation(varr, varr);
+    (void) is_permutation(varr, varr, varr, varr, validating_equal{});
+    (void) is_permutation(varr, varr, validating_equal{});
+    (void) is_permutation(iarr, iarr, iarr, iarr, validating_equal{});
+    (void) is_permutation(iarr, iarr, validating_equal{});
+    (void) is_permutation(iarr, iarr, iarr, iarr, {}, validating_identity{});
+    (void) is_permutation(iarr, iarr, {}, validating_identity{});
+
+    (void) search(varr, varr, varr, varr);
+    (void) search(varr, varr);
+    (void) search(iarr, iarr, iarr, iarr, validating_equal{});
+    (void) search(iarr, iarr, validating_equal{});
+
+    (void) search_n(varr, varr, 0, validator{});
+    (void) search_n(varr, 0, validator{});
+    (void) search_n(iarr, iarr, 0, 0, validating_equal{});
+    (void) search_n(iarr, 0, 0, validating_equal{});
+
+#if _HAS_CXX23
+    (void) starts_with(varr, varr, varr, varr);
+    (void) starts_with(varr, varr);
+    (void) starts_with(iarr, iarr, iarr, iarr, validating_equal{});
+    (void) starts_with(iarr, iarr, validating_equal{});
+
+    (void) ends_with(varr, varr, varr, varr);
+    (void) ends_with(varr, varr);
+    (void) ends_with(iarr, iarr, iarr, iarr, validating_equal{});
+    (void) ends_with(iarr, iarr, validating_equal{});
+#endif // _HAS_CXX23
 }
 
-static_assert(test());
+// Separated test for ranges::count and equality
+static_assert(std::equality_comparable<validator>);
+static_assert(std::indirectly_comparable<validator*, validator*, std::equal_to<>>);
+static_assert(std::sortable<validator*>);
+
+constexpr bool test_ranges_count() {
+    using namespace std::ranges;
+
+    validator a[10]{};
+    assert(count(a, a + 10, nullptr) == 10);
+    assert(count(a, nullptr) == 10);
+    return true;
+}
+static_assert(test_ranges_count());
 #endif // _M_CEE


### PR DESCRIPTION
Towards #140 and #1596, separated from #4004.

The `std::search` overload taking a searcher is not yet handled. I'll created another PR for standard searchers.

- The modification of `_Adl_verify_range` is adopted from https://github.com/microsoft/STL/issues/1596#issuecomment-769841584 (thanks to @miscco).
- A single commit adding `_STD`, `_RANGES`, and `::`-qualifications.
  - I decided to add `::` for `__std_meow` functions because `_CSTD __std_meow` looks very weird to me.
- A single commit removing ADL-dependent structured binding declarations (where the unnamed variables are `pair`s).
  - I'm not sure whether we should avoid structured bindings or change the return type of `_Equal_rev_pred` to avoid ADL.
- A single commit speculatively implementing LWG-3969.
- A single commit for Clang-formatting.

Notes:
- Some _Ugly function names in `<execution>` are not yet qualified, because they take either no arguments or only integers.
- `_Ubegin` and `_Uend` are not qualified because they are function objects.