### PR TITLE
Various cleanups: `<xatomic_wait.h>` constants

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -514,7 +514,7 @@ void _Atomic_wait_direct(
             return;
         }
 
-        __std_atomic_wait_direct(_Storage_ptr, &_Expected_bytes, sizeof(_Value_type), _Atomic_wait_no_timeout);
+        __std_atomic_wait_direct(_Storage_ptr, &_Expected_bytes, sizeof(_Value_type), __std_atomic_wait_no_timeout);
     }
 }
 #endif // _HAS_CXX20
@@ -714,7 +714,7 @@ struct _Atomic_storage {
             } // unlock
 
             __std_atomic_wait_indirect(_Storage_ptr, _Expected_ptr, sizeof(_TVal), &_Spinlock,
-                &_Atomic_wait_compare_non_lock_free<decltype(_Spinlock)>, _Atomic_wait_no_timeout);
+                &_Atomic_wait_compare_non_lock_free<decltype(_Spinlock)>, __std_atomic_wait_no_timeout);
         }
     }
 
@@ -1354,7 +1354,7 @@ struct _Atomic_storage<_Ty&, 16> { // lock-free using 16-byte intrinsics
             }
 
             __std_atomic_wait_indirect(_Storage_ptr, _Expected_ptr, sizeof(_TVal), nullptr,
-                &_Atomic_wait_compare_16_bytes, _Atomic_wait_no_timeout);
+                &_Atomic_wait_compare_16_bytes, __std_atomic_wait_no_timeout);
         }
     }
 

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -3839,7 +3839,7 @@ protected:
             if (!_Equal) {
                 break;
             }
-            __std_atomic_wait_direct(&_Ptr, &_Old, sizeof(_Old), _Atomic_wait_no_timeout);
+            __std_atomic_wait_direct(&_Ptr, &_Old, sizeof(_Old), __std_atomic_wait_no_timeout);
         }
     }
 

--- a/stl/inc/semaphore
+++ b/stl/inc/semaphore
@@ -117,7 +117,7 @@ public:
         ptrdiff_t _Current = _Counter.load(memory_order_relaxed);
         for (;;) {
             while (_Current == 0) {
-                _Wait(_Atomic_wait_no_timeout);
+                _Wait(__std_atomic_wait_no_timeout);
                 _Current = _Counter.load(memory_order_relaxed);
             }
             _STL_VERIFY(_Current > 0 && _Current <= _Least_max_value,

--- a/stl/inc/xatomic_wait.h
+++ b/stl/inc/xatomic_wait.h
@@ -18,9 +18,9 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-_INLINE_VAR constexpr unsigned long _Atomic_wait_no_timeout = 0xFFFF'FFFF; // Pass as partial timeout
-
 _EXTERN_C
+inline constexpr unsigned long __std_atomic_wait_no_timeout = 0xFFFF'FFFF; // Pass as partial timeout
+
 enum class __std_atomic_api_level : unsigned long {
     __not_set,
     __detecting,

--- a/stl/inc/xatomic_wait.h
+++ b/stl/inc/xatomic_wait.h
@@ -18,8 +18,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-_INLINE_VAR constexpr unsigned long long _Atomic_wait_no_deadline = 0xFFFF'FFFF'FFFF'FFFF;
-_INLINE_VAR constexpr unsigned long _Atomic_wait_no_timeout       = 0xFFFF'FFFF; // Pass as partial timeout
+_INLINE_VAR constexpr unsigned long _Atomic_wait_no_timeout = 0xFFFF'FFFF; // Pass as partial timeout
 
 _EXTERN_C
 enum class __std_atomic_api_level : unsigned long {

--- a/stl/src/atomic_wait.cpp
+++ b/stl/src/atomic_wait.cpp
@@ -318,7 +318,7 @@ int __stdcall __std_atomic_wait_indirect(const void* _Storage, void* _Comparand,
             return FALSE;
         }
 
-        if (_Remaining_timeout != _Atomic_wait_no_timeout) {
+        if (_Remaining_timeout != __std_atomic_wait_no_timeout) {
             // spurious wake to recheck the clock
             return TRUE;
         }
@@ -334,8 +334,8 @@ unsigned long long __stdcall __std_atomic_wait_get_deadline(const unsigned long 
 }
 
 unsigned long __stdcall __std_atomic_wait_get_remaining_timeout(unsigned long long _Deadline) noexcept {
-    static_assert(_Atomic_wait_no_timeout == INFINITE,
-        "_Atomic_wait_no_timeout is passed directly to underlying API, so should match it");
+    static_assert(__std_atomic_wait_no_timeout == INFINITE,
+        "__std_atomic_wait_no_timeout is passed directly to underlying API, so should match it");
 
     if (_Deadline == _Atomic_wait_no_deadline) {
         return INFINITE;

--- a/stl/src/atomic_wait.cpp
+++ b/stl/src/atomic_wait.cpp
@@ -11,6 +11,7 @@
 #include <Windows.h>
 
 namespace {
+    constexpr unsigned long long _Atomic_wait_no_deadline = 0xFFFF'FFFF'FFFF'FFFF;
 
     constexpr size_t _Wait_table_size_power = 8;
     constexpr size_t _Wait_table_size       = 1 << _Wait_table_size_power;

--- a/stl/src/parallel_algorithms.cpp
+++ b/stl/src/parallel_algorithms.cpp
@@ -44,7 +44,7 @@ void __stdcall __std_wait_for_threadpool_work_callbacks(PTP_WORK _Work, BOOL _Ca
 }
 
 void __stdcall __std_execution_wait_on_uchar(const volatile unsigned char* _Address, unsigned char _Compare) noexcept {
-    __std_atomic_wait_direct(const_cast<const unsigned char*>(_Address), &_Compare, 1, _Atomic_wait_no_timeout);
+    __std_atomic_wait_direct(const_cast<const unsigned char*>(_Address), &_Compare, 1, __std_atomic_wait_no_timeout);
 }
 
 void __stdcall __std_execution_wake_by_address_all(const volatile void* _Address) noexcept {


### PR DESCRIPTION
One more round of cleanups resulting from my audit of things in the global namespace that aren't `extern "C"`.

* Move `_Atomic_wait_no_deadline` from `<xatomic_wait.h>` to `atomic_wait.cpp`.
  + Nothing else mentions this, obviously.
  + It's moving into the unnamed namespace for isolation, and dropping `_INLINE_VAR`.
* Rename `_Atomic_wait_no_timeout` => `__std_atomic_wait_no_timeout`
  + This is moving into `extern "C"` like `<xfilesystem_abi.h>`'s constants: https://github.com/microsoft/STL/blob/f392449fb72d1a387ac5025d508e8442914477f9/stl/inc/xfilesystem_abi.h#L21-L23
  + `<xatomic_wait.h>` can assume C++20 mode, so we can use `inline` variables unconditionally.
  + There will be a trivial merge conflict with #4143.