### PR TITLE
Fix an issue in the special snowflake windows version of the STL

### DIFF
--- a/stl/inc/xthreads.h
+++ b/stl/inc/xthreads.h
@@ -34,6 +34,7 @@ struct _Stl_critical_section {
 
 struct _Mtx_internal_imp_t {
 #if defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT)
+#pragma detect_mismatch("_CRT_WINDOWS_mutex_size", "1")
 #ifdef _WIN64
     static constexpr size_t _Critical_section_size = 16;
 #else // ^^^ defined(_WIN64) / !defined(_WIN64) vvv
@@ -41,12 +42,14 @@ struct _Mtx_internal_imp_t {
 #endif // ^^^ !defined(_WIN64) ^^^
 #else // ^^^ defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT) / !defined(_CRT_WINDOWS) ||
       // defined(UNDOCKED_WINDOWS_UCRT) vvv
+#pragma detect_mismatch("_CRT_WINDOWS_mutex_size", "0")
 #ifdef _WIN64
     static constexpr size_t _Critical_section_size = 64;
 #else // ^^^ defined(_WIN64) / !defined(_WIN64) vvv
     static constexpr size_t _Critical_section_size = 36;
 #endif // ^^^ !defined(_WIN64) ^^^
 #endif // ^^^ !defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT) ^^^
+
 
     static constexpr size_t _Critical_section_align = alignof(void*);
 

--- a/stl/inc/xthreads.h
+++ b/stl/inc/xthreads.h
@@ -32,23 +32,26 @@ struct _Stl_critical_section {
     _Smtx_t _M_srw_lock = nullptr;
 };
 
+#if defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT)
+#pragma detect_mismatch("windows_mutex", "1")
+#else // ^^^ Windows private STL / public STL vvv
+#pragma detect_mismatch("windows_mutex", "0")
+#endif // ^^^ public STL ^^^
+
 struct _Mtx_internal_imp_t {
 #if defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT)
-#pragma detect_mismatch("_CRT_WINDOWS_mutex_size", "1")
 #ifdef _WIN64
     static constexpr size_t _Critical_section_size = 16;
 #else // ^^^ defined(_WIN64) / !defined(_WIN64) vvv
     static constexpr size_t _Critical_section_size = 8;
 #endif // ^^^ !defined(_WIN64) ^^^
-#else // ^^^ defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT) / !defined(_CRT_WINDOWS) ||
-      // defined(UNDOCKED_WINDOWS_UCRT) vvv
-#pragma detect_mismatch("_CRT_WINDOWS_mutex_size", "0")
+#else // ^^^ Windows private STL / public STL vvv
 #ifdef _WIN64
     static constexpr size_t _Critical_section_size = 64;
 #else // ^^^ defined(_WIN64) / !defined(_WIN64) vvv
     static constexpr size_t _Critical_section_size = 36;
 #endif // ^^^ !defined(_WIN64) ^^^
-#endif // ^^^ !defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT) ^^^
+#endif // ^^^ public STL ^^^
 
 
     static constexpr size_t _Critical_section_align = alignof(void*);

--- a/stl/inc/xthreads.h
+++ b/stl/inc/xthreads.h
@@ -33,19 +33,20 @@ struct _Stl_critical_section {
 };
 
 struct _Mtx_internal_imp_t {
-#ifdef _CRT_WINDOWS
+#if defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT)
 #ifdef _WIN64
     static constexpr size_t _Critical_section_size = 16;
 #else // ^^^ defined(_WIN64) / !defined(_WIN64) vvv
     static constexpr size_t _Critical_section_size = 8;
 #endif // ^^^ !defined(_WIN64) ^^^
-#else // ^^^ defined(_CRT_WINDOWS) / !defined(_CRT_WINDOWS) vvv
+#else // ^^^ defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT) / !defined(_CRT_WINDOWS) ||
+      // defined(UNDOCKED_WINDOWS_UCRT) vvv
 #ifdef _WIN64
     static constexpr size_t _Critical_section_size = 64;
 #else // ^^^ defined(_WIN64) / !defined(_WIN64) vvv
     static constexpr size_t _Critical_section_size = 36;
 #endif // ^^^ !defined(_WIN64) ^^^
-#endif // ^^^ !defined(_CRT_WINDOWS) ^^^
+#endif // ^^^ !defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT) ^^^
 
     static constexpr size_t _Critical_section_align = alignof(void*);
 


### PR DESCRIPTION
We change the size of critical sections based on `_CRT_WINDOWS`, but that macro is defined at build time only, and the size is relevant in our headers. We need to change the size based on `UNDOCKED_WINDOWS_UCRT` as well, which is defined in consumers. 

I've added a pragma detect mismatch as well, but as its own commit. If we don't want it we don't have to accept that commit.