### PR TITLE
ADL-proof implementation of [alg.modifying.operations]

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1468,7 +1468,8 @@ namespace ranges {
             _It _First, _Se _Last, _Out _Result, _Pr _Pred, _Pj _Proj = {}) const {
             _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _Copy_if_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _STD _Pass_fn(_Pred),
+                _STD _Pass_fn(_Proj));
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }
@@ -1534,8 +1535,8 @@ namespace ranges {
             requires indirectly_movable<_It, _Out>
         constexpr move_result<_It, _Out> operator()(_It _First, _Se _Last, _Out _Result) const {
             _STD _Adl_verify_range(_First, _Last);
-            auto _UResult = _RANGES _Move_unchecked(
-                _RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result));
+            auto _UResult = _RANGES _Move_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
@@ -1544,9 +1545,9 @@ namespace ranges {
         template <input_range _Rng, weakly_incrementable _Out>
             requires indirectly_movable<iterator_t<_Rng>, _Out>
         constexpr move_result<borrowed_iterator_t<_Rng>, _Out> operator()(_Rng&& _Range, _Out _Result) const {
-            auto _First = _RANGES begin(_Range);
-            auto _UResult =
-                _RANGES _Move_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD move(_Result));
+            auto _First   = _RANGES begin(_Range);
+            auto _UResult = _RANGES _Move_unchecked(
+                _RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD move(_Result));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
@@ -3337,9 +3338,9 @@ namespace ranges {
             _STD _Adl_verify_range(_First1, _Last1);
             _STD _Adl_verify_range(_First2, _Last2);
 
-            auto _UResult =
-                _Swap_ranges_unchecked(_RANGES _Unwrap_iter<_Se1>(_STD move(_First1)), _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)),
-                    _RANGES _Unwrap_iter<_Se2>(_STD move(_First2)), _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)));
+            auto _UResult = _Swap_ranges_unchecked(_RANGES _Unwrap_iter<_Se1>(_STD move(_First1)),
+                _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)), _RANGES _Unwrap_iter<_Se2>(_STD move(_First2)),
+                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)));
 
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
             _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
@@ -3353,8 +3354,8 @@ namespace ranges {
             auto _First1 = _RANGES begin(_Range1);
             auto _First2 = _RANGES begin(_Range2);
 
-            auto _UResult = _Swap_ranges_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1),
-                _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2));
+            auto _UResult = _Swap_ranges_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)),
+                _Uend(_Range1), _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2));
 
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
             _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
@@ -3507,7 +3508,8 @@ namespace ranges {
             _It _First, _Se _Last, _Out _Result, _Fn _Func, _Pj _Proj = {}) const {
             _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _Transform_unary_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj));
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _STD _Pass_fn(_Func),
+                _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
@@ -3518,8 +3520,8 @@ namespace ranges {
         constexpr unary_transform_result<borrowed_iterator_t<_Rng>, _Out> operator()(
             _Rng&& _Range, _Out _Result, _Fn _Func, _Pj _Proj = {}) const {
             auto _First   = _RANGES begin(_Range);
-            auto _UResult = _Transform_unary_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
-                _STD move(_Result), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj));
+            auto _UResult = _Transform_unary_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)),
+                _Uend(_Range), _STD move(_Result), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
@@ -3534,8 +3536,8 @@ namespace ranges {
             _STD _Adl_verify_range(_First2, _Last2);
             auto _UResult = _Transform_binary_unchecked(_RANGES _Unwrap_iter<_Se1>(_STD move(_First1)),
                 _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)), _RANGES _Unwrap_iter<_Se2>(_STD move(_First2)),
-                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD move(_Result), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj1),
-                _STD _Pass_fn(_Proj2));
+                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD move(_Result), _STD _Pass_fn(_Func),
+                _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
 
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
             _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
@@ -3550,9 +3552,9 @@ namespace ranges {
             _Rng1&& _Range1, _Rng2&& _Range2, _Out _Result, _Fn _Func, _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
             auto _First1  = _RANGES begin(_Range1);
             auto _First2  = _RANGES begin(_Range2);
-            auto _UResult = _Transform_binary_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1),
-                _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2), _STD move(_Result), _STD _Pass_fn(_Func),
-                _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+            auto _UResult = _Transform_binary_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)),
+                _Uend(_Range1), _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2),
+                _STD move(_Result), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
 
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
             _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
@@ -3639,8 +3641,8 @@ namespace ranges {
         constexpr borrowed_iterator_t<_Rng> operator()(
             _Rng&& _Range, const _Ty1& _Oldval, const _Ty2& _Newval, _Pj _Proj = {}) const {
             auto _First   = _RANGES begin(_Range);
-            auto _UResult = _Replace_unchecked(
-                _RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _Oldval, _Newval, _STD _Pass_fn(_Proj));
+            auto _UResult = _Replace_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
+                _Oldval, _Newval, _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
@@ -3710,8 +3712,8 @@ namespace ranges {
         constexpr borrowed_iterator_t<_Rng> operator()(
             _Rng&& _Range, _Pr _Pred, const _Ty& _Newval, _Pj _Proj = {}) const {
             auto _First   = _RANGES begin(_Range);
-            auto _UResult = _Replace_if_unchecked(
-                _RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD _Pass_fn(_Pred), _Newval, _STD _Pass_fn(_Proj));
+            auto _UResult = _Replace_if_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
+                _STD _Pass_fn(_Pred), _Newval, _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
@@ -3787,7 +3789,8 @@ namespace ranges {
             _It _First, _Se _Last, _Out _Result, const _Ty1& _Oldval, const _Ty2& _Newval, _Pj _Proj = {}) const {
             _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _Replace_copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _Oldval, _Newval, _STD _Pass_fn(_Proj));
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _Oldval, _Newval,
+                _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
@@ -3879,7 +3882,8 @@ namespace ranges {
             _It _First, _Se _Last, _Out _Result, _Pr _Pred, const _Ty& _Newval, _Pj _Proj = {}) const {
             _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _Replace_copy_if_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _STD _Pass_fn(_Pred), _Newval, _STD _Pass_fn(_Proj));
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _STD _Pass_fn(_Pred), _Newval,
+                _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
@@ -3891,8 +3895,8 @@ namespace ranges {
         constexpr replace_copy_if_result<borrowed_iterator_t<_Rng>, _Out> operator()(
             _Rng&& _Range, _Out _Result, _Pr _Pred, const _Ty& _Newval, _Pj _Proj = {}) const {
             auto _First   = _RANGES begin(_Range);
-            auto _UResult = _Replace_copy_if_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
-                _STD move(_Result), _STD _Pass_fn(_Pred), _Newval, _STD _Pass_fn(_Proj));
+            auto _UResult = _Replace_copy_if_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)),
+                _Uend(_Range), _STD move(_Result), _STD _Pass_fn(_Pred), _Newval, _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
@@ -3959,7 +3963,8 @@ namespace ranges {
         template <class _Ty, output_range<const _Ty&> _Rng>
         constexpr borrowed_iterator_t<_Rng> operator()(_Rng&& _Range, const _Ty& _Value) const {
             auto _First = _RANGES begin(_Range);
-            _STD _Seek_wrapped(_First, (*this)(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _Value));
+            _STD _Seek_wrapped(
+                _First, (*this)(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _Value));
             return _First;
         }
     };
@@ -3973,7 +3978,7 @@ namespace ranges {
         constexpr _Out operator()(_Out _First, _Se _Last, _Fn _Gen) const {
             _STD _Adl_verify_range(_First, _Last);
             _STD _Seek_wrapped(_First, _Generate_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                                      _RANGES _Unwrap_sent<_Out>(_STD move(_Last)), _STD _Pass_fn(_Gen)));
+                                           _RANGES _Unwrap_sent<_Out>(_STD move(_Last)), _STD _Pass_fn(_Gen)));
             return _First;
         }
 
@@ -3981,8 +3986,8 @@ namespace ranges {
             requires invocable<_Fn&> && output_range<_Rng, invoke_result_t<_Fn&>>
         constexpr borrowed_iterator_t<_Rng> operator()(_Rng&& _Range, _Fn _Gen) const {
             auto _First = _RANGES begin(_Range);
-            _STD _Seek_wrapped(_First,
-                _Generate_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD _Pass_fn(_Gen)));
+            _STD _Seek_wrapped(_First, _Generate_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)),
+                                           _Uend(_Range), _STD _Pass_fn(_Gen)));
             return _First;
         }
 
@@ -4149,8 +4154,8 @@ namespace ranges {
         _NODISCARD_REMOVE_ALG constexpr subrange<_It> operator()(
             _It _First, _Se _Last, const _Ty& _Val, _Pj _Proj = {}) const {
             _STD _Adl_verify_range(_First, _Last);
-            auto _UResult = _Remove_unchecked(
-                _RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _Val, _STD _Pass_fn(_Proj));
+            auto _UResult = _Remove_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _Val, _STD _Pass_fn(_Proj));
 
             return _RANGES _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
         }
