### PR TITLE
`<xutility>`: Fix inaccurate constraint of `_Equal_rev_pred`

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6452,7 +6452,7 @@ namespace ranges {
     concept _Equal_rev_pred_can_memcmp = is_same_v<_Pj1, identity> && is_same_v<_Pj2, identity>
         && sized_sentinel_for<_Se2, _It2> && _Equal_memcmp_is_safe<_It1, _It2, _Pr>;
 
-    template <input_iterator _It1, input_iterator _It2, sentinel_for<_It2> _Se2, class _Pr, class _Pj1, class _Pj2>
+    template <forward_iterator _It1, input_iterator _It2, sentinel_for<_It2> _Se2, class _Pr, class _Pj1, class _Pj2>
         requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
     _NODISCARD constexpr pair<bool, _It1> _Equal_rev_pred(
         _It1 _First1, _It2 _First2, const _Se2 _Last2, _Pr _Pred, _Pj1 _Proj1, _Pj2 _Proj2) {


### PR DESCRIPTION
When no match is found, we `return {false, _It1 {}};` which implies that `_It1` must be a `forward_iterator `that can be default-constructed.
