### PR TITLE
`<random>`: Optimize range adjustment in `uniform_int`

### DIFF
--- a/stl/inc/random
+++ b/stl/inc/random
@@ -2089,12 +2089,7 @@ private:
     static _Uty _Adjust(_Uty _Uval) noexcept { // convert signed ranges to unsigned ranges and vice versa
         if constexpr (is_signed_v<_Ty>) {
             constexpr _Uty _Adjuster = (static_cast<_Uty>(-1) >> 1) + 1; // 2^(N-1)
-
-            if (_Uval < _Adjuster) {
-                return static_cast<_Uty>(_Uval + _Adjuster);
-            } else {
-                return static_cast<_Uty>(_Uval - _Adjuster);
-            }
+            return static_cast<_Uty>(_Uval ^ _Adjuster);
         } else { // _Ty is already unsigned, do nothing
             return _Uval;
         }


### PR DESCRIPTION
Neither Clang nor MSVC is smart enough to optimize the previous code into the simple non-branching non-conditional move variant. (GCC actually is, but GCC does not matter in this context)

See
https://godbolt.org/z/T9GT7s5rG
https://godbolt.org/z/eE7q9G9W8


---------

**Comment on the PR instructions:**

I am working on custom distributions for Catch2, and implemented the range adjustment like this. Afterwards I went to check how the STLs do it and quick test showed that MSVC is better served with my implementation. Since this started as my original work, even though for different repo, I think that's fine.
