### PR TITLE
Various cleanups: Enable more clang-format

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -5185,16 +5185,12 @@ _SampleIt sample(_PopIt _First, _PopIt _Last, _SampleIt _Dest, _Diff _Count, _Ur
 }
 
 #ifdef __cpp_lib_concepts
-// clang-format off
 _EXPORT_STD template <class _Ty>
-concept uniform_random_bit_generator = invocable<_Ty&>
-    && unsigned_integral<invoke_result_t<_Ty&>>
-    && requires {
-        { (_Ty::min)() } -> same_as<invoke_result_t<_Ty&>>;
-        { (_Ty::max)() } -> same_as<invoke_result_t<_Ty&>>;
-        requires bool_constant<(_Ty::min)() < (_Ty::max)()>::value;
-    };
-// clang-format on
+concept uniform_random_bit_generator = invocable<_Ty&> && unsigned_integral<invoke_result_t<_Ty&>> && requires {
+    { (_Ty::min)() } -> same_as<invoke_result_t<_Ty&>>;
+    { (_Ty::max)() } -> same_as<invoke_result_t<_Ty&>>;
+    requires bool_constant<(_Ty::min)() < (_Ty::max)()>::value;
+};
 
 namespace ranges {
     class _Sample_fn {

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -141,7 +141,6 @@ struct _Auto_id_tag {
     explicit _Auto_id_tag() = default;
 };
 
-// clang-format off
 template <class _Ty, class _CharT>
 concept _Parse_arg_id_callbacks = requires(_Ty _At) {
     { _At._On_auto_id() } -> same_as<void>;
@@ -184,6 +183,7 @@ concept _Precision_adapter_callbacks = requires(_Ty _At) {
     { _At._On_dynamic_precision(size_t{}) } -> same_as<void>;
 };
 
+// clang-format off
 template <class _Ty, class _CharT>
 concept _Parse_spec_callbacks = _Parse_align_callbacks<_Ty, _CharT>
                                 && _Parse_width_callbacks<_Ty, _CharT>

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -922,12 +922,11 @@ public:
         return *_Val._Get_first();
     }
 
-    // clang-format off
     _NODISCARD constexpr auto operator->() const
         requires indirectly_readable<const _Iter>
-            && (_Has_member_arrow<const _Iter&> || is_reference_v<iter_reference_t<_Iter>>
-                || constructible_from<iter_value_t<_Iter>, iter_reference_t<_Iter>>) {
-        // clang-format on
+              && (_Has_member_arrow<const _Iter&> || is_reference_v<iter_reference_t<_Iter>>
+                  || constructible_from<iter_value_t<_Iter>, iter_reference_t<_Iter>>)
+    {
 #if _ITERATOR_DEBUG_LEVEL != 0
         _STL_VERIFY(_Val._Contains == _Variantish_state::_Holds_first,
             "common_iterator can only be dereferenced if it holds an iterator");

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -930,14 +930,10 @@ _NODISCARD constexpr bool operator>=(const _Ty1& _Left, const optional<_Ty2>& _R
 }
 
 #ifdef __cpp_lib_concepts
-// clang-format off
 _EXPORT_STD template <class _Ty1, class _Ty2>
-    requires (!_Derived_from_specialization_of<_Ty2, optional>)
-        && three_way_comparable_with<_Ty1, _Ty2>
-_NODISCARD constexpr compare_three_way_result_t<_Ty1, _Ty2>
-    operator<=>(const optional<_Ty1>& _Left, const _Ty2& _Right)
-        noexcept(noexcept(*_Left <=> _Right)) /* strengthened */ {
-    // clang-format on
+    requires (!_Derived_from_specialization_of<_Ty2, optional>) && three_way_comparable_with<_Ty1, _Ty2>
+_NODISCARD constexpr compare_three_way_result_t<_Ty1, _Ty2> operator<=>(
+    const optional<_Ty1>& _Left, const _Ty2& _Right) noexcept(noexcept(*_Left <=> _Right)) /* strengthened */ {
     if (_Left) {
         return *_Left <=> _Right;
     }

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -115,12 +115,10 @@ namespace ranges {
         template <class _Ty>
         _Ty* _Derived_from_range_adaptor_closure(_Base<_Ty>&); // not defined
 
-        // clang-format off
         template <class _Ty>
         concept _Range_adaptor_closure_object = !range<remove_cvref_t<_Ty>> && requires(remove_cvref_t<_Ty>& __t) {
             { _Pipe::_Derived_from_range_adaptor_closure(__t) } -> same_as<remove_cvref_t<_Ty>*>;
         };
-        // clang-format on
 
         template <class _ClosureLeft, class _ClosureRight>
         struct _Pipeline : _Base<_Pipeline<_ClosureLeft, _ClosureRight>> {
@@ -2871,12 +2869,10 @@ namespace ranges {
                 is_nothrow_move_constructible_v<_Base_sentinel>) // strengthened
                 : _Last(_STD move(_Last_)) {}
 
-            // clang-format off
             constexpr _Sentinel(_Sentinel<!_Const, _Wrapped> _That) noexcept(
                 is_nothrow_constructible_v<_Base_sentinel, _Maybe_wrapped<_Wrapped, sentinel_t<_Vw>>>) // strengthened
                 requires _Const && convertible_to<_Maybe_wrapped<_Wrapped, sentinel_t<_Vw>>, _Base_sentinel>
                 : _Last(_STD move(_That._Last)) {}
-            // clang-format on
 
             _NODISCARD constexpr _Base_sentinel base() const
                 noexcept(is_nothrow_copy_constructible_v<_Base_sentinel>) /* strengthened */ {
@@ -3168,12 +3164,10 @@ namespace ranges {
                 is_nothrow_move_constructible_v<_Base_sentinel>) // strengthened
                 : _Last(_STD move(_Last_)), _Pred(_Pred_) {}
 
-            // clang-format off
             constexpr _Sentinel(_Sentinel<!_Const, _Wrapped> _That) noexcept(
                 is_nothrow_constructible_v<_Base_sentinel, _Maybe_wrapped<_Wrapped, sentinel_t<_Vw>>>) // strengthened
                 requires _Const && convertible_to<_Maybe_wrapped<_Wrapped, sentinel_t<_Vw>>, _Base_sentinel>
                 : _Last(_STD move(_That._Last)), _Pred(_That._Pred) {}
-            // clang-format on
 
             _NODISCARD constexpr _Base_sentinel base() const
                 noexcept(is_nothrow_copy_constructible_v<_Base_sentinel>) /* strengthened */ {
@@ -5264,12 +5258,10 @@ namespace ranges {
             static constexpr _Choice_t<_St> _Choice = _Choose<_It>();
 
         public:
-            // clang-format off
             template <class _It>
                 requires (input_or_output_iterator<decay_t<_It>> && _Choice<_It>._Strategy != _St::_None)
             _NODISCARD constexpr auto operator()(_It&& _First, const iter_difference_t<decay_t<_It>> _Count) const
                 noexcept(_Choice<_It>._No_throw) {
-                // clang-format on
                 _STL_ASSERT(_Count >= 0, "The size passed to views::counted must be non-negative");
                 constexpr _St _Strat = _Choice<_It>._Strategy;
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1038,16 +1038,16 @@ namespace ranges {
 
     namespace views {
         struct _Single_fn {
-            // clang-format off
             template <class _Ty>
-            _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(
-                noexcept(single_view<decay_t<_Ty>>(_STD forward<_Ty>(_Val)))) requires requires {
-                typename single_view<decay_t<_Ty>>;
-                single_view<decay_t<_Ty>>(static_cast<_Ty&&>(_Val));
-            } {
+            _NODISCARD constexpr auto operator()(_Ty&& _Val) const
+                noexcept(noexcept(single_view<decay_t<_Ty>>(_STD forward<_Ty>(_Val))))
+                requires requires {
+                    typename single_view<decay_t<_Ty>>;
+                    single_view<decay_t<_Ty>>(static_cast<_Ty&&>(_Val));
+                }
+            {
                 return single_view<decay_t<_Ty>>(_STD forward<_Ty>(_Val));
             }
-            // clang-format on
         };
 
         _EXPORT_STD inline constexpr _Single_fn single;
@@ -1059,7 +1059,6 @@ namespace ranges {
             conditional_t<sizeof(_Ty) < sizeof(long long), long long, _Signed128>>,
         iter_difference_t<_Ty>>;
 
-    // clang-format off
     template <class _Ty>
     concept _Decrementable = incrementable<_Ty> && requires(_Ty __t) {
         { --__t } -> same_as<_Ty&>;
@@ -1067,8 +1066,8 @@ namespace ranges {
     };
 
     template <class _Ty>
-    concept _Advanceable = _Decrementable<_Ty> && totally_ordered<_Ty>
-        && requires(_Ty __i, const _Ty __j, const _Iota_diff_t<_Ty> __n) {
+    concept _Advanceable =
+        _Decrementable<_Ty> && totally_ordered<_Ty> && requires(_Ty __i, const _Ty __j, const _Iota_diff_t<_Ty> __n) {
             { __i += __n } -> same_as<_Ty&>;
             { __i -= __n } -> same_as<_Ty&>;
             _Ty(__j + __n);
@@ -1076,7 +1075,6 @@ namespace ranges {
             _Ty(__j - __n);
             { __j - __j } -> convertible_to<_Iota_diff_t<_Ty>>;
         };
-    // clang-format on
 
     template <class _Wi>
     struct _Ioterator_category_base {};
@@ -1399,12 +1397,10 @@ namespace ranges {
 
 #pragma warning(push)
 #pragma warning(disable : 4146) // unary minus operator applied to unsigned type, result still unsigned
-        // clang-format off
         _NODISCARD constexpr auto size() const noexcept(noexcept(_Bound - _Value)) /* strengthened */
             requires (same_as<_Wi, _Bo> && _Advanceable<_Wi>)
-                || (_Integer_like<_Wi> && _Integer_like<_Bo>)
-                || sized_sentinel_for<_Bo, _Wi> {
-            // clang-format on
+                  || (_Integer_like<_Wi> && _Integer_like<_Bo>) || sized_sentinel_for<_Bo, _Wi>
+        {
             if constexpr (_Integer_like<_Wi> && _Integer_like<_Bo>) {
                 return (_Value < 0) ? ((_Bound < 0) ? (_To_unsigned_like(-_Value) - _To_unsigned_like(-_Bound))
                                                     : (_To_unsigned_like(_Bound) + _To_unsigned_like(-_Value)))
@@ -2208,11 +2204,10 @@ namespace ranges {
                 return *_Current;
             }
 
-            // clang-format off
             _NODISCARD constexpr iterator_t<_Vw> operator->() const
                 noexcept(is_nothrow_copy_constructible_v<iterator_t<_Vw>>) /* strengthened */
-                requires _Has_arrow<iterator_t<_Vw>> && copyable<iterator_t<_Vw>> {
-                // clang-format on
+                requires _Has_arrow<iterator_t<_Vw>> && copyable<iterator_t<_Vw>>
+            {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _Check_dereference();
 #endif // _ITERATOR_DEBUG_LEVEL != 0
@@ -2383,13 +2378,11 @@ namespace ranges {
 
     namespace views {
         struct _Filter_fn {
-            // clang-format off
             template <viewable_range _Rng, class _Pr>
-            _NODISCARD constexpr auto operator()(_Rng&& _Range, _Pr&& _Pred) const noexcept(noexcept(
-                filter_view(_STD forward<_Rng>(_Range), _STD forward<_Pr>(_Pred)))) requires requires {
-                filter_view(static_cast<_Rng&&>(_Range), _STD forward<_Pr>(_Pred));
-            } {
-                // clang-format on
+            _NODISCARD constexpr auto operator()(_Rng&& _Range, _Pr&& _Pred) const
+                noexcept(noexcept(filter_view(_STD forward<_Rng>(_Range), _STD forward<_Pr>(_Pred))))
+                requires requires { filter_view(static_cast<_Rng&&>(_Range), _STD forward<_Pr>(_Pred)); }
+            {
                 return filter_view(_STD forward<_Rng>(_Range), _STD forward<_Pr>(_Pred));
             }
 
@@ -2621,11 +2614,10 @@ namespace ranges {
             {
                 return !(_Left < _Right);
             }
-            // clang-format off
             _NODISCARD_FRIEND constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current <=> _Right._Current)) /* strengthened */
-                requires random_access_range<_Base> && three_way_comparable<iterator_t<_Base>> {
-                // clang-format on
+                requires random_access_range<_Base> && three_way_comparable<iterator_t<_Base>>
+            {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _Left._Same_range(_Right);
 #endif // _ITERATOR_DEBUG_LEVEL != 0
@@ -2704,12 +2696,10 @@ namespace ranges {
                 is_nothrow_move_constructible_v<sentinel_t<_Base>>) // strengthened
                 : _Last(_STD move(_Last_)) {}
 
-            // clang-format off
-            constexpr _Sentinel(_Sentinel<!_Const> _Se)
-                noexcept(is_nothrow_constructible_v<sentinel_t<_Base>, sentinel_t<_Vw>>) // strengthened
+            constexpr _Sentinel(_Sentinel<!_Const> _Se) noexcept(
+                is_nothrow_constructible_v<sentinel_t<_Base>, sentinel_t<_Vw>>) // strengthened
                 requires _Const && convertible_to<sentinel_t<_Vw>, sentinel_t<_Base>>
                 : _Last(_STD move(_Se._Last)) {}
-            // clang-format on
 
             _NODISCARD constexpr sentinel_t<_Base> base() const
                 noexcept(is_nothrow_copy_constructible_v<sentinel_t<_Base>>) /* strengthened */ {
@@ -2723,15 +2713,13 @@ namespace ranges {
                 return _Get_current(_Left) == _Right._Last;
             }
 
-            // clang-format off
             template <bool _OtherConst>
                 requires sized_sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
-            _NODISCARD_FRIEND constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>>
-                operator-(const _Iterator<_OtherConst>& _Left, const _Sentinel& _Right) noexcept(
-                    noexcept(_Get_current(_Left) - _Right._Last)) /* strengthened */ {
+            _NODISCARD_FRIEND constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>> operator-(
+                const _Iterator<_OtherConst>& _Left,
+                const _Sentinel& _Right) noexcept(noexcept(_Get_current(_Left) - _Right._Last)) /* strengthened */ {
                 return _Get_current(_Left) - _Right._Last;
             }
-            // clang-format on
 
             template <bool _OtherConst>
                 requires sized_sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
@@ -2772,10 +2760,9 @@ namespace ranges {
             return _Iterator<true>{*this, _RANGES begin(_Range)};
         }
 
-        // clang-format off
-        _NODISCARD constexpr auto end() noexcept(noexcept(
-            _RANGES end(_Range)) && is_nothrow_move_constructible_v<decltype(_RANGES end(_Range))>) /* strengthened */ {
-            // clang-format on
+        _NODISCARD constexpr auto end() noexcept(
+            noexcept(_RANGES end(_Range))
+            && is_nothrow_move_constructible_v<decltype(_RANGES end(_Range))>) /* strengthened */ {
             if constexpr (common_range<_Vw>) {
                 return _Iterator<false>{*this, _RANGES end(_Range)};
             } else {
@@ -2783,12 +2770,11 @@ namespace ranges {
             }
         }
 
-        // clang-format off
-        _NODISCARD constexpr auto end() const noexcept(noexcept(
-            _RANGES end(_Range)) && is_nothrow_move_constructible_v<decltype(_RANGES end(_Range))>) /* strengthened */
+        _NODISCARD constexpr auto end() const
+            noexcept(noexcept(_RANGES end(_Range))
+                     && is_nothrow_move_constructible_v<decltype(_RANGES end(_Range))>) /* strengthened */
             requires range<const _Vw> && regular_invocable<const _Fn&, range_reference_t<const _Vw>>
         {
-            // clang-format on
             if constexpr (common_range<_Vw>) {
                 return _Iterator<true>{*this, _RANGES end(_Range)};
             } else {
@@ -2821,13 +2807,11 @@ namespace ranges {
 
     namespace views {
         struct _Transform_fn {
-            // clang-format off
             template <viewable_range _Rng, class _Fn>
-            _NODISCARD constexpr auto operator()(_Rng&& _Range, _Fn _Fun) const noexcept(noexcept(
-                transform_view(_STD forward<_Rng>(_Range), _STD move(_Fun)))) requires requires {
-                transform_view(static_cast<_Rng&&>(_Range), _STD move(_Fun));
-            } {
-                // clang-format on
+            _NODISCARD constexpr auto operator()(_Rng&& _Range, _Fn _Fun) const
+                noexcept(noexcept(transform_view(_STD forward<_Rng>(_Range), _STD move(_Fun))))
+                requires requires { transform_view(static_cast<_Rng&&>(_Range), _STD move(_Fun)); }
+            {
                 return transform_view(_STD forward<_Rng>(_Range), _STD move(_Fun));
             }
 
@@ -2892,18 +2876,16 @@ namespace ranges {
 
             using _Prevent_inheriting_unwrap = _Sentinel;
 
-            // clang-format off
-            _NODISCARD constexpr auto _Unwrapped() const&
-                noexcept(noexcept(_Sentinel<_Const, false>{_Last._Unwrapped()}))
-                requires _Wrapped && _Unwrappable_sentinel_for<sentinel_t<_Base_t>, const iterator_t<_Base_t>&> {
-                // clang-format on
+            _NODISCARD constexpr auto _Unwrapped() const& noexcept(
+                noexcept(_Sentinel<_Const, false>{_Last._Unwrapped()}))
+                requires _Wrapped && _Unwrappable_sentinel_for<sentinel_t<_Base_t>, const iterator_t<_Base_t>&>
+            {
                 return _Sentinel<_Const, false>{_Last._Unwrapped()};
             }
-            // clang-format off
-            _NODISCARD constexpr auto _Unwrapped() &&
-                noexcept(noexcept(_Sentinel<_Const, false>{_STD move(_Last)._Unwrapped()}))
-                requires _Wrapped && _Unwrappable_sentinel_for<sentinel_t<_Base_t>, iterator_t<_Base_t>> {
-                // clang-format on
+            _NODISCARD constexpr auto _Unwrapped() && noexcept(
+                noexcept(_Sentinel<_Const, false>{_STD move(_Last)._Unwrapped()}))
+                requires _Wrapped && _Unwrappable_sentinel_for<sentinel_t<_Base_t>, iterator_t<_Base_t>>
+            {
                 return _Sentinel<_Const, false>{_STD move(_Last)._Unwrapped()};
             }
 
@@ -2939,9 +2921,9 @@ namespace ranges {
             return _STD move(_Range);
         }
 
-        // clang-format off
-        _NODISCARD constexpr auto begin() requires (!_Simple_view<_Vw>) {
-            // clang-format on
+        _NODISCARD constexpr auto begin()
+            requires (!_Simple_view<_Vw>)
+        {
             if constexpr (sized_range<_Vw>) {
                 if constexpr (random_access_range<_Vw>) {
                     return _RANGES begin(_Range);
@@ -2977,9 +2959,9 @@ namespace ranges {
             }
         }
 
-        // clang-format off
-        _NODISCARD constexpr auto end() requires (!_Simple_view<_Vw>) {
-            // clang-format on
+        _NODISCARD constexpr auto end()
+            requires (!_Simple_view<_Vw>)
+        {
             if constexpr (sized_range<_Vw>) {
                 if constexpr (random_access_range<_Vw>) {
                     return _RANGES begin(_Range) + static_cast<range_difference_t<_Vw>>(size());
@@ -3187,18 +3169,16 @@ namespace ranges {
 
             using _Prevent_inheriting_unwrap = _Sentinel;
 
-            // clang-format off
-            _NODISCARD constexpr auto _Unwrapped() const&
-                noexcept(noexcept(_Sentinel<_Const, false>{_Last._Unwrapped(), _Pred}))
-                requires _Wrapped && _Unwrappable_sentinel_for<sentinel_t<_Base_t>, const iterator_t<_Base_t>&> {
-                // clang-format on
+            _NODISCARD constexpr auto _Unwrapped() const& noexcept(
+                noexcept(_Sentinel<_Const, false>{_Last._Unwrapped(), _Pred}))
+                requires _Wrapped && _Unwrappable_sentinel_for<sentinel_t<_Base_t>, const iterator_t<_Base_t>&>
+            {
                 return _Sentinel<_Const, false>{_Last._Unwrapped(), _Pred};
             }
-            // clang-format off
-            _NODISCARD constexpr auto _Unwrapped() &&
-                noexcept(noexcept(_Sentinel<_Const, false>{_STD move(_Last)._Unwrapped(), _Pred}))
-                requires _Wrapped && _Unwrappable_sentinel_for<sentinel_t<_Base_t>, iterator_t<_Base_t>> {
-                // clang-format on
+            _NODISCARD constexpr auto _Unwrapped() && noexcept(
+                noexcept(_Sentinel<_Const, false>{_STD move(_Last)._Unwrapped(), _Pred}))
+                requires _Wrapped && _Unwrappable_sentinel_for<sentinel_t<_Base_t>, iterator_t<_Base_t>>
+            {
                 return _Sentinel<_Const, false>{_STD move(_Last)._Unwrapped(), _Pred};
             }
 
@@ -3361,10 +3341,9 @@ namespace ranges {
             return _STD move(_Range);
         }
 
-        // clang-format off
         _NODISCARD constexpr auto begin()
-            requires (!(_Simple_view<_Vw> && random_access_range<const _Vw> && sized_range<const _Vw>)) {
-            // clang-format on
+            requires (!(_Simple_view<_Vw> && random_access_range<const _Vw> && sized_range<const _Vw>) )
+        {
             if constexpr (sized_range<_Vw> && random_access_range<_Vw>) {
                 const auto _Offset = (_STD min)(_RANGES distance(_Range), _Count);
                 return _RANGES begin(_Range) + _Offset;
@@ -3383,17 +3362,16 @@ namespace ranges {
             }
         }
 
-        // clang-format off
         _NODISCARD constexpr auto begin() const
-            requires random_access_range<const _Vw> && sized_range<const _Vw> {
-            // clang-format on
+            requires random_access_range<const _Vw> && sized_range<const _Vw>
+        {
             const auto _Offset = (_STD min)(_RANGES distance(_Range), _Count);
             return _RANGES begin(_Range) + _Offset;
         }
 
-        // clang-format off
-        _NODISCARD constexpr auto end() requires (!_Simple_view<_Vw>) {
-            // clang-format on
+        _NODISCARD constexpr auto end()
+            requires (!_Simple_view<_Vw>)
+        {
             return _RANGES end(_Range);
         }
 
@@ -3808,13 +3786,12 @@ namespace ranges {
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 
         public:
-            // clang-format off
-            using iterator_concept = conditional_t<_Deref_is_glvalue
-                && bidirectional_range<_Base> && bidirectional_range<_InnerRng<_Const>>
-                && common_range<_InnerRng<_Const>>, bidirectional_iterator_tag,
-                conditional_t<_Deref_is_glvalue && forward_range<_Base> && forward_range<_InnerRng<_Const>>,
-                    forward_iterator_tag, input_iterator_tag>>;
-            // clang-format on
+            using iterator_concept =
+                conditional_t<_Deref_is_glvalue && bidirectional_range<_Base> && bidirectional_range<_InnerRng<_Const>>
+                                  && common_range<_InnerRng<_Const>>,
+                    bidirectional_iterator_tag,
+                    conditional_t<_Deref_is_glvalue && forward_range<_Base> && forward_range<_InnerRng<_Const>>,
+                        forward_iterator_tag, input_iterator_tag>>;
             using value_type      = range_value_t<_InnerRng<_Const>>;
             using difference_type = common_type_t<range_difference_t<_Base>, range_difference_t<_InnerRng<_Const>>>;
 
@@ -3870,11 +3847,10 @@ namespace ranges {
                 }
             }
 
-            // clang-format off
             constexpr _Iterator& operator--()
                 requires _Deref_is_glvalue && bidirectional_range<_Base> && bidirectional_range<_InnerRng<_Const>>
-                      && common_range<_InnerRng<_Const>> {
-                // clang-format on
+                      && common_range<_InnerRng<_Const>>
+            {
                 auto& _Outer = _Get_outer();
                 if (_Outer == _RANGES end(_Parent->_Range)) {
                     --_Outer;
@@ -3888,22 +3864,20 @@ namespace ranges {
                 return *this;
             }
 
-            // clang-format off
             constexpr _Iterator operator--(int)
                 requires _Deref_is_glvalue && bidirectional_range<_Base> && bidirectional_range<_InnerRng<_Const>>
-                      && common_range<_InnerRng<_Const>> {
-                // clang-format on
+                      && common_range<_InnerRng<_Const>>
+            {
                 auto _Tmp = *this;
                 --*this;
                 return _Tmp;
             }
 
-            // clang-format off
             _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_Fake_copy_init<bool>(_Left._Outer == _Right._Outer
-                    && _Left._Inner == _Right._Inner))) /* strengthened */
-                requires _Deref_is_glvalue && forward_range<_Base> && equality_comparable<_InnerIter> {
-                // clang-format on
+                noexcept(_Fake_copy_init<bool>(
+                    _Left._Outer == _Right._Outer && _Left._Inner == _Right._Inner))) /* strengthened */
+                requires _Deref_is_glvalue && forward_range<_Base> && equality_comparable<_InnerIter>
+            {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _Left._Same_range(_Right);
 #endif // _ITERATOR_DEBUG_LEVEL != 0
@@ -3918,11 +3892,10 @@ namespace ranges {
                 return _RANGES iter_move(*_It._Inner);
             }
 
-            // clang-format off
             friend constexpr void iter_swap(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_RANGES iter_swap(*_Left._Inner, *_Right._Inner)))
-                requires indirectly_swappable<_InnerIter> {
-                // clang-format on
+                requires indirectly_swappable<_InnerIter>
+            {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _Left._Check_dereference();
                 _Right._Check_dereference();
@@ -3944,12 +3917,10 @@ namespace ranges {
 
             /* [[no_unique_address]] */ sentinel_t<_Base> _Last{};
 
-            // clang-format off
             template <bool _OtherConst>
                 requires sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
-            _NODISCARD constexpr bool _Equal(const _Iterator<_OtherConst>& _It) const noexcept(
-                    noexcept(_Fake_copy_init<bool>(_It._Get_outer() == _Last))) {
-                // clang-format on
+            _NODISCARD constexpr bool _Equal(const _Iterator<_OtherConst>& _It) const
+                noexcept(noexcept(_Fake_copy_init<bool>(_It._Get_outer() == _Last))) {
                 return _It._Get_outer() == _Last;
             }
 
@@ -3960,12 +3931,10 @@ namespace ranges {
                 && is_nothrow_move_constructible_v<sentinel_t<_Base>>) // strengthened
                 : _Last(_RANGES end(_Parent._Range)) {}
 
-            // clang-format off
-            constexpr _Sentinel(_Sentinel<!_Const> _Se)
-                noexcept(is_nothrow_constructible_v<sentinel_t<_Base>, sentinel_t<_Vw>>) // strengthened
+            constexpr _Sentinel(_Sentinel<!_Const> _Se) noexcept(
+                is_nothrow_constructible_v<sentinel_t<_Base>, sentinel_t<_Vw>>) // strengthened
                 requires _Const && convertible_to<sentinel_t<_Vw>, sentinel_t<_Base>>
                 : _Last(_STD move(_Se._Last)) {}
-            // clang-format on
 
             template <bool _OtherConst>
                 requires sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
@@ -4058,13 +4027,11 @@ namespace ranges {
     namespace views {
         class _Join_fn : public _Pipe::_Base<_Join_fn> {
         public:
-            // clang-format off
             template <viewable_range _Rng>
-            _NODISCARD constexpr auto operator()(_Rng&& _Range) const noexcept(noexcept(
-                join_view<views::all_t<_Rng>>{_STD forward<_Rng>(_Range)})) requires requires {
-                join_view<views::all_t<_Rng>>{static_cast<_Rng&&>(_Range)};
-            } {
-                // clang-format on
+            _NODISCARD constexpr auto operator()(_Rng&& _Range) const
+                noexcept(noexcept(join_view<views::all_t<_Rng>>{_STD forward<_Rng>(_Range)}))
+                requires requires { join_view<views::all_t<_Rng>>{static_cast<_Rng&&>(_Range)}; }
+            {
                 return join_view<views::all_t<_Rng>>{_STD forward<_Rng>(_Range)};
             }
         };
@@ -4595,13 +4562,11 @@ namespace ranges {
 
     namespace views {
         struct _Join_with_fn {
-            // clang-format off
             template <viewable_range _Rng, class _Pat>
-            _NODISCARD constexpr auto operator()(_Rng&& _Range, _Pat&& _Pattern) const noexcept(
-                noexcept(join_with_view(_STD forward<_Rng>(_Range), _STD forward<_Pat>(_Pattern)))) requires requires {
-                join_with_view(_STD forward<_Rng>(_Range), _STD forward<_Pat>(_Pattern));
-            }
-            { // clang-format on
+            _NODISCARD constexpr auto operator()(_Rng&& _Range, _Pat&& _Pattern) const
+                noexcept(noexcept(join_with_view(_STD forward<_Rng>(_Range), _STD forward<_Pat>(_Pattern))))
+                requires requires { join_with_view(_STD forward<_Rng>(_Range), _STD forward<_Pat>(_Pattern)); }
+            {
                 return join_with_view(_STD forward<_Rng>(_Range), _STD forward<_Pat>(_Pattern));
             }
 
@@ -4639,13 +4604,10 @@ namespace ranges {
     template <forward_range _Vw, class _Pat>
     class _Lazy_split_view_base<_Vw, _Pat> : public view_interface<lazy_split_view<_Vw, _Pat>> {};
 
-    // clang-format off
     _EXPORT_STD template <input_range _Vw, forward_range _Pat>
-        requires (view<_Vw> && view<_Pat>
-            && indirectly_comparable<iterator_t<_Vw>, iterator_t<_Pat>, _RANGES equal_to>
-            && (forward_range<_Vw> || _Tiny_range<_Pat>))
+        requires (view<_Vw> && view<_Pat> && indirectly_comparable<iterator_t<_Vw>, iterator_t<_Pat>, _RANGES equal_to>
+                  && (forward_range<_Vw> || _Tiny_range<_Pat>) )
     class lazy_split_view : public _Lazy_split_view_base<_Vw, _Pat> {
-        // clang-format on
     private:
         /* [[no_unique_address]] */ _Vw _Range{};
         /* [[no_unique_address]] */ _Pat _Pattern{};
@@ -4727,10 +4689,9 @@ namespace ranges {
 
             _Outer_iter() = default;
 
-            // clang-format off
             constexpr explicit _Outer_iter(_ParentTy& _Parent_) noexcept // strengthened
-                requires (!forward_range<_BaseTy>) : _Parent{_STD addressof(_Parent_)} {}
-            // clang-format on
+                requires (!forward_range<_BaseTy>)
+                : _Parent{_STD addressof(_Parent_)} {}
 
             constexpr _Outer_iter(_ParentTy& _Parent_, iterator_t<_BaseTy> _Current_) noexcept(
                 is_nothrow_move_constructible_v<iterator_t<_BaseTy>>) // strengthened
@@ -4935,11 +4896,10 @@ namespace ranges {
                 return _RANGES iter_move(_Iter._Get_current());
             }
 
-            // clang-format off
-            friend constexpr void iter_swap(const _Inner_iter& _Left, const _Inner_iter& _Right)
-                noexcept(noexcept(_RANGES iter_swap(_Left._Get_current(), _Right._Get_current())))
-                requires indirectly_swappable<iterator_t<_BaseTy>> {
-                // clang-format on
+            friend constexpr void iter_swap(const _Inner_iter& _Left, const _Inner_iter& _Right) noexcept(
+                noexcept(_RANGES iter_swap(_Left._Get_current(), _Right._Get_current())))
+                requires indirectly_swappable<iterator_t<_BaseTy>>
+            {
                 _RANGES iter_swap(_Left._Get_current(), _Right._Get_current());
             }
         };
@@ -4953,15 +4913,12 @@ namespace ranges {
             is_nothrow_move_constructible_v<_Vw>&& is_nothrow_move_constructible_v<_Pat>) // strengthened
             : _Range(_STD move(_Range_)), _Pattern(_STD move(_Pattern_)) {}
 
-        // clang-format off
         template <input_range _Rng>
             requires constructible_from<_Vw, views::all_t<_Rng>>
-                && constructible_from<_Pat, single_view<range_value_t<_Rng>>>
-        constexpr explicit lazy_split_view(_Rng&& _Range_, range_value_t<_Rng> _Elem)
-            noexcept(noexcept(_Vw(views::all(_STD forward<_Rng>(_Range_))))
-                && noexcept(_Pat(views::single(_STD move(_Elem))))) // strengthened
+                      && constructible_from<_Pat, single_view<range_value_t<_Rng>>>
+        constexpr explicit lazy_split_view(_Rng&& _Range_, range_value_t<_Rng> _Elem) noexcept(noexcept(_Vw(views::all(
+            _STD forward<_Rng>(_Range_)))) && noexcept(_Pat(views::single(_STD move(_Elem))))) // strengthened
             : _Range(views::all(_STD forward<_Rng>(_Range_))), _Pattern(views::single(_STD move(_Elem))) {}
-        // clang-format on
 
         _NODISCARD constexpr _Vw base() const& noexcept(is_nothrow_copy_constructible_v<_Vw>) /* strengthened */
             requires copy_constructible<_Vw>
@@ -5022,13 +4979,11 @@ namespace ranges {
 
     namespace views {
         struct _Lazy_split_fn {
-            // clang-format off
             template <viewable_range _Rng, class _Pat>
-            _NODISCARD constexpr auto operator()(_Rng&& _Range, _Pat&& _Pattern) const noexcept(noexcept(
-                lazy_split_view(_STD forward<_Rng>(_Range), _STD forward<_Pat>(_Pattern)))) requires requires {
-                lazy_split_view(static_cast<_Rng&&>(_Range), static_cast<_Pat&&>(_Pattern));
-            } {
-                // clang-format on
+            _NODISCARD constexpr auto operator()(_Rng&& _Range, _Pat&& _Pattern) const
+                noexcept(noexcept(lazy_split_view(_STD forward<_Rng>(_Range), _STD forward<_Pat>(_Pattern))))
+                requires requires { lazy_split_view(static_cast<_Rng&&>(_Range), static_cast<_Pat&&>(_Pattern)); }
+            {
                 return lazy_split_view(_STD forward<_Rng>(_Range), _STD forward<_Pat>(_Pattern));
             }
 
@@ -5211,13 +5166,11 @@ namespace ranges {
 
     namespace views {
         struct _Split_fn {
-            // clang-format off
             template <viewable_range _Rng, class _Pat>
-            _NODISCARD constexpr auto operator()(_Rng&& _Range, _Pat&& _Pattern) const noexcept(noexcept(
-                split_view(_STD forward<_Rng>(_Range), _STD forward<_Pat>(_Pattern)))) requires requires {
-                split_view(static_cast<_Rng&&>(_Range), static_cast<_Pat&&>(_Pattern));
-            } {
-                // clang-format on
+            _NODISCARD constexpr auto operator()(_Rng&& _Range, _Pat&& _Pattern) const
+                noexcept(noexcept(split_view(_STD forward<_Rng>(_Range), _STD forward<_Pat>(_Pattern))))
+                requires requires { split_view(static_cast<_Rng&&>(_Range), static_cast<_Pat&&>(_Pattern)); }
+            {
                 return split_view(_STD forward<_Rng>(_Range), _STD forward<_Pat>(_Pattern));
             }
 
@@ -5913,11 +5866,10 @@ namespace ranges {
                 return !(_Left < _Right);
             }
 
-            // clang-format off
             _NODISCARD_FRIEND constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current <=> _Right._Current)) /* strengthened */
-                requires random_access_range<_Base> && three_way_comparable<iterator_t<_Base>> {
-                // clang-format on
+                requires random_access_range<_Base> && three_way_comparable<iterator_t<_Base>>
+            {
                 return _Left._Current <=> _Right._Current;
             }
 
@@ -5992,12 +5944,10 @@ namespace ranges {
                 is_nothrow_move_constructible_v<sentinel_t<_Base>>) // strengthened
                 : _Last(_STD move(_Last_)) {}
 
-            // clang-format off
-            constexpr _Sentinel(_Sentinel<!_Const> _Se)
-                noexcept(is_nothrow_constructible_v<sentinel_t<_Base>, sentinel_t<_Vw>>) // strengthened
+            constexpr _Sentinel(_Sentinel<!_Const> _Se) noexcept(
+                is_nothrow_constructible_v<sentinel_t<_Base>, sentinel_t<_Vw>>) // strengthened
                 requires _Const && convertible_to<sentinel_t<_Vw>, sentinel_t<_Base>>
                 : _Last(_STD move(_Se._Last)) {}
-            // clang-format on
 
             _NODISCARD constexpr sentinel_t<_Base> base() const
                 noexcept(is_nothrow_copy_constructible_v<sentinel_t<_Base>>) /* strengthened */ {
@@ -6011,23 +5961,19 @@ namespace ranges {
                 return _Get_current(_Left) == _Right._Last;
             }
 
-            // clang-format off
             template <bool _OtherConst>
                 requires sized_sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
             _NODISCARD_FRIEND constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>> operator-(
-                const _Iterator<_OtherConst>& _Left, const _Sentinel& _Right) noexcept(
-                noexcept(_Get_current(_Left) - _Right._Last)) /* strengthened */ {
-                // clang-format on
+                const _Iterator<_OtherConst>& _Left,
+                const _Sentinel& _Right) noexcept(noexcept(_Get_current(_Left) - _Right._Last)) /* strengthened */ {
                 return _Get_current(_Left) - _Right._Last;
             }
 
-            // clang-format off
             template <bool _OtherConst>
                 requires sized_sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
-            _NODISCARD_FRIEND constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>> operator-(
-                const _Sentinel& _Left, const _Iterator<_OtherConst>& _Right) noexcept(
-                noexcept(_Left._Last - _Get_current(_Right))) /* strengthened */ {
-                // clang-format on
+            _NODISCARD_FRIEND constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>>
+                operator-(const _Sentinel& _Left, const _Iterator<_OtherConst>& _Right) noexcept(
+                    noexcept(_Left._Last - _Get_current(_Right))) /* strengthened */ {
                 return _Left._Last - _Get_current(_Right);
             }
         };
@@ -6050,11 +5996,10 @@ namespace ranges {
             return _STD move(_Range);
         }
 
-        // clang-format off
         _NODISCARD constexpr _Iterator<false> begin() noexcept(
             noexcept(_RANGES begin(_Range)) && is_nothrow_move_constructible_v<iterator_t<_Vw>>) /* strengthened */
-            requires (!_Simple_view<_Vw>) {
-            // clang-format on
+            requires (!_Simple_view<_Vw>)
+        {
             return _Iterator<false>{_RANGES begin(_Range)};
         }
 
@@ -6066,11 +6011,10 @@ namespace ranges {
             return _Iterator<true>{_RANGES begin(_Range)};
         }
 
-        // clang-format off
-        _NODISCARD constexpr auto end() noexcept(noexcept(
-            _RANGES end(_Range)) && is_nothrow_move_constructible_v<sentinel_t<_Vw>>) /* strengthened */
-            requires (!_Simple_view<_Vw>) {
-            // clang-format on
+        _NODISCARD constexpr auto end() noexcept(
+            noexcept(_RANGES end(_Range)) && is_nothrow_move_constructible_v<sentinel_t<_Vw>>) /* strengthened */
+            requires (!_Simple_view<_Vw>)
+        {
             if constexpr (common_range<_Vw>) {
                 return _Iterator<false>{_RANGES end(_Range)};
             } else {
@@ -6078,11 +6022,10 @@ namespace ranges {
             }
         }
 
-        // clang-format off
-        _NODISCARD constexpr auto end() const noexcept(noexcept(
-            _RANGES end(_Range)) && is_nothrow_move_constructible_v<sentinel_t<const _Vw>>) /* strengthened */
-            requires range<const _Vw> {
-            // clang-format on
+        _NODISCARD constexpr auto end() const noexcept(
+            noexcept(_RANGES end(_Range)) && is_nothrow_move_constructible_v<sentinel_t<const _Vw>>) /* strengthened */
+            requires range<const _Vw>
+        {
             if constexpr (common_range<const _Vw>) {
                 return _Iterator<true>{_RANGES end(_Range)};
             } else {
@@ -6986,11 +6929,10 @@ namespace ranges {
             return _STD move(_Range);
         }
 
-        // clang-format off
         _NODISCARD constexpr auto begin() noexcept(
             noexcept(_RANGES begin(_Range)) && is_nothrow_move_constructible_v<iterator_t<_Vw>>) /* strengthened */
-            requires (!_Simple_view<_Vw>) {
-            // clang-format on
+            requires (!_Simple_view<_Vw>)
+        {
             return _Iterator<false>{this, _RANGES begin(_Range)};
         }
 
@@ -7002,11 +6944,10 @@ namespace ranges {
             return _Iterator<true>{this, _RANGES begin(_Range)};
         }
 
-        // clang-format off
-        _NODISCARD constexpr auto end() noexcept(noexcept(_RANGES distance(_Range))
-            && noexcept(_RANGES end(_Range)) && is_nothrow_move_constructible_v<iterator_t<_Vw>>) /* strengthened */
-            requires (!_Simple_view<_Vw>) {
-            // clang-format on
+        _NODISCARD constexpr auto end() noexcept(noexcept(_RANGES distance(_Range)) && noexcept(_RANGES end(_Range))
+                                                 && is_nothrow_move_constructible_v<iterator_t<_Vw>>) /* strengthened */
+            requires (!_Simple_view<_Vw>)
+        {
             if constexpr (common_range<_Vw> && sized_range<_Vw>) {
                 const auto _Missing = static_cast<range_difference_t<_Vw>>(_Count - _RANGES distance(_Range) % _Count);
                 if (_Missing == _Count) {
@@ -7020,12 +6961,11 @@ namespace ranges {
             }
         }
 
-        // clang-format off
         _NODISCARD constexpr auto end() const
             noexcept(noexcept(_RANGES distance(_Range)) && noexcept(_RANGES end(_Range))
                      && is_nothrow_move_constructible_v<iterator_t<const _Vw>>) /* strengthened */
-            requires forward_range<const _Vw> {
-            // clang-format on
+            requires forward_range<const _Vw>
+        {
             if constexpr (common_range<const _Vw> && sized_range<const _Vw>) {
                 const auto _Missing = static_cast<range_difference_t<_Vw>>(_Count - _RANGES distance(_Range) % _Count);
                 if (_Missing == _Count) {
@@ -7069,13 +7009,11 @@ namespace ranges {
 
     namespace views {
         struct _Chunk_fn {
-            // clang-format off
             template <viewable_range _Rng>
-            _NODISCARD constexpr auto operator()(_Rng&& _Range, const range_difference_t<_Rng> _Count) const noexcept(
-                noexcept(chunk_view(_STD forward<_Rng>(_Range), _Count))) requires requires {
-                chunk_view(_STD forward<_Rng>(_Range), _Count);
-            } {
-                // clang-format on
+            _NODISCARD constexpr auto operator()(_Rng&& _Range, const range_difference_t<_Rng> _Count) const
+                noexcept(noexcept(chunk_view(_STD forward<_Rng>(_Range), _Count)))
+                requires requires { chunk_view(_STD forward<_Rng>(_Range), _Count); }
+            {
                 return chunk_view(_STD forward<_Rng>(_Range), _Count);
             }
 
@@ -7369,9 +7307,9 @@ namespace ranges {
             return _STD move(_Range);
         }
 
-        // clang-format off
-        _NODISCARD constexpr auto begin() requires (!(_Simple_view<_Vw> && _Slide_caches_nothing<const _Vw>) ) {
-            // clang-format on
+        _NODISCARD constexpr auto begin()
+            requires (!(_Simple_view<_Vw> && _Slide_caches_nothing<const _Vw>) )
+        {
             if constexpr (_Slide_caches_first<_Vw>) {
                 auto _First = _RANGES begin(_Range);
                 if (this->_Has_cache()) {
@@ -7393,9 +7331,9 @@ namespace ranges {
             return _Iterator<true>{_RANGES begin(_Range), _Count};
         }
 
-        // clang-format off
-        _NODISCARD constexpr auto end() requires (!(_Simple_view<_Vw> && _Slide_caches_nothing<const _Vw>) ) {
-            // clang-format on
+        _NODISCARD constexpr auto end()
+            requires (!(_Simple_view<_Vw> && _Slide_caches_nothing<const _Vw>) )
+        {
             if constexpr (_Slide_caches_nothing<_Vw>) {
                 const auto _Size = _RANGES distance(_Range) - (_Count - 1);
                 if (_Size < 0) {
@@ -7469,13 +7407,11 @@ namespace ranges {
 
     namespace views {
         struct _Slide_fn {
-            // clang-format off
             template <viewable_range _Rng>
-            _NODISCARD constexpr auto operator()(_Rng&& _Range, const range_difference_t<_Rng> _Count) const noexcept(
-                noexcept(slide_view(_STD forward<_Rng>(_Range), _Count))) requires requires {
-                slide_view(_STD forward<_Rng>(_Range), _Count);
-            } {
-                // clang-format on
+            _NODISCARD constexpr auto operator()(_Rng&& _Range, const range_difference_t<_Rng> _Count) const
+                noexcept(noexcept(slide_view(_STD forward<_Rng>(_Range), _Count)))
+                requires requires { slide_view(_STD forward<_Rng>(_Range), _Count); }
+            {
                 return slide_view(_STD forward<_Rng>(_Range), _Count);
             }
 
@@ -7673,13 +7609,11 @@ namespace ranges {
 
     namespace views {
         struct _Chunk_by_fn {
-            // clang-format off
             template <viewable_range _Rng, class _Pr>
-            _NODISCARD constexpr auto operator()(_Rng&& _Range, _Pr&& _Pred) const noexcept(
-                noexcept(chunk_by_view(_STD forward<_Rng>(_Range), _STD forward<_Pr>(_Pred)))) requires requires {
-                chunk_by_view(_STD forward<_Rng>(_Range), _STD forward<_Pr>(_Pred));
-            } {
-                // clang-format on
+            _NODISCARD constexpr auto operator()(_Rng&& _Range, _Pr&& _Pred) const
+                noexcept(noexcept(chunk_by_view(_STD forward<_Rng>(_Range), _STD forward<_Pr>(_Pred))))
+                requires requires { chunk_by_view(_STD forward<_Rng>(_Range), _STD forward<_Pr>(_Pred)); }
+            {
                 return chunk_by_view(_STD forward<_Rng>(_Range), _STD forward<_Pr>(_Pred));
             }
 
@@ -8070,13 +8004,11 @@ namespace ranges {
 
     namespace views {
         struct _Stride_fn {
-            // clang-format off
             template <viewable_range _Rng>
-            _NODISCARD constexpr auto operator()(_Rng&& _Range, const range_difference_t<_Rng> _Stride) const noexcept(
-                noexcept(stride_view(_STD forward<_Rng>(_Range), _Stride))) requires requires {
-                stride_view(_STD forward<_Rng>(_Range), _Stride);
-            } {
-                // clang-format on
+            _NODISCARD constexpr auto operator()(_Rng&& _Range, const range_difference_t<_Rng> _Stride) const
+                noexcept(noexcept(stride_view(_STD forward<_Rng>(_Range), _Stride)))
+                requires requires { stride_view(_STD forward<_Rng>(_Range), _Stride); }
+            {
                 return stride_view(_STD forward<_Rng>(_Range), _Stride);
             }
 
@@ -8775,12 +8707,10 @@ namespace ranges {
                 return _Iterator{*_Lhs._Parent, _Lhs._Inner - _Rhs};
             }
 
-            // clang-format off
-            _NODISCARD_FRIEND constexpr difference_type operator-(const _Iterator& _Lhs, const _Iterator& _Rhs)
-                noexcept(noexcept(_Lhs._Inner - _Rhs._Inner)) // strengthened
+            _NODISCARD_FRIEND constexpr difference_type operator-(const _Iterator& _Lhs,
+                const _Iterator& _Rhs) noexcept(noexcept(_Lhs._Inner - _Rhs._Inner)) // strengthened
                 requires sized_sentinel_for<_Ziperator<_IsConst>, _Ziperator<_IsConst>>
             {
-                // clang-format on
                 return _Lhs._Inner - _Rhs._Inner;
             }
 
@@ -8952,10 +8882,9 @@ namespace ranges {
                         return false;
                     }
                 } else {
-                    // clang-format off
-                    return requires(_Func&& _Function, _Types&&... _Args)
-                        { zip_transform_view(_STD forward<_Func>(_Function), _STD forward<_Types>(_Args)...); };
-                    // clang-format on
+                    return requires(_Func&& _Function, _Types&&... _Args) {
+                        zip_transform_view(_STD forward<_Func>(_Function), _STD forward<_Types>(_Args)...);
+                    };
                 }
             }();
 
@@ -10339,13 +10268,11 @@ namespace ranges {
     template <class _Container, class _Reference>
     concept _Can_insert_end = requires(_Container& _Cont) { _Cont.insert(_Cont.end(), _STD declval<_Reference>()); };
 
-    // clang-format off
     template <class _Rng, class _Container, class... _Types>
-    concept _Converts_constructible_insertable = _Ref_converts<_Rng, _Container>
-        && constructible_from<_Container, _Types...>
+    concept _Converts_constructible_insertable =
+        _Ref_converts<_Rng, _Container> && constructible_from<_Container, _Types...>
         && (_Can_push_back<_Container, range_reference_t<_Rng>>
             || _Can_insert_end<_Container, range_reference_t<_Rng>>);
-    // clang-format on
 
     template <class _Reference, class _Container>
     _NODISCARD constexpr auto _Container_inserter(_Container& _Cont) {

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3834,10 +3834,10 @@ namespace ranges {
                 return **_Inner;
             }
 
-            // clang-format off
-            _NODISCARD constexpr _InnerIter operator->() const noexcept(is_nothrow_copy_constructible_v<_InnerIter>)
-                /* strengthened */ requires _Has_arrow<_InnerIter> && copyable<_InnerIter> {
-                // clang-format on
+            _NODISCARD constexpr _InnerIter operator->() const
+                noexcept(is_nothrow_copy_constructible_v<_InnerIter>) // strengthened
+                requires _Has_arrow<_InnerIter> && copyable<_InnerIter>
+            {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _Check_dereference();
 #endif // _ITERATOR_DEBUG_LEVEL != 0

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -5721,13 +5721,11 @@ namespace ranges {
     template <class _Tuple, size_t _Index>
     concept _Returnable_element = is_reference_v<_Tuple> || move_constructible<tuple_element_t<_Index, _Tuple>>;
 
-    // clang-format off
     _EXPORT_STD template <input_range _Vw, size_t _Index>
         requires view<_Vw> && _Has_tuple_element<range_value_t<_Vw>, _Index>
-            && _Has_tuple_element<remove_reference_t<range_reference_t<_Vw>>, _Index>
-            && _Returnable_element<range_reference_t<_Vw>, _Index>
+              && _Has_tuple_element<remove_reference_t<range_reference_t<_Vw>>, _Index>
+              && _Returnable_element<range_reference_t<_Vw>, _Index>
     class elements_view : public view_interface<elements_view<_Vw, _Index>> {
-        // clang-format on
     private:
         /* [[no_unique_address]] */ _Vw _Range{};
 
@@ -10307,15 +10305,13 @@ namespace ranges {
     } // namespace views
 
 #ifdef __cpp_lib_ranges_to_container
-    // clang-format off
     template <class _Range, class _Container>
     concept _Sized_and_reservable = sized_range<_Range> && sized_range<_Container>
-        && requires(_Container& _Cont, const range_size_t<_Container> _Count) {
-            _Cont.reserve(_Count);
-            { _Cont.capacity() } -> same_as<range_size_t<_Container>>;
-            { _Cont.max_size() } -> same_as<range_size_t<_Container>>;
-        };
-    // clang-format on
+                                 && requires(_Container& _Cont, const range_size_t<_Container> _Count) {
+                                        _Cont.reserve(_Count);
+                                        { _Cont.capacity() } -> same_as<range_size_t<_Container>>;
+                                        { _Cont.max_size() } -> same_as<range_size_t<_Container>>;
+                                    };
 
     template <class _Rng, class _Container>
     concept _Ref_converts =

--- a/stl/inc/spanstream
+++ b/stl/inc/spanstream
@@ -216,14 +216,12 @@ public:
     }
 
 #ifdef __cpp_lib_concepts
-    // clang-format off
     template <_RANGES borrowed_range _ReadOnlyRange>
-        requires (!convertible_to<_ReadOnlyRange, _STD span<_Elem>>
-                && convertible_to<_ReadOnlyRange, _STD span<const _Elem>>)
+        requires (
+            !convertible_to<_ReadOnlyRange, _STD span<_Elem>> && convertible_to<_ReadOnlyRange, _STD span<const _Elem>>)
     explicit basic_ispanstream(_ReadOnlyRange&& _Range)
         : basic_ispanstream(
             _STD span<_Elem>{const_cast<_Elem*>(_RANGES data(_Range)), static_cast<size_t>(_RANGES size(_Range))}) {}
-    // clang-format on
 #endif // defined(__cpp_lib_concepts)
 
     basic_ispanstream& operator=(const basic_ispanstream&) = delete;
@@ -254,15 +252,13 @@ public:
     }
 
 #ifdef __cpp_lib_concepts
-    // clang-format off
     template <_RANGES borrowed_range _ReadOnlyRange>
-        requires (!convertible_to<_ReadOnlyRange, _STD span<_Elem>>
-                && convertible_to<_ReadOnlyRange, _STD span<const _Elem>>)
+        requires (
+            !convertible_to<_ReadOnlyRange, _STD span<_Elem>> && convertible_to<_ReadOnlyRange, _STD span<const _Elem>>)
     void span(_ReadOnlyRange&& _Range) noexcept {
         this->span(
             _STD span<_Elem>{const_cast<_Elem*>(_RANGES data(_Range)), static_cast<size_t>(_RANGES size(_Range))});
     }
-    // clang-format on
 #endif // defined(__cpp_lib_concepts)
 
 private:

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6441,16 +6441,14 @@ namespace ranges {
 
     _EXPORT_STD inline constexpr _Adjacent_find_fn adjacent_find;
 
-    // clang-format off
     template <class _It1, class _It2, class _Se2, class _Pr, class _Pj1, class _Pj2>
     concept _Equal_rev_pred_can_memcmp = is_same_v<_Pj1, identity> && is_same_v<_Pj2, identity>
-        && sized_sentinel_for<_Se2, _It2> && _Equal_memcmp_is_safe<_It1, _It2, _Pr>;
+                                      && sized_sentinel_for<_Se2, _It2> && _Equal_memcmp_is_safe<_It1, _It2, _Pr>;
 
     template <forward_iterator _It1, input_iterator _It2, sentinel_for<_It2> _Se2, class _Pr, class _Pj1, class _Pj2>
         requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
     _NODISCARD constexpr pair<bool, _It1> _Equal_rev_pred(
         _It1 _First1, _It2 _First2, const _Se2 _Last2, _Pr _Pred, _Pj1 _Proj1, _Pj2 _Proj2) {
-        // clang-format on
         // Returns {true, _First1 + (_Last2 - _First2)} if [_First1, ...) equals [_First2, _Last2), and {false, {}}
         // otherwise.
         constexpr bool _Optimize = _Equal_rev_pred_can_memcmp<_It1, _It2, _Se2, _Pr, _Pj1, _Pj2>;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -676,13 +676,11 @@ namespace ranges {
 
 // iter_swap defined below since it depends on indirectly_movable_storable
 
-// clang-format off
 _EXPORT_STD template <class _Ty>
     requires _Dereferenceable<_Ty> && requires(_Ty& __t) {
         { _RANGES iter_move(__t) } -> _Can_reference;
     }
 using iter_rvalue_reference_t = decltype(_RANGES iter_move(_STD declval<_Ty&>()));
-// clang-format on
 
 template <class _It>
 concept _Indirectly_readable_impl =
@@ -1692,11 +1690,9 @@ _NODISCARD _CONSTEXPR17 bool
     operator==(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
         noexcept(_Fake_copy_init<bool>(_Left._Get_current() == _Right._Get_current()))) /* strengthened */
 #ifdef __cpp_lib_concepts
-    // clang-format off
     requires requires {
         { _Left._Get_current() == _Right._Get_current() } -> _Implicitly_convertible_to<bool>;
     }
-// clang-format on
 #endif // defined(__cpp_lib_concepts)
 {
     return _Left._Get_current() == _Right._Get_current();
@@ -1707,11 +1703,9 @@ _NODISCARD _CONSTEXPR17 bool
     operator!=(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
         noexcept(_Fake_copy_init<bool>(_Left._Get_current() != _Right._Get_current()))) /* strengthened */
 #ifdef __cpp_lib_concepts
-    // clang-format off
     requires requires {
         { _Left._Get_current() != _Right._Get_current() } -> _Implicitly_convertible_to<bool>;
     }
-// clang-format on
 #endif // defined(__cpp_lib_concepts)
 {
     return _Left._Get_current() != _Right._Get_current();
@@ -1722,11 +1716,9 @@ _NODISCARD _CONSTEXPR17 bool
     operator<(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
         noexcept(_Fake_copy_init<bool>(_Left._Get_current() > _Right._Get_current()))) /* strengthened */
 #ifdef __cpp_lib_concepts
-    // clang-format off
     requires requires {
         { _Left._Get_current() > _Right._Get_current() } -> _Implicitly_convertible_to<bool>;
     }
-// clang-format on
 #endif // defined(__cpp_lib_concepts)
 {
     return _Left._Get_current() > _Right._Get_current();
@@ -1737,11 +1729,9 @@ _NODISCARD _CONSTEXPR17 bool
     operator>(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
         noexcept(_Fake_copy_init<bool>(_Left._Get_current() < _Right._Get_current()))) /* strengthened */
 #ifdef __cpp_lib_concepts
-    // clang-format off
     requires requires {
         { _Left._Get_current() < _Right._Get_current() } -> _Implicitly_convertible_to<bool>;
     }
-// clang-format on
 #endif // defined(__cpp_lib_concepts)
 {
     return _Left._Get_current() < _Right._Get_current();
@@ -1752,11 +1742,9 @@ _NODISCARD _CONSTEXPR17 bool
     operator<=(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
         noexcept(_Fake_copy_init<bool>(_Left._Get_current() >= _Right._Get_current()))) /* strengthened */
 #ifdef __cpp_lib_concepts
-    // clang-format off
     requires requires {
         { _Left._Get_current() >= _Right._Get_current() } -> _Implicitly_convertible_to<bool>;
     }
-// clang-format on
 #endif // defined(__cpp_lib_concepts)
 {
     return _Left._Get_current() >= _Right._Get_current();
@@ -1767,11 +1755,9 @@ _NODISCARD _CONSTEXPR17 bool
     operator>=(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
         noexcept(_Fake_copy_init<bool>(_Left._Get_current() <= _Right._Get_current()))) /* strengthened */
 #ifdef __cpp_lib_concepts
-    // clang-format off
     requires requires {
         { _Left._Get_current() <= _Right._Get_current() } -> _Implicitly_convertible_to<bool>;
     }
-// clang-format on
 #endif // defined(__cpp_lib_concepts)
 {
     return _Left._Get_current() <= _Right._Get_current();
@@ -3080,7 +3066,6 @@ namespace ranges {
             static constexpr _Choice_t<_St> _Choice = _Choose<_Ty>();
 
         public:
-            // clang-format off
             template <class _Ty>
                 requires (_Choice<_Ty&>._Strategy != _St::_None)
             _NODISCARD constexpr bool operator()(_Ty&& _Val) const noexcept(_Choice<_Ty&>._No_throw) {
@@ -3096,7 +3081,6 @@ namespace ranges {
                     static_assert(_Always_false<_Ty>, "should be unreachable");
                 }
             }
-            // clang-format on
         };
     } // namespace _Empty
 
@@ -3967,14 +3951,12 @@ class move_sentinel;
 template <class>
 struct _Move_iterator_category {};
 
-// clang-format off
 template <class _Iter>
     requires requires { typename _Iter_cat_t<_Iter>; }
 struct _Move_iterator_category<_Iter> {
     using iterator_category = conditional_t<derived_from<_Iter_cat_t<_Iter>, random_access_iterator_tag>,
         random_access_iterator_tag, _Iter_cat_t<_Iter>>;
 };
-// clang-format on
 #else // ^^^ Ranges / no Ranges vvv
 template <class _Iter>
 struct _Move_iterator_category {
@@ -4234,11 +4216,9 @@ _NODISCARD _CONSTEXPR17 bool
     operator==(const move_iterator<_Iter1>& _Left, const move_iterator<_Iter2>& _Right) noexcept(
         noexcept(_Fake_copy_init<bool>(_Left.base() == _Right.base()))) /* strengthened */
 #ifdef __cpp_lib_concepts
-    // clang-format off
     requires requires {
         { _Left.base() == _Right.base() } -> _Implicitly_convertible_to<bool>;
     }
-// clang-format on
 #endif // defined(__cpp_lib_concepts)
 {
     return _Left.base() == _Right.base();
@@ -4257,11 +4237,9 @@ _NODISCARD _CONSTEXPR17 bool
     operator<(const move_iterator<_Iter1>& _Left, const move_iterator<_Iter2>& _Right) noexcept(
         noexcept(_Fake_copy_init<bool>(_Left.base() < _Right.base()))) /* strengthened */
 #ifdef __cpp_lib_concepts
-    // clang-format off
     requires requires {
         { _Left.base() < _Right.base() } -> _Implicitly_convertible_to<bool>;
     }
-// clang-format on
 #endif // defined(__cpp_lib_concepts)
 {
     return _Left.base() < _Right.base();
@@ -4317,11 +4295,9 @@ _NODISCARD _CONSTEXPR17 move_iterator<_Iter>
     operator+(typename move_iterator<_Iter>::difference_type _Off, const move_iterator<_Iter>& _Right) noexcept(
         noexcept(move_iterator<_Iter>(_Right.base() + _Off))) /* strengthened */
 #ifdef __cpp_lib_concepts
-    // clang-format off
     requires requires {
         { _Right.base() + _Off } -> same_as<_Iter>;
     }
-// clang-format on
 #endif // defined(__cpp_lib_concepts)
 {
     return move_iterator<_Iter>(_Right.base() + _Off);
@@ -5378,12 +5354,10 @@ namespace ranges {
     _EXPORT_STD template <class _In1, class _In2>
     using mismatch_result = in_in_result<_In1, _In2>;
 
-    // clang-format off
     template <input_iterator _It1, input_iterator _It2, class _Pr, class _Pj1, class _Pj2>
         requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
     _NODISCARD constexpr mismatch_result<_It1, _It2> _Mismatch_n(
         _It1 _First1, _It2 _First2, iter_difference_t<_It1> _Count, _Pr _Pred, _Pj1 _Proj1, _Pj2 _Proj2) {
-        // clang-format on
         _STL_INTERNAL_CHECK(_Count >= 0);
         for (; _Count != 0; ++_First1, (void) ++_First2, --_Count) {
             if (!_STD invoke(_Pred, _STD invoke(_Proj1, *_First1), _STD invoke(_Proj2, *_First2))) {
@@ -5928,11 +5902,9 @@ namespace ranges {
 
     class _Find_fn {
     public:
-        // clang-format off
         template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity>
             requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, const _Ty& _Val, _Pj _Proj = {}) const {
-            // clang-format on
             _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _RANGES _Find_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
                 _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _Val, _STD _Pass_fn(_Proj));

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -617,17 +617,13 @@ namespace ranges {
         void iter_move();
 #endif // ^^^ workaround ^^^
 
-        // clang-format off
         template <class _Ty>
         concept _Has_ADL = _Has_class_or_enum_type<_Ty> && requires(_Ty&& __t) {
             iter_move(static_cast<_Ty&&>(__t)); // intentional ADL
         };
 
         template <class _Ty>
-        concept _Can_deref = requires(_Ty&& __t) {
-            *static_cast<_Ty&&>(__t);
-        };
-        // clang-format on
+        concept _Can_deref = requires(_Ty&& __t) { *static_cast<_Ty&&>(__t); };
 
         class _Cpo {
         private:
@@ -913,14 +909,11 @@ struct _Indirect_value_impl<_ProjTy> {
 _EXPORT_STD template <class _In, class _Out>
 concept indirectly_movable = indirectly_readable<_In> && indirectly_writable<_Out, iter_rvalue_reference_t<_In>>;
 
-// clang-format off
 _EXPORT_STD template <class _In, class _Out>
-concept indirectly_movable_storable = indirectly_movable<_In, _Out>
-    && indirectly_writable<_Out, iter_value_t<_In>>
-    && movable<iter_value_t<_In>>
+concept indirectly_movable_storable =
+    indirectly_movable<_In, _Out> && indirectly_writable<_Out, iter_value_t<_In>> && movable<iter_value_t<_In>>
     && constructible_from<iter_value_t<_In>, iter_rvalue_reference_t<_In>>
-    && assignable_from<iter_value_t<_In>&, iter_rvalue_reference_t<_In> >;
-// clang-format on
+    && assignable_from<iter_value_t<_In>&, iter_rvalue_reference_t<_In>>;
 
 _EXPORT_STD template <class _In, class _Out>
 concept indirectly_copyable = indirectly_readable<_In> && indirectly_writable<_Out, iter_reference_t<_In>>;
@@ -1016,16 +1009,14 @@ namespace ranges {
     }
 } // namespace ranges
 
-// clang-format off
 _EXPORT_STD template <class _It1, class _It2 = _It1>
-concept indirectly_swappable = indirectly_readable<_It1> && indirectly_readable<_It2>
-    && requires(const _It1 __i1, const _It2 __i2) {
+concept indirectly_swappable =
+    indirectly_readable<_It1> && indirectly_readable<_It2> && requires(const _It1 __i1, const _It2 __i2) {
         _RANGES iter_swap(__i1, __i1);
         _RANGES iter_swap(__i2, __i2);
         _RANGES iter_swap(__i1, __i2);
         _RANGES iter_swap(__i2, __i1);
     };
-// clang-format on
 
 _EXPORT_STD template <class _It1, class _It2, class _Rel, class _Proj1 = identity, class _Proj2 = identity>
 concept indirectly_comparable = indirect_binary_predicate<_Rel, projected<_It1, _Proj1>, projected<_It2, _Proj2>>;
@@ -1527,26 +1518,25 @@ public:
         is_nothrow_move_constructible_v<_BidIt>) // strengthened
         : current(_STD move(_Right)) {}
 
-    // clang-format off
     template <class _Other>
 #ifdef __cpp_lib_concepts
         requires (!is_same_v<_Other, _BidIt>) && convertible_to<const _Other&, _BidIt>
 #endif // defined(__cpp_lib_concepts)
     _CONSTEXPR17 reverse_iterator(const reverse_iterator<_Other>& _Right) noexcept(
         is_nothrow_constructible_v<_BidIt, const _Other&>) // strengthened
-        : current(_Right.current) {}
+        : current(_Right.current) {
+    }
 
     template <class _Other>
 #ifdef __cpp_lib_concepts
-        requires (!is_same_v<_Other, _BidIt>) && convertible_to<const _Other&, _BidIt>
-            && assignable_from<_BidIt&, const _Other&>
+        requires (!is_same_v<_Other, _BidIt>)
+              && convertible_to<const _Other&, _BidIt> && assignable_from<_BidIt&, const _Other&>
 #endif // defined(__cpp_lib_concepts)
     _CONSTEXPR17 reverse_iterator& operator=(const reverse_iterator<_Other>& _Right) noexcept(
         is_nothrow_assignable_v<_BidIt&, const _Other&>) /* strengthened */ {
         current = _Right.current;
         return *this;
     }
-    // clang-format on
 
     _NODISCARD _CONSTEXPR17 _BidIt base() const noexcept(is_nothrow_copy_constructible_v<_BidIt>) /* strengthened */ {
         return current;
@@ -3349,14 +3339,14 @@ namespace ranges {
 
     class _Ssize_fn {
     public:
-        // clang-format off
         template <class _Rng>
-        _NODISCARD constexpr auto operator()(_Rng&& _Range) const requires requires { _RANGES size(_Range); } {
+        _NODISCARD constexpr auto operator()(_Rng&& _Range) const
+            requires requires { _RANGES size(_Range); }
+        {
             using _Sty = _Make_signed_like_t<decltype(_RANGES size(_Range))>;
             using _Ty  = common_type_t<conditional_t<is_integral_v<_Sty>, ptrdiff_t, _Sty>, _Sty>;
             return static_cast<_Ty>(_RANGES size(_Range));
         }
-        // clang-format on
     };
 
     inline namespace _Cpos {
@@ -3430,40 +3420,34 @@ namespace ranges {
     }
 
     _EXPORT_STD struct equal_to {
-        // clang-format off
         template <class _Ty1, class _Ty2>
             requires equality_comparable_with<_Ty1, _Ty2>
-        _NODISCARD constexpr bool operator()(_Ty1&& _Left, _Ty2&& _Right) const noexcept(noexcept(
-            static_cast<bool>(static_cast<_Ty1&&>(_Left) == static_cast<_Ty2&&>(_Right)))) /* strengthened */ {
+        _NODISCARD constexpr bool operator()(_Ty1&& _Left, _Ty2&& _Right) const noexcept(
+            noexcept(static_cast<bool>(static_cast<_Ty1&&>(_Left) == static_cast<_Ty2&&>(_Right)))) /* strengthened */ {
             return static_cast<bool>(static_cast<_Ty1&&>(_Left) == static_cast<_Ty2&&>(_Right));
         }
-        // clang-format on
 
         using is_transparent = int;
     };
 
     _EXPORT_STD struct less {
-        // clang-format off
         template <class _Ty1, class _Ty2>
             requires totally_ordered_with<_Ty1, _Ty2>
-        _NODISCARD constexpr bool operator()(_Ty1&& _Left, _Ty2&& _Right) const noexcept(noexcept(
-            static_cast<bool>(static_cast<_Ty1&&>(_Left) < static_cast<_Ty2&&>(_Right)))) /* strengthened */ {
+        _NODISCARD constexpr bool operator()(_Ty1&& _Left, _Ty2&& _Right) const noexcept(
+            noexcept(static_cast<bool>(static_cast<_Ty1&&>(_Left) < static_cast<_Ty2&&>(_Right)))) /* strengthened */ {
             return static_cast<bool>(static_cast<_Ty1&&>(_Left) < static_cast<_Ty2&&>(_Right));
         }
-        // clang-format on
 
         using is_transparent = int;
     };
 
     _EXPORT_STD struct greater {
-        // clang-format off
         template <class _Ty1, class _Ty2>
             requires totally_ordered_with<_Ty1, _Ty2>
-        _NODISCARD constexpr bool operator()(_Ty1&& _Left, _Ty2&& _Right) const noexcept(noexcept(
-            static_cast<bool>(static_cast<_Ty2&&>(_Right) < static_cast<_Ty1&&>(_Left)))) /* strengthened */ {
+        _NODISCARD constexpr bool operator()(_Ty1&& _Left, _Ty2&& _Right) const noexcept(
+            noexcept(static_cast<bool>(static_cast<_Ty2&&>(_Right) < static_cast<_Ty1&&>(_Left)))) /* strengthened */ {
             return static_cast<bool>(static_cast<_Ty2&&>(_Right) < static_cast<_Ty1&&>(_Left));
         }
-        // clang-format on
 
         using is_transparent = int;
     };
@@ -4000,26 +3984,25 @@ public:
     _CONSTEXPR17 explicit move_iterator(_Iter _Right) noexcept(is_nothrow_move_constructible_v<_Iter>) // strengthened
         : _Current(_STD move(_Right)) {}
 
-    // clang-format off
     template <class _Other>
 #ifdef __cpp_lib_concepts
         requires (!is_same_v<_Other, _Iter>) && convertible_to<const _Other&, _Iter>
 #endif // defined(__cpp_lib_concepts)
     _CONSTEXPR17 move_iterator(const move_iterator<_Other>& _Right) noexcept(
         is_nothrow_constructible_v<_Iter, const _Other&>) // strengthened
-        : _Current(_Right.base()) {}
+        : _Current(_Right.base()) {
+    }
 
     template <class _Other>
 #ifdef __cpp_lib_concepts
-        requires (!is_same_v<_Other, _Iter>) && convertible_to<const _Other&, _Iter>
-            && assignable_from<_Iter&, const _Other&>
+        requires (!is_same_v<_Other, _Iter>)
+              && convertible_to<const _Other&, _Iter> && assignable_from<_Iter&, const _Other&>
 #endif // defined(__cpp_lib_concepts)
     _CONSTEXPR17 move_iterator& operator=(const move_iterator<_Other>& _Right) noexcept(
         is_nothrow_assignable_v<_Iter&, const _Other&>) /* strengthened */ {
         _Current = _Right.base();
         return *this;
     }
-    // clang-format on
 
 #ifdef __cpp_lib_concepts
     _NODISCARD constexpr const iterator_type& base() const& noexcept {
@@ -5385,13 +5368,11 @@ namespace ranges {
 
     class _Mismatch_fn {
     public:
-        // clang-format off
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::equal_to, class _Pj1 = identity, class _Pj2 = identity>
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
-        _NODISCARD constexpr mismatch_result<_It1, _It2> operator()(_It1 _First1, _Se1 _Last1,
-            _It2 _First2, _Se2 _Last2, _Pr _Pred = {}, _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
-            // clang-format on
+        _NODISCARD constexpr mismatch_result<_It1, _It2> operator()(_It1 _First1, _Se1 _Last1, _It2 _First2,
+            _Se2 _Last2, _Pr _Pred = {}, _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
             _STD _Adl_verify_range(_First1, _Last1);
             _STD _Adl_verify_range(_First2, _Last2);
 

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -231,11 +231,11 @@ namespace test {
             return *this;
         }
 
-        // clang-format off
-        constexpr operator Element&() const requires derived_from<Category, input> {
+        constexpr operator Element&() const
+            requires derived_from<Category, input>
+        {
             return ref_;
         }
-        // clang-format on
 
         template <class T>
             requires (!std::same_as<std::remove_cvref_t<T>, proxy_reference> && assignable_from<Element&, T>)
@@ -674,26 +674,23 @@ namespace test {
         }
 
         // sized_sentinel_for operations:
-        // clang-format off
         [[nodiscard]] constexpr ptrdiff_t operator-(iterator const& that) const noexcept
-            requires at_least<random> || (to_bool(Diff) && to_bool(Eq)) {
-            // clang-format on
+            requires at_least<random> || (to_bool(Diff) && to_bool(Eq))
+        {
             return ptr_ - that.ptr_;
         }
 
-        // clang-format off
         template <WrappedState OtherWrapped>
         [[nodiscard]] constexpr ptrdiff_t operator-(sentinel<Element, OtherWrapped> const& s) const noexcept
-            requires compatible_wrapped_state<Wrapped, OtherWrapped> && (to_bool(Diff)) {
-            // clang-format on
+            requires compatible_wrapped_state<Wrapped, OtherWrapped> && (to_bool(Diff))
+        {
             return ptr_ - s.peek();
         }
-        // clang-format off
         template <WrappedState OtherWrapped>
         [[nodiscard]] friend constexpr ptrdiff_t operator-(
             sentinel<Element, OtherWrapped> const& s, iterator const& i) noexcept
-            requires compatible_wrapped_state<Wrapped, OtherWrapped> && (to_bool(Diff)) {
-            // clang-format on
+            requires compatible_wrapped_state<Wrapped, OtherWrapped> && (to_bool(Diff))
+        {
             return -(i - s);
         }
 
@@ -871,7 +868,6 @@ namespace test {
         };
     } // namespace detail
 
-    // clang-format off
     template <class Category, class Element,
         // Implement member size? (NB: Not equivalent to "Is this a sized_range?")
         Sized IsSized = Sized::no,
@@ -887,10 +883,9 @@ namespace test {
         CanView IsView = CanView::no,
         // Should this range type be copyable/movable/neither?
         Copyability Copy = IsView == CanView::yes ? Copyability::move_only : Copyability::immobile>
-        requires (!to_bool(IsCommon) || to_bool(Eq))
-            && (to_bool(Eq) || !derived_from<Category, fwd>)
-            && (Proxy == ProxyRef::no || !derived_from<Category, contiguous>)
-            && (!to_bool(IsView) || Copy != Copyability::immobile)
+        requires (!to_bool(IsCommon) || to_bool(Eq)) && (to_bool(Eq) || !derived_from<Category, fwd>)
+              && (Proxy == ProxyRef::no || !derived_from<Category, contiguous>)
+              && (!to_bool(IsView) || Copy != Copyability::immobile)
     class range : public detail::range_base<Element, Copy> {
     private:
         mutable bool begin_called_ = false;
@@ -901,8 +896,8 @@ namespace test {
     public:
         using I = iterator<Category, Element, Diff, Eq, Proxy, WrappedState::wrapped>;
         using S = conditional_t<to_bool(IsCommon), I, sentinel<Element, WrappedState::wrapped>>;
-        using RebindAsMoveOnly = range<Category, Element, IsSized, Diff, IsCommon, Eq, Proxy, IsView,
-            Copyability::move_only>;
+        using RebindAsMoveOnly =
+            range<Category, Element, IsSized, Diff, IsCommon, Eq, Proxy, IsView, Copyability::move_only>;
 
         using detail::range_base<Element, Copy>::range_base;
 
@@ -919,7 +914,9 @@ namespace test {
             return S{elements_.data() + elements_.size()};
         }
 
-        [[nodiscard]] constexpr ptrdiff_t size() const noexcept requires (to_bool(IsSized)) {
+        [[nodiscard]] constexpr ptrdiff_t size() const noexcept
+            requires (to_bool(IsSized))
+        {
             assert(!moved_from());
             if constexpr (!derived_from<Category, fwd>) {
                 assert(!begin_called_);
@@ -927,7 +924,9 @@ namespace test {
             return static_cast<ptrdiff_t>(elements_.size());
         }
 
-        [[nodiscard]] constexpr Element* data() const noexcept requires derived_from<Category, contiguous> {
+        [[nodiscard]] constexpr Element* data() const noexcept
+            requires derived_from<Category, contiguous>
+        {
             assert(!moved_from());
             return elements_.data();
         }
@@ -955,7 +954,6 @@ namespace test {
             STATIC_ASSERT(always_false<Category>);
         }
     };
-    // clang-format on
 } // namespace test
 
 template <class Category, class Element, test::Sized IsSized, test::CanDifference Diff, test::Common IsCommon,

--- a/tests/std/tests/P0896R4_P1614R2_comparisons/test.cpp
+++ b/tests/std/tests/P0896R4_P1614R2_comparisons/test.cpp
@@ -142,8 +142,6 @@ struct std::common_type<three_way_archetype<I1, Cat1>, three_way_archetype<I2, C
     using type = conditional_t<I1 == 5 || I2 == 5, ::common_incomparable, ::common_comparable>;
 };
 
-// clang-format off
-
 // 6: not _Weakly_equality_comparable_with
 template <int I1, class Cat1, int I2, class Cat2>
     requires ((I1 != I2 || !same_as<Cat1, Cat2>) && (I1 == 6 || I2 == 6))
@@ -168,8 +166,6 @@ bool operator<=(three_way_archetype<I1, Cat1> const&, three_way_archetype<I2, Ca
 template <int I1, class Cat1, int I2, class Cat2>
     requires (I1 != I2 || !same_as<Cat1, Cat2>)
 bool operator>=(three_way_archetype<I1, Cat1> const&, three_way_archetype<I2, Cat2> const&);
-
-// clang-format on
 
 // 8: <=> isn't defined
 template <int I1, class Cat1, int I2, class Cat2>

--- a/tests/std/tests/P0896R4_counted_iterator/test.cpp
+++ b/tests/std/tests/P0896R4_counted_iterator/test.cpp
@@ -21,29 +21,26 @@ inline constexpr bool must_be_countable<I> = true;
 template <class... Is>
 concept Counted = (must_be_countable<Is> && ...);
 
-// clang-format off
 template <class I1, class I2>
-concept CountedCompare = Counted<I1, I2>
-    && requires(const counted_iterator<I1>& c1, const counted_iterator<I2>& c2) {
-        c1 == c2;
-        c1 != c2;
-        c1 < c2;
-        c1 > c2;
-        c1 <= c2;
-        c1 >= c2;
-        c1 <=> c2;
-        c1 - c2;
+concept CountedCompare = Counted<I1, I2> && requires(const counted_iterator<I1>& c1, const counted_iterator<I2>& c2) {
+    c1 == c2;
+    c1 != c2;
+    c1 < c2;
+    c1 > c2;
+    c1 <= c2;
+    c1 >= c2;
+    c1 <=> c2;
+    c1 - c2;
 
-        c2 == c1;
-        c2 != c1;
-        c2 < c1;
-        c2 > c1;
-        c2 <= c1;
-        c2 >= c1;
-        c2 <=> c1;
-        c2 - c1;
-    };
-// clang-format on
+    c2 == c1;
+    c2 != c1;
+    c2 < c1;
+    c2 > c1;
+    c2 <= c1;
+    c2 >= c1;
+    c2 <=> c1;
+    c2 - c1;
+};
 
 struct instantiator {
     template <input_or_output_iterator Iter>

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -1177,11 +1177,10 @@ namespace iterator_cust_swap_test {
 
     // N4928 [iterator.cust.swap]/4.2: "Otherwise, if the types of E1 and E2 each model indirectly_readable,
     // and if the reference types of E1 and E2 model swappable_with, then ranges::swap(*E1, *E2)."
-    // clang-format off
     template <class T, class U = T>
-    concept bullet2 = !bullet1<T, U> && indirectly_readable<remove_reference_t<T>>
-        && indirectly_readable<remove_reference_t<U>> && swappable_with<iter_reference_t<T>, iter_reference_t<U>>;
-    // clang-format on
+    concept bullet2 =
+        !bullet1<T, U> && indirectly_readable<remove_reference_t<T>> && indirectly_readable<remove_reference_t<U>>
+        && swappable_with<iter_reference_t<T>, iter_reference_t<U>>;
 
     constexpr bool test() {
         // This test notably executes both at runtime and at compiletime.
@@ -1950,14 +1949,13 @@ namespace iter_ops {
             return *this;
         }
 
-        // clang-format off
         constexpr trace_iterator& operator=(default_sentinel_t) noexcept(NoThrow == nothrow::yes)
-            requires (Assign == assign::yes) {
+            requires (Assign == assign::yes)
+        {
             ++trace_->assignments_;
             pos_ = sentinel_position;
             return *this;
         }
-        // clang-format on
 
         int operator*() const noexcept(NoThrow == nothrow::yes);
 
@@ -3144,17 +3142,13 @@ namespace reverse_iterator_test {
     STATIC_ASSERT(same_as<reverse_iterator<xvalue_bidi_iter>::iterator_category, bidirectional_iterator_tag>);
 
     // Validate operator-> for a pointer, and for non-pointers with and without operator->()
-    // clang-format off
     template <class I, class P>
     concept has_arrow = requires(I i) {
         { i.operator->() } -> same_as<P>;
     };
 
     template <class I>
-    concept has_no_arrow = !requires(I i) {
-        i.operator->();
-    };
-    // clang-format on
+    concept has_no_arrow = !requires(I i) { i.operator->(); };
 
     STATIC_ASSERT(has_arrow<reverse_iterator<int*>, int*>);
     STATIC_ASSERT(same_as<reverse_iterator<int*>::pointer, int*>);

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -420,11 +420,9 @@ struct sentinel_archetype : semiregular_archetype<I> {
         requires (I != 5);
     COPYABLE_OPS(sentinel);
 
-    // clang-format off
     template <std::size_t J>
         requires (I != 6)
     bool operator==(iterator_archetype<J> const&) const;
-    // clang-format on
 };
 
 inline constexpr std::size_t sentinel_archetype_max = 7;
@@ -1770,7 +1768,6 @@ namespace unreachable_sentinel_test {
     STATIC_ASSERT(std::is_nothrow_copy_assignable_v<unreachable_sentinel_t>);
     STATIC_ASSERT(std::is_nothrow_move_assignable_v<unreachable_sentinel_t>);
 
-    // clang-format off
     template <class T>
     concept Comparable = requires(T const& t) {
         { t == unreachable_sentinel } -> std::same_as<bool>;
@@ -1778,7 +1775,6 @@ namespace unreachable_sentinel_test {
         { unreachable_sentinel == t } -> std::same_as<bool>;
         { unreachable_sentinel != t } -> std::same_as<bool>;
     };
-    // clang-format on
 
     STATIC_ASSERT(Comparable<int>);
 

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -1389,93 +1389,131 @@ constexpr bool test_array_ish() { // An actual runtime test!
 }
 
 namespace nothrow_testing {
-    // clang-format off
     template <unsigned int I, bool NoThrow>
     struct range {
         int elements_[3];
 
         // begin/end are members for I == 0, and non-members otherwise
-        int* begin() noexcept(NoThrow) requires (I == 0) {
+        int* begin() noexcept(NoThrow)
+            requires (I == 0)
+        {
             return elements_;
         }
-        int* end() noexcept(NoThrow) requires (I == 0) {
+        int* end() noexcept(NoThrow)
+            requires (I == 0)
+        {
             return elements_ + 3;
         }
-        int const* begin() const noexcept(NoThrow) requires (I == 0) {
+        int const* begin() const noexcept(NoThrow)
+            requires (I == 0)
+        {
             return elements_;
         }
-        int const* end() const noexcept(NoThrow) requires (I == 0) {
+        int const* end() const noexcept(NoThrow)
+            requires (I == 0)
+        {
             return elements_ + 3;
         }
 
         // rbegin/rend are members for I == 0, not provided for I == 1, and non-members otherwise
         // (Not providing operations allows us to test the library-provided fallback behavior)
-        int* rbegin() noexcept(NoThrow) requires (I == 0) {
+        int* rbegin() noexcept(NoThrow)
+            requires (I == 0)
+        {
             return elements_;
         }
-        int* rend() noexcept(NoThrow) requires (I == 0) {
+        int* rend() noexcept(NoThrow)
+            requires (I == 0)
+        {
             return elements_ + 3;
         }
-        int const* rbegin() const noexcept(NoThrow) requires (I == 0) {
+        int const* rbegin() const noexcept(NoThrow)
+            requires (I == 0)
+        {
             return elements_;
         }
-        int const* rend() const noexcept(NoThrow) requires (I == 0) {
+        int const* rend() const noexcept(NoThrow)
+            requires (I == 0)
+        {
             return elements_ + 3;
         }
 
         // empty is not provided when I == 1
-        bool empty() const noexcept(NoThrow) requires (I != 1) {
+        bool empty() const noexcept(NoThrow)
+            requires (I != 1)
+        {
             return false;
         }
 
         // data is not provided when I == 2
-        int* data() noexcept(NoThrow) requires (I != 2) {
+        int* data() noexcept(NoThrow)
+            requires (I != 2)
+        {
             return elements_;
         }
-        int const* data() const noexcept(NoThrow) requires (I != 2) {
+        int const* data() const noexcept(NoThrow)
+            requires (I != 2)
+        {
             return elements_;
         }
 
         // size is not provided when I == 3
-        std::size_t size() const noexcept(NoThrow) requires (I != 3) {
+        std::size_t size() const noexcept(NoThrow)
+            requires (I != 3)
+        {
             return 3;
         }
     };
 
     template <unsigned int I, bool NoThrow>
-    int* begin(range<I, NoThrow>& a) noexcept(NoThrow) requires (I != 0) {
+    int* begin(range<I, NoThrow>& a) noexcept(NoThrow)
+        requires (I != 0)
+    {
         return a.elements_;
     }
     template <unsigned int I, bool NoThrow>
-    int* end(range<I, NoThrow>& a) noexcept(NoThrow) requires (I != 0) {
+    int* end(range<I, NoThrow>& a) noexcept(NoThrow)
+        requires (I != 0)
+    {
         return a.elements_ + 3;
     }
     template <unsigned int I, bool NoThrow>
-    int const* begin(range<I, NoThrow> const& a) noexcept(NoThrow) requires (I != 0) {
+    int const* begin(range<I, NoThrow> const& a) noexcept(NoThrow)
+        requires (I != 0)
+    {
         return a.elements_;
     }
     template <unsigned int I, bool NoThrow>
-    int const* end(range<I, NoThrow> const& a) noexcept(NoThrow) requires (I != 0) {
+    int const* end(range<I, NoThrow> const& a) noexcept(NoThrow)
+        requires (I != 0)
+    {
         return a.elements_ + 3;
     }
 
     template <unsigned int I, bool NoThrow>
-    int* rbegin(range<I, NoThrow>& a) noexcept(NoThrow) requires (I > 2) {
+    int* rbegin(range<I, NoThrow>& a) noexcept(NoThrow)
+        requires (I > 2)
+    {
         return a.elements_;
     }
     template <unsigned int I, bool NoThrow>
-    int* rend(range<I, NoThrow>& a) noexcept(NoThrow) requires (I > 2) {
+    int* rend(range<I, NoThrow>& a) noexcept(NoThrow)
+        requires (I > 2)
+    {
         return a.elements_ + 3;
     }
     template <unsigned int I, bool NoThrow>
-    int const* rbegin(range<I, NoThrow> const& a) noexcept(NoThrow) requires (I > 2) {
+    int const* rbegin(range<I, NoThrow> const& a) noexcept(NoThrow)
+        requires (I > 2)
+    {
         return a.elements_;
     }
     template <unsigned int I, bool NoThrow>
-    int const* rend(range<I, NoThrow> const& a) noexcept(NoThrow) requires (I > 2) {
+    int const* rend(range<I, NoThrow> const& a) noexcept(NoThrow)
+        requires (I > 2)
+    {
         return a.elements_ + 3;
     }
-    // clang-format on
 
     template <class T, bool Nothrow>
     constexpr bool test() {

--- a/tests/std/tests/P0896R4_ranges_subrange/test.compile.pass.cpp
+++ b/tests/std/tests/P0896R4_ranges_subrange/test.compile.pass.cpp
@@ -68,23 +68,24 @@ namespace test_view_interface {
     using test::CanCompare, test::CanDifference, test::Common, test::ProxyRef, test::to_bool;
     enum class ConstRange : bool { no, yes };
 
-    // clang-format off
     template <class Cat, Common IsCommon, CanDifference Diff, ConstRange HasConstRange>
     struct fake_view : ranges::view_interface<fake_view<Cat, IsCommon, Diff, HasConstRange>> {
         using I = test::iterator<Cat, int, Diff, CanCompare::yes, ProxyRef::no>;
         using S = std::conditional_t<to_bool(IsCommon), I, test::sentinel<int>>;
 
         I begin();
-        I begin() const requires (to_bool(HasConstRange));
+        I begin() const
+            requires (to_bool(HasConstRange));
 
         S end();
-        S end() const requires (to_bool(HasConstRange));
+        S end() const
+            requires (to_bool(HasConstRange));
 
-        unsigned int size() requires (to_bool(Diff) && !std::derived_from<Cat, forward_iterator_tag>);
-        unsigned int size() const requires (to_bool(HasConstRange) && to_bool(Diff)
-            && !std::derived_from<Cat, forward_iterator_tag>);
+        unsigned int size()
+            requires (to_bool(Diff) && !std::derived_from<Cat, forward_iterator_tag>);
+        unsigned int size() const
+            requires (to_bool(HasConstRange) && to_bool(Diff) && !std::derived_from<Cat, forward_iterator_tag>);
     };
-    // clang-format on
 
     namespace output_unsized_onlymutable {
         using V = fake_view<output_iterator_tag, Common::no, CanDifference::no, ConstRange::no>;

--- a/tests/std/tests/P0896R4_views_drop/test.cpp
+++ b/tests/std/tests/P0896R4_views_drop/test.cpp
@@ -62,12 +62,9 @@ struct mapped<basic_string_view<CharT, Traits>> {
     template <class>
     using apply = basic_string_view<CharT, Traits>;
 };
-// clang-format off
 template <class W, class B>
-    requires ranges::random_access_range<ranges::iota_view<W, B>>
-        && ranges::sized_range<ranges::iota_view<W, B>>
+    requires ranges::random_access_range<ranges::iota_view<W, B>> && ranges::sized_range<ranges::iota_view<W, B>>
 struct mapped<ranges::iota_view<W, B>> {
-    // clang-format on
     template <class>
     using apply = ranges::iota_view<W, B>;
 };

--- a/tests/std/tests/P0896R4_views_join/test.cpp
+++ b/tests/std/tests/P0896R4_views_join/test.cpp
@@ -143,10 +143,9 @@ constexpr bool test_one(Outer&& rng, Expected&& expected) {
 
         // Validate join_view::begin
         static_assert(CanMemberBegin<R>);
-        // clang-format off
-        static_assert(CanMemberBegin<const R> == (forward_range<const V> && is_reference_v<range_reference_t<const V>>
-                                                  && input_range<range_reference_t<const V>>) );
-        // clang-format on
+        static_assert(CanMemberBegin<const R>
+                      == (forward_range<const V> && is_reference_v<range_reference_t<const V>>
+                          && input_range<range_reference_t<const V>>) );
         if (forward_range<R>) {
             const iterator_t<R> i = r.begin();
             if (!is_empty) {
@@ -180,15 +179,15 @@ constexpr bool test_one(Outer&& rng, Expected&& expected) {
 
         // Validate join_view::end
         static_assert(CanMemberEnd<R>);
-        // clang-format off
-        static_assert(CanMemberEnd<const R> == (forward_range<const V> && is_reference_v<range_reference_t<const V>>
-                                                && input_range<range_reference_t<const V>>) );
-        static_assert(common_range<R> == (forward_range<V> && is_reference_v<range_reference_t<V>> && common_range<V>
-                                          && forward_range<Inner> && common_range<Inner>) );
-        static_assert(common_range<const R> == (forward_range<const V> && is_reference_v<range_reference_t<const V>>
-                                                && common_range<const V> && forward_range<range_reference_t<const V>>
-                                                && common_range<range_reference_t<const V>>) );
-        // clang-format on
+        static_assert(CanMemberEnd<const R>
+                      == (forward_range<const V> && is_reference_v<range_reference_t<const V>>
+                          && input_range<range_reference_t<const V>>) );
+        static_assert(common_range<R>
+                      == (forward_range<V> && is_reference_v<range_reference_t<V>> && common_range<V>
+                          && forward_range<Inner> && common_range<Inner>) );
+        static_assert(common_range<const R>
+                      == (forward_range<const V> && is_reference_v<range_reference_t<const V>> && common_range<const V>
+                          && forward_range<range_reference_t<const V>> && common_range<range_reference_t<const V>>) );
         const ranges::sentinel_t<R> s = r.end();
         if (!is_empty) {
             if constexpr (bidirectional_range<R> && common_range<R>) {
@@ -308,10 +307,9 @@ constexpr bool test_one(Outer&& rng, Expected&& expected) {
         }
 
         static_assert(CanMemberBack<R> == (bidirectional_range<R> && common_range<R>) );
-        // clang-format off
-        static_assert(CanMemberBack<const R> == (bidirectional_range<const R> && common_range<const R>
-                                                 && is_reference_v<range_reference_t<const V>>) );
-        // clang-format on
+        static_assert(
+            CanMemberBack<const R>
+            == (bidirectional_range<const R> && common_range<const R> && is_reference_v<range_reference_t<const V>>) );
         if (!is_empty) {
             if constexpr (CanMemberBack<R>) {
                 assert(r.back() == *prev(end(expected)));

--- a/tests/std/tests/P0896R4_views_lazy_split/test.cpp
+++ b/tests/std/tests/P0896R4_views_lazy_split/test.cpp
@@ -185,10 +185,9 @@ constexpr void test_one(Base&& base, Delimiter&& delimiter, Expected&& expected)
     }
 
     STATIC_ASSERT(CanMemberEnd<const R>);
-    // clang-format off
     constexpr bool should_be_const_common = ranges::forward_range<Base>
-        && ranges::forward_range<const remove_cvref_t<Base>> && ranges::common_range<const remove_cvref_t<Base>>;
-    // clang-format on
+                                         && ranges::forward_range<const remove_cvref_t<Base>>
+                                         && ranges::common_range<const remove_cvref_t<Base>>;
     STATIC_ASSERT(ranges::common_range<const R> == should_be_const_common);
     const auto sc = as_const(r).end();
     if constexpr (ranges::forward_range<Base> && ranges::forward_range<const remove_cvref_t<Base>>) {

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -65,12 +65,9 @@ struct mapped<basic_string_view<CharT, Traits>> {
     template <class>
     using apply = basic_string_view<CharT, Traits>;
 };
-// clang-format off
 template <class W, class B>
-    requires ranges::random_access_range<ranges::iota_view<W, B>>
-        && ranges::sized_range<ranges::iota_view<W, B>>
+    requires ranges::random_access_range<ranges::iota_view<W, B>> && ranges::sized_range<ranges::iota_view<W, B>>
 struct mapped<ranges::iota_view<W, B>> {
-    // clang-format on
     template <class>
     using apply = ranges::iota_view<W, W>;
 };

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -184,9 +184,9 @@ template <class First, class Second = IncompleteClass>
 struct ConvertsFrom {
     ConvertsFrom() = default;
     constexpr ConvertsFrom(First) noexcept {}
-    // clang-format off
-    constexpr ConvertsFrom(Second) noexcept requires (!std::is_same_v<IncompleteClass, Second>) {}
-    // clang-format on
+    constexpr ConvertsFrom(Second) noexcept
+        requires (!std::is_same_v<IncompleteClass, Second>)
+    {}
 };
 
 template <int>
@@ -2112,56 +2112,58 @@ namespace test_swappable_with {
 
     namespace example {
         // The example from [concept.swappable] with changes per the proposed resolution of LWG-3175:
-        // clang-format off
         namespace ranges = std::ranges;
 
         template <class T, std::swappable_with<T> U>
         void value_swap(T&& t, U&& u) {
-          ranges::swap(std::forward<T>(t), std::forward<U>(u));
+            ranges::swap(std::forward<T>(t), std::forward<U>(u));
         }
 
         template <std::swappable T>
         void lv_swap(T& t1, T& t2) {
-          ranges::swap(t1, t2);
+            ranges::swap(t1, t2);
         }
 
         namespace N {
-          struct A { int m; };
-          struct Proxy {
-            A* a;
-            Proxy(A& a) : a{&a} {}
-            friend void swap(Proxy x, Proxy y) {
-              ranges::swap(*x.a, *y.a);
+            struct A {
+                int m;
+            };
+            struct Proxy {
+                A* a;
+                Proxy(A& a) : a{&a} {}
+                friend void swap(Proxy x, Proxy y) {
+                    ranges::swap(*x.a, *y.a);
+                }
+            };
+            Proxy proxy(A& a) {
+                return Proxy{a};
             }
-          };
-          Proxy proxy(A& a) { return Proxy{a}; }
-        }
+        } // namespace N
 
         void test() {
-          int i = 1, j = 2;
-          lv_swap(i, j);
-          assert(i == 2 && j == 1);
+            int i = 1, j = 2;
+            lv_swap(i, j);
+            assert(i == 2 && j == 1);
 
-          N::A a1 = { 5 };
-          N::A a2 = { -5 };
-          value_swap(a1, proxy(a2));
-          assert(a1.m == -5 && a2.m == 5);
+            N::A a1 = {5};
+            N::A a2 = {-5};
+            value_swap(a1, proxy(a2));
+            assert(a1.m == -5 && a2.m == 5);
 
-          // additional test cases not from [concept.swappable] for completeness:
-          STATIC_ASSERT(std::is_same_v<std::common_reference_t<N::Proxy, N::A&>, N::Proxy>);
-          STATIC_ASSERT(swappable_with<N::A&, N::Proxy>);
+            // additional test cases not from [concept.swappable] for completeness:
+            STATIC_ASSERT(std::is_same_v<std::common_reference_t<N::Proxy, N::A&>, N::Proxy>);
+            STATIC_ASSERT(swappable_with<N::A&, N::Proxy>);
 
-          value_swap(proxy(a1), a2);
-          assert(a1.m == 5 && a2.m == -5);
+            value_swap(proxy(a1), a2);
+            assert(a1.m == 5 && a2.m == -5);
 
-          value_swap(proxy(a1), proxy(a2));
-          assert(a1.m == -5 && a2.m == 5);
+            value_swap(proxy(a1), proxy(a2));
+            assert(a1.m == -5 && a2.m == 5);
 
-          value_swap(a1, a2);
-          assert(a1.m == 5 && a2.m == -5);
-          // end additional test cases
+            value_swap(a1, a2);
+            assert(a1.m == 5 && a2.m == -5);
+            // end additional test cases
         }
-        // clang-format on
     } // namespace example
 } // namespace test_swappable_with
 
@@ -3332,13 +3334,12 @@ namespace test_relation {
     STATIC_ASSERT(test<std::less<>, int*, void*>());
 
     struct Equivalent {
-        // clang-format off
         template <class T, class U>
         constexpr decltype(auto) operator()(T&& t, U&& u) const
-            requires requires { static_cast<T&&>(t) == static_cast<U&&>(u); } {
+            requires requires { static_cast<T&&>(t) == static_cast<U&&>(u); }
+        {
             return static_cast<T&&>(t) == static_cast<U&&>(u);
         }
-        // clang-format on
     };
     STATIC_ASSERT(test<Equivalent, int, long>());
 

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -3362,14 +3362,12 @@ namespace test_relation {
     STATIC_ASSERT(test<Equivalent, B<0>>());
     STATIC_ASSERT(!test<Equivalent, B<1>>());
 
-    // clang-format off
     template <unsigned int I>
         requires (2 != I)
     bool operator==(A<I>, B<I>); // A<2> == B<2> rewrites to B<2> == A<2>
     template <unsigned int I>
         requires (3 != I)
     bool operator==(B<I>, A<I>); // B<3> == A<3> rewrites to A<3> == B<3>
-    // clang-format on
 
     STATIC_ASSERT(!test<Equivalent, A<0>, B<0>>());
     STATIC_ASSERT(!test<Equivalent, A<1>, B<1>>());

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -2410,12 +2410,12 @@ namespace test_boolean_testable {
 
     template <unsigned int Select> // values in [0, Archetype_max) select a requirement to violate
     struct Archetype {
-        // clang-format off
-        operator bool() const requires (Select != 0); // Archetype<0> is not implicitly convertible to bool
-        explicit operator bool() const requires (Select < 2); // Archetype<1> is not explicitly convertible
-                                                              // to bool (ambiguity)
-        void operator!() const requires (Select == 2); // !Archetype<2> does not model _Boolean_testable_impl
-        // clang-format on
+        operator bool() const
+            requires (Select != 0); // Archetype<0> is not implicitly convertible to bool
+        explicit operator bool() const
+            requires (Select < 2); // Archetype<1> is not explicitly convertible to bool (ambiguity)
+        void operator!() const
+            requires (Select == 2); // !Archetype<2> does not model _Boolean_testable_impl
     };
 
     STATIC_ASSERT(!_Boolean_testable<Archetype<0>>);

--- a/tests/std/tests/P1206R7_string_insert_range/test.cpp
+++ b/tests/std/tests/P1206R7_string_insert_range/test.cpp
@@ -36,7 +36,6 @@ static constexpr wchar_t whw[] = L"Hello, World!";
 struct string_instantiator {
     template <ranges::input_range R>
     static void call() {
-        // clang-format off
         constexpr auto& text = []() -> auto& {
             if constexpr (is_same_v<ranges::range_value_t<R>, char>) {
                 return hw;
@@ -44,7 +43,6 @@ struct string_instantiator {
                 return whw;
             }
         }();
-        // clang-format on
 
         test_string(0, 0, R{text}, text);
         STATIC_ASSERT(test_string(0, 0, R{text}, text));

--- a/tests/std/tests/P1206R7_string_replace_with_range/test.cpp
+++ b/tests/std/tests/P1206R7_string_replace_with_range/test.cpp
@@ -38,7 +38,6 @@ static constexpr wchar_t whw[] = L"Hello, World!";
 struct string_instantiator {
     template <ranges::input_range R>
     static void call() {
-        // clang-format off
         constexpr auto& text = []() -> auto& {
             if constexpr (is_same_v<ranges::range_value_t<R>, char>) {
                 return hw;
@@ -46,7 +45,6 @@ struct string_instantiator {
                 return whw;
             }
         }();
-        // clang-format on
 
         // insert into empty
         test_string(0, 0, 0, R{text}, text);

--- a/tests/std/tests/P1659R3_ranges_alg_ends_with/test.cpp
+++ b/tests/std/tests/P1659R3_ranges_alg_ends_with/test.cpp
@@ -15,11 +15,10 @@ using namespace std;
 template <class T>
 concept testable_range = ranges::input_range<T> && (ranges::forward_range<T> || ranges::sized_range<T>);
 
-// clang-format off
 template <class T>
-concept testable_sentinel = ranges::input_range<T>
+concept testable_sentinel =
+    ranges::input_range<T>
     && (ranges::forward_range<T> || sized_sentinel_for<ranges::sentinel_t<T>, ranges::iterator_t<T>>);
-// clang-format on
 
 struct instantiator {
     static constexpr pair<int, int> haystack[]       = {{0, 42}, {1, 42}, {2, 42}, {4, 42}};

--- a/tests/std/tests/P2286R8_text_formatting_formattable/test.compile.pass.cpp
+++ b/tests/std/tests/P2286R8_text_formatting_formattable/test.compile.pass.cpp
@@ -54,14 +54,12 @@ concept encoded_character_type = same_as<CharT, char>
 
 template <class T, class CharT>
 void assert_is_not_formattable() {
-    // clang-format off
-    static_assert(!formattable<      T   , CharT>);
-    static_assert(!formattable<      T&  , CharT>);
-    static_assert(!formattable<      T&& , CharT>);
-    static_assert(!formattable<const T   , CharT>);
-    static_assert(!formattable<const T&  , CharT>);
-    static_assert(!formattable<const T&& , CharT>);
-    // clang-format on
+    static_assert(!formattable<T, CharT>);
+    static_assert(!formattable<T&, CharT>);
+    static_assert(!formattable<T&&, CharT>);
+    static_assert(!formattable<const T, CharT>);
+    static_assert(!formattable<const T&, CharT>);
+    static_assert(!formattable<const T&&, CharT>);
 }
 
 template <class T, class CharT>
@@ -69,14 +67,12 @@ void assert_is_formattable() {
     // Only formatters for CharT == char || CharT == wchar_t are enabled for the standard formatters. When CharT is a
     // different type the formatter should be disabled.
     if constexpr (formatter_supporting_character_type<CharT>) {
-        // clang-format off
-        static_assert(formattable<      T   , CharT>);
-        static_assert(formattable<      T&  , CharT>);
-        static_assert(formattable<      T&& , CharT>);
-        static_assert(formattable<const T   , CharT>);
-        static_assert(formattable<const T&  , CharT>);
-        static_assert(formattable<const T&& , CharT>);
-        // clang-format on
+        static_assert(formattable<T, CharT>);
+        static_assert(formattable<T&, CharT>);
+        static_assert(formattable<T&&, CharT>);
+        static_assert(formattable<const T, CharT>);
+        static_assert(formattable<const T&, CharT>);
+        static_assert(formattable<const T&&, CharT>);
     } else {
         assert_is_not_formattable<T, CharT>();
     }

--- a/tests/std/tests/P2404R3_move_only_types_for_comparison_concepts/test.compile.pass.cpp
+++ b/tests/std/tests/P2404R3_move_only_types_for_comparison_concepts/test.compile.pass.cpp
@@ -37,7 +37,6 @@ static_assert(totally_ordered_with<MoveOnly, int>);
 static_assert(totally_ordered_with<int, MoveOnly>);
 
 // Check [diff.cpp20.concepts]
-// clang-format off
 template <class T, class U>
     requires equality_comparable_with<T, U>
 bool attempted_equals(const T&, const U&); // not defined
@@ -45,7 +44,6 @@ bool attempted_equals(const T&, const U&); // not defined
 template <class T, class U>
     requires common_reference_with<const remove_reference_t<T>&, const remove_reference_t<U>&>
 bool attempted_equals(const T&, const U&); // not defined
-// clang-format on
 
 template <class T>
 constexpr bool check_diff_cpp20_concepts = !requires(T p) { attempted_equals(p, nullptr); };


### PR DESCRIPTION
clang-format has significantly improved its handling of concepts, so this PR removes over a hundred suppressions (from 295 down to 173).

In general, we should suppress clang-format only when it would do something egregious, or when there's a significant advantage to manual formatting (e.g. custom alignment of a table, or staying similar to upstream code). I looked at each of these suppression removals, and I believe that they're all neutral or an improvement. (I refrained from removing suppressions where clang-format would damage whitespace around `&&`. I also refrained from removals that would impact a lot of code, even if I thought the impact was positive; those are candidates for future cleanups.)

I've structured this into a series of commits for easier review, listed below. There are no behavioral changes or other drive-by cleanups, and only a couple of manual changes to comments. (In this PR, I've refrained from adding empty comments to partially control formatting.)

* Yay, no reflow!
* Yay, no reflow except indentation!
* Yay, no reflow when shrinking suppressed region!
* Reflow looks good, alignment was unnecessary.
* Reflow looks good, change C to C++ comment to avoid orphaning it.
* Reflow looks good, manually unwrap comment.
* Reflow looks good.
  + This is where the bulk of the changes are happening. I recommend looking at this commit in VSCode, with a non-inline view, so you can focus on the "after" state and verify that it's readable.