### PR TITLE
Add `extern "C++"` as a temporary workaround for `#include`/`import` coexistence

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -265,6 +265,8 @@ SpaceBeforeParensOptions:
 # NOTE: _STD_BEGIN, _STD_END, etc. aren't macros for complete statements, but telling
 # clang-format that they are produces the behavior that we want (with no block indentation).
 StatementMacros:
+  - _EXTERN_CXX_WORKAROUND
+  - _END_EXTERN_CXX_WORKAROUND
   - _STD_BEGIN
   - _STD_END
   - _STDEXT_BEGIN

--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -33,6 +33,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+_EXTERN_CXX_WORKAROUND
 _NODISCARD _Check_return_ inline float acos(_In_ float _Xx) noexcept /* strengthened */ {
     return _CSTD acosf(_Xx);
 }
@@ -552,6 +553,7 @@ _NODISCARD _Check_return_ inline long double trunc(_In_ long double _Xx) noexcep
     return _CSTD truncl(_Xx);
 #endif // ^^^ intrinsics unavailable ^^^
 }
+_END_EXTERN_CXX_WORKAROUND
 
 _STD_BEGIN
 template <class _Ty1, class _Ty2>
@@ -560,6 +562,7 @@ using _Common_float_type_t = conditional_t<is_same_v<_Ty1, long double> || is_sa
         double>>; // find type for two-argument math function
 _STD_END
 
