### PR TITLE
Avoid `_Iter_diff_t` in parameters of `std` function templates

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -5412,7 +5412,8 @@ void random_shuffle(_RanIt _First, _RanIt _Last) { // shuffle [_First, _Last) us
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _FwdIt>
-constexpr _FwdIt shift_left(_FwdIt _First, const _FwdIt _Last, _Iter_diff_t<_FwdIt> _Pos_to_shift) {
+constexpr _FwdIt shift_left(
+    _FwdIt _First, const _FwdIt _Last, typename iterator_traits<_FwdIt>::difference_type _Pos_to_shift) {
     // shift [_First, _Last) left by _Pos_to_shift
     // positions; returns the end of the resulting range
     _STL_ASSERT(_Pos_to_shift >= 0, "shift count must be non-negative (N4950 [alg.shift]/1)");
@@ -5446,7 +5447,8 @@ constexpr _FwdIt shift_left(_FwdIt _First, const _FwdIt _Last, _Iter_diff_t<_Fwd
 }
 
 _EXPORT_STD template <class _ExPo, class _FwdIt, _Enable_if_execution_policy_t<_ExPo> = 0>
-_FwdIt shift_left(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Iter_diff_t<_FwdIt> _Pos_to_shift) noexcept /* terminates */ {
+_FwdIt shift_left(_ExPo&&, _FwdIt _First, _FwdIt _Last,
+    typename iterator_traits<_FwdIt>::difference_type _Pos_to_shift) noexcept /* terminates */ {
     // shift [_First, _Last) left by _Pos_to_shift positions
     // not parallelized as benchmarks show it isn't worth it
     _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
@@ -5454,7 +5456,8 @@ _FwdIt shift_left(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Iter_diff_t<_FwdIt> _Po
 }
 
 _EXPORT_STD template <class _FwdIt>
-constexpr _FwdIt shift_right(_FwdIt _First, const _FwdIt _Last, _Iter_diff_t<_FwdIt> _Pos_to_shift) {
+constexpr _FwdIt shift_right(
+    _FwdIt _First, const _FwdIt _Last, typename iterator_traits<_FwdIt>::difference_type _Pos_to_shift) {
     // shift [_First, _Last) right by _Pos_to_shift
     // positions; returns the beginning of the resulting range
     _STL_ASSERT(_Pos_to_shift >= 0, "shift count must be non-negative (N4950 [alg.shift]/5)");
@@ -5528,7 +5531,8 @@ constexpr _FwdIt shift_right(_FwdIt _First, const _FwdIt _Last, _Iter_diff_t<_Fw
 }
 
 _EXPORT_STD template <class _ExPo, class _FwdIt, _Enable_if_execution_policy_t<_ExPo> = 0>
-_FwdIt shift_right(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Iter_diff_t<_FwdIt> _Pos_to_shift) noexcept /* terminates */ {
+_FwdIt shift_right(_ExPo&&, _FwdIt _First, _FwdIt _Last,
+    typename iterator_traits<_FwdIt>::difference_type _Pos_to_shift) noexcept /* terminates */ {
     // shift [_First, _Last) right by _Pos_to_shift positions
     // not parallelized as benchmarks show it isn't worth it
     _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -646,7 +646,7 @@ namespace ranges {
         public:
             template <class _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
-            _NODISCARD constexpr decltype(auto) operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
+            _NODISCARD constexpr decltype(auto) operator()(_Ty && _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 constexpr _St _Strat = _Choice<_Ty>._Strategy;
 
                 if constexpr (_Strat == _St::_Custom) {
@@ -1464,7 +1464,8 @@ constexpr _InIt _Next_iter(_InIt _First) { // increment iterator
 }
 
 _EXPORT_STD template <class _InIt>
-_NODISCARD _CONSTEXPR17 _InIt next(_InIt _First, _Iter_diff_t<_InIt> _Off = 1) { // increment iterator
+_NODISCARD _CONSTEXPR17 _InIt next(
+    _InIt _First, typename iterator_traits<_InIt>::difference_type _Off = 1) { // increment iterator
     static_assert(_Is_ranges_input_iter_v<_InIt>, "next requires input iterator");
 
     _STD advance(_First, _Off);
@@ -1477,7 +1478,8 @@ constexpr _BidIt _Prev_iter(_BidIt _First) { // decrement iterator
 }
 
 _EXPORT_STD template <class _BidIt>
-_NODISCARD _CONSTEXPR17 _BidIt prev(_BidIt _First, _Iter_diff_t<_BidIt> _Off = 1) { // decrement iterator
+_NODISCARD _CONSTEXPR17 _BidIt prev(
+    _BidIt _First, typename iterator_traits<_BidIt>::difference_type _Off = 1) { // decrement iterator
     static_assert(_Is_ranges_bidi_iter_v<_BidIt>, "prev requires bidirectional iterator");
 
     _STD advance(_First, -_Off);
@@ -1625,7 +1627,8 @@ public:
 
     template <indirectly_swappable<_BidIt> _BidIt2>
     friend constexpr void iter_swap(const reverse_iterator& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
-        is_nothrow_copy_constructible_v<_BidIt>&& is_nothrow_copy_constructible_v<_BidIt2>&& noexcept(
+        is_nothrow_copy_constructible_v<_BidIt>
+        && is_nothrow_copy_constructible_v<_BidIt2>&& noexcept(
             _RANGES iter_swap(--_STD declval<_BidIt&>(), --_STD declval<_BidIt2&>()))) {
         auto _LTmp = _Left.current;
         auto _RTmp = _Right.base();
@@ -5137,7 +5140,7 @@ _INLINE_VAR constexpr bool _Is_pointer_address_comparable =
 #pragma warning(push)
 #pragma warning(disable : 4806) // no value of type 'bool' promoted to type 'char' can equal the given constant
 template <class _Elem1, class _Elem2,
-    bool = sizeof(_Elem1) == sizeof(_Elem2) && is_integral_v<_Elem1>&& is_integral_v<_Elem2>>
+    bool = sizeof(_Elem1) == sizeof(_Elem2) && is_integral_v<_Elem1> && is_integral_v<_Elem2>>
 _INLINE_VAR constexpr bool _Can_memcmp_elements =
     is_same_v<_Elem1, bool> || is_same_v<_Elem2, bool> || static_cast<_Elem1>(-1) == static_cast<_Elem2>(-1);
 #pragma warning(pop)


### PR DESCRIPTION
`_Iter_diff_t<T>` is `typename iterator_traits<T>::difference_type` in C++17-and-earlier, and `iter_difference_t<T>` in C++20-and-later. We use it for the parameter types of a few function templates that are specified to take the former. This is (1) nicely shorter to spell than the long `iterator_traits` type, and (2) possibly a bit cheaper to compile if we can avoid instantiating `iterator_traits`. I convinced myself the difference probably wasn't observable and we made this change hoping to at least see if it would break anything.

Four years later, we now know what will break: subsumption. If I pull e.g. `std::next` into a namespace with a `using` declaration and overload it with constrained function template taking the standard-specified parameters I'll get overload ambiguity on our implementation. The parameter mapping (the transformation from the template parameters to the function parameter types) differs in the two overloads so the constrained overload isn't clearly more specialized.

This PR changes all function template parameters `_Iter_diff_t<meow>` to `typename iterator_traits<meow>::difference_type`. I still believe that the difference isn't observable in return types, so I've left them alone.

There are also some non-local clang-format changes in `<xutility>` that I won't try to explain.

Fixes DevCom-10532126.
