### PR TITLE
Various cleanups: `extern "C"`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -271,8 +271,6 @@ StatementMacros:
   - _STDEXT_END
   - _FMT_P2286_BEGIN
   - _FMT_P2286_END
-  - _EXTERN_C
-  - _END_EXTERN_C
   - _EXTERN_C_UNLESS_PURE
   - _END_EXTERN_C_UNLESS_PURE
 # TabWidth:        8

--- a/stl/inc/__msvc_print.hpp
+++ b/stl/inc/__msvc_print.hpp
@@ -22,7 +22,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-_EXTERN_C
+extern "C" {
 
 enum class __std_unicode_console_handle : intptr_t { _Invalid = -1 };
 
@@ -55,7 +55,7 @@ _NODISCARD _Success_(return == __std_win_error::_Success) __std_win_error
     __stdcall __std_print_to_unicode_console(_In_ __std_unicode_console_handle _Console_handle,
         _In_reads_(_Str_size) const char* _Str, _In_ size_t _Str_size) noexcept;
 
-_END_EXTERN_C
+} // extern "C"
 
 _STD_BEGIN
 

--- a/stl/inc/__msvc_sanitizer_annotate_container.hpp
+++ b/stl/inc/__msvc_sanitizer_annotate_container.hpp
@@ -125,13 +125,13 @@ extern const bool _Asan_vector_should_annotate;
 #ifdef _INSERT_STRING_ANNOTATION
 extern const bool _Asan_string_should_annotate;
 #endif
-}
+} // extern "C"
 
 #if defined(_INSERT_VECTOR_ANNOTATION) || defined(_INSERT_STRING_ANNOTATION)
 extern "C" {
 void __cdecl __sanitizer_annotate_contiguous_container(
     const void* _First, const void* _End, const void* _Old_last, const void* _New_last) noexcept;
-}
+} // extern "C"
 
 #ifdef _M_ARM64EC
 #pragma comment(linker, \

--- a/stl/inc/__msvc_system_error_abi.hpp
+++ b/stl/inc/__msvc_system_error_abi.hpp
@@ -22,14 +22,14 @@ _STL_DISABLE_CLANG_WARNINGS
 #define __CLRCALL_PURE_OR_STDCALL __stdcall
 #endif
 
-_EXTERN_C
+extern "C" {
 _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_get_string_size_without_trailing_whitespace(
     const char* _Str, size_t _Size) noexcept;
 
 _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_system_error_allocate_message(
     unsigned long _Message_id, char** _Ptr_str) noexcept;
 void __CLRCALL_PURE_OR_STDCALL __std_system_error_deallocate_message(char* _Str) noexcept;
-_END_EXTERN_C
+} // extern "C"
 
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/stl/inc/__msvc_tzdb.hpp
+++ b/stl/inc/__msvc_tzdb.hpp
@@ -19,7 +19,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-_EXTERN_C
+extern "C" {
 
 using __std_tzdb_epoch_milli = double;
 
@@ -92,7 +92,7 @@ void __stdcall __std_tzdb_delete_leap_seconds(__std_tzdb_leap_info* _Info) noexc
 _NODISCARD void* __stdcall __std_calloc_crt(size_t _Count, size_t _Size) noexcept;
 void __stdcall __std_free_crt(void* _Ptr) noexcept;
 
-_END_EXTERN_C
+} // extern "C"
 
 _STD_BEGIN
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -28,7 +28,7 @@ _STL_DISABLE_CLANG_WARNINGS
 
 #if _USE_STD_VECTOR_ALGORITHMS
 
