### PR TITLE
`<vector>`: Cast to the correct base type in `vector<bool, Alloc>::_Orphan_range_unlocked`

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -2496,15 +2496,12 @@ protected:
 
 template <class _Alvbase_wrapped>
 class _Vb_const_iterator : public _Vb_iter_base<_Alvbase_wrapped> {
-private:
-    using _Mybase = _Vb_iter_base<_Alvbase_wrapped>;
-
 public:
-    using _Mycont          = typename _Mybase::_Mycont;
-    using _Difference_type = typename _Mybase::_Difference_type;
-    using _Size_type       = typename _Mybase::_Size_type;
-    using _Reft            = _Vb_reference<_Alvbase_wrapped>;
-    using const_reference  = bool;
+    using _Mybase         = _Vb_iter_base<_Alvbase_wrapped>;
+    using _Mycont         = typename _Mybase::_Mycont;
+    using _Size_type      = typename _Mybase::_Size_type;
+    using _Reft           = _Vb_reference<_Alvbase_wrapped>;
+    using const_reference = bool;
 
     using iterator_category = random_access_iterator_tag;
     using value_type        = bool;
@@ -2521,7 +2518,7 @@ public:
 #if _ITERATOR_DEBUG_LEVEL != 0
         const auto _Cont = static_cast<const _Mycont*>(this->_Getcont());
         _STL_VERIFY(_Cont, "cannot dereference value-initialized vector<bool> iterator");
-        _STL_VERIFY(this->_Total_off(_Cont) < static_cast<_Difference_type>(_Cont->_Mysize),
+        _STL_VERIFY(this->_Total_off(_Cont) < static_cast<difference_type>(_Cont->_Mysize),
             "vector<bool> iterator not dereferenceable");
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 
@@ -2559,7 +2556,7 @@ public:
             if (_Off < 0) {
                 _STL_VERIFY(-_Start_offset <= _Off, "cannot seek vector<bool> iterator before begin");
             } else if (0 < _Off) {
-                _STL_VERIFY(_Off <= static_cast<_Difference_type>(_Cont->_Mysize - _Start_offset),
+                _STL_VERIFY(_Off <= static_cast<difference_type>(_Cont->_Mysize - _Start_offset),
                     "cannot seek vector<bool> iterator after end");
             }
         }
@@ -2682,7 +2679,7 @@ public:
 #if _ITERATOR_DEBUG_LEVEL != 0
         const auto _Cont = static_cast<const _Mycont*>(this->_Getcont());
         _STL_VERIFY(_Cont, "cannot increment value-initialized vector<bool> iterator");
-        _STL_VERIFY(this->_Total_off(_Cont) < static_cast<_Difference_type>(_Cont->_Mysize),
+        _STL_VERIFY(this->_Total_off(_Cont) < static_cast<difference_type>(_Cont->_Mysize),
             "cannot increment vector<bool> end iterator");
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 
@@ -2698,9 +2695,8 @@ public:
 template <class _Alvbase_wrapped>
 class _Vb_iterator : public _Vb_const_iterator<_Alvbase_wrapped> {
 public:
-    using _Mybase          = _Vb_const_iterator<_Alvbase_wrapped>;
-    using _Mycont          = typename _Mybase::_Mycont;
-    using _Difference_type = typename _Mybase::_Difference_type;
+    using _Mybase = _Vb_const_iterator<_Alvbase_wrapped>;
+    using _Mycont = typename _Mybase::_Mycont;
 
     using _Reft           = _Vb_reference<_Alvbase_wrapped>;
     using const_reference = bool;
@@ -2717,7 +2713,7 @@ public:
 #if _ITERATOR_DEBUG_LEVEL != 0
         const auto _Cont = static_cast<const _Mycont*>(this->_Getcont());
         _STL_VERIFY(_Cont, "cannot dereference value-initialized vector<bool> iterator");
-        _STL_VERIFY(this->_Total_off(_Cont) < static_cast<_Difference_type>(_Cont->_Mysize),
+        _STL_VERIFY(this->_Total_off(_Cont) < static_cast<difference_type>(_Cont->_Mysize),
             "vector<bool> iterator not dereferenceable");
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 
@@ -3512,7 +3508,7 @@ public:
 
         _Iterator_base12** _Pnext = &this->_Myproxy->_Myfirstiter;
         while (*_Pnext) { // test offset from beginning of vector
-            const auto& _Pnextiter = static_cast<const_iterator&>(**_Pnext);
+            const auto& _Pnextiter = static_cast<typename const_iterator::_Mybase&>(**_Pnext);
             const auto _Temp       = *_Pnext;
             if (!_Pnextiter._Myptr) { // orphan the iterator
                 _Temp->_Myproxy = nullptr;

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -989,10 +989,6 @@ std/containers/sequences/vector/vector.cons/construct_size_value.pass.cpp:1 FAIL
 std/containers/sequences/vector/vector.cons/construct_size_value_alloc.pass.cpp:0 FAIL
 std/containers/sequences/vector/vector.cons/construct_size_value_alloc.pass.cpp:1 FAIL
 
-# Not analyzed. Possible STL bug, _Vb_reference derives from _Vb_iter_base and is adopted by the container, but _Orphan_range_unlocked assumes every child is a const_iterator.
-# note: failure was caused by cast of object of dynamic type 'Ref' to type 'const std::_Vb_const_iterator<std::_Wrap_alloc<std::allocator<std::_Vbase>>>'
-std/containers/sequences/vector.bool/emplace_back.pass.cpp FAIL
-
 # Not analyzed. Looks like a test bug, assuming that hash<vector<bool>> is constexpr.
 std/containers/sequences/vector.bool/enabled_hash.pass.cpp FAIL
 std/containers/sequences/vector.bool/vector_bool.pass.cpp FAIL


### PR DESCRIPTION
I've confirmed that @StephanTLavavej's analysis for the related test failure was correct.
> Possible STL bug, _Vb_reference derives from _Vb_iter_base and is adopted by the container, but _Orphan_range_unlocked assumes every child is a const_iterator.

This PR exposes `_Mybase` for the convenience of casting, and removes some unnecessary `_Difference_type` member type alias as driven-by changes. (It seems better to me to use `difference_type` whenever it's available.)

Unblocks one libcxx test:
- `std/containers/sequences/vector.bool/emplace_back.pass.cpp`