### PR TITLE
Toolset update: VS 2022 17.9 Preview 2, Clang 17

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# https://releases.llvm.org/16.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+# https://releases.llvm.org/17.0.1/tools/clang/docs/ClangFormatStyleOptions.html
 
 ---
 # Language:        Cpp
@@ -38,6 +38,11 @@ AlignConsecutiveAssignments: Consecutive
 #   AlignCompound:   false
 #   PadOperators:    false
 AlignConsecutiveMacros: Consecutive
+# AlignConsecutiveShortCaseStatements:
+#   Enabled:         false
+#   AcrossEmptyLines: false
+#   AcrossComments:  false
+#   AlignCaseColons: false
 # AlignEscapedNewlines: Right
 AlignEscapedNewlines: Left
 # AlignOperands:   Align
@@ -176,6 +181,7 @@ InsertNewlineAtEOF: true
 # JavaScriptQuotes: Leave
 # JavaScriptWrapImports: true
 # KeepEmptyLinesAtTheStartOfBlocks: true
+# KeepEmptyLinesAtEOF: false
 # LambdaBodyIndentation: Signature
 # LineEnding:      DeriveLF
 LineEnding:      CRLF
@@ -209,6 +215,7 @@ PointerAlignment: Left
 # ReferenceAlignment: Pointer
 # ReflowComments:  true
 # RemoveBracesLLVM: false
+# RemoveParentheses: Leave
 # RemoveSemicolon: false
 RemoveSemicolon: true
 # RequiresClausePosition: OwnLine
@@ -228,6 +235,7 @@ SpaceAfterCStyleCast: true
 # SpaceBeforeCpp11BracedList: false
 # SpaceBeforeCtorInitializerColon: true
 # SpaceBeforeInheritanceColon: true
+# SpaceBeforeJsonColon: false
 # SpaceBeforeParens: ControlStatements
 # SpaceBeforeParensOptions:
 #   AfterControlStatements: true
@@ -245,16 +253,18 @@ SpaceBeforeParensOptions:
 # SpaceBeforeRangeBasedForLoopColon: true
 # SpaceBeforeSquareBrackets: false
 # SpaceInEmptyBlock: false
-# SpaceInEmptyParentheses: false
 # SpacesBeforeTrailingComments: 1
 # SpacesInAngles:  Never
-# SpacesInConditionalStatement: false
 # SpacesInContainerLiterals: true
-# SpacesInCStyleCastParentheses: false
 # SpacesInLineCommentPrefix:
 #   Minimum:         1
 #   Maximum:         -1
-# SpacesInParentheses: false
+# SpacesInParens:  Never
+# SpacesInParensOptions:
+#   InCStyleCasts:   false
+#   InConditionalStatements: false
+#   InEmptyParentheses: false
+#   Other:           false
 # SpacesInSquareBrackets: false
 # Standard:        Latest
 # StatementAttributeLikeMacros:
@@ -277,6 +287,7 @@ StatementMacros:
   - _END_EXTERN_C_UNLESS_PURE
 # TabWidth:        8
 # UseTab:          Never
+# VerilogBreakBetweenInstancePorts: true
 # WhitespaceSensitiveMacros:
 #   - BOOST_PP_STRINGIZE
 #   - CF_SWIFT_NAME

--- a/.github/workflows/move-ready-for-review-prs.yml
+++ b/.github/workflows/move-ready-for-review-prs.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Move To Initial Review
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             // Find "Code Reviews" project manually by name matching

--- a/.github/workflows/move-work-in-progress-prs.yml
+++ b/.github/workflows/move-work-in-progress-prs.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Move To Work In Progress
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             // Find "Code Reviews" project manually by name matching

--- a/.github/workflows/update-status-chart.yml
+++ b/.github/workflows/update-status-chart.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ">=20.4.0"
       - name: Install Packages

--- a/.github/workflows/update-status-chart.yml
+++ b/.github/workflows/update-status-chart.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ">=20.4.0"
+          node-version: ">=21.4.0"
       - name: Install Packages
         run: |
           npm ci

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.9 Preview 1 or later.
+1. Install Visual Studio 2022 17.9 Preview 2 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
@@ -156,7 +156,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.9 Preview 1 or later.
+1. Install Visual Studio 2022 17.9 Preview 2 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,7 +5,7 @@
 
 variables:
 - name: poolName
-  value: 'StlBuild-2023-11-15T0519-Pool'
+  value: 'StlBuild-2023-12-12T1453-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals true'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -136,7 +136,7 @@ $Workloads = @(
 )
 
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/17/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.12.0/python-3.12.0-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.12.1/python-3.12.1-amd64.exe'
 
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_511.23_windows.exe'
 

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -91,7 +91,7 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
   $PsExecPath = Join-Path $ExtractedPsToolsPath 'PsExec64.exe'
 
   # https://github.com/PowerShell/PowerShell/releases/latest
-  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.3.9/PowerShell-7.3.9-win-x64.zip'
+  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.4.0/PowerShell-7.4.0-win-x64.zip'
   Write-Host "Downloading: $PowerShellZipUrl"
   $ExtractedPowerShellPath = DownloadAndExtractZip -Url $PowerShellZipUrl
   $PwshPath = Join-Path $ExtractedPowerShellPath 'pwsh.exe'

