### PR TITLE
Add permissions to the Assign New PR action

### DIFF
--- a/.github/workflows/assign-new-prs.yml
+++ b/.github/workflows/assign-new-prs.yml
@@ -9,6 +9,8 @@ on:
       - main
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+permissions:
+  repository-projects: write
 
 jobs:
   initial-review:


### PR DESCRIPTION
As a Microsoft-owned repo, the default permissions for our `GITHUB_TOKEN` are going to change in the near future, so we need to begin explicitly granting what permissions we need.

After looking at the API calls in [srggrs/assign-one-project-github-action](https://github.com/srggrs/assign-one-project-github-action) and reading [GitHub's permissions documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions), I'm 70% confident that `repository-projects: write` is what we need. Note that I am unable to test this PR (because my fork doesn't have any Classic Projects and GitHub frustratingly won't let me create them anymore).

[`.github/workflows/move-ready-for-review-prs.yml`](https://github.com/microsoft/STL/blob/9f9ab8855c9bb5ac68f462fa540ab565d25e34ff/.github/workflows/move-ready-for-review-prs.yml) and [`.github/workflows/move-work-in-progress-prs.yml`](https://github.com/microsoft/STL/blob/9f9ab8855c9bb5ac68f462fa540ab565d25e34ff/.github/workflows/move-work-in-progress-prs.yml) use `actions/github-script` but don't directly mention `GITHUB_TOKEN` so I don't know if they're affected.

[`.github/workflows/update-status-chart.yml`](https://github.com/microsoft/STL/blob/9f9ab8855c9bb5ac68f462fa540ab565d25e34ff/.github/workflows/update-status-chart.yml) mentions `github.token` for the GraphQL API, but all it needs is public read-only access, so I don't think that it'll need to be changed.