### PR TITLE
Mark ASAN failures in libcxx

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -370,6 +370,7 @@ std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp:0 FAIL
 std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp:1 FAIL
 
 # VSO-1271673 "static analyzer doesn't know about short-circuiting"
+# Note: The :1 (ASAN) configuration doesn't run static analysis.
 std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort.pass.cpp:0 FAIL
 std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort_comp.pass.cpp:0 FAIL
 
@@ -399,6 +400,7 @@ std/algorithms/robust_re_difference_type.compile.pass.cpp:1 FAIL
 
 # DevCom-1638563 VSO-1457836: icky static analysis false positive
 # Resolved wontfix, need to report again.
+# Note: The :1 (ASAN) configuration doesn't run static analysis.
 std/language.support/support.coroutines/end.to.end/go.pass.cpp:0 FAIL
 
 # DevCom-1638496 VSO-1462745: C1XX doesn't properly reject int <=> unsigned
@@ -1145,6 +1147,7 @@ std/utilities/format/format.formatter/format.formatter.spec/formatter.unsigned_i
 
 # Not analyzed. Apparent false positives from static analysis where it thinks that array indexing is out of bounds.
 # warning C28020: The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call.
+# Note: The :1 (ASAN) configuration doesn't run static analysis.
 std/containers/views/mdspan/extents/ctor_default.pass.cpp:0 FAIL
 std/containers/views/mdspan/extents/ctor_from_array.pass.cpp:0 FAIL
 std/containers/views/mdspan/extents/ctor_from_integral.pass.cpp:0 FAIL
@@ -1164,6 +1167,7 @@ std/containers/views/mdspan/mdspan/ctor.dh_span.pass.cpp:0 FAIL
 
 # Not analyzed. Apparent false positives from static analysis where it thinks `new (std::nothrow)` could return null, despite an assert().
 # warning C28182: Dereferencing NULL pointer.
+# Note: The :1 (ASAN) configuration doesn't run static analysis.
 std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align_nothrow.pass.cpp:0 FAIL
 std/language.support/support.dynamic/new.delete/new.delete.array/new.size_nothrow.pass.cpp:0 FAIL
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1182,11 +1182,17 @@ std/time/time.syn/formatter.sys_time.pass.cpp:2 FAIL
 
 # Not analyzed. constexpr evaluation fails with "vector iterators incompatible".
 std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.pass.cpp:0 FAIL
+std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.pass.cpp:1 FAIL
 std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.segmented.pass.cpp:0 FAIL
+std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.segmented.pass.cpp:1 FAIL
 std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_n.segmented.pass.cpp:0 FAIL
+std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_n.segmented.pass.cpp:1 FAIL
 std/algorithms/alg.modifying.operations/alg.copy/ranges.copy.segmented.pass.cpp:0 FAIL
+std/algorithms/alg.modifying.operations/alg.copy/ranges.copy.segmented.pass.cpp:1 FAIL
 std/algorithms/alg.modifying.operations/alg.move/ranges.move_backward.segmented.pass.cpp:0 FAIL
+std/algorithms/alg.modifying.operations/alg.move/ranges.move_backward.segmented.pass.cpp:1 FAIL
 std/algorithms/alg.modifying.operations/alg.move/ranges.move.segmented.pass.cpp:0 FAIL
+std/algorithms/alg.modifying.operations/alg.move/ranges.move.segmented.pass.cpp:1 FAIL
 
 # Not analyzed. constexpr evaluation fails with note: subobject '_Val' is not initialized
 std/ranges/range.adaptors/range.join/end.pass.cpp:2 FAIL
@@ -1195,27 +1201,36 @@ std/ranges/range.adaptors/range.join/range.join.sentinel/eq.pass.cpp:2 FAIL
 
 # Not analyzed. constexpr evaluation fails with note: failure was caused by out of range index MEOW; allowed range is 0 <= index < 2
 std/ranges/range.adaptors/range.join/adaptor.pass.cpp:0 FAIL
+std/ranges/range.adaptors/range.join/adaptor.pass.cpp:1 FAIL
 std/ranges/range.adaptors/range.join/range.join.iterator/increment.pass.cpp:0 FAIL
+std/ranges/range.adaptors/range.join/range.join.iterator/increment.pass.cpp:1 FAIL
 
 # Not analyzed. constexpr evaluation fails in assert(*--iter == i).
 std/ranges/range.adaptors/range.join/range.join.iterator/decrement.pass.cpp:0 FAIL
+std/ranges/range.adaptors/range.join/range.join.iterator/decrement.pass.cpp:1 FAIL
 
 # Not analyzed. constexpr evaluation fails in assert(*iter++ == i).
 std/ranges/range.adaptors/range.join/range.join.iterator/star.pass.cpp:0 FAIL
+std/ranges/range.adaptors/range.join/range.join.iterator/star.pass.cpp:1 FAIL
 
 # Not analyzed. constexpr evaluation fails in ranges::swap.
 std/ranges/range.adaptors/range.join/range.join.iterator/iter.swap.pass.cpp:0 FAIL
