### PR TITLE
Mitigate non-conformance of extensions of non-reserved names by the `push_macro`/`pop_macro` mechanism

### DIFF
--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -31,15 +31,7 @@ _STD_END
 #if _HAS_EXCEPTIONS
 
 #include <malloc.h>
-
-// TRANSITION, terminate_function and unexpected_function are defined for source compatibility.
-#pragma push_macro("terminate_function")
-#pragma push_macro("unexpected_function")
-#undef terminate_function
-#undef unexpected_function
 #include <vcruntime_exception.h>
-#pragma pop_macro("unexpected_function")
-#pragma pop_macro("terminate_function")
 
 _STD_BEGIN
 
@@ -76,7 +68,7 @@ _STD_END
 
 #else // ^^^ _HAS_EXCEPTIONS / !_HAS_EXCEPTIONS vvv
 
-#pragma push_macro("stdext") // TRANSITION, vNext
+#pragma push_macro("stdext")
 #undef stdext
 
 _STDEXT_BEGIN
@@ -214,7 +206,7 @@ _EXPORT_STD using _STDEXT bad_exception;
 
 _STD_END
 
-#pragma pop_macro("stdext") // TRANSITION, vNext
+#pragma pop_macro("stdext")
 
 #endif // ^^^ !_HAS_EXCEPTIONS ^^^
 

--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -31,7 +31,15 @@ _STD_END
 #if _HAS_EXCEPTIONS
 
 #include <malloc.h>
+
+// TRANSITION, terminate_function and unexpected_function are defined for source compatibility.
+#pragma push_macro("terminate_function")
+#pragma push_macro("unexpected_function")
+#undef terminate_function
+#undef unexpected_function
 #include <vcruntime_exception.h>
+#pragma pop_macro("unexpected_function")
+#pragma pop_macro("terminate_function")
 
 _STD_BEGIN
 

--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -76,6 +76,9 @@ _STD_END
 
 #else // ^^^ _HAS_EXCEPTIONS / !_HAS_EXCEPTIONS vvv
 
+#pragma push_macro("stdext") // TRANSITION, vNext
+#undef stdext
+
 _STDEXT_BEGIN
 class exception;
 _STDEXT_END
@@ -210,6 +213,8 @@ _EXPORT_STD using _STDEXT bad_array_new_length;
 _EXPORT_STD using _STDEXT bad_exception;
 
 _STD_END
+
+#pragma pop_macro("stdext") // TRANSITION, vNext
 
 #endif // ^^^ !_HAS_EXCEPTIONS ^^^
 

--- a/stl/inc/istream
+++ b/stl/inc/istream
@@ -145,6 +145,10 @@ public:
         return this->good();
     }
 
