### PR TITLE
`<flat_set>`: Correct allocator-extended constructors for `flat_(multi)set`

### DIFF
--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -111,24 +111,31 @@ public:
         : _Base_flat_set(container_type(_First, _Last), _Comp) {}
     template <input_iterator _Iter, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Iter _First, _Iter _Last, const key_compare& _Comp, const _Alloc& _Al)
-        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al, _First, _Last), _Comp) {}
+        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al), _Comp) {
+        insert(_First, _Last);
+    }
     template <input_iterator _Iter, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Iter _First, _Iter _Last, const _Alloc& _Al)
-        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al, _First, _Last)) {}
+        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al)) {
+        insert(_First, _Last);
+    }
 
     template <_Container_compatible_range<_Kty> _Rng>
     _Base_flat_set(from_range_t, _Rng&& _Range)
         : _Base_flat_set(container_type(from_range, _STD forward<_Rng>(_Range))) {}
     template <_Container_compatible_range<_Kty> _Rng, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(from_range_t, _Rng&& _Range, const _Alloc& _Al)
-        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al, from_range, _STD forward<_Rng>(_Range))) {}
+        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al)) {
+        insert_range(_STD forward<_Rng>(_Range));
+    }
     template <_Container_compatible_range<_Kty> _Rng>
     _Base_flat_set(from_range_t, _Rng&& _Range, const key_compare& _Comp)
         : _Base_flat_set(container_type(from_range, _STD forward<_Rng>(_Range)), _Comp) {}
     template <_Container_compatible_range<_Kty> _Rng, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(from_range_t, _Rng&& _Range, const key_compare& _Comp, const _Alloc& _Al)
-        : _Base_flat_set(
-            _STD make_obj_using_allocator<container_type>(_Al, from_range, _STD forward<_Rng>(_Range)), _Comp) {}
+        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al), _Comp) {
+        insert_range(_STD forward<_Rng>(_Range));
+    }
 
     template <input_iterator _Iter>
     _Base_flat_set(_Tsorted _Tsort, _Iter _First, _Iter _Last, const key_compare& _Comp = key_compare())
@@ -144,19 +151,19 @@ public:
         : _Base_flat_set(container_type(_Ilist), _Comp) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(initializer_list<_Kty> _Ilist, const key_compare& _Comp, const _Alloc& _Al)
-        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al, _Ilist), _Comp) {}
+        : _Base_flat_set(_Ilist.begin(), _Ilist.end(), _Comp, _Al) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(initializer_list<_Kty> _Ilist, const _Alloc& _Al)
-        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al, _Ilist)) {}
+        : _Base_flat_set(_Ilist.begin(), _Ilist.end(), _Al) {}
 
     _Base_flat_set(_Tsorted _Tsort, initializer_list<_Kty> _Ilist, const key_compare& _Comp = key_compare())
         : _Base_flat_set(_Tsort, container_type(_Ilist), _Comp) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Tsorted _Tsort, initializer_list<_Kty> _Ilist, const key_compare& _Comp, const _Alloc& _Al)
-        : _Base_flat_set(_Tsort, _STD make_obj_using_allocator<container_type>(_Al, _Ilist), _Comp) {}
+        : _Base_flat_set(_Tsort, _Ilist.begin(), _Ilist.end(), _Comp, _Al) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Tsorted _Tsort, initializer_list<_Kty> _Ilist, const _Alloc& _Al)
-        : _Base_flat_set(_Tsort, _STD make_obj_using_allocator<container_type>(_Al, _Ilist)) {}
+        : _Base_flat_set(_Tsort, _Ilist.begin(), _Ilist.end(), _Al) {}
 
     _Base_flat_set(const _Base_flat_set&) = default;
     _Base_flat_set(_Base_flat_set&& _Other) noexcept(

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -68,10 +68,12 @@ public:
     _Base_flat_set() : _Mycont(), _Mycomp() {}
 
     template <_Allocator_for<container_type> _Alloc>
-    _Base_flat_set(const _Deriv& _Set, const _Alloc& _Al) : _Mycont(_Set._Mycont, _Al), _Mycomp(_Set._Mycomp) {}
+    _Base_flat_set(const _Deriv& _Set, const _Alloc& _Al)
+        : _Mycont(_STD make_obj_using_allocator<container_type>(_Al, _Set._Mycont)), _Mycomp(_Set._Mycomp) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Deriv&& _Set, const _Alloc& _Al)
-        : _Mycont(_STD move(_Set).extract(), _Al), _Mycomp(_Set._Mycomp) // intentionally copy comparator, see LWG-2227
+        : _Mycont(_STD make_obj_using_allocator<container_type>(_Al, _STD move(_Set).extract())),
+          _Mycomp(_Set._Mycomp) // intentionally copy comparator, see LWG-2227
     {}
 
     explicit _Base_flat_set(container_type _Cont, const key_compare& _Comp = key_compare())
