### PR TITLE
Fix truncation warnings in `string`/`vector` iterator subtraction and `ranges::is_permutation`

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -937,7 +937,8 @@ namespace ranges {
             if constexpr (bidirectional_iterator<_It1> && bidirectional_iterator<_It2>) {
                 // determine final iterator values
                 auto _Final1 = _RANGES _Find_last_iterator(_First1, _Last1, _Count);
-                auto _Final2 = _RANGES _Find_last_iterator(_First2, _Last2, _Count);
+                using _Diff2 = iter_difference_t<_It2>; // avoid truncation warnings; ranges are the same length
+                auto _Final2 = _RANGES _Find_last_iterator(_First2, _Last2, static_cast<_Diff2>(_Count));
 
                 for (;;) { // trim matching suffixes
                     --_Final1;

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -154,7 +154,7 @@ public:
 
     _NODISCARD _CONSTEXPR20 difference_type operator-(const _Vector_const_iterator& _Right) const noexcept {
         _Compat(_Right);
-        return _Ptr - _Right._Ptr;
+        return static_cast<difference_type>(_Ptr - _Right._Ptr);
     }
 
     _NODISCARD _CONSTEXPR20 reference operator[](const difference_type _Off) const noexcept {

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1969,7 +1969,7 @@ public:
 
     _NODISCARD _CONSTEXPR20 difference_type operator-(const _String_const_iterator& _Right) const noexcept {
         _Compat(_Right);
-        return _Ptr - _Right._Ptr;
+        return static_cast<difference_type>(_Ptr - _Right._Ptr);
     }
 
     _NODISCARD _CONSTEXPR20 reference operator[](const difference_type _Off) const noexcept {


### PR DESCRIPTION
Test coverage will be provided by `std/strings/basic.string/string.cons/from_range.pass.cpp`, `std/containers/unord/unord.multimap/unord.multimap.cnstr/from_range.pass.cpp`, and more in the upcoming libcxx update that I'm working on. They have allocators with custom size/difference types (e.g. 32-bit types even on 64-bit platforms) that reveal these issues.

When subtracting `string`/`vector` iterators, we can get truncation warnings like `xstring(1972): warning C4244: 'return': conversion from '__int64' to 'int', possible loss of data`. Because we're subtracting iterators into the same `string`/`vector`, casting to the allocator's `difference_type` is always safe.

In `_Is_permutation_sized` powering `ranges::is_permutation`, we can get `algorithm(940): warning C4244: 'argument': conversion from '__int64' to 'const int', possible loss of data`. This happens when the ranges have different difference types. We call `_Is_permutation_sized` after checking that the ranges are the same length, so we only pass the first count, and casting that to the second range's difference type is guaranteed to be value-preserving. This asymmetry looked strange enough that I thought it deserved a comment (even without introducing `using _Diff2`, the line would get long enough to wrap, so we have space for a comment anyways).