### PR TITLE
Various cleanups: Impl and wrapper functions for vector algorithms

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -61,6 +61,7 @@ const void* __stdcall __std_find_last_trivial_4(const void* _First, const void* 
 const void* __stdcall __std_find_last_trivial_8(const void* _First, const void* _Last, uint64_t _Val) noexcept;
 _END_EXTERN_C
 
+_STD_BEGIN
 template <class _Ty>
 _STD pair<_Ty*, _Ty*> __std_minmax_element(_Ty* _First, _Ty* _Last) noexcept {
     constexpr bool _Signed = _STD is_signed_v<_Ty>;
@@ -102,6 +103,7 @@ _Ty* __std_find_last_trivial(_Ty* _First, _Ty* _Last, const _TVal _Val) noexcept
         static_assert(_STD _Always_false<_Ty>, "Unexpected size");
     }
 }
+_STD_END
 #endif // _USE_STD_VECTOR_ALGORITHMS
 
 _STD_BEGIN
@@ -9848,7 +9850,7 @@ namespace ranges {
                 if (!_STD is_constant_evaluated()) {
                     const auto _First_ptr = _STD to_address(_First);
                     const auto _Last_ptr  = _First_ptr + (_Last - _First);
-                    const auto _Result    = _CSTD __std_minmax_element(_First_ptr, _Last_ptr);
+                    const auto _Result    = _STD __std_minmax_element(_First_ptr, _Last_ptr);
                     if constexpr (is_pointer_v<_It>) {
                         return {_Result.first, _Result.second};
                     } else {
@@ -10046,7 +10048,7 @@ namespace ranges {
                 if (!_STD is_constant_evaluated()) {
                     const auto _First_ptr = _STD to_address(_First);
                     const auto _Last_ptr  = _First_ptr + (_Last - _First);
-                    const auto _Result    = _CSTD __std_minmax_element(_First_ptr, _Last_ptr);
+                    const auto _Result    = _STD __std_minmax_element(_First_ptr, _Last_ptr);
                     return {static_cast<_Vty>(*_Result.first), static_cast<_Vty>(*_Result.second)};
                 }
             }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -94,6 +94,7 @@ const void* __stdcall __std_max_element_4(const void* _First, const void* _Last,
 const void* __stdcall __std_max_element_8(const void* _First, const void* _Last, bool _Signed) noexcept;
 _END_EXTERN_C
 
+_STD_BEGIN
 template <class _Ty, class _TVal>
 __declspec(noalias) size_t __std_count_trivial(_Ty* _First, _Ty* _Last, const _TVal _Val) noexcept {
     if constexpr (_STD is_pointer_v<_TVal> || _STD is_null_pointer_v<_TVal>) {
@@ -186,6 +187,7 @@ _Ty* __std_max_element(_Ty* _First, _Ty* _Last) noexcept {
         static_assert(_STD _Always_false<_Ty>, "Unexpected size");
     }
 }
+_STD_END
 
 #endif // _USE_STD_VECTOR_ALGORITHMS
 

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -1240,7 +1240,7 @@ namespace {
     // In optimized builds it avoids an extra call, as this function is too large to inline.
 
     template <class _Traits, class _Ty>
-    const void* __stdcall __std_find_trivial_unsized(const void* _First, const _Ty _Val) noexcept {
+    const void* __stdcall __std_find_trivial_unsized_impl(const void* _First, const _Ty _Val) noexcept {
 #ifndef _M_ARM64EC
         if (_Use_avx2()) {
             _Zeroupper_on_exit _Guard; // TRANSITION, DevCom-10331414
@@ -1326,7 +1326,7 @@ namespace {
     }
 
     template <class _Traits, class _Ty>
-    const void* __stdcall __std_find_trivial(const void* _First, const void* _Last, _Ty _Val) noexcept {
+    const void* __stdcall __std_find_trivial_impl(const void* _First, const void* _Last, _Ty _Val) noexcept {
 #ifndef _M_ARM64EC
         size_t _Size_bytes = _Byte_length(_First, _Last);
 
@@ -1380,7 +1380,7 @@ namespace {
     }
 
     template <class _Traits, class _Ty>
-    const void* __stdcall __std_find_last_trivial(const void* _First, const void* _Last, _Ty _Val) noexcept {
+    const void* __stdcall __std_find_last_trivial_impl(const void* _First, const void* _Last, _Ty _Val) noexcept {
         const void* const _Real_last = _Last;
 #ifndef _M_ARM64EC
         size_t _Size_bytes = _Byte_length(_First, _Last);
@@ -1439,7 +1439,7 @@ namespace {
 
     template <class _Traits, class _Ty>
     __declspec(noalias) size_t
-        __stdcall __std_count_trivial(const void* _First, const void* const _Last, const _Ty _Val) noexcept {
+        __stdcall __std_count_trivial_impl(const void* _First, const void* const _Last, const _Ty _Val) noexcept {
         size_t _Result = 0;
 
 #ifndef _M_ARM64EC
@@ -1488,79 +1488,79 @@ namespace {
 extern "C" {
 
 const void* __stdcall __std_find_trivial_unsized_1(const void* const _First, const uint8_t _Val) noexcept {
-    return __std_find_trivial_unsized<_Find_traits_1>(_First, _Val);
+    return __std_find_trivial_unsized_impl<_Find_traits_1>(_First, _Val);
 }
 
 const void* __stdcall __std_find_trivial_unsized_2(const void* const _First, const uint16_t _Val) noexcept {
-    return __std_find_trivial_unsized<_Find_traits_2>(_First, _Val);
+    return __std_find_trivial_unsized_impl<_Find_traits_2>(_First, _Val);
 }
 
 const void* __stdcall __std_find_trivial_unsized_4(const void* const _First, const uint32_t _Val) noexcept {
-    return __std_find_trivial_unsized<_Find_traits_4>(_First, _Val);
+    return __std_find_trivial_unsized_impl<_Find_traits_4>(_First, _Val);
 }
 
 const void* __stdcall __std_find_trivial_unsized_8(const void* const _First, const uint64_t _Val) noexcept {
-    return __std_find_trivial_unsized<_Find_traits_8>(_First, _Val);
+    return __std_find_trivial_unsized_impl<_Find_traits_8>(_First, _Val);
 }
 
 const void* __stdcall __std_find_trivial_1(
     const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return __std_find_trivial<_Find_traits_1>(_First, _Last, _Val);
+    return __std_find_trivial_impl<_Find_traits_1>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_trivial_2(
     const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return __std_find_trivial<_Find_traits_2>(_First, _Last, _Val);
+    return __std_find_trivial_impl<_Find_traits_2>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_trivial_4(
     const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return __std_find_trivial<_Find_traits_4>(_First, _Last, _Val);
+    return __std_find_trivial_impl<_Find_traits_4>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_trivial_8(
     const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return __std_find_trivial<_Find_traits_8>(_First, _Last, _Val);
+    return __std_find_trivial_impl<_Find_traits_8>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_last_trivial_1(
     const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return __std_find_last_trivial<_Find_traits_1>(_First, _Last, _Val);
+    return __std_find_last_trivial_impl<_Find_traits_1>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_last_trivial_2(
     const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return __std_find_last_trivial<_Find_traits_2>(_First, _Last, _Val);
+    return __std_find_last_trivial_impl<_Find_traits_2>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_last_trivial_4(
     const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return __std_find_last_trivial<_Find_traits_4>(_First, _Last, _Val);
+    return __std_find_last_trivial_impl<_Find_traits_4>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_last_trivial_8(
     const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return __std_find_last_trivial<_Find_traits_8>(_First, _Last, _Val);
+    return __std_find_last_trivial_impl<_Find_traits_8>(_First, _Last, _Val);
 }
 
 __declspec(noalias) size_t
     __stdcall __std_count_trivial_1(const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return __std_count_trivial<_Find_traits_1>(_First, _Last, _Val);
+    return __std_count_trivial_impl<_Find_traits_1>(_First, _Last, _Val);
 }
 
 __declspec(noalias) size_t
     __stdcall __std_count_trivial_2(const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return __std_count_trivial<_Find_traits_2>(_First, _Last, _Val);
+    return __std_count_trivial_impl<_Find_traits_2>(_First, _Last, _Val);
 }
 
 __declspec(noalias) size_t
     __stdcall __std_count_trivial_4(const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return __std_count_trivial<_Find_traits_4>(_First, _Last, _Val);
+    return __std_count_trivial_impl<_Find_traits_4>(_First, _Last, _Val);
 }
 
 __declspec(noalias) size_t
     __stdcall __std_count_trivial_8(const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return __std_count_trivial<_Find_traits_8>(_First, _Last, _Val);
+    return __std_count_trivial_impl<_Find_traits_8>(_First, _Last, _Val);
 }
 
 } // extern "C"


### PR DESCRIPTION
First, `vector_algorithms.cpp` was defining functions within an unnamed namespace that were quasi-shadowing wrapper functions in `<algorithm>` and `<xutility>`:

https://github.com/microsoft/STL/blob/f392449fb72d1a387ac5025d508e8442914477f9/stl/src/vector_algorithms.cpp#L1440-L1442
https://github.com/microsoft/STL/blob/f392449fb72d1a387ac5025d508e8442914477f9/stl/inc/xutility#L97-L98

This was incredibly confusing, so I'm renaming the `vector_algorithms.cpp` functions to `impl`. (I say it was "quasi"-shadowing because we never dragged them into the same scope, but we should never use the same names for things with different signatures/purposes like this. There are specific scenarios where function overloading is fine - usually when the compiler will handle types/arity and there's no risk of confusion about "which one" we're getting - and this is not such a scenario, so we should use different names.)

Next, this moves `<algorithm>` and `<xutility>`'s vector algorithm wrapper templates (that handle 1/2/4/8-byte dispatching) from the global namespace to `std`. I noticed this while auditing the STL for namespace discipline - aside from `extern "C"` machinery in the global namespace, the STL is almost always careful to define all of its internal machinery within `std`. (There are a few special exceptions for bitmask ops.) These wrapper templates were a major exception. I'm keeping their names, since they do strongly resemble the `extern "C"` functions they're wrapping, but we should move them into `std` for cleanliness (and because this may make later work more convenient for me).