+std/ranges/range.adaptors/range.join/range.join.iterator/iter.swap.pass.cpp:1 FAIL
 
 # Not analyzed. Fails static_assert(std::is_default_constructible_v<JoinIterator>).
 std/ranges/range.adaptors/range.join/range.join.iterator/ctor.default.pass.cpp FAIL
 
 # Not analyzed. constexpr evaluation fails in assert(element_moved == 1).
 std/ranges/range.adaptors/range.lazy.split/ctor.range.pass.cpp:0 FAIL
+std/ranges/range.adaptors/range.lazy.split/ctor.range.pass.cpp:1 FAIL
 std/ranges/range.adaptors/range.split/ctor.range.pass.cpp:0 FAIL
+std/ranges/range.adaptors/range.split/ctor.range.pass.cpp:1 FAIL
 
 # Not analyzed. constexpr evaluation fails in assert(view_moved == 1).
 std/ranges/range.adaptors/range.lazy.split/ctor.view.pass.cpp:0 FAIL
+std/ranges/range.adaptors/range.lazy.split/ctor.view.pass.cpp:1 FAIL
 std/ranges/range.adaptors/range.split/ctor.view.pass.cpp:0 FAIL
+std/ranges/range.adaptors/range.split/ctor.view.pass.cpp:1 FAIL
 
 # Not analyzed. Testing split_view with an empty pattern, might be an MSVC constexpr bug.
 std/ranges/range.adaptors/range.split/begin.pass.cpp:0 FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -542,7 +542,7 @@ std/ranges/range.factories/range.repeat.view/iterator/minus.pass.cpp:1 FAIL
 
 # *** VCRUNTIME BUGS ***
 # DevCom-10373274 VSO-1824997 "vcruntime nothrow array operator new falls back on the wrong function"
-# This passes for ASAN, surprisingly.
+# This passes for the :1 (ASAN) configuration, surprisingly.
 std/language.support/support.dynamic/new.delete/new.delete.array/new.size_nothrow.replace.indirect.pass.cpp:0 FAIL
 std/language.support/support.dynamic/new.delete/new.delete.array/new.size_nothrow.replace.indirect.pass.cpp:2 FAIL
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -120,9 +120,12 @@ std/utilities/memory/allocator.traits/allocate_at_least.pass.cpp FAIL
 # libc++ has not implemented P2937R0: "Freestanding Library: Remove strtok"
 std/language.support/support.limits/support.limits.general/cstring.version.compile.pass.cpp FAIL
 
-# Various bogosity (LLVM-D141004)
+# Various bogosity (LLVM-D141004), warning C6011: Dereferencing NULL pointer
+# Note: The :1 (ASAN) configuration doesn't run static analysis.
 std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair_const_lvalue_pair.pass.cpp:0 FAIL
 std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair_values.pass.cpp:0 FAIL
+
+# Various bogosity (LLVM-D141004)
 std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/resource.pass.cpp FAIL
 std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/select_on_container_copy_construction.pass.cpp FAIL
 std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.ctor/ctor_does_not_allocate.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -204,6 +204,12 @@ std/language.support/support.dynamic/new.delete/new.delete.single/new.size_nothr
 # ASAN runtime intercepts `strtol` and breaks LWG-2009 (VSO-1875597)
 std/strings/string.conversions/stol.pass.cpp:1 FAIL
 
+# Not analyzed. SKIPPED because this is x86-specific.
+# ERROR: AddressSanitizer: allocator is out of memory trying to allocate NNNN bytes
+std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_strong.pass.cpp:1 SKIPPED
+std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_weak.pass.cpp:1 SKIPPED
+std/input.output/syncstream/osyncstream/thread/several_threads.pass.cpp:1 SKIPPED
+
 
 # *** MISSING STL FEATURES ***
 # Missing mbrtoc8 and c8rtomb


### PR DESCRIPTION
Followup to #4263.

* For some MSVC-specific failures, I forgot to mark both :0 (MSVC plain) and :1 (MSVC ASAN).
  + I ran ASAN several times while working on the llvm-project update, but forgot to run it at the very end.
* Mark x86-specific "AddressSanitizer: allocator is out of memory" issues as `:1 SKIPPED`.
  + The STL-ASan-CI had to find these, because I was unable to run whole x86 ASAN test runs (they would hang). However, I'm able to reliably reproduce these failures locally by running the individual directories.
* Comment why 2 tests in mem.poly.allocator.mem are marked for :0 (MSVC) only - it's static analysis warning C6011.
* Consistently comment when we're marking only :0 (MSVC) because :1 (ASAN) doesn't run static analysis.
* Enhance a comment to mention that :1 means ASAN.

In the comments, I thought ":0 (MSVC)" and ":1 (ASAN)" were sufficiently clear, but I could say ":0 (MSVC plain)" and ":1 (MSVC ASAN)" to clarify at the cost of some verbosity.