### PR TITLE
Solutions for ClangCL `intrin0.h` header for `_STL_INTRIN_HEADER` macro

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -2036,7 +2036,7 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 #ifdef __clang__
 #if __clang_major__ >= 18
 #define _STL_INTRIN_HEADER <intrin0.h>
-#elif __has_include(<intrin_msvcstl.h>)
+#elif __has_include(<intrin_msvc_stl.h>)
 #define _STL_INTRIN_HEADER <intrin_msvc_stl.h>
 #else
 #define _STL_INTRIN_HEADER <intrin.h>

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -2034,7 +2034,13 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 #endif // ^^^ !defined(__cpp_noexcept_function_type) ^^^
 
 #ifdef __clang__
+#if __clang_major__ >= 18
+#define _STL_INTRIN_HEADER <intrin0.h>
+#elif __has_include(<intrin_msvcstl.h)
+#define _STL_INTRIN_HEADER <intrin_msvc_stl.h>
+#else
 #define _STL_INTRIN_HEADER <intrin.h>
+#endif
 #define _STL_UNREACHABLE   __builtin_unreachable()
 #else // ^^^ defined(__clang__) / !defined(__clang__) vvv
 #define _STL_INTRIN_HEADER <intrin0.h>

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -2036,7 +2036,7 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 #ifdef __clang__
 #if __clang_major__ >= 18
 #define _STL_INTRIN_HEADER <intrin0.h>
-#elif __has_include(<intrin_msvcstl.h)
+#elif __has_include(<intrin_msvcstl.h>)
 #define _STL_INTRIN_HEADER <intrin_msvc_stl.h>
 #else
 #define _STL_INTRIN_HEADER <intrin.h>

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -2041,7 +2041,7 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 #else
 #define _STL_INTRIN_HEADER <intrin.h>
 #endif
-#define _STL_UNREACHABLE   __builtin_unreachable()
+#define _STL_UNREACHABLE __builtin_unreachable()
 #else // ^^^ defined(__clang__) / !defined(__clang__) vvv
 #define _STL_INTRIN_HEADER <intrin0.h>
 #define _STL_UNREACHABLE   __assume(false)


### PR DESCRIPTION
#### Background Reading ####

See this MSVC STL PR from last year for historical context: https://github.com/microsoft/STL/pull/3285

See this Clang bug report that spawned this work: https://github.com/llvm/llvm-project/issues/53520
See this Clang PR for context on the changes we would like to make to clang to support `intrin0.h`: https://github.com/llvm/llvm-project/pull/75711

#### Problem ####

As you are well aware `intrin0.h` is a header shipped with MSVC that stores the minimal set of intrinsics for the MSVC STL to reduce header include time.

`immintrin.h` shipped with ClangCL only includes the simd intrinsics if they are enabled at compile time. This prevents the ability to do runtime simd detection with ClangCL.
This was done to reduce the header include times from `_STL_INTRIN_HEADER` using `intrin.h` which ends up including `immintrin.h`.

To solve this I am adding a similar intrinsic header to ClangCL to mimic `intrin0.h` for MSVC STL.

#### Solution ####

At noted above we already have a PR up that provides the minimal set of intrinsics that the MSVC STL requires.

We would like to come to some agreement about how to do the feature check so we can use this new minimal intrin header when it becomes available. We can be flexible and we want our solution to work for you. Not force our solution onto you.

We can't use `__has_include(<intrin0.h>)` because MSVC ships its own copy of intrin0.h and thus can't distinguish it from ours.
 
We can't use `__has_include_next(<intrin0.h>)` inside `yvals_core.h` to determine if ClangCL is providing its own header since clang will rightfully warn that it will be found by absolute path, "#include_next in file found relative to primary source file or found by absolute path; will search from start of include path [-Winclude-next-absolute-path]".

We can do a version check for when this header will be introduced.

The proposed solution that I am thinking is the way to go is for clang to have its own custom name for the header such as `intrin_msvc_stl.h` and then we can easily do a `__has_include` check.

I don't intend for this PR to get merged before we merge the clang PR linked above. Would appreciate which avenue you guys would like us to go down to support this feature.
Thanks :).