### PR TITLE
Adjusted behavior of filesystem::is_empty and filesystem::directory_iterator to work with empty volumes

### DIFF
--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -2505,7 +2505,7 @@ namespace filesystem {
     _EXPORT_STD enum class directory_options { none = 0, follow_directory_symlink = 1, skip_permission_denied = 2 };
     _BITMASK_OPS(_EXPORT_STD, directory_options)
 
-    _EXPORT_STD _NODISCARD inline bool exists(const path& _Target);
+    _EXPORT_STD _NODISCARD inline bool exists(const path& _Target, error_code& _Ec) noexcept;
 
     struct _Dir_enum_impl {
         _NODISCARD static __std_win_error _Advance_and_reset_if_no_more_files(shared_ptr<_Dir_enum_impl>& _Ptr) {
@@ -2545,6 +2545,7 @@ namespace filesystem {
                 return __std_win_error::_File_not_found;
             }
 
+            const path _Original_path = _Path;
             _Path /= L"*"sv;
             auto _Error = _Dir._Open(_Path.c_str(), &_Data);
             if (_Error == __std_win_error::_Success) {
@@ -2554,9 +2555,13 @@ namespace filesystem {
             if (_Error == __std_win_error::_Access_denied
                 && _Bitmask_includes_any(_Options_arg, directory_options::skip_permission_denied)) {
                 _Error = __std_win_error::_No_more_files;
-            } else if (_Error == __std_win_error::_File_not_found
-                       && exists(std::wstring_view(_Path.c_str(), _Path.native().length() - 1))) {
-                _Error = __std_win_error::_No_more_files;
+            } else if (_Error == __std_win_error::_File_not_found) {
+                error_code _Ignored; // When exists() returns true, that implies that the error_code is successful.
+                // When exists() returns false, we don't want to interfere with _Open_dir()'s behavior,
+                // as it's going to return __std_win_error::_File_not_found.
+                if (_STD filesystem::exists(_Original_path, _Ignored)) {
+                    _Error = __std_win_error::_No_more_files; // Handle empty volumes, see GH-4291
+                }
             }
 
             return _Error;

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -2538,15 +2538,15 @@ namespace filesystem {
             return __std_win_error::_Success;
         }
 
-        _NODISCARD static __std_win_error _Open_dir(path& _Path, const directory_options _Options_arg,
-            _Find_file_handle& _Dir, __std_fs_find_data& _Data) {
+        _NODISCARD static __std_win_error _Open_dir(
+            path& _Path, const directory_options _Options_arg, _Find_file_handle& _Dir, __std_fs_find_data& _Data) {
             const size_t _Null_term_len = _CSTD wcslen(_Path.c_str());
             if (_Null_term_len == 0 || _Null_term_len != _Path.native().size()) {
                 return __std_win_error::_File_not_found;
             }
 
             _Path /= L"*"sv;
-            auto _Error           = _Dir._Open(_Path.c_str(), &_Data);
+            auto _Error = _Dir._Open(_Path.c_str(), &_Data);
             if (_Error == __std_win_error::_Success) {
                 return _Skip_dots(_Dir._Handle, _Data);
             }
@@ -2554,7 +2554,8 @@ namespace filesystem {
             if (_Error == __std_win_error::_Access_denied
                 && _Bitmask_includes_any(_Options_arg, directory_options::skip_permission_denied)) {
                 _Error = __std_win_error::_No_more_files;
-            } else if (_Error == __std_win_error::_File_not_found && exists(std::wstring_view(_Path.c_str(), _Path.native().length() - 1))) {
+            } else if (_Error == __std_win_error::_File_not_found
+                       && exists(std::wstring_view(_Path.c_str(), _Path.native().length() - 1))) {
                 _Error = __std_win_error::_No_more_files;
             }
 

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -2505,6 +2505,8 @@ namespace filesystem {
     _EXPORT_STD enum class directory_options { none = 0, follow_directory_symlink = 1, skip_permission_denied = 2 };
     _BITMASK_OPS(_EXPORT_STD, directory_options)
 
+    _EXPORT_STD _NODISCARD inline bool exists(const path& _Target);
+
     struct _Dir_enum_impl {
         _NODISCARD static __std_win_error _Advance_and_reset_if_no_more_files(shared_ptr<_Dir_enum_impl>& _Ptr) {
             auto& _Impl = *_Ptr;
@@ -2537,20 +2539,23 @@ namespace filesystem {
         }
 
         _NODISCARD static __std_win_error _Open_dir(
-            path& _Path, const directory_options _Options_arg, _Find_file_handle& _Dir, __std_fs_find_data& _Data) {
+            const path& _Path, const directory_options _Options_arg, _Find_file_handle& _Dir, __std_fs_find_data& _Data) {
             const size_t _Null_term_len = _CSTD wcslen(_Path.c_str());
             if (_Null_term_len == 0 || _Null_term_len != _Path.native().size()) {
                 return __std_win_error::_File_not_found;
             }
 
-            _Path /= L"*"sv;
-            auto _Error = _Dir._Open(_Path.c_str(), &_Data);
+            const path _Path_spec = _Path / L"*"sv;
+            auto _Error = _Dir._Open(_Path_spec.c_str(), &_Data);
             if (_Error == __std_win_error::_Success) {
                 return _Skip_dots(_Dir._Handle, _Data);
             }
 
             if (_Error == __std_win_error::_Access_denied
                 && _Bitmask_includes_any(_Options_arg, directory_options::skip_permission_denied)) {
+                _Error = __std_win_error::_No_more_files;
+            } else if (_Error == __std_win_error::_File_not_found
+                       && exists(_Path)) {
                 _Error = __std_win_error::_No_more_files;
             }
 

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -2538,15 +2538,15 @@ namespace filesystem {
             return __std_win_error::_Success;
         }
 
-        _NODISCARD static __std_win_error _Open_dir(
-            const path& _Path, const directory_options _Options_arg, _Find_file_handle& _Dir, __std_fs_find_data& _Data) {
+        _NODISCARD static __std_win_error _Open_dir(const path& _Path, const directory_options _Options_arg,
+            _Find_file_handle& _Dir, __std_fs_find_data& _Data) {
             const size_t _Null_term_len = _CSTD wcslen(_Path.c_str());
             if (_Null_term_len == 0 || _Null_term_len != _Path.native().size()) {
                 return __std_win_error::_File_not_found;
             }
 
             const path _Path_spec = _Path / L"*"sv;
-            auto _Error = _Dir._Open(_Path_spec.c_str(), &_Data);
+            auto _Error           = _Dir._Open(_Path_spec.c_str(), &_Data);
             if (_Error == __std_win_error::_Success) {
                 return _Skip_dots(_Dir._Handle, _Data);
             }
@@ -2554,8 +2554,7 @@ namespace filesystem {
             if (_Error == __std_win_error::_Access_denied
                 && _Bitmask_includes_any(_Options_arg, directory_options::skip_permission_denied)) {
                 _Error = __std_win_error::_No_more_files;
-            } else if (_Error == __std_win_error::_File_not_found
-                       && exists(_Path)) {
+            } else if (_Error == __std_win_error::_File_not_found && exists(_Path)) {
                 _Error = __std_win_error::_No_more_files;
             }
 

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -2538,15 +2538,15 @@ namespace filesystem {
             return __std_win_error::_Success;
         }
 
-        _NODISCARD static __std_win_error _Open_dir(const path& _Path, const directory_options _Options_arg,
+        _NODISCARD static __std_win_error _Open_dir(path& _Path, const directory_options _Options_arg,
             _Find_file_handle& _Dir, __std_fs_find_data& _Data) {
             const size_t _Null_term_len = _CSTD wcslen(_Path.c_str());
             if (_Null_term_len == 0 || _Null_term_len != _Path.native().size()) {
                 return __std_win_error::_File_not_found;
             }
 
-            const path _Path_spec = _Path / L"*"sv;
-            auto _Error           = _Dir._Open(_Path_spec.c_str(), &_Data);
+            _Path /= L"*"sv;
+            auto _Error           = _Dir._Open(_Path.c_str(), &_Data);
             if (_Error == __std_win_error::_Success) {
                 return _Skip_dots(_Dir._Handle, _Data);
             }
@@ -2554,7 +2554,7 @@ namespace filesystem {
             if (_Error == __std_win_error::_Access_denied
                 && _Bitmask_includes_any(_Options_arg, directory_options::skip_permission_denied)) {
                 _Error = __std_win_error::_No_more_files;
-            } else if (_Error == __std_win_error::_File_not_found && exists(_Path)) {
+            } else if (_Error == __std_win_error::_File_not_found && exists(std::wstring_view(_Path.c_str(), _Path.native().length() - 1))) {
                 _Error = __std_win_error::_No_more_files;
             }
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -34,6 +34,9 @@ std/strings/basic.string/string.modifiers/string_assign/string.pass.cpp:2 FAIL
 std/utilities/memory/specialized.algorithms/uninitialized.copy/uninitialized_copy.pass.cpp FAIL
 std/utilities/memory/specialized.algorithms/uninitialized.move/uninitialized_move.pass.cpp FAIL
 
+# LLVM-75611: [libc++] views::take behaves incorrectly for iota_view
+std/ranges/range.adaptors/range.take/adaptor.pass.cpp FAIL
+
 # Non-Standard regex behavior.
 # "It seems likely that the test is still non-conforming due to how libc++ handles the 'w' character class."
 std/re/re.traits/lookup_classname.pass.cpp FAIL
@@ -62,6 +65,7 @@ std/utilities/template.bitset/bitset.cons/string_ctor.pass.cpp FAIL
 # Tests with undefined behavior under N4842 [basic.start.term]/6 (detached threads)
 std/thread/futures/futures.task/futures.task.members/dtor.pass.cpp SKIPPED
 std/thread/futures/futures.unique_future/wait_until.pass.cpp SKIPPED
+std/thread/thread.jthread/detach.pass.cpp SKIPPED
 
 # libcxx is incorrect on what the type passed to allocator::construct should be (LLVM-D61364)
 std/containers/associative/map/map.modifiers/insert_and_emplace_allocator_requirements.pass.cpp FAIL
@@ -1026,11 +1030,6 @@ std/iterators/predef.iterators/move.iterators/move.iter.ops/move.iter.op.comp/op
 # Not analyzed. error C2280: 'std::ranges::lazy_split_view<InputView,ForwardTinyView>::lazy_split_view(const std::ranges::lazy_split_view<InputView,ForwardTinyView> &)': attempting to reference a deleted function
 std/ranges/range.adaptors/range.lazy.split/ctor.copy_move.pass.cpp FAIL
 std/ranges/range.adaptors/range.lazy.split/range.lazy.split.inner/iter_swap.pass.cpp FAIL
-
-# Not analyzed.
-# error: deduced type 'iota_view<_Vt, _Vt>' (aka 'iota_view<int, int>') does not satisfy 'same_as<Result>'
-# note: because '_Same_impl<std::ranges::iota_view<int, int>, std::ranges::iota_view<int, long long> >' evaluated to false
-std/ranges/range.adaptors/range.take/adaptor.pass.cpp FAIL
 
 # Not analyzed. Checking whether packaged_task is constructible from an allocator and a packaged_task of a different type.
 std/thread/futures/futures.task/futures.task.members/ctor2.compile.pass.cpp FAIL


### PR DESCRIPTION
The goal of the implementation was to fix #4291.

Following tables should explain the behavior of the current implementation in comparison to the changed code:

### filesystem::is_empty(...)

| Case       | `filesystem::exists(...)` | current implementation           | this implementation 
| ------------- |:---:|:-------------:| :-----:|
| empty volume<br/>`\\?\Volume{ecab883f-c728-474b-9b40-e90cb2834b66}\` | `true` | `ERROR` :bug: | `true` | 
| not existing volume<br/>`\\?\Volume{ecab883f-c728-474b-9b40-e90cb2834b65}\` | `false` | `ERROR` | `ERROR` | 

### filesystem::directory_iterator(...)

| Case       | `filesystem::exists(...)` | current implementation           | this implementation 
| ------------- |:---:|:-------------:| :-----:|
| empty volume<br/>`\\?\Volume{ecab883f-c728-474b-9b40-e90cb2834b66}\` | `true` | `ERROR` :bug: | `empty` | 
| not existing volume<br/>`\\?\Volume{ecab883f-c728-474b-9b40-e90cb2834b65}\` | `false` | `ERROR` | `ERROR` | 
