### PR TITLE
`<format>`: Fix STL internal check when formatting empty strings

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -327,7 +327,9 @@ public:
 
     constexpr _Unicode_codepoint_iterator(const _CharT* _First_val, const _CharT* _Last_val) noexcept
         : _First(_First_val), _Last(_Last_val) {
-        _Next = _Decode_utf(_First, _Last, _Val)._Next_ptr;
+        if (_First != _Last) {
+            _Next = _Decode_utf(_First, _Last, _Val)._Next_ptr;
+        }
     }
 
     constexpr _Unicode_codepoint_iterator() = default;


### PR DESCRIPTION
Fixes #4241. Test coverage will be provided by the upcoming libcxx update.

When `_First == _Last`, the iterator will compare equal to `default_sentinel_t` and the callsite `_Measure_string_prefix()` will do the right thing, we just need to avoid calling `_Decode_utf()` for an empty range. This will leave `_Next` as null, which is fine - we only need it when we increment the iterator.

`_Measure_string_prefix_iterator_legacy` already appears to handle empty ranges correctly.