### PR TITLE
`<flat_set>`: Restore insertion in `flat_(multi)set`'s iterator-pair/range constructors

### DIFF
--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -111,13 +111,15 @@ public:
         : _Base_flat_set(container_type(_First, _Last), _Comp) {}
     template <input_iterator _Iter, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Iter _First, _Iter _Last, const key_compare& _Comp, const _Alloc& _Al)
-        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al), _Comp) {
-        insert(_First, _Last);
+        : _Mycont(_STD make_obj_using_allocator<container_type>(_Al)), _Mycomp(_Comp) {
+        _Mycont.insert(_Mycont.end(), _First, _Last);
+        _Make_invariants_fulfilled();
     }
     template <input_iterator _Iter, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Iter _First, _Iter _Last, const _Alloc& _Al)
-        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al)) {
-        insert(_First, _Last);
+        : _Mycont(_STD make_obj_using_allocator<container_type>(_Al)), _Mycomp() {
+        _Mycont.insert(_Mycont.end(), _First, _Last);
+        _Make_invariants_fulfilled();
     }
 
     template <_Container_compatible_range<_Kty> _Rng>
@@ -125,16 +127,18 @@ public:
         : _Base_flat_set(container_type(from_range, _STD forward<_Rng>(_Range))) {}
     template <_Container_compatible_range<_Kty> _Rng, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(from_range_t, _Rng&& _Range, const _Alloc& _Al)
-        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al)) {
-        insert_range(_STD forward<_Rng>(_Range));
+        : _Mycont(_STD make_obj_using_allocator<container_type>(_Al)), _Mycomp() {
+        _Mycont.insert_range(_Mycont.end(), _STD forward<_Rng>(_Range));
+        _Make_invariants_fulfilled();
     }
     template <_Container_compatible_range<_Kty> _Rng>
     _Base_flat_set(from_range_t, _Rng&& _Range, const key_compare& _Comp)
         : _Base_flat_set(container_type(from_range, _STD forward<_Rng>(_Range)), _Comp) {}
     template <_Container_compatible_range<_Kty> _Rng, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(from_range_t, _Rng&& _Range, const key_compare& _Comp, const _Alloc& _Al)
-        : _Base_flat_set(_STD make_obj_using_allocator<container_type>(_Al), _Comp) {
-        insert_range(_STD forward<_Rng>(_Range));
+        : _Mycont(_STD make_obj_using_allocator<container_type>(_Al)), _Mycomp(_Comp) {
+        _Mycont.insert_range(_Mycont.end(), _STD forward<_Rng>(_Range));
+        _Make_invariants_fulfilled();
     }
 
     template <input_iterator _Iter>

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -112,13 +112,13 @@ public:
     template <input_iterator _Iter, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Iter _First, _Iter _Last, const key_compare& _Comp, const _Alloc& _Al)
         : _Mycont(_STD make_obj_using_allocator<container_type>(_Al)), _Mycomp(_Comp) {
-        _Mycont.insert(_Mycont.end(), _First, _Last);
+        _Mycont.assign(_First, _Last);
         _Make_invariants_fulfilled();
     }
     template <input_iterator _Iter, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(_Iter _First, _Iter _Last, const _Alloc& _Al)
         : _Mycont(_STD make_obj_using_allocator<container_type>(_Al)), _Mycomp() {
-        _Mycont.insert(_Mycont.end(), _First, _Last);
+        _Mycont.assign(_First, _Last);
         _Make_invariants_fulfilled();
     }
 
@@ -128,7 +128,7 @@ public:
     template <_Container_compatible_range<_Kty> _Rng, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(from_range_t, _Rng&& _Range, const _Alloc& _Al)
         : _Mycont(_STD make_obj_using_allocator<container_type>(_Al)), _Mycomp() {
-        _Mycont.insert_range(_Mycont.end(), _STD forward<_Rng>(_Range));
+        _Mycont.assign_range(_STD forward<_Rng>(_Range));
         _Make_invariants_fulfilled();
     }
     template <_Container_compatible_range<_Kty> _Rng>
@@ -137,7 +137,7 @@ public:
     template <_Container_compatible_range<_Kty> _Rng, _Allocator_for<container_type> _Alloc>
     _Base_flat_set(from_range_t, _Rng&& _Range, const key_compare& _Comp, const _Alloc& _Al)
         : _Mycont(_STD make_obj_using_allocator<container_type>(_Al)), _Mycomp(_Comp) {
-        _Mycont.insert_range(_Mycont.end(), _STD forward<_Rng>(_Range));
+        _Mycont.assign_range(_STD forward<_Rng>(_Range));
         _Make_invariants_fulfilled();
     }
 


### PR DESCRIPTION
This PR restores the original inserting logic by using ~`insert` and `insert_range`~ `assign` and `assign_range` in certain allocator-extended constructors (per [[sequence.reqmts]](https://eel.is/c++draft/sequence.reqmts), they are required for all (adaptable) sequence containers).

Addresses @achabense's review comments in https://github.com/microsoft/STL/pull/4148#discussion_r1388010662.