@@ -79,10 +81,11 @@ public:
         _Make_invariants_fulfilled();
     }
     template <_Allocator_for<container_type> _Alloc>
-    _Base_flat_set(const container_type& _Cont, const _Alloc& _Al) : _Base_flat_set(container_type(_Cont, _Al)) {}
+    _Base_flat_set(const container_type& _Cont, const _Alloc& _Al)
+        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al, _Cont)) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(const container_type& _Cont, const key_compare& _Comp, const _Alloc& _Al)
-        : _Base_flat_set(container_type(_Cont, _Al), _Comp) {}
+        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al, _Cont), _Comp) {}
 
     _Base_flat_set(_Tsorted, container_type _Cont, const key_compare& _Comp = key_compare())
         : _Mycont(_STD move(_Cont)), _Mycomp(_Comp) {
@@ -90,68 +93,70 @@ public:
     }
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Tsorted _Tsort, const container_type& _Cont, const _Alloc& _Al)
-        : _Base_flat_set(_Tsort, container_type(_Cont, _Al)) {}
+        : _Base_flat_set(_Tsort, _STD make_obj_using_allocator<container_type>(_Al, _Cont)) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Tsorted _Tsort, const container_type& _Cont, const key_compare& _Comp, const _Alloc& _Al)
-        : _Base_flat_set(_Tsort, container_type(_Cont, _Al), _Comp) {}
+        : _Base_flat_set(_Tsort, _STD make_obj_using_allocator<container_type>(_Al, _Cont), _Comp) {}
 
     explicit _Base_flat_set(const key_compare& _Comp) : _Mycont(), _Mycomp(_Comp) {}
     template <_Allocator_for<container_type> _Alloc>
-    _Base_flat_set(const key_compare& _Comp, const _Alloc& _Al) : _Mycont(_Al), _Mycomp(_Comp) {}
+    _Base_flat_set(const key_compare& _Comp, const _Alloc& _Al)
+        : _Mycont(_STD make_obj_using_allocator<container_type>(_Al)), _Mycomp(_Comp) {}
     template <_Allocator_for<container_type> _Alloc>
-    explicit _Base_flat_set(const _Alloc& _Al) : _Mycont(_Al), _Mycomp() {}
+    explicit _Base_flat_set(const _Alloc& _Al)
+        : _Mycont(_STD make_obj_using_allocator<container_type>(_Al)), _Mycomp() {}
 
-    // FIXME, an allocator-aware container may not support "C(_First, _Last, _Al)".
     template <input_iterator _Iter>
     _Base_flat_set(_Iter _First, _Iter _Last, const key_compare& _Comp = key_compare())
         : _Base_flat_set(container_type(_First, _Last), _Comp) {}
     template <input_iterator _Iter, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Iter _First, _Iter _Last, const key_compare& _Comp, const _Alloc& _Al)
-        : _Base_flat_set(container_type(_First, _Last, _Al), _Comp) {}
+        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al, _First, _Last), _Comp) {}
     template <input_iterator _Iter, _Allocator_for<container_type> _Alloc>
-    _Base_flat_set(_Iter _First, _Iter _Last, const _Alloc& _Al) : _Base_flat_set(container_type(_First, _Last, _Al)) {}
+    _Base_flat_set(_Iter _First, _Iter _Last, const _Alloc& _Al)
+        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al, _First, _Last)) {}
 
-    // FIXME, an allocator-aware container may not support "C(from_range, _STD forward<_Rng>(_Range), _Al)".
     template <_Container_compatible_range<_Kty> _Rng>
     _Base_flat_set(from_range_t, _Rng&& _Range)
         : _Base_flat_set(container_type(from_range, _STD forward<_Rng>(_Range))) {}
     template <_Container_compatible_range<_Kty> _Rng, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(from_range_t, _Rng&& _Range, const _Alloc& _Al)
-        : _Base_flat_set(container_type(from_range, _STD forward<_Rng>(_Range), _Al)) {}
+        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al, from_range, _STD forward<_Rng>(_Range))) {}
     template <_Container_compatible_range<_Kty> _Rng>
     _Base_flat_set(from_range_t, _Rng&& _Range, const key_compare& _Comp)
         : _Base_flat_set(container_type(from_range, _STD forward<_Rng>(_Range)), _Comp) {}
     template <_Container_compatible_range<_Kty> _Rng, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(from_range_t, _Rng&& _Range, const key_compare& _Comp, const _Alloc& _Al)
