### PR TITLE
Toolset update: VS 2022 17.9 Preview 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.8 Preview 3 or later.
+1. Install Visual Studio 2022 17.9 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
@@ -156,7 +156,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.8 Preview 3 or later.
+1. Install Visual Studio 2022 17.9 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
     * Make sure [Python][] 3.12 or later is available to CMake.
 2. Open a command prompt.
 3. Change directories to a location where you'd like a clone of this STL repository.
-4. `git clone https://github.com/microsoft/STL --recurse-submodules`
+4. `git clone https://github.com/microsoft/STL.git --recurse-submodules`
 
 To build the x86 target:
 

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,7 +5,7 @@
 
 variables:
 - name: poolName
-  value: 'StlBuild-2023-10-10T1443-Pool'
+  value: 'StlBuild-2023-11-15T0519-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals true'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -91,7 +91,7 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
   $PsExecPath = Join-Path $ExtractedPsToolsPath 'PsExec64.exe'
 
   # https://github.com/PowerShell/PowerShell/releases/latest
-  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.3.8/PowerShell-7.3.8-win-x64.zip'
+  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.3.9/PowerShell-7.3.9-win-x64.zip'
   Write-Host "Downloading: $PowerShellZipUrl"
   $ExtractedPowerShellPath = DownloadAndExtractZip -Url $PowerShellZipUrl
   $PwshPath = Join-Path $ExtractedPowerShellPath 'pwsh.exe'

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -25,11 +25,6 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-// TRANSITION, VSO-1885306: warning C5039 shouldn't be emitted when an extern "C" function is marked noexcept(false)
-#pragma warning(disable : 5039) // '__std_stacktrace_meow': pointer or reference to potentially throwing function
-                                // passed to 'extern "C"' function under -EHc. Undefined behavior may occur if this
-                                // function throws an exception. (/Wall)
-
 // The separately compiled part of the <stacktrace> implementation calls a function pointer of _Stacktrace_string_fill
 // type to allocate a buffer for string output. The called function does the buffer allocation and calls a function
 // pointer of _Stacktrace_string_fill_callback type to fill the buffer. This is needed to type-erase <string> or

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -892,8 +892,8 @@ _EMIT_STL_ERROR(STL1002, "Unexpected compiler version, expected CUDA 11.6 or new
 _EMIT_STL_ERROR(STL1000, "Unexpected compiler version, expected Clang 16.0.0 or newer.");
 #endif // ^^^ old Clang ^^^
 #elif defined(_MSC_VER)
-#if _MSC_VER < 1938 // Coarse-grained, not inspecting _MSC_FULL_VER
-_EMIT_STL_ERROR(STL1001, "Unexpected compiler version, expected MSVC 19.38 or newer.");
+#if _MSC_VER < 1939 // Coarse-grained, not inspecting _MSC_FULL_VER
+_EMIT_STL_ERROR(STL1001, "Unexpected compiler version, expected MSVC 19.39 or newer.");
 #endif // ^^^ old MSVC ^^^
 #else // vvv other compilers vvv
 // not attempting to detect other compilers

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1060,8 +1060,6 @@ std/containers/sequences/vector.bool/construct_size_value_alloc.pass.cpp:0 FAIL
 std/containers/sequences/vector.bool/construct_size_value_alloc.pass.cpp:1 FAIL
 std/containers/sequences/vector.bool/emplace_back.pass.cpp FAIL
 std/containers/sequences/vector.bool/enabled_hash.pass.cpp FAIL
-std/containers/sequences/vector.bool/move.pass.cpp:0 FAIL
-std/containers/sequences/vector.bool/move.pass.cpp:1 FAIL
 std/containers/sequences/vector.bool/vector_bool.pass.cpp FAIL
 std/containers/sequences/vector/iterators.pass.cpp:0 FAIL
 std/containers/sequences/vector/iterators.pass.cpp:1 FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -408,10 +408,6 @@ std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset_se
 std/utilities/smartptr/unique.ptr/unique.ptr.create/make_unique.array.pass.cpp:0 FAIL
 std/utilities/smartptr/unique.ptr/unique.ptr.create/make_unique.array.pass.cpp:1 FAIL
 
-# DevCom-10138792: C4455 'operator ""s': literal suffix identifiers that do not start with an underscore are reserved
-std/strings/basic.string.literals/noexcept.compile.pass.cpp:0 FAIL
-std/strings/basic.string.literals/noexcept.compile.pass.cpp:1 FAIL
-
 # DevCom-1626139 "compile-time NaN comparison"
 std/iterators/predef.iterators/reverse.iterators/reverse.iter.cmp/three-way.pass.cpp:0 FAIL
 std/iterators/predef.iterators/reverse.iterators/reverse.iter.cmp/three-way.pass.cpp:1 FAIL

--- a/tests/std/include/test_atomic_wait.hpp
+++ b/tests/std/include/test_atomic_wait.hpp
@@ -286,9 +286,7 @@ inline void test_atomic_wait() {
 #ifndef __clang__ // TRANSITION, LLVM-46685
     test_pad_bits<with_padding_bits<2>>(waiting_duration);
     test_pad_bits<with_padding_bits<4>>(waiting_duration);
-#if !(defined(_M_CEE) && defined(_M_IX86)) // TRANSITION, VSO-1881472
     test_pad_bits<with_padding_bits<8>>(waiting_duration);
-#endif // ^^^ no workaround ^^^
 #ifndef _M_ARM
     test_pad_bits<with_padding_bits<16>>(waiting_duration);
     test_pad_bits<with_padding_bits<32>>(waiting_duration);

--- a/tests/std/tests/P0226R1_math_special_functions/test.cpp
+++ b/tests/std/tests/P0226R1_math_special_functions/test.cpp
@@ -514,9 +514,7 @@ void test_sph_neumann() {
 
 // Also test GH-3076 <cmath>: Invalid output for incomplete elliptic integral of the second kind with k = 1
 void test_gh_3076() {
-#if !defined(_MSVC_INTERNAL_TESTING) || !defined(_DLL) // TRANSITION, 17.6 Preview 2 unlocked redist
     assert(isclose(ellint_2(1, 6.2831853071795862), 4.0));
-#endif // !defined(_MSVC_INTERNAL_TESTING) || !defined(_DLL)
 }
 
 int main() {

--- a/tests/std/tests/VSO_0000000_type_traits/test.cpp
+++ b/tests/std/tests/VSO_0000000_type_traits/test.cpp
@@ -1387,27 +1387,12 @@ STATIC_ASSERT(is_same_v<common_reference_t<simple_base const&&, simple_derived c
 STATIC_ASSERT(is_same_v<common_reference_t<simple_base const&&, simple_derived&&>, simple_base const&&>);
 STATIC_ASSERT(is_same_v<common_reference_t<simple_base const&&, simple_derived const&&>, simple_base const&&>);
 
-#ifdef __EDG__
-// When f is the name of a function of type int(), C1XX incorrectly believes that
-//   decltype(false ? f : f)
-// is int() in permissive mode and int(*)() in strict mode (Yes, two different incorrect results). It also
-// correctly believes that
-//   decltype(false ? declval<decltype((f))>() : declval<decltype((f))>())
-// is int(&)(), which is nice because it allows this test case to pass. EDG believes the type of both the above
-// is int() in all modes. I suspect this is intentional bug compatibility with C1XX, so I'm not filing a bug. I
-// _do_ assert here that EDG produces the _wrong_ type from common_reference_t, however, so that THIS TEST WILL
-// FAIL IF AND WHEN EDG STARTS BEHAVING CORRECTLY. We can then remove the non-workaround to defend against
-// regression.
-STATIC_ASSERT(!is_same_v<common_reference_t<int (&)(), int (&)()>, int (&)()>);
-STATIC_ASSERT(!is_same_v<common_reference_t<int (&&)(), int (&)()>, int (&)()>);
-STATIC_ASSERT(!is_same_v<common_reference_t<int (&)(), int (&&)()>, int (&)()>);
-STATIC_ASSERT(!is_same_v<common_reference_t<int (&&)(), int (&&)()>, int (&&)()>);
-#else // ^^^ EDG / not EDG vvv
+#if !(defined(__EDG__) && defined(_MSVC_INTERNAL_TESTING)) // TRANSITION, remove after EDG is updated internally
 STATIC_ASSERT(is_same_v<common_reference_t<int (&)(), int (&)()>, int (&)()>);
 STATIC_ASSERT(is_same_v<common_reference_t<int (&&)(), int (&)()>, int (&)()>);
 STATIC_ASSERT(is_same_v<common_reference_t<int (&)(), int (&&)()>, int (&)()>);
 STATIC_ASSERT(is_same_v<common_reference_t<int (&&)(), int (&&)()>, int (&&)()>);
-#endif // __EDG__
+#endif // ^^^ no workaround ^^^
 
 STATIC_ASSERT(is_same_v<common_reference_t<int const volatile&&, int volatile&&>, int const volatile&&>);
 STATIC_ASSERT(is_same_v<common_reference_t<int&&, int const&, int volatile&>, int const volatile&>);


### PR DESCRIPTION
* Removed compiler bug workarounds.
  + VSO-1881472 "`/clr` C++20 x86 System.AccessViolationException with `atomic<with_padding_bits<8>>`".
  + VSO-1885306 "warning C5039 shouldn't be emitted when an `extern "C"` function is marked `noexcept(false)`".
    - I manually verified this fix.
  + DevCom-10138792 VSO-1611566 "Bogus warning C4455: '`operator ""s`': literal suffix identifiers that do not start with an underscore are reserved".
    - This bug remains active, but I notified the compiler dev it's assigned to that it appears to be fixed.
  + Remove libcxx skips for `std/containers/sequences/vector.bool/move.pass.cpp`.
    - We never analyzed this failure, but a compiler bug was fixed, yay!
  + Remove an `_MSVC_INTERNAL_TESTING` workaround in `P0226R1_math_special_functions`.
    - This test coverage was enabled for GitHub, and for static linking internally, but was skipped for dynamic linking internally while we waited for the 17.6 Preview 2 redist there. That's ancient history now!
  + EDG `common_reference_t` started behaving correctly in 17.9 Preview 1, so we can enable `VSO_0000000_type_traits` test coverage for GitHub.
    - We'll need to skip it internally until EDG is updated there. I'm skipping it, instead of continuing to assert the incorrect behavior, to avoid blocking the EDG update. This blocked MSVC-PR-509221 on 2023-11-06, but I didn't notice until now. :scream_cat:
* Infrastructure improvements:
  + Updated dependencies.
    - Updated build compiler to VS 2022 17.9 Preview 1 (now required).

Other commits:

* Update to PowerShell 7.3.9 when building the pool.
* New pool.
* README drive-by: Update URL for `git clone`.
  + I noticed that `git` emitted a message about another remote moving from `username/STL` to `username/STL.git`. While I didn't observe that for my `microsoft` remote, it still seems better to use the exact URL that GitHub's Code > Clone displays.

x86chk stlimport passed internally, verifying the `/clr` x86 workaround removal and the `_MSVC_INTERNAL_TESTING` changes.
