### PR TITLE
`<ranges>`: Fix truncation warnings and improve overflow check for `repeat_view`

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1542,6 +1542,11 @@ namespace ranges {
 
             constexpr _Iterator& operator+=(difference_type _Off) noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
+                if constexpr (sizeof(difference_type) > sizeof(_Index_type)) {
+                    _STL_VERIFY(static_cast<_Index_type>(_Off) == _Off,
+                        _Off > 0 ? "cannot advance repeat_view iterator past end (integer overflow)"
+                                 : "cannot advance repeat_view iterator before begin (integer overflow)");
+                }
                 if (_Off > 0) {
                     _STL_VERIFY(_Current <= (numeric_limits<_Index_type>::max)() - static_cast<_Index_type>(_Off),
                         "cannot advance repeat_view iterator past end (integer overflow)");
@@ -1554,11 +1559,16 @@ namespace ranges {
                     _STL_VERIFY(_Current + _Off >= 0, "cannot subtract below 0");
                 }
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-                _Current += _Off;
+                _Current += static_cast<_Index_type>(_Off);
                 return *this;
             }
             constexpr _Iterator& operator-=(difference_type _Off) noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
+                if constexpr (sizeof(difference_type) > sizeof(_Index_type)) {
+                    _STL_VERIFY(static_cast<_Index_type>(_Off) == _Off,
+                        _Off < 0 ? "cannot advance repeat_view iterator past end (integer overflow)"
+                                 : "cannot advance repeat_view iterator before begin (integer overflow)");
+                }
                 if (_Off < 0) {
                     _STL_VERIFY(_Current <= (numeric_limits<_Index_type>::max)() + static_cast<_Index_type>(_Off),
                         "cannot advance repeat_view iterator past end (integer overflow)");
@@ -1571,7 +1581,7 @@ namespace ranges {
                     _STL_VERIFY(_Current - _Off >= 0, "cannot subtract below 0");
                 }
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-                _Current -= _Off;
+                _Current -= static_cast<_Index_type>(_Off);
                 return *this;
             }
             _NODISCARD constexpr const _Ty& operator[](difference_type _Idx) const noexcept {

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1550,6 +1550,7 @@ namespace ranges {
                         _Off > 0 ? "cannot advance repeat_view iterator past end (integer overflow)"
                                  : "cannot advance repeat_view iterator before begin (integer overflow)");
                 }
+
                 if (_Off > 0) {
                     _STL_VERIFY(_Current <= (numeric_limits<_Index_type>::max)() - static_cast<_Index_type>(_Off),
                         "cannot advance repeat_view iterator past end (integer overflow)");
@@ -1572,6 +1573,7 @@ namespace ranges {
                         _Off < 0 ? "cannot advance repeat_view iterator past end (integer overflow)"
                                  : "cannot advance repeat_view iterator before begin (integer overflow)");
                 }
+
                 if (_Off < 0) {
                     _STL_VERIFY(_Current <= (numeric_limits<_Index_type>::max)() + static_cast<_Index_type>(_Off),
                         "cannot advance repeat_view iterator past end (integer overflow)");

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -524,10 +524,6 @@ std/time/time.clock/time.clock.file/ostream.pass.cpp FAIL
 # LLVM-74727: [libc++] Should formatting year{-99} with %C produce "-1" or "-01"?
 std/time/time.syn/formatter.year.pass.cpp:2 FAIL
 
-# GH-4251: <ranges>: repeat_view<T, unsigned int> emits truncation warnings
-std/ranges/range.factories/range.repeat.view/iterator/minus.pass.cpp:0 FAIL
-std/ranges/range.factories/range.repeat.view/iterator/minus.pass.cpp:1 FAIL
-
 
 # *** VCRUNTIME BUGS ***
 # DevCom-10373274 VSO-1824997 "vcruntime nothrow array operator new falls back on the wrong function"

--- a/tests/std/tests/P2474R2_views_repeat/test.cpp
+++ b/tests/std/tests/P2474R2_views_repeat/test.cpp
@@ -288,6 +288,18 @@ struct tuple_tester {
     forward_tester z;
 };
 
+
+template <class IntLike>
+constexpr void test_iterator_arithmetic() {
+    auto rv    = views::repeat(0, IntLike{20u});
+    auto first = rv.begin();
+    auto last  = rv.end();
+    assert(last - first == 20);
+    first += 2;
+    last -= 3;
+    assert(last - first == 15);
+}
+
 constexpr bool test() {
     using namespace string_literals;
 
@@ -323,6 +335,27 @@ constexpr bool test() {
         assert(to_copy.x == 1);
         assert(to_move.x == 2);
     }
+
+    // GH-4251: <ranges>: repeat_view<T, unsigned int> emits truncation warnings
+    test_iterator_arithmetic<unsigned char>();
+    test_iterator_arithmetic<unsigned short>();
+    test_iterator_arithmetic<unsigned int>();
+    test_iterator_arithmetic<unsigned long>();
+    test_iterator_arithmetic<unsigned long long>();
+    test_iterator_arithmetic<char>();
+    test_iterator_arithmetic<short>();
+    test_iterator_arithmetic<int>();
+    test_iterator_arithmetic<long>();
+    test_iterator_arithmetic<long long>();
+    test_iterator_arithmetic<char>();
+#ifdef __cpp_char8_t
+    test_iterator_arithmetic<char8_t>();
+#endif // defined(__cpp_char8_t)
+    test_iterator_arithmetic<char16_t>();
+    test_iterator_arithmetic<char32_t>();
+    test_iterator_arithmetic<wchar_t>();
+    test_iterator_arithmetic<_Signed128>();
+
     return true;
 }
 

--- a/tests/std/tests/P2474R2_views_repeat/test.cpp
+++ b/tests/std/tests/P2474R2_views_repeat/test.cpp
@@ -342,7 +342,7 @@ constexpr bool test() {
     test_iterator_arithmetic<unsigned int>();
     test_iterator_arithmetic<unsigned long>();
     test_iterator_arithmetic<unsigned long long>();
-    test_iterator_arithmetic<char>();
+    test_iterator_arithmetic<signed char>();
     test_iterator_arithmetic<short>();
     test_iterator_arithmetic<int>();
     test_iterator_arithmetic<long>();

--- a/tests/std/tests/P2474R2_views_repeat_death/test.cpp
+++ b/tests/std/tests/P2474R2_views_repeat_death/test.cpp
@@ -81,6 +81,51 @@ void test_iter_add_neg_overflow() {
     it += -1; // integer overflow
 }
 
+template <class I>
+using iota_diff_t = ranges::range_difference_t<ranges::iota_view<I>>;
+
+template <class U>
+constexpr auto positive_huge_diff = iota_diff_t<U>{iota_diff_t<U>{static_cast<U>(-1)} + 1};
+
+template <class U>
+constexpr auto negative_huge_diff = iota_diff_t<U>{-iota_diff_t<U>{static_cast<U>(-1)} - 1};
+
+template <class U>
+void test_iter_add_pos_huge() {
+    auto rv    = views::repeat(0, U{20u});
+    auto first = rv.begin();
+
+    using difference_type = ranges::range_difference_t<decltype(rv)>;
+    first += static_cast<difference_type>(positive_huge_diff<U>);
+}
+
+template <class U>
+void test_iter_add_neg_huge() {
+    auto rv    = views::repeat(0, U{20u});
+    auto first = rv.begin();
+
+    using difference_type = ranges::range_difference_t<decltype(rv)>;
+    first += static_cast<difference_type>(negative_huge_diff<U>);
+}
+
+template <class U>
+void test_iter_sub_pos_huge() {
+    auto rv    = views::repeat(0, U{20u});
+    auto first = rv.begin();
+
+    using difference_type = ranges::range_difference_t<decltype(rv)>;
+    first -= static_cast<difference_type>(positive_huge_diff<U>);
+}
+
+template <class U>
+void test_iter_sub_neg_huge() {
+    auto rv    = views::repeat(0, U{20u});
+    auto first = rv.begin();
+
+    using difference_type = ranges::range_difference_t<decltype(rv)>;
+    first -= static_cast<difference_type>(negative_huge_diff<U>);
+}
+
 int main(int argc, char* argv[]) {
     std_testing::death_test_executive exec;
 
@@ -96,6 +141,19 @@ int main(int argc, char* argv[]) {
         test_iter_add_zero,
         test_iter_add_pos_overflow,
         test_iter_add_neg_overflow,
+        // GH-4251: <ranges>: repeat_view<T, unsigned int> emits truncation warnings
+        test_iter_add_pos_huge<unsigned short>,
+        test_iter_add_pos_huge<unsigned int>,
+        test_iter_add_pos_huge<unsigned long long>,
+        test_iter_add_neg_huge<unsigned short>,
+        test_iter_add_neg_huge<unsigned int>,
+        test_iter_add_neg_huge<unsigned long long>,
+        test_iter_sub_pos_huge<unsigned short>,
+        test_iter_sub_pos_huge<unsigned int>,
+        test_iter_sub_pos_huge<unsigned long long>,
+        test_iter_sub_neg_huge<unsigned short>,
+        test_iter_sub_neg_huge<unsigned int>,
+        test_iter_sub_neg_huge<unsigned long long>,
     });
     return exec.run(argc, argv);
 }

--- a/tests/std/tests/P2474R2_views_repeat_death/test.cpp
+++ b/tests/std/tests/P2474R2_views_repeat_death/test.cpp
@@ -85,10 +85,10 @@ template <class I>
 using iota_diff_t = ranges::range_difference_t<ranges::iota_view<I>>;
 
 template <class U>
-constexpr auto positive_huge_diff = iota_diff_t<U>{iota_diff_t<U>{static_cast<U>(-1)} + 1};
+constexpr iota_diff_t<U> positive_huge_diff{iota_diff_t<U>{static_cast<U>(-1)} + 1};
 
 template <class U>
-constexpr auto negative_huge_diff = iota_diff_t<U>{-iota_diff_t<U>{static_cast<U>(-1)} - 1};
+constexpr iota_diff_t<U> negative_huge_diff{-iota_diff_t<U>{static_cast<U>(-1)} - 1};
 
 template <class U>
 void test_iter_add_pos_huge() {


### PR DESCRIPTION
Fixes #4251.