### PR TITLE
`<sstream>`: Pass the correct size type to `_Allocate_at_least_helper`

### DIFF
--- a/stl/inc/sstream
+++ b/stl/inc/sstream
@@ -243,13 +243,13 @@ protected:
         }
 
         // grow buffer and store element
-        size_t _Oldsize    = 0;
-        const auto _Oldptr = _Mysb::eback();
+        _Mysize_type _Oldsize = 0;
+        const auto _Oldptr    = _Mysb::eback();
         if (_Pptr) {
-            _Oldsize = static_cast<size_t>(_Epptr - _Oldptr);
+            _Oldsize = static_cast<_Mysize_type>(_Epptr - _Oldptr);
         }
 
-        size_t _Newsize;
+        _Mysize_type _Newsize;
         if (_Oldsize < _MINSIZE) {
             _Newsize = _MINSIZE;
         } else if (_Oldsize < INT_MAX / 2) { // grow by 50 percent


### PR DESCRIPTION
I'm working on an llvm-project update, and it has an allocator with a custom size type that found this bug. In this PR, I'm not bothering to add any test coverage since llvm-project will provide so much.

Clang error:
```
sstream(263,39): error: no matching function for call to '_Allocate_at_least_helper'
```

MSVC error:
```
sstream(263): error C2664: 'wchar_t *std::_Allocate_at_least_helper<test_allocator<wchar_t>>(_Alloc &,unsigned int &)': cannot convert argument 2 from 'size_t' to 'unsigned int &'
```

This code was using `size_t` since the beginning of history, we just missed the type mismatch in #3712 / #3864.

Elsewhere we're already using `_Mysize_type`.