### PR TITLE
`<memory>`: Fix constraints of `shared_ptr`'s constructors when the involved pointer type would be invalid

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1469,15 +1469,26 @@ struct _SP_convertible : is_convertible<_Yty*, _Ty*>::type {};
 
 template <class _Yty, class _Uty, class _Void>
 struct _SP_convertible<_Yty, _Uty[], _Void> : false_type {};
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10548086
+template <class _Yty, class _Uty>
+struct _SP_convertible<_Yty, _Uty[], void_t<_Yty (*)[]>> : is_convertible<_Yty (*)[], _Uty (*)[]>::type {};
+#else // ^^^ no workaround / workaround vvv
 template <class _Yty, class _Uty>
 struct _SP_convertible<_Yty, _Uty[], void_t<decltype(static_cast<_Yty (*)[]>(nullptr))>>
     : is_convertible<_Yty (*)[], _Uty (*)[]>::type {};
+#endif // ^^^ workaround ^^^
 
 template <class _Yty, class _Uty, size_t _Ext, class _Void>
 struct _SP_convertible<_Yty, _Uty[_Ext], _Void> : false_type {};
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10548086
+template <class _Yty, class _Uty, size_t _Ext>
+struct _SP_convertible<_Yty, _Uty[_Ext], void_t<_Yty (*)[_Ext]>>
+    : is_convertible<_Yty (*)[_Ext], _Uty (*)[_Ext]>::type {};
+#else // ^^^ no workaround / workaround vvv
 template <class _Yty, class _Uty, size_t _Ext>
 struct _SP_convertible<_Yty, _Uty[_Ext], void_t<decltype(static_cast<_Yty (*)[_Ext]>(nullptr))>>
     : is_convertible<_Yty (*)[_Ext], _Uty (*)[_Ext]>::type {};
+#endif // ^^^ workaround ^^^
 
 template <class _Yty, class _Ty>
 struct _SP_pointer_compatible : is_convertible<_Yty*, _Ty*>::type {

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1464,12 +1464,20 @@ struct _Can_call_function_object : false_type {};
 template <class _Fx, class _Arg>
 struct _Can_call_function_object<_Fx, _Arg, void_t<decltype(_STD declval<_Fx>()(_STD declval<_Arg>()))>> : true_type {};
 
-template <class _Yty, class _Ty>
+template <class _Yty, class _Ty, class = void>
 struct _SP_convertible : is_convertible<_Yty*, _Ty*>::type {};
+
+template <class _Yty, class _Uty, class _Void>
+struct _SP_convertible<_Yty, _Uty[], _Void> : false_type {};
 template <class _Yty, class _Uty>
-struct _SP_convertible<_Yty, _Uty[]> : is_convertible<_Yty (*)[], _Uty (*)[]>::type {};
+struct _SP_convertible<_Yty, _Uty[], void_t<decltype(static_cast<_Yty (*)[]>(nullptr))>>
+    : is_convertible<_Yty (*)[], _Uty (*)[]>::type {};
+
+template <class _Yty, class _Uty, size_t _Ext, class _Void>
+struct _SP_convertible<_Yty, _Uty[_Ext], _Void> : false_type {};
 template <class _Yty, class _Uty, size_t _Ext>
-struct _SP_convertible<_Yty, _Uty[_Ext]> : is_convertible<_Yty (*)[_Ext], _Uty (*)[_Ext]>::type {};
+struct _SP_convertible<_Yty, _Uty[_Ext], void_t<decltype(static_cast<_Yty (*)[_Ext]>(nullptr))>>
+    : is_convertible<_Yty (*)[_Ext], _Uty (*)[_Ext]>::type {};
 
 template <class _Yty, class _Ty>
 struct _SP_pointer_compatible : is_convertible<_Yty*, _Ty*>::type {

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1231,12 +1231,6 @@ std/strings/char.traits/char.traits.specializations/char.traits.specializations.
 # The Standard depicts `atomic& operator=(const atomic&) volatile = delete;` which we seem to be missing.
 std/atomics/atomics.types.generic/atomics.types.float/copy.compile.pass.cpp FAIL
 
-# Not analyzed.
-# MSVC error C2087: 'abstract declarator': missing subscript
-# Clang error: array has incomplete element type 'int[]'
-std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/pointer.pass.cpp FAIL
-std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.mod/reset_pointer.pass.cpp FAIL
-
 # Not analyzed. SKIPPED because this is x86-specific, fatal error C1060: compiler is out of heap space
 std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.iterator.pass.cpp:0 SKIPPED
 std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.iterator.pass.cpp:1 SKIPPED


### PR DESCRIPTION
There are weird things in [[util.smartptr.shared.const]/3](https://eel.is/c++draft/util.smartptr.shared.const#3) and [[util.smartptr.shared.const]/9.1](https://eel.is/c++draft/util.smartptr.shared.const#9.1): `Y(*)[N]` or `Y(*)[]` is not necessary a valid type, e.g. when `Y` is `T[]` or a function type, which means that the constraints themselves can be sometimes ill-formed.

Presumably there should be substitution failures in such cases (instead of hard errors or UB/IFNDR). I've tried to submit an LWG issue for this.

`void_t<decltype(static_cast<_Yty (*)[]>(nullptr))>` works while `void_t<_Yty (*)[]>` doesn't for MSVC. Reported DevCom-10548086.

Unblocks 2 libcxx tests:
- `std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/pointer.pass.cpp`
- `std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.mod/reset_pointer.pass.cpp`