+_EXTERN_CXX_WORKAROUND
 template <class _Ty, _STD enable_if_t<_STD is_integral_v<_Ty>, int> = 0>
 double frexp(_Ty _Value, _Out_ int* const _Exp) noexcept /* strengthened */ {
     return _CSTD frexp(static_cast<double>(_Value), _Exp);
@@ -709,6 +712,7 @@ _GENERIC_MATH2(fmin)
 #undef _GENERIC_MATH2
 #undef _GENERIC_MATH2I
 #undef _HAS_CMATH_INTRINSICS
+_END_EXTERN_CXX_WORKAROUND
 
 _STD_BEGIN
 _EXPORT_STD using _CSTD abs;

--- a/stl/inc/cstddef
+++ b/stl/inc/cstddef
@@ -98,7 +98,9 @@ _NODISCARD _MSVC_INTRINSIC constexpr _IntType to_integer(const byte _Arg) noexce
 
 _STD_END
 
+_EXTERN_CXX_WORKAROUND
 using _STD max_align_t; // intentional, for historical reasons
+_END_EXTERN_CXX_WORKAROUND
 
 // TRANSITION, non-_Ugly attribute tokens
 #pragma pop_macro("intrinsic")

--- a/stl/inc/cstdlib
+++ b/stl/inc/cstdlib
@@ -18,6 +18,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+_EXTERN_CXX_WORKAROUND
 // <stdlib.h> has abs(long) and abs(long long)
 _NODISCARD _Check_return_ inline double abs(_In_ double _Xx) noexcept /* strengthened */ {
     return _CSTD fabs(_Xx);
@@ -30,6 +31,7 @@ _NODISCARD _Check_return_ inline float abs(_In_ float _Xx) noexcept /* strengthe
 _NODISCARD _Check_return_ inline long double abs(_In_ long double _Xx) noexcept /* strengthened */ {
     return _CSTD fabsl(_Xx);
 }
+_END_EXTERN_CXX_WORKAROUND
 
 _STD_BEGIN
 _EXPORT_STD using _CSTD size_t;

--- a/stl/inc/ctime
+++ b/stl/inc/ctime
@@ -29,44 +29,44 @@ _EXPORT_STD using _CSTD strftime;
 _EXPORT_STD using _CSTD timespec;
 #endif // _HAS_CXX17
 
-#ifdef _BUILD_STD_MODULE // TRANSITION, OS-33790456
+#ifdef _BUILD_STD_MODULE // TRANSITION, OS-33790456; `template <int = 0>` avoids ambiguity
 _STL_DISABLE_DEPRECATED_WARNING
 
-_EXPORT_STD
+_EXPORT_STD template <int = 0>
 _Check_return_ _CRT_INSECURE_DEPRECATE(ctime_s) inline char* __CRTDECL ctime(_In_ const time_t* const _Time) noexcept
 /* strengthened */ {
     return _CSTD _ctime64(_Time);
 }
 
-_EXPORT_STD
+_EXPORT_STD template <int = 0>
 _Check_return_ inline double __CRTDECL difftime(_In_ const time_t _Time1, _In_ const time_t _Time2) noexcept
 /* strengthened */ {
     return _CSTD _difftime64(_Time1, _Time2);
 }
 
-_EXPORT_STD
+_EXPORT_STD template <int = 0>
 _Check_return_ _CRT_INSECURE_DEPRECATE(gmtime_s) inline tm* __CRTDECL gmtime(_In_ const time_t* const _Time) noexcept
 /* strengthened */ {
     return _CSTD _gmtime64(_Time);
 }
 
-_EXPORT_STD
+_EXPORT_STD template <int = 0>
 _CRT_INSECURE_DEPRECATE(localtime_s)
 inline tm* __CRTDECL localtime(_In_ const time_t* const _Time) noexcept /* strengthened */ {
     return _CSTD _localtime64(_Time);
 }
 
-_EXPORT_STD
+_EXPORT_STD template <int = 0>
 _Check_return_opt_ inline time_t __CRTDECL mktime(_Inout_ tm* const _Tm) noexcept /* strengthened */ {
     return _CSTD _mktime64(_Tm);
 }
 
-_EXPORT_STD
+_EXPORT_STD template <int = 0>
 inline time_t __CRTDECL time(_Out_opt_ time_t* const _Time) noexcept /* strengthened */ {
     return _CSTD _time64(_Time);
 }
 
-_EXPORT_STD
+_EXPORT_STD template <int = 0>
 _Check_return_ inline int __CRTDECL timespec_get(_Out_ timespec* const _Ts, _In_ const int _Base) noexcept
 /* strengthened */ {
     return _CSTD _timespec64_get(reinterpret_cast<_timespec64*>(_Ts), _Base);

--- a/stl/inc/cwchar
+++ b/stl/inc/cwchar
@@ -18,7 +18,9 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+_EXTERN_CXX_WORKAROUND
 using _Mbstatet = mbstate_t;
+_END_EXTERN_CXX_WORKAROUND
 
 _STD_BEGIN
 #pragma warning(push)

--- a/stl/inc/xfilesystem_abi.h
+++ b/stl/inc/xfilesystem_abi.h
@@ -78,7 +78,9 @@ enum class __std_fs_file_attr : unsigned long {
 };
 } // extern "C"
 
+_EXTERN_CXX_WORKAROUND
 _BITMASK_OPS(_EMPTY_ARGUMENT, __std_fs_file_attr)
+_END_EXTERN_CXX_WORKAROUND
 
 extern "C" {
 enum class __std_fs_reparse_tag : unsigned long {
@@ -123,7 +125,9 @@ enum class __std_fs_stats_flags : unsigned long {
 };
 } // extern "C"
 
+_EXTERN_CXX_WORKAROUND
 _BITMASK_OPS(_EMPTY_ARGUMENT, __std_fs_stats_flags)
+_END_EXTERN_CXX_WORKAROUND
 
 extern "C" {
 struct __std_fs_stats {
@@ -199,7 +203,9 @@ enum class __std_access_rights : unsigned long {
 };
 } // extern "C"
 
+_EXTERN_CXX_WORKAROUND
 _BITMASK_OPS(_EMPTY_ARGUMENT, __std_access_rights)
+_END_EXTERN_CXX_WORKAROUND
 
 extern "C" {
 enum class __std_fs_file_flags : unsigned long {
@@ -209,7 +215,9 @@ enum class __std_fs_file_flags : unsigned long {
 };
 } // extern "C"
 
+_EXTERN_CXX_WORKAROUND
 _BITMASK_OPS(_EMPTY_ARGUMENT, __std_fs_file_flags)
+_END_EXTERN_CXX_WORKAROUND
 
 extern "C" {
 enum class __std_fs_file_handle : intptr_t { _Invalid = -1 };
@@ -236,7 +244,9 @@ enum class __std_fs_copy_options {
 };
 } // extern "C"
 
+_EXTERN_CXX_WORKAROUND
 _BITMASK_OPS(_EMPTY_ARGUMENT, __std_fs_copy_options)
+_END_EXTERN_CXX_WORKAROUND
 
 extern "C" {
 _NODISCARD __std_ulong_and_error __stdcall __std_fs_get_full_path_name(_In_z_ const wchar_t* _Source,

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4518,6 +4518,18 @@ _OutCtgIt _Copy_memmove_n(_CtgIt _First, const size_t _Count, _OutCtgIt _Dest) {
 template <class _It, bool _RequiresMutable = false>
 _INLINE_VAR constexpr bool _Is_vb_iterator = false;
 
+template <class _VbIt, class _OutIt>
+_CONSTEXPR20 _OutIt _Copy_vbool(_VbIt _First, _VbIt _Last, _OutIt _Dest);
+
+template <class _VbIt>
+_NODISCARD _CONSTEXPR20 _Iter_diff_t<_VbIt> _Count_vbool(_VbIt _First, _VbIt _Last, bool _Val) noexcept;
+
+template <class _VbIt>
+_CONSTEXPR20 void _Fill_vbool(_VbIt _First, _VbIt _Last, bool _Val) noexcept;
+
+template <class _VbIt>
+_NODISCARD _CONSTEXPR20 _VbIt _Find_vbool(_VbIt _First, _VbIt _Last, bool _Val) noexcept;
+
 template <class _InIt, class _SizeTy, class _OutIt>
 _CONSTEXPR20 _OutIt _Copy_n_unchecked4(_InIt _First, _SizeTy _Count, _OutIt _Dest) {
     // copy _First + [0, _Count) to _Dest + [0, _Count), returning _Dest + _Count
@@ -4556,7 +4568,7 @@ _CONSTEXPR20 _OutIt _Copy_unchecked(_InIt _First, _Sent _Last, _OutIt _Dest) {
     // copy [_First, _Last) to [_Dest, ...)
     // note: _Copy_unchecked has callers other than the copy family
     if constexpr (_Is_vb_iterator<_InIt> && _Is_vb_iterator<_OutIt, true>) {
-        return _Copy_vbool(_First, _Last, _Dest);
+        return _STD _Copy_vbool(_First, _Last, _Dest);
     } else {
         if constexpr (_Sent_copy_cat<_InIt, _Sent, _OutIt>::_Bitcopy_assignable) {
 #if _HAS_CXX20
@@ -4753,7 +4765,7 @@ _CONSTEXPR20 _OutIt copy_n(_InIt _First, _Diff _Count_raw, _OutIt _Dest) {
     _Algorithm_int_t<_Diff> _Count = _Count_raw;
     if (0 < _Count) {
         if constexpr (_Is_vb_iterator<_InIt> && _Is_vb_iterator<_OutIt, true>) {
-            return _Copy_vbool(_First, _First + _Count, _Dest);
+            return _STD _Copy_vbool(_First, _First + _Count, _Dest);
         } else {
             auto _UFirst = _Get_unwrapped_n(_First, _Count);
             auto _UDest  = _Get_unwrapped_n(_Dest, _Count);
@@ -4856,7 +4868,7 @@ _CONSTEXPR20 _OutIt _Move_unchecked(_InIt _First, _InIt _Last, _OutIt _Dest) {
     // move [_First, _Last) to [_Dest, ...)
     // note: _Move_unchecked has callers other than the move family
     if constexpr (_Is_vb_iterator<_InIt> && _Is_vb_iterator<_OutIt, true>) {
-        return _Copy_vbool(_First, _Last, _Dest);
+        return _STD _Copy_vbool(_First, _Last, _Dest);
     } else {
         if constexpr (_Iter_move_cat<_InIt, _OutIt>::_Bitcopy_assignable) {
 #if _HAS_CXX20
@@ -5006,7 +5018,7 @@ _CONSTEXPR20 void fill(const _FwdIt _First, const _FwdIt _Last, const _Ty& _Val)
     // copy _Val through [_First, _Last)
     _Adl_verify_range(_First, _Last);
     if constexpr (_Is_vb_iterator<_FwdIt, true>) {
-        _Fill_vbool(_First, _Last, _Val);
+        _STD _Fill_vbool(_First, _Last, _Val);
     } else {
         auto _UFirst      = _Get_unwrapped(_First);
         const auto _ULast = _Get_unwrapped(_Last);
@@ -5048,7 +5060,7 @@ _CONSTEXPR20 _OutIt fill_n(_OutIt _Dest, const _Diff _Count_raw, const _Ty& _Val
     if (0 < _Count) {
         if constexpr (_Is_vb_iterator<_OutIt, true>) {
             const auto _Last = _Dest + static_cast<typename _OutIt::difference_type>(_Count);
-            _Fill_vbool(_Dest, _Last, _Val);
+            _STD _Fill_vbool(_Dest, _Last, _Val);
             return _Last;
         } else {
             auto _UDest = _Get_unwrapped_n(_Dest, _Count);
@@ -5814,7 +5826,7 @@ _EXPORT_STD template <class _InIt, class _Ty>
 _NODISCARD _CONSTEXPR20 _InIt find(_InIt _First, const _InIt _Last, const _Ty& _Val) { // find first matching _Val
     _Adl_verify_range(_First, _Last);
     if constexpr (_Is_vb_iterator<_InIt> && is_same_v<_Ty, bool>) {
-        return _Find_vbool(_First, _Last, _Val);
+        return _STD _Find_vbool(_First, _Last, _Val);
     } else {
         _Seek_wrapped(_First, _STD _Find_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Val));
         return _First;
@@ -5944,7 +5956,7 @@ _NODISCARD _CONSTEXPR20 _Iter_diff_t<_InIt> count(const _InIt _First, const _InI
     // count elements that match _Val
     _Adl_verify_range(_First, _Last);
     if constexpr (_Is_vb_iterator<_InIt> && is_same_v<_Ty, bool>) {
-        return _Count_vbool(_First, _Last, _Val);
+        return _STD _Count_vbool(_First, _Last, _Val);
     } else {
         auto _UFirst      = _Get_unwrapped(_First);
         const auto _ULast = _Get_unwrapped(_Last);

--- a/tests/std/tests/P2465R3_standard_library_modules/custom_format.py
+++ b/tests/std/tests/P2465R3_standard_library_modules/custom_format.py
@@ -17,10 +17,12 @@ class CustomTestFormat(STLTestFormat):
         testCpp = test.getSourcePath()
         sourceDir = os.path.dirname(testCpp)
         test2Cpp = os.path.join(sourceDir, 'test2.cpp')
+        test3Cpp = os.path.join(sourceDir, 'test3.cpp')
+        test4Cpp = os.path.join(sourceDir, 'test4.cpp')
         classicCpp = os.path.join(sourceDir, 'classic.cpp')
 
         # Dependency order is important here:
-        inputPaths = [stdIxx, stdCompatIxx, testCpp, test2Cpp, classicCpp]
+        inputPaths = [stdIxx, stdCompatIxx, testCpp, test2Cpp, test3Cpp, test4Cpp, classicCpp]
 
         cmd = [test.cxx, *inputPaths, *test.flags, *test.compileFlags]
 

--- a/tests/std/tests/P2465R3_standard_library_modules/custombuild.pl
+++ b/tests/std/tests/P2465R3_standard_library_modules/custombuild.pl
@@ -16,7 +16,7 @@ sub CustomBuildHook()
     my $stdCompatIxx = "$stlModulesDir\\std.compat.ixx";
 
     # Dependency order is important here:
-    my @inputPaths = ($stdIxx, $stdCompatIxx, "test.cpp", "test2.cpp", "classic.cpp");
+    my @inputPaths = ($stdIxx, $stdCompatIxx, "test.cpp", "test2.cpp", "test3.cpp", "test4.cpp", "classic.cpp");
 
     Run::ExecuteCL(join(" ", @inputPaths, "/Fe$cwd.exe"));
 }

--- a/tests/std/tests/P2465R3_standard_library_modules/test.cpp
+++ b/tests/std/tests/P2465R3_standard_library_modules/test.cpp
@@ -13,12 +13,16 @@ import std;
 void prepare_test_environment();
 void all_std_cmeow_tests();
 void test_module_std_compat();
+void test_include_all_then_import_std();
+void test_include_all_then_import_std_compat();
 
 int main() {
     prepare_test_environment(); // defined in classic.cpp
     all_cpp_header_tests(); // defined in test_header_units_and_modules.hpp
     all_std_cmeow_tests(); // defined below
     test_module_std_compat(); // defined in test2.cpp
+    test_include_all_then_import_std(); // defined in test3.cpp
+    test_include_all_then_import_std_compat(); // defined in test4.cpp
 }
 
 void test_std_cassert() {

--- a/tests/std/tests/P2465R3_standard_library_modules/test3.cpp
+++ b/tests/std/tests/P2465R3_standard_library_modules/test3.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifdef _MSVC_INTERNAL_TESTING // TRANSITION, VS 2022 17.9 Preview 3
+#include <__msvc_all_public_headers.hpp>
+#else // ^^^ no workaround / workaround vvv
+#include <assert.h> // intentionally not <cassert>
+#endif // ^^^ workaround ^^^
+
+import std;
+
+// INTENTIONALLY AVOIDED: using namespace std;
+
+void test_include_all_then_import_std() {
+    // Verify that std::vector and std::ranges algorithms are available:
+    std::vector<int> v{31, 41, 59, 26, 53, 58, 97, 93};
+    assert(!std::ranges::is_sorted(v));
+    std::ranges::sort(v);
+    assert(std::ranges::is_sorted(v));
+    const std::vector<int> sorted{26, 31, 41, 53, 58, 59, 93, 97};
+    assert(v == sorted);
+
+    // Verify that the Sufficient Additional Overloads are available for std::sqrt():
+    assert(std::sqrt(25.0) == 5.0);
+    assert(std::sqrt(25.0f) == 5.0f);
+    assert(std::sqrt(25) == 5.0);
+    static_assert(std::is_same_v<decltype(std::sqrt(25.0)), double>);
+    static_assert(std::is_same_v<decltype(std::sqrt(25.0f)), float>);
+    static_assert(std::is_same_v<decltype(std::sqrt(25)), double>);
+}

--- a/tests/std/tests/P2465R3_standard_library_modules/test4.cpp
+++ b/tests/std/tests/P2465R3_standard_library_modules/test4.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifdef _MSVC_INTERNAL_TESTING // TRANSITION, VS 2022 17.9 Preview 3
+#include <__msvc_all_public_headers.hpp>
+#else // ^^^ no workaround / workaround vvv
+#include <assert.h> // intentionally not <cassert>
+#endif // ^^^ workaround ^^^
+
+import std.compat;
+
+// INTENTIONALLY AVOIDED: using namespace std;
+
+void test_include_all_then_import_std_compat() {
+    // Verify that std::vector and std::ranges algorithms are available:
+    std::vector<int> v{31, 41, 59, 26, 53, 58, 97, 93};
+    assert(!std::ranges::is_sorted(v));
+    std::ranges::sort(v);
+    assert(std::ranges::is_sorted(v));
+    const std::vector<int> sorted{26, 31, 41, 53, 58, 59, 93, 97};
+    assert(v == sorted);
+
+    // Verify that the Sufficient Additional Overloads are available for std::sqrt():
+    assert(std::sqrt(25.0) == 5.0);
+    assert(std::sqrt(25.0f) == 5.0f);
+    assert(std::sqrt(25) == 5.0);
+    static_assert(std::is_same_v<decltype(std::sqrt(25.0)), double>);
+    static_assert(std::is_same_v<decltype(std::sqrt(25.0f)), float>);
+    static_assert(std::is_same_v<decltype(std::sqrt(25)), double>);
+
+    // Verify that the Sufficient Additional Overloads are available for ::sqrt():
+    assert(::sqrt(25.0) == 5.0);
+    assert(::sqrt(25.0f) == 5.0f);
+    assert(::sqrt(25) == 5.0);
+    static_assert(std::is_same_v<decltype(::sqrt(25.0)), double>);
+    static_assert(std::is_same_v<decltype(::sqrt(25.0f)), float>);
+    static_assert(std::is_same_v<decltype(::sqrt(25)), double>);
+}


### PR DESCRIPTION
As my `<yvals_core.h>` comment here explains, `extern "C++"` allows named modules to work with classically separately compiled code, which we've been doing ever since #3108 implemented the Standard Library Modules. It can also allow named modules to work with classic includes in the same TU, in one specific order.

Originally, I thought that wrapping the STL in `extern "C++"` would involve changing every header. I discovered that while I needed to *audit* every header, the necessary changes were far less extensive. I did have to perform several restructurings in other PRs (see below), but after that, we've reached a point where only a few additional changes are necessary. This is because the vast majority of the STL's code is wrapped in the `_STD_BEGIN`/`_STD_END` macro pair, which can be easily enhanced to also wrap code in `extern "C++" {` `}`. Similarly for our small amount of `_STDEXT_BEGIN`/`_STDEXT_END` extensions. For other namespaces, `Concurrency` is already wrapped in `extern "C++"` (most of it was applied in ancient times, surprisingly enough, while the rest was added during the initial Standard Library Modules implementation). As for the global namespace, the vast majority of the machinery that the STL declares/defines is `extern "C"` (which enjoys absolute immunity to module mixing mischief), either because it's UCRT or because that's our modern convention for separately compiled code.

That leaves only a small amount of global namespace code that *isn't* `extern "C"`, which this PR now wraps in `extern "C++"` blocks.

The control macro that I'm adding is `_USE_EXTERN_CXX_EVERYWHERE_FOR_STL`, which defaults to `_HAS_CXX20` but can be overridden. (It would be harmless to enable unconditionally, but I figured there was no reason to emit anything for 14/17 modes when it was so easy to avoid.) This will allow us to suppress the workaround when we develop a superior mechanism for avoiding mixing issues and will also allow users to opt-out if they know they are purely using the named module.

The macro pair that I'm adding to the source code is deliberately named `_EXTERN_CXX_WORKAROUND`/`_END_EXTERN_CXX_WORKAROUND` because we aren't planning to keep this forever. (Also, I wanted to avoid confusion with the permanent `extern "C++"` markings on separately compiled declarations.)

Thanks to @philnik777 for suggesting (in Discord) a workaround for dealing with my `<ctime>` workaround for the UCRT's obnoxious use of `static __inline`. The `<ctime>` workaround is a problem here because the Standard Library Module is emitting functions that *aren't* the same as the ordinary header. Templating the module's functions allows them to coexist with the ordinary functions, due to the overload resolution tiebreaker.

This PR can be reviewed and merged independently, but to take full effect, it needs @cdacamar's compiler fixes MSVC-PR-509344 shipping in VS 2022 17.9 Preview 3. It also needs my #4151 which will be merged soon - note that I've had to include that as a commit here in order to get the tests to pass, which will merge away harmlessly when we commit this. (And it needed my recently merged #4143 #4145 #4146 #4147.) With all of that, this will work, which is further than we've ever gotten before:

```
C:\Temp>type meow.cpp
```
```cpp
#include <__msvc_all_public_headers.hpp>
import std;

int main() {}
```
```
C:\Temp>cl /EHsc /nologo /W4 /std:c++latest /MTd /Od /Femeow.exe D:\msvc\binaries\x86chk\modules\std.ixx meow.cpp
std.ixx
meow.cpp
Generating Code...

C:\Temp>
```

The other order, with `import std;` *before* `#include`, still won't work (it's much more problematic for the compiler). In the medium-term we're looking into developing a "translation mechanism" that will allow arbitrary ordering/interleaving of `#include` and `import` to work, with likely superior throughput. In the short term, this PR's unblocking of one specific pattern will allow motivated users to begin exploring the migration of large real-world projects.

I didn't bother with the deprecation/removal typedefs in `<ccomplex>`, `<ciso646>`, `<cstdalign>`, `<cstdbool>`, and `<ctgmath>`, as they aren't dragged in by the named module. Also, `<__msvc_cxx_stdatomic.hpp>` is special and not dragged in by the named module, so I didn't change it either.

I'm adding test coverage to perform basic verification that the classic includes can coexist with the named modules. I'm testing `std::vector` and `std::ranges` algorithms as examples of "ordinary citizens" of `namespace std`, and the Sufficient Additional Overloads (in `namespace std` for both modules, and in the global namespace for the `std.compat` module) as the most important examples of things that are being directly marked as `extern "C++"` here. The test coverage has to be guarded by `_MSVC_INTERNAL_TESTING` until the compiler fixes ship; I've verified that this is passing internally.