### PR TITLE
`<xlocnum>`: Drop `ios_base::showpoint` flag when printing non-finite values

### DIFF
--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -1371,10 +1371,13 @@ protected:
         }
 
         _Buf.resize(_Bufsize + 50); // add fudge factor
+        const bool _Is_finite      = (_STD isfinite)(_Val);
+        const auto _Adjusted_flags = // TRANSITION, DevCom-10519861
+            _Is_finite ? _Iosbase.flags() : _Iosbase.flags() & ~ios_base::showpoint;
         const auto _Ngen = static_cast<size_t>(_CSTD sprintf_s(
-            &_Buf[0], _Buf.size(), _Ffmt(_Fmt, 0, _Iosbase.flags()), static_cast<int>(_Precision), _Val));
+            &_Buf[0], _Buf.size(), _Ffmt(_Fmt, 0, _Adjusted_flags), static_cast<int>(_Precision), _Val));
 
-        return _Fput_v3(_Dest, _Iosbase, _Fill, _Buf.c_str(), _Ngen, (_STD isfinite)(_Val));
+        return _Fput_v3(_Dest, _Iosbase, _Fill, _Buf.c_str(), _Ngen, _Is_finite);
     }
 
     virtual _OutIt __CLR_OR_THIS_CALL do_put(
@@ -1395,10 +1398,13 @@ protected:
         }
 
         _Buf.resize(_Bufsize + 50); // add fudge factor
+        const bool _Is_finite      = (_STD isfinite)(_Val);
+        const auto _Adjusted_flags = // TRANSITION,  DevCom-10519861
+            _Is_finite ? _Iosbase.flags() : _Iosbase.flags() & ~ios_base::showpoint;
         const auto _Ngen = static_cast<size_t>(_CSTD sprintf_s(
-            &_Buf[0], _Buf.size(), _Ffmt(_Fmt, 'L', _Iosbase.flags()), static_cast<int>(_Precision), _Val));
+            &_Buf[0], _Buf.size(), _Ffmt(_Fmt, 'L', _Adjusted_flags), static_cast<int>(_Precision), _Val));
 
-        return _Fput_v3(_Dest, _Iosbase, _Fill, _Buf.c_str(), _Ngen, (_STD isfinite)(_Val));
+        return _Fput_v3(_Dest, _Iosbase, _Fill, _Buf.c_str(), _Ngen, _Is_finite);
     }
 #pragma warning(pop)
 

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -1399,7 +1399,7 @@ protected:
 
         _Buf.resize(_Bufsize + 50); // add fudge factor
         const bool _Is_finite      = (_STD isfinite)(_Val);
-        const auto _Adjusted_flags = // TRANSITION,  DevCom-10519861
+        const auto _Adjusted_flags = // TRANSITION, DevCom-10519861
             _Is_finite ? _Iosbase.flags() : _Iosbase.flags() & ~ios_base::showpoint;
         const auto _Ngen = static_cast<size_t>(_CSTD sprintf_s(
             &_Buf[0], _Buf.size(), _Ffmt(_Fmt, 'L', _Adjusted_flags), static_cast<int>(_Precision), _Val));

--- a/tests/std/tests/GH_003867_output_nan/test.cpp
+++ b/tests/std/tests/GH_003867_output_nan/test.cpp
@@ -58,14 +58,14 @@ void test_gh_3867() {
 // Also test GH-4210: With setprecision(0) showpoint fixed, a bogus '.' is emitted for infinity and NaN
 
 template <class FloatingPoint>
-void test_output_nonfinite_value(FloatingPoint x) {
-    auto s1 = [x] {
+void test_output_nonfinite_value(const FloatingPoint x) {
+    const auto s1 = [x] {
         ostringstream os;
         os << setprecision(0) << showpoint << fixed;
         os << x;
         return os.str();
     }();
-    auto s2 = [x] {
+    const auto s2 = [x] {
         ostringstream os;
         os << setprecision(0) << noshowpoint << fixed;
         os << x;
@@ -73,30 +73,30 @@ void test_output_nonfinite_value(FloatingPoint x) {
     }();
     assert(s1 == s2);
 
-    auto s3 = [x] {
+    const auto s3 = [x] {
         ostringstream os;
         os << setprecision(0) << showpoint << fixed << showpos;
         os << x;
         return os.str();
     }();
-    auto s4 = [x] {
+    const auto s4 = [x] {
         ostringstream os;
         os << setprecision(0) << noshowpoint << fixed << showpos;
         os << x;
         return os.str();
     }();
-    assert(s3 == s3);
+    assert(s3 == s4);
 }
 
 template <class FloatingPoint>
 void test_gh_4210() {
-    constexpr auto inf_dbl = numeric_limits<FloatingPoint>::infinity();
-    constexpr auto nan_dbl = numeric_limits<FloatingPoint>::quiet_NaN();
+    constexpr auto inf_val = numeric_limits<FloatingPoint>::infinity();
+    constexpr auto nan_val = numeric_limits<FloatingPoint>::quiet_NaN();
 
-    test_output_nonfinite_value(inf_dbl);
-    test_output_nonfinite_value(-inf_dbl);
-    test_output_nonfinite_value(nan_dbl);
-    test_output_nonfinite_value(-nan_dbl);
+    test_output_nonfinite_value(inf_val);
+    test_output_nonfinite_value(-inf_val);
+    test_output_nonfinite_value(nan_val);
+    test_output_nonfinite_value(-nan_val);
 }
 
 int main() {


### PR DESCRIPTION
Fixes #4210.

This PR is a workaround for DevCom-10519861 and may be `affects redist` because it modifies dll-exported functions.