### PR TITLE
Drop `#pragma detect_mismatch` for `mutex` size

### DIFF
--- a/stl/inc/xthreads.h
+++ b/stl/inc/xthreads.h
@@ -32,12 +32,6 @@ struct _Stl_critical_section {
     _Smtx_t _M_srw_lock = nullptr;
 };
 
-#if defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT)
-#pragma detect_mismatch("windows_mutex", "1")
-#else // ^^^ Windows private STL / public STL vvv
-#pragma detect_mismatch("windows_mutex", "0")
-#endif // ^^^ public STL ^^^
-
 struct _Mtx_internal_imp_t {
 #if defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT)
 #ifdef _WIN64
@@ -52,7 +46,6 @@ struct _Mtx_internal_imp_t {
     static constexpr size_t _Critical_section_size = 36;
 #endif // ^^^ !defined(_WIN64) ^^^
 #endif // ^^^ public STL ^^^
-
 
     static constexpr size_t _Critical_section_align = alignof(void*);
 


### PR DESCRIPTION
Followup to #4294.

In theory, this `#pragma detect_mismatch` was a good thing. In practice, it causes ~200 directories to fail with linker errors in the Windows build. That's too many to feasibly deal with on short notice, even if we added an escape hatch, so we should simply drop this attempt to detect mismatch. (The change was originally tested in Windows in December without `detect_mismatch`.)

The net effect of #4294 and this PR is to make `_Critical_section_size` additionally sensitive to `UNDOCKED_WINDOWS_UCRT`. This should be a strict improvement, reducing mismatches between the headers and separately compiled code (we know for a fact that this was causing problems). If these ~200 directories are mixing TUs with varying settings of `UNDOCKED_WINDOWS_UCRT`, then depending on linker behavior that might prevent this fix from taking effect, but it shouldn't make things worse compared to the state before #4294.

If we continue to have problems in this area, we may need to consider removing the Windows special case for `mutex` entirely (according to my understanding, we could do that because Windows is always built fresh with its LKG toolset, so it doesn't actually care about ABI stability here). That would increase `mutex` size, of course, but we've ripped out the other inefficiencies (virtual calls etc.), so the potential performance impact would be less than it previously would have been.