### PR TITLE
`<random>`: Deprecate TR1 components in the `std` namespace

### DIFF
--- a/stl/inc/random
+++ b/stl/inc/random
@@ -918,7 +918,7 @@ public:
 _STL_DISABLE_DEPRECATED_WARNING
 _EXPORT_STD template <class _Ty, size_t _Wx, size_t _Sx, size_t _Rx>
 class subtract_with_carry_engine
-    : public subtract_with_carry<_Ty, static_cast<_Ty>((_Ty{1} << (_Wx - 1)) << 1), _Sx, _Rx> {
+    : private subtract_with_carry<_Ty, static_cast<_Ty>((_Ty{1} << (_Wx - 1)) << 1), _Sx, _Rx> {
     // subtract_with_carry generator
 public:
     _RNG_REQUIRE_UINTTYPE(subtract_with_carry_engine, _Ty);
@@ -980,6 +980,26 @@ public:
 
     _NODISCARD static constexpr _Ty(max)() noexcept /* strengthened */ {
         return _Mx - 1;
+    }
+
+    _NODISCARD_FRIEND bool operator==(
+        const subtract_with_carry_engine& _Left, const subtract_with_carry_engine& _Right) noexcept /* strengthened */ {
+        return static_cast<const _Mybase&>(_Left) == static_cast<const _Mybase&>(_Right);
+    }
+
+#if !_HAS_CXX20
+    _NODISCARD_FRIEND bool operator!=(
+        const subtract_with_carry_engine& _Left, const subtract_with_carry_engine& _Right) noexcept /* strengthened */ {
+        return static_cast<const _Mybase&>(_Left) != static_cast<const _Mybase&>(_Right);
+    }
+#endif // !_HAS_CXX20
+
+    _NODISCARD result_type operator()() {
+        return _Mybase::operator()();
+    }
+
+    void discard(unsigned long long _Nskip) {
+        _Mybase::discard(_Nskip);
     }
 
     template <class _Elem, class _Traits>

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -1598,7 +1598,7 @@ private:
 _STL_DISABLE_DEPRECATED_WARNING
 _EXPORT_STD template <class _Engine, size_t _Px, size_t _Rx>
 class discard_block_engine // discard_block_engine compound engine
-    : public conditional_t<_Px <= INT_MAX, discard_block<_Engine, static_cast<int>(_Px), static_cast<int>(_Rx)>,
+    : private conditional_t<_Px <= INT_MAX, discard_block<_Engine, static_cast<int>(_Px), static_cast<int>(_Rx)>,
           _Discard_block_base<_Engine, _Px, _Rx>> {
 public:
     static_assert(0 < _Rx && _Rx <= _Px, "invalid template argument for discard_block_engine");
@@ -1652,6 +1652,27 @@ public:
 
     _NODISCARD static constexpr result_type(max)() noexcept /* strengthened */ {
         return (_Engine::max)();
+    }
+
+    _NODISCARD_FRIEND bool operator==(const discard_block_engine& _Left, const discard_block_engine& _Right) {
+        return static_cast<const _Mybase&>(_Left) == static_cast<const _Mybase&>(_Right);
+    }
+
+#if !_HAS_CXX20
+    _NODISCARD_FRIEND bool operator!=(const discard_block_engine& _Left, const discard_block_engine& _Right) {
+        return static_cast<const _Mybase&>(_Left) != static_cast<const _Mybase&>(_Right);
+    }
+#endif // !_HAS_CXX20
+
+    template <class _Elem, class _Traits>
+    friend basic_istream<_Elem, _Traits>& operator>>(basic_istream<_Elem, _Traits>& _Istr, discard_block_engine& _Eng) {
+        return _Istr >> static_cast<_Mybase&>(_Eng);
+    }
+
+    template <class _Elem, class _Traits>
+    friend basic_ostream<_Elem, _Traits>& operator<<(
+        basic_ostream<_Elem, _Traits>& _Ostr, const discard_block_engine& _Eng) {
+        return _Ostr << static_cast<const _Mybase&>(_Eng);
     }
 };
 _STL_RESTORE_DEPRECATED_WARNING

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -2218,7 +2218,7 @@ private:
 
 _STL_DISABLE_DEPRECATED_WARNING
 _EXPORT_STD template <class _Ty = int>
-class uniform_int_distribution : public uniform_int<_Ty> { // uniform integer distribution
+class uniform_int_distribution : private uniform_int<_Ty> { // uniform integer distribution
 public:
     _RNG_REQUIRE_INTTYPE(uniform_int_distribution, _Ty);
 

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -3110,7 +3110,7 @@ private:
 
 _STL_DISABLE_DEPRECATED_WARNING
 _EXPORT_STD template <class _Ty = double>
-class uniform_real_distribution : public uniform_real<_Ty> { // uniform real distribution
+class uniform_real_distribution : private uniform_real<_Ty> { // uniform real distribution
 public:
     _RNG_REQUIRE_REALTYPE(uniform_real_distribution, _Ty);
 
@@ -3173,6 +3173,18 @@ public:
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng, const param_type& _Par0) _DISTRIBUTION_CONST {
         return _Mybase::operator()(_Eng, _Par0);
+    }
+
+    template <class _Elem, class _Traits>
+    friend basic_istream<_Elem, _Traits>& operator>>(
+        basic_istream<_Elem, _Traits>& _Istr, uniform_real_distribution& _Dist) {
+        return _Istr >> static_cast<_Mybase&>(_Dist);
+    }
+
+    template <class _Elem, class _Traits>
+    friend basic_ostream<_Elem, _Traits>& operator<<(
+        basic_ostream<_Elem, _Traits>& _Ostr, const uniform_real_distribution& _Dist) {
+        return _Ostr << static_cast<const _Mybase&>(_Dist);
     }
 
     _NODISCARD_FRIEND bool operator==(

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -1381,7 +1381,7 @@ public:
     }
 
     void discard(unsigned long long _Nskip) { // discard _Nskip elements
-        return _Mybase::discard(_Nskip);
+        _Mybase::discard(_Nskip);
     }
 };
 _STL_RESTORE_DEPRECATED_WARNING

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -1397,14 +1397,14 @@ public:
 #endif // !_HAS_CXX20
 
     template <class _Elem, class _S_Traits>
-    friend basic_istream<_Elem, _S_Traits>& operator>>(basic_istream<_Elem, _S_Traits>& _Istr,
-        mersenne_twister_engine& _Eng) { // read state from _Istr
+    friend basic_istream<_Elem, _S_Traits>& operator>>(
+        basic_istream<_Elem, _S_Traits>& _Istr, mersenne_twister_engine& _Eng) {
         return _Istr >> static_cast<_Mybase&>(_Eng);
     }
 
     template <class _Elem, class _S_Traits>
-    friend basic_ostream<_Elem, _S_Traits>& operator<<(basic_ostream<_Elem, _S_Traits>& _Ostr,
-        const mersenne_twister_engine& _Eng) { // write state to _Ostr
+    friend basic_ostream<_Elem, _S_Traits>& operator<<(
+        basic_ostream<_Elem, _S_Traits>& _Ostr, const mersenne_twister_engine& _Eng) {
         return _Ostr << static_cast<const _Mybase&>(_Eng);
     }
 
@@ -1412,7 +1412,7 @@ public:
         return _Mybase::operator()();
     }
 
-    void discard(unsigned long long _Nskip) { // discard _Nskip elements
+    void discard(unsigned long long _Nskip) {
         _Mybase::discard(_Nskip);
     }
 };
@@ -1621,16 +1621,16 @@ public:
     template <class _Seed_seq, _Enable_if_seed_seq_t<_Seed_seq, discard_block_engine, _Engine> = 0>
     explicit discard_block_engine(_Seed_seq& _Seq) : _Mybase(_Seq) {}
 
-    void seed() { // seed engine from default value
+    void seed() {
         _Mybase::seed();
     }
 
-    void seed(result_type _Xx0) { // seed engine from specified value
+    void seed(result_type _Xx0) {
         _Mybase::seed(_Xx0);
     }
 
     template <class _Seed_seq, _Enable_if_seed_seq_t<_Seed_seq, discard_block_engine> = 0>
-    void seed(_Seed_seq& _Seq) { // seed engine from seed sequence
+    void seed(_Seed_seq& _Seq) {
         _Mybase::seed(_Seq);
     }
 
@@ -1642,7 +1642,7 @@ public:
         return _Mybase::operator()();
     }
 
-    void discard(unsigned long long _Nskip) { // discard _Nskip elements
+    void discard(unsigned long long _Nskip) {
         _Mybase::discard(_Nskip);
     }
 
@@ -2260,7 +2260,7 @@ public:
         return _Mybase::param();
     }
 
-    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
+    void param(const param_type& _Par0) noexcept /* strengthened */ {
         _Mybase::param(_Par0);
     }
 
@@ -2272,7 +2272,7 @@ public:
         return (_Mybase::max)();
     }
 
-    void reset() noexcept /* strengthened */ {} // clear internal state
+    void reset() noexcept /* strengthened */ {}
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
@@ -2285,14 +2285,14 @@ public:
     }
 
     template <class _Elem, class _Traits>
-    friend basic_istream<_Elem, _Traits>& operator>>(basic_istream<_Elem, _Traits>& _Istr,
-        uniform_int_distribution& _Dist) { // read state from _Istr
+    friend basic_istream<_Elem, _Traits>& operator>>(
+        basic_istream<_Elem, _Traits>& _Istr, uniform_int_distribution& _Dist) {
         return _Istr >> static_cast<_Mybase&>(_Dist);
     }
 
     template <class _Elem, class _Traits>
-    friend basic_ostream<_Elem, _Traits>& operator<<(basic_ostream<_Elem, _Traits>& _Ostr,
-        const uniform_int_distribution& _Dist) { // write state to _Ostr
+    friend basic_ostream<_Elem, _Traits>& operator<<(
+        basic_ostream<_Elem, _Traits>& _Ostr, const uniform_int_distribution& _Dist) {
         return _Ostr << static_cast<const _Mybase&>(_Dist);
     }
 
@@ -3151,7 +3151,7 @@ public:
         return _Mybase::param();
     }
 
-    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
+    void param(const param_type& _Par0) noexcept /* strengthened */ {
         _Mybase::param(_Par0);
     }
 
@@ -3163,7 +3163,7 @@ public:
         return (_Mybase::max)();
     }
 
-    void reset() noexcept /* strengthened */ {} // clear internal state
+    void reset() noexcept /* strengthened */ {}
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -2231,11 +2231,6 @@ public:
         return _Mybase::operator()(_Eng, _Par0);
     }
 
-    template <class _Engine>
-    _NODISCARD result_type operator()(_Engine& _Eng, result_type _Nx) _DISTRIBUTION_CONST {
-        return _Mybase::operator()(_Eng, _Nx);
-    }
-
     template <class _Elem, class _Traits>
     friend basic_istream<_Elem, _Traits>& operator>>(basic_istream<_Elem, _Traits>& _Istr,
         uniform_int_distribution& _Dist) { // read state from _Istr

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -520,7 +520,7 @@ private:
 };
 
 template <class _Uint, _Uint _Ax, _Uint _Cx, _Uint _Mx>
-class linear_congruential { // linear congruential random engine
+class _DEPRECATE_TR1_RANDOM linear_congruential { // linear congruential random engine
 public:
     _RNG_REQUIRE_UINTTYPE(linear_congruential, _Uint);
 
@@ -884,7 +884,7 @@ struct _Swc_traits { // traits for subtract_with_carry generator
 };
 
 template <class _Ty, _Ty _Mx, size_t _Sx, size_t _Rx>
-class subtract_with_carry
+class _DEPRECATE_TR1_RANDOM subtract_with_carry
     : public _Swc_base<_Ty, _Sx, _Rx, _Swc_traits<_Ty, _Mx, _Rx>> { // subtract_with_carry generator
 public:
     using _Mybase = _Swc_base<_Ty, _Sx, _Rx, _Swc_traits<_Ty, _Mx, _Rx>>;
@@ -901,6 +901,7 @@ public:
     subtract_with_carry(_Gen& _Gx) : _Mybase(_Gx) {}
 };
 
+_STL_DISABLE_DEPRECATED_WARNING
 _EXPORT_STD template <class _Ty, size_t _Wx, size_t _Sx, size_t _Rx>
 class subtract_with_carry_engine
     : public subtract_with_carry<_Ty, static_cast<_Ty>((_Ty{1} << (_Wx - 1)) << 1), _Sx, _Rx> {
@@ -1005,6 +1006,7 @@ public:
         return _Istr;
     }
 };
+_STL_RESTORE_DEPRECATED_WARNING
 
 #if _HAS_TR1_NAMESPACE
 constexpr double _Cx_exp2(const int _Exp) noexcept {
@@ -1094,7 +1096,7 @@ public:
 #endif // _HAS_TR1_NAMESPACE
 
 template <class _Ty, int _Wx, int _Nx, int _Mx, int _Rx, _Ty _Px, int _Ux, int _Sx, _Ty _Bx, int _Tx, _Ty _Cx, int _Lx>
-class mersenne_twister : public _Circ_buf<_Ty, _Nx> { // mersenne twister generator
+class _DEPRECATE_TR1_RANDOM mersenne_twister : public _Circ_buf<_Ty, _Nx> { // mersenne twister generator
 public:
     using result_type = _Ty;
 
@@ -1264,6 +1266,7 @@ protected:
     static constexpr int _M_mod_n   = _Mx % _Nx;
 };
 
+_STL_DISABLE_DEPRECATED_WARNING
 _EXPORT_STD template <class _Ty, size_t _Wx, size_t _Nx, size_t _Mx, size_t _Rx, _Ty _Px, size_t _Ux, _Ty _Dx,
     size_t _Sx, _Ty _Bx, size_t _Tx, _Ty _Cx, size_t _Lx, _Ty _Fx>
 class mersenne_twister_engine : public mersenne_twister<_Ty, _Wx, _Nx, _Mx, _Rx, _Px, _Ux, _Sx, _Bx, _Tx, _Cx, _Lx> {
@@ -1346,10 +1349,31 @@ public:
     _NODISCARD static constexpr result_type(max)() noexcept /* strengthened */ {
         return _Mybase::_WMSK;
     }
+
+    template <class _Elem, class _S_Traits>
+    friend basic_istream<_Elem, _S_Traits>& operator>>(basic_istream<_Elem, _S_Traits>& _Istr,
+        mersenne_twister_engine& _Eng) { // read state from _Istr
+        return _Istr >> static_cast<_Mybase&>(_Eng);
+    }
+
+    template <class _Elem, class _S_Traits>
+    friend basic_ostream<_Elem, _S_Traits>& operator<<(basic_ostream<_Elem, _S_Traits>& _Ostr,
+        const mersenne_twister_engine& _Eng) { // write state to _Ostr
+        return _Ostr << static_cast<const _Mybase&>(_Eng);
+    }
+
+    _NODISCARD result_type operator()() {
+        return _Mybase::operator()();
+    }
+
+    void discard(unsigned long long _Nskip) { // discard _Nskip elements
+        return _Mybase::discard(_Nskip);
+    }
 };
+_STL_RESTORE_DEPRECATED_WARNING
 
 template <class _Engine, int _Px, int _Rx>
-class discard_block { // discard_block compound engine
+class _DEPRECATE_TR1_RANDOM discard_block { // discard_block compound engine
 public:
 #if _HAS_TR1_NAMESPACE
     using base_type _DEPRECATE_TR1_NAMESPACE = _Engine; // TR1-only typedef
@@ -1525,6 +1549,7 @@ private:
     size_t _Nx;
 };
 
+_STL_DISABLE_DEPRECATED_WARNING
 _EXPORT_STD template <class _Engine, size_t _Px, size_t _Rx>
 class discard_block_engine // discard_block_engine compound engine
     : public conditional_t<_Px <= INT_MAX, discard_block<_Engine, static_cast<int>(_Px), static_cast<int>(_Rx)>,
@@ -1550,6 +1575,31 @@ public:
     template <class _Seed_seq, _Enable_if_seed_seq_t<_Seed_seq, discard_block_engine, _Engine> = 0>
     explicit discard_block_engine(_Seed_seq& _Seq) : _Mybase(_Seq) {}
 
+    void seed() { // seed engine from default value
+        _Mybase::seed();
+    }
+
+    void seed(result_type _Xx0) { // seed engine from specified value
+        _Mybase::seed(_Xx0);
+    }
+
+    template <class _Seed_seq, _Enable_if_seed_seq_t<_Seed_seq, discard_block_engine> = 0>
+    void seed(_Seed_seq& _Seq) { // seed engine from seed sequence
+        _Mybase::seed(_Seq);
+    }
+
+    _NODISCARD const _Engine& base() const noexcept {
+        return _Mybase::base();
+    }
+
+    _NODISCARD result_type operator()() {
+        return _Mybase::operator()();
+    }
+
+    void discard(unsigned long long _Nskip) { // discard _Nskip elements
+        _Mybase::discard(_Nskip);
+    }
+
     _NODISCARD static constexpr result_type(min)() noexcept /* strengthened */ {
         return (_Engine::min)();
     }
@@ -1558,6 +1608,7 @@ public:
         return (_Engine::max)();
     }
 };
+_STL_RESTORE_DEPRECATED_WARNING
 
 _EXPORT_STD template <class _Engine, size_t _Wx, class _UIntType>
 class independent_bits_engine { // independent_bits_engine compound engine
@@ -1955,7 +2006,7 @@ private:
 };
 
 template <class _Ty = int>
-class uniform_int { // uniform integer distribution
+class _DEPRECATE_TR1_RANDOM uniform_int { // uniform integer distribution
 public:
     using result_type = _Ty;
 
@@ -2098,6 +2149,7 @@ private:
     param_type _Par;
 };
 
+_STL_DISABLE_DEPRECATED_WARNING
 _EXPORT_STD template <class _Ty = int>
 class uniform_int_distribution : public uniform_int<_Ty> { // uniform integer distribution
 public:
@@ -2129,6 +2181,59 @@ public:
     explicit uniform_int_distribution(const param_type& _Par0) noexcept // strengthened
         : _Mybase(_Par0) {}
 
+    _NODISCARD result_type a() const noexcept /* strengthened */ {
+        return _Mybase::a();
+    }
+
+    _NODISCARD result_type b() const noexcept /* strengthened */ {
+        return _Mybase::b();
+    }
+
+    _NODISCARD param_type param() const noexcept /* strengthened */ {
+        return _Mybase::param();
+    }
+
+    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
+        _Mybase::param(_Par0);
+    }
+
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ {
+        return (_Mybase::min)();
+    }
+
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ {
+        return (_Mybase::max)();
+    }
+
+    void reset() noexcept /* strengthened */ {} // clear internal state
+
+    template <class _Engine>
+    _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
+        return _Mybase::operator()(_Eng);
+    }
+
+    template <class _Engine>
+    _NODISCARD result_type operator()(_Engine& _Eng, const param_type& _Par0) _DISTRIBUTION_CONST {
+        return _Mybase::operator()(_Eng, _Par0);
+    }
+
+    template <class _Engine>
+    _NODISCARD result_type operator()(_Engine& _Eng, result_type _Nx) _DISTRIBUTION_CONST {
+        return _Mybase::operator()(_Eng, _Nx);
+    }
+
+    template <class _Elem, class _Traits>
+    friend basic_istream<_Elem, _Traits>& operator>>(basic_istream<_Elem, _Traits>& _Istr,
+        uniform_int_distribution& _Dist) { // read state from _Istr
+        return _Istr >> static_cast<_Mybase&>(_Dist);
+    }
+
+    template <class _Elem, class _Traits>
+    friend basic_ostream<_Elem, _Traits>& operator<<(basic_ostream<_Elem, _Traits>& _Ostr,
+        const uniform_int_distribution& _Dist) { // write state to _Ostr
+        return _Ostr << static_cast<const _Mybase&>(_Dist);
+    }
+
     _NODISCARD_FRIEND bool operator==(
         const uniform_int_distribution& _Left, const uniform_int_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
@@ -2141,6 +2246,7 @@ public:
     }
 #endif // !_HAS_CXX20
 };
+_STL_RESTORE_DEPRECATED_WARNING
 
 _EXPORT_STD class bernoulli_distribution { // class for bernoulli distribution
 public:
@@ -2814,7 +2920,7 @@ private:
 };
 
 template <class _Ty = double>
-class uniform_real { // uniform real distribution
+class _DEPRECATE_TR1_RANDOM uniform_real { // uniform real distribution
 public:
     using result_type = _Ty;
 
@@ -2940,6 +3046,7 @@ private:
     param_type _Par;
 };
 
+_STL_DISABLE_DEPRECATED_WARNING
 _EXPORT_STD template <class _Ty = double>
 class uniform_real_distribution : public uniform_real<_Ty> { // uniform real distribution
 public:
@@ -2970,6 +3077,42 @@ public:
     explicit uniform_real_distribution(const param_type& _Par0) noexcept // strengthened
         : _Mybase(_Par0) {}
 
+    _NODISCARD result_type a() const noexcept /* strengthened */ {
+        return _Mybase::a();
+    }
+
+    _NODISCARD result_type b() const noexcept /* strengthened */ {
+        return _Mybase::b();
+    }
+
+    _NODISCARD param_type param() const noexcept /* strengthened */ {
+        return _Mybase::param();
+    }
+
+    void param(const param_type& _Par0) noexcept /* strengthened */ { // set parameter package
+        _Mybase::param(_Par0);
+    }
+
+    _NODISCARD result_type(min)() const noexcept /* strengthened */ {
+        return (_Mybase::min)();
+    }
+
+    _NODISCARD result_type(max)() const noexcept /* strengthened */ {
+        return (_Mybase::max)();
+    }
+
+    void reset() noexcept /* strengthened */ {} // clear internal state
+
+    template <class _Engine>
+    _NODISCARD result_type operator()(_Engine& _Eng) _DISTRIBUTION_CONST {
+        return _Mybase::operator()(_Eng);
+    }
+
+    template <class _Engine>
+    _NODISCARD result_type operator()(_Engine& _Eng, const param_type& _Par0) _DISTRIBUTION_CONST {
+        return _Mybase::operator()(_Eng, _Par0);
+    }
+
     _NODISCARD_FRIEND bool operator==(
         const uniform_real_distribution& _Left, const uniform_real_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
@@ -2982,6 +3125,7 @@ public:
     }
 #endif // !_HAS_CXX20
 };
+_STL_RESTORE_DEPRECATED_WARNING
 
 _EXPORT_STD template <class _Ty = double>
 class exponential_distribution { // exponential distribution
@@ -4471,7 +4615,7 @@ private:
         _Ty _Vx2;
         _Ty _Rx0;
         _Ty _Rs;
-        uniform_real<_Ty> _Dist(-1, 1);
+        uniform_real_distribution<_Ty> _Dist(-1, 1);
         for (;;) { // get a point inside unit circle
             _Vx1 = _Dist(_Eng);
             _Vx2 = _Dist(_Eng);
@@ -5006,7 +5150,7 @@ public:
     template <class _Engine>
     result_type _Eval(_Engine& _Eng, const param_type& _Par0) _DISTRIBUTION_CONST {
         size_t _Px = _Mybase::operator()(_Eng, _Par0);
-        uniform_real<_Ty> _Dist(_Par0._Bvec[_Px], _Par0._Bvec[_Px + 1]);
+        uniform_real_distribution<_Ty> _Dist(_Par0._Bvec[_Px], _Par0._Bvec[_Px + 1]);
         return _Dist(_Eng);
     }
 
@@ -5233,7 +5377,7 @@ public:
         size_t _Px  = _Mybase::operator()(_Eng, _Par0);
         double _Px0 = _Par0._Pvec[_Px];
         double _Px1 = _Par0._Pvec[_Px + 1];
-        uniform_real<_Ty> _Dist;
+        uniform_real_distribution<_Ty> _Dist;
         result_type _Xx0 = _Dist(_Eng);
 
         if (_Px0 != _Px1) {

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -1303,7 +1303,7 @@ protected:
 _STL_DISABLE_DEPRECATED_WARNING
 _EXPORT_STD template <class _Ty, size_t _Wx, size_t _Nx, size_t _Mx, size_t _Rx, _Ty _Px, size_t _Ux, _Ty _Dx,
     size_t _Sx, _Ty _Bx, size_t _Tx, _Ty _Cx, size_t _Lx, _Ty _Fx>
-class mersenne_twister_engine : public mersenne_twister<_Ty, _Wx, _Nx, _Mx, _Rx, _Px, _Ux, _Sx, _Bx, _Tx, _Cx, _Lx> {
+class mersenne_twister_engine : private mersenne_twister<_Ty, _Wx, _Nx, _Mx, _Rx, _Px, _Ux, _Sx, _Bx, _Tx, _Cx, _Lx> {
 public:
     static constexpr unsigned long long _Max = (((1ULL << (_Wx - 1)) - 1) << 1) + 1;
 
@@ -1383,6 +1383,18 @@ public:
     _NODISCARD static constexpr result_type(max)() noexcept /* strengthened */ {
         return _Mybase::_WMSK;
     }
+
+    _NODISCARD_FRIEND bool operator==(
+        const mersenne_twister_engine& _Left, const mersenne_twister_engine& _Right) noexcept /* strengthened */ {
+        return static_cast<const _Mybase&>(_Left) == static_cast<const _Mybase&>(_Right);
+    }
+
+#if !_HAS_CXX20
+    _NODISCARD_FRIEND bool operator!=(
+        const mersenne_twister_engine& _Left, const mersenne_twister_engine& _Right) noexcept /* strengthened */ {
+        return static_cast<const _Mybase&>(_Left) != static_cast<const _Mybase&>(_Right);
+    }
+#endif // !_HAS_CXX20
 
     template <class _Elem, class _S_Traits>
     friend basic_istream<_Elem, _S_Traits>& operator>>(basic_istream<_Elem, _S_Traits>& _Istr,

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1525,7 +1525,17 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define _DEPRECATE_IO_PFX_SFX
 #endif // ^^^ warning disabled ^^^
 
-// next warning number: STL4046
+#if _HAS_CXX17 && !defined(_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING) \
+    && !defined(_SILENCE_TR1_RANDOM_DEPRECATION_WARNING) && !defined(_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS)
+#define _DEPRECATE_TR1_RANDOM                                                                                          \
+    [[deprecated("warning STL4046: Non-Standard TR1 components in <random> are deprecated and will be REMOVED. You "   \
+                 "can define _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING, _SILENCE_TR1_RANDOM_DEPRECATION_WARNING, or " \
+                 "_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS to suppress this warning.")]]
+#else // ^^^ warning enabled / warning disabled vvv
+#define _DEPRECATE_TR1_RANDOM
+#endif // ^^^ warning disabled ^^^
+
+// next warning number: STL4047
 
 // next error number: STL1006
 

--- a/tests/std/tests/VSO_0000000_instantiate_iterators_misc/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0000000_instantiate_iterators_misc/test.compile.pass.cpp
@@ -1162,8 +1162,6 @@ void random_test() {
     distribution_test_impl(piece_line_d1);
     distribution_test_impl(piece_line_d2);
     distribution_test_impl(piece_line_d3);
-
-    (void) uni_int_d(gen, uni_int_d(gen));
 }
 
 void ratio_test() {

--- a/tests/tr1/tests/random1/test.cpp
+++ b/tests/tr1/tests/random1/test.cpp
@@ -224,13 +224,15 @@ static void tmt19937() {
     CHECK_INT(rng_t::state_size, 624);
     CHECK_INT(rng_t::shift_size, 397);
     CHECK_INT(rng_t::mask_bits, 31);
-    CHECK_INT((int) rng_t::parameter_a, (int) 0x9908b0df);
-    CHECK_INT(rng_t::output_u, 11);
-    CHECK_INT(rng_t::output_s, 7);
-    CHECK_INT((int) rng_t::output_b, (int) 0x9d2c5680);
-    CHECK_INT(rng_t::output_t, 15);
-    CHECK_INT((int) rng_t::output_c, (int) 0xefc60000);
-    CHECK_INT(rng_t::output_l, 18);
+    CHECK_INT((int) rng_t::xor_mask, (int) 0x9908b0df);
+    CHECK_INT(rng_t::tempering_u, 11);
+    CHECK_INT((int) rng_t::tempering_d, (int) 0xffffffff);
+    CHECK_INT(rng_t::tempering_s, 7);
+    CHECK_INT((int) rng_t::tempering_b, (int) 0x9d2c5680);
+    CHECK_INT(rng_t::tempering_t, 15);
+    CHECK_INT((int) rng_t::tempering_c, (int) 0xefc60000);
+    CHECK_INT(rng_t::tempering_l, 18);
+    CHECK_INT(rng_t::initialization_multiplier, 1812433253);
     rng_t rng;
     Int32 res = 0;
     for (int i = 0; i < 10000; ++i) {

--- a/tests/tr1/tests/random6/test.cpp
+++ b/tests/tr1/tests/random6/test.cpp
@@ -4,6 +4,8 @@
 // test <random> C++11 header, part 6
 #define TEST_NAME "<random>, part 6"
 
+#define _SILENCE_TR1_RANDOM_DEPRECATION_WARNING
+
 #include <math.h>
 #define FLOAT_TYPE IS_DOUBLE
 #include "tdefs.h"


### PR DESCRIPTION
Towards #183 and #1002.

They are internally undeprecated when used as base classes. It seems that when `_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING` is defined, warning should still be suppressed.

~TODO: need to investigate how to reuse functions from base classes.~ DONE