-        : _Base_flat_set(container_type(from_range, _STD forward<_Rng>(_Range), _Al), _Comp) {}
+        : _Base_flat_set(
+            _STD make_obj_using_allocator<container_type>(_Al, from_range, _STD forward<_Rng>(_Range)), _Comp) {}
 
     template <input_iterator _Iter>
     _Base_flat_set(_Tsorted _Tsort, _Iter _First, _Iter _Last, const key_compare& _Comp = key_compare())
         : _Base_flat_set(_Tsort, container_type(_First, _Last), _Comp) {}
     template <input_iterator _Iter, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Tsorted _Tsort, _Iter _First, _Iter _Last, const key_compare& _Comp, const _Alloc& _Al)
-        : _Base_flat_set(_Tsort, container_type(_First, _Last, _Al), _Comp) {}
+        : _Base_flat_set(_Tsort, _STD make_obj_using_allocator<container_type>(_Al, _First, _Last), _Comp) {}
     template <input_iterator _Iter, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Tsorted _Tsort, _Iter _First, _Iter _Last, const _Alloc& _Al)
-        : _Base_flat_set(_Tsort, container_type(_First, _Last, _Al)) {}
+        : _Base_flat_set(_Tsort, _STD make_obj_using_allocator<container_type>(_Al, _First, _Last)) {}
 
-    // FIXME, an allocator-aware container may not support "C(_Ilist, _Al)".
     _Base_flat_set(initializer_list<_Kty> _Ilist, const key_compare& _Comp = key_compare())
         : _Base_flat_set(container_type(_Ilist), _Comp) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(initializer_list<_Kty> _Ilist, const key_compare& _Comp, const _Alloc& _Al)
-        : _Base_flat_set(container_type(_Ilist, _Al), _Comp) {}
+        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al, _Ilist), _Comp) {}
     template <_Allocator_for<container_type> _Alloc>
-    _Base_flat_set(initializer_list<_Kty> _Ilist, const _Alloc& _Al) : _Base_flat_set(container_type(_Ilist, _Al)) {}
+    _Base_flat_set(initializer_list<_Kty> _Ilist, const _Alloc& _Al)
+        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al, _Ilist)) {}
 
     _Base_flat_set(_Tsorted _Tsort, initializer_list<_Kty> _Ilist, const key_compare& _Comp = key_compare())
         : _Base_flat_set(_Tsort, container_type(_Ilist), _Comp) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Tsorted _Tsort, initializer_list<_Kty> _Ilist, const key_compare& _Comp, const _Alloc& _Al)
-        : _Base_flat_set(_Tsort, container_type(_Ilist, _Al), _Comp) {}
+        : _Base_flat_set(_Tsort, _STD make_obj_using_allocator<container_type>(_Al, _Ilist), _Comp) {}
     template <_Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Tsorted _Tsort, initializer_list<_Kty> _Ilist, const _Alloc& _Al)
-        : _Base_flat_set(_Tsort, container_type(_Ilist, _Al)) {}
+        : _Base_flat_set(_Tsort, _STD make_obj_using_allocator<container_type>(_Al, _Ilist)) {}
 
     _Base_flat_set(const _Base_flat_set&) = default;
     _Base_flat_set(_Base_flat_set&& _Other) noexcept(

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -120,6 +120,10 @@ public:
     using base_type::clear;
 
     friend auto operator<=>(const alternative_vector&, const alternative_vector&) = default;
+
+    friend constexpr void swap(alternative_vector& lhs, alternative_vector& rhs) noexcept(noexcept(lhs.swap(rhs))) {
+        lhs.swap(rhs);
+    }
 };
 
 template <class T>

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -30,18 +30,18 @@ private:
     using base_type = vector<T, Alloc>;
 
 public:
-    using base_type::allocator_type;
-    using base_type::const_iterator;
-    using base_type::const_pointer;
-    using base_type::const_reference;
-    using base_type::const_reverse_iterator;
-    using base_type::difference_type;
-    using base_type::iterator;
-    using base_type::pointer;
-    using base_type::reference;
-    using base_type::reverse_iterator;
-    using base_type::size_type;
-    using base_type::value_type;
+    using allocator_type         = base_type::allocator_type;
+    using const_iterator         = base_type::const_iterator;
+    using const_pointer          = base_type::const_pointer;
+    using const_reference        = base_type::const_reference;
+    using const_reverse_iterator = base_type::const_reverse_iterator;
+    using difference_type        = base_type::difference_type;
+    using iterator               = base_type::iterator;
+    using pointer                = base_type::pointer;
+    using reference              = base_type::reference;
+    using reverse_iterator       = base_type::reverse_iterator;
+    using size_type              = base_type::size_type;
+    using value_type             = base_type::value_type;
 
     constexpr alternative_vector() noexcept(noexcept(Alloc())) : base_type(Alloc()) {}
     constexpr explicit alternative_vector(allocator_arg_t, const Alloc& a) : base_type(a) {}

