### PR TITLE
Various cleanups

### DIFF
--- a/benchmarks/src/std_copy.cpp
+++ b/benchmarks/src/std_copy.cpp
@@ -12,7 +12,6 @@
 #include <utility.hpp>
 
 namespace {
-
     template <typename Contained>
     void handwritten_loop(benchmark::State& state) {
         const size_t r0      = static_cast<size_t>(state.range(0));

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -10444,7 +10444,6 @@ _NODISCARD constexpr const _Ty& clamp(const _Ty& _Val, const _Ty& _Min_val, cons
         const _Ty& _Tmp = _DEBUG_LT_PRED(_Pred, _Val, _Min_val) ? _Min_val : _Val;
         return _DEBUG_LT_PRED(_Pred, _Max_val, _Val) ? _Max_val : _Tmp;
     } else {
-
         if (_DEBUG_LT_PRED(_Pred, _Max_val, _Val)) {
             return _Max_val;
         }

--- a/stl/inc/condition_variable
+++ b/stl/inc/condition_variable
@@ -7,6 +7,11 @@
 #define _CONDITION_VARIABLE_
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
+
+#ifdef _M_CEE_PURE
+#error <condition_variable> is not supported when compiling with /clr:pure.
+#endif // defined(_M_CEE_PURE)
+
 #include <__msvc_chrono.hpp>
 #include <memory>
 #include <mutex>
@@ -21,10 +26,6 @@
 _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
-
-#ifdef _M_CEE_PURE
-#error <condition_variable> is not supported when compiling with /clr:pure.
-#endif // defined(_M_CEE_PURE)
 
 _STD_BEGIN
 template <class _Lock>

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1424,7 +1424,6 @@ public:
                 ++_Myoff();
             }
         }
-
 #else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 / _ITERATOR_DEBUG_LEVEL < 2 vvv
         _Alty_traits::destroy(_Getal(), _Get_data()._Address_subscript(_Myoff()));
         if (--_Mysize() == 0) {
@@ -1447,7 +1446,6 @@ public:
                 _Myoff() = 0;
             }
         }
-
 #else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 / _ITERATOR_DEBUG_LEVEL < 2 vvv
         size_type _Newoff = _Myoff() + _Mysize() - 1;
         _Alty_traits::destroy(_Getal(), _Get_data()._Address_subscript(_Newoff));
@@ -1473,7 +1471,6 @@ public:
         auto _Off   = static_cast<size_type>(_First - begin());
         auto _Count = static_cast<size_type>(_Last - _First);
         bool _Moved = _Off > 0 && _Off + _Count < _Mysize();
-
 #else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 / _ITERATOR_DEBUG_LEVEL < 2 vvv
         auto _Off   = static_cast<size_type>(_First - begin());
         auto _Count = static_cast<size_type>(_Last - _First);

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1319,8 +1319,7 @@ public:
         requires is_convertible_v<const _OtherIndexType&, index_type>
               && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
     _NODISCARD constexpr reference operator[](span<_OtherIndexType, rank()> _Indices) const
