### PR TITLE
`<ranges>`: Avoid infinite recursion in `ranges::to` when the inner ranges match but the destination container is still not constructible

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -10383,7 +10383,7 @@ namespace ranges {
             }
             _RANGES copy(_Range, _Container_inserter<range_reference_t<_Rng>>(_Cont));
             return _Cont;
-        } else if constexpr (input_range<range_reference_t<_Rng>>) {
+        } else if constexpr (!_Ref_converts<_Rng, _Container> && input_range<range_reference_t<_Rng>>) {
             const auto _Xform = [](auto&& _Elem) {
                 return _RANGES to<range_value_t<_Container>>(_STD forward<decltype(_Elem)>(_Elem));
             };


### PR DESCRIPTION
Fixes GH-4141.

The standard says ([\[range.utility.conv.to\]](http://eel.is/c++draft/range.utility.conv.to)):

> - (2.1) If `C` does not satisfy `input_range` or `convertible_to<range_reference_t<R>, range_value_t<C>>` is `true`:
>     - [...]
> - (2.2) Otherwise, if `input_range<range_reference_t<R>>` is `true`:
>      ```
>      to<C>(r | views::transform([](auto&& elem) {
>          return to<range_value_t<C>>(std::forward<decltype(elem)>(elem));
>      }), std::forward<Args>(args)...);
>      ```

So `views::transform` shouldn't be used if `convertible_to<range_reference_t<R>, range_value_t<C>>` is `true`.

Notably, when step (2.2) recursively calls `ranges::to<C>`, it passes a `transform_view` whose `range_reference_t` is the same as `range_value_t<C>`. So in this case `convertible_to<range_reference_t<R>, range_value_t<C>>` is `convertible_to<range_value_t<C>, range_value_t<C>>`, which should usually be true, which prevents infinite recursion.

***But***, `convertible_to<range_value_t<C>, range_value_t<C>>` may be false (i.e. `range_value_t<C>` may not be move-constructible):

```c++
#include <ranges>

struct ImmovableRange {
    ImmovableRange(int*, int*);
    ImmovableRange(ImmovableRange&&) = delete;

    int* begin();
    int* end();
};

struct C {
    ImmovableRange* begin();
    ImmovableRange* end();
};

using R = int[1][2];

void test() {
    (void)std::ranges::to<C>(R{});  // infinite recursion
}
```

This PR does *not* fix this case, as I can't find where the standard addresses this. Maybe it really is a defect in the standard after all.