### PR TITLE
`<expected>`: Make copy/move assignment operators of `expected` propagate triviality

### DIFF
--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -419,13 +419,11 @@ public:
     }
 
     expected& operator=(const expected&)
-        requires _Expected_binary_copy_assignable<_Ty, _Err> //
-                  && is_trivially_copy_constructible_v<_Ty> && is_trivially_copy_assignable_v<_Ty>
-                  && is_trivially_destructible_v<_Ty>
-                  // clang-format off
+        requires _Expected_binary_copy_assignable<_Ty, _Err> && is_trivially_copy_constructible_v<_Ty>
+                  && is_trivially_copy_assignable_v<_Ty> && is_trivially_destructible_v<_Ty>
                   && is_trivially_copy_constructible_v<_Err> && is_trivially_copy_assignable_v<_Err>
-                  && is_trivially_destructible_v<_Err> = default;
-    // clang-format on
+                  && is_trivially_destructible_v<_Err>
+    = default;
 
     constexpr expected& operator=(expected&& _Other) noexcept(
         is_nothrow_move_constructible_v<_Ty> && is_nothrow_move_constructible_v<_Err>
@@ -447,13 +445,11 @@ public:
     }
 
     expected& operator=(expected&&)
-        requires _Expected_binary_move_assignable<_Ty, _Err> //
-                  && is_trivially_move_constructible_v<_Ty> && is_trivially_move_assignable_v<_Ty>
-                  && is_trivially_destructible_v<_Ty>
-                  // clang-format off
+        requires _Expected_binary_move_assignable<_Ty, _Err> && is_trivially_move_constructible_v<_Ty>
+                  && is_trivially_move_assignable_v<_Ty> && is_trivially_destructible_v<_Ty>
                   && is_trivially_move_constructible_v<_Err> && is_trivially_move_assignable_v<_Err>
-                  && is_trivially_destructible_v<_Err> = default;
-    // clang-format on
+                  && is_trivially_destructible_v<_Err>
+    = default;
 
     template <class _Uty = _Ty>
         requires (!is_same_v<remove_cvref_t<_Uty>, expected> && !_Is_specialization_v<remove_cvref_t<_Uty>, unexpected>
@@ -1330,11 +1326,9 @@ public:
     }
 
     expected& operator=(const expected&)
-        requires _Expected_unary_copy_assignable<_Err>
-                  // clang-format off
-                  && is_trivially_copy_constructible_v<_Err> && is_trivially_copy_assignable_v<_Err>
-                  && is_trivially_destructible_v<_Err> = default;
-    // clang-format on
+        requires _Expected_unary_copy_assignable<_Err> && is_trivially_copy_constructible_v<_Err>
+                  && is_trivially_copy_assignable_v<_Err> && is_trivially_destructible_v<_Err>
+    = default;
 
     constexpr expected& operator=(expected&& _Other) noexcept(
         is_nothrow_move_constructible_v<_Err> && is_nothrow_move_assignable_v<_Err>)
@@ -1358,11 +1352,9 @@ public:
     }
 
     expected& operator=(expected&&)
-        requires _Expected_unary_move_assignable<_Err>
-                  // clang-format off
-                  && is_trivially_move_constructible_v<_Err> && is_trivially_move_assignable_v<_Err>
-                  && is_trivially_destructible_v<_Err> = default;
-    // clang-format on
+        requires _Expected_unary_move_assignable<_Err> && is_trivially_move_constructible_v<_Err>
+                  && is_trivially_move_assignable_v<_Err> && is_trivially_destructible_v<_Err>
+    = default;
 
     template <class _UErr>
         requires is_constructible_v<_Err, const _UErr&> && is_assignable_v<_Err&, const _UErr&>

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -182,6 +182,18 @@ struct _Check_expected_argument : true_type {
         "T must not be a (possibly cv-qualified) specialization of unexpected. (N4950 [expected.object.general]/2)");
 };
 