--- a/tests/std/tests/P1222R4_flat_set/test.cpp
+++ b/tests/std/tests/P1222R4_flat_set/test.cpp
@@ -319,6 +319,7 @@ void test_allocator_extended_constructors() {
 
         fms s{3, 7, 1, 85, 222, 1};
         fms s_expected{1, 1, 3, 7, 85, 222};
+        vec v_raw{3, 7, 1, 85, 222, 1};
         vec v_sorted_eq{1, 1, 3, 7, 85, 222};
 
         TEST_ASSERT(fms{comp, ator} == fms{});
@@ -328,15 +329,15 @@ void test_allocator_extended_constructors() {
         TEST_ASSERT(fms{std::move(s), ator} == s_expected);
         TEST_ASSERT(fms{fms{s_expected}, ator} == s_expected);
 
-        TEST_ASSERT(fms{v_sorted_eq, ator} == s_expected);
+        TEST_ASSERT(fms{v_raw, ator} == s_expected);
         TEST_ASSERT(fms{{3, 7, 1, 85, 222, 1}, ator} == s_expected);
-        TEST_ASSERT(fms{v_sorted_eq.begin(), v_sorted_eq.end(), ator} == s_expected);
-        TEST_ASSERT(fms{from_range, v_sorted_eq, ator} == s_expected);
+        TEST_ASSERT(fms{v_raw.begin(), v_raw.end(), ator} == s_expected);
+        TEST_ASSERT(fms{from_range, v_raw, ator} == s_expected);
 
-        TEST_ASSERT(fms{v_sorted_eq, comp, ator} == s_expected);
+        TEST_ASSERT(fms{v_raw, comp, ator} == s_expected);
         TEST_ASSERT(fms{{3, 7, 1, 85, 222, 1}, comp, ator} == s_expected);
-        TEST_ASSERT(fms{v_sorted_eq.begin(), v_sorted_eq.end(), comp, ator} == s_expected);
-        TEST_ASSERT(fms{from_range, v_sorted_eq, comp, ator} == s_expected);
+        TEST_ASSERT(fms{v_raw.begin(), v_raw.end(), comp, ator} == s_expected);
+        TEST_ASSERT(fms{from_range, v_raw, comp, ator} == s_expected);
 
         TEST_ASSERT(fms{sorted_equivalent, v_sorted_eq, ator} == s_expected);
         TEST_ASSERT(fms{sorted_equivalent, v_sorted_eq, comp, ator} == s_expected);


### PR DESCRIPTION
None of allocator-extended constructors of `flat_meow` requires the adapted container to be allocator-aware. The container may be constructed in some other style than standard containers.
(Actually, `flat_meow` don't care whether an adapted container is allocator-aware anywhere.)

IIUC we should unconditionally use `std::make_obj_using_allocator` ([[allocator.uses.construction]/1](https://eel.is/c++draft/allocator.uses.construction#1)).

See also https://github.com/microsoft/STL/pull/4084#discussion_r1364824733.

---
### Rationale
For non-allocator-extended allocators, the adapted container is only constructed in 4 ways ([[flat.set.defn]](https://eel.is/c++draft/flat.set.defn), [[flat.multiset.defn]](https://eel.is/c++draft/flat.multiset.defn) [[flat.set.cons]](https://eel.is/c++draft/flat.set.cons), [[flat.set.cons]](https://eel.is/c++draft/flat.set.cons), [[flat.multiset.cons]](https://eel.is/c++draft/flat.multiset.cons)):
- default construction (or value-initialization),
- copy construction,
- move construction, and
- iterator pair construction.

Note that iterator pair construction is only used in `sorted_*_t` constructors.

Given `flat_(multi)set` requires the adapted container to be a sequence iterator ([[flat.set.overview]](https://eel.is/c++draft/flat.set.overview), [[flat.multiset.overview]](https://eel.is/c++draft/flat.multiset.overview)), we can use directly use `from_range_t` constructors, iterator pair constructors, and initializer-list constructors of the container ([[sequence.reqmts]](https://eel.is/c++draft/sequence.reqmts)) in non-allocator extended constructors of  `flat_(multi)set`.

However, since nothing in `flat_meow` and the requirements for sequence container requires an adapted container to be allocator-aware, there's no guarantee that the container can be constructed by some convention. As a result, I think we should construct the container exactly following the standard wording, with `c(args...)` replaced with `c(std::make_obj_using_allocator<container_type>(a, args...))`.

Particularly, the allocator-extended constructors that don't take `sorted_*_t`, and take
- a pair of iterators, or
- `from_range_t` and a range, or
- an `initializer_list`,

should just construct the container by `std::make_obj_using_allocator<Container>(a)`.

### Other concerns
It may be a defect that there's no constructor taking both `sorted_*_t` and `from_range_t`.