### PR TITLE
Remove more unnecessary `typename`s

### DIFF
--- a/stl/inc/__msvc_iter_core.hpp
+++ b/stl/inc/__msvc_iter_core.hpp
@@ -96,7 +96,7 @@ struct incrementable_traits<const _Ty> : incrementable_traits<_Ty> {};
 
 template <_Has_member_difference_type _Ty>
 struct incrementable_traits<_Ty> {
-    using difference_type = typename _Ty::difference_type;
+    using difference_type = _Ty::difference_type;
 };
 
 template <class _Ty>
@@ -117,7 +117,7 @@ _EXPORT_STD template <class>
 struct iterator_traits;
 
 _EXPORT_STD template <class _Ty>
-using iter_difference_t = typename conditional_t<_Is_from_primary<iterator_traits<remove_cvref_t<_Ty>>>,
+using iter_difference_t = conditional_t<_Is_from_primary<iterator_traits<remove_cvref_t<_Ty>>>,
     incrementable_traits<remove_cvref_t<_Ty>>, iterator_traits<remove_cvref_t<_Ty>>>::difference_type;
 
 template <class>
@@ -160,7 +160,7 @@ template <_Has_member_value_type _Ty>
 struct indirectly_readable_traits<_Ty> : _Cond_value_type<typename _Ty::value_type> {};
 
 _EXPORT_STD template <class _Ty>
-using iter_value_t = typename conditional_t<_Is_from_primary<iterator_traits<remove_cvref_t<_Ty>>>,
+using iter_value_t = conditional_t<_Is_from_primary<iterator_traits<remove_cvref_t<_Ty>>>,
     indirectly_readable_traits<remove_cvref_t<_Ty>>, iterator_traits<remove_cvref_t<_Ty>>>::value_type;
 
 _EXPORT_STD template <_Dereferenceable _Ty>
@@ -176,7 +176,7 @@ concept _Has_iter_types = _Has_member_difference_type<_It> && _Has_member_value_
 template <bool _Has_member_typedef>
 struct _Old_iter_traits_pointer {
     template <class _It>
-    using _Apply = typename _It::pointer;
+    using _Apply = _It::pointer;
 };
 
 template <>
