### PR TITLE
Fix truncation warnings in `allocate_shared()`

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -2670,7 +2670,8 @@ private:
 
         this->~_Ref_count_unbounded_array_alloc();
 
-        _Al.deallocate(_STD _Refancy<_Alloc_ptr_t<_Rebound_alloc>>(reinterpret_cast<_Storage*>(this)), _Storage_units);
+        _Al.deallocate(_STD _Refancy<_Alloc_ptr_t<_Rebound_alloc>>(reinterpret_cast<_Storage*>(this)),
+            static_cast<_Alloc_size_t<_Rebound_alloc>>(_Storage_units));
     }
 };
 
@@ -2851,11 +2852,12 @@ struct _Allocate_n_ptr {
     _Alloc_ptr_t<_Alloc> _Ptr;
     size_t _Nx;
 
-    _Allocate_n_ptr(_Alloc& _Al_, const size_t _Nx_) : _Al(_Al_), _Ptr(_Al_.allocate(_Nx_)), _Nx(_Nx_) {}
+    _Allocate_n_ptr(_Alloc& _Al_, const size_t _Nx_)
+        : _Al(_Al_), _Ptr(_Al_.allocate(_Convert_size<_Alloc_size_t<_Alloc>>(_Nx_))), _Nx(_Nx_) {}
 
     ~_Allocate_n_ptr() {
         if (_Ptr) {
-            _Al.deallocate(_Ptr, _Nx);
+            _Al.deallocate(_Ptr, static_cast<_Alloc_size_t<_Alloc>>(_Nx));
         }
     }
 


### PR DESCRIPTION
Found by `std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/allocate_shared_for_overwrite.pass.cpp` in the upcoming libcxx update.

```
memory(2858): warning C4267: 'argument': conversion from 'size_t' to 'test_allocator<U>::size_type', possible loss of data
```

We need to `_Convert_size` when allocating, but if that succeeds, we can simply `static_cast` when deallocating.