### PR TITLE
`<ranges>`: Fix a correctness-damaging typo in `ranges::to`

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -10298,7 +10298,7 @@ namespace ranges {
         } else if constexpr (_Converts_tag_constructible<_Rng, _Container, _Types...>) {
             return _Container(from_range, _STD forward<_Rng>(_Range), _STD forward<_Types>(_Args)...);
         } else if constexpr (_Converts_and_common_constructible<_Rng, _Container, _Types...>) {
-            return _Container(_RANGES begin(_Range), _RANGES end(_Range), _STD forward<_Types...>(_Args)...);
+            return _Container(_RANGES begin(_Range), _RANGES end(_Range), _STD forward<_Types>(_Args)...);
         } else if constexpr (_Converts_constructible_insertable<_Rng, _Container, _Types...>) {
             _Container _Cont(_STD forward<_Types>(_Args)...);
             if constexpr (_Sized_and_reservable<_Rng, _Container>) {

--- a/tests/std/tests/P1206R7_ranges_to_misc/test.cpp
+++ b/tests/std/tests/P1206R7_ranges_to_misc/test.cpp
@@ -67,13 +67,17 @@ constexpr bool test_common_constructible() {
         using value_type = int;
 
         constexpr common_constructible(const int* const first, const int* const last, secret_key_t)
-            : first_{first}, last_{last} {}
+            : first_{first}, last_{last}, args_{3} {}
+
+        constexpr common_constructible(const int* const first, const int* const last, secret_key_t, double)
+            : first_{first}, last_{last}, args_{4} {}
 
         const int* begin() const; // not defined
         const int* end() const; // not defined
 
         const int* first_;
         const int* last_;
+        int args_;
     };
 
     int some_ints[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
@@ -82,11 +86,27 @@ constexpr bool test_common_constructible() {
         std::same_as<common_constructible> auto c0 = ranges::to<common_constructible>(some_ints, secret_key);
         assert(c0.first_ == ranges::begin(some_ints));
         assert(c0.last_ == ranges::end(some_ints));
+        assert(c0.args_ == 3);
     }
     {
         std::same_as<common_constructible> auto c1 = some_ints | ranges::to<common_constructible>(secret_key);
         assert(c1.first_ == ranges::begin(some_ints));
         assert(c1.last_ == ranges::end(some_ints));
+        assert(c1.args_ == 3);
+    }
+
+    // Verify that more than one argument can be passed after the range:
+    {
+        std::same_as<common_constructible> auto c2 = ranges::to<common_constructible>(some_ints, secret_key, 3.14);
+        assert(c2.first_ == ranges::begin(some_ints));
+        assert(c2.last_ == ranges::end(some_ints));
+        assert(c2.args_ == 4);
+    }
+    {
+        std::same_as<common_constructible> auto c3 = some_ints | ranges::to<common_constructible>(secret_key, 3.14);
+        assert(c3.first_ == ranges::begin(some_ints));
+        assert(c3.last_ == ranges::end(some_ints));
+        assert(c3.args_ == 4);
     }
 
     return true;


### PR DESCRIPTION
I'm working on an llvm-project update, and `std/ranges/range.utility/range.utility.conv/to.pass.cpp` found this bug.

I'm extending `P1206R7_ranges_to_misc` to cover this scenario. I also searched for other occurrences and didn't find any.