+template <class _Ty, class _Err>
+concept _Expected_binary_copy_assignable =
+    is_copy_assignable_v<_Ty> && is_copy_constructible_v<_Ty> //
+    && is_copy_assignable_v<_Err> && is_copy_constructible_v<_Err>
+    && (is_nothrow_move_constructible_v<_Ty> || is_nothrow_move_constructible_v<_Err>);
+
+template <class _Ty, class _Err>
+concept _Expected_binary_move_assignable =
+    is_move_assignable_v<_Ty> && is_move_constructible_v<_Ty> //
+    && is_move_assignable_v<_Err> && is_move_constructible_v<_Err>
+    && (is_nothrow_move_constructible_v<_Ty> || is_nothrow_move_constructible_v<_Err>);
+
 _EXPORT_STD template <class _Ty, class _Err>
 class expected {
 private:
@@ -390,9 +402,7 @@ public:
     constexpr expected& operator=(const expected& _Other) noexcept(
         is_nothrow_copy_constructible_v<_Ty> && is_nothrow_copy_constructible_v<_Err>
         && is_nothrow_copy_assignable_v<_Ty> && is_nothrow_copy_assignable_v<_Err>) // strengthened
-        requires is_copy_assignable_v<_Ty> && is_copy_constructible_v<_Ty> //
-              && is_copy_assignable_v<_Err> && is_copy_constructible_v<_Err>
-              && (is_nothrow_move_constructible_v<_Ty> || is_nothrow_move_constructible_v<_Err>)
+        requires _Expected_binary_copy_assignable<_Ty, _Err>
     {
         if (_Has_value && _Other._Has_value) {
             _Value = _Other._Value;
@@ -408,12 +418,19 @@ public:
         return *this;
     }
 
+    expected& operator=(const expected&)
+        requires _Expected_binary_copy_assignable<_Ty, _Err> //
+                  && is_trivially_copy_constructible_v<_Ty> && is_trivially_copy_assignable_v<_Ty>
+                  && is_trivially_destructible_v<_Ty>
+                  // clang-format off
+                  && is_trivially_copy_constructible_v<_Err> && is_trivially_copy_assignable_v<_Err>
+                  && is_trivially_destructible_v<_Err> = default;
+    // clang-format on
+
     constexpr expected& operator=(expected&& _Other) noexcept(
         is_nothrow_move_constructible_v<_Ty> && is_nothrow_move_constructible_v<_Err>
         && is_nothrow_move_assignable_v<_Ty> && is_nothrow_move_assignable_v<_Err>)
-        requires is_move_assignable_v<_Ty> && is_move_constructible_v<_Ty> //
-              && is_move_assignable_v<_Err> && is_move_constructible_v<_Err>
-              && (is_nothrow_move_constructible_v<_Ty> || is_nothrow_move_constructible_v<_Err>)
+        requires _Expected_binary_move_assignable<_Ty, _Err>
     {
         if (_Has_value && _Other._Has_value) {
             _Value = _STD move(_Other._Value);
@@ -428,6 +445,15 @@ public:
         _Has_value = _Other._Has_value;
         return *this;
     }
+
+    expected& operator=(expected&&)
+        requires _Expected_binary_move_assignable<_Ty, _Err> //
+                  && is_trivially_move_constructible_v<_Ty> && is_trivially_move_assignable_v<_Ty>
+                  && is_trivially_destructible_v<_Ty>
+                  // clang-format off
+                  && is_trivially_move_constructible_v<_Err> && is_trivially_move_assignable_v<_Err>
+                  && is_trivially_destructible_v<_Err> = default;
+    // clang-format on
 
     template <class _Uty = _Ty>
         requires (!is_same_v<remove_cvref_t<_Uty>, expected> && !_Is_specialization_v<remove_cvref_t<_Uty>, unexpected>
@@ -1162,6 +1188,12 @@ private:
     bool _Has_value;
 };
 
+template <class _Err>
+concept _Expected_unary_copy_assignable = is_copy_assignable_v<_Err> && is_copy_constructible_v<_Err>;
+
+template <class _Err>
+concept _Expected_unary_move_assignable = is_move_assignable_v<_Err> && is_move_constructible_v<_Err>;
+
 template <class _Ty, class _Err>
     requires is_void_v<_Ty>
 class expected<_Ty, _Err> {
@@ -1278,7 +1310,7 @@ public:
     // [expected.void.assign]
     constexpr expected& operator=(const expected& _Other) noexcept(
         is_nothrow_copy_constructible_v<_Err> && is_nothrow_copy_assignable_v<_Err>) // strengthened
-        requires is_copy_assignable_v<_Err> && is_copy_constructible_v<_Err>
+        requires _Expected_unary_copy_assignable<_Err>
     {
         if (_Has_value && _Other._Has_value) {
             // nothing to do
@@ -1297,9 +1329,16 @@ public:
         return *this;
     }
 
+    expected& operator=(const expected&)
+        requires _Expected_unary_copy_assignable<_Err>
+                  // clang-format off
+                  && is_trivially_copy_constructible_v<_Err> && is_trivially_copy_assignable_v<_Err>
+                  && is_trivially_destructible_v<_Err> = default;
+    // clang-format on
+
     constexpr expected& operator=(expected&& _Other) noexcept(
         is_nothrow_move_constructible_v<_Err> && is_nothrow_move_assignable_v<_Err>)
-        requires is_move_assignable_v<_Err> && is_move_constructible_v<_Err>
+        requires _Expected_unary_move_assignable<_Err>
     {
         if (_Has_value && _Other._Has_value) {
             // nothing to do
@@ -1317,6 +1356,13 @@ public:
 
         return *this;
     }
+
+    expected& operator=(expected&&)
+        requires _Expected_unary_move_assignable<_Err>
+                  // clang-format off
+                  && is_trivially_move_constructible_v<_Err> && is_trivially_move_assignable_v<_Err>
+                  && is_trivially_destructible_v<_Err> = default;
+    // clang-format on
 
     template <class _UErr>
         requires is_constructible_v<_Err, const _UErr&> && is_assignable_v<_Err&, const _UErr&>

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -194,6 +194,16 @@ concept _Expected_binary_move_assignable =
     && is_move_assignable_v<_Err> && is_move_constructible_v<_Err>
     && (is_nothrow_move_constructible_v<_Ty> || is_nothrow_move_constructible_v<_Err>);
 
+template <class _Type> // used with both _Ty and _Err
+concept _Trivially_copy_constructible_assignable_destructible =
+    is_trivially_copy_constructible_v<_Type> && is_trivially_copy_assignable_v<_Type>
+    && is_trivially_destructible_v<_Type>;
+
+template <class _Type> // used with both _Ty and _Err
+concept _Trivially_move_constructible_assignable_destructible =
+    is_trivially_move_constructible_v<_Type> && is_trivially_move_assignable_v<_Type>
+    && is_trivially_destructible_v<_Type>;
+
 _EXPORT_STD template <class _Ty, class _Err>
 class expected {
 private:
@@ -419,10 +429,9 @@ public:
     }
 
     expected& operator=(const expected&)
-        requires _Expected_binary_copy_assignable<_Ty, _Err> && is_trivially_copy_constructible_v<_Ty>
-                  && is_trivially_copy_assignable_v<_Ty> && is_trivially_destructible_v<_Ty>
-                  && is_trivially_copy_constructible_v<_Err> && is_trivially_copy_assignable_v<_Err>
-                  && is_trivially_destructible_v<_Err>
+        requires _Expected_binary_copy_assignable<_Ty, _Err>
+                  && _Trivially_copy_constructible_assignable_destructible<_Ty>
+                  && _Trivially_copy_constructible_assignable_destructible<_Err>
     = default;
 
     constexpr expected& operator=(expected&& _Other) noexcept(
@@ -445,10 +454,9 @@ public:
     }
 
     expected& operator=(expected&&)
-        requires _Expected_binary_move_assignable<_Ty, _Err> && is_trivially_move_constructible_v<_Ty>
-                  && is_trivially_move_assignable_v<_Ty> && is_trivially_destructible_v<_Ty>
-                  && is_trivially_move_constructible_v<_Err> && is_trivially_move_assignable_v<_Err>
-                  && is_trivially_destructible_v<_Err>
+        requires _Expected_binary_move_assignable<_Ty, _Err>
+                  && _Trivially_move_constructible_assignable_destructible<_Ty>
+                  && _Trivially_move_constructible_assignable_destructible<_Err>
     = default;
 
     template <class _Uty = _Ty>
@@ -1326,8 +1334,7 @@ public:
     }
 
     expected& operator=(const expected&)
-        requires _Expected_unary_copy_assignable<_Err> && is_trivially_copy_constructible_v<_Err>
-                  && is_trivially_copy_assignable_v<_Err> && is_trivially_destructible_v<_Err>
+        requires _Expected_unary_copy_assignable<_Err> && _Trivially_copy_constructible_assignable_destructible<_Err>
     = default;
 
     constexpr expected& operator=(expected&& _Other) noexcept(
@@ -1352,8 +1359,7 @@ public:
     }
 
     expected& operator=(expected&&)
-        requires _Expected_unary_move_assignable<_Err> && is_trivially_move_constructible_v<_Err>
-                  && is_trivially_move_assignable_v<_Err> && is_trivially_destructible_v<_Err>
+        requires _Expected_unary_move_assignable<_Err> && _Trivially_move_constructible_assignable_destructible<_Err>
     = default;
 
     template <class _UErr>

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -1188,7 +1188,7 @@ namespace test_expected {
         test_assignment<NCC::Yes, NMC::Yes, NCA::Yes, NMA::Yes>();
     }
 
-    // per unnumbered LWG issue submitted on 2023-12-16, see also LLVM-74768
+    // per LWG-4026, see also LLVM-74768
     template <class PODType, IsTriviallyCopyConstructible CopyCtorTriviality,
         IsTriviallyMoveConstructible MoveCtorTriviality, IsTriviallyCopyAssignable CopyAssignTriviality,
         IsTriviallyMoveAssignable MoveAssignTriviality, IsTriviallyDestructible DtorTriviality>
@@ -2193,7 +2193,7 @@ namespace test_expected {
         test_special_members();
         test_constructors();
         test_assignment();
-        test_triviality_of_assignment_all(); // per unnumbered LWG issue submitted on 2023-12-16, see also LLVM-74768
+        test_triviality_of_assignment_all(); // per LWG-4026, see also LLVM-74768
         test_emplace();
         test_swap();
         test_access();

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -1308,145 +1308,55 @@ namespace test_expected {
             assert(e1.error().val == 42);
         }
 
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Not,
+        // Test trivially copyable cases.
+        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
             IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Yes>();
 
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Not>();
+        // Test non-trivial copy constructors.
         test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Yes,
             IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Yes>();
 
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Not>();
+        // Test non-trivial move constructors.
         test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Not,
             IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Yes>();
 
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Not>();
+        // Test non-trivial copy assignment operators.
         test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
             IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Not>();
+
+        // Test non-trivial move assignment operators.
         test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
             IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Yes>();
+
+        // Test non-trivial destructors.
         test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
             IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment_binary<Val, IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Yes>();
     }
 
-    constexpr bool test_triviality_of_assignment_all() {
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Yes>();
-
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Yes>();
-
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Not,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Yes>();
-
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Not>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Yes>();
-        test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
-            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Not>();
+    constexpr void test_triviality_of_assignment_all() {
+        // Test trivially copyable cases.
         test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
             IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Yes>();
 
-        return true;
+        // Test non-trivial copy constructors.
+        test_triviality_of_assignment<IsTriviallyCopyConstructible::Not, IsTriviallyMoveConstructible::Yes,
+            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Yes>();
+
+        // Test non-trivial move constructors.
+        test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Not,
+            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Yes>();
+
+        // Test non-trivial copy assignment operators.
+        test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
+            IsTriviallyCopyAssignable::Not, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Yes>();
+
+        // Test non-trivial move assignment operators.
+        test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
+            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Not, IsTriviallyDestructible::Yes>();
+
+        // Test non-trivial destructors.
+        test_triviality_of_assignment<IsTriviallyCopyConstructible::Yes, IsTriviallyMoveConstructible::Yes,
+            IsTriviallyCopyAssignable::Yes, IsTriviallyMoveAssignable::Yes, IsTriviallyDestructible::Not>();
     }
 
     constexpr void test_emplace() noexcept {


### PR DESCRIPTION
The conditions for triviality should be consistent with `optional` and `variant` (see WG21-P0602R4). I've tried to submit an LWG issue for this, but I believe we can conformingly do this without changing the standard wording. Edit: the issue is now LWG-4026.

The changes are also being made in libc++, see LLVM-74768.

<details><summary>Old test coverage was a bit crazy</summary>
<p>
More than 1000 function template specializations are instantiated. But I have no good idea to reduce the instantiation.
<ul dir="auto">
<li>It was actually somehow bad, there're failures with "fatal error C1060: compiler is out of heap space".</li>
</ul>
</p>
</details>

Edit: reduced the cases from 32×32 to 6×6.