### PR TITLE
`<mdspan>`: Construct mappings from `extents_type` rvalues when necessary

### DIFF
--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1075,6 +1075,8 @@ struct _Mdspan_mapping_base {
 
     constexpr explicit _Mdspan_mapping_base(const _Extents& _Exts) : _Map(_Exts) {}
 
+    constexpr explicit _Mdspan_mapping_base(_Extents&& _Exts) : _Map(_STD move(_Exts)) {}
+
     template <class _OtherMapping>
     constexpr explicit _Mdspan_mapping_base(const _OtherMapping& _Map_) : _Map(_Map_) {}
 
@@ -1090,6 +1092,8 @@ struct _Mdspan_mapping_base<_Extents, _LayoutPolicy> {
     constexpr _Mdspan_mapping_base() noexcept = default;
 
     constexpr explicit _Mdspan_mapping_base(const _Extents&) noexcept {}
+
+    constexpr explicit _Mdspan_mapping_base(_Extents&&) noexcept {}
 
     template <class _OtherMapping>
     constexpr explicit _Mdspan_mapping_base(const _OtherMapping& _Map_) {


### PR DESCRIPTION
WG21-N4964 \[mdspan.mdspan.cons]\/10.2:

> direct-non-list-initializes *`map_`* with `extents_type(exts)`

We were correctly passing `extents_type` rvalues up to the `_Mdspan_mapping_base` layer, but that was incorrectly always copying.

Test coverage will be provided by `std/containers/views/mdspan/mdspan/ctor.dh_span.pass.cpp` in the upcoming libcxx update that I'm working on.