### PR TITLE
Update `P1208R6_source_location` after MSVC-internal changes

### DIFF
--- a/tests/std/tests/P1208R6_source_location/test.cpp
+++ b/tests/std/tests/P1208R6_source_location/test.cpp
@@ -181,7 +181,11 @@ constexpr void lambda_test() {
     assert(x1.column() == 53);
     assert(x2.column() == 58);
 #else // ^^^ EDG / C1XX vvv
+#ifdef _MSVC_INTERNAL_TESTING // TRANSITION, VS 2022 17.10 Preview 1
+    assert(x1.column() == 45);
+#else // ^^^ no workaround / workaround vvv
     assert(x1.column() == 52);
+#endif // ^^^ workaround ^^^
     assert(x2.column() == 50);
 #endif // ^^^ C1XX ^^^
 #if _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION


### PR DESCRIPTION
MSVC-internal MSVC-PR-512527 and MSVC-PR-512932 updated the `P1208R6_source_location` test without being properly mirrored to GitHub.

We'll need to add `_MSVC_INTERNAL_TESTING` logic until the fixed compiler ships. I've verified that this passes in both repos.