@@ -4211,7 +4216,8 @@ namespace ranges {
             requires permutable<iterator_t<_Rng>>
         _NODISCARD_REMOVE_ALG constexpr borrowed_subrange_t<_Rng> operator()(
             _Rng&& _Range, _Pr _Pred, _Pj _Proj = {}) const {
-            auto _UResult = _Remove_if_unchecked(_Ubegin(_Range), _Uend(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+            auto _UResult =
+                _Remove_if_unchecked(_Ubegin(_Range), _Uend(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
             return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Range, _STD move(_UResult));
         }
@@ -4255,9 +4261,9 @@ namespace ranges {
         constexpr remove_copy_result<_It, _Out> operator()(
             _It _First, _Se _Last, _Out _Result, const _Ty& _Val, _Pj _Proj = {}) const {
             _STD _Adl_verify_range(_First, _Last);
-            auto _UResult =
-                _Remove_copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)),
-                    _STD _Get_unwrapped_unverified(_STD move(_Result)), _Val, _STD _Pass_fn(_Proj));
+            auto _UResult = _Remove_copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Get_unwrapped_unverified(_STD move(_Result)), _Val,
+                _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
@@ -4313,9 +4319,9 @@ namespace ranges {
         constexpr remove_copy_if_result<_It, _Out> operator()(
             _It _First, _Se _Last, _Out _Result, _Pr _Pred, _Pj _Proj = {}) const {
             _STD _Adl_verify_range(_First, _Last);
-            auto _UResult =
-                _Remove_copy_if_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)),
-                    _STD _Get_unwrapped_unverified(_STD move(_Result)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+            auto _UResult = _Remove_copy_if_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Get_unwrapped_unverified(_STD move(_Result)),
+                _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
@@ -4327,9 +4333,10 @@ namespace ranges {
             requires indirectly_copyable<iterator_t<_Rng>, _Out>
         constexpr remove_copy_if_result<borrowed_iterator_t<_Rng>, _Out> operator()(
             _Rng&& _Range, _Out _Result, _Pr _Pred, _Pj _Proj = {}) const {
-            auto _First   = _RANGES begin(_Range);
-            auto _UResult = _Remove_copy_if_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
-                _STD _Get_unwrapped_unverified(_STD move(_Result)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+            auto _First = _RANGES begin(_Range);
+            auto _UResult =
+                _Remove_copy_if_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
+                    _STD _Get_unwrapped_unverified(_STD move(_Result)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
@@ -4419,8 +4426,8 @@ namespace ranges {
         _NODISCARD_UNIQUE_ALG constexpr subrange<_It> operator()(
             _It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
             _STD _Adl_verify_range(_First, _Last);
-            auto _UResult = _Unique_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)),
-                _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+            auto _UResult = _Unique_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
             return _RANGES _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
         }
@@ -4430,7 +4437,8 @@ namespace ranges {
             requires permutable<iterator_t<_Rng>>
         _NODISCARD_UNIQUE_ALG constexpr borrowed_subrange_t<_Rng> operator()(
             _Rng&& _Range, _Pr _Pred = {}, _Pj _Proj = {}) const {
-            auto _UResult = _Unique_unchecked(_Ubegin(_Range), _Uend(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+            auto _UResult =
+                _Unique_unchecked(_Ubegin(_Range), _Uend(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
             return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Range, _STD move(_UResult));
         }
@@ -4584,9 +4592,9 @@ namespace ranges {
         constexpr unique_copy_result<_It, _Out> operator()(
             _It _First, _Se _Last, _Out _Result, _Pr _Pred = {}, _Pj _Proj = {}) const {
             _STD _Adl_verify_range(_First, _Last);
-            auto _UResult =
-                _Unique_copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)),
-                    _STD _Get_unwrapped_unverified(_STD move(_Result)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+            auto _UResult = _Unique_copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Get_unwrapped_unverified(_STD move(_Result)),
+                _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
@@ -4751,13 +4759,17 @@ _CONSTEXPR20 _OutIt reverse_copy(_BidIt _First, _BidIt _Last, _OutIt _Dest) {
 #endif // _HAS_CXX20
         {
             if constexpr (_Nx == 1) {
-                ::__std_reverse_copy_trivially_copyable_1(_STD _To_address(_UFirst), _STD _To_address(_ULast), _STD _To_address(_UDest));
+                ::__std_reverse_copy_trivially_copyable_1(
+                    _STD _To_address(_UFirst), _STD _To_address(_ULast), _STD _To_address(_UDest));
             } else if constexpr (_Nx == 2) {
-                ::__std_reverse_copy_trivially_copyable_2(_STD _To_address(_UFirst), _STD _To_address(_ULast), _STD _To_address(_UDest));
+                ::__std_reverse_copy_trivially_copyable_2(
+                    _STD _To_address(_UFirst), _STD _To_address(_ULast), _STD _To_address(_UDest));
             } else if constexpr (_Nx == 4) {
-                ::__std_reverse_copy_trivially_copyable_4(_STD _To_address(_UFirst), _STD _To_address(_ULast), _STD _To_address(_UDest));
+                ::__std_reverse_copy_trivially_copyable_4(
+                    _STD _To_address(_UFirst), _STD _To_address(_ULast), _STD _To_address(_UDest));
             } else {
-                ::__std_reverse_copy_trivially_copyable_8(_STD _To_address(_UFirst), _STD _To_address(_ULast), _STD _To_address(_UDest));
+                ::__std_reverse_copy_trivially_copyable_8(
+                    _STD _To_address(_UFirst), _STD _To_address(_ULast), _STD _To_address(_UDest));
             }
 
             _UDest += _ULast - _UFirst;
@@ -4962,8 +4974,8 @@ namespace ranges {
         constexpr borrowed_subrange_t<_Rng> operator()(_Rng&& _Range, iterator_t<_Rng> _Mid) const {
             _STD _Adl_verify_range(_RANGES begin(_Range), _Mid);
             _STD _Adl_verify_range(_Mid, _RANGES end(_Range));
-            auto _UResult =
-                _RANGES _Rotate_unchecked(_Ubegin(_Range), _RANGES _Unwrap_range_iter<_Rng>(_STD move(_Mid)), _Uend(_Range));
+            auto _UResult = _RANGES _Rotate_unchecked(
+                _Ubegin(_Range), _RANGES _Unwrap_range_iter<_Rng>(_STD move(_Mid)), _Uend(_Range));
 
             return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Mid, _STD move(_UResult));
         }
@@ -5010,7 +5022,8 @@ namespace ranges {
             _STD _Adl_verify_range(_First, _Mid);
             _STD _Adl_verify_range(_Mid, _Last);
             auto _UResult = _Rotate_copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_iter<_Se>(_STD move(_Mid)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result));
+                _RANGES _Unwrap_iter<_Se>(_STD move(_Mid)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)),
+                _STD move(_Result));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
@@ -5182,13 +5195,13 @@ _SampleIt sample(_PopIt _First, _PopIt _Last, _SampleIt _Dest, _Diff _Count, _Ur
                 _Count = static_cast<_Diff>(_Pop_size); // narrowing OK because _Count is getting smaller
             }
 
-            _STD _Seek_wrapped(_Dest,
-                _STD _Sample_selection_unchecked(_UFirst, _Pop_size, _STD _Get_unwrapped_n(_Dest, _Count), _Count, _RngFunc));
+            _STD _Seek_wrapped(_Dest, _STD _Sample_selection_unchecked(
+                                          _UFirst, _Pop_size, _STD _Get_unwrapped_n(_Dest, _Count), _Count, _RngFunc));
         } else {
             static_assert(_Is_ranges_input_iter_v<_PopIt>, "Source iterators must be at least input iterators");
             // source is input: use reservoir sampling (unstable)
-            _STD _Seek_wrapped(_Dest,
-                _STD _Sample_reservoir_unchecked(_UFirst, _ULast, _STD _Get_unwrapped_unverified(_Dest), _Count, _RngFunc));
+            _STD _Seek_wrapped(_Dest, _STD _Sample_reservoir_unchecked(
+                                          _UFirst, _ULast, _STD _Get_unwrapped_unverified(_Dest), _Count, _RngFunc));
         }
     }
 
@@ -5344,8 +5357,8 @@ namespace ranges {
             _STD _Adl_verify_range(_First, _Last);
 
             _Rng_from_urng<iter_difference_t<_It>, remove_reference_t<_Urng>> _RngFunc(_Func);
-            auto _UResult =
-                _Shuffle_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _RngFunc);
+            auto _UResult = _Shuffle_unchecked(
+                _RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _RngFunc);
 
             _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
@@ -5561,7 +5574,8 @@ namespace ranges {
             if (_Pos_to_shift == 0) {
                 _UResult = _RANGES _Get_final_iterator_unwrapped<_It>(_RANGES _Unwrap_iter<_Se>(_Result), _Last);
             } else {
-                _UResult = _Shift_left_impl(_RANGES _Unwrap_iter<_Se>(_First), _RANGES _Unwrap_sent<_It>(_Last), _Pos_to_shift);
+                _UResult = _Shift_left_impl(
+                    _RANGES _Unwrap_iter<_Se>(_First), _RANGES _Unwrap_sent<_It>(_Last), _Pos_to_shift);
             }
             _STD _Seek_wrapped(_Result, _UResult);
             return {_STD move(_First), _STD move(_Result)};

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1376,12 +1376,12 @@ namespace ranges {
         template <input_iterator _It, weakly_incrementable _Out>
             requires indirectly_copyable<_It, _Out>
         constexpr copy_n_result<_It, _Out> operator()(_It _First, iter_difference_t<_It> _Count, _Out _Result) const {
-            auto _UFirst = _Get_unwrapped_n(_STD move(_First), _Count);
+            auto _UFirst = _STD _Get_unwrapped_n(_STD move(_First), _Count);
             if constexpr (_Iter_copy_cat<decltype(_UFirst), _Out>::_Bitcopy_assignable) {
                 if (!_STD is_constant_evaluated()) {
-                    _Result = _Copy_memmove_n(_UFirst, static_cast<size_t>(_Count), _STD move(_Result));
+                    _Result = _STD _Copy_memmove_n(_UFirst, static_cast<size_t>(_Count), _STD move(_Result));
                     _UFirst += _Count;
-                    _Seek_wrapped(_First, _STD move(_UFirst));
+                    _STD _Seek_wrapped(_First, _STD move(_UFirst));
                     return {_STD move(_First), _STD move(_Result)};
                 }
             }
@@ -1390,7 +1390,7 @@ namespace ranges {
                 *_Result = *_UFirst;
             }
 
-            _Seek_wrapped(_First, _STD move(_UFirst));
+            _STD _Seek_wrapped(_First, _STD move(_UFirst));
             return {_STD move(_First), _STD move(_Result)};
         }
     };
@@ -1405,20 +1405,20 @@ namespace ranges {
         template <bidirectional_iterator _It1, sentinel_for<_It1> _Se1, bidirectional_iterator _It2>
             requires indirectly_copyable<_It1, _It2>
         constexpr copy_backward_result<_It1, _It2> operator()(_It1 _First, _Se1 _Last, _It2 _Result) const {
-            _Adl_verify_range(_First, _Last);
-            auto _UFirst = _Unwrap_iter<_Se1>(_STD move(_First));
-            auto _ULast  = _Get_final_iterator_unwrapped<_It1>(_UFirst, _STD move(_Last));
-            _Seek_wrapped(_First, _ULast);
-            _Result = _Copy_backward_unchecked(_STD move(_UFirst), _STD move(_ULast), _STD move(_Result));
+            _STD _Adl_verify_range(_First, _Last);
+            auto _UFirst = _RANGES _Unwrap_iter<_Se1>(_STD move(_First));
+            auto _ULast  = _RANGES _Get_final_iterator_unwrapped<_It1>(_UFirst, _STD move(_Last));
+            _STD _Seek_wrapped(_First, _ULast);
+            _Result = _STD _Copy_backward_unchecked(_STD move(_UFirst), _STD move(_ULast), _STD move(_Result));
             return {_STD move(_First), _STD move(_Result)};
         }
 
         template <bidirectional_range _Rng, bidirectional_iterator _It>
             requires indirectly_copyable<iterator_t<_Rng>, _It>
         constexpr copy_backward_result<borrowed_iterator_t<_Rng>, _It> operator()(_Rng&& _Range, _It _Result) const {
-            auto _ULast = _Get_final_iterator_unwrapped(_Range);
-            _Result     = _Copy_backward_unchecked(_Ubegin(_Range), _ULast, _STD move(_Result));
-            return {_Rewrap_iterator(_Range, _STD move(_ULast)), _STD move(_Result)};
+            auto _ULast = _RANGES _Get_final_iterator_unwrapped(_Range);
+            _Result     = _STD _Copy_backward_unchecked(_Ubegin(_Range), _ULast, _STD move(_Result));
+            return {_RANGES _Rewrap_iterator(_Range, _STD move(_ULast)), _STD move(_Result)};
         }
     };
 
@@ -1428,10 +1428,10 @@ namespace ranges {
 
 _EXPORT_STD template <class _InIt, class _OutIt, class _Pr>
 _CONSTEXPR20 _OutIt copy_if(_InIt _First, _InIt _Last, _OutIt _Dest, _Pr _Pred) { // copy each satisfying _Pred
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
-    auto _UDest       = _Get_unwrapped_unverified(_Dest);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
+    auto _UDest       = _STD _Get_unwrapped_unverified(_Dest);
     for (; _UFirst != _ULast; ++_UFirst) {
         if (_Pred(*_UFirst)) {
             *_UDest = *_UFirst;
@@ -1439,7 +1439,7 @@ _CONSTEXPR20 _OutIt copy_if(_InIt _First, _InIt _Last, _OutIt _Dest, _Pr _Pred) 
         }
     }
 
-    _Seek_wrapped(_Dest, _UDest);
+    _STD _Seek_wrapped(_Dest, _UDest);
     return _Dest;
 }
 
@@ -1450,7 +1450,7 @@ _FwdIt2 copy_if(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, _Pr _Pred
     // not parallelized at present, parallelism expected to be feasible in a future release
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
-    return _STD copy_if(_First, _Last, _Dest, _Pass_fn(_Pred));
+    return _STD copy_if(_First, _Last, _Dest, _STD _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX17
 
@@ -1466,10 +1466,10 @@ namespace ranges {
             requires indirectly_copyable<_It, _Out>
         constexpr copy_if_result<_It, _Out> operator()(
             _It _First, _Se _Last, _Out _Result, _Pr _Pred, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
-            auto _UResult = _Copy_if_unchecked(_Unwrap_iter<_Se>(_STD move(_First)),
-                _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _Pass_fn(_Pred), _Pass_fn(_Proj));
-            _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Adl_verify_range(_First, _Last);
+            auto _UResult = _Copy_if_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }
 
@@ -1479,9 +1479,9 @@ namespace ranges {
         constexpr copy_if_result<borrowed_iterator_t<_Rng>, _Out> operator()(
             _Rng&& _Range, _Out _Result, _Pr _Pred, _Pj _Proj = {}) const {
             auto _First   = _RANGES begin(_Range);
-            auto _UResult = _Copy_if_unchecked(_Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
-                _STD move(_Result), _Pass_fn(_Pred), _Pass_fn(_Proj));
-            _Seek_wrapped(_First, _STD move(_UResult.in));
+            auto _UResult = _Copy_if_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
+                _STD move(_Result), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }
 
@@ -1516,7 +1516,7 @@ namespace ranges {
         if constexpr (_Iter_move_cat<_It, _Out>::_Bitcopy_assignable) {
             if (!_STD is_constant_evaluated()) {
                 auto _Final = _RANGES next(_First, _STD move(_Last));
-                _Result     = _Copy_memmove(_STD move(_First), _Final, _STD move(_Result));
+                _Result     = _STD _Copy_memmove(_STD move(_First), _Final, _STD move(_Result));
                 return {_STD move(_Final), _STD move(_Result)};
             }
         }
@@ -1533,11 +1533,11 @@ namespace ranges {
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
             requires indirectly_movable<_It, _Out>
         constexpr move_result<_It, _Out> operator()(_It _First, _Se _Last, _Out _Result) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _RANGES _Move_unchecked(
-                _Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result));
+                _RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result));
 
-            _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }
 
@@ -1546,9 +1546,9 @@ namespace ranges {
         constexpr move_result<borrowed_iterator_t<_Rng>, _Out> operator()(_Rng&& _Range, _Out _Result) const {
             auto _First = _RANGES begin(_Range);
             auto _UResult =
-                _RANGES _Move_unchecked(_Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD move(_Result));
+                _RANGES _Move_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD move(_Result));
 
-            _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }
     };
@@ -1564,7 +1564,7 @@ namespace ranges {
     constexpr _It2 _Move_backward_common(const _It1 _First, _It1 _Last, _It2 _Result) {
         if constexpr (_Iter_move_cat<_It1, _It2>::_Bitcopy_assignable) {
             if (!_STD is_constant_evaluated()) {
-                return _Copy_backward_memmove(_First, _Last, _Result);
+                return _STD _Copy_backward_memmove(_First, _Last, _Result);
             }
         }
 
@@ -1580,10 +1580,10 @@ namespace ranges {
         template <bidirectional_iterator _It1, sentinel_for<_It1> _Se1, bidirectional_iterator _It2>
             requires indirectly_movable<_It1, _It2>
         constexpr move_backward_result<_It1, _It2> operator()(_It1 _First, _Se1 _Last, _It2 _Result) const {
-            _Adl_verify_range(_First, _Last);
-            auto _UFirst = _Unwrap_iter<_Se1>(_STD move(_First));
-            auto _ULast  = _Get_final_iterator_unwrapped<_It1>(_UFirst, _STD move(_Last));
-            _Seek_wrapped(_First, _ULast);
+            _STD _Adl_verify_range(_First, _Last);
+            auto _UFirst = _RANGES _Unwrap_iter<_Se1>(_STD move(_First));
+            auto _ULast  = _RANGES _Get_final_iterator_unwrapped<_It1>(_UFirst, _STD move(_Last));
+            _STD _Seek_wrapped(_First, _ULast);
             _Result = _RANGES _Move_backward_common(_STD move(_UFirst), _STD move(_ULast), _STD move(_Result));
             return {_STD move(_First), _STD move(_Result)};
         }
@@ -1591,9 +1591,9 @@ namespace ranges {
         template <bidirectional_range _Rng, bidirectional_iterator _It>
             requires indirectly_movable<iterator_t<_Rng>, _It>
         constexpr move_backward_result<borrowed_iterator_t<_Rng>, _It> operator()(_Rng&& _Range, _It _Result) const {
-            auto _ULast = _Get_final_iterator_unwrapped(_Range);
+            auto _ULast = _RANGES _Get_final_iterator_unwrapped(_Range);
             _Result     = _RANGES _Move_backward_common(_Ubegin(_Range), _ULast, _STD move(_Result));
-            return {_Rewrap_iterator(_Range, _STD move(_ULast)), _STD move(_Result)};
+            return {_RANGES _Rewrap_iterator(_Range, _STD move(_ULast)), _STD move(_Result)};
         }
     };
 
@@ -3315,6 +3315,16 @@ namespace ranges {
 
     _EXPORT_STD inline constexpr _Find_first_of_fn find_first_of;
 
+    template <class _Ty>
+    inline constexpr bool _Is_trivially_ranges_swappable_v =
+        disjunction_v<conjunction<is_scalar<_Ty>, negation<is_enum<_Ty>>>, _Is_trivially_swappable<_Ty>>;
+
+    template <class _Ty, size_t _Len>
+    inline constexpr bool _Is_trivially_ranges_swappable_v<_Ty[_Len]> = _Is_trivially_ranges_swappable_v<_Ty>;
+
+    template <class _Ty>
+    struct _Is_trivially_ranges_swappable : bool_constant<_Is_trivially_ranges_swappable_v<_Ty>> {};
+
     _EXPORT_STD template <class _In1, class _In2>
     using swap_ranges_result = in_in_result<_In1, _In2>;
 
@@ -3324,15 +3334,15 @@ namespace ranges {
             requires indirectly_swappable<_It1, _It2>
         constexpr swap_ranges_result<_It1, _It2> operator()(
             _It1 _First1, _Se1 _Last1, _It2 _First2, _Se2 _Last2) const {
-            _Adl_verify_range(_First1, _Last1);
-            _Adl_verify_range(_First2, _Last2);
+            _STD _Adl_verify_range(_First1, _Last1);
+            _STD _Adl_verify_range(_First2, _Last2);
 
             auto _UResult =
-                _Swap_ranges_unchecked(_Unwrap_iter<_Se1>(_STD move(_First1)), _Unwrap_sent<_It1>(_STD move(_Last1)),
-                    _Unwrap_iter<_Se2>(_STD move(_First2)), _Unwrap_sent<_It2>(_STD move(_Last2)));
+                _Swap_ranges_unchecked(_RANGES _Unwrap_iter<_Se1>(_STD move(_First1)), _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)),
+                    _RANGES _Unwrap_iter<_Se2>(_STD move(_First2)), _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)));
 
-            _Seek_wrapped(_First1, _STD move(_UResult.in1));
-            _Seek_wrapped(_First2, _STD move(_UResult.in2));
+            _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
+            _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
             return {_STD move(_First1), _STD move(_First2)};
         }
 
@@ -3343,11 +3353,11 @@ namespace ranges {
             auto _First1 = _RANGES begin(_Range1);
             auto _First2 = _RANGES begin(_Range2);
 
-            auto _UResult = _Swap_ranges_unchecked(_Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1),
-                _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2));
+            auto _UResult = _Swap_ranges_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1),
+                _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2));
 
-            _Seek_wrapped(_First1, _STD move(_UResult.in1));
-            _Seek_wrapped(_First2, _STD move(_UResult.in2));
+            _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
+            _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
             return {_STD move(_First1), _STD move(_First2)};
         }
 
@@ -3364,7 +3374,7 @@ namespace ranges {
 #if _USE_STD_VECTOR_ALGORITHMS
             using _Elem1 = remove_reference_t<iter_reference_t<_It1>>;
             using _Elem2 = remove_reference_t<iter_reference_t<_It2>>;
-            if constexpr (same_as<_Elem1, _Elem2> && _Is_trivially_swappable_v<_Elem1> //
+            if constexpr (same_as<_Elem1, _Elem2> && _Is_trivially_ranges_swappable_v<_Elem1> //
                           && contiguous_iterator<_It1> && _Sized_or_unreachable_sentinel_for<_Se1, _It1> //
                           && contiguous_iterator<_It2> && _Sized_or_unreachable_sentinel_for<_Se2, _It2>) {
                 if (!_STD is_constant_evaluated()) {
@@ -3376,17 +3386,17 @@ namespace ranges {
                         const size_t _Count =
                             (_STD min)(static_cast<size_t>(_Last1 - _First1), static_cast<size_t>(_Last2 - _First2));
                         const auto _Last1_addr = _First1_addr + _Count;
-                        __std_swap_ranges_trivially_swappable_noalias(_First1_addr, _Last1_addr, _First2_addr);
+                        ::__std_swap_ranges_trivially_swappable_noalias(_First1_addr, _Last1_addr, _First2_addr);
                         return {_First1 + _Count, _First2 + _Count};
                     } else if constexpr (_Is_sized1) {
                         const auto _Final1     = _RANGES next(_First1, _Last1);
                         const auto _Last1_addr = _STD to_address(_Final1);
-                        __std_swap_ranges_trivially_swappable_noalias(_First1_addr, _Last1_addr, _First2_addr);
+                        ::__std_swap_ranges_trivially_swappable_noalias(_First1_addr, _Last1_addr, _First2_addr);
                         return {_Final1, _First2 + (_Last1 - _First1)};
                     } else if constexpr (_Is_sized2) {
                         const auto _Final2     = _RANGES next(_First2, _Last2);
                         const auto _Last2_addr = _STD to_address(_Final2);
-                        __std_swap_ranges_trivially_swappable_noalias(_First2_addr, _Last2_addr, _First1_addr);
+                        ::__std_swap_ranges_trivially_swappable_noalias(_First2_addr, _Last2_addr, _First1_addr);
                         return {_First1 + (_Last2 - _First2), _Final2};
                     } else {
                         _STL_ASSERT(false, "Tried to swap_ranges with two unreachable sentinels");
@@ -3410,12 +3420,12 @@ namespace ranges {
 _EXPORT_STD template <class _FwdIt1, class _FwdIt2>
 _CONSTEXPR20 _FwdIt2 swap_ranges(const _FwdIt1 _First1, const _FwdIt1 _Last1, _FwdIt2 _First2) {
     // swap [_First1, _Last1) with [_First2, ...)
-    _Adl_verify_range(_First1, _Last1);
-    const auto _UFirst1 = _Get_unwrapped(_First1);
-    const auto _ULast1  = _Get_unwrapped(_Last1);
-    const auto _UFirst2 = _Get_unwrapped_n(_First2, _Idl_distance<_FwdIt1>(_UFirst1, _ULast1));
-    _Verify_ranges_do_not_overlap(_UFirst1, _ULast1, _UFirst2);
-    _Seek_wrapped(_First2, _Swap_ranges_unchecked(_UFirst1, _ULast1, _UFirst2));
+    _STD _Adl_verify_range(_First1, _Last1);
+    const auto _UFirst1 = _STD _Get_unwrapped(_First1);
+    const auto _ULast1  = _STD _Get_unwrapped(_Last1);
+    const auto _UFirst2 = _STD _Get_unwrapped_n(_First2, _STD _Idl_distance<_FwdIt1>(_UFirst1, _ULast1));
+    _STD _Verify_ranges_do_not_overlap(_UFirst1, _ULast1, _UFirst2);
+    _STD _Seek_wrapped(_First2, _STD _Swap_ranges_unchecked(_UFirst1, _ULast1, _UFirst2));
     return _First2;
 }
 
@@ -3438,15 +3448,15 @@ _CONSTEXPR20 void iter_swap(_FwdIt1 _Left, _FwdIt2 _Right) { // swap *_Left and 
 _EXPORT_STD template <class _InIt, class _OutIt, class _Fn>
 _CONSTEXPR20 _OutIt transform(const _InIt _First, const _InIt _Last, _OutIt _Dest, _Fn _Func) {
     // transform [_First, _Last) with _Func
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
-    auto _UDest       = _Get_unwrapped_n(_Dest, _Idl_distance<_InIt>(_UFirst, _ULast));
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
+    auto _UDest       = _STD _Get_unwrapped_n(_Dest, _STD _Idl_distance<_InIt>(_UFirst, _ULast));
     for (; _UFirst != _ULast; ++_UFirst, (void) ++_UDest) {
         *_UDest = _Func(*_UFirst);
     }
 
-    _Seek_wrapped(_Dest, _UDest);
+    _STD _Seek_wrapped(_Dest, _UDest);
     return _Dest;
 }
 
@@ -3459,17 +3469,17 @@ _EXPORT_STD template <class _InIt1, class _InIt2, class _OutIt, class _Fn>
 _CONSTEXPR20 _OutIt transform(
     const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _First2, _OutIt _Dest, _Fn _Func) {
     // transform [_First1, _Last1) and [_First2, ...) with _Func
-    _Adl_verify_range(_First1, _Last1);
-    auto _UFirst1      = _Get_unwrapped(_First1);
-    const auto _ULast1 = _Get_unwrapped(_Last1);
-    const auto _Count  = _Idl_distance<_InIt1>(_UFirst1, _ULast1);
-    auto _UFirst2      = _Get_unwrapped_n(_First2, _Count);
-    auto _UDest        = _Get_unwrapped_n(_Dest, _Count);
+    _STD _Adl_verify_range(_First1, _Last1);
+    auto _UFirst1      = _STD _Get_unwrapped(_First1);
+    const auto _ULast1 = _STD _Get_unwrapped(_Last1);
+    const auto _Count  = _STD _Idl_distance<_InIt1>(_UFirst1, _ULast1);
+    auto _UFirst2      = _STD _Get_unwrapped_n(_First2, _Count);
+    auto _UDest        = _STD _Get_unwrapped_n(_Dest, _Count);
     for (; _UFirst1 != _ULast1; ++_UFirst1, (void) ++_UFirst2, ++_UDest) {
         *_UDest = _Func(*_UFirst1, *_UFirst2);
     }
 
-    _Seek_wrapped(_Dest, _UDest);
+    _STD _Seek_wrapped(_Dest, _UDest);
     return _Dest;
 }
 
@@ -3495,11 +3505,11 @@ namespace ranges {
             requires indirectly_writable<_Out, indirect_result_t<_Fn&, projected<_It, _Pj>>>
         constexpr unary_transform_result<_It, _Out> operator()(
             _It _First, _Se _Last, _Out _Result, _Fn _Func, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
-            auto _UResult = _Transform_unary_unchecked(_Unwrap_iter<_Se>(_STD move(_First)),
-                _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _Pass_fn(_Func), _Pass_fn(_Proj));
+            _STD _Adl_verify_range(_First, _Last);
+            auto _UResult = _Transform_unary_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }
 
@@ -3508,10 +3518,10 @@ namespace ranges {
         constexpr unary_transform_result<borrowed_iterator_t<_Rng>, _Out> operator()(
             _Rng&& _Range, _Out _Result, _Fn _Func, _Pj _Proj = {}) const {
             auto _First   = _RANGES begin(_Range);
-            auto _UResult = _Transform_unary_unchecked(_Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
-                _STD move(_Result), _Pass_fn(_Func), _Pass_fn(_Proj));
+            auto _UResult = _Transform_unary_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
+                _STD move(_Result), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }
 
@@ -3520,15 +3530,15 @@ namespace ranges {
             requires indirectly_writable<_Out, indirect_result_t<_Fn&, projected<_It1, _Pj1>, projected<_It2, _Pj2>>>
         constexpr binary_transform_result<_It1, _It2, _Out> operator()(_It1 _First1, _Se1 _Last1, _It2 _First2,
             _Se2 _Last2, _Out _Result, _Fn _Func, _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
-            _Adl_verify_range(_First1, _Last1);
-            _Adl_verify_range(_First2, _Last2);
-            auto _UResult = _Transform_binary_unchecked(_Unwrap_iter<_Se1>(_STD move(_First1)),
-                _Unwrap_sent<_It1>(_STD move(_Last1)), _Unwrap_iter<_Se2>(_STD move(_First2)),
-                _Unwrap_sent<_It2>(_STD move(_Last2)), _STD move(_Result), _Pass_fn(_Func), _Pass_fn(_Proj1),
-                _Pass_fn(_Proj2));
+            _STD _Adl_verify_range(_First1, _Last1);
+            _STD _Adl_verify_range(_First2, _Last2);
+            auto _UResult = _Transform_binary_unchecked(_RANGES _Unwrap_iter<_Se1>(_STD move(_First1)),
+                _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)), _RANGES _Unwrap_iter<_Se2>(_STD move(_First2)),
+                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD move(_Result), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj1),
+                _STD _Pass_fn(_Proj2));
 
-            _Seek_wrapped(_First1, _STD move(_UResult.in1));
-            _Seek_wrapped(_First2, _STD move(_UResult.in2));
+            _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
+            _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
             return {_STD move(_First1), _STD move(_First2), _STD move(_UResult.out)};
         }
 
@@ -3540,12 +3550,12 @@ namespace ranges {
             _Rng1&& _Range1, _Rng2&& _Range2, _Out _Result, _Fn _Func, _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
             auto _First1  = _RANGES begin(_Range1);
             auto _First2  = _RANGES begin(_Range2);
-            auto _UResult = _Transform_binary_unchecked(_Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1),
-                _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2), _STD move(_Result), _Pass_fn(_Func),
-                _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+            auto _UResult = _Transform_binary_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1),
+                _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2), _STD move(_Result), _STD _Pass_fn(_Func),
+                _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
 
-            _Seek_wrapped(_First1, _STD move(_UResult.in1));
-            _Seek_wrapped(_First2, _STD move(_UResult.in2));
+            _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
+            _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
             return {_STD move(_First1), _STD move(_First2), _STD move(_UResult.out)};
         }
 
@@ -3590,9 +3600,9 @@ namespace ranges {
 _EXPORT_STD template <class _FwdIt, class _Ty>
 _CONSTEXPR20 void replace(const _FwdIt _First, const _FwdIt _Last, const _Ty& _Oldval, const _Ty& _Newval) {
     // replace each matching _Oldval with _Newval
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     for (; _UFirst != _ULast; ++_UFirst) {
         if (*_UFirst == _Oldval) {
             *_UFirst = _Newval;
@@ -3615,11 +3625,11 @@ namespace ranges {
                   && indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty1*>
         constexpr _It operator()(
             _It _First, _Se _Last, const _Ty1& _Oldval, const _Ty2& _Newval, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
-            auto _UResult = _Replace_unchecked(_Unwrap_iter<_Se>(_STD move(_First)),
-                _Unwrap_sent<_It>(_STD move(_Last)), _Oldval, _Newval, _Pass_fn(_Proj));
+            _STD _Adl_verify_range(_First, _Last);
+            auto _UResult = _Replace_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _Oldval, _Newval, _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult));
+            _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
         }
 
@@ -3630,9 +3640,9 @@ namespace ranges {
             _Rng&& _Range, const _Ty1& _Oldval, const _Ty2& _Newval, _Pj _Proj = {}) const {
             auto _First   = _RANGES begin(_Range);
             auto _UResult = _Replace_unchecked(
-                _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _Oldval, _Newval, _Pass_fn(_Proj));
+                _RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _Oldval, _Newval, _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult));
+            _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
         }
 
@@ -3663,9 +3673,9 @@ namespace ranges {
 _EXPORT_STD template <class _FwdIt, class _Pr, class _Ty>
 _CONSTEXPR20 void replace_if(const _FwdIt _First, const _FwdIt _Last, _Pr _Pred, const _Ty& _Val) {
     // replace each satisfying _Pred with _Val
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     for (; _UFirst != _ULast; ++_UFirst) {
         if (_Pred(*_UFirst)) {
             *_UFirst = _Val;
@@ -3686,11 +3696,11 @@ namespace ranges {
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
             requires indirectly_writable<_It, const _Ty&>
         constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred, const _Ty& _Newval, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
-            auto _UResult = _Replace_if_unchecked(_Unwrap_iter<_Se>(_STD move(_First)),
-                _Unwrap_sent<_It>(_STD move(_Last)), _Pass_fn(_Pred), _Newval, _Pass_fn(_Proj));
+            _STD _Adl_verify_range(_First, _Last);
+            auto _UResult = _Replace_if_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Pass_fn(_Pred), _Newval, _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult));
+            _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
         }
 
@@ -3701,9 +3711,9 @@ namespace ranges {
             _Rng&& _Range, _Pr _Pred, const _Ty& _Newval, _Pj _Proj = {}) const {
             auto _First   = _RANGES begin(_Range);
             auto _UResult = _Replace_if_unchecked(
-                _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _Pass_fn(_Pred), _Newval, _Pass_fn(_Proj));
+                _RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD _Pass_fn(_Pred), _Newval, _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult));
+            _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
         }
 
@@ -3734,10 +3744,10 @@ namespace ranges {
 _EXPORT_STD template <class _InIt, class _OutIt, class _Ty>
 _CONSTEXPR20 _OutIt replace_copy(_InIt _First, _InIt _Last, _OutIt _Dest, const _Ty& _Oldval, const _Ty& _Newval) {
     // copy replacing each matching _Oldval with _Newval
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
-    auto _UDest       = _Get_unwrapped_n(_Dest, _Idl_distance<_InIt>(_UFirst, _ULast));
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
+    auto _UDest       = _STD _Get_unwrapped_n(_Dest, _STD _Idl_distance<_InIt>(_UFirst, _ULast));
     for (; _UFirst != _ULast; ++_UFirst, (void) ++_UDest) {
         if (*_UFirst == _Oldval) {
             *_UDest = _Newval;
@@ -3746,7 +3756,7 @@ _CONSTEXPR20 _OutIt replace_copy(_InIt _First, _InIt _Last, _OutIt _Dest, const 
         }
     }
 
-    _Seek_wrapped(_Dest, _UDest);
+    _STD _Seek_wrapped(_Dest, _UDest);
     return _Dest;
 }
 
@@ -3775,11 +3785,11 @@ namespace ranges {
                   && indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty1*>
         constexpr replace_copy_result<_It, _Out> operator()(
             _It _First, _Se _Last, _Out _Result, const _Ty1& _Oldval, const _Ty2& _Newval, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
-            auto _UResult = _Replace_copy_unchecked(_Unwrap_iter<_Se>(_STD move(_First)),
-                _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _Oldval, _Newval, _Pass_fn(_Proj));
+            _STD _Adl_verify_range(_First, _Last);
+            auto _UResult = _Replace_copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _Oldval, _Newval, _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }
 
@@ -3789,10 +3799,10 @@ namespace ranges {
         constexpr replace_copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(
             _Rng&& _Range, _Out _Result, const _Ty1& _Oldval, const _Ty2& _Newval, _Pj _Proj = {}) const {
             auto _First   = _RANGES begin(_Range);
-            auto _UResult = _Replace_copy_unchecked(_Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
-                _STD move(_Result), _Oldval, _Newval, _Pass_fn(_Proj));
+            auto _UResult = _Replace_copy_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
+                _STD move(_Result), _Oldval, _Newval, _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }
 
@@ -3826,10 +3836,10 @@ namespace ranges {
 _EXPORT_STD template <class _InIt, class _OutIt, class _Pr, class _Ty>
 _CONSTEXPR20 _OutIt replace_copy_if(_InIt _First, _InIt _Last, _OutIt _Dest, _Pr _Pred, const _Ty& _Val) {
     // copy replacing each satisfying _Pred with _Val
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
-    auto _UDest       = _Get_unwrapped_n(_Dest, _Idl_distance<_InIt>(_UFirst, _ULast));
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
+    auto _UDest       = _STD _Get_unwrapped_n(_Dest, _STD _Idl_distance<_InIt>(_UFirst, _ULast));
     for (; _UFirst != _ULast; ++_UFirst, (void) ++_UDest) {
         if (_Pred(*_UFirst)) {
             *_UDest = _Val;
@@ -3838,7 +3848,7 @@ _CONSTEXPR20 _OutIt replace_copy_if(_InIt _First, _InIt _Last, _OutIt _Dest, _Pr
         }
     }
 
-    _Seek_wrapped(_Dest, _UDest);
+    _STD _Seek_wrapped(_Dest, _UDest);
     return _Dest;
 }
 
@@ -3851,7 +3861,7 @@ _FwdIt2 replace_copy_if(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, _
     // not parallelized at present, parallelism expected to be feasible in a future release
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
-    return _STD replace_copy_if(_First, _Last, _Dest, _Pass_fn(_Pred), _Val);
+    return _STD replace_copy_if(_First, _Last, _Dest, _STD _Pass_fn(_Pred), _Val);
 }
 #endif // _HAS_CXX17
 
@@ -3867,11 +3877,11 @@ namespace ranges {
             requires indirectly_copyable<_It, _Out>
         constexpr replace_copy_if_result<_It, _Out> operator()(
             _It _First, _Se _Last, _Out _Result, _Pr _Pred, const _Ty& _Newval, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
-            auto _UResult = _Replace_copy_if_unchecked(_Unwrap_iter<_Se>(_STD move(_First)),
-                _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _Pass_fn(_Pred), _Newval, _Pass_fn(_Proj));
+            _STD _Adl_verify_range(_First, _Last);
+            auto _UResult = _Replace_copy_if_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _STD _Pass_fn(_Pred), _Newval, _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }
 
@@ -3881,10 +3891,10 @@ namespace ranges {
         constexpr replace_copy_if_result<borrowed_iterator_t<_Rng>, _Out> operator()(
             _Rng&& _Range, _Out _Result, _Pr _Pred, const _Ty& _Newval, _Pj _Proj = {}) const {
             auto _First   = _RANGES begin(_Range);
-            auto _UResult = _Replace_copy_if_unchecked(_Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
-                _STD move(_Result), _Pass_fn(_Pred), _Newval, _Pass_fn(_Proj));
+            auto _UResult = _Replace_copy_if_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
+                _STD move(_Result), _STD _Pass_fn(_Pred), _Newval, _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }
 
@@ -3917,21 +3927,21 @@ namespace ranges {
     public:
         template <class _Ty, output_iterator<const _Ty&> _It, sentinel_for<_It> _Se>
         constexpr _It operator()(_It _First, _Se _Last, const _Ty& _Value) const {
-            _Adl_verify_range(_First, _Last);
-            auto _UFirst      = _Unwrap_iter<_Se>(_STD move(_First));
-            const auto _ULast = _Unwrap_sent<_It>(_STD move(_Last));
+            _STD _Adl_verify_range(_First, _Last);
+            auto _UFirst      = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
+            const auto _ULast = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
             if (!_STD is_constant_evaluated()) {
                 if constexpr (sized_sentinel_for<decltype(_ULast), decltype(_UFirst)>) {
                     if constexpr (_Fill_memset_is_safe<decltype(_UFirst), _Ty>) {
                         const auto _Distance = static_cast<size_t>(_ULast - _UFirst);
-                        _Fill_memset(_UFirst, _Value, _Distance);
-                        _Seek_wrapped(_First, _UFirst + _Distance);
+                        _STD _Fill_memset(_UFirst, _Value, _Distance);
+                        _STD _Seek_wrapped(_First, _UFirst + _Distance);
                         return _First;
                     } else if constexpr (_Fill_zero_memset_is_safe<decltype(_UFirst), _Ty>) {
-                        if (_Is_all_bits_zero(_Value)) {
+                        if (_STD _Is_all_bits_zero(_Value)) {
                             const auto _Distance = static_cast<size_t>(_ULast - _UFirst);
-                            _Fill_zero_memset(_UFirst, _Distance);
-                            _Seek_wrapped(_First, _UFirst + _Distance);
+                            _STD _Fill_zero_memset(_UFirst, _Distance);
+                            _STD _Seek_wrapped(_First, _UFirst + _Distance);
                             return _First;
                         }
                     }
@@ -3942,14 +3952,14 @@ namespace ranges {
                 *_UFirst = _Value;
             }
 
-            _Seek_wrapped(_First, _STD move(_UFirst));
+            _STD _Seek_wrapped(_First, _STD move(_UFirst));
             return _First;
         }
 
         template <class _Ty, output_range<const _Ty&> _Rng>
         constexpr borrowed_iterator_t<_Rng> operator()(_Rng&& _Range, const _Ty& _Value) const {
             auto _First = _RANGES begin(_Range);
-            _Seek_wrapped(_First, (*this)(_Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _Value));
+            _STD _Seek_wrapped(_First, (*this)(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _Value));
             return _First;
         }
     };
@@ -3961,9 +3971,9 @@ namespace ranges {
         template <input_or_output_iterator _Out, sentinel_for<_Out> _Se, copy_constructible _Fn>
             requires invocable<_Fn&> && indirectly_writable<_Out, invoke_result_t<_Fn&>>
         constexpr _Out operator()(_Out _First, _Se _Last, _Fn _Gen) const {
-            _Adl_verify_range(_First, _Last);
-            _Seek_wrapped(_First, _Generate_unchecked(_Unwrap_iter<_Se>(_STD move(_First)),
-                                      _Unwrap_sent<_Out>(_STD move(_Last)), _Pass_fn(_Gen)));
+            _STD _Adl_verify_range(_First, _Last);
+            _STD _Seek_wrapped(_First, _Generate_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                                      _RANGES _Unwrap_sent<_Out>(_STD move(_Last)), _STD _Pass_fn(_Gen)));
             return _First;
         }
 
@@ -3971,8 +3981,8 @@ namespace ranges {
             requires invocable<_Fn&> && output_range<_Rng, invoke_result_t<_Fn&>>
         constexpr borrowed_iterator_t<_Rng> operator()(_Rng&& _Range, _Fn _Gen) const {
             auto _First = _RANGES begin(_Range);
-            _Seek_wrapped(_First,
-                _Generate_unchecked(_Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _Pass_fn(_Gen)));
+            _STD _Seek_wrapped(_First,
+                _Generate_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD _Pass_fn(_Gen)));
             return _First;
         }
 
@@ -4001,13 +4011,13 @@ namespace ranges {
             requires invocable<_Fn&> && indirectly_writable<_Out, invoke_result_t<_Fn&>>
         constexpr _Out operator()(_Out _First, iter_difference_t<_Out> _Count, _Fn _Gen) const {
             if (_Count > 0) {
-                auto _UFirst = _Get_unwrapped_n(_STD move(_First), _Count);
+                auto _UFirst = _STD _Get_unwrapped_n(_STD move(_First), _Count);
                 do {
                     *_UFirst = _Gen();
                     ++_UFirst;
                 } while (--_Count > 0);
 
-                _Seek_wrapped(_First, _STD move(_UFirst));
+                _STD _Seek_wrapped(_First, _STD move(_UFirst));
             }
 
             return _First;
@@ -4020,9 +4030,9 @@ namespace ranges {
 
 _EXPORT_STD template <class _FwdIt, class _Fn>
 _CONSTEXPR20 void generate(_FwdIt _First, _FwdIt _Last, _Fn _Func) { // replace [_First, _Last) with _Func()
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     for (; _UFirst != _ULast; ++_UFirst) {
         *_UFirst = _Func();
     }
@@ -4034,7 +4044,7 @@ void generate(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Fn _Func) noexcept /* termi
     // replace [_First, _Last) with _Func()
     // not parallelized at present due to unclear parallelism requirements on _Func
     _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
-    return _STD generate(_First, _Last, _Pass_fn(_Func));
+    return _STD generate(_First, _Last, _STD _Pass_fn(_Func));
 }
 #endif // _HAS_CXX17
 
@@ -4043,14 +4053,14 @@ _CONSTEXPR20 _OutIt generate_n(_OutIt _Dest, const _Diff _Count_raw, _Fn _Func) 
     // replace [_Dest, _Dest + _Count) with _Func()
     _Algorithm_int_t<_Diff> _Count = _Count_raw;
     if (0 < _Count) {
-        auto _UDest = _Get_unwrapped_n(_Dest, _Count);
+        auto _UDest = _STD _Get_unwrapped_n(_Dest, _Count);
         do {
             *_UDest = _Func();
             --_Count;
             ++_UDest;
         } while (0 < _Count);
 
-        _Seek_wrapped(_Dest, _UDest);
+        _STD _Seek_wrapped(_Dest, _UDest);
     }
 
     return _Dest;
@@ -4062,17 +4072,17 @@ _FwdIt generate_n(_ExPo&&, const _FwdIt _Dest, const _Diff _Count_raw, _Fn _Func
     // replace [_Dest, _Dest + _Count) with _Func()
     // not parallelized at present due to unclear parallelism requirements on _Func
     _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
-    return _STD generate_n(_Dest, _Count_raw, _Pass_fn(_Func));
+    return _STD generate_n(_Dest, _Count_raw, _STD _Pass_fn(_Func));
 }
 #endif // _HAS_CXX17
 
 _EXPORT_STD template <class _InIt, class _OutIt, class _Ty>
 _CONSTEXPR20 _OutIt remove_copy(_InIt _First, _InIt _Last, _OutIt _Dest, const _Ty& _Val) {
     // copy omitting each matching _Val
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
-    auto _UDest       = _Get_unwrapped_unverified(_Dest);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
+    auto _UDest       = _STD _Get_unwrapped_unverified(_Dest);
     for (; _UFirst != _ULast; ++_UFirst) {
         if (!(*_UFirst == _Val)) {
             *_UDest = *_UFirst;
@@ -4080,7 +4090,7 @@ _CONSTEXPR20 _OutIt remove_copy(_InIt _First, _InIt _Last, _OutIt _Dest, const _
         }
     }
 
-    _Seek_wrapped(_Dest, _UDest);
+    _STD _Seek_wrapped(_Dest, _UDest);
     return _Dest;
 }
 
@@ -4098,10 +4108,10 @@ _FwdIt2 remove_copy(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, const
 _EXPORT_STD template <class _InIt, class _OutIt, class _Pr>
 _CONSTEXPR20 _OutIt remove_copy_if(_InIt _First, _InIt _Last, _OutIt _Dest, _Pr _Pred) {
     // copy omitting each element satisfying _Pred
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
-    auto _UDest       = _Get_unwrapped_unverified(_Dest);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
+    auto _UDest       = _STD _Get_unwrapped_unverified(_Dest);
     for (; _UFirst != _ULast; ++_UFirst) {
         if (!_Pred(*_UFirst)) {
             *_UDest = *_UFirst;
@@ -4109,7 +4119,7 @@ _CONSTEXPR20 _OutIt remove_copy_if(_InIt _First, _InIt _Last, _OutIt _Dest, _Pr 
         }
     }
 
-    _Seek_wrapped(_Dest, _UDest);
+    _STD _Seek_wrapped(_Dest, _UDest);
     return _Dest;
 }
 
@@ -4120,7 +4130,7 @@ _FwdIt2 remove_copy_if(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, _P
     // not parallelized at present, parallelism expected to be feasible in a future release
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
-    return _STD remove_copy_if(_First, _Last, _Dest, _Pass_fn(_Pred));
+    return _STD remove_copy_if(_First, _Last, _Dest, _STD _Pass_fn(_Pred));
 }
 
 _EXPORT_STD template <class _ExPo, class _FwdIt, class _Ty, _Enable_if_execution_policy_t<_ExPo> = 0>
@@ -4138,11 +4148,11 @@ namespace ranges {
             requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
         _NODISCARD_REMOVE_ALG constexpr subrange<_It> operator()(
             _It _First, _Se _Last, const _Ty& _Val, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _Remove_unchecked(
-                _Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)), _Val, _Pass_fn(_Proj));
+                _RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _Val, _STD _Pass_fn(_Proj));
 
-            return _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
+            return _RANGES _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
         }
 
         template <forward_range _Rng, class _Ty, class _Pj = identity>
@@ -4150,9 +4160,9 @@ namespace ranges {
                   && indirect_binary_predicate<ranges::equal_to, projected<iterator_t<_Rng>, _Pj>, const _Ty*>
         _NODISCARD_REMOVE_ALG constexpr borrowed_subrange_t<_Rng> operator()(
             _Rng&& _Range, const _Ty& _Val, _Pj _Proj = {}) const {
-            auto _UResult = _Remove_unchecked(_Ubegin(_Range), _Uend(_Range), _Val, _Pass_fn(_Proj));
+            auto _UResult = _Remove_unchecked(_Ubegin(_Range), _Uend(_Range), _Val, _STD _Pass_fn(_Proj));
 
-            return _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Range, _STD move(_UResult));
+            return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Range, _STD move(_UResult));
         }
 
     private:
@@ -4189,11 +4199,11 @@ namespace ranges {
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD_REMOVE_ALG constexpr subrange<_It> operator()(
             _It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
-            auto _UResult = _Remove_if_unchecked(_Unwrap_iter<_Se>(_STD move(_First)),
-                _Unwrap_sent<_It>(_STD move(_Last)), _Pass_fn(_Pred), _Pass_fn(_Proj));
+            _STD _Adl_verify_range(_First, _Last);
+            auto _UResult = _Remove_if_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
-            return _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
+            return _RANGES _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
         }
 
         template <forward_range _Rng, class _Pj = identity,
@@ -4201,9 +4211,9 @@ namespace ranges {
             requires permutable<iterator_t<_Rng>>
         _NODISCARD_REMOVE_ALG constexpr borrowed_subrange_t<_Rng> operator()(
             _Rng&& _Range, _Pr _Pred, _Pj _Proj = {}) const {
-            auto _UResult = _Remove_if_unchecked(_Ubegin(_Range), _Uend(_Range), _Pass_fn(_Pred), _Pass_fn(_Proj));
+            auto _UResult = _Remove_if_unchecked(_Ubegin(_Range), _Uend(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
-            return _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Range, _STD move(_UResult));
+            return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Range, _STD move(_UResult));
         }
 
     private:
@@ -4244,13 +4254,13 @@ namespace ranges {
                   && indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
         constexpr remove_copy_result<_It, _Out> operator()(
             _It _First, _Se _Last, _Out _Result, const _Ty& _Val, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
             auto _UResult =
-                _Remove_copy_unchecked(_Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)),
-                    _Get_unwrapped_unverified(_STD move(_Result)), _Val, _Pass_fn(_Proj));
+                _Remove_copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)),
+                    _STD _Get_unwrapped_unverified(_STD move(_Result)), _Val, _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult.in));
-            _Seek_wrapped(_Result, _STD move(_UResult.out));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
             return {_STD move(_First), _STD move(_Result)};
         }
 
@@ -4260,11 +4270,11 @@ namespace ranges {
         constexpr remove_copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(
             _Rng&& _Range, _Out _Result, const _Ty& _Val, _Pj _Proj = {}) const {
             auto _First   = _RANGES begin(_Range);
-            auto _UResult = _Remove_copy_unchecked(_Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
-                _Get_unwrapped_unverified(_STD move(_Result)), _Val, _Pass_fn(_Proj));
+            auto _UResult = _Remove_copy_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
+                _STD _Get_unwrapped_unverified(_STD move(_Result)), _Val, _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult.in));
-            _Seek_wrapped(_Result, _STD move(_UResult.out));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
             return {_STD move(_First), _STD move(_Result)};
         }
 
@@ -4302,13 +4312,13 @@ namespace ranges {
             requires indirectly_copyable<_It, _Out>
         constexpr remove_copy_if_result<_It, _Out> operator()(
             _It _First, _Se _Last, _Out _Result, _Pr _Pred, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
             auto _UResult =
-                _Remove_copy_if_unchecked(_Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)),
-                    _Get_unwrapped_unverified(_STD move(_Result)), _Pass_fn(_Pred), _Pass_fn(_Proj));
+                _Remove_copy_if_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)),
+                    _STD _Get_unwrapped_unverified(_STD move(_Result)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult.in));
-            _Seek_wrapped(_Result, _STD move(_UResult.out));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
             return {_STD move(_First), _STD move(_Result)};
         }
 
@@ -4318,11 +4328,11 @@ namespace ranges {
         constexpr remove_copy_if_result<borrowed_iterator_t<_Rng>, _Out> operator()(
             _Rng&& _Range, _Out _Result, _Pr _Pred, _Pj _Proj = {}) const {
             auto _First   = _RANGES begin(_Range);
-            auto _UResult = _Remove_copy_if_unchecked(_Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
-                _Get_unwrapped_unverified(_STD move(_Result)), _Pass_fn(_Pred), _Pass_fn(_Proj));
+            auto _UResult = _Remove_copy_if_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
+                _STD _Get_unwrapped_unverified(_STD move(_Result)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult.in));
-            _Seek_wrapped(_Result, _STD move(_UResult.out));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
             return {_STD move(_First), _STD move(_Result)};
         }
 
@@ -4355,9 +4365,9 @@ namespace ranges {
 _EXPORT_STD template <class _FwdIt, class _Pr>
 _NODISCARD_UNIQUE_ALG _CONSTEXPR20 _FwdIt unique(_FwdIt _First, _FwdIt _Last, _Pr _Pred) {
     // remove each satisfying _Pred with previous
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     if (_UFirst != _ULast) {
         for (auto _UFirstb = _UFirst; ++_UFirst != _ULast; _UFirstb = _UFirst) {
             if (_Pred(*_UFirstb, *_UFirst)) { // copy down
@@ -4367,13 +4377,13 @@ _NODISCARD_UNIQUE_ALG _CONSTEXPR20 _FwdIt unique(_FwdIt _First, _FwdIt _Last, _P
                     }
                 }
 
-                _Seek_wrapped(_Last, ++_UFirstb);
+                _STD _Seek_wrapped(_Last, ++_UFirstb);
                 return _Last;
             }
         }
     }
 
-    _Seek_wrapped(_Last, _ULast);
+    _STD _Seek_wrapped(_Last, _ULast);
     return _Last;
 }
 
@@ -4388,7 +4398,7 @@ _NODISCARD_UNIQUE_ALG _FwdIt unique(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _P
     // remove each satisfying _Pred with previous
     // not parallelized at present, parallelism expected to be feasible in a future release
     _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
-    return _STD unique(_First, _Last, _Pass_fn(_Pred));
+    return _STD unique(_First, _Last, _STD _Pass_fn(_Pred));
 }
 
 _EXPORT_STD template <class _ExPo, class _FwdIt, _Enable_if_execution_policy_t<_ExPo> = 0>
@@ -4408,11 +4418,11 @@ namespace ranges {
             indirect_equivalence_relation<projected<_It, _Pj>> _Pr = ranges::equal_to>
         _NODISCARD_UNIQUE_ALG constexpr subrange<_It> operator()(
             _It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
-            auto _UResult = _Unique_unchecked(_Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)),
-                _Pass_fn(_Pred), _Pass_fn(_Proj));
+            _STD _Adl_verify_range(_First, _Last);
+            auto _UResult = _Unique_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)),
+                _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
-            return _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
+            return _RANGES _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
         }
 
         template <forward_range _Rng, class _Pj = identity,
@@ -4420,9 +4430,9 @@ namespace ranges {
             requires permutable<iterator_t<_Rng>>
         _NODISCARD_UNIQUE_ALG constexpr borrowed_subrange_t<_Rng> operator()(
             _Rng&& _Range, _Pr _Pred = {}, _Pj _Proj = {}) const {
-            auto _UResult = _Unique_unchecked(_Ubegin(_Range), _Uend(_Range), _Pass_fn(_Pred), _Pass_fn(_Proj));
+            auto _UResult = _Unique_unchecked(_Ubegin(_Range), _Uend(_Range), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
-            return _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Range, _STD move(_UResult));
+            return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Range, _STD move(_UResult));
         }
 
     private:
@@ -4476,16 +4486,16 @@ _INLINE_VAR constexpr bool
 _EXPORT_STD template <class _InIt, class _OutIt, class _Pr>
 _CONSTEXPR20 _OutIt unique_copy(_InIt _First, _InIt _Last, _OutIt _Dest, _Pr _Pred) {
     // copy compressing pairs that match
-    _Adl_verify_range(_First, _Last);
+    _STD _Adl_verify_range(_First, _Last);
 
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
 
     if (_UFirst == _ULast) {
         return _Dest;
     }
 
-    auto _UDest = _Get_unwrapped_unverified(_Dest);
+    auto _UDest = _STD _Get_unwrapped_unverified(_Dest);
 
     if constexpr (_Is_ranges_fwd_iter_v<_InIt>) { // can reread the source for comparison
         auto _Firstb = _UFirst;
@@ -4525,7 +4535,7 @@ _CONSTEXPR20 _OutIt unique_copy(_InIt _First, _InIt _Last, _OutIt _Dest, _Pr _Pr
         }
     }
 
-    _Seek_wrapped(_Dest, _UDest);
+    _STD _Seek_wrapped(_Dest, _UDest);
     return _Dest;
 }
 
@@ -4541,7 +4551,7 @@ _FwdIt2 unique_copy(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, _Pr _
     // not parallelized at present, parallelism expected to be feasible in a future release
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
-    return _STD unique_copy(_First, _Last, _Dest, _Pass_fn(_Pred));
+    return _STD unique_copy(_First, _Last, _Dest, _STD _Pass_fn(_Pred));
 }
 
 _EXPORT_STD template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy_t<_ExPo> = 0>
@@ -4573,13 +4583,13 @@ namespace ranges {
             requires indirectly_copyable<_It, _Out> && _Can_reread_or_store<_It, _Out>
         constexpr unique_copy_result<_It, _Out> operator()(
             _It _First, _Se _Last, _Out _Result, _Pr _Pred = {}, _Pj _Proj = {}) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
             auto _UResult =
-                _Unique_copy_unchecked(_Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)),
-                    _Get_unwrapped_unverified(_STD move(_Result)), _Pass_fn(_Pred), _Pass_fn(_Proj));
+                _Unique_copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)),
+                    _STD _Get_unwrapped_unverified(_STD move(_Result)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult.in));
-            _Seek_wrapped(_Result, _STD move(_UResult.out));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
             return {_STD move(_First), _STD move(_Result)};
         }
 
@@ -4589,11 +4599,11 @@ namespace ranges {
         constexpr unique_copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(
             _Rng&& _Range, _Out _Result, _Pr _Pred = {}, _Pj _Proj = {}) const {
             auto _First   = _RANGES begin(_Range);
-            auto _UResult = _Unique_copy_unchecked(_Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
-                _Get_unwrapped_unverified(_STD move(_Result)), _Pass_fn(_Pred), _Pass_fn(_Proj));
+            auto _UResult = _Unique_copy_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
+                _STD _Get_unwrapped_unverified(_STD move(_Result)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult.in));
-            _Seek_wrapped(_Result, _STD move(_UResult.out));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
             return {_STD move(_First), _STD move(_Result)};
         }
 
@@ -4666,20 +4676,20 @@ namespace ranges {
             using _Elem          = remove_reference_t<iter_reference_t<_It>>;
             constexpr size_t _Nx = sizeof(_Elem);
             constexpr bool _Allow_vectorization =
-                conjunction_v<_Is_trivially_swappable<_Elem>, negation<is_volatile<_Elem>>>;
+                conjunction_v<_Is_trivially_ranges_swappable<_Elem>, negation<is_volatile<_Elem>>>;
 
             if constexpr (_Allow_vectorization && _Nx <= 8 && (_Nx & (_Nx - 1)) == 0) {
                 if (!_STD is_constant_evaluated()) {
                     _Elem* const _First_addr = _STD to_address(_First);
                     _Elem* const _Last_addr  = _STD to_address(_Last);
                     if constexpr (_Nx == 1) {
-                        __std_reverse_trivially_swappable_1(_First_addr, _Last_addr);
+                        ::__std_reverse_trivially_swappable_1(_First_addr, _Last_addr);
                     } else if constexpr (_Nx == 2) {
-                        __std_reverse_trivially_swappable_2(_First_addr, _Last_addr);
+                        ::__std_reverse_trivially_swappable_2(_First_addr, _Last_addr);
                     } else if constexpr (_Nx == 4) {
-                        __std_reverse_trivially_swappable_4(_First_addr, _Last_addr);
+                        ::__std_reverse_trivially_swappable_4(_First_addr, _Last_addr);
                     } else {
-                        __std_reverse_trivially_swappable_8(_First_addr, _Last_addr);
+                        ::__std_reverse_trivially_swappable_8(_First_addr, _Last_addr);
                     }
 
                     return;
@@ -4698,20 +4708,20 @@ namespace ranges {
         template <bidirectional_iterator _It, sentinel_for<_It> _Se>
             requires permutable<_It>
         constexpr _It operator()(_It _First, _Se _Last) const {
-            _Adl_verify_range(_First, _Last);
-            auto _UFirst = _Unwrap_iter<_Se>(_STD move(_First));
-            auto _ULast  = _Get_final_iterator_unwrapped<_It>(_UFirst, _STD move(_Last));
-            _Seek_wrapped(_First, _ULast);
-            _Reverse_common(_STD move(_UFirst), _STD move(_ULast));
+            _STD _Adl_verify_range(_First, _Last);
+            auto _UFirst = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
+            auto _ULast  = _RANGES _Get_final_iterator_unwrapped<_It>(_UFirst, _STD move(_Last));
+            _STD _Seek_wrapped(_First, _ULast);
+            _RANGES _Reverse_common(_STD move(_UFirst), _STD move(_ULast));
             return _First;
         }
 
         template <bidirectional_range _Rng>
             requires permutable<iterator_t<_Rng>>
         constexpr borrowed_iterator_t<_Rng> operator()(_Rng&& _Range) const {
-            auto _ULast = _Get_final_iterator_unwrapped(_Range);
-            _Reverse_common(_Ubegin(_Range), _ULast);
-            return _Rewrap_iterator(_Range, _STD move(_ULast));
+            auto _ULast = _RANGES _Get_final_iterator_unwrapped(_Range);
+            _RANGES _Reverse_common(_Ubegin(_Range), _ULast);
+            return _RANGES _Rewrap_iterator(_Range, _STD move(_ULast));
         }
     };
 
@@ -4722,10 +4732,10 @@ namespace ranges {
 _EXPORT_STD template <class _BidIt, class _OutIt>
 _CONSTEXPR20 _OutIt reverse_copy(_BidIt _First, _BidIt _Last, _OutIt _Dest) {
     // copy reversing elements in [_First, _Last)
-    _Adl_verify_range(_First, _Last);
-    const auto _UFirst = _Get_unwrapped(_First);
-    auto _ULast        = _Get_unwrapped(_Last);
-    auto _UDest        = _Get_unwrapped_n(_Dest, _Idl_distance<_BidIt>(_UFirst, _ULast));
+    _STD _Adl_verify_range(_First, _Last);
+    const auto _UFirst = _STD _Get_unwrapped(_First);
+    auto _ULast        = _STD _Get_unwrapped(_Last);
+    auto _UDest        = _STD _Get_unwrapped_n(_Dest, _STD _Idl_distance<_BidIt>(_UFirst, _ULast));
 
 #if _USE_STD_VECTOR_ALGORITHMS
     using _Elem                         = remove_reference_t<_Iter_ref_t<remove_const_t<decltype(_UFirst)>>>;
@@ -4741,17 +4751,17 @@ _CONSTEXPR20 _OutIt reverse_copy(_BidIt _First, _BidIt _Last, _OutIt _Dest) {
 #endif // _HAS_CXX20
         {
             if constexpr (_Nx == 1) {
-                __std_reverse_copy_trivially_copyable_1(_To_address(_UFirst), _To_address(_ULast), _To_address(_UDest));
+                ::__std_reverse_copy_trivially_copyable_1(_STD _To_address(_UFirst), _STD _To_address(_ULast), _STD _To_address(_UDest));
             } else if constexpr (_Nx == 2) {
-                __std_reverse_copy_trivially_copyable_2(_To_address(_UFirst), _To_address(_ULast), _To_address(_UDest));
+                ::__std_reverse_copy_trivially_copyable_2(_STD _To_address(_UFirst), _STD _To_address(_ULast), _STD _To_address(_UDest));
             } else if constexpr (_Nx == 4) {
-                __std_reverse_copy_trivially_copyable_4(_To_address(_UFirst), _To_address(_ULast), _To_address(_UDest));
+                ::__std_reverse_copy_trivially_copyable_4(_STD _To_address(_UFirst), _STD _To_address(_ULast), _STD _To_address(_UDest));
             } else {
-                __std_reverse_copy_trivially_copyable_8(_To_address(_UFirst), _To_address(_ULast), _To_address(_UDest));
+                ::__std_reverse_copy_trivially_copyable_8(_STD _To_address(_UFirst), _STD _To_address(_ULast), _STD _To_address(_UDest));
             }
 
             _UDest += _ULast - _UFirst;
-            _Seek_wrapped(_Dest, _UDest);
+            _STD _Seek_wrapped(_Dest, _UDest);
             return _Dest;
         }
     }
@@ -4761,7 +4771,7 @@ _CONSTEXPR20 _OutIt reverse_copy(_BidIt _First, _BidIt _Last, _OutIt _Dest) {
         *_UDest = *--_ULast;
     }
 
-    _Seek_wrapped(_Dest, _UDest);
+    _STD _Seek_wrapped(_Dest, _UDest);
     return _Dest;
 }
 
@@ -4785,10 +4795,10 @@ namespace ranges {
         template <bidirectional_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
             requires indirectly_copyable<_It, _Out>
         constexpr reverse_copy_result<_It, _Out> operator()(_It _First, _Se _Last, _Out _Result) const {
-            _Adl_verify_range(_First, _Last);
-            auto _UFirst = _Unwrap_iter<_Se>(_STD move(_First));
-            auto _ULast  = _Get_final_iterator_unwrapped<_It>(_UFirst, _STD move(_Last));
-            _Seek_wrapped(_First, _ULast);
+            _STD _Adl_verify_range(_First, _Last);
+            auto _UFirst = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
+            auto _ULast  = _RANGES _Get_final_iterator_unwrapped<_It>(_UFirst, _STD move(_Last));
+            _STD _Seek_wrapped(_First, _ULast);
             _Result = _Reverse_copy_common(_STD move(_UFirst), _STD move(_ULast), _STD move(_Result));
             return {_STD move(_First), _STD move(_Result)};
         }
@@ -4800,9 +4810,9 @@ namespace ranges {
                 _Result = _Reverse_copy_common(_Ubegin(_Range), _Uend(_Range), _STD move(_Result));
                 return {_RANGES end(_Range), _STD move(_Result)};
             } else {
-                auto _ULast = _Get_final_iterator_unwrapped(_Range);
+                auto _ULast = _RANGES _Get_final_iterator_unwrapped(_Range);
                 _Result     = _Reverse_copy_common(_Ubegin(_Range), _ULast, _STD move(_Result));
-                return {_Rewrap_iterator(_Range, _STD move(_ULast)), _STD move(_Result)};
+                return {_RANGES _Rewrap_iterator(_Range, _STD move(_ULast)), _STD move(_Result)};
             }
         }
 
@@ -4827,13 +4837,13 @@ namespace ranges {
                         _Elem* const _Last_addr       = _STD to_address(_Last);
                         _DestElem* const _Result_addr = _STD to_address(_Result);
                         if constexpr (_Nx == 1) {
-                            __std_reverse_copy_trivially_copyable_1(_First_addr, _Last_addr, _Result_addr);
+                            ::__std_reverse_copy_trivially_copyable_1(_First_addr, _Last_addr, _Result_addr);
                         } else if constexpr (_Nx == 2) {
-                            __std_reverse_copy_trivially_copyable_2(_First_addr, _Last_addr, _Result_addr);
+                            ::__std_reverse_copy_trivially_copyable_2(_First_addr, _Last_addr, _Result_addr);
                         } else if constexpr (_Nx == 4) {
-                            __std_reverse_copy_trivially_copyable_4(_First_addr, _Last_addr, _Result_addr);
+                            ::__std_reverse_copy_trivially_copyable_4(_First_addr, _Last_addr, _Result_addr);
                         } else {
-                            __std_reverse_copy_trivially_copyable_8(_First_addr, _Last_addr, _Result_addr);
+                            ::__std_reverse_copy_trivially_copyable_8(_First_addr, _Last_addr, _Result_addr);
                         }
 
                         _Result += _Last - _First;
@@ -4877,7 +4887,7 @@ namespace ranges {
         // that is, rotates [_First, _Last) left by distance(_First, _Mid) positions
 
         if (_First == _Mid) {
-            auto _Final = _Get_final_iterator_unwrapped<_It>(_Mid, _STD move(_Last));
+            auto _Final = _RANGES _Get_final_iterator_unwrapped<_It>(_Mid, _STD move(_Last));
             return {_Final, _Final};
         }
 
@@ -4886,12 +4896,12 @@ namespace ranges {
         }
 
         if constexpr (bidirectional_iterator<_It>) {
-            _Reverse_common(_First, _Mid);
-            auto _Final = _Get_final_iterator_unwrapped<_It>(_Mid, _STD move(_Last));
-            _Reverse_common(_Mid, _Final);
+            _RANGES _Reverse_common(_First, _Mid);
+            auto _Final = _RANGES _Get_final_iterator_unwrapped<_It>(_Mid, _STD move(_Last));
+            _RANGES _Reverse_common(_Mid, _Final);
 
             if constexpr (random_access_iterator<_It>) {
-                _Reverse_common(_First, _Final);
+                _RANGES _Reverse_common(_First, _Final);
                 _First += _Final - _Mid;
 
                 return {_STD move(_First), _STD move(_Final)};
@@ -4899,7 +4909,7 @@ namespace ranges {
                 const auto _Result = _RANGES _Reverse_until_mid_unchecked(_STD move(_First), _Mid, _Final);
                 auto _Mid_first    = _Result.begin();
                 auto _Mid_last     = _Result.end();
-                _Reverse_common(_Mid_first, _Mid_last);
+                _RANGES _Reverse_common(_Mid_first, _Mid_last);
 
                 if (_Mid_first == _Mid) {
                     return {_STD move(_Mid_last), _STD move(_Final)};
@@ -4939,23 +4949,23 @@ namespace ranges {
     public:
         template <permutable _It, sentinel_for<_It> _Se>
         constexpr subrange<_It> operator()(_It _First, _It _Mid, _Se _Last) const {
-            _Adl_verify_range(_First, _Mid);
-            _Adl_verify_range(_Mid, _Last);
-            auto _UResult = _RANGES _Rotate_unchecked(_Unwrap_iter<_Se>(_STD move(_First)),
-                _Unwrap_iter<_Se>(_STD move(_Mid)), _Unwrap_sent<_It>(_STD move(_Last)));
+            _STD _Adl_verify_range(_First, _Mid);
+            _STD _Adl_verify_range(_Mid, _Last);
+            auto _UResult = _RANGES _Rotate_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_iter<_Se>(_STD move(_Mid)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)));
 
-            return _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
+            return _RANGES _Rewrap_subrange<subrange<_It>>(_First, _STD move(_UResult));
         }
 
         template <forward_range _Rng>
             requires permutable<iterator_t<_Rng>>
         constexpr borrowed_subrange_t<_Rng> operator()(_Rng&& _Range, iterator_t<_Rng> _Mid) const {
-            _Adl_verify_range(_RANGES begin(_Range), _Mid);
-            _Adl_verify_range(_Mid, _RANGES end(_Range));
+            _STD _Adl_verify_range(_RANGES begin(_Range), _Mid);
+            _STD _Adl_verify_range(_Mid, _RANGES end(_Range));
             auto _UResult =
-                _RANGES _Rotate_unchecked(_Ubegin(_Range), _Unwrap_range_iter<_Rng>(_STD move(_Mid)), _Uend(_Range));
+                _RANGES _Rotate_unchecked(_Ubegin(_Range), _RANGES _Unwrap_range_iter<_Rng>(_STD move(_Mid)), _Uend(_Range));
 
-            return _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Mid, _STD move(_UResult));
+            return _RANGES _Rewrap_subrange<borrowed_subrange_t<_Rng>>(_Mid, _STD move(_UResult));
         }
     };
 
@@ -4966,14 +4976,14 @@ namespace ranges {
 _EXPORT_STD template <class _FwdIt, class _OutIt>
 _CONSTEXPR20 _OutIt rotate_copy(_FwdIt _First, _FwdIt _Mid, _FwdIt _Last, _OutIt _Dest) {
     // copy rotating [_First, _Last)
-    _Adl_verify_range(_First, _Mid);
-    _Adl_verify_range(_Mid, _Last);
-    const auto _UFirst = _Get_unwrapped(_First);
-    const auto _UMid   = _Get_unwrapped(_Mid);
-    const auto _ULast  = _Get_unwrapped(_Last);
-    auto _UDest        = _Get_unwrapped_n(_Dest, _Idl_distance<_FwdIt>(_UFirst, _ULast));
+    _STD _Adl_verify_range(_First, _Mid);
+    _STD _Adl_verify_range(_Mid, _Last);
+    const auto _UFirst = _STD _Get_unwrapped(_First);
+    const auto _UMid   = _STD _Get_unwrapped(_Mid);
+    const auto _ULast  = _STD _Get_unwrapped(_Last);
+    auto _UDest        = _STD _Get_unwrapped_n(_Dest, _STD _Idl_distance<_FwdIt>(_UFirst, _ULast));
     _UDest             = _STD _Copy_unchecked(_UMid, _ULast, _UDest);
-    _Seek_wrapped(_Dest, _STD _Copy_unchecked(_UFirst, _UMid, _UDest));
+    _STD _Seek_wrapped(_Dest, _STD _Copy_unchecked(_UFirst, _UMid, _UDest));
     return _Dest;
 }
 
@@ -4997,12 +5007,12 @@ namespace ranges {
         template <forward_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
             requires indirectly_copyable<_It, _Out>
         constexpr rotate_copy_result<_It, _Out> operator()(_It _First, _It _Mid, _Se _Last, _Out _Result) const {
-            _Adl_verify_range(_First, _Mid);
-            _Adl_verify_range(_Mid, _Last);
-            auto _UResult = _Rotate_copy_unchecked(_Unwrap_iter<_Se>(_STD move(_First)),
-                _Unwrap_iter<_Se>(_STD move(_Mid)), _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result));
+            _STD _Adl_verify_range(_First, _Mid);
+            _STD _Adl_verify_range(_Mid, _Last);
+            auto _UResult = _Rotate_copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_iter<_Se>(_STD move(_Mid)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result));
 
-            _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }
 
@@ -5010,12 +5020,12 @@ namespace ranges {
             requires indirectly_copyable<iterator_t<_Rng>, _Out>
         constexpr rotate_copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(
             _Rng&& _Range, iterator_t<_Rng> _Mid, _Out _Result) const {
-            _Adl_verify_range(_RANGES begin(_Range), _Mid);
-            _Adl_verify_range(_Mid, _RANGES end(_Range));
+            _STD _Adl_verify_range(_RANGES begin(_Range), _Mid);
+            _STD _Adl_verify_range(_Mid, _RANGES end(_Range));
             auto _UResult = _Rotate_copy_unchecked(
-                _Ubegin(_Range), _Unwrap_range_iter<_Rng>(_STD move(_Mid)), _Uend(_Range), _STD move(_Result));
+                _Ubegin(_Range), _RANGES _Unwrap_range_iter<_Rng>(_STD move(_Mid)), _Uend(_Range), _STD move(_Result));
 
-            return {_Rewrap_iterator(_Range, _STD move(_UResult.in)), _STD move(_UResult.out)};
+            return {_RANGES _Rewrap_iterator(_Range, _STD move(_UResult.in)), _STD move(_UResult.out)};
         }
 
     private:
@@ -5158,10 +5168,10 @@ _SampleIt sample(_PopIt _First, _PopIt _Last, _SampleIt _Dest, _Diff _Count, _Ur
         "If the source range is not forward, the destination range must be a Cpp17RandomAccessIterator.");
 
     static_assert(is_integral_v<_Diff>, "The sample size must have an integer type.");
-    _Adl_verify_range(_First, _Last);
+    _STD _Adl_verify_range(_First, _Last);
     if (0 < _Count) {
-        auto _UFirst   = _Get_unwrapped(_First);
-        auto _ULast    = _Get_unwrapped(_Last);
+        auto _UFirst   = _STD _Get_unwrapped(_First);
+        auto _ULast    = _STD _Get_unwrapped(_Last);
         using _PopDiff = _Iter_diff_t<_PopIt>;
         _Rng_from_urng<_PopDiff, remove_reference_t<_Urng>> _RngFunc(_Func);
         if constexpr (_Is_ranges_fwd_iter_v<_PopIt>) {
@@ -5172,13 +5182,13 @@ _SampleIt sample(_PopIt _First, _PopIt _Last, _SampleIt _Dest, _Diff _Count, _Ur
                 _Count = static_cast<_Diff>(_Pop_size); // narrowing OK because _Count is getting smaller
             }
 
-            _Seek_wrapped(_Dest,
-                _Sample_selection_unchecked(_UFirst, _Pop_size, _Get_unwrapped_n(_Dest, _Count), _Count, _RngFunc));
+            _STD _Seek_wrapped(_Dest,
+                _STD _Sample_selection_unchecked(_UFirst, _Pop_size, _STD _Get_unwrapped_n(_Dest, _Count), _Count, _RngFunc));
         } else {
             static_assert(_Is_ranges_input_iter_v<_PopIt>, "Source iterators must be at least input iterators");
             // source is input: use reservoir sampling (unstable)
-            _Seek_wrapped(_Dest,
-                _Sample_reservoir_unchecked(_UFirst, _ULast, _Get_unwrapped_unverified(_Dest), _Count, _RngFunc));
+            _STD _Seek_wrapped(_Dest,
+                _STD _Sample_reservoir_unchecked(_UFirst, _ULast, _STD _Get_unwrapped_unverified(_Dest), _Count, _RngFunc));
         }
     }
 
@@ -5200,19 +5210,19 @@ namespace ranges {
             requires (forward_iterator<_It> || random_access_iterator<_Out>)
                   && indirectly_copyable<_It, _Out> && uniform_random_bit_generator<remove_reference_t<_Urng>>
         _Out operator()(_It _First, _Se _Last, _Out _Result, iter_difference_t<_It> _Count, _Urng&& _Func) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
             if (_Count <= 0) {
                 return _Result;
             }
 
             _Rng_from_urng<iter_difference_t<_It>, remove_reference_t<_Urng>> _RngFunc(_Func);
             if constexpr (forward_iterator<_It>) {
-                auto _UFirst   = _Unwrap_iter<_Se>(_STD move(_First));
-                auto _Pop_size = _RANGES distance(_UFirst, _Unwrap_sent<_It>(_STD move(_Last)));
+                auto _UFirst   = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
+                auto _Pop_size = _RANGES distance(_UFirst, _RANGES _Unwrap_sent<_It>(_STD move(_Last)));
                 return _Sample_selection_unchecked(_STD move(_UFirst), _Pop_size, _STD move(_Result), _Count, _RngFunc);
             } else {
-                return _Sample_reservoir_unchecked(_Unwrap_iter<_Se>(_STD move(_First)),
-                    _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _Count, _RngFunc);
+                return _Sample_reservoir_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                    _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _Count, _RngFunc);
             }
         }
 
@@ -5298,9 +5308,9 @@ namespace ranges {
 template <class _RanIt, class _RngFn>
 void _Random_shuffle1(_RanIt _First, _RanIt _Last, _RngFn& _RngFunc) {
     // shuffle [_First, _Last) using random function _RngFunc
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     if (_UFirst == _ULast) {
         return;
     }
@@ -5321,7 +5331,7 @@ _EXPORT_STD template <class _RanIt, class _Urng>
 void shuffle(_RanIt _First, _RanIt _Last, _Urng&& _Func) { // shuffle [_First, _Last) using URNG _Func
     using _Urng0 = remove_reference_t<_Urng>;
     _Rng_from_urng<_Iter_diff_t<_RanIt>, _Urng0> _RngFunc(_Func);
-    _Random_shuffle1(_First, _Last, _RngFunc);
+    _STD _Random_shuffle1(_First, _Last, _RngFunc);
 }
 
 #ifdef __cpp_lib_concepts
@@ -5331,13 +5341,13 @@ namespace ranges {
         template <random_access_iterator _It, sentinel_for<_It> _Se, class _Urng>
             requires permutable<_It> && uniform_random_bit_generator<remove_reference_t<_Urng>>
         _It operator()(_It _First, _Se _Last, _Urng&& _Func) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
 
             _Rng_from_urng<iter_difference_t<_It>, remove_reference_t<_Urng>> _RngFunc(_Func);
             auto _UResult =
-                _Shuffle_unchecked(_Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)), _RngFunc);
+                _Shuffle_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _RngFunc);
 
-            _Seek_wrapped(_First, _STD move(_UResult));
+            _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
         }
 
@@ -5346,7 +5356,7 @@ namespace ranges {
         borrowed_iterator_t<_Rng> operator()(_Rng&& _Range, _Urng&& _Func) const {
             _Rng_from_urng<range_difference_t<_Rng>, remove_reference_t<_Urng>> _RngFunc(_Func);
 
-            return _Rewrap_iterator(_Range, _Shuffle_unchecked(_Ubegin(_Range), _Uend(_Range), _RngFunc));
+            return _RANGES _Rewrap_iterator(_Range, _Shuffle_unchecked(_Ubegin(_Range), _Uend(_Range), _RngFunc));
         }
 
     private:
@@ -5384,7 +5394,7 @@ namespace ranges {
 _EXPORT_STD template <class _RanIt, class _RngFn>
 void random_shuffle(_RanIt _First, _RanIt _Last, _RngFn&& _RngFunc) {
     // shuffle [_First, _Last) using random function _RngFunc
-    _Random_shuffle1(_First, _Last, _RngFunc);
+    _STD _Random_shuffle1(_First, _Last, _RngFunc);
 }
 
 struct _Rand_urng_from_func { // wrap rand() as a URNG
@@ -5417,14 +5427,14 @@ constexpr _FwdIt shift_left(_FwdIt _First, const _FwdIt _Last, _Iter_diff_t<_Fwd
     // positions; returns the end of the resulting range
     _STL_ASSERT(_Pos_to_shift >= 0, "shift count must be non-negative (N4950 [alg.shift]/1)");
 
-    _Adl_verify_range(_First, _Last);
+    _STD _Adl_verify_range(_First, _Last);
 
     if (_Pos_to_shift == 0) {
         return _Last;
     }
 
-    const auto _UFirst = _Get_unwrapped(_First);
-    const auto _ULast  = _Get_unwrapped(_Last);
+    const auto _UFirst = _STD _Get_unwrapped(_First);
+    const auto _ULast  = _STD _Get_unwrapped(_Last);
     auto _Start_at     = _UFirst;
 
     if constexpr (_Is_cpp17_random_iter_v<_FwdIt>) {
@@ -5441,7 +5451,7 @@ constexpr _FwdIt shift_left(_FwdIt _First, const _FwdIt _Last, _Iter_diff_t<_Fwd
         }
     }
 
-    _Seek_wrapped(_First, _STD _Move_unchecked(_Start_at, _ULast, _UFirst));
+    _STD _Seek_wrapped(_First, _STD _Move_unchecked(_Start_at, _ULast, _UFirst));
     return _First;
 }
 
@@ -5459,14 +5469,14 @@ constexpr _FwdIt shift_right(_FwdIt _First, const _FwdIt _Last, _Iter_diff_t<_Fw
     // positions; returns the beginning of the resulting range
     _STL_ASSERT(_Pos_to_shift >= 0, "shift count must be non-negative (N4950 [alg.shift]/5)");
 
-    _Adl_verify_range(_First, _Last);
+    _STD _Adl_verify_range(_First, _Last);
 
     if (_Pos_to_shift == 0) {
         return _First;
     }
 
-    const auto _UFirst = _Get_unwrapped(_First);
-    const auto _ULast  = _Get_unwrapped(_Last);
+    const auto _UFirst = _STD _Get_unwrapped(_First);
+    const auto _ULast  = _STD _Get_unwrapped(_Last);
 
     if constexpr (_Is_cpp17_bidi_iter_v<_FwdIt>) {
         auto _UEnd_at = _ULast;
@@ -5484,7 +5494,7 @@ constexpr _FwdIt shift_right(_FwdIt _First, const _FwdIt _Last, _Iter_diff_t<_Fw
             }
         }
 
-        _Seek_wrapped(_First, _Move_backward_unchecked(_UFirst, _UEnd_at, _ULast));
+        _STD _Seek_wrapped(_First, _STD _Move_backward_unchecked(_UFirst, _UEnd_at, _ULast));
         return _First;
     } else {
         auto _UResult = _UFirst;
@@ -5495,7 +5505,7 @@ constexpr _FwdIt shift_right(_FwdIt _First, const _FwdIt _Last, _Iter_diff_t<_Fw
             }
             ++_UResult;
         }
-        _Seek_wrapped(_First, _UResult);
+        _STD _Seek_wrapped(_First, _UResult);
 
         auto _Trail = _UFirst;
         auto _Lead  = _UResult;
@@ -5544,16 +5554,16 @@ namespace ranges {
         constexpr subrange<_It> operator()(_It _First, const _Se _Last, iter_difference_t<_It> _Pos_to_shift) const {
             _STL_ASSERT(_Pos_to_shift >= 0, "shift count must be non-negative (N4950 [alg.shift]/1)");
 
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
             auto _Result = _First;
             _Unwrap_iter_t<_It, _Se> _UResult;
 
             if (_Pos_to_shift == 0) {
-                _UResult = _Get_final_iterator_unwrapped<_It>(_Unwrap_iter<_Se>(_Result), _Last);
+                _UResult = _RANGES _Get_final_iterator_unwrapped<_It>(_RANGES _Unwrap_iter<_Se>(_Result), _Last);
             } else {
-                _UResult = _Shift_left_impl(_Unwrap_iter<_Se>(_First), _Unwrap_sent<_It>(_Last), _Pos_to_shift);
+                _UResult = _Shift_left_impl(_RANGES _Unwrap_iter<_Se>(_First), _RANGES _Unwrap_sent<_It>(_Last), _Pos_to_shift);
             }
-            _Seek_wrapped(_Result, _UResult);
+            _STD _Seek_wrapped(_Result, _UResult);
             return {_STD move(_First), _STD move(_Result)};
         }
 
@@ -5563,7 +5573,7 @@ namespace ranges {
             _STL_ASSERT(_Pos_to_shift >= 0, "shift count must be non-negative (N4950 [alg.shift]/1)");
 
             if (_Pos_to_shift == 0) {
-                auto _Last = _Rewrap_iterator(_Range, _Get_final_iterator_unwrapped(_Range));
+                auto _Last = _RANGES _Rewrap_iterator(_Range, _RANGES _Get_final_iterator_unwrapped(_Range));
                 return {_RANGES begin(_Range), _STD move(_Last)};
             }
 
@@ -5573,13 +5583,13 @@ namespace ranges {
                     return {_First, _First};
                 }
 
-                auto _UFirst   = _Unwrap_range_iter<_Rng>(_First);
+                auto _UFirst   = _RANGES _Unwrap_range_iter<_Rng>(_First);
                 auto _Start_at = _RANGES next(_UFirst, _Pos_to_shift);
                 auto _Result   = _RANGES _Move_unchecked(_STD move(_Start_at), _Uend(_Range), _UFirst).out;
-                return {_STD move(_First), _Rewrap_iterator(_Range, _STD move(_Result))};
+                return {_STD move(_First), _RANGES _Rewrap_iterator(_Range, _STD move(_Result))};
             } else {
                 auto _Result = _Shift_left_impl(_Ubegin(_Range), _Uend(_Range), _Pos_to_shift);
-                return {_RANGES begin(_Range), _Rewrap_iterator(_Range, _STD move(_Result))};
+                return {_RANGES begin(_Range), _RANGES _Rewrap_iterator(_Range, _STD move(_Result))};
             }
         }
 
@@ -5605,14 +5615,14 @@ namespace ranges {
     public:
         template <permutable _It, sentinel_for<_It> _Se>
         constexpr subrange<_It> operator()(_It _First, const _Se _Last, iter_difference_t<_It> _Pos_to_shift) const {
-            _Adl_verify_range(_First, _Last);
-            auto _UFirst     = _Unwrap_iter<_Se>(_First);
-            auto _ULast      = _Unwrap_sent<_It>(_Last);
+            _STD _Adl_verify_range(_First, _Last);
+            auto _UFirst     = _RANGES _Unwrap_iter<_Se>(_First);
+            auto _ULast      = _RANGES _Unwrap_sent<_It>(_Last);
             const auto _Size = _Size_helper(_UFirst, _ULast);
             auto _Result     = _Shift_right_impl(_STD move(_UFirst), _STD move(_ULast), _Pos_to_shift, _Size);
-            _Seek_wrapped(_First, _Result.begin());
+            _STD _Seek_wrapped(_First, _Result.begin());
             auto _Final = _First;
-            _Seek_wrapped(_Final, _Result.end());
+            _STD _Seek_wrapped(_Final, _Result.end());
             return {_STD move(_First), _STD move(_Final)};
         }
 
@@ -5621,8 +5631,8 @@ namespace ranges {
         constexpr borrowed_subrange_t<_Rng> operator()(_Rng&& _Range, range_difference_t<_Rng> _Pos_to_shift) const {
             const auto _Size = _Size_helper(_Range);
             auto _Result     = _Shift_right_impl(_Ubegin(_Range), _Uend(_Range), _Pos_to_shift, _Size);
-            auto _First      = _Rewrap_iterator(_Range, _Result.begin());
-            auto _Final      = _Rewrap_iterator(_Range, _Result.end());
+            auto _First      = _RANGES _Rewrap_iterator(_Range, _Result.begin());
+            auto _Final      = _RANGES _Rewrap_iterator(_Range, _Result.end());
             return {_STD move(_First), _STD move(_Final)};
         }
 

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -2336,7 +2336,8 @@ _FwdIt2 transform(_ExPo&&, const _FwdIt1 _First, const _FwdIt1 _Last, _FwdIt2 _D
             const auto _UDest = _STD _Get_unwrapped_n(_Dest, _Count);
             if (_Count >= 2) { // ... with at least 2 elements
                 _TRY_BEGIN
-                _Static_partitioned_unary_transform2 _Operation{_Hw_threads, _Count, _UFirst, _STD _Pass_fn(_Func), _UDest};
+                _Static_partitioned_unary_transform2 _Operation{
+                    _Hw_threads, _Count, _UFirst, _STD _Pass_fn(_Func), _UDest};
                 _STD _Seek_wrapped(_Dest, _Operation._Dest_basis._Populate(_Operation._Team, _UDest));
                 _STD _Run_chunked_parallel_work(_Hw_threads, _Operation);
                 return _Dest;
@@ -2348,14 +2349,15 @@ _FwdIt2 transform(_ExPo&&, const _FwdIt1 _First, const _FwdIt1 _Last, _FwdIt2 _D
             _STD _Seek_wrapped(_Dest, _STD transform(_UFirst, _ULast, _UDest, _STD _Pass_fn(_Func)));
             return _Dest;
         } else {
-            _STD _Seek_wrapped(
-                _Dest, _STD transform(_UFirst, _ULast, _STD _Get_unwrapped_n(_Dest, _STD _Idl_distance<_FwdIt1>(_UFirst, _ULast)),
-                           _STD _Pass_fn(_Func)));
+            _STD _Seek_wrapped(_Dest,
+                _STD transform(_UFirst, _ULast,
+                    _STD _Get_unwrapped_n(_Dest, _STD _Idl_distance<_FwdIt1>(_UFirst, _ULast)), _STD _Pass_fn(_Func)));
             return _Dest;
         }
     } else {
-        _STD _Seek_wrapped(_Dest, _STD transform(_UFirst, _ULast,
-                                 _STD _Get_unwrapped_n(_Dest, _STD _Idl_distance<_FwdIt1>(_UFirst, _ULast)), _STD _Pass_fn(_Func)));
+        _STD _Seek_wrapped(_Dest,
+            _STD transform(_UFirst, _ULast, _STD _Get_unwrapped_n(_Dest, _STD _Idl_distance<_FwdIt1>(_UFirst, _ULast)),
+                _STD _Pass_fn(_Func)));
         return _Dest;
     }
 }
@@ -2429,13 +2431,13 @@ _FwdIt3 transform(_ExPo&&, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _F
         } else {
             const auto _Count = _STD _Idl_distance<_FwdIt1>(_UFirst1, _ULast1);
             _STD _Seek_wrapped(_Dest, _STD transform(_UFirst1, _ULast1, _STD _Get_unwrapped_n(_First2, _Count),
-                                     _STD _Get_unwrapped_n(_Dest, _Count), _STD _Pass_fn(_Func)));
+                                          _STD _Get_unwrapped_n(_Dest, _Count), _STD _Pass_fn(_Func)));
             return _Dest;
         }
     } else {
         const auto _Count = _STD _Idl_distance<_FwdIt1>(_UFirst1, _ULast1);
         _STD _Seek_wrapped(_Dest, _STD transform(_UFirst1, _ULast1, _STD _Get_unwrapped_n(_First2, _Count),
-                                 _STD _Get_unwrapped_n(_Dest, _Count), _STD _Pass_fn(_Func)));
+                                      _STD _Get_unwrapped_n(_Dest, _Count), _STD _Pass_fn(_Func)));
         return _Dest;
     }
 }
@@ -2458,12 +2460,11 @@ void replace_if(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt _Last, _Pr _Pre
     // replace each satisfying _Pred with _Val
     _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     auto _Lambda_pred = _STD _Pass_fn(_Pred); // TRANSITION, DevCom-10456445
-    _STD for_each(
-        _STD forward<_ExPo>(_Exec), _First, _Last, [&_Val, _Lambda_pred](auto&& _Value) mutable {
-            if (_Lambda_pred(_STD forward<decltype(_Value)>(_Value))) {
-                _STD forward<decltype(_Value)>(_Value) = _Val;
-            }
-        });
+    _STD for_each(_STD forward<_ExPo>(_Exec), _First, _Last, [&_Val, _Lambda_pred](auto&& _Value) mutable {
+        if (_Lambda_pred(_STD forward<decltype(_Value)>(_Value))) {
+            _STD forward<decltype(_Value)>(_Value) = _Val;
+        }
+    });
 }
 
 template <class _FwdIt, class _Pr>

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -2315,7 +2315,7 @@ struct _Static_partitioned_unary_transform2 {
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_unary_transform2*>(_Context));
+        _STD _Run_available_chunked_work(*static_cast<_Static_partitioned_unary_transform2*>(_Context));
     }
 };
 
@@ -2326,36 +2326,36 @@ _FwdIt2 transform(_ExPo&&, const _FwdIt1 _First, const _FwdIt1 _Last, _FwdIt2 _D
     // transform [_First, _Last) with _Func
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     if constexpr (remove_reference_t<_ExPo>::_Parallelize) {
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
         if (_Hw_threads > 1) { // parallelize on multiprocessor machines...
             const auto _Count = _STD distance(_UFirst, _ULast);
-            const auto _UDest = _Get_unwrapped_n(_Dest, _Count);
+            const auto _UDest = _STD _Get_unwrapped_n(_Dest, _Count);
             if (_Count >= 2) { // ... with at least 2 elements
                 _TRY_BEGIN
-                _Static_partitioned_unary_transform2 _Operation{_Hw_threads, _Count, _UFirst, _Pass_fn(_Func), _UDest};
-                _Seek_wrapped(_Dest, _Operation._Dest_basis._Populate(_Operation._Team, _UDest));
-                _Run_chunked_parallel_work(_Hw_threads, _Operation);
+                _Static_partitioned_unary_transform2 _Operation{_Hw_threads, _Count, _UFirst, _STD _Pass_fn(_Func), _UDest};
+                _STD _Seek_wrapped(_Dest, _Operation._Dest_basis._Populate(_Operation._Team, _UDest));
+                _STD _Run_chunked_parallel_work(_Hw_threads, _Operation);
                 return _Dest;
                 _CATCH(const _Parallelism_resources_exhausted&)
                 // fall through to serial case below
                 _CATCH_END
             }
 
-            _Seek_wrapped(_Dest, _STD transform(_UFirst, _ULast, _UDest, _Pass_fn(_Func)));
+            _STD _Seek_wrapped(_Dest, _STD transform(_UFirst, _ULast, _UDest, _STD _Pass_fn(_Func)));
             return _Dest;
         } else {
-            _Seek_wrapped(
-                _Dest, _STD transform(_UFirst, _ULast, _Get_unwrapped_n(_Dest, _Idl_distance<_FwdIt1>(_UFirst, _ULast)),
-                           _Pass_fn(_Func)));
+            _STD _Seek_wrapped(
+                _Dest, _STD transform(_UFirst, _ULast, _STD _Get_unwrapped_n(_Dest, _STD _Idl_distance<_FwdIt1>(_UFirst, _ULast)),
+                           _STD _Pass_fn(_Func)));
             return _Dest;
         }
     } else {
-        _Seek_wrapped(_Dest, _STD transform(_UFirst, _ULast,
-                                 _Get_unwrapped_n(_Dest, _Idl_distance<_FwdIt1>(_UFirst, _ULast)), _Pass_fn(_Func)));
+        _STD _Seek_wrapped(_Dest, _STD transform(_UFirst, _ULast,
+                                 _STD _Get_unwrapped_n(_Dest, _STD _Idl_distance<_FwdIt1>(_UFirst, _ULast)), _STD _Pass_fn(_Func)));
         return _Dest;
     }
 }
@@ -2391,7 +2391,7 @@ struct _Static_partitioned_binary_transform2 {
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_binary_transform2*>(_Context));
+        _STD _Run_available_chunked_work(*static_cast<_Static_partitioned_binary_transform2*>(_Context));
     }
 };
 
@@ -2403,39 +2403,39 @@ _FwdIt3 transform(_ExPo&&, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _F
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt3);
-    _Adl_verify_range(_First1, _Last1);
-    const auto _UFirst1 = _Get_unwrapped(_First1);
-    const auto _ULast1  = _Get_unwrapped(_Last1);
+    _STD _Adl_verify_range(_First1, _Last1);
+    const auto _UFirst1 = _STD _Get_unwrapped(_First1);
+    const auto _ULast1  = _STD _Get_unwrapped(_Last1);
     if constexpr (remove_reference_t<_ExPo>::_Parallelize) {
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
         if (_Hw_threads > 1) { // parallelize on multiprocessor machines...
             const auto _Count   = _STD distance(_UFirst1, _ULast1);
-            const auto _UFirst2 = _Get_unwrapped_n(_First2, _Count);
-            const auto _UDest   = _Get_unwrapped_n(_Dest, _Count);
+            const auto _UFirst2 = _STD _Get_unwrapped_n(_First2, _Count);
+            const auto _UDest   = _STD _Get_unwrapped_n(_Dest, _Count);
             if (_Count >= 2) { // ... with at least 2 elements
                 _TRY_BEGIN
                 _Static_partitioned_binary_transform2 _Operation{
-                    _Hw_threads, _Count, _UFirst1, _UFirst2, _Pass_fn(_Func), _UDest};
-                _Seek_wrapped(_Dest, _Operation._Dest_basis._Populate(_Operation._Team, _UDest));
-                _Run_chunked_parallel_work(_Hw_threads, _Operation);
+                    _Hw_threads, _Count, _UFirst1, _UFirst2, _STD _Pass_fn(_Func), _UDest};
+                _STD _Seek_wrapped(_Dest, _Operation._Dest_basis._Populate(_Operation._Team, _UDest));
+                _STD _Run_chunked_parallel_work(_Hw_threads, _Operation);
                 return _Dest;
                 _CATCH(const _Parallelism_resources_exhausted&)
                 // fall through to serial case below
                 _CATCH_END
             }
 
-            _Seek_wrapped(_Dest, _STD transform(_UFirst1, _ULast1, _UFirst2, _UDest, _Pass_fn(_Func)));
+            _STD _Seek_wrapped(_Dest, _STD transform(_UFirst1, _ULast1, _UFirst2, _UDest, _STD _Pass_fn(_Func)));
             return _Dest;
         } else {
-            const auto _Count = _Idl_distance<_FwdIt1>(_UFirst1, _ULast1);
-            _Seek_wrapped(_Dest, _STD transform(_UFirst1, _ULast1, _Get_unwrapped_n(_First2, _Count),
-                                     _Get_unwrapped_n(_Dest, _Count), _Pass_fn(_Func)));
+            const auto _Count = _STD _Idl_distance<_FwdIt1>(_UFirst1, _ULast1);
+            _STD _Seek_wrapped(_Dest, _STD transform(_UFirst1, _ULast1, _STD _Get_unwrapped_n(_First2, _Count),
+                                     _STD _Get_unwrapped_n(_Dest, _Count), _STD _Pass_fn(_Func)));
             return _Dest;
         }
     } else {
-        const auto _Count = _Idl_distance<_FwdIt1>(_UFirst1, _ULast1);
-        _Seek_wrapped(_Dest, _STD transform(_UFirst1, _ULast1, _Get_unwrapped_n(_First2, _Count),
-                                 _Get_unwrapped_n(_Dest, _Count), _Pass_fn(_Func)));
+        const auto _Count = _STD _Idl_distance<_FwdIt1>(_UFirst1, _ULast1);
+        _STD _Seek_wrapped(_Dest, _STD transform(_UFirst1, _ULast1, _STD _Get_unwrapped_n(_First2, _Count),
+                                 _STD _Get_unwrapped_n(_Dest, _Count), _STD _Pass_fn(_Func)));
         return _Dest;
     }
 }
@@ -2457,8 +2457,9 @@ void replace_if(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt _Last, _Pr _Pre
 /* terminates */ {
     // replace each satisfying _Pred with _Val
     _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
+    auto _Lambda_pred = _STD _Pass_fn(_Pred); // TRANSITION, DevCom-10456445
     _STD for_each(
-        _STD forward<_ExPo>(_Exec), _First, _Last, [&_Val, _Lambda_pred = _Pass_fn(_Pred)](auto&& _Value) mutable {
+        _STD forward<_ExPo>(_Exec), _First, _Last, [&_Val, _Lambda_pred](auto&& _Value) mutable {
             if (_Lambda_pred(_STD forward<decltype(_Value)>(_Value))) {
                 _STD forward<decltype(_Value)>(_Value) = _Val;
             }
@@ -2530,7 +2531,7 @@ struct _Static_partitioned_remove_if2 {
                 if (_Merge_index == 0 || _Results == _Range._First) {
                     _Results = _STD remove_if(_Range._First, _Range._Last, _Pred);
                 } else {
-                    _Results = _Remove_move_if_unchecked(_Range._First, _Range._Last, _Results, _Pred);
+                    _Results = _STD _Remove_move_if_unchecked(_Range._First, _Range._Last, _Results, _Pred);
                 }
 
                 _Chunk_data._State.store(_Chunk_state::_Done);
@@ -2572,7 +2573,7 @@ struct _Static_partitioned_remove_if2 {
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_remove_if2*>(_Context));
+        _STD _Run_available_chunked_work(*static_cast<_Static_partitioned_remove_if2*>(_Context));
     }
 };
 
@@ -2581,18 +2582,18 @@ _NODISCARD_REMOVE_ALG _FwdIt remove_if(_ExPo&&, _FwdIt _First, const _FwdIt _Las
 /* terminates */ {
     // remove each satisfying _Pred
     _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     if constexpr (remove_reference_t<_ExPo>::_Parallelize) {
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
         if (_Hw_threads > 1) {
             const auto _Count = _STD distance(_UFirst, _ULast);
             if (_Count >= 2) {
                 _TRY_BEGIN
-                _Static_partitioned_remove_if2 _Operation{_Hw_threads, _Count, _UFirst, _Pass_fn(_Pred)};
-                _Run_chunked_parallel_work(_Hw_threads, _Operation);
-                _Seek_wrapped(_First, _Operation._Results);
+                _Static_partitioned_remove_if2 _Operation{_Hw_threads, _Count, _UFirst, _STD _Pass_fn(_Pred)};
+                _STD _Run_chunked_parallel_work(_Hw_threads, _Operation);
+                _STD _Seek_wrapped(_First, _Operation._Results);
                 return _First;
                 _CATCH(const _Parallelism_resources_exhausted&)
                 // fall through to serial case below
@@ -2601,7 +2602,7 @@ _NODISCARD_REMOVE_ALG _FwdIt remove_if(_ExPo&&, _FwdIt _First, const _FwdIt _Las
         }
     }
 
-    _Seek_wrapped(_First, _STD remove_if(_UFirst, _ULast, _Pass_fn(_Pred)));
+    _STD _Seek_wrapped(_First, _STD remove_if(_UFirst, _ULast, _STD _Pass_fn(_Pred)));
     return _First;
 }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4447,13 +4447,13 @@ _CONSTEXPR20 void _Verify_ranges_do_not_overlap(const _Iter1& _First1, const _Se
 #endif // _HAS_CXX20
 
         const auto _Offset     = _Last1 - _First1;
-        const auto _Ptr1Offset = _Offset * sizeof(*_To_address(_First1));
-        const auto _Ptr2Offset = _Offset * sizeof(*_To_address(_First2));
+        const auto _Ptr1Offset = _Offset * sizeof(*_STD _To_address(_First1));
+        const auto _Ptr2Offset = _Offset * sizeof(*_STD _To_address(_First2));
         // This cast to `cv char*` allows us to compare pointers to distinct types,
         // in case one range provides storage for the other.
-        const auto _PtrFirst1 = reinterpret_cast<const volatile char*>(_To_address(_First1));
+        const auto _PtrFirst1 = reinterpret_cast<const volatile char*>(_STD _To_address(_First1));
         const auto _PtrLast1  = _PtrFirst1 + _Ptr1Offset;
-        const auto _PtrFirst2 = reinterpret_cast<const volatile char*>(_To_address(_First2));
+        const auto _PtrFirst2 = reinterpret_cast<const volatile char*>(_STD _To_address(_First2));
         const auto _PtrLast2  = _PtrFirst2 + _Ptr2Offset;
         _STL_VERIFY(_PtrLast1 <= _PtrFirst2 || _PtrLast2 <= _PtrFirst1, "ranges should not overlap each other");
     }
@@ -4466,9 +4466,9 @@ _CONSTEXPR20 void _Verify_ranges_do_not_overlap(const _Iter1& _First1, const _Se
 
 template <class _CtgIt, class _OutCtgIt>
 _OutCtgIt _Copy_memmove(_CtgIt _First, _CtgIt _Last, _OutCtgIt _Dest) {
-    auto _FirstPtr              = _To_address(_First);
-    auto _LastPtr               = _To_address(_Last);
-    auto _DestPtr               = _To_address(_Dest);
+    auto _FirstPtr              = _STD _To_address(_First);
+    auto _LastPtr               = _STD _To_address(_Last);
+    auto _DestPtr               = _STD _To_address(_Dest);
     const char* const _First_ch = const_cast<const char*>(reinterpret_cast<const volatile char*>(_FirstPtr));
     const char* const _Last_ch  = const_cast<const char*>(reinterpret_cast<const volatile char*>(_LastPtr));
     char* const _Dest_ch        = const_cast<char*>(reinterpret_cast<const volatile char*>(_DestPtr));
@@ -4483,7 +4483,7 @@ _OutCtgIt _Copy_memmove(_CtgIt _First, _CtgIt _Last, _OutCtgIt _Dest) {
 
 template <class _CtgIt, class _OutCtgIt>
 _OutCtgIt _Copy_memmove_n(_CtgIt _First, const size_t _Count, _OutCtgIt _Dest) {
-    const auto _Result = _Copy_memmove(_First, _First + _Count, _Dest);
+    const auto _Result = _STD _Copy_memmove(_First, _First + _Count, _Dest);
     if constexpr (is_pointer_v<_OutCtgIt>) {
         return _Result;
     } else { // _Result is unused so the compiler can optimize it away
@@ -4553,11 +4553,11 @@ _CONSTEXPR20 _OutIt _Copy_unchecked(_InIt _First, _Sent _Last, _OutIt _Dest) {
             {
 #ifdef __cpp_lib_concepts
                 if constexpr (!is_same_v<_InIt, _Sent>) {
-                    return _Copy_memmove_n(_First, static_cast<size_t>(_Last - _First), _Dest);
+                    return _STD _Copy_memmove_n(_First, static_cast<size_t>(_Last - _First), _Dest);
                 } else
 #endif // defined(__cpp_lib_concepts)
                 {
-                    return _Copy_memmove(_First, _Last, _Dest);
+                    return _STD _Copy_memmove(_First, _Last, _Dest);
                 }
             }
         }
@@ -4572,11 +4572,11 @@ _CONSTEXPR20 _OutIt _Copy_unchecked(_InIt _First, _Sent _Last, _OutIt _Dest) {
 
 _EXPORT_STD template <class _InIt, class _OutIt>
 _CONSTEXPR20 _OutIt copy(_InIt _First, _InIt _Last, _OutIt _Dest) { // copy [_First, _Last) to [_Dest, ...)
-    _Adl_verify_range(_First, _Last);
-    const auto _UFirst = _Get_unwrapped(_First);
-    const auto _ULast  = _Get_unwrapped(_Last);
-    const auto _UDest  = _Get_unwrapped_n(_Dest, _Idl_distance<_InIt>(_UFirst, _ULast));
-    _Seek_wrapped(_Dest, _STD _Copy_unchecked(_UFirst, _ULast, _UDest));
+    _STD _Adl_verify_range(_First, _Last);
+    const auto _UFirst = _STD _Get_unwrapped(_First);
+    const auto _ULast  = _STD _Get_unwrapped(_Last);
+    const auto _UDest  = _STD _Get_unwrapped_n(_Dest, _STD _Idl_distance<_InIt>(_UFirst, _ULast));
+    _STD _Seek_wrapped(_Dest, _STD _Copy_unchecked(_UFirst, _ULast, _UDest));
     return _Dest;
 }
 
@@ -4690,11 +4690,11 @@ namespace ranges {
         if constexpr (_Sent_copy_cat<_It, _Se, _Out>::_Bitcopy_assignable) {
             if (!_STD is_constant_evaluated()) {
                 if constexpr (is_same_v<_It, _Se>) {
-                    _Result = _Copy_memmove(_STD move(_First), _Last, _STD move(_Result));
+                    _Result = _STD _Copy_memmove(_STD move(_First), _Last, _STD move(_Result));
                     return {_STD move(_Last), _STD move(_Result)};
                 } else {
                     const auto _Count = static_cast<size_t>(_Last - _First);
-                    _Result           = _Copy_memmove_n(_First, _Count, _STD move(_Result));
+                    _Result           = _STD _Copy_memmove_n(_First, _Count, _STD move(_Result));
                     _First += _Count;
                     return {_STD move(_First), _STD move(_Result)};
                 }
@@ -4713,10 +4713,10 @@ namespace ranges {
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
             requires indirectly_copyable<_It, _Out>
         constexpr copy_result<_It, _Out> operator()(_It _First, _Se _Last, _Out _Result) const {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _RANGES _Copy_unchecked(
-                _Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result));
-            _Seek_wrapped(_First, _STD move(_UResult.in));
+                _RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }
 
@@ -4725,8 +4725,8 @@ namespace ranges {
         constexpr copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(_Rng&& _Range, _Out _Result) const {
             auto _First = _RANGES begin(_Range);
             auto _UResult =
-                _RANGES _Copy_unchecked(_Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD move(_Result));
-            _Seek_wrapped(_First, _STD move(_UResult.in));
+                _RANGES _Copy_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD move(_Result));
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }
     };
@@ -4743,15 +4743,15 @@ _CONSTEXPR20 _OutIt copy_n(_InIt _First, _Diff _Count_raw, _OutIt _Dest) {
         if constexpr (_Is_vb_iterator<_InIt> && _Is_vb_iterator<_OutIt, true>) {
             return _STD _Copy_vbool(_First, _First + _Count, _Dest);
         } else {
-            auto _UFirst = _Get_unwrapped_n(_First, _Count);
-            auto _UDest  = _Get_unwrapped_n(_Dest, _Count);
+            auto _UFirst = _STD _Get_unwrapped_n(_First, _Count);
+            auto _UDest  = _STD _Get_unwrapped_n(_Dest, _Count);
             if constexpr (_Iter_copy_cat<decltype(_UFirst), decltype(_UDest)>::_Bitcopy_assignable) {
 #if _HAS_CXX20
                 if (!_STD is_constant_evaluated())
 #endif // _HAS_CXX20
                 {
-                    _UDest = _Copy_memmove_n(_UFirst, static_cast<size_t>(_Count), _UDest);
-                    _Seek_wrapped(_Dest, _UDest);
+                    _UDest = _STD _Copy_memmove_n(_UFirst, static_cast<size_t>(_Count), _UDest);
+                    _STD _Seek_wrapped(_Dest, _UDest);
                     return _Dest;
                 }
             }
@@ -4768,7 +4768,7 @@ _CONSTEXPR20 _OutIt copy_n(_InIt _First, _Diff _Count_raw, _OutIt _Dest) {
                 ++_UFirst;
             }
 
-            _Seek_wrapped(_Dest, _UDest);
+            _STD _Seek_wrapped(_Dest, _UDest);
         }
     }
 
@@ -4789,9 +4789,9 @@ _FwdIt2 copy_n(_ExPo&&, _FwdIt1 _First, _Diff _Count_raw, _FwdIt2 _Dest) noexcep
 template <class _CtgIt1, class _CtgIt2>
 _CtgIt2 _Copy_backward_memmove(_CtgIt1 _First, _CtgIt1 _Last, _CtgIt2 _Dest) {
     // implement copy_backward-like function as memmove
-    auto _FirstPtr              = _To_address(_First);
-    auto _LastPtr               = _To_address(_Last);
-    auto _DestPtr               = _To_address(_Dest);
+    auto _FirstPtr              = _STD _To_address(_First);
+    auto _LastPtr               = _STD _To_address(_Last);
+    auto _DestPtr               = _STD _To_address(_Dest);
     const char* const _First_ch = const_cast<const char*>(reinterpret_cast<const volatile char*>(_FirstPtr));
     const char* const _Last_ch  = const_cast<const char*>(reinterpret_cast<const volatile char*>(_LastPtr));
     char* const _Dest_ch        = const_cast<char*>(reinterpret_cast<const volatile char*>(_DestPtr));
@@ -4806,7 +4806,7 @@ _CtgIt2 _Copy_backward_memmove(_CtgIt1 _First, _CtgIt1 _Last, _CtgIt2 _Dest) {
 
 template <class _BidIt1, class _BidIt2>
 _BidIt2 _Copy_backward_memmove(move_iterator<_BidIt1> _First, move_iterator<_BidIt1> _Last, _BidIt2 _Dest) {
-    return _Copy_backward_memmove(_First.base(), _Last.base(), _Dest);
+    return _STD _Copy_backward_memmove(_First.base(), _Last.base(), _Dest);
 }
 
 template <class _BidIt1, class _BidIt2>
@@ -4817,7 +4817,7 @@ _NODISCARD _CONSTEXPR20 _BidIt2 _Copy_backward_unchecked(_BidIt1 _First, _BidIt1
         if (!_STD is_constant_evaluated())
 #endif // _HAS_CXX20
         {
-            return _Copy_backward_memmove(_First, _Last, _Dest);
+            return _STD _Copy_backward_memmove(_First, _Last, _Dest);
         }
     }
 
@@ -4831,11 +4831,11 @@ _NODISCARD _CONSTEXPR20 _BidIt2 _Copy_backward_unchecked(_BidIt1 _First, _BidIt1
 _EXPORT_STD template <class _BidIt1, class _BidIt2>
 _CONSTEXPR20 _BidIt2 copy_backward(_BidIt1 _First, _BidIt1 _Last, _BidIt2 _Dest) {
     // copy [_First, _Last) backwards to [..., _Dest)
-    _Adl_verify_range(_First, _Last);
-    const auto _UFirst = _Get_unwrapped(_First);
-    const auto _ULast  = _Get_unwrapped(_Last);
-    const auto _UDest  = _Get_unwrapped_n(_Dest, -_Idl_distance<_BidIt1>(_UFirst, _ULast));
-    _Seek_wrapped(_Dest, _Copy_backward_unchecked(_UFirst, _ULast, _UDest));
+    _STD _Adl_verify_range(_First, _Last);
+    const auto _UFirst = _STD _Get_unwrapped(_First);
+    const auto _ULast  = _STD _Get_unwrapped(_Last);
+    const auto _UDest  = _STD _Get_unwrapped_n(_Dest, -_STD _Idl_distance<_BidIt1>(_UFirst, _ULast));
+    _STD _Seek_wrapped(_Dest, _STD _Copy_backward_unchecked(_UFirst, _ULast, _UDest));
     return _Dest;
 }
 
@@ -4851,7 +4851,7 @@ _CONSTEXPR20 _OutIt _Move_unchecked(_InIt _First, _InIt _Last, _OutIt _Dest) {
             if (!_STD is_constant_evaluated())
 #endif // _HAS_CXX20
             {
-                return _Copy_memmove(_First, _Last, _Dest);
+                return _STD _Copy_memmove(_First, _Last, _Dest);
             }
         }
 
@@ -4866,11 +4866,11 @@ _CONSTEXPR20 _OutIt _Move_unchecked(_InIt _First, _InIt _Last, _OutIt _Dest) {
 _EXPORT_STD template <class _InIt, class _OutIt>
 _CONSTEXPR20 _OutIt move(_InIt _First, _InIt _Last, _OutIt _Dest) {
     // move [_First, _Last) to [_Dest, ...)
-    _Adl_verify_range(_First, _Last);
-    const auto _UFirst = _Get_unwrapped(_First);
-    const auto _ULast  = _Get_unwrapped(_Last);
-    const auto _UDest  = _Get_unwrapped_n(_Dest, _Idl_distance<_InIt>(_UFirst, _ULast));
-    _Seek_wrapped(_Dest, _STD _Move_unchecked(_UFirst, _ULast, _UDest));
+    _STD _Adl_verify_range(_First, _Last);
+    const auto _UFirst = _STD _Get_unwrapped(_First);
+    const auto _ULast  = _STD _Get_unwrapped(_Last);
+    const auto _UDest  = _STD _Get_unwrapped_n(_Dest, _STD _Idl_distance<_InIt>(_UFirst, _ULast));
+    _STD _Seek_wrapped(_Dest, _STD _Move_unchecked(_UFirst, _ULast, _UDest));
     return _Dest;
 }
 
@@ -4894,7 +4894,7 @@ _CONSTEXPR20 _BidIt2 _Move_backward_unchecked(_BidIt1 _First, _BidIt1 _Last, _Bi
         if (!_STD is_constant_evaluated())
 #endif // _HAS_CXX20
         {
-            return _Copy_backward_memmove(_First, _Last, _Dest);
+            return _STD _Copy_backward_memmove(_First, _Last, _Dest);
         }
     }
 
@@ -4908,11 +4908,11 @@ _CONSTEXPR20 _BidIt2 _Move_backward_unchecked(_BidIt1 _First, _BidIt1 _Last, _Bi
 _EXPORT_STD template <class _BidIt1, class _BidIt2>
 _CONSTEXPR20 _BidIt2 move_backward(_BidIt1 _First, _BidIt1 _Last, _BidIt2 _Dest) {
     // move [_First, _Last) backwards to [..., _Dest)
-    _Adl_verify_range(_First, _Last);
-    const auto _UFirst = _Get_unwrapped(_First);
-    const auto _ULast  = _Get_unwrapped(_Last);
-    const auto _UDest  = _Get_unwrapped_n(_Dest, -_Idl_distance<_BidIt1>(_UFirst, _ULast));
-    _Seek_wrapped(_Dest, _Move_backward_unchecked(_UFirst, _ULast, _UDest));
+    _STD _Adl_verify_range(_First, _Last);
+    const auto _UFirst = _STD _Get_unwrapped(_First);
+    const auto _ULast  = _STD _Get_unwrapped(_Last);
+    const auto _UDest  = _STD _Get_unwrapped_n(_Dest, -_STD _Idl_distance<_BidIt1>(_UFirst, _ULast));
+    _STD _Seek_wrapped(_Dest, _STD _Move_backward_unchecked(_UFirst, _ULast, _UDest));
     return _Dest;
 }
 
@@ -4969,12 +4969,12 @@ template <class _CtgIt, class _Ty>
 void _Fill_memset(_CtgIt _Dest, const _Ty _Val, const size_t _Count) {
     // implicitly convert (a cast would suppress warnings); also handles _Iter_value_t<_CtgIt> being bool
     _Iter_value_t<_CtgIt> _Dest_val = _Val;
-    _CSTD memset(_To_address(_Dest), static_cast<unsigned char>(_Dest_val), _Count);
+    _CSTD memset(_STD _To_address(_Dest), static_cast<unsigned char>(_Dest_val), _Count);
 }
 
 template <class _CtgIt>
 void _Fill_zero_memset(_CtgIt _Dest, const size_t _Count) {
-    _CSTD memset(_To_address(_Dest), 0, _Count * sizeof(_Iter_value_t<_CtgIt>));
+    _CSTD memset(_STD _To_address(_Dest), 0, _Count * sizeof(_Iter_value_t<_CtgIt>));
 }
 
 template <class _Ty>
@@ -4992,22 +4992,22 @@ _NODISCARD bool _Is_all_bits_zero(const _Ty& _Val) {
 _EXPORT_STD template <class _FwdIt, class _Ty>
 _CONSTEXPR20 void fill(const _FwdIt _First, const _FwdIt _Last, const _Ty& _Val) {
     // copy _Val through [_First, _Last)
-    _Adl_verify_range(_First, _Last);
+    _STD _Adl_verify_range(_First, _Last);
     if constexpr (_Is_vb_iterator<_FwdIt, true>) {
         _STD _Fill_vbool(_First, _Last, _Val);
     } else {
-        auto _UFirst      = _Get_unwrapped(_First);
-        const auto _ULast = _Get_unwrapped(_Last);
+        auto _UFirst      = _STD _Get_unwrapped(_First);
+        const auto _ULast = _STD _Get_unwrapped(_Last);
 #if _HAS_CXX20
         if (!_STD is_constant_evaluated())
 #endif // _HAS_CXX20
         {
             if constexpr (_Fill_memset_is_safe<decltype(_UFirst), _Ty>) {
-                _Fill_memset(_UFirst, _Val, static_cast<size_t>(_ULast - _UFirst));
+                _STD _Fill_memset(_UFirst, _Val, static_cast<size_t>(_ULast - _UFirst));
                 return;
             } else if constexpr (_Fill_zero_memset_is_safe<decltype(_UFirst), _Ty>) {
-                if (_Is_all_bits_zero(_Val)) {
-                    _Fill_zero_memset(_UFirst, static_cast<size_t>(_ULast - _UFirst));
+                if (_STD _Is_all_bits_zero(_Val)) {
+                    _STD _Fill_zero_memset(_UFirst, static_cast<size_t>(_ULast - _UFirst));
                     return;
                 }
             }
@@ -5039,19 +5039,19 @@ _CONSTEXPR20 _OutIt fill_n(_OutIt _Dest, const _Diff _Count_raw, const _Ty& _Val
             _STD _Fill_vbool(_Dest, _Last, _Val);
             return _Last;
         } else {
-            auto _UDest = _Get_unwrapped_n(_Dest, _Count);
+            auto _UDest = _STD _Get_unwrapped_n(_Dest, _Count);
 #if _HAS_CXX20
             if (!_STD is_constant_evaluated())
 #endif // _HAS_CXX20
             {
                 if constexpr (_Fill_memset_is_safe<decltype(_UDest), _Ty>) {
-                    _Fill_memset(_UDest, _Val, static_cast<size_t>(_Count));
-                    _Seek_wrapped(_Dest, _UDest + _Count);
+                    _STD _Fill_memset(_UDest, _Val, static_cast<size_t>(_Count));
+                    _STD _Seek_wrapped(_Dest, _UDest + _Count);
                     return _Dest;
                 } else if constexpr (_Fill_zero_memset_is_safe<decltype(_UDest), _Ty>) {
-                    if (_Is_all_bits_zero(_Val)) {
-                        _Fill_zero_memset(_UDest, static_cast<size_t>(_Count));
-                        _Seek_wrapped(_Dest, _UDest + _Count);
+                    if (_STD _Is_all_bits_zero(_Val)) {
+                        _STD _Fill_zero_memset(_UDest, static_cast<size_t>(_Count));
+                        _STD _Seek_wrapped(_Dest, _UDest + _Count);
                         return _Dest;
                     }
                 }
@@ -5061,7 +5061,7 @@ _CONSTEXPR20 _OutIt fill_n(_OutIt _Dest, const _Diff _Count_raw, const _Ty& _Val
                 *_UDest = _Val;
             }
 
-            _Seek_wrapped(_Dest, _UDest);
+            _STD _Seek_wrapped(_Dest, _UDest);
         }
     }
     return _Dest;
@@ -5084,16 +5084,16 @@ namespace ranges {
         template <class _Ty, output_iterator<const _Ty&> _It>
         constexpr _It operator()(_It _First, iter_difference_t<_It> _Count, const _Ty& _Value) const {
             if (_Count > 0) {
-                auto _UFirst = _Get_unwrapped_n(_STD move(_First), _Count);
+                auto _UFirst = _STD _Get_unwrapped_n(_STD move(_First), _Count);
                 if (!_STD is_constant_evaluated()) {
                     if constexpr (_Fill_memset_is_safe<decltype(_UFirst), _Ty>) {
-                        _Fill_memset(_UFirst, _Value, static_cast<size_t>(_Count));
-                        _Seek_wrapped(_First, _UFirst + _Count); // no need to move since _UFirst is a pointer
+                        _STD _Fill_memset(_UFirst, _Value, static_cast<size_t>(_Count));
+                        _STD _Seek_wrapped(_First, _UFirst + _Count); // no need to move since _UFirst is a pointer
                         return _First;
                     } else if constexpr (_Fill_zero_memset_is_safe<decltype(_UFirst), _Ty>) {
-                        if (_Is_all_bits_zero(_Value)) {
-                            _Fill_zero_memset(_UFirst, static_cast<size_t>(_Count));
-                            _Seek_wrapped(_First, _UFirst + _Count); // no need to move since _UFirst is a pointer
+                        if (_STD _Is_all_bits_zero(_Value)) {
+                            _STD _Fill_zero_memset(_UFirst, static_cast<size_t>(_Count));
+                            _STD _Seek_wrapped(_First, _UFirst + _Count); // no need to move since _UFirst is a pointer
                             return _First;
                         }
                     }
@@ -5103,7 +5103,7 @@ namespace ranges {
                     *_UFirst = _Value;
                 }
 
-                _Seek_wrapped(_First, _STD move(_UFirst));
+                _STD _Seek_wrapped(_First, _STD move(_UFirst));
             }
 
             return _First;
@@ -6134,9 +6134,9 @@ _NODISCARD _CONSTEXPR20 bool _Check_match_counts(
 
 _EXPORT_STD template <class _BidIt>
 _CONSTEXPR20 void reverse(const _BidIt _First, const _BidIt _Last) { // reverse elements in [_First, _Last)
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst = _Get_unwrapped(_First);
-    auto _ULast  = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst = _STD _Get_unwrapped(_First);
+    auto _ULast  = _STD _Get_unwrapped(_Last);
 #if _USE_STD_VECTOR_ALGORITHMS
     using _Elem                         = remove_reference_t<_Iter_ref_t<decltype(_UFirst)>>;
     constexpr bool _Allow_vectorization = conjunction_v<bool_constant<_Iterator_is_contiguous<decltype(_UFirst)>>,
@@ -6149,13 +6149,13 @@ _CONSTEXPR20 void reverse(const _BidIt _First, const _BidIt _Last) { // reverse 
 #endif // _HAS_CXX20
         {
             if constexpr (_Nx == 1) {
-                __std_reverse_trivially_swappable_1(_To_address(_UFirst), _To_address(_ULast));
+                ::__std_reverse_trivially_swappable_1(_STD _To_address(_UFirst), _STD _To_address(_ULast));
             } else if constexpr (_Nx == 2) {
-                __std_reverse_trivially_swappable_2(_To_address(_UFirst), _To_address(_ULast));
+                ::__std_reverse_trivially_swappable_2(_STD _To_address(_UFirst), _STD _To_address(_ULast));
             } else if constexpr (_Nx == 4) {
-                __std_reverse_trivially_swappable_4(_To_address(_UFirst), _To_address(_ULast));
+                ::__std_reverse_trivially_swappable_4(_STD _To_address(_UFirst), _STD _To_address(_ULast));
             } else {
-                __std_reverse_trivially_swappable_8(_To_address(_UFirst), _To_address(_ULast));
+                ::__std_reverse_trivially_swappable_8(_STD _To_address(_UFirst), _STD _To_address(_ULast));
             }
 
             return;
@@ -6194,11 +6194,11 @@ _CONSTEXPR20 _FwdIt rotate(_FwdIt _First, _FwdIt _Mid, _FwdIt _Last) {
     // exchange the ranges [_First, _Mid) and [_Mid, _Last)
     // that is, rotates [_First, _Last) left by distance(_First, _Mid) positions
     // returns the iterator pointing at *_First's new home
-    _Adl_verify_range(_First, _Mid);
-    _Adl_verify_range(_Mid, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    auto _UMid        = _Get_unwrapped(_Mid);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Mid);
+    _STD _Adl_verify_range(_Mid, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    auto _UMid        = _STD _Get_unwrapped(_Mid);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     if (_UFirst == _UMid) {
         return _Last;
     }
@@ -6211,13 +6211,13 @@ _CONSTEXPR20 _FwdIt rotate(_FwdIt _First, _FwdIt _Mid, _FwdIt _Last) {
         _STD reverse(_UFirst, _UMid);
         _STD reverse(_UMid, _ULast);
         _STD reverse(_UFirst, _ULast);
-        _Seek_wrapped(_First, _UFirst + (_ULast - _UMid));
+        _STD _Seek_wrapped(_First, _UFirst + (_ULast - _UMid));
     } else if constexpr (_Is_cpp17_bidi_iter_v<_FwdIt>) {
         _STD reverse(_UFirst, _UMid);
         _STD reverse(_UMid, _ULast);
-        auto _Tmp = _Reverse_until_sentinel_unchecked(_UFirst, _UMid, _ULast);
+        auto _Tmp = _STD _Reverse_until_sentinel_unchecked(_UFirst, _UMid, _ULast);
         _STD reverse(_Tmp.first, _Tmp.second);
-        _Seek_wrapped(_First, _UMid != _Tmp.first ? _Tmp.first : _Tmp.second);
+        _STD _Seek_wrapped(_First, _UMid != _Tmp.first ? _Tmp.first : _Tmp.second);
     } else {
         auto _UNext = _UMid;
         do { // rotate the first cycle
@@ -6228,7 +6228,7 @@ _CONSTEXPR20 _FwdIt rotate(_FwdIt _First, _FwdIt _Mid, _FwdIt _Last) {
                 _UMid = _UNext;
             }
         } while (_UNext != _ULast);
-        _Seek_wrapped(_First, _UFirst);
+        _STD _Seek_wrapped(_First, _UFirst);
         while (_UMid != _ULast) { // rotate subsequent cycles
             _UNext = _UMid;
             do {
@@ -7035,8 +7035,8 @@ _CONSTEXPR20 _FwdIt2 _Swap_ranges_unchecked(_FwdIt1 _First1, const _FwdIt1 _Last
         if (!_STD is_constant_evaluated())
 #endif // _HAS_CXX20
         {
-            __std_swap_ranges_trivially_swappable_noalias(
-                _To_address(_First1), _To_address(_Last1), _To_address(_First2));
+            ::__std_swap_ranges_trivially_swappable_noalias(
+                _STD _To_address(_First1), _STD _To_address(_Last1), _STD _To_address(_First2));
             return _First2 + (_Last1 - _First1);
         }
     }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4714,8 +4714,8 @@ namespace ranges {
             requires indirectly_copyable<_It, _Out>
         constexpr copy_result<_It, _Out> operator()(_It _First, _Se _Last, _Out _Result) const {
             _STD _Adl_verify_range(_First, _Last);
-            auto _UResult = _RANGES _Copy_unchecked(
-                _RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result));
+            auto _UResult = _RANGES _Copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result));
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }
@@ -4723,9 +4723,9 @@ namespace ranges {
         template <input_range _Rng, weakly_incrementable _Out>
             requires indirectly_copyable<iterator_t<_Rng>, _Out>
         constexpr copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(_Rng&& _Range, _Out _Result) const {
-            auto _First = _RANGES begin(_Range);
-            auto _UResult =
-                _RANGES _Copy_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD move(_Result));
+            auto _First   = _RANGES begin(_Range);
+            auto _UResult = _RANGES _Copy_unchecked(
+                _RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD move(_Result));
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }

--- a/tests/std/tests/GH_001596_adl_proof_algorithms/test.compile.pass.cpp
+++ b/tests/std/tests/GH_001596_adl_proof_algorithms/test.compile.pass.cpp
@@ -44,12 +44,33 @@ struct tagged_compare_three_way {
 };
 #endif // _HAS_CXX20
 
-template <class T>
-struct holder {
-    T t;
+template <class Tag>
+struct tagged_identity {
+    template <class T>
+    constexpr T&& operator()(T&& t) const noexcept {
+        return std::forward<T>(t);
+    }
 };
 
-#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+template <class Tag>
+struct tagged_urng {
+    using result_type = unsigned int;
+
+    static constexpr result_type max() noexcept {
+        return static_cast<result_type>(-1);
+    }
+
+    static constexpr result_type min() noexcept {
+        return 0;
+    }
+
+    result_type operator()() noexcept {
+        return value_++;
+    }
+
+    result_type value_{};
+};
+
 template <class Tag>
 struct tagged_left_selector {
     template <class T>
@@ -57,26 +78,37 @@ struct tagged_left_selector {
         return lhs;
     }
 };
-#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+
+template <class T>
+struct holder {
+    T t;
+};
 
 struct incomplete;
 
-using simple_truth = tagged_truth<void>;
+using simple_truth         = tagged_truth<void>;
+using simple_identity      = tagged_identity<void>;
+using simple_left_selector = tagged_left_selector<void>;
+using simple_urng          = tagged_urng<void>;
 
-using validator        = holder<incomplete>*;
-using validating_truth = tagged_truth<holder<incomplete>>;
-using validating_equal = tagged_equal<holder<incomplete>>;
-using validating_less  = tagged_less<holder<incomplete>>;
+using validator                = holder<incomplete>*;
+using validating_truth         = tagged_truth<holder<incomplete>>;
+using validating_equal         = tagged_equal<holder<incomplete>>;
+using validating_less          = tagged_less<holder<incomplete>>;
+using validating_identity      = tagged_identity<holder<incomplete>>;
+using validating_left_selector = tagged_left_selector<holder<incomplete>>;
+using validating_urng          = tagged_urng<holder<incomplete>>;
 
 #if _HAS_CXX20
 using validating_compare_three_way = tagged_compare_three_way<holder<incomplete>>;
 #endif // _HAS_CXX20
 
-#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-using simple_left_selector = tagged_left_selector<void>;
-
-using validating_left_selector = tagged_left_selector<holder<incomplete>>;
-#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+template <class T>
+struct value_generator {
+    T operator()() const {
+        return T{};
+    }
+};
 
 void test_algorithms() {
     int iarr[1]{};
@@ -145,10 +177,91 @@ void test_algorithms() {
     (void) std::search(varr, varr, varr, varr);
     (void) std::search(iarr, iarr, iarr, iarr, validating_equal{});
 
+    (void) std::search_n(varr, varr, 0, validator{});
+    (void) std::search_n(iarr, iarr, 0, 0, validating_equal{});
+
+    int iarr2[1]{};
+    validator varr2[1]{};
+
+    (void) std::copy(varr, varr + 1, varr2);
+
+    (void) std::copy_n(varr, 1, varr2);
+
+    (void) std::copy_if(varr, varr + 1, varr2, simple_truth{});
+    (void) std::copy_if(iarr, iarr + 1, iarr2, validating_truth{});
+
+    (void) std::copy_backward(varr, varr + 1, varr2 + 1);
+
+    (void) std::move(varr, varr + 1, varr2);
+
+    (void) std::move_backward(varr, varr + 1, varr2 + 1);
+
+    // (void) std::swap_ranges(varr, varr, varr2); // requires Cpp17ValueSwappable
+
+    // std::iter_swap(varr, varr2); // requires Cpp17ValueSwappable
+
+    (void) std::transform(varr, varr, varr2, simple_identity{});
+    (void) std::transform(varr, varr, varr, varr2, simple_left_selector{});
+    (void) std::transform(iarr, iarr, iarr2, validating_identity{});
+    (void) std::transform(iarr, iarr, iarr, iarr2, validating_left_selector{});
+
+    std::replace(varr, varr, validator{}, validator{});
+
+    std::replace_if(varr, varr, simple_truth{}, validator{});
+    std::replace_if(iarr, iarr, validating_truth{}, 0);
+
+    (void) std::replace_copy(varr, varr, varr2, validator{}, validator{});
+
+    (void) std::replace_copy_if(varr, varr, varr2, simple_truth{}, validator{});
+    (void) std::replace_copy_if(iarr, iarr, iarr2, validating_truth{}, 0);
+
+    std::fill(varr, varr, validator{});
+
+    (void) std::fill_n(varr, 0, validator{});
+
+    std::generate(varr, varr, value_generator<validator>{});
+
+    (void) std::generate_n(varr, 0, value_generator<validator>{});
+
     (void) std::remove(varr, varr, validator{});
 
     (void) std::remove_if(varr, varr, simple_truth{});
     (void) std::remove_if(iarr, iarr, validating_truth{});
+
+    (void) std::remove_copy(varr, varr, varr2, validator{});
+
+    (void) std::remove_copy_if(varr, varr, varr2, simple_truth{});
+    (void) std::remove_copy_if(iarr, iarr, iarr2, validating_truth{});
+
+    (void) std::unique(varr, varr);
+    (void) std::unique(iarr, iarr, validating_equal{});
+
+    (void) std::unique_copy(varr, varr, varr2);
+    (void) std::unique_copy(iarr, iarr, iarr2, validating_equal{});
+
+    // (void) std::reverse(varr, varr); // requires Cpp17ValueSwappable
+
+    (void) std::reverse_copy(varr, varr, varr2);
+
+    // (void) std::rotate(varr, varr, varr); // requires Cpp17ValueSwappable
+
+    (void) std::rotate_copy(varr, varr, varr, varr2);
+
+#if _HAS_CXX17
+    (void) std::sample(varr, varr, varr2, 0, simple_urng{});
+    (void) std::sample(iarr, iarr, iarr2, 0, validating_urng{});
+#endif // _HAS_CXX17
+
+    // std::shuffle(varr, varr, simple_urng{}); // requires Cpp17ValueSwappable
+    // std::shuffle(iarr, iarr, validating_urng{}); // requires Cpp17ValueSwappable
+
+    // std::random_shuffle (removed in C++17) also requires Cpp17ValueSwappable
+
+#if _HAS_CXX20
+    (void) std::shift_left(varr, varr, 0);
+
+    // (void) std::shift_right(varr, varr, 0); // requires Cpp17ValueSwappable
+#endif // _HAS_CXX20
 
     (void) std::min(+varr, +varr);
     (void) std::min(+iarr, +iarr, validating_less{});
@@ -251,6 +364,73 @@ void test_per_execution_policy() {
     (void) std::search_n(ExecutionPolicy, varr, varr, 0, validator{});
     (void) std::search_n(ExecutionPolicy, iarr, iarr, 0, 0, validating_equal{});
 
+    int iarr2[1]{};
+    validator varr2[1]{};
+
+    (void) std::copy(ExecutionPolicy, varr, varr + 1, varr2);
+
+    (void) std::copy_n(ExecutionPolicy, varr, 1, varr2);
+
+    (void) std::copy_if(ExecutionPolicy, varr, varr + 1, varr2, simple_truth{});
+    (void) std::copy_if(ExecutionPolicy, iarr, iarr + 1, iarr2, validating_truth{});
+
+    (void) std::move(ExecutionPolicy, varr, varr + 1, varr2);
+
+    // (void) std::swap_ranges(ExecutionPolicy, varr, varr, varr2);  // requires Cpp17ValueSwappable
+
+    (void) std::transform(ExecutionPolicy, varr, varr, varr2, simple_identity{});
+    (void) std::transform(ExecutionPolicy, varr, varr, varr, varr2, simple_left_selector{});
+    (void) std::transform(ExecutionPolicy, iarr, iarr, iarr2, validating_identity{});
+    (void) std::transform(ExecutionPolicy, iarr, iarr, iarr, iarr2, validating_left_selector{});
+
+    std::replace(ExecutionPolicy, varr, varr, validator{}, validator{});
+
+    std::replace_if(ExecutionPolicy, varr, varr, simple_truth{}, validator{});
+    std::replace_if(ExecutionPolicy, iarr, iarr, validating_truth{}, 0);
+
+    (void) std::replace_copy(ExecutionPolicy, varr, varr, varr2, validator{}, validator{});
+
+    (void) std::replace_copy_if(ExecutionPolicy, varr, varr, varr2, simple_truth{}, validator{});
+    (void) std::replace_copy_if(ExecutionPolicy, iarr, iarr, iarr2, validating_truth{}, 0);
+
+    std::fill(ExecutionPolicy, varr, varr, validator{});
+
+    (void) std::fill_n(ExecutionPolicy, varr, 0, validator{});
+
+    std::generate(ExecutionPolicy, varr, varr, value_generator<validator>{});
+
+    (void) std::generate_n(ExecutionPolicy, varr, 0, value_generator<validator>{});
+
+    (void) std::remove(ExecutionPolicy, varr, varr, validator{});
+
+    (void) std::remove_if(ExecutionPolicy, varr, varr, simple_truth{});
+    (void) std::remove_if(ExecutionPolicy, iarr, iarr, validating_truth{});
+
+    (void) std::remove_copy(ExecutionPolicy, varr, varr, varr2, validator{});
+
+    (void) std::remove_copy_if(ExecutionPolicy, varr, varr, varr2, simple_truth{});
+    (void) std::remove_copy_if(ExecutionPolicy, iarr, iarr, iarr2, validating_truth{});
+
+    (void) std::unique(ExecutionPolicy, varr, varr);
+    (void) std::unique(ExecutionPolicy, iarr, iarr, validating_equal{});
+
+    (void) std::unique_copy(ExecutionPolicy, varr, varr, varr2);
+    (void) std::unique_copy(ExecutionPolicy, iarr, iarr, iarr2, validating_equal{});
+
+    // std::reverse(ExecutionPolicy, varr, varr); // requires Cpp17ValueSwappable
+
+    (void) std::reverse_copy(ExecutionPolicy, varr, varr, varr2);
+
+    // (void) std::rotate(ExecutionPolicy, varr, varr, varr); // requires Cpp17ValueSwappable
+
+    (void) std::rotate_copy(ExecutionPolicy, varr, varr, varr, varr2);
+
+#if _HAS_CXX20
+    (void) std::shift_left(ExecutionPolicy, varr, varr, 0);
+
+    // (void) std::shift_right(ExecutionPolicy, varr, varr, 0); // requires Cpp17ValueSwappable
+#endif // _HAS_CXX20
+
     (void) std::min_element(ExecutionPolicy, varr, varr + 1);
     (void) std::min_element(ExecutionPolicy, iarr, iarr + 1, validating_less{});
 
@@ -274,13 +454,14 @@ void test_parallel_algorithms() {
 }
 #endif // _HAS_CXX17
 
-#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 void test_ranges_non_projected_algorithms() {
     using namespace std::ranges;
 
     int iarr[1]{};
     validator varr[1]{};
 
+#if _HAS_CXX23
     (void) fold_left(varr, varr, validator{}, simple_left_selector{});
     (void) fold_left(varr, validator{}, simple_left_selector{});
     (void) fold_left(iarr, iarr, 0, validating_left_selector{});
@@ -310,6 +491,67 @@ void test_ranges_non_projected_algorithms() {
     (void) fold_left_first_with_iter(varr, simple_left_selector{});
     (void) fold_left_first_with_iter(iarr, iarr, validating_left_selector{});
     (void) fold_left_first_with_iter(iarr, validating_left_selector{});
+#endif // _HAS_CXX23
+
+    int iarr2[1]{};
+    validator varr2[1]{};
+
+    (void) copy(varr, varr + 1, varr2);
+    (void) copy(varr, varr2);
+
+    (void) copy_n(varr, 1, varr2);
+
+    (void) copy_backward(varr, varr + 1, varr2 + 1);
+    (void) copy_backward(varr, varr2 + 1);
+
+    (void) move(varr, varr + 1, varr2);
+    (void) move(varr, varr2);
+
+    (void) move_backward(varr, varr + 1, varr2 + 1);
+    (void) move_backward(varr, varr2 + 1);
+
+    (void) swap_ranges(varr, varr, varr2, varr2);
+    (void) swap_ranges(varr, varr2);
+
+    (void) fill(varr, varr, validator{});
+    (void) fill(varr, validator{});
+
+    (void) fill_n(varr, 0, validator{});
+
+    (void) generate(varr, varr, value_generator<validator>{});
+    (void) generate(varr, value_generator<validator>{});
+
+    (void) generate_n(varr, 0, value_generator<validator>{});
+
+    (void) reverse(varr, varr);
+    (void) reverse(varr);
+
+    (void) reverse_copy(varr, varr, varr2);
+    (void) reverse_copy(varr, varr2);
+
+    (void) rotate(varr, varr, varr);
+    (void) rotate(varr, varr);
+
+    (void) rotate_copy(varr, varr, varr, varr2);
+    (void) rotate_copy(varr, varr, varr2);
+
+    (void) sample(varr, varr, varr2, 0, simple_urng{});
+    (void) sample(varr, varr2, 0, simple_urng{});
+    (void) sample(iarr, iarr, iarr2, 0, validating_urng{});
+    (void) sample(iarr, iarr2, 0, validating_urng{});
+
+    (void) shuffle(varr, varr, simple_urng{});
+    (void) shuffle(varr, simple_urng{});
+    (void) shuffle(iarr, iarr, validating_urng{});
+    (void) shuffle(iarr, validating_urng{});
+
+#if _HAS_CXX23
+    (void) shift_left(varr, varr, 0);
+    (void) shift_left(varr, 0);
+
+    (void) shift_right(varr, varr, 0);
+    (void) shift_right(varr, 0);
+#endif // _HAS_CXX23
 }
-#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+#endif // _HAS_CXX20 && defined(__cpp_lib_concepts)
 #endif // _M_CEE

--- a/tests/std/tests/P2538R1_adl_proof_std_projected/test.compile.pass.cpp
+++ b/tests/std/tests/P2538R1_adl_proof_std_projected/test.compile.pass.cpp
@@ -222,11 +222,11 @@ void test_ranges_algorithms() {
 
     (void) transform(varr, varr, varr2, std::identity{});
     (void) transform(varr, varr2, std::identity{});
-    (void) transform(varr, varr, varr, varr2, varr2, simple_left_selector{});
+    (void) transform(varr, varr, varr, varr, varr2, simple_left_selector{});
     (void) transform(varr, varr, varr2, simple_left_selector{});
     (void) transform(iarr, iarr, iarr2, validating_identity{});
-    (void) transform(iarr, iarr, iarr2, iarr2, iarr2, validating_left_selector{});
-    (void) transform(iarr, iarr2, iarr2, validating_left_selector{});
+    (void) transform(iarr, iarr, iarr, iarr, iarr2, validating_left_selector{});
+    (void) transform(iarr, iarr, iarr2, validating_left_selector{});
 
     (void) replace(varr, varr, validator{}, validator{});
     (void) replace(varr, validator{}, validator{});

--- a/tests/std/tests/P2538R1_adl_proof_std_projected/test.compile.pass.cpp
+++ b/tests/std/tests/P2538R1_adl_proof_std_projected/test.compile.pass.cpp
@@ -56,14 +56,16 @@ struct holder {
 
 struct incomplete;
 
-using simple_truth    = tagged_truth<void>;
-using simple_identity = tagged_identity<void>;
+using simple_truth         = tagged_truth<void>;
+using simple_identity      = tagged_identity<void>;
+using simple_left_selector = tagged_left_selector<void>;
 
-using validator           = holder<incomplete>*;
-using validating_truth    = tagged_truth<holder<incomplete>>;
-using validating_equal    = tagged_equal<holder<incomplete>>;
-using validating_less     = tagged_less<holder<incomplete>>;
-using validating_identity = tagged_identity<holder<incomplete>>;
+using validator                = holder<incomplete>*;
+using validating_truth         = tagged_truth<holder<incomplete>>;
+using validating_equal         = tagged_equal<holder<incomplete>>;
+using validating_less          = tagged_less<holder<incomplete>>;
+using validating_identity      = tagged_identity<holder<incomplete>>;
+using validating_left_selector = tagged_left_selector<holder<incomplete>>;
 
 void test_ranges_algorithms() {
     using namespace std::ranges;
@@ -209,6 +211,73 @@ void test_ranges_algorithms() {
     (void) ends_with(iarr, iarr, iarr, iarr, validating_equal{});
     (void) ends_with(iarr, iarr, validating_equal{});
 #endif // _HAS_CXX23
+
+    int iarr2[1]{};
+    validator varr2[1]{};
+
+    (void) copy_if(varr, varr + 1, varr2, simple_truth{});
+    (void) copy_if(varr, varr2, simple_truth{});
+    (void) copy_if(iarr, iarr + 1, iarr2, validating_truth{});
+    (void) copy_if(iarr, iarr2, validating_truth{});
+
+    (void) transform(varr, varr, varr2, std::identity{});
+    (void) transform(varr, varr2, std::identity{});
+    (void) transform(varr, varr, varr, varr2, varr2, simple_left_selector{});
+    (void) transform(varr, varr, varr2, simple_left_selector{});
+    (void) transform(iarr, iarr, iarr2, validating_identity{});
+    (void) transform(iarr, iarr, iarr2, iarr2, iarr2, validating_left_selector{});
+    (void) transform(iarr, iarr2, iarr2, validating_left_selector{});
+
+    (void) replace(varr, varr, validator{}, validator{});
+    (void) replace(varr, validator{}, validator{});
+    (void) replace(iarr, iarr, 0, 0, validating_identity{});
+    (void) replace(iarr, 0, 0, validating_identity{});
+
+    (void) replace_if(varr, varr, simple_truth{}, validator{});
+    (void) replace_if(varr, simple_truth{}, validator{});
+    (void) replace_if(iarr, iarr, validating_truth{}, 0);
+    (void) replace_if(iarr, validating_truth{}, 0);
+
+    (void) replace_copy(varr, varr, varr2, validator{}, validator{});
+    (void) replace_copy(varr, varr2, validator{}, validator{});
+    (void) replace_copy(iarr, iarr, iarr2, 0, 0, validating_identity{});
+    (void) replace_copy(iarr, iarr2, 0, 0, validating_identity{});
+
+    (void) replace_copy_if(varr, varr, varr2, simple_truth{}, validator{});
+    (void) replace_copy_if(varr, varr2, simple_truth{}, validator{});
+    (void) replace_copy_if(iarr, iarr, iarr2, validating_truth{}, 0);
+    (void) replace_copy_if(iarr, iarr2, validating_truth{}, 0);
+
+    using std::ranges::remove; // avoid ambiguity
+    (void) remove(varr, varr, validator{});
+    (void) remove(varr, validator{});
+
+    (void) remove_if(varr, varr, simple_truth{});
+    (void) remove_if(varr, simple_truth{});
+    (void) remove_if(iarr, iarr, validating_truth{});
+    (void) remove_if(iarr, validating_truth{});
+
+    (void) remove_copy(varr, varr, varr2, validator{});
+    (void) remove_copy(varr, varr2, validator{});
+
+    (void) remove_copy_if(varr, varr, varr2, simple_truth{});
+    (void) remove_copy_if(varr, varr2, simple_truth{});
+    (void) remove_copy_if(iarr, iarr, iarr2, validating_truth{});
+    (void) remove_copy_if(iarr, iarr2, validating_truth{});
+
+    (void) unique(varr, varr);
+    (void) unique(varr);
+    // (void) unique(iarr, iarr, validating_equal{}); // needs to check ADL-found swap
+    // (void) unique(iarr, validating_equal{}); // needs to check ADL-found swap
+    (void) unique(iarr, iarr, {}, validating_identity{});
+    (void) unique(iarr, {}, validating_identity{});
+
+    (void) unique_copy(varr, varr, varr2);
+    (void) unique_copy(varr, varr2);
+    // (void) unique_copy(iarr, iarr, iarr2, validating_equal{}); // needs to check ADL-found swap
+    // (void) unique_copy(iarr, iarr2, validating_equal{}); // needs to check ADL-found swap
+    (void) unique_copy(iarr, iarr, iarr2, {}, validating_identity{});
+    (void) unique_copy(iarr, iarr2, {}, validating_identity{});
 
     (void) min(+varr, +varr);
     (void) min({+varr, +varr});


### PR DESCRIPTION
Split from #4004, towards #140 and #1596.

Fixes #4043 by `::`-qualifying all remaining `__std_meow` vectorizing functions (some are `_STD`-qualified in #4146).

Also adds `_Is_trivially_ranges_swappable(_v)` to handle triviality of swapping by `ranges::swap` (which gets rid of ADL for pointers and pointers-to-members), along with workaround for DevCom-10456445.