### PR TITLE
Defend sequence container constructors from bad CTAD

### DIFF
--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -650,6 +650,9 @@ public:
         _Construct_n(_Count, _Val);
     }
 
+#if _HAS_CXX17
+    template <class _Alloc2 = _Alloc, enable_if_t<_Is_allocator<_Alloc2>::value, int> = 0>
+#endif // _HAS_CXX17
     deque(_CRT_GUARDOVERFLOW size_type _Count, const _Ty& _Val, const _Alloc& _Al)
         : _Mypair(_One_then_variadic_args_t{}, _Al) {
         _Construct_n(_Count, _Val);

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -561,6 +561,9 @@ public:
         _Insert_op._Attach_after(_Mypair._Myval2._Before_head());
     }
 
+#if _HAS_CXX17
+    template <class _Alloc2 = _Alloc, enable_if_t<_Is_allocator<_Alloc2>::value, int> = 0>
+#endif // _HAS_CXX17
     forward_list(_CRT_GUARDOVERFLOW size_type _Count, const _Ty& _Val, const _Alloc& _Al)
         : _Mypair(_One_then_variadic_args_t{}, _Al) { // construct list from _Count * _Val, allocator
         _Flist_insert_after_op2<_Alnode> _Insert_op(_Getal());

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -845,6 +845,9 @@ public:
         _Construct_n(_Count, _Val);
     }
 
+#if _HAS_CXX17
+    template <class _Alloc2 = _Alloc, enable_if_t<_Is_allocator<_Alloc2>::value, int> = 0>
+#endif // _HAS_CXX17
     list(_CRT_GUARDOVERFLOW size_type _Count, const _Ty& _Val, const _Alloc& _Al)
         : _Mypair(_One_then_variadic_args_t{}, _Al) { // construct list from _Count * _Val, allocator
         _Construct_n(_Count, _Val);

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -622,6 +622,9 @@ public:
         _Construct_n(_Count);
     }
 
+#if _HAS_CXX17
+    template <class _Alloc2 = _Alloc, enable_if_t<_Is_allocator<_Alloc2>::value, int> = 0>
+#endif // _HAS_CXX17
     _CONSTEXPR20 vector(_CRT_GUARDOVERFLOW const size_type _Count, const _Ty& _Val, const _Alloc& _Al = _Alloc())
         : _Mypair(_One_then_variadic_args_t{}, _Al) {
         _Construct_n(_Count, _Val);

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2547,6 +2547,9 @@ public:
         _Construct<_Construct_strategy::_From_ptr>(_Ptr, _Count);
     }
 
+#if _HAS_CXX17
+    template <class _Alloc2 = _Alloc, enable_if_t<_Is_allocator<_Alloc2>::value, int> = 0>
+#endif // _HAS_CXX17
     _CONSTEXPR20 basic_string(
         _In_reads_(_Count) const _Elem* const _Ptr, _CRT_GUARDOVERFLOW const size_type _Count, const _Alloc& _Al)
         : _Mypair(_One_then_variadic_args_t{}, _Al) {

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -905,7 +905,6 @@ std/containers/associative/map/map.cons/deduct_const.pass.cpp FAIL
 std/containers/associative/multimap/multimap.cons/deduct.pass.cpp FAIL
 std/containers/associative/multimap/multimap.cons/deduct_const.pass.cpp FAIL
 std/containers/container.adaptors/priority.queue/priqueue.cons/deduct.pass.cpp FAIL
-std/containers/sequences/list/list.cons/deduct.pass.cpp FAIL
 std/containers/unord/unord.map/unord.map.cnstr/deduct.pass.cpp FAIL
 std/containers/unord/unord.map/unord.map.cnstr/deduct_const.pass.cpp FAIL
 std/containers/unord/unord.multimap/unord.multimap.cnstr/deduct.pass.cpp FAIL
@@ -942,11 +941,6 @@ std/utilities/memory/allocator.traits/allocator.traits.members/destroy.pass.cpp 
 
 # Not analyzed. Error mentions allocator<const T>.
 std/utilities/memory/specialized.algorithms/specialized.construct/construct_at.pass.cpp FAIL
-
-# Not analyzed. Looks like deduction guide SFINAE failure.
-std/containers/sequences/deque/deque.cons/deduct.pass.cpp FAIL
-std/containers/sequences/forwardlist/forwardlist.cons/deduct.pass.cpp FAIL
-std/containers/sequences/vector/vector.cons/deduct.pass.cpp FAIL
 
 # Not analyzed. Seems to force a sign conversion error?
 std/iterators/iterator.primitives/iterator.operations/advance.pass.cpp SKIPPED


### PR DESCRIPTION
Found by the upcoming libcxx update, where they test CTAD for `(Iter, Iter, BadAlloc)` and expect it to SFINAE away.

(The explicit deduction guides are already constrained to take only things that qualify as allocators. The issue is that every constructor generates an implicit guide, and those can lead to the container being instantiated with a BadAlloc unless we guard against that.)

It's actually unclear to me whether this is guaranteed by the Standard, but the defense is simple and we already do this in `basic_string`.