### PR TITLE
P2836R1: `basic_const_iterator` Should Follow Its Underlying Type's Convertibility

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2155,6 +2155,19 @@ public:
         return _Current == _Se;
     }
 
+    template <_Not_a_const_iterator _Other>
+        requires _Constant_iterator<_Other> && convertible_to<const _Iter&, _Other>
+    _NODISCARD constexpr operator _Other() const& noexcept(
+        is_nothrow_convertible_v<const _Iter&, _Other>) /* strengthened */ {
+        return _Current;
+    }
+
+    template <_Not_a_const_iterator _Other>
+        requires _Constant_iterator<_Other> && convertible_to<_Iter, _Other>
+    _NODISCARD constexpr operator _Other() && noexcept(is_nothrow_convertible_v<_Iter, _Other>) /* strengthened */ {
+        return _STD move(_Current);
+    }
+
     _NODISCARD constexpr bool operator<(const basic_const_iterator& _Right) const
         noexcept(noexcept(_Fake_copy_init<bool>(_Current < _Right._Current))) // strengthened
         requires random_access_iterator<_Iter>

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -383,6 +383,7 @@
 // P2693R1 Formatting thread::id And stacktrace
 // P2713R1 Escaping Improvements In std::format
 // P2763R1 Fixing layout_stride's Default Constructor For Fully Static Extents
+// P2836R1 basic_const_iterator Should Follow Its Underlying Type's Convertibility
 
 // _HAS_CXX23 and _SILENCE_ALL_CXX23_DEPRECATION_WARNINGS control:
 // P1413R3 Deprecate aligned_storage And aligned_union
@@ -1831,7 +1832,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #ifdef __cpp_lib_concepts
 #define __cpp_lib_out_ptr                  202106L
 #define __cpp_lib_print                    202207L
-#define __cpp_lib_ranges_as_const          202207L
+#define __cpp_lib_ranges_as_const          202311L
 #define __cpp_lib_ranges_as_rvalue         202207L
 #define __cpp_lib_ranges_cartesian_product 202207L
 #define __cpp_lib_ranges_chunk             202202L

--- a/tests/std/tests/P2278R4_basic_const_iterator/test.cpp
+++ b/tests/std/tests/P2278R4_basic_const_iterator/test.cpp
@@ -299,7 +299,7 @@ constexpr void instantiation_test() {
 }
 
 template <class T>
-struct tracking_input_iterator {
+class tracking_input_iterator {
 public:
     using value_type      = remove_const_t<T>;
     using difference_type = ptrdiff_t;
@@ -325,12 +325,12 @@ public:
     constexpr void operator++(int); // not defined
     T& operator*() const; // not defined
 
-    constexpr bool is_moved() const {
-        return moved;
-    }
-
     constexpr bool is_copied() const {
         return copied;
+    }
+
+    constexpr bool is_moved() const {
+        return moved;
     }
 
 private:
@@ -345,10 +345,10 @@ static_assert(_Constant_iterator<tracking_input_iterator<const int>>);
 // P2836R1 basic_const_iterator Should Follow Its Underlying Type's Convertibility
 constexpr void test_p2836r1() {
     { // Code from P2836R1
-        std::vector<int> v;
-        auto t  = v | views::take_while([](int const x) { return x < 100; });
-        auto f  = [](std::vector<int>::const_iterator) {};
-        auto i2 = std::ranges::cbegin(t);
+        vector<int> v;
+        auto t  = v | views::take_while([](const int x) { return x < 100; });
+        auto f  = [](vector<int>::const_iterator) {};
+        auto i2 = ranges::cbegin(t);
         f(i2); // Error before P2836R1
     }
 

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -674,7 +674,7 @@ STATIC_ASSERT(__cpp_lib_ranges == 202110L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-STATIC_ASSERT(__cpp_lib_ranges_as_const == 202207L);
+STATIC_ASSERT(__cpp_lib_ranges_as_const == 202311L);
 #elif defined(__cpp_lib_ranges_as_const)
 #error __cpp_lib_ranges_as_const is defined
 #endif


### PR DESCRIPTION
Closes #4183.