+#pragma push_macro("ipfx")
+#pragma push_macro("isfx")
+#undef ipfx
+#undef isfx
     // TRANSITION, ABI: non-Standard ipfx() is preserved for binary compatibility
     _DEPRECATE_IO_PFX_SFX bool __CLR_OR_THIS_CALL ipfx(bool _Noskip = false) {
         // test stream state and skip whitespace as needed
@@ -153,6 +157,8 @@ public:
 
     // TRANSITION, ABI: non-Standard isfx() is preserved for binary compatibility
     _DEPRECATE_IO_PFX_SFX void __CLR_OR_THIS_CALL isfx() {} // perform any wrapup
+#pragma pop_macro("isfx")
+#pragma pop_macro("ipfx")
 
 #ifdef _M_CEE_PURE
     basic_istream& __CLR_OR_THIS_CALL operator>>(basic_istream&(__clrcall* _Pfn)(basic_istream&) ) {

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -1467,6 +1467,16 @@ struct iterator_traits<counted_iterator<_Iter>> : iterator_traits<_Iter> {
 
 _STD_END
 
+// TRANSITION, vNext
+#pragma push_macro("checked_array_iterator")
+#pragma push_macro("make_checked_array_iterator")
+#pragma push_macro("make_unchecked_array_iterator")
+#pragma push_macro("unchecked_array_iterator")
+#undef checked_array_iterator
+#undef make_checked_array_iterator
+#undef make_unchecked_array_iterator
+#undef unchecked_array_iterator
+
 _STDEXT_BEGIN
 template <class _Ptr>
 class _DEPRECATE_STDEXT_ARR_ITERS checked_array_iterator { // wrap a pointer with checking
@@ -1856,6 +1866,12 @@ struct pointer_traits<_STDEXT checked_array_iterator<_Ty*>> {
 _STL_RESTORE_DEPRECATED_WARNING
 _STD_END
 #endif // _HAS_CXX20
+
+// TRANSITION, vNext
+#pragma pop_macro("unchecked_array_iterator")
+#pragma pop_macro("make_unchecked_array_iterator")
+#pragma pop_macro("make_checked_array_iterator")
+#pragma pop_macro("checked_array_iterator")
 
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -1467,7 +1467,6 @@ struct iterator_traits<counted_iterator<_Iter>> : iterator_traits<_Iter> {
 
 _STD_END
 
-// TRANSITION, vNext
 #pragma push_macro("stdext")
 #pragma push_macro("checked_array_iterator")
 #pragma push_macro("make_checked_array_iterator")
@@ -1869,7 +1868,6 @@ _STL_RESTORE_DEPRECATED_WARNING
 _STD_END
 #endif // _HAS_CXX20
 
-// TRANSITION, vNext
 #pragma pop_macro("unchecked_array_iterator")
 #pragma pop_macro("make_unchecked_array_iterator")
 #pragma pop_macro("make_checked_array_iterator")

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -1468,10 +1468,12 @@ struct iterator_traits<counted_iterator<_Iter>> : iterator_traits<_Iter> {
 _STD_END
 
 // TRANSITION, vNext
+#pragma push_macro("stdext")
 #pragma push_macro("checked_array_iterator")
 #pragma push_macro("make_checked_array_iterator")
 #pragma push_macro("make_unchecked_array_iterator")
 #pragma push_macro("unchecked_array_iterator")
+#undef stdext
 #undef checked_array_iterator
 #undef make_checked_array_iterator
 #undef make_unchecked_array_iterator
@@ -1872,6 +1874,7 @@ _STD_END
 #pragma pop_macro("make_unchecked_array_iterator")
 #pragma pop_macro("make_checked_array_iterator")
 #pragma pop_macro("checked_array_iterator")
+#pragma pop_macro("stdext")
 
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -136,6 +136,10 @@ public:
         bool _Ok; // true if stream state okay at construction
     };
 
+#pragma push_macro("opfx")
+#pragma push_macro("osfx")
+#undef opfx
+#undef osfx
     // TRANSITION, ABI: non-Standard opfx() is preserved for binary compatibility
     _DEPRECATE_IO_PFX_SFX bool __CLR_OR_THIS_CALL opfx() { // test stream state and flush tie stream as needed
         if (!this->good()) {
@@ -155,6 +159,8 @@ public:
     _DEPRECATE_IO_PFX_SFX void __CLR_OR_THIS_CALL osfx() noexcept { // perform any wrapup
         _Osfx();
     }
+#pragma pop_macro("osfx")
+#pragma pop_macro("opfx")
 
     void __CLR_OR_THIS_CALL _Osfx() noexcept { // perform any wrapup
         _TRY_BEGIN

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -24,6 +24,20 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+// TRANSITION, GH-183
+#pragma push_macro("discard_block")
+#pragma push_macro("linear_congruential")
+#pragma push_macro("mersenne_twister")
+#pragma push_macro("subtract_with_carry")
+#pragma push_macro("uniform_int")
+#pragma push_macro("uniform_real")
+#undef discard_block
+#undef linear_congruential
+#undef mersenne_twister
+#undef subtract_with_carry
+#undef uniform_int
+#undef uniform_real
+
 #ifdef _ALLOW_RANDOM_DISTRIBUTION_CONST_OPERATOR
 #define _DISTRIBUTION_CONST const
 #else
@@ -5369,6 +5383,14 @@ _STD_END
 
 #undef _NRAND
 #undef _DISTRIBUTION_CONST
+
+// TRANSITION, GH-183
+#pragma pop_macro("uniform_real")
+#pragma pop_macro("uniform_int")
+#pragma pop_macro("subtract_with_carry")
+#pragma pop_macro("mersenne_twister")
+#pragma pop_macro("linear_congruential")
+#pragma pop_macro("discard_block")
 
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/stl/inc/typeindex
+++ b/stl/inc/typeindex
@@ -45,7 +45,10 @@ public:
             return strong_ordering::equal;
         }
 
+#pragma push_macro("raw_name") // TRANSITION, GH-2195
+#undef raw_name
         return _CSTD strcmp(_Tptr->raw_name() + 1, _Right._Tptr->raw_name() + 1) <=> 0;
+#pragma pop_macro("raw_name")
     }
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
     _NODISCARD bool operator!=(const type_index& _Right) const noexcept {

--- a/stl/inc/typeinfo
+++ b/stl/inc/typeinfo
@@ -18,7 +18,10 @@ _STL_DISABLE_CLANG_WARNINGS
 
 #pragma warning(disable : 4275) // non dll-interface class 'X' used as base for dll-interface class 'Y'
 
+#pragma push_macro("raw_name") // TRANSITION, GH-2195
+#undef raw_name
 #include <vcruntime_typeinfo.h>
+#pragma pop_macro("raw_name")
 
 _EXPORT_STD extern "C++" class type_info; // for typeid, MSVC looks for type_info in the global namespace
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1980,6 +1980,8 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 #define _RANGES ::std::ranges::
 
 // We use the stdext (standard extension) namespace to contain extensions that are not part of the current standard
+#pragma push_macro("stdext") // Conforming C++ code may `#define stdext`, so we should push & pop it.
+#undef stdext
 #define _STDEXT_BEGIN      \
     _EXTERN_CXX_WORKAROUND \
     namespace stdext {
@@ -1988,6 +1990,7 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
     _END_EXTERN_CXX_WORKAROUND
 
 #define _STDEXT ::stdext::
+#pragma pop_macro("stdext")
 
 #define _CSTD ::
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1979,8 +1979,8 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 #define _CHRONO ::std::chrono::
 #define _RANGES ::std::ranges::
 
-// We use the stdext (standard extension) namespace to contain extensions that are not part of the current standard
-#pragma push_macro("stdext") // Conforming C++ code may `#define stdext`, so we should push & pop it.
+// We use the stdext (standard extension) namespace to contain non-standard extensions
+#pragma push_macro("stdext")
 #undef stdext
 #define _STDEXT_BEGIN      \
     _EXTERN_CXX_WORKAROUND \

--- a/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
@@ -72,15 +72,15 @@
 
 #if isfx != 1003
 #error bad macro expansion
-#endif // raw_name != 1003
+#endif // isfx != 1003
 
 #if opfx != 1004
 #error bad macro expansion
-#endif // raw_name != 1004
+#endif // opfx != 1004
 
 #if osfx != 1005
 #error bad macro expansion
-#endif // raw_name != 1005
+#endif // osfx != 1005
 
 #if checked_array_iterator != 1006
 #error bad macro expansion

--- a/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
@@ -7,6 +7,30 @@
 #define xtime            delete
 #define xtime_get        delete
 
+// Test workaround for extensions of non-reserved names that can't be removed at this moment.
+#define terminate_function  1001
+#define unexpected_function 1002
+
+#define raw_name 1003
+
+#define ipfx 1004
+#define isfx 1005
+
+#define opfx 1006
+#define osfx 1007
+
+#define checked_array_iterator        1008
+#define make_checked_array_iterator   1009
+#define make_unchecked_array_iterator 1010
+#define unchecked_array_iterator      1011
+
+#define discard_block       1012
+#define linear_congruential 1013
+#define mersenne_twister    1014
+#define subtract_with_carry 1015
+#define uniform_int         1016
+#define uniform_real        1017
+
 // Also test GH-2645: <yvals_core.h>: Conformance issue on [[msvc::known_semantics]]
 #define msvc            1
 #define known_semantics 2
@@ -40,3 +64,71 @@
 #if empty_bases != 6
 #error bad macro expansion
 #endif // empty_bases != 6
+
+#if terminate_function != 1001
+#error bad macro expansion
+#endif // terminate_function != 1001
+
+#if unexpected_function != 1002
+#error bad macro expansion
+#endif // unexpected_function != 1002
+
+#if raw_name != 1003
+#error bad macro expansion
+#endif // raw_name != 1003
+
+#if ipfx != 1004
+#error bad macro expansion
+#endif // ipfx != 1004
+
+#if isfx != 1005
+#error bad macro expansion
+#endif // raw_name != 1005
+
+#if opfx != 1006
+#error bad macro expansion
+#endif // raw_name != 1006
+
+#if osfx != 1007
+#error bad macro expansion
+#endif // raw_name != 1007
+
+#if checked_array_iterator != 1008
+#error bad macro expansion
+#endif // checked_array_iterator != 1008
+
+#if make_checked_array_iterator != 1009
+#error bad macro expansion
+#endif // make_checked_array_iterator != 1009
+
+#if make_unchecked_array_iterator != 1010
+#error bad macro expansion
+#endif // make_unchecked_array_iterator != 1010
+
+#if unchecked_array_iterator != 1011
+#error bad macro expansion
+#endif // unchecked_array_iterator != 1011
+
+#if discard_block != 1012
+#error bad macro expansion
+#endif // discard_block != 1012
+
+#if linear_congruential != 1013
+#error bad macro expansion
+#endif // linear_congruential != 1013
+
+#if mersenne_twister != 1014
+#error bad macro expansion
+#endif // mersenne_twister != 1014
+
+#if subtract_with_carry != 1015
+#error bad macro expansion
+#endif // subtract_with_carry != 1015
+
+#if uniform_int != 1016
+#error bad macro expansion
+#endif // uniform_int != 1016
+
+#if uniform_real != 1017
+#error bad macro expansion
+#endif // uniform_real != 1017

--- a/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
@@ -8,28 +8,25 @@
 #define xtime_get        delete
 
 // Test workaround for extensions of non-reserved names that can't be removed at this moment.
-#define terminate_function  1001
-#define unexpected_function 1002
+#define raw_name 1001
 
-#define raw_name 1003
+#define ipfx 1002
+#define isfx 1003
 
-#define ipfx 1004
-#define isfx 1005
+#define opfx 1004
+#define osfx 1005
 
-#define opfx 1006
-#define osfx 1007
+#define checked_array_iterator        1006
+#define make_checked_array_iterator   1007
+#define make_unchecked_array_iterator 1008
+#define unchecked_array_iterator      1009
 
-#define checked_array_iterator        1008
-#define make_checked_array_iterator   1009
-#define make_unchecked_array_iterator 1010
-#define unchecked_array_iterator      1011
-
-#define discard_block       1012
-#define linear_congruential 1013
-#define mersenne_twister    1014
-#define subtract_with_carry 1015
-#define uniform_int         1016
-#define uniform_real        1017
+#define discard_block       1010
+#define linear_congruential 1011
+#define mersenne_twister    1012
+#define subtract_with_carry 1013
+#define uniform_int         1014
+#define uniform_real        1015
 
 // Also test GH-2645: <yvals_core.h>: Conformance issue on [[msvc::known_semantics]]
 #define msvc            1
@@ -65,70 +62,62 @@
 #error bad macro expansion
 #endif // empty_bases != 6
 
-#if terminate_function != 1001
+#if raw_name != 1001
 #error bad macro expansion
-#endif // terminate_function != 1001
+#endif // raw_name != 1001
 
-#if unexpected_function != 1002
+#if ipfx != 1002
 #error bad macro expansion
-#endif // unexpected_function != 1002
+#endif // ipfx != 1002
 
-#if raw_name != 1003
+#if isfx != 1003
 #error bad macro expansion
 #endif // raw_name != 1003
 
-#if ipfx != 1004
+#if opfx != 1004
 #error bad macro expansion
-#endif // ipfx != 1004
+#endif // raw_name != 1004
 
-#if isfx != 1005
+#if osfx != 1005
 #error bad macro expansion
 #endif // raw_name != 1005
 
-#if opfx != 1006
+#if checked_array_iterator != 1006
 #error bad macro expansion
-#endif // raw_name != 1006
+#endif // checked_array_iterator != 1006
 
-#if osfx != 1007
+#if make_checked_array_iterator != 1007
 #error bad macro expansion
-#endif // raw_name != 1007
+#endif // make_checked_array_iterator != 1007
 
-#if checked_array_iterator != 1008
+#if make_unchecked_array_iterator != 1008
 #error bad macro expansion
-#endif // checked_array_iterator != 1008
+#endif // make_unchecked_array_iterator != 1008
 
-#if make_checked_array_iterator != 1009
+#if unchecked_array_iterator != 1009
 #error bad macro expansion
-#endif // make_checked_array_iterator != 1009
+#endif // unchecked_array_iterator != 1009
 
-#if make_unchecked_array_iterator != 1010
+#if discard_block != 1010
 #error bad macro expansion
-#endif // make_unchecked_array_iterator != 1010
+#endif // discard_block != 1010
 
-#if unchecked_array_iterator != 1011
+#if linear_congruential != 1011
 #error bad macro expansion
-#endif // unchecked_array_iterator != 1011
+#endif // linear_congruential != 1011
 
-#if discard_block != 1012
+#if mersenne_twister != 1012
 #error bad macro expansion
-#endif // discard_block != 1012
+#endif // mersenne_twister != 1012
 
-#if linear_congruential != 1013
+#if subtract_with_carry != 1013
 #error bad macro expansion
-#endif // linear_congruential != 1013
+#endif // subtract_with_carry != 1013
 
-#if mersenne_twister != 1014
+#if uniform_int != 1014
 #error bad macro expansion
-#endif // mersenne_twister != 1014
+#endif // uniform_int != 1014
 
-#if subtract_with_carry != 1015
+#if uniform_real != 1015
 #error bad macro expansion
-#endif // subtract_with_carry != 1015
-
-#if uniform_int != 1016
-#error bad macro expansion
-#endif // uniform_int != 1016
-
-#if uniform_real != 1017
-#error bad macro expansion
-#endif // uniform_real != 1017
+#endif // uniform_real != 1015


### PR DESCRIPTION
Towards #2206. The posted example should compile with the changes landed when pre-standard hash containers are disabled.

- Not sure how to test `stdext`, because `<__msvc_all_public_headers.hpp>` is currently including non-Standard `<hash_map>` & `<hash_set>`.
- `<arm64_neon.h>` (which is surprisingly heavy), `<ppltasks.h>`, and UCRT stuffs are not handled currently.

Some extensions may become conforming with deprecation warnings enabled, others are not yet because they're visible via SFINAE.