### PR TITLE
`<type_traits>`: Workaround for DevCom-10543093 (ICE with some uses of pointers to data members)

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1746,7 +1746,12 @@ constexpr auto invoke(_Callable&& _Obj, _Ty1&& _Arg1, _Types2&&... _Args2) noexc
     } else if constexpr (_Invoker1<_Callable, _Ty1>::_Strategy == _Invoker_strategy::_Pmd_object) {
         return static_cast<_Ty1&&>(_Arg1).*_Obj;
     } else if constexpr (_Invoker1<_Callable, _Ty1>::_Strategy == _Invoker_strategy::_Pmd_refwrap) {
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10543093
         return _Arg1.get().*_Obj;
+#else // ^^^ no workaround / workaround vvv
+        auto& _Ref = _Arg1.get();
+        return _Ref.*_Obj;
+#endif // ^^^ workaround ^^^
     } else {
         _STL_INTERNAL_STATIC_ASSERT(_Invoker1<_Callable, _Ty1>::_Strategy == _Invoker_strategy::_Pmd_pointer);
         return (*static_cast<_Ty1&&>(_Arg1)).*_Obj;

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -869,10 +869,6 @@ std/containers/sequences/deque/deque.modifiers/insert_iter_iter.pass.cpp SKIPPED
 # Not analyzed. Failing after LLVM-D75622.
 std/re/re.const/re.matchflag/match_prev_avail.pass.cpp FAIL
 
-# Not analyzed. Possibly C1XX constexpr bug.
-std/utilities/function.objects/func.invoke/invoke_constexpr.pass.cpp:0 FAIL
-std/utilities/function.objects/func.invoke/invoke_constexpr.pass.cpp:1 FAIL
-
 # Not analyzed. Failing for "[a[.ch.]z]".
 std/re/re.alg/re.alg.match/awk.locale.pass.cpp FAIL
 std/re/re.alg/re.alg.match/basic.locale.pass.cpp FAIL


### PR DESCRIPTION
The bug was not previously analyzed. I reduced the test case and reported DevCom-10543093.

Unblocks one libcxx test:
- `std/utilities/function.objects/func.invoke/invoke_constexpr.pass.cpp`