### PR TITLE
Disable CodeQL

### DIFF
--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -19,3 +19,6 @@ variables:
 - name: benchmarkBuildOutputLocation
   value: 'D:\benchmark'
   readonly: true
+- name: Codeql.Enabled
+  value: false
+  readonly: true

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -19,6 +19,6 @@ variables:
 - name: benchmarkBuildOutputLocation
   value: 'D:\benchmark'
   readonly: true
-- name: Codeql.Enabled
-  value: false
+- name: Codeql.SkipTaskAutoInjection
+  value: true
   readonly: true


### PR DESCRIPTION
Azure Pipelines recently started auto-injecting CodeQL, which sometimes takes so long that it causes test runs to sporadically fail. We don't need CodeQL here because it also runs in the MSVC-internal repo.

This disables the auto-injection, based on the internal documentation at https://aka.ms/codeql3000 .