### PR TITLE
Update boost-math to 1.84

### DIFF
--- a/docs/cgmanifest.json
+++ b/docs/cgmanifest.json
@@ -6,7 +6,7 @@
                 "type": "git",
                 "git": {
                     "repositoryUrl": "https://github.com/boostorg/math",
-                    "commitHash": "1a7be5d895d266a870af7a6ed258e5bcf9838277"
+                    "commitHash": "44af29a78c85ee89ce37f7f43d532afd05c3d981"
                 }
             }
         },


### PR DESCRIPTION
https://github.com/boostorg/math/releases/tag/boost-1.84.0