### PR TITLE
`<sstream>`: Avoid truncation warnings in `basic_stringbuf`'s constructor

### DIFF
--- a/stl/inc/sstream
+++ b/stl/inc/sstream
@@ -54,7 +54,7 @@ public:
     template <class _Alloc2>
     basic_stringbuf(const basic_string<_Elem, _Traits, _Alloc2>& _Str, ios_base::openmode _Mode, const _Alloc& _Al_)
         : _Al(_Al_) {
-        _Init(_Str.c_str(), _Str.size(), _Getstate(_Mode));
+        _Init(_Str.c_str(), _Convert_size<_Mysize_type>(_Str.size()), _Getstate(_Mode));
     }
 
     template <class _Alloc2>


### PR DESCRIPTION
Test coverage will be provided by the upcoming libcxx update, which has allocators with custom size types. #4219 fixed outright compiler errors, but there's still a compiler warning:

```
sstream(57): warning C4267: 'argument': conversion from 'size_t' to 'const unsigned int', possible loss of data
```

`_Convert_size` is our machinery for dealing with this.