### PR TITLE
`<chrono>`: Make `format()` accept `%X` and `%EX` for `duration` and `hh_mm_ss`

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5398,7 +5398,7 @@ namespace chrono {
                     || _Is_valid_type<month>(_Type) || _Is_valid_type<day>(_Type) || _Is_valid_type<weekday>(_Type);
             } else if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
                 return _Type == 'H' || _Type == 'I' || _Type == 'M' || _Type == 'S' || _Type == 'r' || _Type == 'R'
-                    || _Type == 'T' || _Type == 'p';
+                    || _Type == 'T' || _Type == 'p' || _Type == 'X';
             } else if constexpr (_Is_any_of_v<_Ty, sys_info, local_info>) {
                 return _Type == 'z' || _Type == 'Z';
             } else if constexpr (_Is_specialization_v<_Ty, time_point>) {
@@ -5407,7 +5407,7 @@ namespace chrono {
                         return true;
                     }
                 }
-                return _Type == 'c' || _Type == 'X' || _Is_valid_type<year_month_day>(_Type)
+                return _Type == 'c' || _Is_valid_type<year_month_day>(_Type)
                     || _Is_valid_type<hh_mm_ss<seconds>>(_Type);
             } else if constexpr (_Is_specialization_v<_Ty, _Local_time_format_t>) {
                 return _Type == 'z' || _Type == 'Z' || _Is_valid_type<decltype(_Ty::_Time)>(_Type);

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -282,6 +282,10 @@ void test_duration_formatter() {
     assert(format(STR("{:%T %j}"), -days{4} - 23h - 30min) == STR("-119:30:00 4"));
     assert(format(STR("{:%T %j}"), duration<float, days::period>{1.55f}) == STR("37:11:59 1"));
     assert(format(STR("{:%T %j}"), duration<float, days::period>{-1.55f}) == STR("-37:11:59 1"));
+
+    // GH-4247: <chrono>: format() should accept %X and %EX for duration and hh_mm_ss
+    assert(format(STR("{:%X}"), 9h + 7min + 5s) == STR("09:07:05"));
+    assert(format(STR("{:%EX}"), 9h + 7min + 5s) == STR("09:07:05"));
 }
 
 template <typename CharT>
@@ -765,6 +769,10 @@ void test_hh_mm_ss_formatter() {
     assert(format(STR("{:%H}"), hh_mm_ss{24h}) == STR("24"));
     assert(format(STR("{:%H}"), hh_mm_ss{-24h}) == STR("-24"));
     assert(format(STR("{:%M %S}"), hh_mm_ss{27h + 12min + 30s}) == STR("12 30"));
+
+    // GH-4247: <chrono>: format() should accept %X and %EX for duration and hh_mm_ss
+    assert(format(STR("{:%X}"), hh_mm_ss{9h + 7min + 5s}) == STR("09:07:05"));
+    assert(format(STR("{:%EX}"), hh_mm_ss{9h + 7min + 5s}) == STR("09:07:05"));
 }
 
 void test_exception_classes() {


### PR DESCRIPTION
Fixes #4247 