### PR TITLE
All atomic exchanges with _Api_level should be acq_rel

### DIFF
--- a/stl/src/atomic_wait.cpp
+++ b/stl/src/atomic_wait.cpp
@@ -119,7 +119,8 @@ namespace {
     void _Force_wait_functions_srwlock_only() noexcept {
         auto _Local = _Wait_functions._Api_level.load(_STD memory_order_acquire);
         if (_Local <= __std_atomic_api_level::__detecting) {
-            while (!_Wait_functions._Api_level.compare_exchange_weak(_Local, __std_atomic_api_level::__has_srwlock)) {
+            while (!_Wait_functions._Api_level.compare_exchange_weak(
+                _Local, __std_atomic_api_level::__has_srwlock, _STD memory_order_acq_rel)) {
                 if (_Local > __std_atomic_api_level::__detecting) {
                     return;
                 }
@@ -128,7 +129,8 @@ namespace {
     }
 
     [[nodiscard]] __std_atomic_api_level _Init_wait_functions(__std_atomic_api_level _Level) {
-        while (!_Wait_functions._Api_level.compare_exchange_weak(_Level, __std_atomic_api_level::__detecting)) {
+        while (!_Wait_functions._Api_level.compare_exchange_weak(
+            _Level, __std_atomic_api_level::__detecting, _STD memory_order_acq_rel)) {
             if (_Level > __std_atomic_api_level::__detecting) {
                 return _Level;
             }


### PR DESCRIPTION
As _Api_level is not always accessed with sequential ordering, and _Level is thread-local, acq_rel is good enough for all compare_exchange successes. However, this means we need to explicitly mention acquire for the failure case.