### PR TITLE
Add Non-exception Throwing Specifier to `ranges::ssize`

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -646,7 +646,7 @@ namespace ranges {
         public:
             template <class _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
-            _NODISCARD constexpr decltype(auto) operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
+            _NODISCARD constexpr decltype(auto) operator()(_Ty && _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 constexpr _St _Strat = _Choice<_Ty>._Strategy;
 
                 if constexpr (_Strat == _St::_Custom) {
@@ -1625,7 +1625,8 @@ public:
 
     template <indirectly_swappable<_BidIt> _BidIt2>
     friend constexpr void iter_swap(const reverse_iterator& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
-        is_nothrow_copy_constructible_v<_BidIt>&& is_nothrow_copy_constructible_v<_BidIt2>&& noexcept(
+        is_nothrow_copy_constructible_v<_BidIt>
+        && is_nothrow_copy_constructible_v<_BidIt2>&& noexcept(
             _RANGES iter_swap(--_STD declval<_BidIt&>(), --_STD declval<_BidIt2&>()))) {
         auto _LTmp = _Left.current;
         auto _RTmp = _Right.base();
@@ -3353,7 +3354,7 @@ namespace ranges {
     class _Ssize_fn {
     public:
         template <class _Rng>
-        _NODISCARD constexpr auto operator()(_Rng&& _Range) const
+        _NODISCARD constexpr auto operator()(_Rng&& _Range) const noexcept
             requires requires { _RANGES size(_Range); }
         {
             using _Sty = _Make_signed_like_t<decltype(_RANGES size(_Range))>;
@@ -5137,7 +5138,7 @@ _INLINE_VAR constexpr bool _Is_pointer_address_comparable =
 #pragma warning(push)
 #pragma warning(disable : 4806) // no value of type 'bool' promoted to type 'char' can equal the given constant
 template <class _Elem1, class _Elem2,
-    bool = sizeof(_Elem1) == sizeof(_Elem2) && is_integral_v<_Elem1>&& is_integral_v<_Elem2>>
+    bool = sizeof(_Elem1) == sizeof(_Elem2) && is_integral_v<_Elem1> && is_integral_v<_Elem2>>
 _INLINE_VAR constexpr bool _Can_memcmp_elements =
     is_same_v<_Elem1, bool> || is_same_v<_Elem2, bool> || static_cast<_Elem1>(-1) == static_cast<_Elem2>(-1);
 #pragma warning(pop)

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3353,7 +3353,7 @@ namespace ranges {
     class _Ssize_fn {
     public:
         template <class _Rng>
-        _NODISCARD constexpr auto operator()(_Rng&& _Range) const noexcept
+        _NODISCARD constexpr auto operator()(_Rng&& _Range) const noexcept(noexcept(_RANGES size(_Range)))
             requires requires { _RANGES size(_Range); }
         {
             using _Sty = _Make_signed_like_t<decltype(_RANGES size(_Range))>;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -646,7 +646,7 @@ namespace ranges {
         public:
             template <class _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
-            _NODISCARD constexpr decltype(auto) operator()(_Ty && _Val) const noexcept(_Choice<_Ty>._No_throw) {
+            _NODISCARD constexpr decltype(auto) operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 constexpr _St _Strat = _Choice<_Ty>._Strategy;
 
                 if constexpr (_Strat == _St::_Custom) {
@@ -1625,8 +1625,7 @@ public:
 
     template <indirectly_swappable<_BidIt> _BidIt2>
     friend constexpr void iter_swap(const reverse_iterator& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
-        is_nothrow_copy_constructible_v<_BidIt>
-        && is_nothrow_copy_constructible_v<_BidIt2>&& noexcept(
+        is_nothrow_copy_constructible_v<_BidIt>&& is_nothrow_copy_constructible_v<_BidIt2>&& noexcept(
             _RANGES iter_swap(--_STD declval<_BidIt&>(), --_STD declval<_BidIt2&>()))) {
         auto _LTmp = _Left.current;
         auto _RTmp = _Right.base();
@@ -5138,7 +5137,7 @@ _INLINE_VAR constexpr bool _Is_pointer_address_comparable =
 #pragma warning(push)
 #pragma warning(disable : 4806) // no value of type 'bool' promoted to type 'char' can equal the given constant
 template <class _Elem1, class _Elem2,
-    bool = sizeof(_Elem1) == sizeof(_Elem2) && is_integral_v<_Elem1> && is_integral_v<_Elem2>>
+    bool = sizeof(_Elem1) == sizeof(_Elem2) && is_integral_v<_Elem1>&& is_integral_v<_Elem2>>
 _INLINE_VAR constexpr bool _Can_memcmp_elements =
     is_same_v<_Elem1, bool> || is_same_v<_Elem2, bool> || static_cast<_Elem1>(-1) == static_cast<_Elem2>(-1);
 #pragma warning(pop)

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -1529,6 +1529,7 @@ namespace nothrow_testing {
         STATIC_ASSERT(noexcept(ranges::crend(t)) == Nothrow);
         STATIC_ASSERT(noexcept(ranges::empty(t)) == Nothrow);
         STATIC_ASSERT(noexcept(ranges::size(t)) == Nothrow);
+        STATIC_ASSERT(noexcept(ranges::ssize(t)) == Nothrow);
         STATIC_ASSERT(noexcept(ranges::data(t)) == Nothrow);
         STATIC_ASSERT(noexcept(ranges::cdata(t)) == Nothrow);
 


### PR DESCRIPTION
Fixes #4107.

Non-exception throwing specifier added in ```stl/inc/xutility:3357```

Besides, some improper fomats are changed in ```stl/inc/xutility```