-_EXTERN_C
+extern "C" {
 struct _Min_max_element_t {
     const void* _Min;
     const void* _Max;
@@ -59,7 +59,7 @@ const void* __stdcall __std_find_last_trivial_1(const void* _First, const void* 
 const void* __stdcall __std_find_last_trivial_2(const void* _First, const void* _Last, uint16_t _Val) noexcept;
 const void* __stdcall __std_find_last_trivial_4(const void* _First, const void* _Last, uint32_t _Val) noexcept;
 const void* __stdcall __std_find_last_trivial_8(const void* _First, const void* _Last, uint64_t _Val) noexcept;
-_END_EXTERN_C
+} // extern "C"
 
 template <class _Ty>
 _STD pair<_Ty*, _Ty*> __std_minmax_element(_Ty* _First, _Ty* _Last) noexcept {

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -83,6 +83,7 @@ extern "C" _NODISCARD char __stdcall __std_atomic_has_cmpxchg16b() noexcept;
 // should be mirrored. Also: if any macros are added they should be
 // #undefed in vcruntime as well
 
+extern "C" {
 enum {
     _Atomic_memory_order_relaxed,
     _Atomic_memory_order_consume,
@@ -91,6 +92,7 @@ enum {
     _Atomic_memory_order_acq_rel,
     _Atomic_memory_order_seq_cst,
 };
+} // extern "C"
 
 #ifndef _INVALID_MEMORY_ORDER
 #ifdef _DEBUG

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -282,9 +282,9 @@ extern "C" inline void _Atomic_thread_fence(const unsigned int _Order) noexcept 
 
 // End of code shared with vcruntime
 
-_EXTERN_C
+extern "C" {
 _Smtx_t* __stdcall __std_atomic_get_mutex(const void* _Key) noexcept;
-_END_EXTERN_C
+} // extern "C"
 // Padding bits should not participate in cmpxchg comparison starting in C++20.
 // Clang does not have __builtin_zero_non_value_bits to exclude these bits to implement this C++20 feature.
 // The EDG front-end substitutes everything and runs into incomplete types passed to atomic<T>.

--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -911,7 +911,7 @@ _EXPORT_STD using _CSTD isunordered;
 _STD_END
 
 #if _HAS_CXX17
-_EXTERN_C
+extern "C" {
 _NODISCARD _CRT_SATELLITE_2 double __stdcall __std_smf_assoc_laguerre(unsigned int, unsigned int, double) noexcept;
 _NODISCARD _CRT_SATELLITE_2 float __stdcall __std_smf_assoc_laguerref(unsigned int, unsigned int, float) noexcept;
 _NODISCARD _CRT_SATELLITE_2 double __stdcall __std_smf_assoc_legendre(unsigned int, unsigned int, double) noexcept;
@@ -956,7 +956,7 @@ _NODISCARD _CRT_SATELLITE_2 double __stdcall __std_smf_sph_neumann(unsigned int,
 _NODISCARD _CRT_SATELLITE_2 float __stdcall __std_smf_sph_neumannf(unsigned int, float) noexcept;
 _NODISCARD _CRT_SATELLITE_2 double __stdcall __std_smf_hypot3(double, double, double) noexcept;
 _NODISCARD _CRT_SATELLITE_2 float __stdcall __std_smf_hypot3f(float, float, float) noexcept;
-_END_EXTERN_C
+} // extern "C"
 
 _STD_BEGIN
 _EXPORT_STD _NODISCARD inline double assoc_laguerre(

--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -40,6 +40,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #ifndef _C_COMPLEX_T
 #define _C_COMPLEX_T // Also defined by UCRT <complex.h>
 
+extern "C" {
 struct _C_double_complex {
     double _Val[2];
 };
@@ -51,6 +52,7 @@ struct _C_float_complex {
 struct _C_ldouble_complex {
     long double _Val[2];
 };
+} // extern "C"
 #endif // _C_COMPLEX_T
 
 // complex _Val offsets

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -27,7 +27,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-_EXTERN_C
+extern "C" {
 #ifdef _M_CEE
 using __std_TP_WORK              = void;
 using __std_TP_CALLBACK_INSTANCE = void;
@@ -62,7 +62,7 @@ void __stdcall __std_execution_wait_on_uchar(
     _In_ const volatile unsigned char* _Address, _In_ unsigned char _Compare) noexcept;
 
 void __stdcall __std_execution_wake_by_address_all(_In_ const volatile void* _Address) noexcept;
-_END_EXTERN_C
+} // extern "C"
 
 _STD_BEGIN
 inline constexpr size_t _Oversubscription_multiplier = 32;

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -3717,10 +3717,10 @@ _NODISCARD_ASSUME_ALIGNED constexpr _Ty* assume_aligned(_Ty* const _Ptr) noexcep
 }
 #endif // _HAS_CXX20
 
-_EXTERN_C
+extern "C" {
 _CRTIMP2_PURE void __cdecl _Lock_shared_ptr_spin_lock() noexcept;
 _CRTIMP2_PURE void __cdecl _Unlock_shared_ptr_spin_lock() noexcept;
-_END_EXTERN_C
+} // extern "C"
 
 struct _Shared_ptr_spin_lock { // class to manage a spin lock for shared_ptr atomic operations
     _Shared_ptr_spin_lock() { // lock the spin lock

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -39,12 +39,12 @@ _STL_DISABLE_CLANG_WARNINGS
 // string buffer for cases when the size is not known before an attempt to fill it -- this potentially avoids both an
 // extra fill attempt and an extra allocation if the reserved size is enough.
 
+extern "C" {
 using _Stacktrace_string_fill_callback = size_t(__stdcall*)(char* _Data, size_t _Size, void* _Context) _NOEXCEPT_FNPTR;
 
 using _Stacktrace_string_fill = size_t(__stdcall*)(
     size_t _Size, void* _String, void* _Context, _Stacktrace_string_fill_callback _Callback);
 
-extern "C" {
 _NODISCARD unsigned short __stdcall __std_stacktrace_capture(unsigned long _Frames_to_skip,
     unsigned long _Frames_to_capture, void** _Back_trace, unsigned long* _Back_trace_hash) noexcept;
 

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -44,7 +44,7 @@ using _Stacktrace_string_fill_callback = size_t(__stdcall*)(char* _Data, size_t 
 using _Stacktrace_string_fill = size_t(__stdcall*)(
     size_t _Size, void* _String, void* _Context, _Stacktrace_string_fill_callback _Callback);
 
-_EXTERN_C
+extern "C" {
 _NODISCARD unsigned short __stdcall __std_stacktrace_capture(unsigned long _Frames_to_skip,
     unsigned long _Frames_to_capture, void** _Back_trace, unsigned long* _Back_trace_hash) noexcept;
 
@@ -64,7 +64,7 @@ _NODISCARD unsigned int __stdcall __std_stacktrace_source_line(const void* _Addr
 
 void __stdcall __std_stacktrace_to_string(
     const void* const* _Addresses, size_t _Size, void* _Str, _Stacktrace_string_fill _Fill) noexcept(false);
-_END_EXTERN_C
+} // extern "C"
 
 _STD_BEGIN
 inline size_t __stdcall _Stacktrace_string_fill_impl(

--- a/stl/inc/syncstream
+++ b/stl/inc/syncstream
@@ -24,10 +24,10 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 #undef emit
 
-_EXTERN_C
+extern "C" {
 _NODISCARD _STD shared_mutex* __stdcall __std_acquire_shared_mutex_for_instance(void* _Ptr) noexcept;
 void __stdcall __std_release_shared_mutex_for_instance(void* _Ptr) noexcept;
-_END_EXTERN_C
+} // extern "C"
 
 _STD_BEGIN
 

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -711,9 +711,9 @@ _EXPORT_STD _NODISCARD inline const error_category& system_category() noexcept {
 _STD_END
 
 #if _HAS_CXX17
-_EXTERN_C
+extern "C" {
 enum class __std_win_error : unsigned long;
-_END_EXTERN_C
+} // extern "C"
 
 _STD_BEGIN
 // We would really love to use the proper way of building error_code by specializing

--- a/stl/inc/xatomic_wait.h
+++ b/stl/inc/xatomic_wait.h
@@ -21,7 +21,7 @@ _STL_DISABLE_CLANG_WARNINGS
 _INLINE_VAR constexpr unsigned long long _Atomic_wait_no_deadline = 0xFFFF'FFFF'FFFF'FFFF;
 _INLINE_VAR constexpr unsigned long _Atomic_wait_no_timeout       = 0xFFFF'FFFF; // Pass as partial timeout
 
-_EXTERN_C
+extern "C" {
 enum class __std_atomic_api_level : unsigned long {
     __not_set,
     __detecting,
@@ -61,7 +61,7 @@ void __stdcall __std_atomic_notify_all_indirect(const void* _Storage) noexcept;
 unsigned long long __stdcall __std_atomic_wait_get_deadline(unsigned long long _Timeout) noexcept;
 unsigned long __stdcall __std_atomic_wait_get_remaining_timeout(unsigned long long _Deadline) noexcept;
 
-_END_EXTERN_C
+} // extern "C"
 
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/stl/inc/xfilesystem_abi.h
+++ b/stl/inc/xfilesystem_abi.h
@@ -18,7 +18,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-_EXTERN_C
+extern "C" {
 inline constexpr size_t __std_fs_max_path      = 260; // #define MAX_PATH          260
 inline constexpr size_t __std_fs_temp_path_max = __std_fs_max_path + 1;
 
@@ -76,11 +76,11 @@ enum class __std_fs_file_attr : unsigned long {
 
     _Invalid = 0xFFFFFFFF, // #define INVALID_FILE_ATTRIBUTES ((DWORD)-1)
 };
-_END_EXTERN_C
+} // extern "C"
 
 _BITMASK_OPS(_EMPTY_ARGUMENT, __std_fs_file_attr)
 
-_EXTERN_C
+extern "C" {
 enum class __std_fs_reparse_tag : unsigned long {
     _None        = 0,
     _Mount_point = (0xA0000003L), // #define IO_REPARSE_TAG_MOUNT_POINT              (0xA0000003L)
@@ -121,11 +121,11 @@ enum class __std_fs_stats_flags : unsigned long {
 
     _All_data = _Attributes | _Reparse_tag | _File_size | _Link_count | _Last_write_time
 };
-_END_EXTERN_C
+} // extern "C"
 
 _BITMASK_OPS(_EMPTY_ARGUMENT, __std_fs_stats_flags)
 
-_EXTERN_C
+extern "C" {
 struct __std_fs_stats {
     long long _Last_write_time;
     unsigned long long _File_size;
@@ -197,21 +197,21 @@ enum class __std_access_rights : unsigned long {
     //                                   | FILE_WRITE_EA | FILE_APPEND_DATA | SYNCHRONIZE)
     _File_generic_write = 0x00120116,
 };
-_END_EXTERN_C
+} // extern "C"
 
 _BITMASK_OPS(_EMPTY_ARGUMENT, __std_access_rights)
 
-_EXTERN_C
+extern "C" {
 enum class __std_fs_file_flags : unsigned long {
     _None               = 0,
     _Backup_semantics   = 0x02000000, // #define FILE_FLAG_BACKUP_SEMANTICS      0x02000000
     _Open_reparse_point = 0x00200000, // #define FILE_FLAG_OPEN_REPARSE_POINT    0x00200000
 };
-_END_EXTERN_C
+} // extern "C"
 
 _BITMASK_OPS(_EMPTY_ARGUMENT, __std_fs_file_flags)
 
-_EXTERN_C
+extern "C" {
 enum class __std_fs_file_handle : intptr_t { _Invalid = -1 };
 
 enum class __std_code_page : unsigned int { _Acp = 0, _Utf8 = 65001 };
@@ -234,11 +234,11 @@ enum class __std_fs_copy_options {
     _Overwrite_existing = 0x2,
     _Update_existing    = 0x4,
 };
-_END_EXTERN_C
+} // extern "C"
 
 _BITMASK_OPS(_EMPTY_ARGUMENT, __std_fs_copy_options)
 
-_EXTERN_C
+extern "C" {
 _NODISCARD __std_ulong_and_error __stdcall __std_fs_get_full_path_name(_In_z_ const wchar_t* _Source,
     _In_ unsigned long _Target_size, _Out_writes_z_(_Target_size) wchar_t* _Target) noexcept;
 
@@ -352,7 +352,7 @@ _NODISCARD __std_win_error __stdcall __std_fs_resize_file(_In_z_ const wchar_t* 
 
 _NODISCARD __std_win_error __stdcall __std_fs_space(_In_z_ const wchar_t* _Target, _Out_ uintmax_t* _Available,
     _Out_ uintmax_t* _Total_bytes, _Out_ uintmax_t* _Free_bytes) noexcept;
-_END_EXTERN_C
+} // extern "C"
 
 _STD_BEGIN
 struct _Fs_file {

--- a/stl/inc/xlocinfo
+++ b/stl/inc/xlocinfo
@@ -81,7 +81,7 @@ _CRTIMP2_PURE wchar_t __CLRCALL_PURE_OR_CDECL _Towupper(wchar_t, const _Ctypevec
 
 _END_EXTERN_C_UNLESS_PURE
 
-_EXTERN_C
+extern "C" {
 // These _should_ be explicitly `noexcept` but cannot be made so here because
 // the primary declarations in the C runtime headers are not.
 
@@ -102,7 +102,7 @@ _ACRTIMP void* __cdecl _W_Gettnames();
 
 _Success_(return > 0) _ACRTIMP size_t __cdecl _Wcsftime(
     _Out_writes_z_(_Maxsize) wchar_t*, _In_ size_t _Maxsize, _In_z_ const wchar_t*, _In_ const tm*, _In_opt_ void*);
-_END_EXTERN_C
+} // extern "C"
 
 _STD_BEGIN
 extern "C++" class _CRTIMP2_PURE_IMPORT _Timevec { // smart pointer to information used by _Strftime

--- a/stl/inc/xthreads.h
+++ b/stl/inc/xthreads.h
@@ -18,7 +18,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-_EXTERN_C
+extern "C" {
 using _Thrd_id_t = unsigned int;
 struct _Thrd_t { // thread identifier for Win32
     void* _Hnd; // Win32 HANDLE
@@ -130,7 +130,7 @@ _CRTIMP2_PURE _Thrd_result __cdecl _Cnd_signal(_Cnd_t) noexcept; // TRANSITION, 
 _CRTIMP2_PURE void __cdecl _Cnd_register_at_thread_exit(_Cnd_t, _Mtx_t, int*) noexcept;
 _CRTIMP2_PURE void __cdecl _Cnd_unregister_at_thread_exit(_Mtx_t) noexcept;
 _CRTIMP2_PURE void __cdecl _Cnd_do_broadcast_at_thread_exit() noexcept;
-_END_EXTERN_C
+} // extern "C"
 
 _STD_BEGIN
 enum { // constants for error codes

--- a/stl/inc/xtimec.h
+++ b/stl/inc/xtimec.h
@@ -17,7 +17,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-_EXTERN_C
+extern "C" {
 
 #ifdef _CRTBLD
 _CRTIMP2_PURE long __cdecl _Xtime_diff_to_millis2(const _timespec64*, const _timespec64*) noexcept;
@@ -33,7 +33,7 @@ void _Timespec64_get_sys(_timespec64*) noexcept;
 _CRTIMP2_PURE long long __cdecl _Query_perf_counter() noexcept;
 _CRTIMP2_PURE long long __cdecl _Query_perf_frequency() noexcept;
 
-_END_EXTERN_C
+} // extern "C"
 
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -49,7 +49,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #endif // ^^^ no support for vector algorithms ^^^
 
 #if _USE_STD_VECTOR_ALGORITHMS
-_EXTERN_C
+extern "C" {
 // The "noalias" attribute tells the compiler optimizer that pointers going into these hand-vectorized algorithms
 // won't be stored beyond the lifetime of the function, and that the function will only reference arrays denoted by
 // those pointers. The optimizer also assumes in that case that a pointer parameter is not returned to the caller via
@@ -92,7 +92,7 @@ const void* __stdcall __std_max_element_1(const void* _First, const void* _Last,
 const void* __stdcall __std_max_element_2(const void* _First, const void* _Last, bool _Signed) noexcept;
 const void* __stdcall __std_max_element_4(const void* _First, const void* _Last, bool _Signed) noexcept;
 const void* __stdcall __std_max_element_8(const void* _First, const void* _Last, bool _Signed) noexcept;
-_END_EXTERN_C
+} // extern "C"
 
 template <class _Ty, class _TVal>
 __declspec(noalias) size_t __std_count_trivial(_Ty* _First, _Ty* _Last, const _TVal _Val) noexcept {

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1954,15 +1954,12 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 
 #define _CSTD ::
 
-#define _EXTERN_C     extern "C" {
-#define _END_EXTERN_C }
-
 #ifdef _M_CEE_PURE
 #define _EXTERN_C_UNLESS_PURE
 #define _END_EXTERN_C_UNLESS_PURE
 #else // ^^^ defined(_M_CEE_PURE) / !defined(_M_CEE_PURE) vvv
-#define _EXTERN_C_UNLESS_PURE     _EXTERN_C
-#define _END_EXTERN_C_UNLESS_PURE _END_EXTERN_C
+#define _EXTERN_C_UNLESS_PURE     extern "C" {
+#define _END_EXTERN_C_UNLESS_PURE } // extern "C"
 #endif // ^^^ !defined(_M_CEE_PURE) ^^^
 
 #if defined(MRTDLL) && !defined(_CRTBLD)

--- a/stl/src/asan.cpp
+++ b/stl/src/asan.cpp
@@ -5,5 +5,5 @@ namespace std {
     extern "C" {
     extern const bool _Asan_string_should_annotate = true;
     extern const bool _Asan_vector_should_annotate = true;
-    }
+    } // extern "C"
 } // namespace std

--- a/stl/src/asan_noop.cpp
+++ b/stl/src/asan_noop.cpp
@@ -7,4 +7,4 @@ extern const bool _Asan_vector_should_annotate_default = false;
 
 void __cdecl __sanitizer_annotate_contiguous_container_default(
     const void*, const void*, const void*, const void*) noexcept {}
-}
+} // extern "C"

--- a/stl/src/atomic.cpp
+++ b/stl/src/atomic.cpp
@@ -11,7 +11,7 @@ namespace {
     SRWLOCK _Shared_ptr_lock = SRWLOCK_INIT;
 } // unnamed namespace
 
-_EXTERN_C
+extern "C" {
 
 _CRTIMP2_PURE void __cdecl _Lock_shared_ptr_spin_lock() noexcept { // TRANSITION, ABI: "spin_lock" name is outdated
     AcquireSRWLockExclusive(&_Shared_ptr_lock);
@@ -22,4 +22,4 @@ _CRTIMP2_PURE void __cdecl _Unlock_shared_ptr_spin_lock() noexcept { // release 
     ReleaseSRWLockExclusive(&_Shared_ptr_lock);
 }
 
-_END_EXTERN_C
+} // extern "C"

--- a/stl/src/atomic_wait.cpp
+++ b/stl/src/atomic_wait.cpp
@@ -219,7 +219,7 @@ namespace {
     }
 } // unnamed namespace
 
-_EXTERN_C
+extern "C" {
 int __stdcall __std_atomic_wait_direct(const void* const _Storage, void* const _Comparand, const size_t _Size,
     const unsigned long _Remaining_timeout) noexcept {
 #if _ATOMIC_WAIT_ON_ADDRESS_STATICALLY_AVAILABLE == 0
@@ -431,4 +431,4 @@ _Smtx_t* __stdcall __std_atomic_get_mutex(const void* const _Key) noexcept {
     return _Value;
 #endif // ^^^ _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0
 }
-_END_EXTERN_C
+} // extern "C"

--- a/stl/src/cond.cpp
+++ b/stl/src/cond.cpp
@@ -11,7 +11,7 @@
 
 #include "primitives.hpp"
 
-_EXTERN_C
+extern "C" {
 
 struct _Cnd_internal_imp_t { // condition variable implementation for ConcRT
     typename std::_Aligned_storage<_Cnd_internal_imp_size, _Cnd_internal_imp_alignment>::type cv;
@@ -102,7 +102,7 @@ _CRTIMP2_PURE _Thrd_result __cdecl _Cnd_broadcast(const _Cnd_t cond) noexcept { 
     return _Thrd_result::_Success; // TRANSITION, ABI: Always succeeds
 }
 
-_END_EXTERN_C
+} // extern "C"
 
 /*
  * This file is derived from software bearing the following

--- a/stl/src/cthread.cpp
+++ b/stl/src/cthread.cpp
@@ -37,7 +37,7 @@ namespace {
     }
 } // unnamed namespace
 
-_EXTERN_C
+extern "C" {
 
 // TRANSITION, ABI: _Thrd_exit() is preserved for binary compatibility
 [[noreturn]] _CRTIMP2_PURE void __cdecl _Thrd_exit(int res) noexcept { // terminate execution of calling thread
@@ -136,7 +136,7 @@ _CRTIMP2_PURE _Thrd_result __cdecl _Thrd_create(_Thrd_t* thr, _Thrd_start_t func
     return res;
 }
 
-_END_EXTERN_C
+} // extern "C"
 
 /*
  * This file is derived from software bearing the following

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -187,7 +187,7 @@ namespace {
     }
 } // unnamed namespace
 
-_EXTERN_C
+extern "C" {
 
 [[nodiscard]] __std_ulong_and_error __stdcall __std_fs_get_full_path_name(_In_z_ const wchar_t* _Source,
     _In_ unsigned long _Target_size, _Out_writes_z_(_Target_size) wchar_t* _Target) noexcept { // calls GetFullPathNameW
@@ -1028,4 +1028,4 @@ namespace {
     return __std_win_error{GetLastError()};
 }
 
-_END_EXTERN_C
+} // extern "C"

--- a/stl/src/locale0.cpp
+++ b/stl/src/locale0.cpp
@@ -78,7 +78,7 @@ _STD_END
 #include <cstdlib>
 #include <locale>
 
-_EXTERN_C
+extern "C" {
 
 void __CLRCALL_OR_CDECL _Deletegloballocale(void* ptr) noexcept { // delete a global locale reference
     std::locale::_Locimp* locptr = *static_cast<std::locale::_Locimp**>(ptr);
@@ -96,7 +96,7 @@ static void __CLRCALL_PURE_OR_CDECL tidy_global() noexcept { // delete static gl
     _END_LOCK()
 }
 
-_END_EXTERN_C
+} // extern "C"
 
 _MRTIMP2 void __cdecl _Atexit(void(__cdecl*)());
 

--- a/stl/src/mutex.cpp
+++ b/stl/src/mutex.cpp
@@ -13,7 +13,7 @@
 
 #include "primitives.hpp"
 
-_EXTERN_C
+extern "C" {
 
 // TRANSITION, ABI: exported only for ABI compat
 [[noreturn]] _CRTIMP2_PURE void __cdecl _Thrd_abort(const char* msg) noexcept { // abort on precondition failure
@@ -191,7 +191,7 @@ _CRTIMP2_PURE void* __cdecl _Mtx_getconcrtcs(_Mtx_t mtx) noexcept { // get inter
     return &mtx->_Critical_section;
 }
 
-_END_EXTERN_C
+} // extern "C"
 
 /*
  * This file is derived from software bearing the following

--- a/stl/src/print.cpp
+++ b/stl/src/print.cpp
@@ -12,7 +12,7 @@
 
 #include <Windows.h>
 
-_EXTERN_C
+extern "C" {
 
 [[nodiscard]] _Success_(return._Error == __std_win_error::_Success) __std_unicode_console_retrieval_result
     __stdcall __std_get_unicode_console_handle_from_file_stream(_In_ FILE* const _Stream) noexcept {
@@ -52,7 +52,7 @@ _EXTERN_C
         ._Error = __std_win_error::_Success};
 }
 
-_END_EXTERN_C
+} // extern "C"
 
 namespace {
     class _Allocated_string {
@@ -222,7 +222,7 @@ namespace {
     }
 } // unnamed namespace
 
-_EXTERN_C
+extern "C" {
 
 [[nodiscard]] _Success_(return == __std_win_error::_Success) __std_win_error
     __stdcall __std_print_to_unicode_console(_In_ const __std_unicode_console_handle _Console_handle,
@@ -266,4 +266,4 @@ _EXTERN_C
     }
 }
 
-_END_EXTERN_C
+} // extern "C"

--- a/stl/src/sharedmutex.cpp
+++ b/stl/src/sharedmutex.cpp
@@ -40,4 +40,4 @@ void __cdecl _Smtx_unlock_shared(_Smtx_t* smtx) noexcept { // unlock non-exclusi
 void __stdcall _Thrd_sleep_for(const unsigned long ms) noexcept { // suspend current thread for `ms` milliseconds
     Sleep(ms);
 }
-}
+} // extern "C"

--- a/stl/src/sharedmutex.cpp
+++ b/stl/src/sharedmutex.cpp
@@ -5,9 +5,9 @@
 
 // these declarations must be in sync with those in xthreads.h
 
-using _Smtx_t = void*;
-
 extern "C" {
+
+using _Smtx_t = void*;
 
 static_assert(sizeof(_Smtx_t) == sizeof(SRWLOCK), "_Smtx_t must be the same size as SRWLOCK.");
 static_assert(alignof(_Smtx_t) == alignof(SRWLOCK), "_Smtx_t must be the same alignment as SRWLOCK.");

--- a/stl/src/special_math.cpp
+++ b/stl/src/special_math.cpp
@@ -58,7 +58,7 @@ namespace {
     }
 } // unnamed namespace
 
-_EXTERN_C
+extern "C" {
 [[nodiscard]] _CRT_SATELLITE_2 double __stdcall __std_smf_assoc_laguerre(
     const unsigned int _Pn, const unsigned int _Pm, const double _Px) noexcept {
     if (_STD isnan(_Px)) {
@@ -475,7 +475,7 @@ _EXTERN_C
 
     return _Boost_call([=] { return ::boost::math::sph_neumann(_Pn, _Px); });
 }
-_END_EXTERN_C
+} // extern "C"
 
 namespace {
     template <class _Ty>
@@ -510,7 +510,7 @@ namespace {
     }
 } // unnamed namespace
 
-_EXTERN_C
+extern "C" {
 [[nodiscard]] _CRT_SATELLITE_2 double __stdcall __std_smf_hypot3(
     const double _Dx, const double _Dy, const double _Dz) noexcept {
     return _Hypot3(_Dx, _Dy, _Dz);
@@ -520,4 +520,4 @@ _EXTERN_C
     const float _Dx, const float _Dy, const float _Dz) noexcept {
     return _Hypot3(_Dx, _Dy, _Dz);
 }
-_END_EXTERN_C
+} // extern "C"

--- a/stl/src/stacktrace.cpp
+++ b/stl/src/stacktrace.cpp
@@ -245,7 +245,7 @@ namespace {
     }
 } // namespace
 
-_EXTERN_C
+extern "C" {
 #pragma optimize("", off) // inhibit tail call optimization to have consistent _Frames_to_skip adjustment here
 [[nodiscard]] unsigned short __stdcall __std_stacktrace_capture(unsigned long _Frames_to_skip,
     const unsigned long _Frames_to_capture, void** const _Back_trace, unsigned long* const _Back_trace_hash) noexcept {
@@ -330,4 +330,4 @@ void __stdcall __std_stacktrace_to_string(const void* const* const _Addresses, c
         off = locked_data.address_to_string(_Addresses[i], _Str, off, _Fill);
     }
 }
-_END_EXTERN_C
+} // extern "C"

--- a/stl/src/stacktrace.cpp
+++ b/stl/src/stacktrace.cpp
@@ -13,10 +13,12 @@
 
 // The below function pointer types must be in sync with <stacktrace>
 
+extern "C" {
 using _Stacktrace_string_fill_callback = size_t(__stdcall*)(char* _Data, size_t _Size, void* _Context) _NOEXCEPT_FNPTR;
 
 using _Stacktrace_string_fill = size_t(__stdcall*)(
     size_t _Size, void* _String, void* _Context, _Stacktrace_string_fill_callback _Callback);
+} // extern "C"
 
 namespace {
     template <class F>

--- a/stl/src/syncstream.cpp
+++ b/stl/src/syncstream.cpp
@@ -30,7 +30,7 @@ namespace {
     _STD shared_mutex _Lookup_mutex;
 } // unnamed namespace
 
-_EXTERN_C
+extern "C" {
 
 // TRANSITION, ABI: This returns a pointer to a C++ type.
 // A flat C interface would return an opaque handle and would provide separate functions for locking and unlocking.
@@ -55,4 +55,4 @@ void __stdcall __std_release_shared_mutex_for_instance(void* _Ptr) noexcept {
     }
 }
 
-_END_EXTERN_C
+} // extern "C"

--- a/stl/src/syserror_import_lib.cpp
+++ b/stl/src/syserror_import_lib.cpp
@@ -25,7 +25,7 @@ namespace {
     constexpr _Whitespace_bitmap_t _Whitespace_bitmap;
 } // unnamed namespace
 
-_EXTERN_C
+extern "C" {
 [[nodiscard]] size_t __CLRCALL_PURE_OR_STDCALL __std_get_string_size_without_trailing_whitespace(
     const char* const _Str, size_t _Size) noexcept {
     while (_Size != 0 && _Whitespace_bitmap._Test(_Str[_Size - 1])) {
@@ -56,4 +56,4 @@ _EXTERN_C
 void __CLRCALL_PURE_OR_STDCALL __std_system_error_deallocate_message(char* const _Str) noexcept {
     LocalFree(_Str);
 }
-_END_EXTERN_C
+} // extern "C"

--- a/stl/src/tzdb.cpp
+++ b/stl/src/tzdb.cpp
@@ -338,7 +338,7 @@ namespace {
     }
 } // unnamed namespace
 
-_EXTERN_C
+extern "C" {
 
 [[nodiscard]] __std_tzdb_time_zones_info* __stdcall __std_tzdb_get_time_zones() noexcept {
     // On exit---
@@ -640,4 +640,4 @@ void __stdcall __std_free_crt(void* p) noexcept {
     _free_crt(p);
 }
 
-_END_EXTERN_C
+} // extern "C"

--- a/stl/src/xlock.cpp
+++ b/stl/src/xlock.cpp
@@ -122,13 +122,13 @@ void __cdecl _Lockit::_Lockit_dtor(int kind) noexcept { // unlock the mutex
     }
 }
 
-_EXTERN_C
+extern "C" {
 void _Lock_at_thread_exit_mutex() noexcept { // lock the at-thread-exit mutex
     _Mtxlock(&mtx[_LOCK_AT_THREAD_EXIT]);
 }
 void _Unlock_at_thread_exit_mutex() noexcept { // unlock the at-thread-exit mutex
     _Mtxunlock(&mtx[_LOCK_AT_THREAD_EXIT]);
 }
-_END_EXTERN_C
+} // extern "C"
 
 _STD_END

--- a/stl/src/xnotify.cpp
+++ b/stl/src/xnotify.cpp
@@ -27,7 +27,7 @@ namespace {
     _At_thread_exit_block _Thread_exit_data;
 } // unnamed namespace
 
-_EXTERN_C
+extern "C" {
 
 void _Lock_at_thread_exit_mutex() noexcept;
 void _Unlock_at_thread_exit_mutex() noexcept;
@@ -109,7 +109,7 @@ _CRTIMP2_PURE void __cdecl _Cnd_do_broadcast_at_thread_exit() noexcept {
     _Unlock_at_thread_exit_mutex();
 }
 
-_END_EXTERN_C
+} // extern "C"
 
 /*
  * This file is derived from software bearing the following

--- a/stl/src/xonce2.cpp
+++ b/stl/src/xonce2.cpp
@@ -10,7 +10,7 @@
 // environments that can't use /ALTERNATENAME.
 // They were originally specific to /clr but are now used in other scenarios.
 
-_EXTERN_C
+extern "C" {
 
 int __stdcall __std_init_once_begin_initialize_clr(
     void** _LpInitOnce, unsigned long _DwFlags, int* _FPending, void** _LpContext) noexcept {
@@ -38,4 +38,4 @@ int __stdcall __std_init_once_complete_clr(void** _LpInitOnce, unsigned long _Dw
 #error Unknown architecture
 #endif // ^^^ unknown architecture ^^^
 
-_END_EXTERN_C
+} // extern "C"

--- a/stl/src/xtime.cpp
+++ b/stl/src/xtime.cpp
@@ -44,7 +44,7 @@ namespace {
     }
 } // namespace
 
-_EXTERN_C
+extern "C" {
 
 _CRTIMP2_PURE long long __cdecl _Xtime_get_ticks() noexcept {
     // get system time in 100-nanosecond intervals since the epoch
@@ -106,7 +106,7 @@ _CRTIMP2_PURE long long __cdecl _Query_perf_frequency() noexcept { // get freque
     return freq;
 }
 
-_END_EXTERN_C
+} // extern "C"
 
 /*
  * This file is derived from software bearing the following

--- a/stl/src/xxxdtent.hpp
+++ b/stl/src/xxxdtent.hpp
@@ -6,7 +6,7 @@
 #include "xmath.hpp"
 
 #if !defined(MRTDLL)
-_EXTERN_C
+extern "C" {
 #endif // defined(MRTDLL)
 
 // macros
@@ -89,5 +89,5 @@ FTYPE FNAME(Dtento)(FTYPE* xpx, long n, int* perr) noexcept { // compute *px * 1
 }
 
 #if !defined(MRTDLL)
-_END_EXTERN_C
+} // extern "C"
 #endif // !defined(MRTDLL)

--- a/stl/src/xxxprec.hpp
+++ b/stl/src/xxxprec.hpp
@@ -11,7 +11,7 @@
 #pragma warning(disable : _STL_DISABLED_WARNINGS)
 
 #if !defined(MRTDLL)
-_EXTERN_C
+extern "C" {
 #endif // defined(MRTDLL)
 
 #define BIG_EXP   (2 * FMAXEXP) // very large, as exponents go
@@ -345,7 +345,7 @@ FTYPE* FNAME(Xp_mulx)(FTYPE* p, int n, const FTYPE* q, int m, FTYPE* ptemp2) noe
 }
 
 #if !defined(MRTDLL)
-_END_EXTERN_C
+} // extern "C"
 #endif // !defined(MRTDLL)
 
 #pragma warning(pop)


### PR DESCRIPTION
We've accumulated inconsistency between using our `_EXTERN_C` macro and directly saying `extern "C"`:

https://github.com/microsoft/STL/blob/f392449fb72d1a387ac5025d508e8442914477f9/stl/inc/memory#L3720-L3723
https://github.com/microsoft/STL/blob/f392449fb72d1a387ac5025d508e8442914477f9/stl/inc/__msvc_sanitizer_annotate_container.hpp#L131-L134

The macro used to be important when some of our headers were dual C and C++. Now that they're always C++, and that we don't expect to play special games with `extern "C"` in the foreseeable future, we should resolve this inconsistency and favor dropping the macro.

(In contrast, we're quite disciplined about `_STD_BEGIN` in product code, and I do want to play special games with it soon.)

* Replace: `_EXTERN_C ... _END_EXTERN_C` => `extern "C" { ... } // extern "C"`
* Add `// extern "C"` comments.
* Wrap `stacktrace`'s function pointer typedefs in `extern "C"`.
  + It doesn't really matter because typedefs are "transparent" (they don't create new types), but I believe it's desirable for the signatures of `extern "C"` functions to restrict themselves to mentioning only things that are within the `extern "C"` universe. During the initial modularization effort, I overhauled `extern "C"` functions to mention only `extern "C"` structs, where it did matter.
* `sharedmutex.cpp`: Move the `_Smtx_t` typedef within `extern "C"`.
  + Again, it doesn't really matter for typedefs, but this is now consistent with `stl/inc/xthreads.h`: https://github.com/microsoft/STL/blob/f392449fb72d1a387ac5025d508e8442914477f9/stl/inc/xthreads.h#L21-L28
* Mark `_Atomic_memory_order_meow` as `extern "C"` to match vcruntime.
* Mark `_C_meow_complex` as `extern "C"` to match the UCRT.
