### PR TITLE
ASan: Remove `noexcept` from `__sanitizer_annotate_contiguous_container`

### DIFF
--- a/stl/inc/__msvc_sanitizer_annotate_container.hpp
+++ b/stl/inc/__msvc_sanitizer_annotate_container.hpp
@@ -129,8 +129,9 @@ extern const bool _Asan_string_should_annotate;
 
 #if defined(_INSERT_VECTOR_ANNOTATION) || defined(_INSERT_STRING_ANNOTATION)
 extern "C" {
+// This must match ASan's primary declaration, which isn't marked `noexcept`.
 void __cdecl __sanitizer_annotate_contiguous_container(
-    const void* _First, const void* _End, const void* _Old_last, const void* _New_last) noexcept;
+    const void* _First, const void* _End, const void* _Old_last, const void* _New_last);
 }
 
 #ifdef _M_ARM64EC


### PR DESCRIPTION
#4106 marked `__sanitizer_annotate_contiguous_container` as `noexcept` because it's `extern "C"`. However, it has to match ASan's primary declaration, so we can't mark it.

This PR reverts this declaration to its original form, and adds a comment for future maintainers.