### PR TITLE
Various cleanups: Declare `_Meow_vbool` to avoid ADL

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4518,6 +4518,18 @@ _OutCtgIt _Copy_memmove_n(_CtgIt _First, const size_t _Count, _OutCtgIt _Dest) {
 template <class _It, bool _RequiresMutable = false>
 _INLINE_VAR constexpr bool _Is_vb_iterator = false;
 
+template <class _VbIt, class _OutIt>
+_CONSTEXPR20 _OutIt _Copy_vbool(_VbIt _First, _VbIt _Last, _OutIt _Dest);
+
+template <class _VbIt>
+_NODISCARD _CONSTEXPR20 _Iter_diff_t<_VbIt> _Count_vbool(_VbIt _First, _VbIt _Last, bool _Val) noexcept;
+
+template <class _VbIt>
+_CONSTEXPR20 void _Fill_vbool(_VbIt _First, _VbIt _Last, bool _Val) noexcept;
+
+template <class _VbIt>
+_NODISCARD _CONSTEXPR20 _VbIt _Find_vbool(_VbIt _First, _VbIt _Last, bool _Val) noexcept;
+
 template <class _InIt, class _SizeTy, class _OutIt>
 _CONSTEXPR20 _OutIt _Copy_n_unchecked4(_InIt _First, _SizeTy _Count, _OutIt _Dest) {
     // copy _First + [0, _Count) to _Dest + [0, _Count), returning _Dest + _Count
@@ -4556,7 +4568,7 @@ _CONSTEXPR20 _OutIt _Copy_unchecked(_InIt _First, _Sent _Last, _OutIt _Dest) {
     // copy [_First, _Last) to [_Dest, ...)
     // note: _Copy_unchecked has callers other than the copy family
     if constexpr (_Is_vb_iterator<_InIt> && _Is_vb_iterator<_OutIt, true>) {
-        return _Copy_vbool(_First, _Last, _Dest);
+        return _STD _Copy_vbool(_First, _Last, _Dest);
     } else {
         if constexpr (_Sent_copy_cat<_InIt, _Sent, _OutIt>::_Bitcopy_assignable) {
 #if _HAS_CXX20
@@ -4753,7 +4765,7 @@ _CONSTEXPR20 _OutIt copy_n(_InIt _First, _Diff _Count_raw, _OutIt _Dest) {
     _Algorithm_int_t<_Diff> _Count = _Count_raw;
     if (0 < _Count) {
         if constexpr (_Is_vb_iterator<_InIt> && _Is_vb_iterator<_OutIt, true>) {
-            return _Copy_vbool(_First, _First + _Count, _Dest);
+            return _STD _Copy_vbool(_First, _First + _Count, _Dest);
         } else {
             auto _UFirst = _Get_unwrapped_n(_First, _Count);
             auto _UDest  = _Get_unwrapped_n(_Dest, _Count);
@@ -4856,7 +4868,7 @@ _CONSTEXPR20 _OutIt _Move_unchecked(_InIt _First, _InIt _Last, _OutIt _Dest) {
     // move [_First, _Last) to [_Dest, ...)
     // note: _Move_unchecked has callers other than the move family
     if constexpr (_Is_vb_iterator<_InIt> && _Is_vb_iterator<_OutIt, true>) {
-        return _Copy_vbool(_First, _Last, _Dest);
+        return _STD _Copy_vbool(_First, _Last, _Dest);
     } else {
         if constexpr (_Iter_move_cat<_InIt, _OutIt>::_Bitcopy_assignable) {
 #if _HAS_CXX20
@@ -5006,7 +5018,7 @@ _CONSTEXPR20 void fill(const _FwdIt _First, const _FwdIt _Last, const _Ty& _Val)
     // copy _Val through [_First, _Last)
     _Adl_verify_range(_First, _Last);
     if constexpr (_Is_vb_iterator<_FwdIt, true>) {
-        _Fill_vbool(_First, _Last, _Val);
+        _STD _Fill_vbool(_First, _Last, _Val);
     } else {
         auto _UFirst      = _Get_unwrapped(_First);
         const auto _ULast = _Get_unwrapped(_Last);
@@ -5048,7 +5060,7 @@ _CONSTEXPR20 _OutIt fill_n(_OutIt _Dest, const _Diff _Count_raw, const _Ty& _Val
     if (0 < _Count) {
         if constexpr (_Is_vb_iterator<_OutIt, true>) {
             const auto _Last = _Dest + static_cast<typename _OutIt::difference_type>(_Count);
-            _Fill_vbool(_Dest, _Last, _Val);
+            _STD _Fill_vbool(_Dest, _Last, _Val);
             return _Last;
         } else {
             auto _UDest = _Get_unwrapped_n(_Dest, _Count);
@@ -5814,7 +5826,7 @@ _EXPORT_STD template <class _InIt, class _Ty>
 _NODISCARD _CONSTEXPR20 _InIt find(_InIt _First, const _InIt _Last, const _Ty& _Val) { // find first matching _Val
     _Adl_verify_range(_First, _Last);
     if constexpr (_Is_vb_iterator<_InIt> && is_same_v<_Ty, bool>) {
-        return _Find_vbool(_First, _Last, _Val);
+        return _STD _Find_vbool(_First, _Last, _Val);
     } else {
         _Seek_wrapped(_First, _STD _Find_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Val));
         return _First;
@@ -5944,7 +5956,7 @@ _NODISCARD _CONSTEXPR20 _Iter_diff_t<_InIt> count(const _InIt _First, const _InI
     // count elements that match _Val
     _Adl_verify_range(_First, _Last);
     if constexpr (_Is_vb_iterator<_InIt> && is_same_v<_Ty, bool>) {
-        return _Count_vbool(_First, _Last, _Val);
+        return _STD _Count_vbool(_First, _Last, _Val);
     } else {
         auto _UFirst      = _Get_unwrapped(_First);
         const auto _ULast = _Get_unwrapped(_Last);


### PR DESCRIPTION
I noticed this a while ago, but it's increasingly important due to modules. (This PR avoids the likely compiler bug VSO-1914077 "Modules: `extern "C++"` interferes with ADL".)

The `vector<bool>` algorithm optimizations (#879 #1131 #3353) detect `vector<bool>` iterators via an internal type trait, then dispatch to dedicated functions. We were defining those functions in `<vector>`, but were never declaring them before calling them in `<xutility>` (which is "higher up" in the dependency graph), so our calls were actually using ADL. That was squirrelly :chipmunk: since we never rely on ADL like this for internal functions.

This PR adds declarations (dropping `const` on value parameters as usual), then qualifies the calls for good measure (also aligning with our developing practice of qualifying internal calls, which personally hasn't filled me with delight elsewhere but is definitely reassuring here).