--- a/stl/inc/__msvc_chrono.hpp
+++ b/stl/inc/__msvc_chrono.hpp
@@ -75,7 +75,7 @@ namespace chrono {
 
     _EXPORT_STD template <class _To, class _Rep, class _Period, enable_if_t<_Is_duration_v<_To>, int> = 0>
     constexpr _To duration_cast(const duration<_Rep, _Period>&) noexcept(
-        is_arithmetic_v<_Rep>&& is_arithmetic_v<typename _To::rep>); // strengthened
+        is_arithmetic_v<_Rep> && is_arithmetic_v<typename _To::rep>); // strengthened
 
     _EXPORT_STD template <class _Rep, class _Period>
     class duration { // represents a time duration
@@ -94,7 +94,7 @@ namespace chrono {
                             && (treat_as_floating_point_v<_Rep> || !treat_as_floating_point_v<_Rep2>),
                 int> = 0>
         constexpr explicit duration(const _Rep2& _Val) noexcept(
-            is_arithmetic_v<_Rep>&& is_arithmetic_v<_Rep2>) // strengthened
+            is_arithmetic_v<_Rep> && is_arithmetic_v<_Rep2>) // strengthened
             : _MyRep(static_cast<_Rep>(_Val)) {}
 
         template <class _Rep2, class _Period2,
@@ -102,7 +102,7 @@ namespace chrono {
                             || (_Ratio_divide_sfinae<_Period2, _Period>::den == 1 && !treat_as_floating_point_v<_Rep2>),
                 int> = 0>
         constexpr duration(const duration<_Rep2, _Period2>& _Dur) noexcept(
-            is_arithmetic_v<_Rep>&& is_arithmetic_v<_Rep2>) // strengthened
+            is_arithmetic_v<_Rep> && is_arithmetic_v<_Rep2>) // strengthened
             : _MyRep(_CHRONO duration_cast<duration>(_Dur).count()) {}
 
         _NODISCARD constexpr _Rep count() const noexcept(is_arithmetic_v<_Rep>) /* strengthened */ {
@@ -204,7 +204,7 @@ namespace chrono {
 
         template <class _Duration2, enable_if_t<is_convertible_v<_Duration2, _Duration>, int> = 0>
         constexpr time_point(const time_point<_Clock, _Duration2>& _Tp) noexcept(
-            is_arithmetic_v<rep>&& is_arithmetic_v<typename _Duration2::rep>) // strengthened
+            is_arithmetic_v<rep> && is_arithmetic_v<typename _Duration2::rep>) // strengthened
             : _MyDur(_Tp.time_since_epoch()) {}
 
         _NODISCARD constexpr _Duration time_since_epoch() const noexcept(is_arithmetic_v<rep>) /* strengthened */ {
@@ -278,7 +278,7 @@ namespace chrono {
     _EXPORT_STD template <class _Rep1, class _Period1, class _Rep2, class _Period2>
     _NODISCARD constexpr common_type_t<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>
         operator+(const duration<_Rep1, _Period1>& _Left, const duration<_Rep2, _Period2>& _Right) noexcept(
-            is_arithmetic_v<_Rep1>&& is_arithmetic_v<_Rep2>) /* strengthened */ {
+            is_arithmetic_v<_Rep1> && is_arithmetic_v<_Rep2>) /* strengthened */ {
         using _CD = common_type_t<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>;
         return _CD(_CD(_Left).count() + _CD(_Right).count());
     }
@@ -286,7 +286,7 @@ namespace chrono {
     _EXPORT_STD template <class _Rep1, class _Period1, class _Rep2, class _Period2>
     _NODISCARD constexpr common_type_t<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>
         operator-(const duration<_Rep1, _Period1>& _Left, const duration<_Rep2, _Period2>& _Right) noexcept(
-            is_arithmetic_v<_Rep1>&& is_arithmetic_v<_Rep2>) /* strengthened */ {
+            is_arithmetic_v<_Rep1> && is_arithmetic_v<_Rep2>) /* strengthened */ {
         using _CD = common_type_t<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>;
         return _CD(_CD(_Left).count() - _CD(_Right).count());
     }
@@ -295,7 +295,7 @@ namespace chrono {
         enable_if_t<is_convertible_v<const _Rep2&, common_type_t<_Rep1, _Rep2>>, int> = 0>
     _NODISCARD constexpr duration<common_type_t<_Rep1, _Rep2>, _Period1> operator*(
         const duration<_Rep1, _Period1>& _Left,
-        const _Rep2& _Right) noexcept(is_arithmetic_v<_Rep1>&& is_arithmetic_v<_Rep2>) /* strengthened */ {
+        const _Rep2& _Right) noexcept(is_arithmetic_v<_Rep1> && is_arithmetic_v<_Rep2>) /* strengthened */ {
         using _CR = common_type_t<_Rep1, _Rep2>;
         using _CD = duration<_CR, _Period1>;
         return _CD(_CD(_Left).count() * _Right);
@@ -303,9 +303,9 @@ namespace chrono {
 
     _EXPORT_STD template <class _Rep1, class _Rep2, class _Period2,
         enable_if_t<is_convertible_v<const _Rep1&, common_type_t<_Rep1, _Rep2>>, int> = 0>
-    _NODISCARD constexpr duration<common_type_t<_Rep1, _Rep2>, _Period2>
-        operator*(const _Rep1& _Left, const duration<_Rep2, _Period2>& _Right) noexcept(
-            is_arithmetic_v<_Rep1>&& is_arithmetic_v<_Rep2>) /* strengthened */ {
+    _NODISCARD constexpr duration<common_type_t<_Rep1, _Rep2>, _Period2> operator*(const _Rep1& _Left,
+        const duration<_Rep2, _Period2>& _Right) noexcept(is_arithmetic_v<_Rep1>
+                                                          && is_arithmetic_v<_Rep2>) /* strengthened */ {
         return _Right * _Left;
     }
 
@@ -328,16 +328,16 @@ namespace chrono {
     _EXPORT_STD template <class _Rep1, class _Period1, class _Rep2>
     _NODISCARD constexpr typename _Duration_div_mod<common_type_t<_Rep1, _Rep2>, _Period1, _Rep2>::type operator/(
         const duration<_Rep1, _Period1>& _Left,
-        const _Rep2& _Right) noexcept(is_arithmetic_v<_Rep1>&& is_arithmetic_v<_Rep2>) /* strengthened */ {
+        const _Rep2& _Right) noexcept(is_arithmetic_v<_Rep1> && is_arithmetic_v<_Rep2>) /* strengthened */ {
         using _CR = common_type_t<_Rep1, _Rep2>;
         using _CD = duration<_CR, _Period1>;
         return _CD(_CD(_Left).count() / _Right);
     }
 
     _EXPORT_STD template <class _Rep1, class _Period1, class _Rep2, class _Period2>
-    _NODISCARD constexpr common_type_t<_Rep1, _Rep2>
-        operator/(const duration<_Rep1, _Period1>& _Left, const duration<_Rep2, _Period2>& _Right) noexcept(
-            is_arithmetic_v<_Rep1>&& is_arithmetic_v<_Rep2>) /* strengthened */ {
+    _NODISCARD constexpr common_type_t<_Rep1, _Rep2> operator/(const duration<_Rep1, _Period1>& _Left,
+        const duration<_Rep2, _Period2>& _Right) noexcept(is_arithmetic_v<_Rep1>
+                                                          && is_arithmetic_v<_Rep2>) /* strengthened */ {
         using _CD = common_type_t<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>;
         return _CD(_Left).count() / _CD(_Right).count();
     }
@@ -345,7 +345,7 @@ namespace chrono {
     _EXPORT_STD template <class _Rep1, class _Period1, class _Rep2>
     _NODISCARD constexpr typename _Duration_div_mod<common_type_t<_Rep1, _Rep2>, _Period1, _Rep2>::type operator%(
         const duration<_Rep1, _Period1>& _Left,
-        const _Rep2& _Right) noexcept(is_arithmetic_v<_Rep1>&& is_arithmetic_v<_Rep2>) /* strengthened */ {
+        const _Rep2& _Right) noexcept(is_arithmetic_v<_Rep1> && is_arithmetic_v<_Rep2>) /* strengthened */ {
         using _CR = common_type_t<_Rep1, _Rep2>;
         using _CD = duration<_CR, _Period1>;
         return _CD(_CD(_Left).count() % _Right);
@@ -354,63 +354,63 @@ namespace chrono {
     _EXPORT_STD template <class _Rep1, class _Period1, class _Rep2, class _Period2>
     _NODISCARD constexpr common_type_t<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>
         operator%(const duration<_Rep1, _Period1>& _Left, const duration<_Rep2, _Period2>& _Right) noexcept(
-            is_arithmetic_v<_Rep1>&& is_arithmetic_v<_Rep2>) /* strengthened */ {
+            is_arithmetic_v<_Rep1> && is_arithmetic_v<_Rep2>) /* strengthened */ {
         using _CD = common_type_t<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>;
         return _CD(_CD(_Left).count() % _CD(_Right).count());
     }
 
     _EXPORT_STD template <class _Rep1, class _Period1, class _Rep2, class _Period2>
-    _NODISCARD constexpr bool
-        operator==(const duration<_Rep1, _Period1>& _Left, const duration<_Rep2, _Period2>& _Right) noexcept(
-            is_arithmetic_v<_Rep1>&& is_arithmetic_v<_Rep2>) /* strengthened */ {
+    _NODISCARD constexpr bool operator==(const duration<_Rep1, _Period1>& _Left,
+        const duration<_Rep2, _Period2>& _Right) noexcept(is_arithmetic_v<_Rep1>
+                                                          && is_arithmetic_v<_Rep2>) /* strengthened */ {
         using _CT = common_type_t<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>;
         return _CT(_Left).count() == _CT(_Right).count();
     }
 
 #if !_HAS_CXX20
     template <class _Rep1, class _Period1, class _Rep2, class _Period2>
-    _NODISCARD constexpr bool
-        operator!=(const duration<_Rep1, _Period1>& _Left, const duration<_Rep2, _Period2>& _Right) noexcept(
-            is_arithmetic_v<_Rep1>&& is_arithmetic_v<_Rep2>) /* strengthened */ {
+    _NODISCARD constexpr bool operator!=(const duration<_Rep1, _Period1>& _Left,
+        const duration<_Rep2, _Period2>& _Right) noexcept(is_arithmetic_v<_Rep1>
+                                                          && is_arithmetic_v<_Rep2>) /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
 
     _EXPORT_STD template <class _Rep1, class _Period1, class _Rep2, class _Period2>
-    _NODISCARD constexpr bool
-        operator<(const duration<_Rep1, _Period1>& _Left, const duration<_Rep2, _Period2>& _Right) noexcept(
-            is_arithmetic_v<_Rep1>&& is_arithmetic_v<_Rep2>) /* strengthened */ {
+    _NODISCARD constexpr bool operator<(const duration<_Rep1, _Period1>& _Left,
+        const duration<_Rep2, _Period2>& _Right) noexcept(is_arithmetic_v<_Rep1>
+                                                          && is_arithmetic_v<_Rep2>) /* strengthened */ {
         using _CT = common_type_t<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>;
         return _CT(_Left).count() < _CT(_Right).count();
     }
 
     _EXPORT_STD template <class _Rep1, class _Period1, class _Rep2, class _Period2>
-    _NODISCARD constexpr bool
-        operator<=(const duration<_Rep1, _Period1>& _Left, const duration<_Rep2, _Period2>& _Right) noexcept(
-            is_arithmetic_v<_Rep1>&& is_arithmetic_v<_Rep2>) /* strengthened */ {
+    _NODISCARD constexpr bool operator<=(const duration<_Rep1, _Period1>& _Left,
+        const duration<_Rep2, _Period2>& _Right) noexcept(is_arithmetic_v<_Rep1>
+                                                          && is_arithmetic_v<_Rep2>) /* strengthened */ {
         return !(_Right < _Left);
     }
 
     _EXPORT_STD template <class _Rep1, class _Period1, class _Rep2, class _Period2>
-    _NODISCARD constexpr bool
-        operator>(const duration<_Rep1, _Period1>& _Left, const duration<_Rep2, _Period2>& _Right) noexcept(
-            is_arithmetic_v<_Rep1>&& is_arithmetic_v<_Rep2>) /* strengthened */ {
+    _NODISCARD constexpr bool operator>(const duration<_Rep1, _Period1>& _Left,
+        const duration<_Rep2, _Period2>& _Right) noexcept(is_arithmetic_v<_Rep1>
+                                                          && is_arithmetic_v<_Rep2>) /* strengthened */ {
         return _Right < _Left;
     }
 
     _EXPORT_STD template <class _Rep1, class _Period1, class _Rep2, class _Period2>
-    _NODISCARD constexpr bool
-        operator>=(const duration<_Rep1, _Period1>& _Left, const duration<_Rep2, _Period2>& _Right) noexcept(
-            is_arithmetic_v<_Rep1>&& is_arithmetic_v<_Rep2>) /* strengthened */ {
+    _NODISCARD constexpr bool operator>=(const duration<_Rep1, _Period1>& _Left,
+        const duration<_Rep2, _Period2>& _Right) noexcept(is_arithmetic_v<_Rep1>
+                                                          && is_arithmetic_v<_Rep2>) /* strengthened */ {
         return !(_Left < _Right);
     }
 
 #ifdef __cpp_lib_concepts
     _EXPORT_STD template <class _Rep1, class _Period1, class _Rep2, class _Period2>
         requires three_way_comparable<typename common_type_t<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>::rep>
-    _NODISCARD constexpr auto
-        operator<=>(const duration<_Rep1, _Period1>& _Left, const duration<_Rep2, _Period2>& _Right) noexcept(
-            is_arithmetic_v<_Rep1>&& is_arithmetic_v<_Rep2>) /* strengthened */ {
+    _NODISCARD constexpr auto operator<=>(const duration<_Rep1, _Period1>& _Left,
+        const duration<_Rep2, _Period2>& _Right) noexcept(is_arithmetic_v<_Rep1>
+                                                          && is_arithmetic_v<_Rep2>) /* strengthened */ {
         using _CT = common_type_t<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>;
         return _CT(_Left).count() <=> _CT(_Right).count();
     }
@@ -418,7 +418,7 @@ namespace chrono {
 
     _EXPORT_STD template <class _To, class _Rep, class _Period, enable_if_t<_Is_duration_v<_To>, int> /* = 0 */>
     _NODISCARD constexpr _To duration_cast(const duration<_Rep, _Period>& _Dur) noexcept(
-        is_arithmetic_v<_Rep>&& is_arithmetic_v<typename _To::rep>) /* strengthened */ {
+        is_arithmetic_v<_Rep> && is_arithmetic_v<typename _To::rep>) /* strengthened */ {
         // convert duration to another duration; truncate
         using _CF = ratio_divide<_Period, typename _To::period>;
 
@@ -448,7 +448,7 @@ namespace chrono {
 
     _EXPORT_STD template <class _To, class _Rep, class _Period, enable_if_t<_Is_duration_v<_To>, int> = 0>
     _NODISCARD constexpr _To floor(const duration<_Rep, _Period>& _Dur) noexcept(
-        is_arithmetic_v<_Rep>&& is_arithmetic_v<typename _To::rep>) /* strengthened */ {
+        is_arithmetic_v<_Rep> && is_arithmetic_v<typename _To::rep>) /* strengthened */ {
         // convert duration to another duration; round towards negative infinity
         // i.e. the greatest integral result such that the result <= _Dur
         const _To _Casted{_CHRONO duration_cast<_To>(_Dur)};
@@ -461,7 +461,7 @@ namespace chrono {
 
     _EXPORT_STD template <class _To, class _Rep, class _Period, enable_if_t<_Is_duration_v<_To>, int> = 0>
     _NODISCARD constexpr _To ceil(const duration<_Rep, _Period>& _Dur) noexcept(
-        is_arithmetic_v<_Rep>&& is_arithmetic_v<typename _To::rep>) /* strengthened */ {
+        is_arithmetic_v<_Rep> && is_arithmetic_v<typename _To::rep>) /* strengthened */ {
         // convert duration to another duration; round towards positive infinity
         // i.e. the least integral result such that _Dur <= the result
         const _To _Casted{_CHRONO duration_cast<_To>(_Dur)};
@@ -481,7 +481,7 @@ namespace chrono {
     _EXPORT_STD template <class _To, class _Rep, class _Period,
         enable_if_t<_Is_duration_v<_To> && !treat_as_floating_point_v<typename _To::rep>, int> = 0>
     _NODISCARD constexpr _To round(const duration<_Rep, _Period>& _Dur) noexcept(
-        is_arithmetic_v<_Rep>&& is_arithmetic_v<typename _To::rep>) /* strengthened */ {
+        is_arithmetic_v<_Rep> && is_arithmetic_v<typename _To::rep>) /* strengthened */ {
         // convert duration to another duration, round to nearest, ties to even
         const _To _Floored{_CHRONO floor<_To>(_Dur)};
         const _To _Ceiled{_Floored + _To{1}};
@@ -522,7 +522,7 @@ namespace chrono {
     _EXPORT_STD template <class _Clock, class _Duration, class _Rep, class _Period>
     _NODISCARD constexpr time_point<_Clock, common_type_t<_Duration, duration<_Rep, _Period>>>
         operator+(const time_point<_Clock, _Duration>& _Left, const duration<_Rep, _Period>& _Right) noexcept(
-            is_arithmetic_v<typename _Duration::rep>&& is_arithmetic_v<_Rep>) /* strengthened */ {
+            is_arithmetic_v<typename _Duration::rep> && is_arithmetic_v<_Rep>) /* strengthened */ {
         using _RT = time_point<_Clock, common_type_t<_Duration, duration<_Rep, _Period>>>;
         return _RT(_Left.time_since_epoch() + _Right);
     }
@@ -530,14 +530,14 @@ namespace chrono {
     _EXPORT_STD template <class _Rep, class _Period, class _Clock, class _Duration>
     _NODISCARD constexpr time_point<_Clock, common_type_t<duration<_Rep, _Period>, _Duration>>
         operator+(const duration<_Rep, _Period>& _Left, const time_point<_Clock, _Duration>& _Right) noexcept(
-            is_arithmetic_v<_Rep>&& is_arithmetic_v<typename _Duration::rep>) /* strengthened */ {
+            is_arithmetic_v<_Rep> && is_arithmetic_v<typename _Duration::rep>) /* strengthened */ {
         return _Right + _Left;
     }
 
     _EXPORT_STD template <class _Clock, class _Duration, class _Rep, class _Period>
     _NODISCARD constexpr time_point<_Clock, common_type_t<_Duration, duration<_Rep, _Period>>>
         operator-(const time_point<_Clock, _Duration>& _Left, const duration<_Rep, _Period>& _Right) noexcept(
-            is_arithmetic_v<typename _Duration::rep>&& is_arithmetic_v<_Rep>) /* strengthened */ {
+            is_arithmetic_v<typename _Duration::rep> && is_arithmetic_v<_Rep>) /* strengthened */ {
         using _RT = time_point<_Clock, common_type_t<_Duration, duration<_Rep, _Period>>>;
         return _RT(_Left.time_since_epoch() - _Right);
     }
@@ -545,14 +545,14 @@ namespace chrono {
     _EXPORT_STD template <class _Clock, class _Duration1, class _Duration2>
     _NODISCARD constexpr common_type_t<_Duration1, _Duration2>
         operator-(const time_point<_Clock, _Duration1>& _Left, const time_point<_Clock, _Duration2>& _Right) noexcept(
-            is_arithmetic_v<typename _Duration1::rep>&& is_arithmetic_v<typename _Duration2::rep>) /* strengthened */ {
+            is_arithmetic_v<typename _Duration1::rep> && is_arithmetic_v<typename _Duration2::rep>) /* strengthened */ {
         return _Left.time_since_epoch() - _Right.time_since_epoch();
     }
 
     _EXPORT_STD template <class _Clock, class _Duration1, class _Duration2>
     _NODISCARD constexpr bool
         operator==(const time_point<_Clock, _Duration1>& _Left, const time_point<_Clock, _Duration2>& _Right) noexcept(
-            is_arithmetic_v<typename _Duration1::rep>&& is_arithmetic_v<typename _Duration2::rep>) /* strengthened */ {
+            is_arithmetic_v<typename _Duration1::rep> && is_arithmetic_v<typename _Duration2::rep>) /* strengthened */ {
         return _Left.time_since_epoch() == _Right.time_since_epoch();
     }
 
@@ -560,7 +560,7 @@ namespace chrono {
     template <class _Clock, class _Duration1, class _Duration2>
     _NODISCARD constexpr bool
         operator!=(const time_point<_Clock, _Duration1>& _Left, const time_point<_Clock, _Duration2>& _Right) noexcept(
-            is_arithmetic_v<typename _Duration1::rep>&& is_arithmetic_v<typename _Duration2::rep>) /* strengthened */ {
+            is_arithmetic_v<typename _Duration1::rep> && is_arithmetic_v<typename _Duration2::rep>) /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -568,28 +568,28 @@ namespace chrono {
     _EXPORT_STD template <class _Clock, class _Duration1, class _Duration2>
     _NODISCARD constexpr bool
         operator<(const time_point<_Clock, _Duration1>& _Left, const time_point<_Clock, _Duration2>& _Right) noexcept(
-            is_arithmetic_v<typename _Duration1::rep>&& is_arithmetic_v<typename _Duration2::rep>) /* strengthened */ {
+            is_arithmetic_v<typename _Duration1::rep> && is_arithmetic_v<typename _Duration2::rep>) /* strengthened */ {
         return _Left.time_since_epoch() < _Right.time_since_epoch();
     }
 
     _EXPORT_STD template <class _Clock, class _Duration1, class _Duration2>
     _NODISCARD constexpr bool
         operator<=(const time_point<_Clock, _Duration1>& _Left, const time_point<_Clock, _Duration2>& _Right) noexcept(
-            is_arithmetic_v<typename _Duration1::rep>&& is_arithmetic_v<typename _Duration2::rep>) /* strengthened */ {
+            is_arithmetic_v<typename _Duration1::rep> && is_arithmetic_v<typename _Duration2::rep>) /* strengthened */ {
         return !(_Right < _Left);
     }
 
     _EXPORT_STD template <class _Clock, class _Duration1, class _Duration2>
     _NODISCARD constexpr bool
         operator>(const time_point<_Clock, _Duration1>& _Left, const time_point<_Clock, _Duration2>& _Right) noexcept(
-            is_arithmetic_v<typename _Duration1::rep>&& is_arithmetic_v<typename _Duration2::rep>) /* strengthened */ {
+            is_arithmetic_v<typename _Duration1::rep> && is_arithmetic_v<typename _Duration2::rep>) /* strengthened */ {
         return _Right < _Left;
     }
 
     _EXPORT_STD template <class _Clock, class _Duration1, class _Duration2>
     _NODISCARD constexpr bool
         operator>=(const time_point<_Clock, _Duration1>& _Left, const time_point<_Clock, _Duration2>& _Right) noexcept(
-            is_arithmetic_v<typename _Duration1::rep>&& is_arithmetic_v<typename _Duration2::rep>) /* strengthened */ {
+            is_arithmetic_v<typename _Duration1::rep> && is_arithmetic_v<typename _Duration2::rep>) /* strengthened */ {
         return !(_Left < _Right);
     }
 
@@ -597,28 +597,28 @@ namespace chrono {
     _EXPORT_STD template <class _Clock, class _Duration1, three_way_comparable_with<_Duration1> _Duration2>
     _NODISCARD constexpr auto
         operator<=>(const time_point<_Clock, _Duration1>& _Left, const time_point<_Clock, _Duration2>& _Right) noexcept(
-            is_arithmetic_v<typename _Duration1::rep>&& is_arithmetic_v<typename _Duration2::rep>) /* strengthened */ {
+            is_arithmetic_v<typename _Duration1::rep> && is_arithmetic_v<typename _Duration2::rep>) /* strengthened */ {
         return _Left.time_since_epoch() <=> _Right.time_since_epoch();
     }
 #endif // defined(__cpp_lib_concepts)
 
     _EXPORT_STD template <class _To, class _Clock, class _Duration, enable_if_t<_Is_duration_v<_To>, int> = 0>
     _NODISCARD constexpr time_point<_Clock, _To> time_point_cast(const time_point<_Clock, _Duration>& _Time) noexcept(
-        is_arithmetic_v<typename _Duration::rep>&& is_arithmetic_v<typename _To::rep>) /* strengthened */ {
+        is_arithmetic_v<typename _Duration::rep> && is_arithmetic_v<typename _To::rep>) /* strengthened */ {
         // change the duration type of a time_point; truncate
         return time_point<_Clock, _To>(_CHRONO duration_cast<_To>(_Time.time_since_epoch()));
     }
 
     _EXPORT_STD template <class _To, class _Clock, class _Duration, enable_if_t<_Is_duration_v<_To>, int> = 0>
     _NODISCARD constexpr time_point<_Clock, _To> floor(const time_point<_Clock, _Duration>& _Time) noexcept(
-        is_arithmetic_v<typename _Duration::rep>&& is_arithmetic_v<typename _To::rep>) /* strengthened */ {
+        is_arithmetic_v<typename _Duration::rep> && is_arithmetic_v<typename _To::rep>) /* strengthened */ {
         // change the duration type of a time_point; round towards negative infinity
         return time_point<_Clock, _To>(_CHRONO floor<_To>(_Time.time_since_epoch()));
     }
 
     _EXPORT_STD template <class _To, class _Clock, class _Duration, enable_if_t<_Is_duration_v<_To>, int> = 0>
     _NODISCARD constexpr time_point<_Clock, _To> ceil(const time_point<_Clock, _Duration>& _Time) noexcept(
-        is_arithmetic_v<typename _Duration::rep>&& is_arithmetic_v<typename _To::rep>) /* strengthened */ {
+        is_arithmetic_v<typename _Duration::rep> && is_arithmetic_v<typename _To::rep>) /* strengthened */ {
         // change the duration type of a time_point; round towards positive infinity
         return time_point<_Clock, _To>(_CHRONO ceil<_To>(_Time.time_since_epoch()));
     }
@@ -626,7 +626,7 @@ namespace chrono {
     _EXPORT_STD template <class _To, class _Clock, class _Duration,
         enable_if_t<_Is_duration_v<_To> && !treat_as_floating_point_v<typename _To::rep>, int> = 0>
     _NODISCARD constexpr time_point<_Clock, _To> round(const time_point<_Clock, _Duration>& _Time) noexcept(
-        is_arithmetic_v<typename _Duration::rep>&& is_arithmetic_v<typename _To::rep>) /* strengthened */ {
+        is_arithmetic_v<typename _Duration::rep> && is_arithmetic_v<typename _To::rep>) /* strengthened */ {
         // change the duration type of a time_point; round to nearest, ties to even
         return time_point<_Clock, _To>(_CHRONO round<_To>(_Time.time_since_epoch()));
     }

--- a/stl/inc/__msvc_sanitizer_annotate_container.hpp
+++ b/stl/inc/__msvc_sanitizer_annotate_container.hpp
@@ -136,30 +136,30 @@ void __cdecl __sanitizer_annotate_contiguous_container(
 
 #ifdef _M_ARM64EC
 #pragma comment(linker, \
-        "/alternatename:#__sanitizer_annotate_contiguous_container=#__sanitizer_annotate_contiguous_container_default")
+    "/alternatename:#__sanitizer_annotate_contiguous_container=#__sanitizer_annotate_contiguous_container_default")
 #pragma comment(linker, \
-        "/alternatename:__sanitizer_annotate_contiguous_container=__sanitizer_annotate_contiguous_container_default")
+    "/alternatename:__sanitizer_annotate_contiguous_container=__sanitizer_annotate_contiguous_container_default")
 #pragma comment(linker, "/alternatename:#_Asan_vector_should_annotate=#_Asan_vector_should_annotate_default")
 #pragma comment(linker, "/alternatename:_Asan_vector_should_annotate=_Asan_vector_should_annotate_default")
 #pragma comment(linker, "/alternatename:#_Asan_string_should_annotate=#_Asan_string_should_annotate_default")
 #pragma comment(linker, "/alternatename:_Asan_string_should_annotate=_Asan_string_should_annotate_default")
 #elif defined(_M_HYBRID)
 #pragma comment(linker, \
-        "/alternatename:#__sanitizer_annotate_contiguous_container=#__sanitizer_annotate_contiguous_container_default")
+    "/alternatename:#__sanitizer_annotate_contiguous_container=#__sanitizer_annotate_contiguous_container_default")
 #pragma comment(linker, \
-        "/alternatename:___sanitizer_annotate_contiguous_container=___sanitizer_annotate_contiguous_container_default")
+    "/alternatename:___sanitizer_annotate_contiguous_container=___sanitizer_annotate_contiguous_container_default")
 #pragma comment(linker, "/alternatename:#_Asan_vector_should_annotate=#_Asan_vector_should_annotate_default")
 #pragma comment(linker, "/alternatename:__Asan_vector_should_annotate=__Asan_vector_should_annotate_default")
 #pragma comment(linker, "/alternatename:#_Asan_string_should_annotate=#_Asan_string_should_annotate_default")
 #pragma comment(linker, "/alternatename:__Asan_string_should_annotate=__Asan_string_should_annotate_default")
 #elif defined(_M_IX86)
 #pragma comment(linker, \
-        "/alternatename:___sanitizer_annotate_contiguous_container=___sanitizer_annotate_contiguous_container_default")
+    "/alternatename:___sanitizer_annotate_contiguous_container=___sanitizer_annotate_contiguous_container_default")
 #pragma comment(linker, "/alternatename:__Asan_vector_should_annotate=__Asan_vector_should_annotate_default")
 #pragma comment(linker, "/alternatename:__Asan_string_should_annotate=__Asan_string_should_annotate_default")
 #elif defined(_M_X64) || defined(_M_ARM) || defined(_M_ARM64)
 #pragma comment(linker, \
-        "/alternatename:__sanitizer_annotate_contiguous_container=__sanitizer_annotate_contiguous_container_default")
+    "/alternatename:__sanitizer_annotate_contiguous_container=__sanitizer_annotate_contiguous_container_default")
 #pragma comment(linker, "/alternatename:_Asan_vector_should_annotate=_Asan_vector_should_annotate_default")
 #pragma comment(linker, "/alternatename:_Asan_string_should_annotate=_Asan_string_should_annotate_default")
 #else // ^^^ known architecture / unknown architecture vvv

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -437,10 +437,10 @@ struct _Atomic_padded {
 #else // ^^^ don't break ABI / break ABI vvv
 template <class _Ty>
 struct _Atomic_storage_traits { // properties for how _Ty is stored in an atomic
-    static constexpr size_t _Storage_size = sizeof(_Ty) == 1  ? 1
-                                          : sizeof(_Ty) == 2  ? 2
-                                          : sizeof(_Ty) <= 4  ? 4
-                                          : sizeof(_Ty) <= 8  ? 8
+    static constexpr size_t _Storage_size = sizeof(_Ty) == 1 ? 1
+                                          : sizeof(_Ty) == 2 ? 2
+                                          : sizeof(_Ty) <= 4 ? 4
+                                          : sizeof(_Ty) <= 8 ? 8
 #if defined(_M_X64) || defined(_M_ARM64) || defined(_M_ARM64EC)
                                           : sizeof(_Ty) <= 16 ? 16
 #endif // 64 bits

--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -955,19 +955,19 @@ public:
 
 protected:
     template <class _Other>
-    _CONSTEXPR20 void _Add(const complex<_Other>& _Right) noexcept(_Is_for_standard_complex&& _Is_unqual_fp<_Other>) {
+    _CONSTEXPR20 void _Add(const complex<_Other>& _Right) noexcept(_Is_for_standard_complex && _Is_unqual_fp<_Other>) {
         this->_Val[_RE] = this->_Val[_RE] + static_cast<_Ty>(_Right.real());
         this->_Val[_IM] = this->_Val[_IM] + static_cast<_Ty>(_Right.imag());
     }
 
     template <class _Other>
-    _CONSTEXPR20 void _Sub(const complex<_Other>& _Right) noexcept(_Is_for_standard_complex&& _Is_unqual_fp<_Other>) {
+    _CONSTEXPR20 void _Sub(const complex<_Other>& _Right) noexcept(_Is_for_standard_complex && _Is_unqual_fp<_Other>) {
         this->_Val[_RE] = this->_Val[_RE] - static_cast<_Ty>(_Right.real());
         this->_Val[_IM] = this->_Val[_IM] - static_cast<_Ty>(_Right.imag());
     }
 
     template <class _Other>
-    _CONSTEXPR20 void _Mul(const complex<_Other>& _Right) noexcept(_Is_for_standard_complex&& _Is_unqual_fp<_Other>) {
+    _CONSTEXPR20 void _Mul(const complex<_Other>& _Right) noexcept(_Is_for_standard_complex && _Is_unqual_fp<_Other>) {
         _Ty _Rightreal = static_cast<_Ty>(_Right.real());
         _Ty _Rightimag = static_cast<_Ty>(_Right.imag());
 
@@ -977,7 +977,7 @@ protected:
     }
 
     template <class _Other>
-    _CONSTEXPR20 void _Div(const complex<_Other>& _Right) noexcept(_Is_for_standard_complex&& _Is_unqual_fp<_Other>) {
+    _CONSTEXPR20 void _Div(const complex<_Other>& _Right) noexcept(_Is_for_standard_complex && _Is_unqual_fp<_Other>) {
         using _Myctraits = _Ctraits<_Ty>;
 
         _Ty _Rightreal = static_cast<_Ty>(_Right.real());
@@ -2212,7 +2212,7 @@ _NODISCARD complex<_Upgrade_to_double<_Ty>> proj(_Ty _Left) noexcept /* strength
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 _NODISCARD complex<_Common_float_type_t<_Ty1, _Ty2>> pow(const complex<_Ty1>& _Left,
-    const complex<_Ty2>& _Right) noexcept(_Is_unqual_fp<_Ty1>&& _Is_unqual_fp<_Ty2>) /* strengthened */ {
+    const complex<_Ty2>& _Right) noexcept(_Is_unqual_fp<_Ty1> && _Is_unqual_fp<_Ty2>) /* strengthened */ {
     using _Type = complex<_Common_float_type_t<_Ty1, _Ty2>>;
     return _STD pow(_Type(_Left), _Type(_Right));
 }

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -1756,8 +1756,8 @@ _NODISCARD _Iter_diff_t<_FwdIt> count(_ExPo&& _Exec, const _FwdIt _First, const 
 }
 
 template <class _FwdIt1, class _FwdIt2,
-    bool = _Use_atomic_iterator<_Unwrapped_t<const _FwdIt1&>>&& _Is_ranges_random_iter_v<_FwdIt2>,
-    bool = _Use_atomic_iterator<_Unwrapped_t<const _FwdIt2&>>&& _Is_ranges_random_iter_v<_FwdIt1>>
+    bool = _Use_atomic_iterator<_Unwrapped_t<const _FwdIt1&>> && _Is_ranges_random_iter_v<_FwdIt2>,
+    bool = _Use_atomic_iterator<_Unwrapped_t<const _FwdIt2&>> && _Is_ranges_random_iter_v<_FwdIt1>>
 struct _Static_partitioned_mismatch_results;
 
 template <class _FwdIt1, class _FwdIt2, bool _Unused>
@@ -2808,10 +2808,10 @@ inline size_t _Get_stable_sort_tree_height(const size_t _Count, const size_t _Hw
     // go to the next smaller power of 2
     const auto _Count_max_tree_height = _Log_count_max_chunks & ~static_cast<size_t>(1);
 
-    const auto _Ideal_chunks           = _Hw_threads * _Oversubscription_multiplier;
-    const size_t _Log_ideal_chunks     = _Floor_of_log_2(_Ideal_chunks);
+    const auto _Ideal_chunks       = _Hw_threads * _Oversubscription_multiplier;
+    const size_t _Log_ideal_chunks = _Floor_of_log_2(_Ideal_chunks);
 #ifdef _WIN64
-    constexpr size_t _Max_tree_height  = 62; // to avoid ptrdiff_t overflow
+    constexpr size_t _Max_tree_height = 62; // to avoid ptrdiff_t overflow
 #else // ^^^ defined(_WIN64) / !defined(_WIN64) vvv
     constexpr size_t _Max_tree_height = 30;
 #endif // ^^^ !defined(_WIN64) ^^^

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -220,7 +220,7 @@ public:
         : _Value(), _Has_value(true) {}
 
     constexpr expected(const expected& _Other) noexcept(
-        is_nothrow_copy_constructible_v<_Ty>&& is_nothrow_copy_constructible_v<_Err>) // strengthened
+        is_nothrow_copy_constructible_v<_Ty> && is_nothrow_copy_constructible_v<_Err>) // strengthened
         requires (!(is_trivially_copy_constructible_v<_Ty> && is_trivially_copy_constructible_v<_Err>)
                   && is_copy_constructible_v<_Ty> && is_copy_constructible_v<_Err>)
         : _Has_value(_Other._Has_value) {
@@ -237,7 +237,7 @@ public:
     // clang-format on
 
     constexpr expected(expected&& _Other) noexcept(
-        is_nothrow_move_constructible_v<_Ty>&& is_nothrow_move_constructible_v<_Err>)
+        is_nothrow_move_constructible_v<_Ty> && is_nothrow_move_constructible_v<_Err>)
         requires (!(is_trivially_move_constructible_v<_Ty> && is_trivially_move_constructible_v<_Err>)
                   && is_move_constructible_v<_Ty> && is_move_constructible_v<_Err>)
         : _Has_value(_Other._Has_value) {
@@ -256,9 +256,9 @@ public:
     template <class _Uty, class _UErr>
         requires _Different_from<expected<_Uty, _UErr>, expected> && is_constructible_v<_Ty, const _Uty&>
               && is_constructible_v<_Err, const _UErr&> && _Allow_unwrapping<_Uty, _UErr>
-    constexpr explicit(!is_convertible_v<const _Uty&, _Ty> || !is_convertible_v<const _UErr&, _Err>)
-        expected(const expected<_Uty, _UErr>& _Other) noexcept(is_nothrow_constructible_v<_Ty, const _Uty&> //
-                && is_nothrow_constructible_v<_Err, const _UErr&>) // strengthened
+    constexpr explicit(!is_convertible_v<const _Uty&, _Ty> || !is_convertible_v<const _UErr&, _Err>) expected(
+        const expected<_Uty, _UErr>& _Other) noexcept(is_nothrow_constructible_v<_Ty, const _Uty&> //
+                                                      && is_nothrow_constructible_v<_Err, const _UErr&>) // strengthened
         : _Has_value(_Other._Has_value) {
         if (_Has_value) {
             _STD construct_at(_STD addressof(_Value), _Other._Value);
@@ -272,7 +272,7 @@ public:
               && is_constructible_v<_Err, _UErr> && _Allow_unwrapping<_Uty, _UErr>
     constexpr explicit(!is_convertible_v<_Uty, _Ty> || !is_convertible_v<_UErr, _Err>)
         expected(expected<_Uty, _UErr>&& _Other) noexcept(
-            is_nothrow_constructible_v<_Ty, _Uty>&& is_nothrow_constructible_v<_Err, _UErr>) // strengthened
+            is_nothrow_constructible_v<_Ty, _Uty> && is_nothrow_constructible_v<_Err, _UErr>) // strengthened
         : _Has_value(_Other._Has_value) {
         if (_Has_value) {
             _STD construct_at(_STD addressof(_Value), _STD move(_Other._Value));
@@ -388,8 +388,8 @@ public:
     }
 
     constexpr expected& operator=(const expected& _Other) noexcept(
-        is_nothrow_copy_constructible_v<_Ty>&& is_nothrow_copy_constructible_v<_Err> //
-            && is_nothrow_copy_assignable_v<_Ty>&& is_nothrow_copy_assignable_v<_Err>) // strengthened
+        is_nothrow_copy_constructible_v<_Ty> && is_nothrow_copy_constructible_v<_Err> //
+        && is_nothrow_copy_assignable_v<_Ty> && is_nothrow_copy_assignable_v<_Err>) // strengthened
         requires is_copy_assignable_v<_Ty> && is_copy_constructible_v<_Ty> //
               && is_copy_assignable_v<_Err> && is_copy_constructible_v<_Err>
               && (is_nothrow_move_constructible_v<_Ty> || is_nothrow_move_constructible_v<_Err>)
@@ -409,8 +409,8 @@ public:
     }
 
     constexpr expected& operator=(expected&& _Other) noexcept(
-        is_nothrow_move_constructible_v<_Ty>&& is_nothrow_move_constructible_v<_Err> //
-            && is_nothrow_move_assignable_v<_Ty>&& is_nothrow_move_assignable_v<_Err>)
+        is_nothrow_move_constructible_v<_Ty> && is_nothrow_move_constructible_v<_Err> //
+        && is_nothrow_move_assignable_v<_Ty> && is_nothrow_move_assignable_v<_Err>)
         requires is_move_assignable_v<_Ty> && is_move_constructible_v<_Ty> //
               && is_move_assignable_v<_Err> && is_move_constructible_v<_Err>
               && (is_nothrow_move_constructible_v<_Ty> || is_nothrow_move_constructible_v<_Err>)
@@ -435,7 +435,7 @@ public:
                   && (is_nothrow_constructible_v<_Ty, _Uty> || is_nothrow_move_constructible_v<_Ty>
                       || is_nothrow_move_constructible_v<_Err>) )
     constexpr expected& operator=(_Uty&& _Other) noexcept(
-        is_nothrow_constructible_v<_Ty, _Uty>&& is_nothrow_assignable_v<_Ty&, _Uty>) /* strengthened */ {
+        is_nothrow_constructible_v<_Ty, _Uty> && is_nothrow_assignable_v<_Ty&, _Uty>) /* strengthened */ {
         if (_Has_value) {
             _Value = _STD forward<_Uty>(_Other);
         } else {
@@ -451,8 +451,8 @@ public:
                   && (is_nothrow_constructible_v<_Err, const _UErr&> || is_nothrow_move_constructible_v<_Ty>
                       || is_nothrow_move_constructible_v<_Err>) )
     constexpr expected& operator=(const unexpected<_UErr>& _Other) noexcept(
-        is_nothrow_constructible_v<_Err, const _UErr&>&&
-            is_nothrow_assignable_v<_Err&, const _UErr&>) /* strengthened */ {
+        is_nothrow_constructible_v<_Err, const _UErr&>
+        && is_nothrow_assignable_v<_Err&, const _UErr&>) /* strengthened */ {
         if (_Has_value) {
             _Reinit_expected(_Unexpected, _Value, _Other._Unexpected);
             _Has_value = false;
@@ -468,7 +468,7 @@ public:
                   && (is_nothrow_constructible_v<_Err, _UErr> || is_nothrow_move_constructible_v<_Ty>
                       || is_nothrow_move_constructible_v<_Err>) )
     constexpr expected& operator=(unexpected<_UErr>&& _Other) noexcept(
-        is_nothrow_constructible_v<_Err, _UErr>&& is_nothrow_assignable_v<_Err&, _UErr>) /* strengthened */ {
+        is_nothrow_constructible_v<_Err, _UErr> && is_nothrow_assignable_v<_Err&, _UErr>) /* strengthened */ {
         if (_Has_value) {
             _Reinit_expected(_Unexpected, _Value, _STD move(_Other._Unexpected));
             _Has_value = false;
@@ -514,8 +514,9 @@ public:
     }
 
     // [expected.object.swap]
-    constexpr void swap(expected& _Other) noexcept(is_nothrow_move_constructible_v<_Ty>&& is_nothrow_swappable_v<_Ty>&&
-            is_nothrow_move_constructible_v<_Err>&& is_nothrow_swappable_v<_Err>)
+    constexpr void swap(expected& _Other) noexcept(is_nothrow_move_constructible_v<_Ty> && is_nothrow_swappable_v<_Ty>
+                                                   && is_nothrow_move_constructible_v<_Err>
+                                                   && is_nothrow_swappable_v<_Err>)
         requires is_swappable_v<_Ty> && is_swappable_v<_Err> //
               && is_move_constructible_v<_Ty> && is_move_constructible_v<_Err>
               && (is_nothrow_move_constructible_v<_Ty> || is_nothrow_move_constructible_v<_Err>)
@@ -567,8 +568,9 @@ public:
         }
     }
 
-    friend constexpr void swap(expected& _Lhs, expected& _Rhs) noexcept(is_nothrow_move_constructible_v<_Ty>&&
-            is_nothrow_swappable_v<_Ty>&& is_nothrow_move_constructible_v<_Err>&& is_nothrow_swappable_v<_Err>)
+    friend constexpr void swap(expected& _Lhs, expected& _Rhs) noexcept(
+        is_nothrow_move_constructible_v<_Ty> && is_nothrow_swappable_v<_Ty> && is_nothrow_move_constructible_v<_Err>
+        && is_nothrow_swappable_v<_Err>)
         requires is_swappable_v<_Ty> && is_swappable_v<_Err> //
               && is_move_constructible_v<_Ty> && is_move_constructible_v<_Err>
               && (is_nothrow_move_constructible_v<_Ty> || is_nothrow_move_constructible_v<_Err>)
@@ -690,7 +692,7 @@ public:
 
     template <class _Uty>
     _NODISCARD constexpr _Ty value_or(_Uty&& _Other) const& noexcept(
-        is_nothrow_copy_constructible_v<_Ty>&& is_nothrow_convertible_v<_Uty, _Ty>) /* strengthened */ {
+        is_nothrow_copy_constructible_v<_Ty> && is_nothrow_convertible_v<_Uty, _Ty>) /* strengthened */ {
         static_assert(
             is_copy_constructible_v<_Ty>, "is_copy_constructible_v<T> must be true. (N4950 [expected.object.obs]/18)");
         static_assert(
@@ -704,7 +706,7 @@ public:
     }
     template <class _Uty>
     _NODISCARD constexpr _Ty value_or(_Uty&& _Other) && noexcept(
-        is_nothrow_move_constructible_v<_Ty>&& is_nothrow_convertible_v<_Uty, _Ty>) /* strengthened */ {
+        is_nothrow_move_constructible_v<_Ty> && is_nothrow_convertible_v<_Uty, _Ty>) /* strengthened */ {
         static_assert(
             is_move_constructible_v<_Ty>, "is_move_constructible_v<T> must be true. (N4950 [expected.object.obs]/20)");
         static_assert(
@@ -719,7 +721,7 @@ public:
 
     template <class _Uty = _Err>
     _NODISCARD constexpr _Err error_or(_Uty&& _Other) const& noexcept(
-        is_nothrow_copy_constructible_v<_Err>&& is_nothrow_convertible_v<_Uty, _Err>) /* strengthened */ {
+        is_nothrow_copy_constructible_v<_Err> && is_nothrow_convertible_v<_Uty, _Err>) /* strengthened */ {
         static_assert(
             is_copy_constructible_v<_Err>, "is_copy_constructible_v<E> must be true. (N4950 [expected.object.obs]/22)");
         static_assert(
@@ -734,7 +736,7 @@ public:
 
     template <class _Uty = _Err>
     _NODISCARD constexpr _Err error_or(_Uty&& _Other) && noexcept(
-        is_nothrow_move_constructible_v<_Err>&& is_nothrow_convertible_v<_Uty, _Err>) /* strengthened */ {
+        is_nothrow_move_constructible_v<_Err> && is_nothrow_convertible_v<_Uty, _Err>) /* strengthened */ {
         static_assert(
             is_move_constructible_v<_Err>, "is_move_constructible_v<E> must be true. (N4950 [expected.object.obs]/24)");
         static_assert(
@@ -1275,7 +1277,7 @@ public:
 
     // [expected.void.assign]
     constexpr expected& operator=(const expected& _Other) noexcept(
-        is_nothrow_copy_constructible_v<_Err>&& is_nothrow_copy_assignable_v<_Err>) // strengthened
+        is_nothrow_copy_constructible_v<_Err> && is_nothrow_copy_assignable_v<_Err>) // strengthened
         requires is_copy_assignable_v<_Err> && is_copy_constructible_v<_Err>
     {
         if (_Has_value && _Other._Has_value) {
@@ -1296,7 +1298,7 @@ public:
     }
 
     constexpr expected& operator=(expected&& _Other) noexcept(
-        is_nothrow_move_constructible_v<_Err>&& is_nothrow_move_assignable_v<_Err>)
+        is_nothrow_move_constructible_v<_Err> && is_nothrow_move_assignable_v<_Err>)
         requires is_move_assignable_v<_Err> && is_move_constructible_v<_Err>
     {
         if (_Has_value && _Other._Has_value) {
@@ -1319,8 +1321,8 @@ public:
     template <class _UErr>
         requires is_constructible_v<_Err, const _UErr&> && is_assignable_v<_Err&, const _UErr&>
     constexpr expected& operator=(const unexpected<_UErr>& _Other) noexcept(
-        is_nothrow_constructible_v<_Err, const _UErr&>&&
-            is_nothrow_assignable_v<_Err&, const _UErr&>) /* strengthened */ {
+        is_nothrow_constructible_v<_Err, const _UErr&>
+        && is_nothrow_assignable_v<_Err&, const _UErr&>) /* strengthened */ {
         if (_Has_value) {
             _STD construct_at(_STD addressof(_Unexpected), _Other._Unexpected);
             _Has_value = false;
@@ -1334,7 +1336,7 @@ public:
     template <class _UErr>
         requires is_constructible_v<_Err, _UErr> && is_assignable_v<_Err&, _UErr>
     constexpr expected& operator=(unexpected<_UErr>&& _Other) noexcept(
-        is_nothrow_constructible_v<_Err, _UErr>&& is_nothrow_assignable_v<_Err&, _UErr>) /* strengthened */ {
+        is_nothrow_constructible_v<_Err, _UErr> && is_nothrow_assignable_v<_Err&, _UErr>) /* strengthened */ {
         if (_Has_value) {
             _STD construct_at(_STD addressof(_Unexpected), _STD move(_Other._Unexpected));
             _Has_value = false;
@@ -1356,7 +1358,7 @@ public:
 
     // [expected.void.swap]
     constexpr void swap(expected& _Other) noexcept(
-        is_nothrow_move_constructible_v<_Err>&& is_nothrow_swappable_v<_Err>) //
+        is_nothrow_move_constructible_v<_Err> && is_nothrow_swappable_v<_Err>) //
         requires is_swappable_v<_Err> && is_move_constructible_v<_Err>
     {
         using _STD swap;
@@ -1382,7 +1384,7 @@ public:
     }
 
     friend constexpr void swap(expected& _Left, expected& _Right) noexcept(
-        is_nothrow_move_constructible_v<_Err>&& is_nothrow_swappable_v<_Err>)
+        is_nothrow_move_constructible_v<_Err> && is_nothrow_swappable_v<_Err>)
         requires is_swappable_v<_Err> && is_move_constructible_v<_Err>
     {
         _Left.swap(_Right);
@@ -1444,7 +1446,7 @@ public:
 
     template <class _Uty = _Err>
     _NODISCARD constexpr _Err error_or(_Uty&& _Other) const& noexcept(
-        is_nothrow_copy_constructible_v<_Err>&& is_nothrow_convertible_v<_Uty, _Err>) /* strengthened */ {
+        is_nothrow_copy_constructible_v<_Err> && is_nothrow_convertible_v<_Uty, _Err>) /* strengthened */ {
         static_assert(
             is_copy_constructible_v<_Err>, "is_copy_constructible_v<E> must be true. (N4950 [expected.void.obs]/9)");
         static_assert(
@@ -1459,7 +1461,7 @@ public:
 
     template <class _Uty = _Err>
     _NODISCARD constexpr _Err error_or(_Uty&& _Other) && noexcept(
-        is_nothrow_move_constructible_v<_Err>&& is_nothrow_convertible_v<_Uty, _Err>) /* strengthened */ {
+        is_nothrow_move_constructible_v<_Err> && is_nothrow_convertible_v<_Uty, _Err>) /* strengthened */ {
         static_assert(
             is_move_constructible_v<_Err>, "is_move_constructible_v<E> must be true. (N4950 [expected.void.obs]/11)");
         static_assert(

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -200,10 +200,10 @@ private:
                                                       is_convertible<expected<_Uty, _UErr>&, _Ty>, //
                                                       is_convertible<expected<_Uty, _UErr>&&, _Ty>, //
                                                       is_convertible<const expected<_Uty, _UErr>&, _Ty>, //
-                                                      is_convertible<const expected<_Uty, _UErr>&&, _Ty>>>> //
-                                           && !is_constructible_v<unexpected<_Err>, expected<_Uty, _UErr>&> //
-                                           && !is_constructible_v<unexpected<_Err>, expected<_Uty, _UErr>> //
-                                           && !is_constructible_v<unexpected<_Err>, const expected<_Uty, _UErr>&> //
+                                                      is_convertible<const expected<_Uty, _UErr>&&, _Ty>>>>
+                                           && !is_constructible_v<unexpected<_Err>, expected<_Uty, _UErr>&>
+                                           && !is_constructible_v<unexpected<_Err>, expected<_Uty, _UErr>>
+                                           && !is_constructible_v<unexpected<_Err>, const expected<_Uty, _UErr>&>
                                            && !is_constructible_v<unexpected<_Err>, const expected<_Uty, _UErr>>;
 
 public:
@@ -257,7 +257,7 @@ public:
         requires _Different_from<expected<_Uty, _UErr>, expected> && is_constructible_v<_Ty, const _Uty&>
               && is_constructible_v<_Err, const _UErr&> && _Allow_unwrapping<_Uty, _UErr>
     constexpr explicit(!is_convertible_v<const _Uty&, _Ty> || !is_convertible_v<const _UErr&, _Err>) expected(
-        const expected<_Uty, _UErr>& _Other) noexcept(is_nothrow_constructible_v<_Ty, const _Uty&> //
+        const expected<_Uty, _UErr>& _Other) noexcept(is_nothrow_constructible_v<_Ty, const _Uty&>
                                                       && is_nothrow_constructible_v<_Err, const _UErr&>) // strengthened
         : _Has_value(_Other._Has_value) {
         if (_Has_value) {
@@ -388,7 +388,7 @@ public:
     }
 
     constexpr expected& operator=(const expected& _Other) noexcept(
-        is_nothrow_copy_constructible_v<_Ty> && is_nothrow_copy_constructible_v<_Err> //
+        is_nothrow_copy_constructible_v<_Ty> && is_nothrow_copy_constructible_v<_Err>
         && is_nothrow_copy_assignable_v<_Ty> && is_nothrow_copy_assignable_v<_Err>) // strengthened
         requires is_copy_assignable_v<_Ty> && is_copy_constructible_v<_Ty> //
               && is_copy_assignable_v<_Err> && is_copy_constructible_v<_Err>
@@ -409,7 +409,7 @@ public:
     }
 
     constexpr expected& operator=(expected&& _Other) noexcept(
-        is_nothrow_move_constructible_v<_Ty> && is_nothrow_move_constructible_v<_Err> //
+        is_nothrow_move_constructible_v<_Ty> && is_nothrow_move_constructible_v<_Err>
         && is_nothrow_move_assignable_v<_Ty> && is_nothrow_move_assignable_v<_Err>)
         requires is_move_assignable_v<_Ty> && is_move_constructible_v<_Ty> //
               && is_move_assignable_v<_Err> && is_move_constructible_v<_Err>
@@ -1358,7 +1358,7 @@ public:
 
     // [expected.void.swap]
     constexpr void swap(expected& _Other) noexcept(
-        is_nothrow_move_constructible_v<_Err> && is_nothrow_swappable_v<_Err>) //
+        is_nothrow_move_constructible_v<_Err> && is_nothrow_swappable_v<_Err>)
         requires is_swappable_v<_Err> && is_move_constructible_v<_Err>
     {
         using _STD swap;

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -575,13 +575,11 @@ public:
         is_nothrow_constructible_v<_Ty2, _Types...>)
         : _Second(_STD forward<_Types>(_Args)...), _Contains{_Variantish_state::_Holds_second} {}
 
-    // clang-format off
     template <class _Uty1, class _Uty2>
         requires _Different_from<_Variantish<_Uty1, _Uty2>, _Variantish>
     constexpr _Variantish(const _Variantish<_Uty1, _Uty2>& _That) noexcept(
         is_nothrow_constructible_v<_Ty1, const _Uty1&> && is_nothrow_constructible_v<_Ty2, const _Uty2&>)
         : _Contains{_That._Contains} {
-        // clang-format on
         switch (_That._Contains) {
         case _Variantish_state::_Holds_first:
             _STD _Construct_in_place(_First, _That._Get_first());

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -600,7 +600,7 @@ public:
     // clang-format on
 
     constexpr _Variantish(const _Variantish& _That) noexcept(
-        is_nothrow_copy_constructible_v<_Ty1>&& is_nothrow_copy_constructible_v<_Ty2>)
+        is_nothrow_copy_constructible_v<_Ty1> && is_nothrow_copy_constructible_v<_Ty2>)
         : _Contains{_That._Contains} {
         switch (_Contains) {
         case _Variantish_state::_Holds_first:
@@ -620,7 +620,7 @@ public:
     // clang-format on
 
     constexpr _Variantish(_Variantish&& _That) noexcept(
-        is_nothrow_move_constructible_v<_Ty1>&& is_nothrow_move_constructible_v<_Ty2>)
+        is_nothrow_move_constructible_v<_Ty1> && is_nothrow_move_constructible_v<_Ty2>)
         : _Contains{_That._Contains} {
         switch (_Contains) {
         case _Variantish_state::_Holds_first:
@@ -650,8 +650,8 @@ public:
     // clang-format on
 
     constexpr _Variantish& operator=(const _Variantish& _That) noexcept(
-        is_nothrow_copy_constructible_v<_Ty1>&& is_nothrow_copy_constructible_v<_Ty2>&&
-            is_nothrow_copy_assignable_v<_Ty1>&& is_nothrow_copy_assignable_v<_Ty2>) {
+        is_nothrow_copy_constructible_v<_Ty1> && is_nothrow_copy_constructible_v<_Ty2>
+        && is_nothrow_copy_assignable_v<_Ty1> && is_nothrow_copy_assignable_v<_Ty2>) {
         if (_Contains == _That._Contains) {
             switch (_Contains) {
             case _Variantish_state::_Holds_first:
@@ -695,8 +695,8 @@ public:
     // clang-format on
 
     constexpr _Variantish& operator=(_Variantish&& _That) noexcept(
-        is_nothrow_move_constructible_v<_Ty1>&& is_nothrow_move_constructible_v<_Ty2>&&
-            is_nothrow_move_assignable_v<_Ty1>&& is_nothrow_move_assignable_v<_Ty2>) {
+        is_nothrow_move_constructible_v<_Ty1> && is_nothrow_move_constructible_v<_Ty2>
+        && is_nothrow_move_assignable_v<_Ty1> && is_nothrow_move_assignable_v<_Ty2>) {
         if (_Contains == _That._Contains) {
             switch (_Contains) {
             case _Variantish_state::_Holds_first:
@@ -888,7 +888,8 @@ public:
     template <class _OIter, class _OSe>
         requires convertible_to<const _OIter&, _Iter> && convertible_to<const _OSe&, _Se>
     constexpr common_iterator(const common_iterator<_OIter, _OSe>& _Right) noexcept(
-        is_nothrow_constructible_v<_Iter, const _OIter&>&& is_nothrow_constructible_v<_Se, const _OSe&>) // strengthened
+        is_nothrow_constructible_v<_Iter, const _OIter&>
+        && is_nothrow_constructible_v<_Se, const _OSe&>) // strengthened
         : _Val{_Right._Get_val()} {}
 
     // clang-format off

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -728,13 +728,11 @@ public:
         return *this;
     }
 
-    // clang-format off
     template <class _Uty1, class _Uty2>
         requires _Different_from<_Variantish<_Uty1, _Uty2>, _Variantish>
     constexpr _Variantish& operator=(const _Variantish<_Uty1, _Uty2>& _That) noexcept(
         is_nothrow_constructible_v<_Ty1, const _Uty1&> && is_nothrow_constructible_v<_Ty2, const _Uty2&>
-            && is_nothrow_assignable_v<_Ty1&, const _Uty1&> && is_nothrow_assignable_v<_Ty2&, const _Uty2&>) {
-        // clang-format on
+        && is_nothrow_assignable_v<_Ty1&, const _Uty1&> && is_nothrow_assignable_v<_Ty2&, const _Uty2&>) {
         if (_Contains == _That._Contains) {
             switch (_Contains) {
             case _Variantish_state::_Holds_first:
@@ -890,15 +888,13 @@ public:
         && is_nothrow_constructible_v<_Se, const _OSe&>) // strengthened
         : _Val{_Right._Get_val()} {}
 
-    // clang-format off
     template <class _OIter, class _OSe>
         requires convertible_to<const _OIter&, _Iter> && convertible_to<const _OSe&, _Se>
-            && assignable_from<_Iter&, const _OIter&> && assignable_from<_Se&, const _OSe&>
+              && assignable_from<_Iter&, const _OIter&> && assignable_from<_Se&, const _OSe&>
     constexpr common_iterator& operator=(const common_iterator<_OIter, _OSe>& _Right) noexcept(
         is_nothrow_constructible_v<_Iter, const _OIter&> && is_nothrow_constructible_v<_Se, const _OSe&>
-            && is_nothrow_assignable_v<_Iter&, const _OIter&>
-            && is_nothrow_assignable_v<_Se&, const _OSe&>) /* strengthened */ {
-        // clang-format on
+        && is_nothrow_assignable_v<_Iter&, const _OIter&>
+        && is_nothrow_assignable_v<_Se&, const _OSe&>) /* strengthened */ {
         _Val = _Right._Get_val();
         return *this;
     }

--- a/stl/inc/map
+++ b/stl/inc/map
@@ -166,7 +166,7 @@ public:
 
     map(map&& _Right, const allocator_type& _Al) : _Mybase(_STD move(_Right), _Al) {}
 
-    map& operator=(map&& _Right) noexcept(_Alnode_traits::is_always_equal::value&& is_nothrow_move_assignable_v<_Pr>) {
+    map& operator=(map&& _Right) noexcept(_Alnode_traits::is_always_equal::value && is_nothrow_move_assignable_v<_Pr>) {
         _Mybase::operator=(_STD move(_Right));
         return *this;
     }
@@ -547,7 +547,7 @@ public:
     multimap(multimap&& _Right, const allocator_type& _Al) : _Mybase(_STD move(_Right), _Al) {}
 
     multimap& operator=(multimap&& _Right) noexcept(
-        _Alnode_traits::is_always_equal::value&& is_nothrow_move_assignable_v<_Pr>) {
+        _Alnode_traits::is_always_equal::value && is_nothrow_move_assignable_v<_Pr>) {
         _Mybase::operator=(_STD move(_Right));
         return *this;
     }

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1204,9 +1204,9 @@ public:
         return this->_Map.extents().extent(_Idx);
     }
 
-    constexpr mdspan() noexcept(
-        is_nothrow_default_constructible_v<data_handle_type>&& is_nothrow_default_constructible_v<mapping_type>&&
-            is_nothrow_default_constructible_v<accessor_type>) // strengthened
+    constexpr mdspan() noexcept(is_nothrow_default_constructible_v<data_handle_type>
+                                && is_nothrow_default_constructible_v<mapping_type>
+                                && is_nothrow_default_constructible_v<accessor_type>) // strengthened
         requires (rank_dynamic() > 0) && is_default_constructible_v<data_handle_type>
               && is_default_constructible_v<mapping_type> && is_default_constructible_v<accessor_type>
     {}
@@ -1220,8 +1220,8 @@ public:
                   && (sizeof...(_OtherIndexTypes) == rank() || sizeof...(_OtherIndexTypes) == rank_dynamic())
                   && is_constructible_v<mapping_type, extents_type> && is_default_constructible_v<accessor_type>
     constexpr explicit mdspan(data_handle_type _Ptr_, _OtherIndexTypes... _Exts) noexcept(
-        is_nothrow_constructible_v<mapping_type, extents_type>&&
-            is_nothrow_default_constructible_v<accessor_type>) // strengthened
+        is_nothrow_constructible_v<mapping_type, extents_type>
+        && is_nothrow_default_constructible_v<accessor_type>) // strengthened
         : _Mapping_base(extents_type{static_cast<index_type>(_STD move(_Exts))...}), _Accessor_base(),
           _Ptr(_STD move(_Ptr_)) {}
 
@@ -1230,9 +1230,10 @@ public:
                   && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
                   && (_Size == rank() || _Size == rank_dynamic())
                   && is_constructible_v<mapping_type, extents_type> && is_default_constructible_v<accessor_type>
-    constexpr explicit(_Size != rank_dynamic()) mdspan(data_handle_type _Ptr_,
-        span<_OtherIndexType, _Size> _Exts) noexcept(is_nothrow_constructible_v<mapping_type, extents_type>&&
-            is_nothrow_default_constructible_v<accessor_type>) // strengthened
+    constexpr explicit(_Size != rank_dynamic())
+        mdspan(data_handle_type _Ptr_, span<_OtherIndexType, _Size> _Exts) noexcept(
+            is_nothrow_constructible_v<mapping_type, extents_type>
+            && is_nothrow_default_constructible_v<accessor_type>) // strengthened
         : _Mapping_base(extents_type{_Exts}), _Accessor_base(), _Ptr(_STD move(_Ptr_)) {}
 
     template <class _OtherIndexType, size_t _Size>
@@ -1240,25 +1241,27 @@ public:
                   && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
                   && (_Size == rank() || _Size == rank_dynamic())
                   && is_constructible_v<mapping_type, extents_type> && is_default_constructible_v<accessor_type>
-    constexpr explicit(_Size != rank_dynamic()) mdspan(data_handle_type _Ptr_,
-        const array<_OtherIndexType, _Size>& _Exts) noexcept(is_nothrow_constructible_v<mapping_type, extents_type>&&
-            is_nothrow_default_constructible_v<accessor_type>) // strengthened
+    constexpr explicit(_Size != rank_dynamic())
+        mdspan(data_handle_type _Ptr_, const array<_OtherIndexType, _Size>& _Exts) noexcept(
+            is_nothrow_constructible_v<mapping_type, extents_type>
+            && is_nothrow_default_constructible_v<accessor_type>) // strengthened
         : _Mapping_base(extents_type{_Exts}), _Accessor_base(), _Ptr(_STD move(_Ptr_)) {}
 
     constexpr mdspan(data_handle_type _Ptr_, const extents_type& _Exts) noexcept(
         is_nothrow_constructible_v<mapping_type,
-            const extents_type&>&& is_nothrow_default_constructible_v<accessor_type>) // strengthened
+            const extents_type&>
+        && is_nothrow_default_constructible_v<accessor_type>) // strengthened
         requires is_constructible_v<mapping_type, const extents_type&> && is_default_constructible_v<accessor_type>
         : _Mapping_base(_Exts), _Accessor_base(), _Ptr(_STD move(_Ptr_)) {}
 
     constexpr mdspan(data_handle_type _Ptr_, const mapping_type& _Map_) noexcept(
-        is_nothrow_copy_constructible_v<mapping_type>&&
-            is_nothrow_default_constructible_v<accessor_type>) // strengthened
+        is_nothrow_copy_constructible_v<mapping_type>
+        && is_nothrow_default_constructible_v<accessor_type>) // strengthened
         requires is_default_constructible_v<accessor_type>
         : _Mapping_base(_Map_), _Accessor_base(), _Ptr(_STD move(_Ptr_)) {}
 
     constexpr mdspan(data_handle_type _Ptr_, const mapping_type& _Map_, const accessor_type& _Acc_) noexcept(
-        is_nothrow_copy_constructible_v<mapping_type>&& is_nothrow_copy_constructible_v<accessor_type>) // strengthened
+        is_nothrow_copy_constructible_v<mapping_type> && is_nothrow_copy_constructible_v<accessor_type>) // strengthened
         : _Mapping_base(_Map_), _Accessor_base(_Acc_), _Ptr(_STD move(_Ptr_)) {}
 
     template <class _OtherElementType, class _OtherExtents, class _OtherLayoutPolicy, class _OtherAccessor>
@@ -1268,10 +1271,10 @@ public:
         !is_convertible_v<const typename _OtherLayoutPolicy::template mapping<_OtherExtents>&, mapping_type>
         || !is_convertible_v<const _OtherAccessor&, accessor_type>)
         mdspan(const mdspan<_OtherElementType, _OtherExtents, _OtherLayoutPolicy, _OtherAccessor>& _Other) noexcept(
-            is_nothrow_constructible_v<data_handle_type, const typename _OtherAccessor::data_handle_type&>&&
-                is_nothrow_constructible_v<mapping_type,
-                    const typename _OtherLayoutPolicy::template mapping<_OtherExtents>&>&&
-                    is_nothrow_constructible_v<accessor_type, const _OtherAccessor&>) // strengthened
+            is_nothrow_constructible_v<data_handle_type, const typename _OtherAccessor::data_handle_type&>
+            && is_nothrow_constructible_v<mapping_type,
+                const typename _OtherLayoutPolicy::template mapping<_OtherExtents>&>
+            && is_nothrow_constructible_v<accessor_type, const _OtherAccessor&>) // strengthened
         : _Mapping_base(_Other.mapping()), _Accessor_base(_Other.accessor()), _Ptr(_Other.data_handle()) {
         static_assert(is_constructible_v<data_handle_type, const typename _OtherAccessor::data_handle_type&>,
             "The data_handle_type must be constructible from const typename OtherAccessor::data_handle_type& (N4950 "

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1248,8 +1248,7 @@ public:
         : _Mapping_base(extents_type{_Exts}), _Accessor_base(), _Ptr(_STD move(_Ptr_)) {}
 
     constexpr mdspan(data_handle_type _Ptr_, const extents_type& _Exts) noexcept(
-        is_nothrow_constructible_v<mapping_type,
-            const extents_type&>
+        is_nothrow_constructible_v<mapping_type, const extents_type&>
         && is_nothrow_default_constructible_v<accessor_type>) // strengthened
         requires is_constructible_v<mapping_type, const extents_type&> && is_default_constructible_v<accessor_type>
         : _Mapping_base(_Exts), _Accessor_base(), _Ptr(_STD move(_Ptr_)) {}

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -4233,8 +4233,8 @@ private:
 
 public:
     explicit inout_ptr_t(_SmartPtr& _Smart_ptr_, _ArgsT... _Args_) noexcept(
-        is_nothrow_constructible_v<tuple<_ArgsT...>, _ArgsT...>&& noexcept(
-            _Get_ptr_from_smart(_Smart_ptr_))) /* strengthened */
+        is_nothrow_constructible_v<tuple<_ArgsT...>, _ArgsT...> //
+            && noexcept(_Get_ptr_from_smart(_Smart_ptr_))) /* strengthened */
         : _Smart_ptr(_Smart_ptr_),
           _Mypair(_One_then_variadic_args_t{}, tuple<_ArgsT...>{_STD forward<_ArgsT>(_Args_)...},
               _Get_ptr_from_smart(_Smart_ptr_)) {}

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1457,7 +1457,7 @@ struct _Can_scalar_delete<_Yty, void_t<decltype(delete _STD declval<_Yty*>())>> 
 template <class _Yty, class = void>
 struct _Can_array_delete : false_type {};
 template <class _Yty>
-struct _Can_array_delete<_Yty, void_t<decltype(delete[] _STD declval<_Yty*>())>> : true_type{};
+struct _Can_array_delete<_Yty, void_t<decltype(delete[] _STD declval<_Yty*>())>> : true_type {};
 
 template <class _Fx, class _Arg, class = void>
 struct _Can_call_function_object : false_type {};

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -259,7 +259,7 @@ _CONSTEXPR20 _OutIt partial_sum(const _InIt _First, const _InIt _Last, _OutIt _D
 #if _HAS_CXX20
             _Val = _Reduce_op(_STD move(_Val), *_UFirst);
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
-            _Val      = _Reduce_op(_Val, *_UFirst);
+            _Val = _Reduce_op(_Val, *_UFirst);
 #endif // ^^^ !_HAS_CXX20 ^^^
         }
     }

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -150,7 +150,7 @@ struct _Optional_construct_base : _Optional_destruct_base<_Ty> {
 
     template <class _Ty2>
     _CONSTEXPR20 void _Assign(_Ty2&& _Right) noexcept(
-        is_nothrow_assignable_v<_Ty&, _Ty2>&& is_nothrow_constructible_v<_Ty, _Ty2>) {
+        is_nothrow_assignable_v<_Ty&, _Ty2> && is_nothrow_constructible_v<_Ty, _Ty2>) {
         // assign / initialize the contained value from _Right
         if (this->_Has_value) {
             static_cast<_Ty&>(this->_Value) = _STD forward<_Ty2>(_Right);
@@ -170,8 +170,8 @@ struct _Optional_construct_base : _Optional_destruct_base<_Ty> {
 
     template <class _Self>
     _CONSTEXPR20 void _Assign_from(_Self&& _Right) noexcept(
-        is_nothrow_constructible_v<_Ty, decltype(*_STD forward<_Self>(_Right))>&&
-            is_nothrow_assignable_v<_Ty&, decltype(*_STD forward<_Self>(_Right))>) {
+        is_nothrow_constructible_v<_Ty, decltype(*_STD forward<_Self>(_Right))>
+        && is_nothrow_assignable_v<_Ty&, decltype(*_STD forward<_Self>(_Right))>) {
         // assign/initialize/destroy contained value from _Right
         if (_Right._Has_value) {
             _Assign(*_STD forward<_Self>(_Right));
@@ -290,7 +290,7 @@ public:
                                                 is_constructible<_Ty, _Ty2>, is_assignable<_Ty&, _Ty2>>,
                                     int> = 0>
     _CONSTEXPR20 optional& operator=(_Ty2&& _Right) noexcept(
-        is_nothrow_assignable_v<_Ty&, _Ty2>&& is_nothrow_constructible_v<_Ty, _Ty2>) /* strengthened */ {
+        is_nothrow_assignable_v<_Ty&, _Ty2> && is_nothrow_constructible_v<_Ty, _Ty2>) /* strengthened */ {
         this->_Assign(_STD forward<_Ty2>(_Right));
         return *this;
     }
@@ -305,7 +305,7 @@ public:
                                           is_constructible<_Ty, const _Ty2&>, is_assignable<_Ty&, const _Ty2&>>,
                               int> = 0>
     _CONSTEXPR20 optional& operator=(const optional<_Ty2>& _Right) noexcept(
-        is_nothrow_assignable_v<_Ty&, const _Ty2&>&& is_nothrow_constructible_v<_Ty, const _Ty2&>) /* strengthened */ {
+        is_nothrow_assignable_v<_Ty&, const _Ty2&> && is_nothrow_constructible_v<_Ty, const _Ty2&>) /* strengthened */ {
         if (_Right) {
             this->_Assign(*_Right);
         } else {
@@ -319,7 +319,7 @@ public:
                                           is_assignable<_Ty&, _Ty2>>,
                               int> = 0>
     _CONSTEXPR20 optional& operator=(optional<_Ty2>&& _Right) noexcept(
-        is_nothrow_assignable_v<_Ty&, _Ty2>&& is_nothrow_constructible_v<_Ty, _Ty2>) /* strengthened */ {
+        is_nothrow_assignable_v<_Ty&, _Ty2> && is_nothrow_constructible_v<_Ty, _Ty2>) /* strengthened */ {
         if (_Right) {
             this->_Assign(_STD move(*_Right));
         } else {
@@ -345,7 +345,7 @@ public:
     }
 
     _CONSTEXPR20 void swap(optional& _Right) noexcept(
-        is_nothrow_move_constructible_v<_Ty>&& is_nothrow_swappable_v<_Ty>) {
+        is_nothrow_move_constructible_v<_Ty> && is_nothrow_swappable_v<_Ty>) {
         static_assert(is_move_constructible_v<_Ty>,
             "optional<T>::swap requires T to be move constructible (N4950 [optional.swap]/1).");
         static_assert(!is_move_constructible_v<_Ty> || is_swappable_v<_Ty>,

--- a/stl/inc/queue
+++ b/stl/inc/queue
@@ -242,7 +242,8 @@ public:
     priority_queue() = default;
 
     explicit priority_queue(const _Pr& _Pred) noexcept(
-        is_nothrow_default_constructible_v<_Container>&& is_nothrow_copy_constructible_v<value_compare>) // strengthened
+        is_nothrow_default_constructible_v<_Container>
+        && is_nothrow_copy_constructible_v<value_compare>) // strengthened
         : c(), comp(_Pred) {}
 
     priority_queue(const _Pr& _Pred, const _Container& _Cont) : c(_Cont), comp(_Pred) {
@@ -284,13 +285,15 @@ public:
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     template <class _Alloc, enable_if_t<uses_allocator_v<_Container, _Alloc>, int> = 0>
-    explicit priority_queue(const _Alloc& _Al) noexcept(is_nothrow_constructible_v<_Container, const _Alloc&>&&
-            is_nothrow_default_constructible_v<value_compare>) // strengthened
+    explicit priority_queue(const _Alloc& _Al) noexcept(
+        is_nothrow_constructible_v<_Container, const _Alloc&>
+        && is_nothrow_default_constructible_v<value_compare>) // strengthened
         : c(_Al), comp() {}
 
     template <class _Alloc, enable_if_t<uses_allocator_v<_Container, _Alloc>, int> = 0>
-    priority_queue(const _Pr& _Pred, const _Alloc& _Al) noexcept(is_nothrow_constructible_v<_Container, const _Alloc&>&&
-            is_nothrow_copy_constructible_v<value_compare>) // strengthened
+    priority_queue(const _Pr& _Pred, const _Alloc& _Al) noexcept(
+        is_nothrow_constructible_v<_Container, const _Alloc&>
+        && is_nothrow_copy_constructible_v<value_compare>) // strengthened
         : c(_Al), comp(_Pred) {}
 
     template <class _Alloc, enable_if_t<uses_allocator_v<_Container, _Alloc>, int> = 0>
@@ -308,8 +311,8 @@ public:
 
     template <class _Alloc, enable_if_t<uses_allocator_v<_Container, _Alloc>, int> = 0>
     priority_queue(priority_queue&& _Right, const _Alloc& _Al) noexcept(
-        is_nothrow_constructible_v<_Container, _Container, const _Alloc&>&&
-            is_nothrow_move_constructible_v<value_compare>) // strengthened
+        is_nothrow_constructible_v<_Container, _Container, const _Alloc&>
+        && is_nothrow_move_constructible_v<value_compare>) // strengthened
         : c(_STD move(_Right.c), _Al), comp(_STD move(_Right.comp)) {}
 
     template <class _InIt, class _Alloc,
@@ -416,7 +419,7 @@ public:
     }
 
     void swap(priority_queue& _Right) noexcept(
-        _Is_nothrow_swappable<_Container>::value&& _Is_nothrow_swappable<_Pr>::value) {
+        _Is_nothrow_swappable<_Container>::value && _Is_nothrow_swappable<_Pr>::value) {
         using _STD swap;
         swap(c, _Right.c); // intentional ADL
         swap(comp, _Right.comp); // intentional ADL

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -5130,16 +5130,14 @@ namespace ranges {
             is_nothrow_move_constructible_v<_Vw> && is_nothrow_move_constructible_v<_Pat>) // strengthened
             : _Range(_STD move(_Range_)), _Pattern(_STD move(_Pattern_)) {}
 
-        // clang-format off
         template <forward_range _Rng>
             requires constructible_from<_Vw, views::all_t<_Rng>>
-                && constructible_from<_Pat, single_view<range_value_t<_Rng>>>
-        constexpr explicit split_view(_Rng&& _Range_, range_value_t<_Rng> _Elem)
-            noexcept(is_nothrow_constructible_v<_Vw, views::all_t<_Rng>>
-                && is_nothrow_constructible_v<_Pat, single_view<range_value_t<_Rng>>>
-                && is_nothrow_move_constructible_v<range_value_t<_Rng>>) // strengthened
+                      && constructible_from<_Pat, single_view<range_value_t<_Rng>>>
+        constexpr explicit split_view(_Rng&& _Range_, range_value_t<_Rng> _Elem) noexcept(
+            is_nothrow_constructible_v<_Vw, views::all_t<_Rng>>
+            && is_nothrow_constructible_v<_Pat, single_view<range_value_t<_Rng>>>
+            && is_nothrow_move_constructible_v<range_value_t<_Rng>>) // strengthened
             : _Range(views::all(_STD forward<_Rng>(_Range_))), _Pattern(views::single(_STD move(_Elem))) {}
-        // clang-format on
 
         _NODISCARD constexpr _Vw base() const& noexcept(is_nothrow_copy_constructible_v<_Vw>) /* strengthened */
             requires copy_constructible<_Vw>

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -130,7 +130,7 @@ namespace ranges {
 
             template <class _Ty1, class _Ty2>
             constexpr explicit _Pipeline(_Ty1&& _Val1, _Ty2&& _Val2) noexcept(
-                is_nothrow_constructible_v<_Ty1, _ClosureLeft>&& is_nothrow_constructible_v<_Ty2, _ClosureRight>)
+                is_nothrow_constructible_v<_Ty1, _ClosureLeft> && is_nothrow_constructible_v<_Ty2, _ClosureRight>)
                 : _Left(_STD forward<_Ty1>(_Val1)), _Right(_STD forward<_Ty2>(_Val2)) {}
 
             void operator()(auto&&) &       = delete;
@@ -141,7 +141,7 @@ namespace ranges {
             // TRANSITION, DevCom-10519736, explicit `this->` shouldn't be needed.
 
             template <class _Ty>
-            _NODISCARD constexpr decltype(auto) operator()(_Ty&& _Val) & noexcept(
+            _NODISCARD constexpr decltype(auto) operator()(_Ty && _Val) & noexcept(
                 noexcept(_Right(_Left(_STD forward<_Ty>(_Val)))))
                 requires requires { this->_Right(this->_Left(_STD forward<_Ty>(_Val))); }
             {
@@ -149,7 +149,7 @@ namespace ranges {
             }
 
             template <class _Ty>
-            _NODISCARD constexpr decltype(auto) operator()(_Ty&& _Val) const& noexcept(
+            _NODISCARD constexpr decltype(auto) operator()(_Ty && _Val) const& noexcept(
                 noexcept(_Right(_Left(_STD forward<_Ty>(_Val)))))
                 requires requires { this->_Right(this->_Left(_STD forward<_Ty>(_Val))); }
             {
@@ -157,7 +157,7 @@ namespace ranges {
             }
 
             template <class _Ty>
-            _NODISCARD constexpr decltype(auto) operator()(_Ty&& _Val) && noexcept(
+            _NODISCARD constexpr decltype(auto) operator()(_Ty && _Val) && noexcept(
                 noexcept(_STD move(_Right)(_STD move(_Left)(_STD forward<_Ty>(_Val)))))
                 requires requires { _STD move(this->_Right)(_STD move(this->_Left)(_STD forward<_Ty>(_Val))); }
             {
@@ -165,7 +165,7 @@ namespace ranges {
             }
 
             template <class _Ty>
-            _NODISCARD constexpr decltype(auto) operator()(_Ty&& _Val) const&& noexcept(
+            _NODISCARD constexpr decltype(auto) operator()(_Ty && _Val) const&& noexcept(
                 noexcept(_STD move(_Right)(_STD move(_Left)(_STD forward<_Ty>(_Val)))))
                 requires requires { _STD move(this->_Right)(_STD move(this->_Left)(_STD forward<_Ty>(_Val))); }
             {
@@ -187,7 +187,7 @@ namespace ranges {
 
         _EXPORT_STD template <class _Left, class _Right>
             requires (_Range_adaptor_closure_object<_Right> && range<_Left>)
-        _NODISCARD constexpr decltype(auto) operator|(_Left&& __l, _Right&& __r) noexcept(
+        _NODISCARD constexpr decltype(auto) operator|(_Left && __l, _Right && __r) noexcept(
             noexcept(_STD forward<_Right>(__r)(_STD forward<_Left>(__l))))
             requires requires { static_cast<_Right&&>(__r)(static_cast<_Left&&>(__l)); }
         {
@@ -342,7 +342,7 @@ namespace ranges {
         // clang-format on
 
         constexpr _Movable_box& operator=(const _Movable_box& _That) noexcept(
-            is_nothrow_copy_constructible_v<_Ty>&& is_nothrow_copy_assignable_v<_Ty>) // strengthened
+            is_nothrow_copy_constructible_v<_Ty> && is_nothrow_copy_assignable_v<_Ty>) // strengthened
             requires copyable<_Ty>
         {
             if (_Engaged) {
@@ -390,7 +390,7 @@ namespace ranges {
         // clang-format on
 
         constexpr _Movable_box& operator=(_Movable_box&& _That) noexcept(
-            is_nothrow_move_constructible_v<_Ty>&& is_nothrow_move_assignable_v<_Ty>) // strengthened
+            is_nothrow_move_constructible_v<_Ty> && is_nothrow_move_assignable_v<_Ty>) // strengthened
             requires movable<_Ty>
         {
             if (_Engaged) {
@@ -600,7 +600,7 @@ namespace ranges {
         // clang-format on
 
         constexpr _Defaultabox& operator=(const _Defaultabox& _That) noexcept(
-            is_nothrow_copy_constructible_v<_Ty>&& is_nothrow_copy_assignable_v<_Ty>)
+            is_nothrow_copy_constructible_v<_Ty> && is_nothrow_copy_assignable_v<_Ty>)
             requires copyable<_Ty>
         {
             if (_Engaged) {
@@ -627,7 +627,7 @@ namespace ranges {
         // clang-format on
 
         constexpr _Defaultabox& operator=(_Defaultabox&& _That) noexcept(
-            is_nothrow_move_constructible_v<_Ty>&& is_nothrow_move_assignable_v<_Ty>) {
+            is_nothrow_move_constructible_v<_Ty> && is_nothrow_move_assignable_v<_Ty>) {
             if (_Engaged) {
                 if (_That._Engaged) {
                     static_cast<_Ty&>(_Val) = static_cast<_Ty&&>(_That._Val);
@@ -648,7 +648,7 @@ namespace ranges {
         }
 
         constexpr _Defaultabox& operator=(_Ty&& _That) noexcept(
-            is_nothrow_move_constructible_v<_Ty>&& is_nothrow_move_assignable_v<_Ty>) {
+            is_nothrow_move_constructible_v<_Ty> && is_nothrow_move_assignable_v<_Ty>) {
             if (_Engaged) {
                 static_cast<_Ty&>(_Val) = _STD move(_That);
             } else {
@@ -660,7 +660,7 @@ namespace ranges {
         }
 
         constexpr _Defaultabox& operator=(const _Ty& _That) noexcept(
-            is_nothrow_copy_constructible_v<_Ty>&& is_nothrow_copy_assignable_v<_Ty>)
+            is_nothrow_copy_constructible_v<_Ty> && is_nothrow_copy_assignable_v<_Ty>)
             requires copyable<_Ty>
         {
             if (_Engaged) {
@@ -922,28 +922,28 @@ namespace ranges {
 
         template <class _Ty>
             requires invocable<_Fn, _Ty, _Types&...>
-        constexpr decltype(auto) operator()(_Ty&& _Arg) & noexcept(
+        constexpr decltype(auto) operator()(_Ty && _Arg) & noexcept(
             noexcept(_Call(*this, _STD forward<_Ty>(_Arg), _Indices{}))) {
             return _Call(*this, _STD forward<_Ty>(_Arg), _Indices{});
         }
 
         template <class _Ty>
             requires invocable<_Fn, _Ty, const _Types&...>
-        constexpr decltype(auto) operator()(_Ty&& _Arg) const& noexcept(
+        constexpr decltype(auto) operator()(_Ty && _Arg) const& noexcept(
             noexcept(_Call(*this, _STD forward<_Ty>(_Arg), _Indices{}))) {
             return _Call(*this, _STD forward<_Ty>(_Arg), _Indices{});
         }
 
         template <class _Ty>
             requires invocable<_Fn, _Ty, _Types...>
-        constexpr decltype(auto) operator()(_Ty&& _Arg) && noexcept(
+        constexpr decltype(auto) operator()(_Ty && _Arg) && noexcept(
             noexcept(_Call(_STD move(*this), _STD forward<_Ty>(_Arg), _Indices{}))) {
             return _Call(_STD move(*this), _STD forward<_Ty>(_Arg), _Indices{});
         }
 
         template <class _Ty>
             requires invocable<_Fn, _Ty, const _Types...>
-        constexpr decltype(auto) operator()(_Ty&& _Arg) const&& noexcept(
+        constexpr decltype(auto) operator()(_Ty && _Arg) const&& noexcept(
             noexcept(_Call(_STD move(*this), _STD forward<_Ty>(_Arg), _Indices{}))) {
             return _Call(_STD move(*this), _STD forward<_Ty>(_Arg), _Indices{});
         }
@@ -1367,7 +1367,7 @@ namespace ranges {
         // clang-format on
 
         constexpr explicit iota_view(_Wi _Value_) noexcept(
-            is_nothrow_move_constructible_v<_Wi>&& is_nothrow_default_constructible_v<_Bo>) // strengthened
+            is_nothrow_move_constructible_v<_Wi> && is_nothrow_default_constructible_v<_Bo>) // strengthened
             : _Value(_STD move(_Value_)) {
             if constexpr (totally_ordered_with<_Wi, _Bo>) {
                 _STL_ASSERT(_Value_ <= _Bound, "Per N4950 [range.iota.view]/6, the first argument must not exceed the "
@@ -1376,7 +1376,7 @@ namespace ranges {
         }
 
         constexpr explicit iota_view(type_identity_t<_Wi> _Value_, type_identity_t<_Bo> _Bound_) noexcept(
-            is_nothrow_move_constructible_v<_Wi>&& is_nothrow_move_constructible_v<_Bo>) // strengthened
+            is_nothrow_move_constructible_v<_Wi> && is_nothrow_move_constructible_v<_Bo>) // strengthened
             : _Value(_STD move(_Value_)), _Bound(_STD move(_Bound_)) {
             if constexpr (totally_ordered_with<_Wi, _Bo>) {
                 _STL_ASSERT(_Value_ <= _Bound_, "Per N4950 [range.iota.view]/8, the first argument must not exceed the "
@@ -1385,7 +1385,7 @@ namespace ranges {
         }
 
         constexpr explicit iota_view(_It _First, _Se _Last) noexcept(
-            is_nothrow_move_constructible_v<_Wi>&& is_nothrow_move_constructible_v<_Bo>) // strengthened
+            is_nothrow_move_constructible_v<_Wi> && is_nothrow_move_constructible_v<_Bo>) // strengthened
             : _Value(_STD move(_First._Current)), _Bound(_STD move(_Bound_from(_Last))) {}
 
         _NODISCARD constexpr _It begin() const noexcept(is_nothrow_copy_constructible_v<_Wi>) /* strengthened */ {
@@ -2332,7 +2332,7 @@ namespace ranges {
         // clang-format on
 
         constexpr explicit filter_view(_Vw _Range_, _Pr _Pred_) noexcept(
-            is_nothrow_move_constructible_v<_Vw>&& is_nothrow_move_constructible_v<_Pr>) // strengthened
+            is_nothrow_move_constructible_v<_Vw> && is_nothrow_move_constructible_v<_Pr>) // strengthened
             : _Range(_STD move(_Range_)), _Pred{in_place, _STD move(_Pred_)} {}
 
         _NODISCARD constexpr _Vw base() const& noexcept(is_nothrow_copy_constructible_v<_Vw>) /* strengthened */
@@ -2747,7 +2747,7 @@ namespace ranges {
         // clang-format on
 
         constexpr explicit transform_view(_Vw _Range_, _Fn _Fun_) noexcept(
-            is_nothrow_move_constructible_v<_Vw>&& is_nothrow_move_constructible_v<_Fn>) // strengthened
+            is_nothrow_move_constructible_v<_Vw> && is_nothrow_move_constructible_v<_Fn>) // strengthened
             : _Range(_STD move(_Range_)), _Fun{in_place, _STD move(_Fun_)} {}
 
         _NODISCARD constexpr _Vw base() const& noexcept(is_nothrow_copy_constructible_v<_Vw>) /* strengthened */
@@ -3213,7 +3213,7 @@ namespace ranges {
         // clang-format on
 
         constexpr explicit take_while_view(_Vw _Range_, _Pr _Pred_) noexcept(
-            is_nothrow_move_constructible_v<_Vw>&& is_nothrow_move_constructible_v<_Pr>) // strengthened
+            is_nothrow_move_constructible_v<_Vw> && is_nothrow_move_constructible_v<_Pr>) // strengthened
             : _Range(_STD move(_Range_)), _Pred{in_place, _STD move(_Pred_)} {}
 
         _NODISCARD constexpr _Vw base() const& noexcept(is_nothrow_copy_constructible_v<_Vw>) /* strengthened */
@@ -3547,7 +3547,7 @@ namespace ranges {
         // clang-format on
 
         constexpr explicit drop_while_view(_Vw _Range_, _Pr _Pred_) noexcept(
-            is_nothrow_move_constructible_v<_Vw>&& is_nothrow_move_constructible_v<_Pr>) // strengthened
+            is_nothrow_move_constructible_v<_Vw> && is_nothrow_move_constructible_v<_Pr>) // strengthened
             : _Range(_STD move(_Range_)), _Pred{in_place, _STD move(_Pred_)} {}
 
         _NODISCARD constexpr _Vw base() const& noexcept(is_nothrow_copy_constructible_v<_Vw>) /* strengthened */
@@ -4474,7 +4474,7 @@ namespace ranges {
         // clang-format on
 
         constexpr explicit join_with_view(_Vw _Range_, _Pat _Pattern_) noexcept(
-            is_nothrow_move_constructible_v<_Vw>&& is_nothrow_move_constructible_v<_Pat>) // strengthened
+            is_nothrow_move_constructible_v<_Vw> && is_nothrow_move_constructible_v<_Pat>) // strengthened
             : _Range{_STD move(_Range_)}, _Pattern{_STD move(_Pattern_)} {}
 
         template <input_range _Rng>
@@ -4921,7 +4921,7 @@ namespace ranges {
         // clang-format on
 
         constexpr explicit lazy_split_view(_Vw _Range_, _Pat _Pattern_) noexcept(
-            is_nothrow_move_constructible_v<_Vw>&& is_nothrow_move_constructible_v<_Pat>) // strengthened
+            is_nothrow_move_constructible_v<_Vw> && is_nothrow_move_constructible_v<_Pat>) // strengthened
             : _Range(_STD move(_Range_)), _Pattern(_STD move(_Pattern_)) {}
 
         template <input_range _Rng>
@@ -5124,7 +5124,7 @@ namespace ranges {
         // clang-format on
 
         constexpr explicit split_view(_Vw _Range_, _Pat _Pattern_) noexcept(
-            is_nothrow_move_constructible_v<_Vw>&& is_nothrow_move_constructible_v<_Pat>) // strengthened
+            is_nothrow_move_constructible_v<_Vw> && is_nothrow_move_constructible_v<_Pat>) // strengthened
             : _Range(_STD move(_Range_)), _Pattern(_STD move(_Pattern_)) {}
 
         // clang-format off
@@ -6731,7 +6731,7 @@ namespace ranges {
 
             constexpr _Iterator(_Iterator<!_Const> _Other) noexcept(
                 is_nothrow_constructible_v<_Base_iterator, typename _Iterator<!_Const>::_Base_iterator> //
-                    && is_nothrow_constructible_v<_Base_sentinel, typename _Iterator<!_Const>::_Base_sentinel> //
+                && is_nothrow_constructible_v<_Base_sentinel, typename _Iterator<!_Const>::_Base_sentinel> //
                 ) /* strengthened */
                 requires _Const && convertible_to<iterator_t<_Vw>, _Base_iterator>
                           && convertible_to<sentinel_t<_Vw>, _Base_sentinel>
@@ -7566,7 +7566,7 @@ namespace ranges {
         // clang-format on
 
         constexpr explicit chunk_by_view(_Vw _Range_, _Pr _Pred_) noexcept(
-            is_nothrow_move_constructible_v<_Vw>&& is_nothrow_move_constructible_v<_Pr>) // strengthened
+            is_nothrow_move_constructible_v<_Vw> && is_nothrow_move_constructible_v<_Pr>) // strengthened
             : _Range(_STD move(_Range_)), _Pred{in_place, _STD move(_Pred_)} {}
 
         _NODISCARD constexpr _Vw base() const& noexcept(is_nothrow_copy_constructible_v<_Vw>) /* strengthened */
@@ -7694,7 +7694,7 @@ namespace ranges {
 
             constexpr _Iterator(_Iterator<!_Const> _Other) noexcept(
                 is_nothrow_constructible_v<_Base_iterator, iterator_t<_Vw>> //
-                    && is_nothrow_constructible_v<_Base_sentinel, sentinel_t<_Vw>> //
+                && is_nothrow_constructible_v<_Base_sentinel, sentinel_t<_Vw>> //
                 ) /* strengthened */
                 requires _Const && convertible_to<iterator_t<_Vw>, _Base_iterator>
                           && convertible_to<sentinel_t<_Vw>, _Base_sentinel>
@@ -8114,7 +8114,7 @@ namespace ranges {
         // clang-format on
         const auto _Evaluate_equality_closure =
             [&_Lhs_tuple, &_Rhs_tuple]<size_t... _Indices>(index_sequence<_Indices...>) noexcept(
-                (noexcept(_STD declval<const _LHSTupleTypes&>() == _STD declval<const _RHSTupleTypes&>()) && ...)) {
+                (noexcept(_STD declval<const _LHSTupleTypes&>() == _STD declval<const _RHSTupleTypes&>())&&...)) {
                 return ((_STD get<_Indices>(_Lhs_tuple) == _STD get<_Indices>(_Rhs_tuple)) || ...);
             };
 
@@ -8780,7 +8780,7 @@ namespace ranges {
             template <bool _IteratorConst>
                 requires sized_sentinel_for<_Zentinel<_IsConst>, _Ziperator<_IteratorConst>>
             _NODISCARD_FRIEND constexpr _Iter_sent_difference_type<_IteratorConst> // TRANSITION, DevCom-10253131
-                operator-(const _Iterator<_IteratorConst>& _Lhs, const _Sentinel& _Rhs) noexcept(
+                operator-(const _Iterator<_IteratorConst>& _Lhs, const _Sentinel & _Rhs) noexcept(
                     noexcept(_Get_iterator_inner(_Lhs) - _Rhs._Inner)) /* strengthened */ {
                 return _Get_iterator_inner(_Lhs) - _Rhs._Inner;
             }
@@ -8788,7 +8788,7 @@ namespace ranges {
             template <bool _IteratorConst>
                 requires sized_sentinel_for<_Zentinel<_IsConst>, _Ziperator<_IteratorConst>>
             _NODISCARD_FRIEND constexpr _Iter_sent_difference_type<_IteratorConst> // TRANSITION, DevCom-10253131
-                operator-(const _Sentinel& _Lhs, const _Iterator<_IteratorConst>& _Rhs) noexcept(
+                operator-(const _Sentinel & _Lhs, const _Iterator<_IteratorConst>& _Rhs) noexcept(
                     noexcept(_Lhs._Inner - _Get_iterator_inner(_Rhs))) /* strengthened */ {
                 return _Lhs._Inner - _Get_iterator_inner(_Rhs);
             }
@@ -8811,8 +8811,8 @@ namespace ranges {
         zip_transform_view() = default;
 
         constexpr explicit zip_transform_view(_Func _Function_, _ViewTypes... _Views) noexcept(
-            is_nothrow_move_constructible_v<_Func>&&
-                is_nothrow_constructible_v<_Inner_view, remove_reference_t<_ViewTypes>&&...>) // strengthened
+            is_nothrow_move_constructible_v<_Func>
+            && is_nothrow_constructible_v<_Inner_view, remove_reference_t<_ViewTypes>&&...>) // strengthened
             : _Function(in_place, _STD move(_Function_)), _Zip(_STD move(_Views)...) {}
 
         _NODISCARD constexpr auto begin() noexcept(noexcept(_Iterator<false>{*this, _Zip.begin()})) /* strengthened */ {
@@ -9617,7 +9617,7 @@ namespace ranges {
         adjacent_transform_view() = default;
 
         constexpr explicit adjacent_transform_view(_Vw _Range_, _Fn _Func_) noexcept(
-            is_nothrow_move_constructible_v<_Vw>&& is_nothrow_move_constructible_v<_Fn>) // strengthened
+            is_nothrow_move_constructible_v<_Vw> && is_nothrow_move_constructible_v<_Fn>) // strengthened
             : _Func(in_place, _STD move(_Func_)), _Inner(_STD move(_Range_)) {}
 
         _NODISCARD constexpr _Vw base() const& noexcept(noexcept(_Inner.base())) // strengthened

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -715,8 +715,8 @@ namespace ranges {
 
         template <_Different_from<_Ty> _Uty>
             requires convertible_to<const _Uty&, _Ty>
-        constexpr _Defaultabox(const _Defaultabox<_Uty>& _That) noexcept(
-            is_nothrow_default_constructible_v<_Ty>&& noexcept(_Value = static_cast<_Ty>(*_That))) {
+        constexpr _Defaultabox(const _Defaultabox<_Uty>& _That) noexcept(is_nothrow_default_constructible_v<_Ty> //
+                && noexcept(_Value = static_cast<_Ty>(*_That))) {
             if (_That) {
                 _Value = static_cast<_Ty>(*_That);
             }
@@ -724,8 +724,8 @@ namespace ranges {
 
         template <_Different_from<_Ty> _Uty>
             requires convertible_to<_Uty, _Ty>
-        constexpr _Defaultabox(_Defaultabox<_Uty>&& _That) noexcept(
-            is_nothrow_default_constructible_v<_Ty>&& noexcept(_Value = static_cast<_Ty>(_STD move(*_That)))) {
+        constexpr _Defaultabox(_Defaultabox<_Uty>&& _That) noexcept(is_nothrow_default_constructible_v<_Ty> //
+                && noexcept(_Value = static_cast<_Ty>(_STD move(*_That)))) {
             if (_That) {
                 _Value = static_cast<_Ty>(_STD move(*_That));
             }
@@ -1137,8 +1137,8 @@ namespace ranges {
             return *this;
         }
 
-        constexpr _Ioterator operator--(int) noexcept(
-            is_nothrow_copy_constructible_v<_Wi>&& noexcept(--_Current)) /* strengthened */
+        constexpr _Ioterator operator--(int) noexcept(is_nothrow_copy_constructible_v<_Wi> //
+                && noexcept(--_Current)) /* strengthened */
             requires _Decrementable<_Wi>
         {
             auto _Tmp = *this;
@@ -1260,21 +1260,24 @@ namespace ranges {
         }
 
         _NODISCARD_FRIEND constexpr _Ioterator operator+(_Ioterator _It, const difference_type _Off) noexcept(
-            is_nothrow_move_constructible_v<_Ioterator>&& noexcept(_It += _Off)) /* strengthened */
+            is_nothrow_move_constructible_v<_Ioterator> //
+                && noexcept(_It += _Off)) /* strengthened */
             requires _Advanceable<_Wi>
         {
             _It += _Off;
             return _It;
         }
         _NODISCARD_FRIEND constexpr _Ioterator operator+(const difference_type _Off, _Ioterator _It) noexcept(
-            is_nothrow_move_constructible_v<_Wi>&& noexcept(static_cast<_Wi>(_It._Current + _Off))) /* strengthened */
+            is_nothrow_move_constructible_v<_Wi> //
+                && noexcept(static_cast<_Wi>(_It._Current + _Off))) /* strengthened */
             requires _Advanceable<_Wi>
         {
             return _Ioterator{static_cast<_Wi>(_It._Current + _Off)};
         }
 
         _NODISCARD_FRIEND constexpr _Ioterator operator-(_Ioterator _It, const difference_type _Off) noexcept(
-            is_nothrow_move_constructible_v<_Ioterator>&& noexcept(_It -= _Off)) /* strengthened */
+            is_nothrow_move_constructible_v<_Ioterator> //
+                && noexcept(_It -= _Off)) /* strengthened */
             requires _Advanceable<_Wi>
         {
             _It -= _Off;
@@ -1645,8 +1648,8 @@ namespace ranges {
         template <class... _TArgs, class... _BArgs>
             requires constructible_from<_Ty, _TArgs...> && constructible_from<_Bo, _BArgs...>
         _NODISCARD_CTOR constexpr explicit repeat_view(piecewise_construct_t, tuple<_TArgs...> _Val_args,
-            tuple<_BArgs...> _Bound_args = tuple<>{}) noexcept(is_nothrow_constructible_v<_Ty,
-            _TArgs...>&& noexcept(_STD make_from_tuple<_Bo>(_Bound_args))) // strengthened
+            tuple<_BArgs...> _Bound_args = tuple<>{}) noexcept(is_nothrow_constructible_v<_Ty, _TArgs...> //
+                && noexcept(_STD make_from_tuple<_Bo>(_Bound_args))) // strengthened
             : repeat_view(_Val_args, index_sequence_for<_TArgs...>{}, _STD make_from_tuple<_Bo>(_Bound_args)) {
 #if _CONTAINER_DEBUG_LEVEL > 0
             if constexpr (_Signed_integer_like<_Bo>) {
@@ -6225,8 +6228,8 @@ namespace ranges {
             }
 
             _NODISCARD_FRIEND constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off) noexcept(
-                is_nothrow_copy_constructible_v<_Iterator>&& noexcept(
-                    _STD declval<_Iterator&>() += _Off)) // strengthened
+                is_nothrow_copy_constructible_v<_Iterator> //
+                    && noexcept(_STD declval<_Iterator&>() += _Off)) // strengthened
                 requires random_access_range<_Base_t>
             {
                 auto _Tmp = _It;
@@ -6242,8 +6245,8 @@ namespace ranges {
             }
 
             _NODISCARD_FRIEND constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off) noexcept(
-                is_nothrow_copy_constructible_v<_Iterator>&& noexcept(
-                    _STD declval<_Iterator&>() -= _Off)) // strengthened
+                is_nothrow_copy_constructible_v<_Iterator> //
+                    && noexcept(_STD declval<_Iterator&>() -= _Off)) // strengthened
                 requires random_access_range<_Base_t>
             {
                 auto _Tmp = _It;
@@ -6870,8 +6873,8 @@ namespace ranges {
             }
 
             _NODISCARD_FRIEND constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off) noexcept(
-                is_nothrow_copy_constructible_v<_Iterator>&& noexcept(
-                    _STD declval<_Iterator&>() += _Off)) /* strengthened */
+                is_nothrow_copy_constructible_v<_Iterator> //
+                    && noexcept(_STD declval<_Iterator&>() += _Off)) /* strengthened */
                 requires random_access_range<_Base>
             {
                 auto _Copy = _It;
@@ -6880,8 +6883,8 @@ namespace ranges {
             }
 
             _NODISCARD_FRIEND constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It) noexcept(
-                is_nothrow_copy_constructible_v<_Iterator>&& noexcept(
-                    _STD declval<_Iterator&>() += _Off)) /* strengthened */
+                is_nothrow_copy_constructible_v<_Iterator> //
+                    && noexcept(_STD declval<_Iterator&>() += _Off)) /* strengthened */
                 requires random_access_range<_Base>
             {
                 auto _Copy = _It;
@@ -6890,8 +6893,8 @@ namespace ranges {
             }
 
             _NODISCARD_FRIEND constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off) noexcept(
-                is_nothrow_copy_constructible_v<_Iterator>&& noexcept(
-                    _STD declval<_Iterator&>() -= _Off)) /* strengthened */
+                is_nothrow_copy_constructible_v<_Iterator> //
+                    && noexcept(_STD declval<_Iterator&>() -= _Off)) /* strengthened */
                 requires random_access_range<_Base>
             {
                 auto _Copy = _It;
@@ -7124,8 +7127,8 @@ namespace ranges {
                 return *this;
             }
 
-            constexpr _Iterator operator++(int) noexcept(
-                is_nothrow_copy_constructible_v<_Base_iterator>&& noexcept(++_Current)) /* strengthened */ {
+            constexpr _Iterator operator++(int) noexcept(is_nothrow_copy_constructible_v<_Base_iterator> //
+                    && noexcept(++_Current)) /* strengthened */ {
                 auto _Tmp = *this;
                 ++*this;
                 return _Tmp;
@@ -7142,8 +7145,8 @@ namespace ranges {
                 return *this;
             }
 
-            constexpr _Iterator operator--(int) noexcept(
-                is_nothrow_copy_constructible_v<_Base_iterator>&& noexcept(--_Current)) /* strengthened */
+            constexpr _Iterator operator--(int) noexcept(is_nothrow_copy_constructible_v<_Base_iterator> //
+                    && noexcept(--_Current)) /* strengthened */
                 requires bidirectional_range<_Base>
             {
                 auto _Tmp = *this;
@@ -8635,8 +8638,8 @@ namespace ranges {
                 ++*this;
             }
 
-            constexpr _Iterator operator++(int) noexcept(
-                is_nothrow_copy_constructible_v<_Iterator>&& noexcept(++*this)) // strengthened
+            constexpr _Iterator operator++(int) noexcept(is_nothrow_copy_constructible_v<_Iterator> //
+                    && noexcept(++*this)) // strengthened
                 requires forward_range<_Base_t>
             {
                 auto _Temp = *this;
@@ -8651,8 +8654,8 @@ namespace ranges {
                 return *this;
             }
 
-            constexpr _Iterator operator--(int) noexcept(
-                is_nothrow_copy_constructible_v<_Iterator>&& noexcept(--*this)) // strengthened
+            constexpr _Iterator operator--(int) noexcept(is_nothrow_copy_constructible_v<_Iterator> //
+                    && noexcept(--*this)) // strengthened
                 requires bidirectional_range<_Base_t>
             {
                 auto _Temp = *this;

--- a/stl/inc/set
+++ b/stl/inc/set
@@ -143,7 +143,7 @@ public:
 
     set(set&& _Right, const allocator_type& _Al) : _Mybase(_STD move(_Right), _Al) {}
 
-    set& operator=(set&& _Right) noexcept(_Alnode_traits::is_always_equal::value&& is_nothrow_move_assignable_v<_Pr>) {
+    set& operator=(set&& _Right) noexcept(_Alnode_traits::is_always_equal::value && is_nothrow_move_assignable_v<_Pr>) {
         _Mybase::operator=(_STD move(_Right));
         return *this;
     }
@@ -354,7 +354,7 @@ public:
     multiset(multiset&& _Right, const allocator_type& _Al) : _Mybase(_STD move(_Right), _Al) {}
 
     multiset& operator=(multiset&& _Right) noexcept(
-        _Alnode_traits::is_always_equal::value&& is_nothrow_move_assignable_v<_Pr>) {
+        _Alnode_traits::is_always_equal::value && is_nothrow_move_assignable_v<_Pr>) {
         _Mybase::operator=(_STD move(_Right));
         return *this;
     }

--- a/stl/inc/source_location
+++ b/stl/inc/source_location
@@ -23,11 +23,9 @@ _STL_DISABLE_CLANG_WARNINGS
 #ifndef _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
 #ifdef __EDG__ // TRANSITION, DevCom-10199227
 #define _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION 0
-#elif defined(__clang__) // TRANSITION, Clang 17 has this builtin
-#define _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION __has_builtin(__builtin_FUNCSIG)
-#else // ^^^ Clang / MSVC vvv
+#else // ^^^ workaround / no workaround vvv
 #define _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION 1
-#endif // ^^^ MSVC ^^^
+#endif // ^^^ no workaround ^^^
 #endif // ^^^ !defined(_USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION) ^^^
 
 _STD_BEGIN

--- a/stl/inc/span
+++ b/stl/inc/span
@@ -30,7 +30,7 @@ _EXPORT_STD inline constexpr size_t dynamic_extent = static_cast<size_t>(-1);
 template <class _Ty>
 struct _Span_iterator {
 #ifdef __cpp_lib_concepts
-    using iterator_concept  = contiguous_iterator_tag;
+    using iterator_concept = contiguous_iterator_tag;
 #endif // defined(__cpp_lib_concepts)
     using iterator_category = random_access_iterator_tag;
     using value_type        = remove_cv_t<_Ty>;
@@ -178,7 +178,7 @@ struct _Span_iterator {
         _Myptr = _It;
     }
 
-    pointer _Myptr   = nullptr;
+    pointer _Myptr = nullptr;
 #if _ITERATOR_DEBUG_LEVEL >= 1
     pointer _Mybegin = nullptr;
     pointer _Myend   = nullptr;
@@ -301,16 +301,16 @@ private:
     using _Mybase::_Mysize;
 
 public:
-    using element_type           = _Ty;
-    using value_type             = remove_cv_t<_Ty>;
-    using size_type              = size_t;
-    using difference_type        = ptrdiff_t;
-    using pointer                = _Ty*;
-    using const_pointer          = const _Ty*;
-    using reference              = _Ty&;
-    using const_reference        = const _Ty&;
-    using iterator               = _Span_iterator<_Ty>;
-    using reverse_iterator       = _STD reverse_iterator<iterator>;
+    using element_type     = _Ty;
+    using value_type       = remove_cv_t<_Ty>;
+    using size_type        = size_t;
+    using difference_type  = ptrdiff_t;
+    using pointer          = _Ty*;
+    using const_pointer    = const _Ty*;
+    using reference        = _Ty&;
+    using const_reference  = const _Ty&;
+    using iterator         = _Span_iterator<_Ty>;
+    using reverse_iterator = _STD reverse_iterator<iterator>;
 #if _HAS_CXX23 && defined(__cpp_lib_concepts)
     using const_iterator         = _STD const_iterator<iterator>;
     using const_reverse_iterator = _STD const_iterator<reverse_iterator>;

--- a/stl/inc/span
+++ b/stl/inc/span
@@ -323,6 +323,7 @@ public:
 
     // clang-format off
     constexpr span() noexcept requires (_Extent == 0 || _Extent == dynamic_extent) = default;
+    // clang-format on
 
     template <_Span_compatible_iterator<element_type> _It>
     constexpr explicit(_Extent != dynamic_extent) span(_It _First, size_type _Count) noexcept // strengthened
@@ -336,8 +337,8 @@ public:
     }
 
     template <_Span_compatible_iterator<element_type> _It, _Span_compatible_sentinel<_It> _Sentinel>
-    constexpr explicit(_Extent != dynamic_extent) span(_It _First, _Sentinel _Last)
-        noexcept(noexcept(_Last - _First)) // strengthened
+    constexpr explicit(_Extent != dynamic_extent)
+        span(_It _First, _Sentinel _Last) noexcept(noexcept(_Last - _First)) // strengthened
         : _Mybase(_STD to_address(_First), static_cast<size_type>(_Last - _First)) {
         _Adl_verify_range(_First, _Last);
 #if _CONTAINER_DEBUG_LEVEL > 0
@@ -353,8 +354,7 @@ public:
     constexpr span(type_identity_t<element_type> (&_Arr)[_Size]) noexcept : _Mybase(_Arr, _Size) {}
 
     template <class _OtherTy, size_t _Size>
-        requires (_Extent == dynamic_extent || _Extent == _Size)
-              && is_convertible_v<_OtherTy (*)[], element_type (*)[]>
+        requires (_Extent == dynamic_extent || _Extent == _Size) && is_convertible_v<_OtherTy (*)[], element_type (*)[]>
     constexpr span(array<_OtherTy, _Size>& _Arr) noexcept : _Mybase(_Arr.data(), _Size) {}
 
     template <class _OtherTy, size_t _Size>
@@ -371,13 +371,13 @@ public:
                 "Cannot construct span with static extent from range r as std::ranges::size(r) != extent");
         }
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-        }
+    }
 
     template <class _OtherTy, size_t _OtherExtent>
         requires (_Extent == dynamic_extent || _OtherExtent == dynamic_extent || _Extent == _OtherExtent)
               && is_convertible_v<_OtherTy (*)[], element_type (*)[]>
     constexpr explicit(_Extent != dynamic_extent && _OtherExtent == dynamic_extent)
-    span(const span<_OtherTy, _OtherExtent>& _Other) noexcept
+        span(const span<_OtherTy, _OtherExtent>& _Other) noexcept
         : _Mybase(_Other.data(), _Other.size()) {
 #if _CONTAINER_DEBUG_LEVEL > 0
         if constexpr (_Extent != dynamic_extent) {
@@ -385,8 +385,7 @@ public:
                 "Cannot construct span with static extent from other span as other.size() != extent");
         }
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-        }
-    // clang-format on
+    }
 
 #else // ^^^ defined(__cpp_lib_concepts) / !defined(__cpp_lib_concepts) vvv
 

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -2125,7 +2125,7 @@ _EXPORT_STD template <class _Ty, enable_if_t<is_move_constructible_v<_Ty> && is_
 #else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
 template <class _Ty, int _Enabled = 0>
 #endif // ^^^ !_HAS_CXX17 ^^^
-_CONSTEXPR20 void swap(_Ty&, _Ty&) noexcept(is_nothrow_move_constructible_v<_Ty>&& is_nothrow_move_assignable_v<_Ty>);
+_CONSTEXPR20 void swap(_Ty&, _Ty&) noexcept(is_nothrow_move_constructible_v<_Ty> && is_nothrow_move_assignable_v<_Ty>);
 
 _EXPORT_STD template <class _Ty, size_t _Size, enable_if_t<_Is_swappable<_Ty>::value, int> = 0>
 _CONSTEXPR20 void swap(_Ty (&)[_Size], _Ty (&)[_Size]) noexcept(_Is_nothrow_swappable<_Ty>::value);

--- a/stl/inc/unordered_map
+++ b/stl/inc/unordered_map
@@ -254,8 +254,9 @@ public:
 
     unordered_map(unordered_map&& _Right, const allocator_type& _Al) : _Mybase(_STD move(_Right), _Al) {}
 
-    unordered_map& operator=(unordered_map&& _Right) noexcept(_Alnode_traits::is_always_equal::value&&
-            is_nothrow_move_assignable_v<_Hasher>&& is_nothrow_move_assignable_v<_Keyeq>) {
+    unordered_map& operator=(unordered_map&& _Right) noexcept(_Alnode_traits::is_always_equal::value
+                                                              && is_nothrow_move_assignable_v<_Hasher>
+                                                              && is_nothrow_move_assignable_v<_Keyeq>) {
         _Mybase::operator=(_STD move(_Right));
         return *this;
     }
@@ -741,8 +742,9 @@ public:
 
     unordered_multimap(unordered_multimap&& _Right, const allocator_type& _Al) : _Mybase(_STD move(_Right), _Al) {}
 
-    unordered_multimap& operator=(unordered_multimap&& _Right) noexcept(_Alnode_traits::is_always_equal::value&&
-            is_nothrow_move_assignable_v<_Hasher>&& is_nothrow_move_assignable_v<_Keyeq>) {
+    unordered_multimap& operator=(unordered_multimap&& _Right) noexcept(_Alnode_traits::is_always_equal::value
+                                                                        && is_nothrow_move_assignable_v<_Hasher>
+                                                                        && is_nothrow_move_assignable_v<_Keyeq>) {
         _Mybase::operator=(_STD move(_Right));
         return *this;
     }

--- a/stl/inc/unordered_set
+++ b/stl/inc/unordered_set
@@ -249,8 +249,9 @@ public:
 
     unordered_set(unordered_set&& _Right, const allocator_type& _Al) : _Mybase(_STD move(_Right), _Al) {}
 
-    unordered_set& operator=(unordered_set&& _Right) noexcept(_Alnode_traits::is_always_equal::value&&
-            is_nothrow_move_assignable_v<_Hasher>&& is_nothrow_move_assignable_v<_Keyeq>) {
+    unordered_set& operator=(unordered_set&& _Right) noexcept(_Alnode_traits::is_always_equal::value
+                                                              && is_nothrow_move_assignable_v<_Hasher>
+                                                              && is_nothrow_move_assignable_v<_Keyeq>) {
         _Mybase::operator=(_STD move(_Right));
         return *this;
     }
@@ -590,8 +591,9 @@ public:
     }
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
-    unordered_multiset& operator=(unordered_multiset&& _Right) noexcept(_Alnode_traits::is_always_equal::value&&
-            is_nothrow_move_assignable_v<_Hasher>&& is_nothrow_move_assignable_v<_Keyeq>) {
+    unordered_multiset& operator=(unordered_multiset&& _Right) noexcept(_Alnode_traits::is_always_equal::value
+                                                                        && is_nothrow_move_assignable_v<_Hasher>
+                                                                        && is_nothrow_move_assignable_v<_Keyeq>) {
         _Mybase::operator=(_STD move(_Right));
         return *this;
     }

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -125,7 +125,7 @@ _EXPORT_STD template <class _Ty, enable_if_t<is_move_constructible_v<_Ty> && is_
 template <class _Ty, int _Enabled /* = 0 */>
 #endif // ^^^ !_HAS_CXX17 ^^^
 _CONSTEXPR20 void swap(_Ty& _Left, _Ty& _Right) noexcept(
-    is_nothrow_move_constructible_v<_Ty>&& is_nothrow_move_assignable_v<_Ty>) {
+    is_nothrow_move_constructible_v<_Ty> && is_nothrow_move_assignable_v<_Ty>) {
     _Ty _Tmp = _STD move(_Left);
     _Left    = _STD move(_Right);
     _Right   = _STD move(_Tmp);
@@ -228,14 +228,14 @@ struct pair { // store a pair of values
     constexpr explicit(
         !conjunction_v<_Is_implicitly_default_constructible<_Uty1>, _Is_implicitly_default_constructible<_Uty2>>)
         pair() noexcept(
-            is_nothrow_default_constructible_v<_Uty1>&& is_nothrow_default_constructible_v<_Uty2>) // strengthened
+            is_nothrow_default_constructible_v<_Uty1> && is_nothrow_default_constructible_v<_Uty2>) // strengthened
         : first(), second() {}
 
     template <class _Uty1 = _Ty1, class _Uty2 = _Ty2,
         enable_if_t<conjunction_v<is_copy_constructible<_Uty1>, is_copy_constructible<_Uty2>>, int> = 0>
     constexpr explicit(!conjunction_v<is_convertible<const _Uty1&, _Uty1>, is_convertible<const _Uty2&, _Uty2>>)
         pair(const _Ty1& _Val1, const _Ty2& _Val2) noexcept(
-            is_nothrow_copy_constructible_v<_Uty1>&& is_nothrow_copy_constructible_v<_Uty2>) // strengthened
+            is_nothrow_copy_constructible_v<_Uty1> && is_nothrow_copy_constructible_v<_Uty2>) // strengthened
         : first(_Val1), second(_Val2) {}
 
 #if _HAS_CXX23
@@ -246,7 +246,7 @@ struct pair { // store a pair of values
         enable_if_t<conjunction_v<is_constructible<_Ty1, _Other1>, is_constructible<_Ty2, _Other2>>, int> = 0>
     constexpr explicit(!conjunction_v<is_convertible<_Other1, _Ty1>, is_convertible<_Other2, _Ty2>>)
         pair(_Other1&& _Val1, _Other2&& _Val2) noexcept(
-            is_nothrow_constructible_v<_Ty1, _Other1>&& is_nothrow_constructible_v<_Ty2, _Other2>) // strengthened
+            is_nothrow_constructible_v<_Ty1, _Other1> && is_nothrow_constructible_v<_Ty2, _Other2>) // strengthened
         : first(_STD forward<_Other1>(_Val1)), second(_STD forward<_Other2>(_Val2)) {
     }
 
@@ -258,7 +258,7 @@ struct pair { // store a pair of values
         enable_if_t<conjunction_v<is_constructible<_Ty1, _Other1&>, is_constructible<_Ty2, _Other2&>>, int> = 0>
     constexpr explicit(!conjunction_v<is_convertible<_Other1&, _Ty1>, is_convertible<_Other2&, _Ty2>>)
         pair(pair<_Other1, _Other2>& _Right) noexcept(
-            is_nothrow_constructible_v<_Ty1, _Other1&>&& is_nothrow_constructible_v<_Ty2, _Other2&>) // strengthened
+            is_nothrow_constructible_v<_Ty1, _Other1&> && is_nothrow_constructible_v<_Ty2, _Other2&>) // strengthened
         : first(_Right.first), second(_Right.second) {}
 #endif // _HAS_CXX23
 
@@ -266,15 +266,16 @@ struct pair { // store a pair of values
         enable_if_t<conjunction_v<is_constructible<_Ty1, const _Other1&>, is_constructible<_Ty2, const _Other2&>>,
             int> = 0>
     constexpr explicit(!conjunction_v<is_convertible<const _Other1&, _Ty1>, is_convertible<const _Other2&, _Ty2>>)
-        pair(const pair<_Other1, _Other2>& _Right) noexcept(is_nothrow_constructible_v<_Ty1, const _Other1&>&&
-                is_nothrow_constructible_v<_Ty2, const _Other2&>) // strengthened
+        pair(const pair<_Other1, _Other2>& _Right) noexcept(
+            is_nothrow_constructible_v<_Ty1, const _Other1&>
+            && is_nothrow_constructible_v<_Ty2, const _Other2&>) // strengthened
         : first(_Right.first), second(_Right.second) {}
 
     template <class _Other1, class _Other2,
         enable_if_t<conjunction_v<is_constructible<_Ty1, _Other1>, is_constructible<_Ty2, _Other2>>, int> = 0>
     constexpr explicit(!conjunction_v<is_convertible<_Other1, _Ty1>, is_convertible<_Other2, _Ty2>>)
         pair(pair<_Other1, _Other2>&& _Right) noexcept(
-            is_nothrow_constructible_v<_Ty1, _Other1>&& is_nothrow_constructible_v<_Ty2, _Other2>) // strengthened
+            is_nothrow_constructible_v<_Ty1, _Other1> && is_nothrow_constructible_v<_Ty2, _Other2>) // strengthened
         : first(_STD forward<_Other1>(_Right.first)), second(_STD forward<_Other2>(_Right.second)) {}
 
 #if _HAS_CXX23
@@ -282,8 +283,9 @@ struct pair { // store a pair of values
         enable_if_t<conjunction_v<is_constructible<_Ty1, const _Other1>, is_constructible<_Ty2, const _Other2>>, int> =
             0>
     constexpr explicit(!conjunction_v<is_convertible<const _Other1, _Ty1>, is_convertible<const _Other2, _Ty2>>)
-        pair(const pair<_Other1, _Other2>&& _Right) noexcept(is_nothrow_constructible_v<_Ty1, const _Other1>&&
-                is_nothrow_constructible_v<_Ty2, const _Other2>) // strengthened
+        pair(const pair<_Other1, _Other2>&& _Right) noexcept(
+            is_nothrow_constructible_v<_Ty1, const _Other1>
+            && is_nothrow_constructible_v<_Ty2, const _Other2>) // strengthened
         : first(_STD forward<const _Other1>(_Right.first)), second(_STD forward<const _Other2>(_Right.second)) {}
 
 #ifdef __cpp_lib_concepts
@@ -297,8 +299,9 @@ struct pair { // store a pair of values
 #endif // ^^^ no workaround ^^^
     constexpr explicit(!conjunction_v<is_convertible<decltype(_STD get<0>(_STD declval<_Other>())), _Ty1>,
                        is_convertible<decltype(_STD get<1>(_STD declval<_Other>())), _Ty2>>)
-        pair(_Other&& _Right) noexcept(is_nothrow_constructible_v<_Ty1, decltype(_STD get<0>(_STD declval<_Other>()))>&&
-                is_nothrow_constructible_v<_Ty2, decltype(_STD get<1>(_STD declval<_Other>()))>) // strengthened
+        pair(_Other&& _Right) noexcept(
+            is_nothrow_constructible_v<_Ty1, decltype(_STD get<0>(_STD declval<_Other>()))>
+            && is_nothrow_constructible_v<_Ty2, decltype(_STD get<1>(_STD declval<_Other>()))>) // strengthened
         : first(_STD get<0>(_STD forward<_Other>(_Right))), second(_STD get<1>(_STD forward<_Other>(_Right))) {
     }
 #endif // defined(__cpp_lib_concepts)
@@ -369,8 +372,8 @@ struct pair { // store a pair of values
                         is_assignable<_Ty2&, const _Other2&>>,
             int> = 0>
     _CONSTEXPR20 pair& operator=(const pair<_Other1, _Other2>& _Right) noexcept(
-        is_nothrow_assignable_v<_Ty1&, const _Other1&>&&
-            is_nothrow_assignable_v<_Ty2&, const _Other2&>) /* strengthened */ {
+        is_nothrow_assignable_v<_Ty1&, const _Other1&>
+        && is_nothrow_assignable_v<_Ty2&, const _Other2&>) /* strengthened */ {
         first  = _Right.first;
         second = _Right.second;
         return *this;
@@ -382,8 +385,8 @@ struct pair { // store a pair of values
                         is_assignable<const _Ty1&, const _Other1&>, is_assignable<const _Ty2&, const _Other2&>>,
             int> = 0>
     constexpr const pair& operator=(const pair<_Other1, _Other2>& _Right) const
-        noexcept(is_nothrow_assignable_v<const _Ty1&, const _Other1&>&&
-                is_nothrow_assignable_v<const _Ty2&, const _Other2&>) /* strengthened */ {
+        noexcept(is_nothrow_assignable_v<const _Ty1&, const _Other1&>
+                 && is_nothrow_assignable_v<const _Ty2&, const _Other2&>) /* strengthened */ {
         first  = _Right.first;
         second = _Right.second;
         return *this;
@@ -395,7 +398,7 @@ struct pair { // store a pair of values
                         is_assignable<_Ty2&, _Other2>>,
             int> = 0>
     _CONSTEXPR20 pair& operator=(pair<_Other1, _Other2>&& _Right) noexcept(
-        is_nothrow_assignable_v<_Ty1&, _Other1>&& is_nothrow_assignable_v<_Ty2&, _Other2>) /* strengthened */ {
+        is_nothrow_assignable_v<_Ty1&, _Other1> && is_nothrow_assignable_v<_Ty2&, _Other2>) /* strengthened */ {
         first  = _STD forward<_Other1>(_Right.first);
         second = _STD forward<_Other2>(_Right.second);
         return *this;
@@ -407,8 +410,8 @@ struct pair { // store a pair of values
                         is_assignable<const _Ty2&, _Other2>>,
             int> = 0>
     constexpr const pair& operator=(pair<_Other1, _Other2>&& _Right) const
-        noexcept(is_nothrow_assignable_v<const _Ty1&, _Other1>&&
-                is_nothrow_assignable_v<const _Ty2&, _Other2>) /* strengthened */ {
+        noexcept(is_nothrow_assignable_v<const _Ty1&, _Other1>
+                 && is_nothrow_assignable_v<const _Ty2&, _Other2>) /* strengthened */ {
         first  = _STD forward<_Other1>(_Right.first);
         second = _STD forward<_Other2>(_Right.second);
         return *this;
@@ -420,8 +423,8 @@ struct pair { // store a pair of values
               && is_assignable_v<_Ty1&, decltype(_STD get<0>(_STD declval<_Other>()))>
               && is_assignable_v<_Ty2&, decltype(_STD get<1>(_STD declval<_Other>()))>
     constexpr pair& operator=(_Other&& _Right) noexcept(
-        is_nothrow_assignable_v<_Ty1&, decltype(_STD get<0>(_STD declval<_Other>()))>&&
-            is_nothrow_assignable_v<_Ty2&, decltype(_STD get<1>(_STD declval<_Other>()))>) /* strengthened */ {
+        is_nothrow_assignable_v<_Ty1&, decltype(_STD get<0>(_STD declval<_Other>()))>
+        && is_nothrow_assignable_v<_Ty2&, decltype(_STD get<1>(_STD declval<_Other>()))>) /* strengthened */ {
         first  = _STD get<0>(_STD forward<_Other>(_Right));
         second = _STD get<1>(_STD forward<_Other>(_Right));
         return *this;
@@ -432,8 +435,8 @@ struct pair { // store a pair of values
               && is_assignable_v<const _Ty1&, decltype(_STD get<0>(_STD declval<_Other>()))>
               && is_assignable_v<const _Ty2&, decltype(_STD get<1>(_STD declval<_Other>()))>
     constexpr const pair& operator=(_Other&& _Right) const noexcept(
-        is_nothrow_assignable_v<const _Ty1&, decltype(_STD get<0>(_STD declval<_Other>()))>&&
-            is_nothrow_assignable_v<const _Ty2&, decltype(_STD get<1>(_STD declval<_Other>()))>) /* strengthened */ {
+        is_nothrow_assignable_v<const _Ty1&, decltype(_STD get<0>(_STD declval<_Other>()))>
+        && is_nothrow_assignable_v<const _Ty2&, decltype(_STD get<1>(_STD declval<_Other>()))>) /* strengthened */ {
         first  = _STD get<0>(_STD forward<_Other>(_Right));
         second = _STD get<1>(_STD forward<_Other>(_Right));
         return *this;
@@ -442,7 +445,7 @@ struct pair { // store a pair of values
 #endif // _HAS_CXX23
 
     _CONSTEXPR20 void swap(pair& _Right) noexcept(
-        _Is_nothrow_swappable<_Ty1>::value&& _Is_nothrow_swappable<_Ty2>::value) {
+        _Is_nothrow_swappable<_Ty1>::value && _Is_nothrow_swappable<_Ty2>::value) {
         using _STD swap;
         if (this != _STD addressof(_Right)) {
             swap(first, _Right.first); // intentional ADL
@@ -453,7 +456,7 @@ struct pair { // store a pair of values
 #if _HAS_CXX23
     template <int = 0> // see GH-3013
     constexpr void swap(const pair& _Right) const
-        noexcept(is_nothrow_swappable_v<const _Ty1>&& is_nothrow_swappable_v<const _Ty2>) {
+        noexcept(is_nothrow_swappable_v<const _Ty1> && is_nothrow_swappable_v<const _Ty2>) {
         using _STD swap;
         if (this != _STD addressof(_Right)) {
             swap(first, _Right.first); // intentional ADL
@@ -563,8 +566,8 @@ using _Unrefwrap_t = typename _Unrefwrap_helper<decay_t<_Ty>>::type;
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 _NODISCARD constexpr pair<_Unrefwrap_t<_Ty1>, _Unrefwrap_t<_Ty2>> make_pair(_Ty1&& _Val1, _Ty2&& _Val2) noexcept(
-    is_nothrow_constructible_v<_Unrefwrap_t<_Ty1>, _Ty1>&&
-        is_nothrow_constructible_v<_Unrefwrap_t<_Ty2>, _Ty2>) /* strengthened */ {
+    is_nothrow_constructible_v<_Unrefwrap_t<_Ty1>, _Ty1>
+    && is_nothrow_constructible_v<_Unrefwrap_t<_Ty2>, _Ty2>) /* strengthened */ {
     // return pair composed from arguments
     using _Mypair = pair<_Unrefwrap_t<_Ty1>, _Unrefwrap_t<_Ty2>>;
     return _Mypair(_STD forward<_Ty1>(_Val1), _STD forward<_Ty2>(_Val2));

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -1023,8 +1023,8 @@ public:
                                          && is_assignable_v<_Variant_init_type<_Ty, _Types...>&, _Ty>,
                              int> = 0>
     _CONSTEXPR20 variant& operator=(_Ty&& _Obj) noexcept(
-        is_nothrow_assignable_v<_Variant_init_type<_Ty, _Types...>&, _Ty>&&
-            is_nothrow_constructible_v<_Variant_init_type<_Ty, _Types...>, _Ty>) {
+        is_nothrow_assignable_v<_Variant_init_type<_Ty, _Types...>&, _Ty>
+        && is_nothrow_constructible_v<_Variant_init_type<_Ty, _Types...>, _Ty>) {
         // assign/emplace the alternative chosen by overload resolution of _Obj with f(_Types)...
         constexpr size_t _TargetIdx = _Variant_init_index<_Ty, _Types...>::value;
         if (index() == _TargetIdx) {

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -1286,7 +1286,7 @@ private:
 
     template <class _Keyty>
     _NODISCARD _Equal_range_result _Equal_range(const _Keyty& _Keyval, const size_t _Hashval) const
-        noexcept(_Nothrow_compare<_Traits, key_type, _Keyty>&& _Nothrow_compare<_Traits, _Keyty, key_type>) {
+        noexcept(_Nothrow_compare<_Traits, key_type, _Keyty> && _Nothrow_compare<_Traits, _Keyty, key_type>) {
         const size_type _Bucket              = _Hashval & _Mask;
         _Unchecked_const_iterator _Where     = _Vec._Mypair._Myval2._Myfirst[_Bucket << 1];
         const _Unchecked_const_iterator _End = _Unchecked_end();

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -127,7 +127,7 @@ _STL_INTERNAL_STATIC_ASSERT(_Is_pow_2(_Big_allocation_alignment));
 #ifdef _DEBUG
 _INLINE_VAR constexpr size_t _Non_user_size = 2 * sizeof(void*) + _Big_allocation_alignment - 1;
 #else // ^^^ defined(_DEBUG) / !defined(_DEBUG) vvv
-_INLINE_VAR constexpr size_t _Non_user_size           = sizeof(void*) + _Big_allocation_alignment - 1;
+_INLINE_VAR constexpr size_t _Non_user_size = sizeof(void*) + _Big_allocation_alignment - 1;
 #endif // ^^^ !defined(_DEBUG) ^^^
 
 #ifdef _WIN64

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -1682,7 +1682,7 @@ protected:
 
     template <class _Other>
     pair<_Nodeptr, _Nodeptr> _Eqrange(const _Other& _Keyval) const
-        noexcept(_Nothrow_compare<key_compare, key_type, _Other>&& _Nothrow_compare<key_compare, _Other, key_type>) {
+        noexcept(_Nothrow_compare<key_compare, key_type, _Other> && _Nothrow_compare<key_compare, _Other, key_type>) {
         // find range of nodes equivalent to _Keyval
         const auto _Scary = _Get_scary();
         const auto& _Comp = _Getcomp();

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -941,17 +941,17 @@ namespace ranges {
             && requires(_Ty1&& __t1, _Ty2&& __t2) {
                 iter_swap(static_cast<_Ty1&&>(__t1), static_cast<_Ty2&&>(__t2)); // intentional ADL
             };
+        // clang-format on
 
         template <class _Ty1, class _Ty2>
-        concept _Can_swap_references = indirectly_readable<remove_reference_t<_Ty1>>
-            && indirectly_readable<remove_reference_t<_Ty2>>
+        concept _Can_swap_references =
+            indirectly_readable<remove_reference_t<_Ty1>> && indirectly_readable<remove_reference_t<_Ty2>>
             && swappable_with<iter_reference_t<_Ty1>, iter_reference_t<_Ty2>>;
 
         template <class _Ty1, class _Ty2>
         concept _Symmetric_indirectly_movable_storable =
-               indirectly_movable_storable<remove_reference_t<_Ty1>, remove_reference_t<_Ty2>>
+            indirectly_movable_storable<remove_reference_t<_Ty1>, remove_reference_t<_Ty2>>
             && indirectly_movable_storable<remove_reference_t<_Ty2>, remove_reference_t<_Ty1>>;
-        // clang-format on
 
         template <class _Xty, class _Yty>
         _NODISCARD constexpr iter_value_t<remove_reference_t<_Xty>> _Iter_exchange_move(_Xty&& _XVal,

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -646,7 +646,7 @@ namespace ranges {
         public:
             template <class _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
-            _NODISCARD constexpr decltype(auto) operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
+            _NODISCARD constexpr decltype(auto) operator()(_Ty && _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 constexpr _St _Strat = _Choice<_Ty>._Strategy;
 
                 if constexpr (_Strat == _St::_Custom) {
@@ -1625,7 +1625,8 @@ public:
 
     template <indirectly_swappable<_BidIt> _BidIt2>
     friend constexpr void iter_swap(const reverse_iterator& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
-        is_nothrow_copy_constructible_v<_BidIt>&& is_nothrow_copy_constructible_v<_BidIt2>&& noexcept(
+        is_nothrow_copy_constructible_v<_BidIt>
+        && is_nothrow_copy_constructible_v<_BidIt2>&& noexcept(
             _RANGES iter_swap(--_STD declval<_BidIt&>(), --_STD declval<_BidIt2&>()))) {
         auto _LTmp = _Left.current;
         auto _RTmp = _Right.base();
@@ -5137,7 +5138,7 @@ _INLINE_VAR constexpr bool _Is_pointer_address_comparable =
 #pragma warning(push)
 #pragma warning(disable : 4806) // no value of type 'bool' promoted to type 'char' can equal the given constant
 template <class _Elem1, class _Elem2,
-    bool = sizeof(_Elem1) == sizeof(_Elem2) && is_integral_v<_Elem1>&& is_integral_v<_Elem2>>
+    bool = sizeof(_Elem1) == sizeof(_Elem2) && is_integral_v<_Elem1> && is_integral_v<_Elem2>>
 _INLINE_VAR constexpr bool _Can_memcmp_elements =
     is_same_v<_Elem1, bool> || is_same_v<_Elem2, bool> || static_cast<_Elem1>(-1) == static_cast<_Elem2>(-1);
 #pragma warning(pop)

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1542,14 +1542,15 @@ public:
         return current;
     }
 
-    _NODISCARD _CONSTEXPR17 reference operator*() const
-        noexcept(is_nothrow_copy_constructible_v<_BidIt>&& noexcept(*--(_STD declval<_BidIt&>()))) /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 reference operator*() const noexcept(is_nothrow_copy_constructible_v<_BidIt> //
+            && noexcept(*--(_STD declval<_BidIt&>()))) /* strengthened */ {
         _BidIt _Tmp = current;
         return *--_Tmp;
     }
 
     _NODISCARD _CONSTEXPR17 pointer operator->() const
-        noexcept(is_nothrow_copy_constructible_v<_BidIt>&& noexcept(--(_STD declval<_BidIt&>()))
+        noexcept(is_nothrow_copy_constructible_v<_BidIt> //
+                     && noexcept(--(_STD declval<_BidIt&>()))
                  && _Has_nothrow_operator_arrow<_BidIt&, pointer>) /* strengthened */
 #ifdef __cpp_lib_concepts
         requires (is_pointer_v<_BidIt> || requires(const _BidIt __i) { __i.operator->(); })
@@ -1569,8 +1570,8 @@ public:
         return *this;
     }
 
-    _CONSTEXPR17 reverse_iterator operator++(int) noexcept(
-        is_nothrow_copy_constructible_v<_BidIt>&& noexcept(--current)) /* strengthened */ {
+    _CONSTEXPR17 reverse_iterator operator++(int) noexcept(is_nothrow_copy_constructible_v<_BidIt> //
+            && noexcept(--current)) /* strengthened */ {
         reverse_iterator _Tmp = *this;
         --current;
         return _Tmp;
@@ -1581,8 +1582,8 @@ public:
         return *this;
     }
 
-    _CONSTEXPR17 reverse_iterator operator--(int) noexcept(
-        is_nothrow_copy_constructible_v<_BidIt>&& noexcept(++current)) /* strengthened */ {
+    _CONSTEXPR17 reverse_iterator operator--(int) noexcept(is_nothrow_copy_constructible_v<_BidIt> //
+            && noexcept(++current)) /* strengthened */ {
         reverse_iterator _Tmp = *this;
         ++current;
         return _Tmp;
@@ -1617,7 +1618,8 @@ public:
 
 #ifdef __cpp_lib_concepts
     _NODISCARD_FRIEND constexpr iter_rvalue_reference_t<_BidIt> iter_move(const reverse_iterator& _It) noexcept(
-        is_nothrow_copy_constructible_v<_BidIt>&& noexcept(_RANGES iter_move(--_STD declval<_BidIt&>()))) {
+        is_nothrow_copy_constructible_v<_BidIt> //
+            && noexcept(_RANGES iter_move(--_STD declval<_BidIt&>()))) {
         auto _Tmp = _It.current;
         --_Tmp;
         return _RANGES iter_move(_Tmp);
@@ -1626,8 +1628,8 @@ public:
     template <indirectly_swappable<_BidIt> _BidIt2>
     friend constexpr void iter_swap(const reverse_iterator& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
         is_nothrow_copy_constructible_v<_BidIt>
-        && is_nothrow_copy_constructible_v<_BidIt2>&& noexcept(
-            _RANGES iter_swap(--_STD declval<_BidIt&>(), --_STD declval<_BidIt2&>()))) {
+        && is_nothrow_copy_constructible_v<_BidIt2> //
+            && noexcept(_RANGES iter_swap(--_STD declval<_BidIt&>(), --_STD declval<_BidIt2&>()))) {
         auto _LTmp = _Left.current;
         auto _RTmp = _Right.base();
         --_LTmp;
@@ -4053,8 +4055,8 @@ public:
         return *this;
     }
 
-    _CONSTEXPR17 auto operator++(int) noexcept(
-        is_nothrow_copy_constructible_v<_Iter>&& noexcept(++_Current)) /* strengthened */ {
+    _CONSTEXPR17 auto operator++(int) noexcept(is_nothrow_copy_constructible_v<_Iter> //
+            && noexcept(++_Current)) /* strengthened */ {
 #ifdef __cpp_lib_concepts
         if constexpr (forward_iterator<_Iter>) {
 #endif // defined(__cpp_lib_concepts)
@@ -4073,8 +4075,8 @@ public:
         return *this;
     }
 
-    _CONSTEXPR17 move_iterator operator--(int) noexcept(
-        is_nothrow_copy_constructible_v<_Iter>&& noexcept(--_Current)) /* strengthened */ {
+    _CONSTEXPR17 move_iterator operator--(int) noexcept(is_nothrow_copy_constructible_v<_Iter> //
+            && noexcept(--_Current)) /* strengthened */ {
         move_iterator _Tmp = *this;
         --_Current;
         return _Tmp;

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -891,8 +891,8 @@ _EMIT_STL_ERROR(STL1002, "Unexpected compiler version, expected CUDA 11.6 or new
 #elif defined(__EDG__)
 // not attempting to detect __EDG_VERSION__ being less than expected
 #elif defined(__clang__)
-#if __clang_major__ < 16
-_EMIT_STL_ERROR(STL1000, "Unexpected compiler version, expected Clang 16.0.0 or newer.");
+#if __clang_major__ < 17
+_EMIT_STL_ERROR(STL1000, "Unexpected compiler version, expected Clang 17.0.0 or newer.");
 #endif // ^^^ old Clang ^^^
 #elif defined(_MSC_VER)
 #if _MSC_VER < 1939 // Coarse-grained, not inspecting _MSC_FULL_VER

--- a/stl/src/excptptr.cpp
+++ b/stl/src/excptptr.cpp
@@ -499,7 +499,7 @@ _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL __ExceptionPtrCurrentException(void* 
         const auto _PType = reinterpret_cast<CatchableType*>(
             static_cast<uintptr_t>(_CatchableTypeArray->arrayOfCatchableTypes[0]) + _ThrowImageBase);
 #else // ^^^ _EH_RELATIVE_TYPEINFO / !_EH_RELATIVE_TYPEINFO vvv
-        const auto _PType              = _PThrow->pCatchableTypeArray->arrayOfCatchableTypes[0];
+        const auto _PType = _PThrow->pCatchableTypeArray->arrayOfCatchableTypes[0];
 #endif // ^^^ !_EH_RELATIVE_TYPEINFO ^^^
 
         // Alloc memory on stack for exception object. This might cause a stack overflow SEH exception, or another C++

--- a/tests/std/include/test_header_units_and_modules.hpp
+++ b/tests/std/include/test_header_units_and_modules.hpp
@@ -395,12 +395,35 @@ void test_map() {
 void test_mdspan() {
     using namespace std;
     puts("Testing <mdspan>.");
-    int arr[] = {10, 0, 0, 0, 20, 0, 0, 0, 30};
-    layout_right::mapping<extents<int, 3, 3>> mp;
-    assert(arr[mp(0, 0)] == 10);
-    assert(arr[mp(1, 1)] == 20);
-    assert(arr[mp(2, 2)] == 30);
-    // TRANSITION, test std::mdspan too (DevCom-10359857)
+
+    {
+        int arr[] = {10, 0, 0, 0, 20, 0, 0, 0, 30};
+        layout_right::mapping<extents<int, 3, 3>> mp;
+        assert(arr[mp(0, 0)] == 10);
+        assert(arr[mp(1, 1)] == 20);
+        assert(arr[mp(2, 2)] == 30);
+    }
+
+    {
+        array<int, 15> arr{//
+            50, 60, 70, 80, 90, //
+            51, 61, 71, 81, 91, //
+            52, 62, 72, 82, 92};
+
+        mdspan md{arr.data(), extents<size_t, 3, 5>{}};
+
+        static_assert(is_same_v<decltype(md), mdspan<int, extents<size_t, 3, 5>>>);
+
+        assert((md[array{0, 0}] == 50));
+        assert((md[array{0, 4}] == 90));
+        assert((md[array{1, 1}] == 61));
+        assert((md[array{2, 0}] == 52));
+        assert((md[array{2, 4}] == 92));
+
+        md[array{2, 4}] = 1729;
+
+        assert(arr.back() == 1729);
+    }
 }
 #endif // TEST_STANDARD >= 23
 

--- a/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
+++ b/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
@@ -1910,90 +1910,91 @@ void test_bind() {
     {
 #ifndef _M_CEE_PURE
 
-        {auto lambda = [](int x, int y, int&& z) { return x * 100 + y * 10 + z; };
+        {
+            auto lambda = [](int x, int y, int&& z) { return x * 100 + y * 10 + z; };
 
-    auto b = bind(lambda, 7, _1, _2);
+            auto b = bind(lambda, 7, _1, _2);
 
-    function<int(int, int&&)> f(b);
+            function<int(int, int&&)> f(b);
 
-    assert(f(8, 9) == 789);
-}
-
-{
-    struct Thingy {
-        int mf(int&& n) {
-            return n * 5;
+            assert(f(8, 9) == 789);
         }
-    };
 
-    Thingy t;
+        {
+            struct Thingy {
+                int mf(int&& n) {
+                    return n * 5;
+                }
+            };
 
-    auto b = bind(&Thingy::mf, t, _1);
+            Thingy t;
 
-    assert(b(7) == 35);
-}
+            auto b = bind(&Thingy::mf, t, _1);
 
-{
-    auto consume_up = [](unique_ptr<int>&& up, int n) { return *up / n; };
+            assert(b(7) == 35);
+        }
 
-    auto b = bind(consume_up, _1, 3);
+        {
+            auto consume_up = [](unique_ptr<int>&& up, int n) { return *up / n; };
 
-    assert(b(make_unique<int>(1000)) == 333);
-}
+            auto b = bind(consume_up, _1, 3);
+
+            assert(b(make_unique<int>(1000)) == 333);
+        }
 
 #endif // _M_CEE_PURE
-}
+    }
 
 
-// Test DevDiv-487679 "<functional> bind: MSVS 2012 C++ std::bind illegal indirection compiler error".
-// Test DevDiv-617421 "<functional> bind: Bind failing to compile with a vector of functions".
-{
-    struct BaseFunctor {
-        int operator()(int n) const {
-            return n + 5;
-        }
-    };
+    // Test DevDiv-487679 "<functional> bind: MSVS 2012 C++ std::bind illegal indirection compiler error".
+    // Test DevDiv-617421 "<functional> bind: Bind failing to compile with a vector of functions".
+    {
+        struct BaseFunctor {
+            int operator()(int n) const {
+                return n + 5;
+            }
+        };
 
-    struct DerivedFunctor : BaseFunctor {};
+        struct DerivedFunctor : BaseFunctor {};
 
-    auto b = bind(&DerivedFunctor::operator(), _1, 200);
+        auto b = bind(&DerivedFunctor::operator(), _1, 200);
 
-    DerivedFunctor df;
+        DerivedFunctor df;
 
-    assert(b(df) == 205);
-}
-
-
-// Test DevDiv-505570 "<functional> bind: Can't bind a pointer to a data member using a pointer, smart pointer or
-// iterator to the object".
-{
-    struct Object {
-        int member = 1000;
-    };
-
-    auto pmd = &Object::member;
-    auto sp  = make_shared<Object>();
-
-    auto b1 = bind(pmd, ref(*sp));
-    auto b2 = bind(pmd, sp.get());
-    auto b3 = bind(pmd, sp);
-
-    assert(sp->member == 1000);
-    ++b1();
-    assert(sp->member == 1001);
-    ++b2();
-    assert(sp->member == 1002);
-    ++b3();
-    assert(sp->member == 1003);
-}
+        assert(b(df) == 205);
+    }
 
 
-// Test DevDiv-535246 "<functional> bind: Cannot call const forwarding call wrapper result of std::bind".
-{
-    const auto cb = bind(&quadruple, 11);
+    // Test DevDiv-505570 "<functional> bind: Can't bind a pointer to a data member using a pointer, smart pointer or
+    // iterator to the object".
+    {
+        struct Object {
+            int member = 1000;
+        };
 
-    assert(cb() == 44);
-}
+        auto pmd = &Object::member;
+        auto sp  = make_shared<Object>();
+
+        auto b1 = bind(pmd, ref(*sp));
+        auto b2 = bind(pmd, sp.get());
+        auto b3 = bind(pmd, sp);
+
+        assert(sp->member == 1000);
+        ++b1();
+        assert(sp->member == 1001);
+        ++b2();
+        assert(sp->member == 1002);
+        ++b3();
+        assert(sp->member == 1003);
+    }
+
+
+    // Test DevDiv-535246 "<functional> bind: Cannot call const forwarding call wrapper result of std::bind".
+    {
+        const auto cb = bind(&quadruple, 11);
+
+        assert(cb() == 44);
+    }
 }
 
 

--- a/tests/std/tests/GH_000935_complex_numerical_accuracy/floating_point_utils.hpp
+++ b/tests/std/tests/GH_000935_complex_numerical_accuracy/floating_point_utils.hpp
@@ -76,7 +76,7 @@ namespace fputil {
 #ifdef __clang__
 // TRANSITION, should be #pragma STDC FENV_ACCESS ON
 #else // ^^^ clang / MSVC vvv
-// TRANSITION, VSO-923474 -- should be #pragma STDC FENV_ACCESS ON
+    // TRANSITION, VSO-923474 -- should be #pragma STDC FENV_ACCESS ON
 #pragma fenv_access(on)
 #endif // ^^^ MSVC ^^^
 

--- a/tests/std/tests/GH_000935_complex_numerical_accuracy/test.cpp
+++ b/tests/std/tests/GH_000935_complex_numerical_accuracy/test.cpp
@@ -16,7 +16,7 @@ void test_sqrt(const rounding_mode mode) {
 #if FP_PRESET_FAST
     constexpr int ulp_tolerance = 4;
 #else // ^^^ fp:fast / not fp:fast vvv
-    const int ulp_tolerance                          = is_directed_rounding_mode(mode) ? 3 : 2;
+    const int ulp_tolerance = is_directed_rounding_mode(mode) ? 3 : 2;
 #endif // ^^^ not fp:fast ^^^
 
     const auto check_result = [&](const auto& result, const auto& test_case) {

--- a/tests/std/tests/P0896R4_ranges_alg_find_first_of/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_first_of/test.cpp
@@ -73,7 +73,7 @@ int main() {
 #else // ^^^ test all range combinations / test only interesting range combos vvv
 constexpr bool run_tests() {
     // The algorithm is oblivious to anything except maybe proxies so take the bare minimum input/forward range
-    using in_test_range  = test::range<input_iterator_tag, const P, test::Sized::no, test::CanDifference::no,
+    using in_test_range = test::range<input_iterator_tag, const P, test::Sized::no, test::CanDifference::no,
         test::Common::no, test::CanCompare::no, test::ProxyRef::yes>;
     using fwd_test_range = test::range<forward_iterator_tag, const int, test::Sized::no, test::CanDifference::no,
         test::Common::no, test::CanCompare::yes, test::ProxyRef::yes>;

--- a/tests/std/tests/P0896R4_ranges_alg_search/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_search/test.cpp
@@ -159,8 +159,8 @@ constexpr bool run_tests() {
     {
         // Validate the memcmp optimization
         const int haystack[] = {1, 2, 3, 1, 2, 3, 1, 2, 3};
-        const int needle[]   = {1, 2, 3};
-        const auto result    = ranges::search(span<const int>{haystack}, needle);
+        const int needle[] = {1, 2, 3};
+        const auto result = ranges::search(span<const int>{haystack}, needle);
         STATIC_ASSERT(same_as<decltype(result), const ranges::subrange<span<const int>::iterator>>);
         assert(to_address(result.begin()) == haystack + 0);
         assert(to_address(result.end()) == haystack + 3);

--- a/tests/std/tests/P0898R3_concepts/invocable_cc.hpp
+++ b/tests/std/tests/P0898R3_concepts/invocable_cc.hpp
@@ -57,7 +57,6 @@ void NAME() {
         }
     }
 
-    // clang-format off
     {
         // N4849 [func.require]/1.7: "f(t_1, t_2, ..., t_N) in all other cases"
         {
@@ -818,7 +817,6 @@ void NAME() {
         STATIC_ASSERT(!test<PMF1PCVRR, S&, int>());
         STATIC_ASSERT(!test<PMF1PCVRR, S&, int, long>());
     }
-    // clang-format on
 }
 
 #undef CALLCONV

--- a/tests/std/tests/P0898R3_concepts/invocable_cc.hpp
+++ b/tests/std/tests/P0898R3_concepts/invocable_cc.hpp
@@ -818,7 +818,7 @@ void NAME() {
         STATIC_ASSERT(!test<PMF1PCVRR, S&, int>());
         STATIC_ASSERT(!test<PMF1PCVRR, S&, int, long>());
     }
-// clang-format on
+    // clang-format on
 }
 
 #undef CALLCONV

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -3335,7 +3335,7 @@ namespace test_relation {
 
     struct Equivalent {
         template <class T, class U>
-        constexpr decltype(auto) operator()(T&& t, U&& u) const
+        constexpr decltype(auto) operator()(T && t, U && u) const
             requires requires { static_cast<T&&>(t) == static_cast<U&&>(u); }
         {
             return static_cast<T&&>(t) == static_cast<U&&>(u);

--- a/tests/std/tests/P1208R6_source_location/test.cpp
+++ b/tests/std/tests/P1208R6_source_location/test.cpp
@@ -270,13 +270,11 @@ constexpr bool test() {
     return true;
 }
 
-#ifndef __EDG__ // TRANSITION, VSO-1849463
 // Also test GH-2822 Failed to specialize std::invoke on operator() with default argument
 // std::source_location::current()
 void test_gh_2822() { // COMPILE-ONLY
     invoke([](source_location = source_location::current()) {});
 }
-#endif // ^^^ no workaround ^^^
 
 int main() {
     test();

--- a/tests/std/tests/P1502R1_standard_library_header_units/env.lst
+++ b/tests/std/tests/P1502R1_standard_library_header_units/env.lst
@@ -17,6 +17,6 @@ RUNALL_CROSSLIST
 *	PM_CL="/DTEST_HEADER_UNITS"
 RUNALL_CROSSLIST
 PM_CL=""
-# ASAN	PM_CL="-fsanitize=address /Zi" PM_LINK="/debug" # TRANSITION, DevCom-10439535
+ASAN	PM_CL="-fsanitize=address /Zi" PM_LINK="/debug"
 # PM_CL="/analyze:only /analyze:autolog-" # TRANSITION, works correctly but slowly
 # PM_CL="/BE" # TRANSITION, VSO-1232145 "EDG ICEs when consuming Standard Library Header Units"

--- a/tests/std/tests/P1645R1_constexpr_numeric/test.cpp
+++ b/tests/std/tests/P1645R1_constexpr_numeric/test.cpp
@@ -11,21 +11,21 @@ using namespace std;
 
 struct not_std_plus {
     template <class T, class U>
-    constexpr decltype(auto) operator()(T&& t, U&& u) const {
+    constexpr decltype(auto) operator()(T && t, U && u) const {
         return forward<T>(t) + forward<U>(u);
     }
 };
 
 struct not_std_minus {
     template <class T, class U>
-    constexpr decltype(auto) operator()(T&& t, U&& u) const {
+    constexpr decltype(auto) operator()(T && t, U && u) const {
         return forward<T>(t) - forward<U>(u);
     }
 };
 
 struct not_std_multiplies {
     template <class T, class U>
-    constexpr decltype(auto) operator()(T&& t, U&& u) const {
+    constexpr decltype(auto) operator()(T && t, U && u) const {
         return forward<T>(t) * forward<U>(u);
     }
 };

--- a/tests/std/tests/P2387R3_pipe_support_for_user_defined_range_adaptors/test.cpp
+++ b/tests/std/tests/P2387R3_pipe_support_for_user_defined_range_adaptors/test.cpp
@@ -40,7 +40,7 @@ constexpr bool is_range_adaptor_closure() {
 
 struct IdentityRangeAdaptorClosure : ranges::range_adaptor_closure<IdentityRangeAdaptorClosure> {
     template <class T>
-    constexpr decltype(auto) operator()(T&& range) const {
+    constexpr decltype(auto) operator()(T && range) const {
         return forward<T>(range);
     }
 };

--- a/tests/std/tests/P2465R3_standard_library_modules/env.lst
+++ b/tests/std/tests/P2465R3_standard_library_modules/env.lst
@@ -17,5 +17,4 @@ RUNALL_CROSSLIST
 *	PM_CL="/MDd /utf-8"
 RUNALL_CROSSLIST
 PM_CL=""
-# TRANSITION, DevCom-10439535
-# ASAN	PM_CL="-fsanitize=address /Zi" PM_LINK="/debug"
+ASAN	PM_CL="-fsanitize=address /Zi" PM_LINK="/debug"

--- a/tests/std/tests/P2465R3_standard_library_modules/test3.cpp
+++ b/tests/std/tests/P2465R3_standard_library_modules/test3.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifdef _MSVC_INTERNAL_TESTING // TRANSITION, VS 2022 17.9 Preview 3
+#ifdef _MSVC_INTERNAL_TESTING // TRANSITION, VS 2022 17.10 Preview 1
 #include <__msvc_all_public_headers.hpp>
 #else // ^^^ no workaround / workaround vvv
 #include <assert.h> // intentionally not <cassert>

--- a/tests/std/tests/P2465R3_standard_library_modules/test4.cpp
+++ b/tests/std/tests/P2465R3_standard_library_modules/test4.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifdef _MSVC_INTERNAL_TESTING // TRANSITION, VS 2022 17.9 Preview 3
+#ifdef _MSVC_INTERNAL_TESTING // TRANSITION, VS 2022 17.10 Preview 1
 #include <__msvc_all_public_headers.hpp>
 #else // ^^^ no workaround / workaround vvv
 #include <assert.h> // intentionally not <cassert>

--- a/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
+++ b/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
@@ -464,12 +464,7 @@ _CONSTEXPR20 bool test_sequence() {
     test_sequence_copy_assign<Sequence, CopyAlloc<int>>(11, 22, 11); // POCCA, non-equal allocators
     test_sequence_copy_assign<Sequence, CopyEqualAlloc<int>>(11, 22, 11); // POCCA, always-equal allocators
 
-#if _HAS_CXX20 && !defined(__clang__) && !defined(__EDG__) // TRANSITION, VSO-1888462
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
-    {
-        test_sequence_move_ctor<Sequence>();
-    }
+    test_sequence_move_ctor<Sequence>();
 
     test_sequence_move_alloc_ctor<Sequence>(11, 11); // equal allocators
     test_sequence_move_alloc_ctor<Sequence>(11, 22); // non-equal allocators

--- a/tests/std/tests/VSO_0000000_type_traits/test.cpp
+++ b/tests/std/tests/VSO_0000000_type_traits/test.cpp
@@ -1387,12 +1387,10 @@ STATIC_ASSERT(is_same_v<common_reference_t<simple_base const&&, simple_derived c
 STATIC_ASSERT(is_same_v<common_reference_t<simple_base const&&, simple_derived&&>, simple_base const&&>);
 STATIC_ASSERT(is_same_v<common_reference_t<simple_base const&&, simple_derived const&&>, simple_base const&&>);
 
-#if !(defined(__EDG__) && defined(_MSVC_INTERNAL_TESTING)) // TRANSITION, remove after EDG is updated internally
 STATIC_ASSERT(is_same_v<common_reference_t<int (&)(), int (&)()>, int (&)()>);
 STATIC_ASSERT(is_same_v<common_reference_t<int (&&)(), int (&)()>, int (&)()>);
 STATIC_ASSERT(is_same_v<common_reference_t<int (&)(), int (&&)()>, int (&)()>);
 STATIC_ASSERT(is_same_v<common_reference_t<int (&&)(), int (&&)()>, int (&&)()>);
-#endif // ^^^ no workaround ^^^
 
 STATIC_ASSERT(is_same_v<common_reference_t<int const volatile&&, int volatile&&>, int const volatile&&>);
 STATIC_ASSERT(is_same_v<common_reference_t<int&&, int const&, int volatile&>, int const volatile&>);

--- a/tests/std/tests/VSO_0105317_expression_sfinae/test.cpp
+++ b/tests/std/tests/VSO_0105317_expression_sfinae/test.cpp
@@ -625,9 +625,7 @@ NonMovable getNonMovable() noexcept(Nothrow);
 STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getNonMovable<false>)>);
 STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getNonMovable<true>)>);
 STATIC_ASSERT(!is_nothrow_invocable_r_v<NonMovable, decltype(&getNonMovable<false>)>);
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1899423
 STATIC_ASSERT(is_nothrow_invocable_r_v<NonMovable, decltype(&getNonMovable<true>)>);
-#endif // ^^^ no workaround ^^^
 
 template <bool Nothrow>
 struct ConvertsToNonMovable {
@@ -637,18 +635,14 @@ struct ConvertsToNonMovable {
 template <bool Nothrow, bool NothrowReturn>
 ConvertsToNonMovable<NothrowReturn> getConvertsToNonMovable() noexcept(Nothrow);
 
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1899423
 STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<false, false>)>);
 STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<false, true>)>);
 STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<true, false>)>);
 STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<true, true>)>);
-#endif // ^^^ no workaround ^^^
 STATIC_ASSERT(!is_nothrow_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<false, false>)>);
 STATIC_ASSERT(!is_nothrow_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<false, true>)>);
 STATIC_ASSERT(!is_nothrow_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<true, false>)>);
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1899423
 STATIC_ASSERT(is_nothrow_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<true, true>)>);
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX17
 
 

--- a/tests/std/tests/VSO_0105317_expression_sfinae/test.cpp
+++ b/tests/std/tests/VSO_0105317_expression_sfinae/test.cpp
@@ -625,7 +625,7 @@ NonMovable getNonMovable() noexcept(Nothrow);
 STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getNonMovable<false>)>);
 STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getNonMovable<true>)>);
 STATIC_ASSERT(!is_nothrow_invocable_r_v<NonMovable, decltype(&getNonMovable<false>)>);
-STATIC_ASSERT(is_nothrow_invocable_r_v<NonMovable, decltype(&getNonMovable<true>)>);
+STATIC_ASSERT(is_nothrow_invocable_r_v<NonMovable, decltype(&getNonMovable<true>)> == noexcept_in_the_type_system);
 
 template <bool Nothrow>
 struct ConvertsToNonMovable {
@@ -642,7 +642,8 @@ STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<tru
 STATIC_ASSERT(!is_nothrow_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<false, false>)>);
 STATIC_ASSERT(!is_nothrow_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<false, true>)>);
 STATIC_ASSERT(!is_nothrow_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<true, false>)>);
-STATIC_ASSERT(is_nothrow_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<true, true>)>);
+STATIC_ASSERT(is_nothrow_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<true, true>)>
+              == noexcept_in_the_type_system);
 #endif // _HAS_CXX17
 
 

--- a/tests/tr1/include/tdefs.h
+++ b/tests/tr1/include/tdefs.h
@@ -81,13 +81,13 @@ int total_fail = 0;
 #ifdef AFMT
 int afmt = 1;
 #else // AFMT
-int afmt    = 0;
+int afmt = 0;
 #endif // AFMT
 
 #ifdef TERSE
 int terse = 1;
 #else // TERSE
-int terse   = 0;
+int terse = 0;
 #endif // TERSE
 
 #ifdef VERBOSE


### PR DESCRIPTION
- Code cleanups:
  * Removed compiler bug workarounds.
- Infrastructure improvements:
  * Updated dependencies.
    + Updated build compiler to VS 2022 17.9 Preview 2.
    + Updated Clang to 17.0.3 (now required).
    + Updated Python to 3.12.1.

Commits:

* Update GitHub Actions.
* Update Node.js.
* Use PowerShell 7.4.0.
* Python 3.12.1.
* New pool.
* VS 2022 17.9 Preview 2.
* Remove EDG `_MSVC_INTERNAL_TESTING` workaround in `VSO_0000000_type_traits`.
  + EDG has been updated internally.
* MSVC changes expected in 17.9 Preview 3 will actually ship in 17.10 Preview 1.
* Remove workaround for VSO-1888462 "Bogus `constexpr` error C2131 'failure was caused by allocated storage not being deallocated'".
* Remove workarounds for VSO-1899423 "C1XX mishandles C++17 deferred temporary materialization in `is_invocable_r_v` and `is_nothrow_invocable_r_v`".
* Handle `/Zc:noexceptTypes-` after workaround removal.
* Remove workaround for VSO-1849463 "EDG silently rejects `source_location::current()` as a default argument".
* Remove workarounds for DevCom-10439535 "`import std;` with address sanitizer option does not compile(C1358)".
* Test `mdspan` via modules after the fix for DevCom-10359857 "\[C++\]\[Modules\] `std::mdspan` is unusable with C++20 modules".
* Require Clang 17.
* Clang 17 supports `__builtin_FUNCSIG`.
* Update clang-format 17 defaults.
* clang-format, no manual changes.
  + Almost all changes are neutral or desirable.
  + In `<ranges>`, spaces are being lost in `_Zip_iterator_sentinel_equal()`'s `_Evaluate_equality_closure` which is annoying but tolerable.
  + In a few files (`<ranges>`, `<xutility>`, `P0898R3_concepts/test.cpp`, `P1645R1_constexpr_numeric/test.cpp`, `P2387R3_pipe_support_for_user_defined_range_adaptors/test.cpp`), spaces are appearing in parameters like `_Ty &&`. This is also annoying but tolerable.
* Manually unwrap a line in `<mdspan>`. This is "sticky".
* Add empty comments to improve `IS_MEOW && noexcept(EXPR)`.
* Remove empty comments with literally no effect.
* Remove clang-format suppressions with literally no effect.
* Remove or shrink clang-format suppressions, with only minimal, desirable reflow.
