### PR TITLE
`<chrono>`: Fix `formatter` ignoring dynamically provided width

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5477,7 +5477,14 @@ namespace chrono {
 
             int _Estimated_width = -1;
             (void) _Measure_string_prefix(_Stream.view(), _Estimated_width);
-            return _Write_aligned(_STD move(_FormatCtx.out()), _Estimated_width, _Specs, _Fmt_align::_Left,
+
+            auto _FormatSpecs = _Specs;
+            if (_Specs._Dynamic_width_index >= 0) {
+                _FormatSpecs._Width = _Get_dynamic_specs<_Width_checker>(
+                    _FormatCtx.arg(static_cast<size_t>(_Specs._Dynamic_width_index)));
+            }
+
+            return _Write_aligned(_STD move(_FormatCtx.out()), _Estimated_width, _FormatSpecs, _Fmt_align::_Left,
                 [&](auto _Out) { return _Fmt_write(_STD move(_Out), _Stream.view()); });
         }
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5478,13 +5478,13 @@ namespace chrono {
             int _Estimated_width = -1;
             (void) _Measure_string_prefix(_Stream.view(), _Estimated_width);
 
-            auto _FormatSpecs = _Specs;
+            auto _Format_specs = _Specs;
             if (_Specs._Dynamic_width_index >= 0) {
-                _FormatSpecs._Width = _Get_dynamic_specs<_Width_checker>(
+                _Format_specs._Width = _Get_dynamic_specs<_Width_checker>(
                     _FormatCtx.arg(static_cast<size_t>(_Specs._Dynamic_width_index)));
             }
 
-            return _Write_aligned(_STD move(_FormatCtx.out()), _Estimated_width, _FormatSpecs, _Fmt_align::_Left,
+            return _Write_aligned(_STD move(_FormatCtx.out()), _Estimated_width, _Format_specs, _Fmt_align::_Left,
                 [&](auto _Out) { return _Fmt_write(_STD move(_Out), _Stream.view()); });
         }
 

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -234,6 +234,7 @@ tests\GH_003840_tellg_when_reading_lf_file_in_text_mode
 tests\GH_003867_output_nan
 tests\GH_004023_mdspan_fwd_prod_overflow
 tests\GH_004040_container_nonmember_functions
+tests\GH_004201_chrono_formatter
 tests\LWG2381_num_get_floating_point
 tests\LWG2597_complex_branch_cut
 tests\LWG3018_shared_ptr_function

--- a/tests/std/tests/GH_004201_chrono_formatter/env.lst
+++ b/tests/std/tests/GH_004201_chrono_formatter/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/GH_004201_chrono_formatter/test.cpp
+++ b/tests/std/tests/GH_004201_chrono_formatter/test.cpp
@@ -1,9 +1,9 @@
+#include <cassert>
 #include <chrono>
 #include <format>
 #include <iostream>
 #include <string>
 #include <thread>
-#include <cassert>
 
 using namespace std::literals::chrono_literals;
 

--- a/tests/std/tests/GH_004201_chrono_formatter/test.cpp
+++ b/tests/std/tests/GH_004201_chrono_formatter/test.cpp
@@ -1,9 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #include <cassert>
 #include <chrono>
 #include <format>
-#include <iostream>
 #include <string>
-#include <thread>
 
 using namespace std::literals::chrono_literals;
 

--- a/tests/std/tests/GH_004201_chrono_formatter/test.cpp
+++ b/tests/std/tests/GH_004201_chrono_formatter/test.cpp
@@ -1,0 +1,15 @@
+#include <chrono>
+#include <format>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <cassert>
+
+using namespace std::literals::chrono_literals;
+
+int main() {
+    assert(std::format("[{:20%T}]", 314159s) == "[87:15:59            ]");
+
+    // std::formatter specializations for <chrono> types used to ignore dynamically provided width
+    assert(std::format("[{:{}%T}]", 314159s, 20) == "[87:15:59            ]");
+}


### PR DESCRIPTION

Fixes #4201.

As has @cpplearner noted, `_Chrono_formatter::_Write()` calls and returns `_Write_aligned` before trying to check if a width is provided dynamically. The updated behavior is now similar to that of `_Formatter_base::format()`.