### PR TITLE
Allow `locale{nullptr}` to compile

### DIFF
--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -226,7 +226,7 @@ public:
         _Newimp->_Addfac(_Facptr, _Facet::id);
         _Newimp->_Catmask = none;
         _Newimp->_Name    = "*";
-        return locale{_Newimp};
+        return locale{_Secret_locale_construct_tag{}, _Newimp};
     }
 
     template <class _Facet>
@@ -391,7 +391,11 @@ public:
     static _MRTIMP2_PURE locale __CLRCALL_PURE_OR_CDECL empty(); // empty (transparent) locale
 
 private:
-    locale(_Locimp* _Ptrimp) : _Ptr(_Ptrimp) {}
+    struct _Secret_locale_construct_tag {
+        explicit _Secret_locale_construct_tag() = default;
+    };
+
+    explicit locale(_Secret_locale_construct_tag, _Locimp* _Ptrimp) : _Ptr(_Ptrimp) {}
 
     static _MRTIMP2_PURE _Locimp* __CLRCALL_PURE_OR_CDECL _Init(bool _Do_incref = false); // initialize locale
     static _MRTIMP2_PURE _Locimp* __CLRCALL_PURE_OR_CDECL _Getgloballocale();

--- a/stl/src/locale0.cpp
+++ b/stl/src/locale0.cpp
@@ -159,7 +159,7 @@ _MRTIMP2_PURE const locale& __CLRCALL_PURE_OR_CDECL locale::classic() { // get r
 
 _MRTIMP2_PURE locale __CLRCALL_PURE_OR_CDECL locale::empty() { // make empty transparent locale
     _Init();
-    return locale{_Locimp::_New_Locimp(true)};
+    return locale{_Secret_locale_construct_tag{}, _Locimp::_New_Locimp(true)};
 }
 
 _MRTIMP2_PURE locale::_Locimp* __CLRCALL_PURE_OR_CDECL locale::_Init(bool _Do_incref) { // setup global and "C" locales
@@ -176,7 +176,7 @@ _MRTIMP2_PURE locale::_Locimp* __CLRCALL_PURE_OR_CDECL locale::_Init(bool _Do_in
 
         // set classic to match
         ptr->_Incref();
-        ::new (&classic_locale) locale{ptr};
+        ::new (&classic_locale) locale{_Secret_locale_construct_tag{}, ptr};
 #if defined(_M_CEE_PURE)
         locale::_Locimp::_Clocptr = ptr;
 #else // ^^^ defined(_M_CEE_PURE) / !defined(_M_CEE_PURE) vvv


### PR DESCRIPTION
Found by `std/localization/locales/locale/locale.cons/char_pointer.pass.cpp` in the upcoming libcxx update:

```
D:\GitHub\STL\llvm-project\libcxx\test\std\localization\locales\locale\locale.cons\char_pointer.pass.cpp(92): error C2440: '<function-style-cast>': cannot convert from 'nullptr' to 'std::locale'
D:\GitHub\STL\llvm-project\libcxx\test\std\localization\locales\locale\locale.cons\char_pointer.pass.cpp(92): note: 'std::locale::locale': ambiguous call to overloaded function
D:\GitHub\STL\out\x64\out\inc\xlocale(304): note: could be 'std::locale::locale(const char *,std::locale::category)'
D:\GitHub\STL\out\x64\out\inc\xlocale(394): note: or       'std::locale::locale(std::locale::_Locimp *)'
D:\GitHub\STL\llvm-project\libcxx\test\std\localization\locales\locale\locale.cons\char_pointer.pass.cpp(92): note: while trying to match the argument list '(nullptr)'
```

WG21-N4964 \[member.functions\]/2:

> For a non-virtual member function described in the C++ standard library, an implementation may declare a different set of member function signatures, provided that any call to the member function that would select an overload from the set of declarations described in this document behaves as if that overload were selected.

The set of constructors depicted in \[locale.general\] means that `locale{nullptr}` should compile, even though \[locale.cons\]/3 says that when it selects `explicit locale(const char* std_name);`:

> *Throws:* `runtime_error` if the argument is not valid, or is null.

libc++'s test suite expects exactly this.

C++ is intentionally designed to perform access control after overload resolution (citation left as an exercise to the reader), so the `private` constructor `locale(_Locimp*)` disrupts this. We can add an internal tag to restore conformance. Because this is `private`, the tag can also be `private`.

Verified that there are no differences in release or debug exports (perhaps surprisingly, `locale` isn't separately compiled, although its unindicted co-conspirators are).