### PR TITLE
Toolset update: Jan 2024 Patch Tuesday

### DIFF
--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,7 +5,7 @@
 
 variables:
 - name: poolName
-  value: 'StlBuild-2023-12-12T1453-Pool'
+  value: 'StlBuild-2024-01-09T1215-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals true'


### PR DESCRIPTION
Today is Patch Tuesday, but due to the holidays there's no new VS Preview (and VS 2022 17.9 Preview 3 won't contain significant MSVC toolset changes anyways). As there are no other dependency updates, this is one line.

As usual, I verified that this actually picked up the Patch Tuesday OS, since occasionally there are delays in the VM image becoming available. (The wiki has a PowerShell incantation that reports whether Patch Tuesday is available as a VM image, then the script prints out `winver` to confirm what was picked up.)