-        noexcept(noexcept(_Multidimensional_subscript(_Indices, make_index_sequence<rank()>{}))) /* strengthened */
-    {
+        noexcept(noexcept(_Multidimensional_subscript(_Indices, make_index_sequence<rank()>{}))) /* strengthened */ {
         return _Multidimensional_subscript(_Indices, make_index_sequence<rank()>{});
     }
 
@@ -1328,8 +1327,7 @@ public:
         requires is_convertible_v<const _OtherIndexType&, index_type>
               && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
     _NODISCARD constexpr reference operator[](const array<_OtherIndexType, rank()>& _Indices) const noexcept(
-        noexcept(_Multidimensional_subscript(span{_Indices}, make_index_sequence<rank()>{}))) /* strengthened */
-    {
+        noexcept(_Multidimensional_subscript(span{_Indices}, make_index_sequence<rank()>{}))) /* strengthened */ {
         return _Multidimensional_subscript(span{_Indices}, make_index_sequence<rank()>{});
     }
 

--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -30,7 +30,6 @@ _STL_DISABLE_CLANG_WARNINGS
 _STD_BEGIN
 
 namespace pmr {
-
     extern "C" _CRT_SATELLITE_1 memory_resource* __cdecl _Aligned_set_default_resource(memory_resource*) noexcept;
     extern "C" _CRT_SATELLITE_1 memory_resource* __cdecl _Unaligned_set_default_resource(memory_resource*) noexcept;
 

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -693,7 +693,7 @@ _EXPORT_STD template <class _Ty1, class _Ty2>
 _NODISCARD constexpr bool operator<=(const optional<_Ty1>& _Left, const optional<_Ty2>& _Right) noexcept(
     noexcept(_Fake_copy_init<bool>(*_Left <= *_Right))) /* strengthened */
 #ifdef __cpp_lib_concepts
-    requires requires(const _Ty1& _Elem1, const _Ty2& _Elem2) {
+    requires requires {
         { *_Left <= *_Right } -> _Implicitly_convertible_to<bool>;
     }
 #endif // defined(__cpp_lib_concepts)

--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -7,6 +7,11 @@
 #define _THREAD_
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
+
+#ifdef _M_CEE_PURE
+#error <thread> is not supported when compiling with /clr:pure.
+#endif // defined(_M_CEE_PURE)
+
 #include <__msvc_chrono.hpp>
 #include <memory>
 #include <process.h>
@@ -21,10 +26,6 @@
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 #include <format>
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
-
-#ifdef _M_CEE_PURE
-#error <thread> is not supported when compiling with /clr:pure.
-#endif // defined(_M_CEE_PURE)
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -3408,7 +3408,6 @@ public:
         _STL_VERIFY(end() > _Where, "vector<bool> erase iterator outside range");
         _STD copy(_Next_iter(_Where), end(), _Where);
         _Orphan_range(static_cast<size_type>(_Off), this->_Mysize);
-
 #else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 / _ITERATOR_DEBUG_LEVEL < 2 vvv
         _STD copy(_Next_iter(_Where), end(), _Where);
 #endif // ^^^ _ITERATOR_DEBUG_LEVEL < 2 ^^^
@@ -3430,7 +3429,6 @@ public:
             const auto _Newsize = static_cast<size_type>(_Next - begin());
             _Orphan_range(_Newsize, this->_Mysize);
             _Trim(_Newsize);
-
 #else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 / _ITERATOR_DEBUG_LEVEL < 2 vvv
             iterator _Next = _STD copy(_Last, end(), _First);
             _Trim(static_cast<size_type>(_Next - begin()));

--- a/stl/inc/xbit_ops.h
+++ b/stl/inc/xbit_ops.h
@@ -35,7 +35,6 @@ _NODISCARD inline unsigned long _Floor_of_log_2(size_t _Value) noexcept { // ret
     while ((size_t{1} << _Result) > _Value) {
         --_Result;
     }
-
 #else // ^^^ defined(_M_CEE_PURE) / !defined(_M_CEE_PURE) vvv
 #ifdef _WIN64
     _BitScanReverse64(&_Result, _Value); // lgtm [cpp/conditionallyuninitializedvariable]

--- a/stl/inc/xlocinfo
+++ b/stl/inc/xlocinfo
@@ -52,7 +52,6 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Getdateorder() noexcept;
 [System::Runtime::InteropServices::DllImport(_CRT_MSVCP_CURRENT, EntryPoint = "_Mbrtowc",
     CallingConvention = System::Runtime::InteropServices::CallingConvention::Cdecl)] extern "C" int
     _Mbrtowc(_Out_opt_ wchar_t*, const char*, size_t, mbstate_t*, const _Cvtvec*) noexcept;
-
 #else // ^^^ defined(_M_CEE_PURE) / !defined(_M_CEE_PURE) vvv
 _MRTIMP2 _Success_(return >= 0) int __cdecl _Mbrtowc(_When_(_Max_multibyte != 0, _Out_) wchar_t*, const char*,
     size_t _Max_multibyte, mbstate_t*, const _Cvtvec*) noexcept;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5369,7 +5369,6 @@ namespace ranges {
         requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
     _NODISCARD constexpr mismatch_result<_It1, _It2> _Mismatch_4(
         _It1 _First1, _Se1 _Last1, _It2 _First2, _Se2 _Last2, _Pr _Pred, _Pj1 _Proj1, _Pj2 _Proj2) {
-
         for (; _First1 != _Last1 && _First2 != _Last2; ++_First1, (void) ++_First2) {
             if (!_STD invoke(_Pred, _STD invoke(_Proj1, *_First1), _STD invoke(_Proj2, *_First2))) {
                 break;

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -452,7 +452,7 @@ private:
 #define _CATCH_END }
 
 #define _RERAISE    throw
-#define _THROW(...) throw __VA_ARGS__
+#define _THROW(...) throw(__VA_ARGS__)
 
 #else // ^^^ _HAS_EXCEPTIONS / !_HAS_EXCEPTIONS vvv
 #define _TRY_BEGIN \
@@ -475,7 +475,7 @@ private:
 #endif
 
 #define _RERAISE
-#define _THROW(...) __VA_ARGS__._Raise()
+#define _THROW(...) (__VA_ARGS__)._Raise()
 #endif // ^^^ !_HAS_EXCEPTIONS ^^^
 _STD_END
 

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -350,7 +350,6 @@ public:
     __CLR_OR_THIS_CALL ~_Lockit() noexcept { // clear the lock
         _Lockit_dtor(this);
     }
-
 #else // ^^^ defined(_M_CEE_PURE) / !defined(_M_CEE_PURE) vvv
     __thiscall _Lockit() noexcept;
     explicit __thiscall _Lockit(int) noexcept; // set the lock

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1954,7 +1954,7 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 
 // TRANSITION: _USE_EXTERN_CXX_EVERYWHERE_FOR_STL controls whether we also wrap the STL's
 // header-only code in this linkage-specification, as a temporary workaround to allow
-// the named module to coexist with classic includes in the same translation unit.
+// importing the named module in a translation unit with classic includes.
 
 #ifndef _USE_EXTERN_CXX_EVERYWHERE_FOR_STL
 #define _USE_EXTERN_CXX_EVERYWHERE_FOR_STL _HAS_CXX20

--- a/stl/src/cerr.cpp
+++ b/stl/src/cerr.cpp
@@ -18,7 +18,6 @@ __PURE_APPDOMAIN_GLOBAL static filebuf ferr(stderr);
 
 #if defined(_M_CEE_PURE)
 __PURE_APPDOMAIN_GLOBAL extern ostream cerr(&ferr);
-
 #else // ^^^ defined(_M_CEE_PURE) / !defined(_M_CEE_PURE) vvv
 __PURE_APPDOMAIN_GLOBAL extern _CRTDATA2_IMPORT ostream cerr(&ferr);
 #endif // ^^^ !defined(_M_CEE_PURE) ^^^

--- a/stl/src/cin.cpp
+++ b/stl/src/cin.cpp
@@ -18,7 +18,6 @@ __PURE_APPDOMAIN_GLOBAL static filebuf fin(stdin);
 
 #if defined(_M_CEE_PURE)
 __PURE_APPDOMAIN_GLOBAL extern istream cin(&fin);
-
 #else // ^^^ defined(_M_CEE_PURE) / !defined(_M_CEE_PURE) vvv
 __PURE_APPDOMAIN_GLOBAL extern _CRTDATA2_IMPORT istream cin(&fin);
 #endif // ^^^ !defined(_M_CEE_PURE) ^^^

--- a/stl/src/clog.cpp
+++ b/stl/src/clog.cpp
@@ -20,7 +20,6 @@ __PURE_APPDOMAIN_GLOBAL static filebuf flog(stderr);
 
 #if defined(_M_CEE_PURE)
 __PURE_APPDOMAIN_GLOBAL extern ostream clog(&flog);
-
 #else // ^^^ defined(_M_CEE_PURE) / !defined(_M_CEE_PURE) vvv
 __PURE_APPDOMAIN_GLOBAL extern _CRTDATA2_IMPORT ostream clog(&flog);
 #endif // ^^^ !defined(_M_CEE_PURE) ^^^

--- a/stl/src/cond.cpp
+++ b/stl/src/cond.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// condition variable functions
-
 #include <cstdlib>
 #include <internal_shared.h>
 #include <type_traits>
@@ -13,7 +11,7 @@
 
 extern "C" {
 
-struct _Cnd_internal_imp_t { // condition variable implementation for ConcRT
+struct _Cnd_internal_imp_t {
     typename std::_Aligned_storage<_Cnd_internal_imp_size, _Cnd_internal_imp_alignment>::type cv;
 
     [[nodiscard]] Concurrency::details::stl_condition_variable_win7* _get_cv() noexcept {

--- a/stl/src/cout.cpp
+++ b/stl/src/cout.cpp
@@ -18,7 +18,6 @@ __PURE_APPDOMAIN_GLOBAL static filebuf fout(stdout);
 
 #if defined(_M_CEE_PURE)
 __PURE_APPDOMAIN_GLOBAL extern ostream cout(&fout);
-
 #else // ^^^ defined(_M_CEE_PURE) / !defined(_M_CEE_PURE) vvv
 __PURE_APPDOMAIN_GLOBAL extern _CRTDATA2_IMPORT ostream cout(&fout);
 #endif // ^^^ !defined(_M_CEE_PURE) ^^^

--- a/stl/src/cthread.cpp
+++ b/stl/src/cthread.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// thread functions
-
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -599,7 +599,6 @@ _Success_(return == __std_win_error::_Success) __std_win_error
     }
 
     if (_Last_error == __std_win_error::_Access_denied && _Able_to_change_attributes) {
-
         FILE_BASIC_INFO _Basic_info;
         if (!GetFileInformationByHandleEx(_Handle._Get(), FileBasicInfo, &_Basic_info, sizeof(_Basic_info))) {
             return {false, __std_win_error{GetLastError()}};

--- a/stl/src/init_locks.hpp
+++ b/stl/src/init_locks.hpp
@@ -17,7 +17,6 @@ public:
     __CLR_OR_THIS_CALL ~_Init_locks() noexcept {
         _Init_locks_dtor(this);
     }
-
 #else // ^^^ defined(_M_CEE_PURE) / !defined(_M_CEE_PURE) vvv
     __thiscall _Init_locks() noexcept;
     __thiscall ~_Init_locks() noexcept;

--- a/stl/src/mutex.cpp
+++ b/stl/src/mutex.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// mutex functions
-
 #include <cstdio>
 #include <cstdlib>
 #include <internal_shared.h>

--- a/stl/src/sharedmutex.cpp
+++ b/stl/src/sharedmutex.cpp
@@ -6,7 +6,6 @@
 // these declarations must be in sync with those in xthreads.h
 
 extern "C" {
-
 using _Smtx_t = void*;
 
 static_assert(sizeof(_Smtx_t) == sizeof(SRWLOCK), "_Smtx_t must be the same size as SRWLOCK.");

--- a/stl/src/thread0.cpp
+++ b/stl/src/thread0.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// thread support functions
-
 #include <cstdlib>
 #include <system_error>
 #include <xthreads.h>

--- a/stl/src/xcosh.cpp
+++ b/stl/src/xcosh.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _Cosh function
-
 #include "xmath.hpp"
 
 _EXTERN_C_UNLESS_PURE

--- a/stl/src/xexp.cpp
+++ b/stl/src/xexp.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _Exp function
-
 #include "xmath.hpp"
 
 _EXTERN_C_UNLESS_PURE

--- a/stl/src/xfcosh.cpp
+++ b/stl/src/xfcosh.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _FCosh function
-
 #include "xmath.hpp"
 
 _EXTERN_C_UNLESS_PURE

--- a/stl/src/xferaise.cpp
+++ b/stl/src/xferaise.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _Feraise function
-
 #include "xmath.hpp"
 
 _EXTERN_C_UNLESS_PURE

--- a/stl/src/xfexp.cpp
+++ b/stl/src/xfexp.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _FExp function
-
 #include "xmath.hpp"
 
 _EXTERN_C_UNLESS_PURE

--- a/stl/src/xfsinh.cpp
+++ b/stl/src/xfsinh.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _FSinh function
-
 #include "xmath.hpp"
 
 _EXTERN_C_UNLESS_PURE

--- a/stl/src/xlcosh.cpp
+++ b/stl/src/xlcosh.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _LCosh function
-
 #include "xmath.hpp"
 
 _EXTERN_C_UNLESS_PURE

--- a/stl/src/xlexp.cpp
+++ b/stl/src/xlexp.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _LExp function
-
 #include "xmath.hpp"
 
 _EXTERN_C_UNLESS_PURE

--- a/stl/src/xlpoly.cpp
+++ b/stl/src/xlpoly.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _LPoly function
-
 #include "xmath.hpp"
 
 _EXTERN_C_UNLESS_PURE

--- a/stl/src/xlsinh.cpp
+++ b/stl/src/xlsinh.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _LSinh function
-
 #include <xutility>
 
 #include "xmath.hpp"

--- a/stl/src/xnotify.cpp
+++ b/stl/src/xnotify.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// thread exit notification functions
-
 #include <cstdlib>
 #include <xthreads.h>
 

--- a/stl/src/xpoly.cpp
+++ b/stl/src/xpoly.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _Poly function
-
 #include "xmath.hpp"
 
 _EXTERN_C_UNLESS_PURE

--- a/stl/src/xsinh.cpp
+++ b/stl/src/xsinh.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _Sinh function
-
 #include <xutility>
 
 #include "xmath.hpp"

--- a/stl/src/xstod.cpp
+++ b/stl/src/xstod.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _Stod function
-
 #include <yvals.h> // include first, for native shared
 
 #include <cstdlib>

--- a/stl/src/xstof.cpp
+++ b/stl/src/xstof.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _Stof function
-
 #include <yvals.h> // include first, for native shared
 
 #include <cstdlib>

--- a/stl/src/xstoflt.cpp
+++ b/stl/src/xstoflt.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _Stoflt function
-
 #include <cctype>
 #include <clocale>
 #include <cstdlib>

--- a/stl/src/xstol.cpp
+++ b/stl/src/xstol.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _Stolx function
-
 #include <yvals.h>
 
 #include <cctype>

--- a/stl/src/xstold.cpp
+++ b/stl/src/xstold.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _Stold function
-
 #include <yvals.h> // include first, for native shared
 
 #include <cstdlib>

--- a/stl/src/xstoll.cpp
+++ b/stl/src/xstoll.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _Stoll function
-
 #include <yvals.h>
 
 #include <cctype>

--- a/stl/src/xstoll.cpp
+++ b/stl/src/xstoll.cpp
@@ -48,7 +48,8 @@ _CRTIMP2_PURE long long __CLRCALL_PURE_OR_CDECL _Stollx(const char* s, char** en
     return static_cast<long long>(sign == '-' ? 0 - x : x);
 }
 
-_CRTIMP2_PURE long long(__CLRCALL_PURE_OR_CDECL _Stoll)(const char* s, char** endptr, int base) noexcept {
+// TRANSITION, ABI: preserved for binary compatibility
+_CRTIMP2_PURE long long __CLRCALL_PURE_OR_CDECL _Stoll(const char* s, char** endptr, int base) noexcept {
     // convert string, discard error code
     return _Stollx(s, endptr, base, nullptr);
 }

--- a/stl/src/xstopfx.cpp
+++ b/stl/src/xstopfx.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _Stopfx function
-
 #include <cctype>
 
 #include "xmath.hpp"

--- a/stl/src/xstoul.cpp
+++ b/stl/src/xstoul.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _Stoul function
-
 #include <yvals.h>
 
 #include <cctype>

--- a/stl/src/xstoul.cpp
+++ b/stl/src/xstoul.cpp
@@ -109,6 +109,7 @@ _CRTIMP2_PURE unsigned long __CLRCALL_PURE_OR_CDECL _Stoulx(
     return x;
 }
 
+// TRANSITION, ABI: preserved for binary compatibility
 _CRTIMP2_PURE unsigned long __CLRCALL_PURE_OR_CDECL _Stoul(const char* s, char** endptr, int base) noexcept {
     // convert string, discard error code
     return _Stoulx(s, endptr, base, nullptr);

--- a/stl/src/xstoull.cpp
+++ b/stl/src/xstoull.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _Stoull function
-
 #include <yvals.h>
 
 #include <cctype>

--- a/stl/src/xstoull.cpp
+++ b/stl/src/xstoull.cpp
@@ -107,6 +107,7 @@ _CRTIMP2_PURE unsigned long long __CLRCALL_PURE_OR_CDECL _Stoullx(
     return x;
 }
 
+// TRANSITION, ABI: preserved for binary compatibility
 _CRTIMP2_PURE unsigned long long __CLRCALL_PURE_OR_CDECL _Stoull(const char* s, char** endptr, int base) noexcept {
     // convert string, discard error code
     return _Stoullx(s, endptr, base, nullptr);

--- a/stl/src/xstoxflt.cpp
+++ b/stl/src/xstoxflt.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _Stoxflt function
-
 #include <cctype>
 #include <clocale>
 #include <cstdlib>

--- a/stl/src/xthrow.cpp
+++ b/stl/src/xthrow.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// exception handling support functions
-
 #include <functional>
 #include <new>
 #include <regex>

--- a/stl/src/xwcsxfrm.cpp
+++ b/stl/src/xwcsxfrm.cpp
@@ -64,7 +64,6 @@ _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Wcsxfrm(_Out_writes_(end1 - string
         }
         size = n2;
     } else {
-
         // When using LCMAP_SORTKEY, LCMapStringW handles BYTES not wide
         // chars. We use a byte buffer to hold bytes and then convert the
         // byte string to a wide char string and return this so it can be

--- a/stl/src/xwstod.cpp
+++ b/stl/src/xwstod.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _WStod function
-
 #include <cstdlib>
 #include <cwchar>
 

--- a/stl/src/xwstof.cpp
+++ b/stl/src/xwstof.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _WStof function
-
 #include <cwchar>
 
 #include "xmath.hpp"

--- a/stl/src/xwstoflt.cpp
+++ b/stl/src/xwstoflt.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _WStoflt function
-
 #include <clocale>
 #include <cwchar>
 #include <cwctype>

--- a/stl/src/xwstold.cpp
+++ b/stl/src/xwstold.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _WStold function
-
 #include <cwchar>
 
 #include "xmath.hpp"

--- a/stl/src/xwstopfx.cpp
+++ b/stl/src/xwstopfx.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _WStopfx function
-
 #include <cwctype>
 
 #include "xmath.hpp"

--- a/stl/src/xwstoxfl.cpp
+++ b/stl/src/xwstoxfl.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// _WStoxflt function
-
 #include <cctype>
 #include <clocale>
 #include <cwchar>

--- a/tests/std/tests/P2387R3_pipe_support_for_user_defined_range_adaptors/test.cpp
+++ b/tests/std/tests/P2387R3_pipe_support_for_user_defined_range_adaptors/test.cpp
@@ -267,7 +267,6 @@ void test_perfect_forwarding_properties() { // COMPILE-ONLY
         static_assert(same_as<decltype(move(as_const(raco))(TestRange{})), const Pinned&>);
     }
     {
-
         auto combined_pipeline = RangeIdentity{} | PinnedReturningRaco{};
 
         static_assert(same_as<decltype(TestRange{} | combined_pipeline), const Pinned&>);


### PR DESCRIPTION
Usual disclaimer about how I'm being a bit of a bad kitty :smirk_cat: because "grab bag PRs" can be challenging to review and risky to merge. This PR is structured into fine-grained commits for easier reviewing and restricts itself to very low-risk changes (I have separate PRs for fixing libcxx failures).

* `<optional>`: Drop unused *requires-expression* parameters that appeared only in `operator<=`.
* `<yvals.h>`: `_THROW` should expand with parens.
  + Pre-existing since the beginning of time, noted by @CaseyCarter while reviewing #4119. clang-format produces `throw(__VA_ARGS__)` with no space, which is annoying but not worth suppressing.
* `<condition_variable>` and `<thread>` should immediately reject `/clr:pure`.
  + All other headers (e.g. `<mutex>`) follow this pattern.
* Comment that `_Stoll`, `_Stoul`, `_Stoull` are preserved for bincompat. Nobody declares or calls them, including via the `CNAME` macro.
  + Also, don't defend `_Stoll`'s definition against macros - this is `stl/src` where we have complete control.
* `<mdspan>`: `operator[]` overloads can attach their open braces.
  + clang-format exhibits "sticky" behavior here - it's happy either way.
* `<yvals_core.h>`: Improve the `_USE_EXTERN_CXX_EVERYWHERE_FOR_STL` comment.
  + Suggested by @CaseyCarter while reviewing #4154, applied without further changes.
* Drop low-value file comments and outdated "for ConcRT" comment.
  + This was the only remaining mention of ConcRT outside of ABI-preserved code. We don't need to preserve the "condition variable implementation" part for `_Cnd_internal_imp_t` as the type name is sufficiently clear.
  + This doesn't drop all file comments, just the ones that I thought were especially unnecessary (due to the filenames and file contents).
* Remove more unnecessary file comments.
  + Every single one of these was `// MEOW function` where `MEOW` appears below (without any macroization). Similar rationale to #2074 addressing #306, these comments are counterproductive in a world where editors like VSCode provide easy global search.
* Drop unnecessary/inconsistent newlines after open braces.
  + This doesn't attempt to drop all newlines after open braces - many of them are arguably providing clarity.
* Drop unnecessary/inconsistent newlines before `#else`.
  + Again, this doesn't attempt to drop all such newlines, many of which are providing clarity. The occurrences I'm changing, all involving `_ITERATOR_DEBUG_LEVEL` or `_M_CEE_PURE`, looked imbalanced and were ancient relics of codebase processing.
