### PR TITLE
`<numeric>`: switch `transform_reduce` from direct list initialization to copy non-list initialization

### DIFF
--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -4235,6 +4235,7 @@ struct _Static_partitioned_transform_reduce2 { // transformed reduction task sch
             auto& _Transform_op = _This->_Transform_op;
             auto _Chunk         = _This->_Basis._Get_chunk(_Key);
             auto _Next          = _Chunk._First;
+
             _Ty _Val = _Reduce_op(_Transform_op(*_Chunk._First), _Transform_op(*++_Next));
             while (++_Next != _Chunk._Last) {
                 _Val = _Reduce_op(_STD move(_Val), _Transform_op(*_Next));

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -4235,7 +4235,7 @@ struct _Static_partitioned_transform_reduce2 { // transformed reduction task sch
             auto& _Transform_op = _This->_Transform_op;
             auto _Chunk         = _This->_Basis._Get_chunk(_Key);
             auto _Next          = _Chunk._First;
-            _Ty _Val{_Reduce_op(_Transform_op(*_Chunk._First), _Transform_op(*++_Next))};
+            _Ty _Val = _Reduce_op(_Transform_op(*_Chunk._First), _Transform_op(*++_Next));
             while (++_Next != _Chunk._Last) {
                 _Val = _Reduce_op(_STD move(_Val), _Transform_op(*_Next));
             }

--- a/tests/std/tests/P0024R2_parallel_algorithms_transform_reduce/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_transform_reduce/test.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // test_case_incorrect_special_case_reasoning & test_case_narrowing_conversion tests narrowing on purpose
-#pragma warning(disable : 4242 4244 4365)
+#pragma warning(disable : 4242 4244 4267 4365)
 
 #include <algorithm>
 #include <cassert>

--- a/tests/std/tests/P0024R2_parallel_algorithms_transform_reduce/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_transform_reduce/test.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// test_case_incorrect_special_case_reasoning & test_case_narrowing_conversion tests narrowing on purpose
+// test_case_incorrect_special_case_reasoning and test_case_narrowing_conversion test narrowing on purpose
 #pragma warning(disable : 4242 4244 4267 4365)
 
 #include <algorithm>
@@ -148,9 +148,9 @@ void test_case_incorrect_special_case_reasoning() {
 
 void test_case_narrowing_conversion() {
     size_t a[]         = {1, 2, 3};
-    auto return_itself = [](size_t a) { return a; };
+    auto return_itself = [](size_t x) { return x; };
     // Initializing a smaller type (int here) with a larger type (size_t here).
-    // According to [transform.reduce](7.1-7.4),
+    // According to N4971 [transform.reduce]/7,
     // this narrowing conversion should compile without error.
     assert(transform_reduce(begin(a), end(a), 0, plus<size_t>{}, return_itself) == 6);
     assert(transform_reduce(seq, begin(a), end(a), 0, plus<size_t>{}, return_itself) == 6);
@@ -158,7 +158,7 @@ void test_case_narrowing_conversion() {
 
     size_t b[] = {1, 2, 3};
     // Initializing a smaller type (int here) with a larger type (size_t here).
-    // According to [transform.reduce](3.1-3.4),
+    // According to N4971 [transform.reduce]/3,
     // this narrowing conversion should compile without error.
     assert(transform_reduce(begin(a), end(a), b, 0, plus<size_t>{}, plus<size_t>{}) == 12);
     assert(transform_reduce(seq, begin(a), end(a), b, 0, plus<size_t>{}, plus<size_t>{}) == 12);

--- a/tests/std/tests/P0024R2_parallel_algorithms_transform_reduce/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_transform_reduce/test.cpp
@@ -147,7 +147,7 @@ void test_case_incorrect_special_case_reasoning() {
 }
 
 void test_case_narrowing_conversion() {
-    size_t a[] = {1, 2, 3};
+    size_t a[]         = {1, 2, 3};
     auto return_itself = [](size_t a) { return a; };
     // Initializing a smaller type (int here) with a larger type (size_t here).
     // According to [transform.reduce](7.1-7.4),

--- a/tests/std/tests/P0024R2_parallel_algorithms_transform_reduce/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_transform_reduce/test.cpp
@@ -174,4 +174,5 @@ int main() {
     parallel_test_case([](const size_t testSize) { test_case_move_only(seq, testSize); });
     parallel_test_case([](const size_t testSize) { test_case_move_only(par, testSize); });
     test_case_incorrect_special_case_reasoning();
+    test_case_narrowing_conversion();
 }


### PR DESCRIPTION
Fixes #4129.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