@@ -187,17 +187,17 @@ struct _Old_iter_traits_pointer<false> {
 
 template <_Has_iter_types _It>
 struct _Iterator_traits_base<_It> {
-    using iterator_category = typename _It::iterator_category;
-    using value_type        = typename _It::value_type;
-    using difference_type   = typename _It::difference_type;
-    using pointer           = typename _Old_iter_traits_pointer<_Has_member_pointer<_It>>::template _Apply<_It>;
-    using reference         = typename _It::reference;
+    using iterator_category = _It::iterator_category;
+    using value_type        = _It::value_type;
+    using difference_type   = _It::difference_type;
+    using pointer           = _Old_iter_traits_pointer<_Has_member_pointer<_It>>::template _Apply<_It>;
+    using reference         = _It::reference;
 };
 
 template <bool _Has_member_typedef>
 struct _Iter_traits_difference {
     template <class _It>
-    using _Apply = typename incrementable_traits<_It>::difference_type;
+    using _Apply = incrementable_traits<_It>::difference_type;
 };
 
 template <>
@@ -233,7 +233,7 @@ struct _Iterator_traits_base<_It> {
     using iterator_category = output_iterator_tag;
     using value_type = void;
     using difference_type =
-        typename _Iter_traits_difference<_Has_member_difference_type<incrementable_traits<_It>>>::template _Apply<_It>;
+        _Iter_traits_difference<_Has_member_difference_type<incrementable_traits<_It>>>::template _Apply<_It>;
     using pointer    = void;
     using reference  = void;
 };
@@ -253,7 +253,7 @@ struct _Iter_traits_pointer<_Itraits_pointer_strategy::_Use_void> {
 template <>
 struct _Iter_traits_pointer<_Itraits_pointer_strategy::_Use_member> {
     template <class _It>
-    using _Apply = typename _It::pointer;
+    using _Apply = _It::pointer;
 };
 
 template <>
@@ -268,7 +268,7 @@ concept _Has_member_arrow = requires(_Ty&& __t) { static_cast<_Ty&&>(__t).operat
 template <bool _Has_member_typedef>
 struct _Iter_traits_reference {
     template <class _It>
-    using _Apply = typename _It::reference;
+    using _Apply = _It::reference;
 };
 
 template <>
@@ -290,7 +290,7 @@ struct _Iter_traits_category4<false> {
 // clang-format off
 template <class _It>
 concept _Cpp17_random_delta = totally_ordered<_It>
-    && requires(_It __i, typename incrementable_traits<_It>::difference_type __n) {
+    && requires(_It __i, incrementable_traits<_It>::difference_type __n) {
         { __i += __n } -> same_as<_It&>;
         { __i -= __n } -> same_as<_It&>;
         { __i +  __n } -> same_as<_It>;
@@ -304,7 +304,7 @@ concept _Cpp17_random_delta = totally_ordered<_It>
 template <bool _Is_bidi>
 struct _Iter_traits_category3 {
     template <class _It>
-    using _Apply = typename _Iter_traits_category4<_Cpp17_random_delta<_It>>::type;
+    using _Apply = _Iter_traits_category4<_Cpp17_random_delta<_It>>::type;
 };
 
 template <>
@@ -323,7 +323,7 @@ concept _Cpp17_bidi_delta = requires(_It __i) {
 template <bool _Is_forward>
 struct _Iter_traits_category2 {
     template <class _It>
-    using _Apply = typename _Iter_traits_category3<_Cpp17_bidi_delta<_It>>::template _Apply<_It>;
+    using _Apply = _Iter_traits_category3<_Cpp17_bidi_delta<_It>>::template _Apply<_It>;
 };
 
 template <>
@@ -345,27 +345,27 @@ concept _Cpp17_forward_delta = constructible_from<_It> && is_reference_v<iter_re
 template <bool _Has_member_typedef>
 struct _Iter_traits_category {
     template <class _It>
-    using _Apply = typename _It::iterator_category;
+    using _Apply = _It::iterator_category;
 };
 
 template <>
 struct _Iter_traits_category<false> {
     template <class _It>
-    using _Apply = typename _Iter_traits_category2<_Cpp17_forward_delta<_It>>::template _Apply<_It>;
+    using _Apply = _Iter_traits_category2<_Cpp17_forward_delta<_It>>::template _Apply<_It>;
 };
 
 // clang-format off
 template <class _It>
     requires (!_Has_iter_types<_It> && _Cpp17_input_iterator<_It>)
 struct _Iterator_traits_base<_It> {
-    using iterator_category = typename _Iter_traits_category<_Has_member_iterator_category<_It>>::template _Apply<_It>;
-    using value_type        = typename indirectly_readable_traits<_It>::value_type;
-    using difference_type   = typename incrementable_traits<_It>::difference_type;
-    using pointer           = typename _Iter_traits_pointer<(
+    using iterator_category = _Iter_traits_category<_Has_member_iterator_category<_It>>::template _Apply<_It>;
+    using value_type        = indirectly_readable_traits<_It>::value_type;
+    using difference_type   = incrementable_traits<_It>::difference_type;
+    using pointer           = _Iter_traits_pointer<(
         _Has_member_pointer<_It> ? _Itraits_pointer_strategy::_Use_member
                                  : _Has_member_arrow<_It&> ? _Itraits_pointer_strategy::_Use_decltype
                                                        : _Itraits_pointer_strategy::_Use_void)>::template _Apply<_It>;
-    using reference         = typename _Iter_traits_reference<_Has_member_reference<_It>>::template _Apply<_It>;
+    using reference         = _Iter_traits_reference<_Has_member_reference<_It>>::template _Apply<_It>;
 };
 // clang-format on
 

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -1109,7 +1109,7 @@ struct iterator_traits<common_iterator<_Iter, _Se>> {
     using iterator_category = conditional_t<_Has_forward_category<_Iter>, forward_iterator_tag, input_iterator_tag>;
     using value_type        = iter_value_t<_Iter>;
     using difference_type   = iter_difference_t<_Iter>;
-    using pointer           = typename _Common_iterator_pointer_type<_Iter, _Se>::pointer;
+    using pointer           = _Common_iterator_pointer_type<_Iter, _Se>::pointer;
     using reference         = iter_reference_t<_Iter>;
 };
 
@@ -1126,7 +1126,7 @@ struct _Counted_iterator_category_base : _Counted_iterator_value_type_base<_Iter
 
 template <_Has_member_iterator_category _Iter>
 struct _Counted_iterator_category_base<_Iter> : _Counted_iterator_value_type_base<_Iter> {
-    using iterator_category = typename _Iter::iterator_category;
+    using iterator_category = _Iter::iterator_category;
 };
 
 template <class _Iter>
@@ -1134,7 +1134,7 @@ struct _Counted_iterator_concept_base : _Counted_iterator_category_base<_Iter> {
 
 template <_Has_member_iterator_concept _Iter>
 struct _Counted_iterator_concept_base<_Iter> : _Counted_iterator_category_base<_Iter> {
-    using iterator_concept = typename _Iter::iterator_concept;
+    using iterator_concept = _Iter::iterator_concept;
 };
 
 _EXPORT_STD template <input_or_output_iterator _Iter>

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -932,7 +932,7 @@ namespace test {
             return elements_.data();
         }
 
-        using UI = typename I::unwrap;
+        using UI = I::unwrap;
         using US = conditional_t<to_bool(IsCommon), UI, sentinel<Element, WrappedState::unwrapped>>;
 
         [[nodiscard]] constexpr UI _Unchecked_begin() const noexcept {

--- a/tests/std/include/test_mdspan_support.hpp
+++ b/tests/std/include/test_mdspan_support.hpp
@@ -258,7 +258,7 @@ inline constexpr bool is_permissive = details::PermissiveTest<int>::test();
 
 template <class Mapping>
 struct MappingProperties {
-    typename Mapping::index_type req_span_size;
+    Mapping::index_type req_span_size;
     bool uniqueness;
     bool exhaustiveness;
     bool strideness;
@@ -267,7 +267,7 @@ struct MappingProperties {
 template <class Mapping>
     requires (!details::PermissiveTest<Mapping>::test())
 MappingProperties<Mapping> get_mapping_properties(const Mapping& mapping) {
-    using IndexType     = typename Mapping::index_type;
+    using IndexType     = Mapping::index_type;
     constexpr auto rank = Mapping::extents_type::rank();
     constexpr std::make_index_sequence<rank> rank_indices;
 

--- a/tests/std/tests/P0053R7_cpp_synchronized_buffered_ostream/test.cpp
+++ b/tests/std/tests/P0053R7_cpp_synchronized_buffered_ostream/test.cpp
@@ -16,10 +16,10 @@ static_assert(is_destructible_v<syncbuf>);
 template <class Elem, class Traits, class Alloc>
 class test_syncbuf : public basic_syncbuf<Elem, Traits, Alloc> {
 public:
-    using size_type      = typename Alloc::size_type;
-    using value_type     = typename Alloc::value_type;
+    using size_type      = Alloc::size_type;
+    using value_type     = Alloc::value_type;
     using Mybase         = basic_syncbuf<Elem, Traits, Alloc>;
-    using streambuf_type = typename Mybase::streambuf_type;
+    using streambuf_type = Mybase::streambuf_type;
 
     using Mybase::epptr;
     using Mybase::pbase;
@@ -49,7 +49,7 @@ public:
 template <class Alloc>
 void test_syncbuf_member_functions(string_buffer<typename Alloc::value_type>* buf = nullptr) {
 
-    using value_type = typename Alloc::value_type;
+    using value_type = Alloc::value_type;
     using Syncbuf    = test_syncbuf<value_type, char_traits<value_type>, Alloc>;
     using OStream    = basic_ostream<value_type, char_traits<value_type>>;
 
@@ -124,7 +124,7 @@ template <class Alloc, bool ThrowOnSync = false>
 void test_syncbuf_synchronization(string_buffer<typename Alloc::value_type, ThrowOnSync>* buf) {
     assert(buf); // meaningless to run with nullptr
 
-    using value_type = typename Alloc::value_type;
+    using value_type = Alloc::value_type;
     using Syncbuf    = test_syncbuf<value_type, char_traits<value_type>, Alloc>;
     using OStream    = basic_ostream<value_type, char_traits<value_type>>;
 
@@ -182,7 +182,7 @@ void test_syncbuf_synchronization(string_buffer<typename Alloc::value_type, Thro
 template <class Alloc>
 void test_syncbuf_move_swap_operations(string_buffer<typename Alloc::value_type>* buf) {
 
-    using value_type = typename Alloc::value_type;
+    using value_type = Alloc::value_type;
     using Syncbuf    = test_syncbuf<value_type, char_traits<value_type>, Alloc>;
     using OStream    = basic_ostream<value_type, char_traits<value_type>>;
 
@@ -261,7 +261,7 @@ void test_syncbuf_move_swap_operations(string_buffer<typename Alloc::value_type>
 
 template <class Alloc>
 void test_osyncstream(string_buffer<typename Alloc::value_type>* buf = nullptr) {
-    using value_type  = typename Alloc::value_type;
+    using value_type  = Alloc::value_type;
     using OSyncStream = basic_osyncstream<value_type, char_traits<value_type>, Alloc>;
 
     {

--- a/tests/std/tests/P0631R8_numbers_math_constants/test.cpp
+++ b/tests/std/tests/P0631R8_numbers_math_constants/test.cpp
@@ -43,7 +43,7 @@ struct apply_modify_cv<modify_cv::add_cv, T> {
 };
 
 template <modify_cv Modification, class T>
-using apply_modify_cv_t = typename apply_modify_cv<Modification, T>::type;
+using apply_modify_cv_t = apply_modify_cv<Modification, T>::type;
 
 template <modify_cv Modification>
 constexpr void test_cv_floating_point() {

--- a/tests/std/tests/P0645R10_text_formatting_args/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_args/test.cpp
@@ -52,7 +52,7 @@ enum class Arg_type : uint8_t {
 template <class Context>
 constexpr auto visitor = [](auto&& arg) {
     using T         = decay_t<decltype(arg)>;
-    using char_type = typename Context::char_type;
+    using char_type = Context::char_type;
     if constexpr (is_same_v<T, monostate>) {
         return Arg_type::none;
     } else if constexpr (is_same_v<T, int>) {
@@ -84,7 +84,7 @@ constexpr auto visitor = [](auto&& arg) {
 
 template <class Context>
 void test_basic_format_arg() {
-    using char_type = typename Context::char_type;
+    using char_type = Context::char_type;
 
     { // construction
         basic_format_arg<Context> default_constructed;
@@ -161,7 +161,7 @@ void test_single_format_arg(Type value) {
 
 template <class Context>
 void test_format_arg_store() {
-    using char_type = typename Context::char_type;
+    using char_type = Context::char_type;
 
     test_empty_format_arg<Context>();
 

--- a/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
@@ -235,7 +235,7 @@ void test_mixed_custom_formattable_type() {
 
 template <class OutIt, class CharT>
 void test_basic_format_arg_handle_construction() {
-    using handle = typename basic_format_arg<basic_format_context<OutIt, CharT>>::handle;
+    using handle = basic_format_arg<basic_format_context<OutIt, CharT>>::handle;
 
     static_assert(is_constructible_v<handle, int&>);
     static_assert(is_constructible_v<handle, const int&>);

--- a/tests/std/tests/P0753R2_manipulators_for_cpp_synchronized_buffered_ostream/test.cpp
+++ b/tests/std/tests/P0753R2_manipulators_for_cpp_synchronized_buffered_ostream/test.cpp
@@ -38,8 +38,8 @@ public:
 template <class Ty, class Alloc = void, bool ThrowOnSync = false>
 void test_osyncstream_manipulators(
     string_buffer<typename Ty::char_type, ThrowOnSync>* buf = nullptr, bool buffer_can_sync = true) {
-    using char_type   = typename Ty::char_type;
-    using traits_type = typename Ty::traits_type;
+    using char_type   = Ty::char_type;
+    using traits_type = Ty::traits_type;
 
     static_assert(is_base_of_v<basic_ostream<char_type, traits_type>, Ty>);
 

--- a/tests/std/tests/P0768R1_spaceship_cpos/test.cpp
+++ b/tests/std/tests/P0768R1_spaceship_cpos/test.cpp
@@ -31,7 +31,7 @@ struct CpoResultImpl<CPO, E, F> {
 };
 
 template <const auto& CPO, typename E, typename F = E>
-using CpoResult = typename CpoResultImpl<CPO, E, F>::type;
+using CpoResult = CpoResultImpl<CPO, E, F>::type;
 
 template <const auto& CPO, typename E, typename F = E>
 inline constexpr bool NoexceptCpo = noexcept(CPO(declval<E>(), declval<F>()));

--- a/tests/std/tests/P0896R4_common_iterator/test.cpp
+++ b/tests/std/tests/P0896R4_common_iterator/test.cpp
@@ -34,7 +34,7 @@ struct instantiator {
     template <input_or_output_iterator Iter>
     static constexpr void call() {
         if constexpr (copyable<Iter>) {
-            using ConstIter = typename Iter::Consterator;
+            using ConstIter = Iter::Consterator;
             using Sen       = test::sentinel<iter_value_t<Iter>>;
             using OSen      = test::sentinel<const iter_value_t<Iter>>;
             using Cit       = common_iterator<Iter, Sen>;
@@ -43,21 +43,21 @@ struct instantiator {
 
             // [common.iter.types]
             {
-                using iconcept = typename iterator_traits<Cit>::iterator_concept;
+                using iconcept = iterator_traits<Cit>::iterator_concept;
                 if constexpr (forward_iterator<Iter>) {
                     STATIC_ASSERT(same_as<iconcept, forward_iterator_tag>);
                 } else {
                     STATIC_ASSERT(same_as<typename iterator_traits<Cit>::iterator_concept, input_iterator_tag>);
                 }
 
-                using icat = typename iterator_traits<Cit>::iterator_category;
+                using icat = iterator_traits<Cit>::iterator_category;
                 if constexpr (derived_from<icat, forward_iterator_tag>) {
                     STATIC_ASSERT(same_as<icat, forward_iterator_tag>);
                 } else {
                     STATIC_ASSERT(same_as<icat, input_iterator_tag>);
                 }
 
-                using ipointer = typename iterator_traits<Cit>::pointer;
+                using ipointer = iterator_traits<Cit>::pointer;
                 if constexpr (CanArrow<Cit>) {
                     STATIC_ASSERT(same_as<ipointer, decltype(declval<const Cit&>().operator->())>);
                 } else {

--- a/tests/std/tests/P0896R4_counted_iterator/test.cpp
+++ b/tests/std/tests/P0896R4_counted_iterator/test.cpp
@@ -48,7 +48,7 @@ concept CountedCompare = Counted<I1, I2>
 struct instantiator {
     template <input_or_output_iterator Iter>
     static constexpr void call() {
-        using ConstIter = typename Iter::Consterator;
+        using ConstIter = Iter::Consterator;
 
         int input[5] = {1, 2, 3, 4, 5};
         // [counted.iter.const]

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -773,18 +773,18 @@ constexpr bool is_forward_list<std::forward_list<T, A>> = true;
 
 template <class T, class IterConcept>
 constexpr bool test_std_container() {
-    using I  = typename T::iterator;
+    using I  = T::iterator;
     using D  = std::iter_difference_t<I>;
-    using CI = typename T::const_iterator;
+    using CI = T::const_iterator;
     STATIC_ASSERT(std::same_as<std::iter_difference_t<CI>, D>);
 
-    using Category = typename std::iterator_traits<I>::iterator_category;
+    using Category = std::iterator_traits<I>::iterator_category;
     STATIC_ASSERT(std::derived_from<IterConcept, Category>);
 
     using RI  = std::conditional_t<std::bidirectional_iterator<I>, std::reverse_iterator<I>, invalid_type>;
     using RCI = std::conditional_t<std::bidirectional_iterator<I>, std::reverse_iterator<CI>, invalid_type>;
 
-    using V = typename T::value_type;
+    using V = T::value_type;
 
     STATIC_ASSERT(test_begin<T>());
     STATIC_ASSERT(test_end<T>());

--- a/tests/std/tests/P0896R4_ranges_to_address/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_to_address/test.cpp
@@ -56,7 +56,7 @@ void test_positive_cases() {
 // Negative tests:
 template <class C, bool IsConst>
 void test_invalidated_by_pop_back() {
-    using T = typename C::value_type;
+    using T = C::value_type;
     C c     = {T{}, {}, {}};
 
     maybe_const_iter<IsConst, C> const pos = c.end() - 1;
@@ -68,7 +68,7 @@ void test_invalidated_by_pop_back() {
 
 template <class C, bool IsConst>
 void test_invalidated_by_push_back() {
-    using T = typename C::value_type;
+    using T = C::value_type;
     C c;
     c.resize(1024, T{});
     c.resize(512);
@@ -82,7 +82,7 @@ void test_invalidated_by_push_back() {
 
 template <class C, bool IsConst>
 void test_invalidated_by_reallocation() {
-    using T = typename C::value_type;
+    using T = C::value_type;
     C c     = {T{}, {}, {}};
 
     maybe_const_iter<IsConst, C> const pos = c.begin();
@@ -94,7 +94,7 @@ void test_invalidated_by_reallocation() {
 
 template <class C, bool IsConst>
 void test_out_of_range() {
-    using T = typename C::value_type;
+    using T = C::value_type;
     C c     = {T{}, {}, {}};
 
     maybe_const_iter<IsConst, C> const last = c.end();

--- a/tests/std/tests/P0896R4_views_drop/test.cpp
+++ b/tests/std/tests/P0896R4_views_drop/test.cpp
@@ -79,7 +79,7 @@ struct mapped<ranges::subrange<I, S, ranges::subrange_kind::sized>> {
 };
 
 template <ranges::viewable_range Rng>
-using mapped_t = typename mapped<remove_cvref_t<Rng>>::template apply<Rng>;
+using mapped_t = mapped<remove_cvref_t<Rng>>::template apply<Rng>;
 
 template <ranges::viewable_range Rng>
 using pipeline_t = mapped_t<mapped_t<mapped_t<mapped_t<Rng>>>>;

--- a/tests/std/tests/P0896R4_views_filter_iterator/test.cpp
+++ b/tests/std/tests/P0896R4_views_filter_iterator/test.cpp
@@ -32,7 +32,7 @@ struct iterator_instantiator {
 
         static_assert(_Has_member_iterator_category<I> == forward_iterator<Iter>);
         if constexpr (forward_iterator<Iter>) {
-            using C = typename iterator_traits<Iter>::iterator_category;
+            using C = iterator_traits<Iter>::iterator_category;
             static_assert(is_same_v<typename I::iterator_category,
                 conditional_t<derived_from<C, bidirectional_iterator_tag>, bidirectional_iterator_tag,
                     conditional_t<derived_from<C, forward_iterator_tag>, forward_iterator_tag, input_iterator_tag>>>);

--- a/tests/std/tests/P0896R4_views_lazy_split/test.cpp
+++ b/tests/std/tests/P0896R4_views_lazy_split/test.cpp
@@ -33,8 +33,7 @@ struct delimiter_view_impl<false> {
 };
 template <class Base, class Delimiter>
 using delimiter_view_t =
-    typename delimiter_view_impl<is_convertible_v<Delimiter, ranges::range_value_t<Base>>>::template apply<Base,
-        Delimiter>;
+    delimiter_view_impl<is_convertible_v<Delimiter, ranges::range_value_t<Base>>>::template apply<Base, Delimiter>;
 
 template <ranges::input_range Base, class Delimiter, ranges::input_range Expected>
 constexpr void test_one(Base&& base, Delimiter&& delimiter, Expected&& expected) {

--- a/tests/std/tests/P0896R4_views_split/test.cpp
+++ b/tests/std/tests/P0896R4_views_split/test.cpp
@@ -35,8 +35,7 @@ struct delimiter_view_impl<false> {
 };
 template <class Base, class Delimiter>
 using delimiter_view_t =
-    typename delimiter_view_impl<is_convertible_v<Delimiter, ranges::range_value_t<Base>>>::template apply<Base,
-        Delimiter>;
+    delimiter_view_impl<is_convertible_v<Delimiter, ranges::range_value_t<Base>>>::template apply<Base, Delimiter>;
 
 template <ranges::forward_range Base, class Delimiter, ranges::forward_range Expected>
 constexpr void test_one(Base&& base, Delimiter&& delimiter, Expected&& expected) {

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -82,7 +82,7 @@ struct mapped<ranges::subrange<I, S, ranges::subrange_kind::sized>> {
 };
 
 template <ranges::viewable_range Rng>
-using mapped_t = typename mapped<remove_cvref_t<Rng>>::template apply<Rng>;
+using mapped_t = mapped<remove_cvref_t<Rng>>::template apply<Rng>;
 
 template <ranges::viewable_range Rng>
 using pipeline_t = mapped_t<mapped_t<mapped_t<mapped_t<Rng>>>>;

--- a/tests/std/tests/P0896R4_views_transform/test.cpp
+++ b/tests/std/tests/P0896R4_views_transform/test.cpp
@@ -399,8 +399,8 @@ constexpr void test_difference_on_const_functor(Rng&& rng) {
     if constexpr (forward_range<V>) {
         using It      = iterator_t<V>;
         using TVIt    = iterator_t<TV>;
-        using VItCat  = typename iterator_traits<It>::iterator_category;
-        using TVItCat = typename iterator_traits<TVIt>::iterator_category;
+        using VItCat  = iterator_traits<It>::iterator_category;
+        using TVItCat = iterator_traits<TVIt>::iterator_category;
         STATIC_ASSERT(
             is_same_v<TVItCat, VItCat>
             || (is_same_v<TVItCat, random_access_iterator_tag> && is_same_v<VItCat, contiguous_iterator_tag>) );
@@ -433,8 +433,8 @@ constexpr void test_xvalue_ranges(Rng&& rng) {
     if constexpr (forward_range<V>) {
         using It      = iterator_t<V>;
         using TVIt    = iterator_t<TV>;
-        using VItCat  = typename iterator_traits<It>::iterator_category;
-        using TVItCat = typename iterator_traits<TVIt>::iterator_category;
+        using VItCat  = iterator_traits<It>::iterator_category;
+        using TVItCat = iterator_traits<TVIt>::iterator_category;
         STATIC_ASSERT(
             is_same_v<TVItCat, VItCat>
             || (is_same_v<TVItCat, random_access_iterator_tag> && is_same_v<VItCat, contiguous_iterator_tag>) );

--- a/tests/std/tests/P0898R3_identity/test.cpp
+++ b/tests/std/tests/P0898R3_identity/test.cpp
@@ -16,7 +16,7 @@ struct S {
 };
 
 template <typename T>
-using test = typename T::is_transparent;
+using test = T::is_transparent;
 
 int main() {
     STATIC_ASSERT(identity{}(42) == 42);

--- a/tests/std/tests/P1206R7_ranges_to_mappish/test.cpp
+++ b/tests/std/tests/P1206R7_ranges_to_mappish/test.cpp
@@ -73,7 +73,7 @@ struct mappish_instantiator {
     };
 
     template <template <class...> class C, class Key, class Val, class... Args>
-    using deduce_container = typename deduce_container_impl<C>::template apply<Key, Val, Args...>;
+    using deduce_container = deduce_container_impl<C>::template apply<Key, Val, Args...>;
 
     template <template <class...> class C>
     static void test_copy_move() {

--- a/tests/std/tests/P1206R7_ranges_to_sequence/test.cpp
+++ b/tests/std/tests/P1206R7_ranges_to_sequence/test.cpp
@@ -55,7 +55,7 @@ struct sequence_instantiator {
     };
 
     template <template <class...> class C, class T, class... Args>
-    using deduce_container = typename deduce_container_impl<C>::template apply<T, Args...>;
+    using deduce_container = deduce_container_impl<C>::template apply<T, Args...>;
 
     static constexpr auto meow = "meow"sv;
 

--- a/tests/std/tests/P1206R7_ranges_to_settish/test.cpp
+++ b/tests/std/tests/P1206R7_ranges_to_settish/test.cpp
@@ -67,7 +67,7 @@ struct settish_instantiator {
     };
 
     template <template <class...> class C, class Key, class... Args>
-    using deduce_container = typename deduce_container_impl<C>::template apply<Key, Args...>;
+    using deduce_container = deduce_container_impl<C>::template apply<Key, Args...>;
 
     template <template <class...> class C>
     static void test_copy_move() {

--- a/tests/std/tests/P1614R2_spaceship/test.cpp
+++ b/tests/std/tests/P1614R2_spaceship/test.cpp
@@ -181,7 +181,7 @@ inline constexpr bool has_synth_ordered<SynthOrdered> = true;
 template <class Container>
 constexpr void ordered_containers_test(
     const Container& smaller, const Container& smaller_equal, const Container& larger) {
-    using Elem = typename Container::value_type;
+    using Elem = Container::value_type;
 
     if constexpr (has_synth_ordered<Elem>) {
         spaceship_test<std::weak_ordering>(smaller, smaller_equal, larger);

--- a/tests/std/tests/P1899R3_views_stride/test.cpp
+++ b/tests/std/tests/P1899R3_views_stride/test.cpp
@@ -360,8 +360,8 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     {
         // Check iterator_category
         if constexpr (forward_range<R>) {
-            using IterCat = typename iterator_t<R>::iterator_category;
-            using C       = typename iterator_traits<iterator_t<V>>::iterator_category;
+            using IterCat = iterator_t<R>::iterator_category;
+            using C       = iterator_traits<iterator_t<V>>::iterator_category;
             STATIC_ASSERT((derived_from<C, random_access_iterator_tag> && same_as<IterCat, random_access_iterator_tag>)
                           || same_as<IterCat, C>);
         }
@@ -454,8 +454,8 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     if constexpr (CanMemberBegin<const R>) {
         // Check iterator_category
         if constexpr (forward_range<const R>) {
-            using IterCat = typename iterator_t<const R>::iterator_category;
-            using C       = typename iterator_traits<iterator_t<const V>>::iterator_category;
+            using IterCat = iterator_t<const R>::iterator_category;
+            using C       = iterator_traits<iterator_t<const V>>::iterator_category;
             STATIC_ASSERT((derived_from<C, random_access_iterator_tag> && same_as<IterCat, random_access_iterator_tag>)
                           || same_as<IterCat, C>);
         }

--- a/tests/std/tests/P2165R4_tuple_like_tuple_members/test.cpp
+++ b/tests/std/tests/P2165R4_tuple_like_tuple_members/test.cpp
@@ -27,7 +27,7 @@ struct repeat_type_injection_impl<Template, T, N, index_sequence<Indices...>> {
 };
 
 template <template <class...> class Template, class T, size_t N>
-using repeat_type_injection = typename repeat_type_injection_impl<Template, T, N>::type;
+using repeat_type_injection = repeat_type_injection_impl<Template, T, N>::type;
 
 static_assert(same_as<repeat_type_injection<tuple, int, 0>, tuple<>>);
 static_assert(same_as<repeat_type_injection<pair, int, 2>, pair<int, int>>);
@@ -292,7 +292,7 @@ struct TupleLikeArrayImpl<Head, Rest...> {
 };
 
 template <class... Ts>
-using TupleLikeArray = typename TupleLikeArrayImpl<Ts...>::type;
+using TupleLikeArray = TupleLikeArrayImpl<Ts...>::type;
 
 int main() {
     static_assert(tester<0, TupleLikeArray>::run());

--- a/tests/std/tests/P2278R4_basic_const_iterator/test.cpp
+++ b/tests/std/tests/P2278R4_basic_const_iterator/test.cpp
@@ -41,7 +41,7 @@ constexpr void test_one(It iter) {
     static_assert(same_as<typename ConstIt::value_type, iter_value_t<It>>);
     static_assert(same_as<typename ConstIt::difference_type, iter_difference_t<It>>);
     if constexpr (forward_iterator<It>) {
-        using Cat = typename iterator_traits<It>::iterator_category;
+        using Cat = iterator_traits<It>::iterator_category;
         static_assert(same_as<typename ConstIt::iterator_category, Cat>);
     }
 

--- a/tests/std/tests/P2278R4_const_span/test.cpp
+++ b/tests/std/tests/P2278R4_const_span/test.cpp
@@ -20,8 +20,8 @@ template <Const IsConst, Dynamic IsDynamic>
 constexpr bool test() {
     using T      = conditional_t<to_underlying(IsConst), const int, int>;
     using Span   = span<T, to_underlying(IsDynamic) ? dynamic_extent : 3>;
-    using CIt    = typename Span::const_iterator;
-    using CRevIt = typename Span::const_reverse_iterator;
+    using CIt    = Span::const_iterator;
+    using CRevIt = Span::const_reverse_iterator;
 
     // Validate iterator properties
     static_assert(contiguous_iterator<CIt>);

--- a/tests/std/tests/P2286R8_text_formatting_formattable/test.compile.pass.cpp
+++ b/tests/std/tests/P2286R8_text_formatting_formattable/test.compile.pass.cpp
@@ -297,12 +297,12 @@ struct abstract {
 template <formatter_supporting_character_type CharT>
 struct formatter<abstract, CharT> {
     template <class ParseContext>
-    constexpr typename ParseContext::iterator parse(ParseContext& parse_ctx) {
+    constexpr ParseContext::iterator parse(ParseContext& parse_ctx) {
         return parse_ctx.begin();
     }
 
     template <class FormatContext>
-    typename FormatContext::iterator format(const abstract&, FormatContext& ctx) const {
+    FormatContext::iterator format(const abstract&, FormatContext& ctx) const {
         return ctx.out();
     }
 };

--- a/tests/std/tests/P2321R2_views_adjacent/test.cpp
+++ b/tests/std/tests/P2321R2_views_adjacent/test.cpp
@@ -34,7 +34,7 @@ struct repeated_tuple_impl<T, index_sequence<Indices...>> {
 };
 
 template <class T, size_t N>
-using repeated_tuple = typename repeated_tuple_impl<T, make_index_sequence<N>>::type;
+using repeated_tuple = repeated_tuple_impl<T, make_index_sequence<N>>::type;
 
 STATIC_ASSERT(same_as<repeated_tuple<int, 0>, tuple<>>);
 STATIC_ASSERT(same_as<repeated_tuple<int, 3>, tuple<int, int, int>>);
@@ -330,7 +330,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         STATIC_ASSERT(same_as<typename I::iterator_category, input_iterator_tag>);
 
         // Check iterator_concept
-        using IterConcept = typename I::iterator_concept;
+        using IterConcept = I::iterator_concept;
         STATIC_ASSERT(random_access_range<V> == same_as<IterConcept, random_access_iterator_tag>);
         STATIC_ASSERT(
             (bidirectional_range<V> && !random_access_range<V>) == same_as<IterConcept, bidirectional_iterator_tag>);
@@ -511,7 +511,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         STATIC_ASSERT(same_as<typename CI::iterator_category, input_iterator_tag>);
 
         // Check iterator_concept
-        using IterConcept = typename CI::iterator_concept;
+        using IterConcept = CI::iterator_concept;
         STATIC_ASSERT(random_access_range<const V> == same_as<IterConcept, random_access_iterator_tag>);
         STATIC_ASSERT((bidirectional_range<const V> && !random_access_range<const V>)
                       == same_as<IterConcept, bidirectional_iterator_tag>);

--- a/tests/std/tests/P2321R2_views_adjacent_transform/test.cpp
+++ b/tests/std/tests/P2321R2_views_adjacent_transform/test.cpp
@@ -32,7 +32,7 @@ struct repeated_tuple_impl<T, index_sequence<Indices...>> {
 };
 
 template <class T, size_t N>
-using repeated_tuple = typename repeated_tuple_impl<T, make_index_sequence<N>>::type;
+using repeated_tuple = repeated_tuple_impl<T, make_index_sequence<N>>::type;
 
 STATIC_ASSERT(same_as<repeated_tuple<int, 0>, tuple<>>);
 STATIC_ASSERT(same_as<repeated_tuple<int, 3>, tuple<int, int, int>>);
@@ -67,7 +67,7 @@ struct invoke_result_with_repeated_type_impl<Fn, Ty, 0, Repeated...> {
 };
 
 template <class Fn, class Ty, size_t Nx>
-using invoke_result_with_repeated_type = typename invoke_result_with_repeated_type_impl<Fn, Ty, Nx>::type;
+using invoke_result_with_repeated_type = invoke_result_with_repeated_type_impl<Fn, Ty, Nx>::type;
 
 static_assert(same_as<invoke_result_with_repeated_type<plus<int>, int, 2>, int>);
 static_assert(same_as<invoke_result_with_repeated_type<equal_to<int>, int, 2>, bool>);
@@ -389,11 +389,11 @@ constexpr bool test_one(Rng&& rng, Fn func, Expected&& expected_rng) {
         STATIC_ASSERT(forward_iterator<I>);
 
         // Check iterator_category
-        using IterCat = typename I::iterator_category;
+        using IterCat = I::iterator_category;
         if constexpr (!is_reference_v<invoke_result_with_repeated_type<Fn, range_reference_t<V>, N>>) {
             STATIC_ASSERT(same_as<IterCat, input_iterator_tag>);
         } else {
-            using BaseCat = typename iterator_traits<BI>::iterator_category;
+            using BaseCat = iterator_traits<BI>::iterator_category;
             if constexpr (derived_from<BaseCat, random_access_iterator_tag>) {
                 STATIC_ASSERT(same_as<IterCat, random_access_iterator_tag>);
             } else if constexpr (derived_from<BaseCat, bidirectional_iterator_tag>) {
@@ -406,7 +406,7 @@ constexpr bool test_one(Rng&& rng, Fn func, Expected&& expected_rng) {
         }
 
         // Check iterator_concept
-        using IterConcept = typename I::iterator_concept;
+        using IterConcept = I::iterator_concept;
         STATIC_ASSERT(same_as<IterConcept, typename iterator_t<adjacent_view<V, N>>::iterator_concept>);
 
         // Check value_type
@@ -567,11 +567,11 @@ constexpr bool test_one(Rng&& rng, Fn func, Expected&& expected_rng) {
         STATIC_ASSERT(forward_iterator<CI>);
 
         // Check iterator_category
-        using IterCat = typename CI::iterator_category;
+        using IterCat = CI::iterator_category;
         if constexpr (!is_reference_v<invoke_result_with_repeated_type<Fn, range_reference_t<const V>, N>>) {
             STATIC_ASSERT(same_as<IterCat, input_iterator_tag>);
         } else {
-            using BaseCat = typename iterator_traits<CBI>::iterator_category;
+            using BaseCat = iterator_traits<CBI>::iterator_category;
             if constexpr (derived_from<BaseCat, random_access_iterator_tag>) {
                 STATIC_ASSERT(same_as<IterCat, random_access_iterator_tag>);
             } else if constexpr (derived_from<BaseCat, bidirectional_iterator_tag>) {
@@ -584,7 +584,7 @@ constexpr bool test_one(Rng&& rng, Fn func, Expected&& expected_rng) {
         }
 
         // Check iterator_concept
-        using IterConcept = typename CI::iterator_concept;
+        using IterConcept = CI::iterator_concept;
         STATIC_ASSERT(same_as<IterConcept, typename iterator_t<const adjacent_view<V, N>>::iterator_concept>);
 
         // Check value_type

--- a/tests/std/tests/P2321R2_views_zip/test.cpp
+++ b/tests/std/tests/P2321R2_views_zip/test.cpp
@@ -208,7 +208,7 @@ constexpr bool do_tuples_reference_same_objects(const LHSTupleType& lhs_tuple, c
     STATIC_ASSERT(tuple_size_v<LHSTupleType> == tuple_size_v<RHSTupleType>);
 
     const auto evaluate_single_element_lambda = [&lhs_tuple, &rhs_tuple]<size_t CurrIndex>() {
-        using reference_type = typename reference_type_solver<tuple_element_t<CurrIndex, LHSTupleType>>::reference_type;
+        using reference_type = reference_type_solver<tuple_element_t<CurrIndex, LHSTupleType>>::reference_type;
         return addressof(static_cast<reference_type>(get<CurrIndex>(lhs_tuple)))
             == addressof(static_cast<reference_type>(get<CurrIndex>(rhs_tuple)));
     };
@@ -674,7 +674,7 @@ class instantiator_impl : private range_type_solver<IsMoveOnly> {
 private:
     template <class OtherCategory, class Element, test::Sized OtherIsSized, test::Common OtherIsCommon,
         test::CanDifference OtherDiff>
-    using range_type = typename range_type_solver<IsMoveOnly>::template range_type<OtherCategory, Element, OtherIsSized,
+    using range_type = range_type_solver<IsMoveOnly>::template range_type<OtherCategory, Element, OtherIsSized,
         OtherIsCommon, OtherDiff>;
 
     template <class... Types>

--- a/tests/std/tests/P2321R2_views_zip_transform/test.cpp
+++ b/tests/std/tests/P2321R2_views_zip_transform/test.cpp
@@ -63,7 +63,7 @@ constexpr bool validate_iterators_sentinels(
         if constexpr (ranges::forward_range<BaseType>) {
             STATIC_ASSERT(HasIteratorCategory<LocalZipTransformType>);
 
-            using Cat                = typename ranges::iterator_t<LocalZipTransformType>::iterator_category;
+            using Cat                = ranges::iterator_t<LocalZipTransformType>::iterator_category;
             using transform_result_t = TransformResultType<is_const, TransformType, RangeTypes...>;
 
             if constexpr (!is_reference_v<transform_result_t>) {
@@ -687,7 +687,7 @@ class instantiator_impl : private range_type_solver<IsMoveOnly> {
 private:
     template <class OtherCategory, class Element, test::Sized OtherIsSized, test::Common OtherIsCommon,
         test::CanDifference OtherDiff>
-    using range_type = typename range_type_solver<IsMoveOnly>::template range_type<OtherCategory, Element, OtherIsSized,
+    using range_type = range_type_solver<IsMoveOnly>::template range_type<OtherCategory, Element, OtherIsSized,
         OtherIsCommon, OtherDiff>;
 
     using standard_range_type = range_type<Category, const int, IsSized, IsCommon, Diff>;

--- a/tests/std/tests/P2374R4_views_cartesian_product/test.cpp
+++ b/tests/std/tests/P2374R4_views_cartesian_product/test.cpp
@@ -379,7 +379,7 @@ constexpr bool test_one(Expected&& expected_range, First&& first, Rest&&... rest
         STATIC_ASSERT(same_as<typename I::iterator_category, input_iterator_tag>);
 
         // Check iterator_concept
-        using IterConcept = typename I::iterator_concept;
+        using IterConcept = I::iterator_concept;
         STATIC_ASSERT(is_random_access == same_as<IterConcept, random_access_iterator_tag>);
         STATIC_ASSERT((is_bidirectional && !is_random_access) == same_as<IterConcept, bidirectional_iterator_tag>);
         STATIC_ASSERT((forward_range<VFirst> && !is_bidirectional) == same_as<IterConcept, forward_iterator_tag>);
@@ -551,7 +551,7 @@ constexpr bool test_one(Expected&& expected_range, First&& first, Rest&&... rest
         STATIC_ASSERT(same_as<typename CI::iterator_category, input_iterator_tag>);
 
         // Check iterator_concept
-        using IterConcept = typename CI::iterator_concept;
+        using IterConcept = CI::iterator_concept;
         STATIC_ASSERT(is_const_random_access == same_as<IterConcept, random_access_iterator_tag>);
         STATIC_ASSERT(
             (is_const_bidirectional && !is_const_random_access) == same_as<IterConcept, bidirectional_iterator_tag>);

--- a/tests/std/tests/P2408R5_ranges_iterators_to_classic_algorithms/test.cpp
+++ b/tests/std/tests/P2408R5_ranges_iterators_to_classic_algorithms/test.cpp
@@ -29,7 +29,7 @@ struct iterator_adaptor {
     iterator_adaptor(size_t n) : v(n) {}
 
     using iterator       = I;
-    using const_iterator = typename I::Consterator;
+    using const_iterator = I::Consterator;
 
     iterator begin() {
         return iterator{v.data()};
@@ -182,7 +182,7 @@ struct instantiator {
             C<cpp17_random_iter, Its...>::call();
         }
     };
-    using curry = typename curry_t<>::curry;
+    using curry = curry_t<>::curry;
 
     static void call() {
         curry_t<>::call();

--- a/tests/std/tests/P2441R2_views_join_with/test.cpp
+++ b/tests/std/tests/P2441R2_views_join_with/test.cpp
@@ -30,8 +30,7 @@ struct delimiter_view_impl<false> {
 };
 template <class Base, class Delimiter>
 using delimiter_view_t =
-    typename delimiter_view_impl<is_convertible_v<Delimiter, ranges::range_value_t<Base>>>::template apply<Base,
-        Delimiter>;
+    delimiter_view_impl<is_convertible_v<Delimiter, ranges::range_value_t<Base>>>::template apply<Base, Delimiter>;
 
 template <ranges::input_range Outer, class Delimiter, ranges::forward_range Expected>
 constexpr void test_one(Outer&& rng, Delimiter&& delimiter, Expected&& expected) {
@@ -60,9 +59,9 @@ constexpr void test_one(Outer&& rng, Delimiter&& delimiter, Expected&& expected)
         using OuterIter   = iterator_t<Outer>;
         using InnerIter   = iterator_t<range_reference_t<Outer>>;
         using PatternIter = iterator_t<DV>;
-        using OuterCat    = typename iterator_traits<OuterIter>::iterator_category;
-        using InnerCat    = typename iterator_traits<InnerIter>::iterator_category;
-        using PatternCat  = typename iterator_traits<PatternIter>::iterator_category;
+        using OuterCat    = iterator_traits<OuterIter>::iterator_category;
+        using InnerCat    = iterator_traits<InnerIter>::iterator_category;
+        using PatternCat  = iterator_traits<PatternIter>::iterator_category;
 
         if constexpr (!is_reference_v<common_reference_t<iter_reference_t<InnerIter>, iter_reference_t<PatternIter>>>) {
             STATIC_ASSERT(same_as<typename iterator_t<R>::iterator_category, input_iterator_tag>);
@@ -84,9 +83,9 @@ constexpr void test_one(Outer&& rng, Delimiter&& delimiter, Expected&& expected)
         using OuterIter   = iterator_t<const Outer>;
         using InnerIter   = iterator_t<range_reference_t<const Outer>>;
         using PatternIter = iterator_t<const DV>;
-        using OuterCat    = typename iterator_traits<OuterIter>::iterator_category;
-        using InnerCat    = typename iterator_traits<InnerIter>::iterator_category;
-        using PatternCat  = typename iterator_traits<PatternIter>::iterator_category;
+        using OuterCat    = iterator_traits<OuterIter>::iterator_category;
+        using InnerCat    = iterator_traits<InnerIter>::iterator_category;
+        using PatternCat  = iterator_traits<PatternIter>::iterator_category;
 
         if constexpr (!is_reference_v<common_reference_t<iter_reference_t<InnerIter>, iter_reference_t<PatternIter>>>) {
             STATIC_ASSERT(same_as<typename iterator_t<const R>::iterator_category, input_iterator_tag>);

--- a/tests/std/tests/P2505R5_monadic_functions_for_std_expected/test.cpp
+++ b/tests/std/tests/P2505R5_monadic_functions_for_std_expected/test.cpp
@@ -49,7 +49,7 @@ constexpr void test_impl(Expected&& engaged, Expected&& unengaged) {
     assert(engaged.has_value());
     assert(!unengaged.has_value());
     static_assert(is_same_v<typename remove_cvref_t<Expected>::error_type, int>);
-    using Val = typename remove_cvref_t<Expected>::value_type;
+    using Val = remove_cvref_t<Expected>::value_type;
 
     const auto succeed = [](auto...) { return expected<int, int>{33}; };
     const auto fail    = [](auto...) { return expected<int, int>{unexpect, 44}; };
@@ -357,11 +357,11 @@ constexpr bool is_specialization_of<Tmpl<Args...>, Tmpl> = true;
 
 template <class T>
     requires is_specialization_of<remove_cvref_t<T>, expected>
-using expected_value_t = typename remove_cvref_t<T>::value_type;
+using expected_value_t = remove_cvref_t<T>::value_type;
 
 template <class T>
     requires is_specialization_of<remove_cvref_t<T>, expected>
-using expected_error_t = typename remove_cvref_t<T>::error_type;
+using expected_error_t = remove_cvref_t<T>::error_type;
 
 template <class R>
 struct DefaultTransformer {


### PR DESCRIPTION
Works towards #3718. Might be complete, but I'm not 100% sure.

In addition to finding some occurrences in product code that we previously missed, I audited the test code, especially focusing on 20/23 tests.