### PR TITLE
Fix `sub_match <=> basic_string` with custom traits/allocators

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -907,7 +907,7 @@ _NODISCARD bool operator==(
 _EXPORT_STD template <class _BidIt, class _Traits, class _Alloc>
 _NODISCARD auto operator<=>(
     const sub_match<_BidIt>& _Left, const basic_string<_Iter_value_t<_BidIt>, _Traits, _Alloc>& _Right) {
-    return static_cast<sub_match<_BidIt>::_Comparison_category>(_Left.compare(_Right) <=> 0);
+    return static_cast<sub_match<_BidIt>::_Comparison_category>(_Left._Compare(_Right.data(), _Right.size()) <=> 0);
 }
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 template <class _BidIt, class _Traits, class _Alloc>


### PR DESCRIPTION
Found by `std/re/re.submatch/re.submatch.op/compare.pass.cpp` in the upcoming libcxx update.

This follows WG21-N4964 \[re.submatch.op\]/5:

```cpp
template<class BiIter, class ST, class SA>
  auto operator<=>(
      const sub_match<BiIter>& lhs,
      const basic_string<typename iterator_traits<BiIter>::value_type, ST, SA>& rhs);
```

*Returns:*
```cpp
static_cast<SM-CAT(BiIter)>(lhs.compare(
    typename sub_match<BiIter>::string_type(rhs.data(), rhs.size()))
      <=> 0
    )
```

without constructing a temporary. Our equality operators are already correct.