### PR TITLE
Support instrumenting the STL with ASan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ option(BUILD_TESTING "Enable testing" ON)
 set(VCLIBS_SUFFIX "_oss" CACHE STRING "suffix for built DLL names to avoid conflicts with distributed DLLs")
 
 option(STL_USE_ANALYZE "Pass the /analyze flag to MSVC" OFF)
+option(STL_ASAN_BUILD "Build the STL with ASan enabled" OFF)
 
 set(VCLIBS_EXPLICIT_MACHINE "")
 
@@ -117,10 +118,15 @@ set(VCLIBS_DEBUG_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:/Od>")
 # See GH-2108 for more info.
 set(VCLIBS_RELEASE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:/O2;/Os>")
 
-add_subdirectory(boost-math)
-add_subdirectory(stl)
-
 if(BUILD_TESTING)
     enable_testing()
     add_subdirectory(tests)
 endif()
+
+if(STL_ASAN_BUILD)
+    message(STATUS "Building with ASan enabled")
+    add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-fsanitize=address;-fno-sanitize-address-vcasan-lib>")
+endif()
+
+add_subdirectory(boost-math)
+add_subdirectory(stl)

--- a/azure-devops/asan-pipeline.yml
+++ b/azure-devops/asan-pipeline.yml
@@ -29,6 +29,7 @@ stages:
           targetPlatform: x64
           vsDevCmdArch: amd64
           buildBenchmarks: false
+          asanBuild: true
           testSelection: ${{ variables.testSelection }}
 
   - stage: Build_And_Test_x86
@@ -43,6 +44,7 @@ stages:
           targetPlatform: x86
           vsDevCmdArch: x86
           buildBenchmarks: false
+          asanBuild: true
           testSelection: ${{ variables.testSelection }}
 
   # no coverage for ARM and ARM64

--- a/azure-devops/cmake-configure-build.yml
+++ b/azure-devops/cmake-configure-build.yml
@@ -10,6 +10,9 @@ parameters:
   type: string
 - name: buildBenchmarks
   type: boolean
+- name: asanBuild
+  type: boolean
+  default: false
 - name: cmakeAdditionalFlags
   type: string
   default: ''
@@ -43,6 +46,7 @@ steps:
     -DCMAKE_BUILD_TYPE=Release ^
     -DLIT_FLAGS=${{ join(';', parameters.litFlags) }} ^
     -DSTL_USE_ANALYZE=ON ^
+    -DSTL_ASAN_BUILD=${{ parameters.asanBuild }} ^
     -S $(Build.SourcesDirectory) -B "$(buildOutputLocation)"
   displayName: 'Configure the STL'
   timeoutInMinutes: 2

--- a/azure-devops/cmake-configure-build.yml
+++ b/azure-devops/cmake-configure-build.yml
@@ -41,6 +41,7 @@ steps:
     )
     call "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\Common7\Tools\VsDevCmd.bat" ^
     -host_arch=${{ parameters.hostArch }} -arch=${{ parameters.targetArch }} -no_logo
+    echo "##[debug]cmake ${{ parameters.cmakeAdditionalFlags }} -G Ninja -DCMAKE_CXX_COMPILER=cl -DCMAKE_BUILD_TYPE=Release -DLIT_FLAGS=${{ join(';', parameters.litFlags) }} -DSTL_USE_ANALYZE=ON -DSTL_ASAN_BUILD=${{ parameters.asanBuild }} -S $(Build.SourcesDirectory) -B $(buildOutputLocation)"
     cmake ${{ parameters.cmakeAdditionalFlags }} -G Ninja ^
     -DCMAKE_CXX_COMPILER=cl ^
     -DCMAKE_BUILD_TYPE=Release ^

--- a/azure-devops/cmake-configure-build.yml
+++ b/azure-devops/cmake-configure-build.yml
@@ -41,7 +41,6 @@ steps:
     )
     call "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\Common7\Tools\VsDevCmd.bat" ^
     -host_arch=${{ parameters.hostArch }} -arch=${{ parameters.targetArch }} -no_logo
-    echo "##[debug]cmake ${{ parameters.cmakeAdditionalFlags }} -G Ninja -DCMAKE_CXX_COMPILER=cl -DCMAKE_BUILD_TYPE=Release -DLIT_FLAGS=${{ join(';', parameters.litFlags) }} -DSTL_USE_ANALYZE=ON -DSTL_ASAN_BUILD=${{ parameters.asanBuild }} -S $(Build.SourcesDirectory) -B $(buildOutputLocation)"
     cmake ${{ parameters.cmakeAdditionalFlags }} -G Ninja ^
     -DCMAKE_CXX_COMPILER=cl ^
     -DCMAKE_BUILD_TYPE=Release ^

--- a/azure-devops/native-build-test.yml
+++ b/azure-devops/native-build-test.yml
@@ -9,6 +9,9 @@ parameters:
 - name: buildBenchmarks
   type: boolean
   default: true
+- name: asanBuild
+  type: boolean
+  default: false
 - name: numShards
   type: number
   default: 8
@@ -35,6 +38,7 @@ jobs:
       targetArch: ${{ parameters.vsDevCmdArch }}
       hostArch: ${{ parameters.vsDevCmdArch }}
       buildBenchmarks: ${{ parameters.buildBenchmarks }}
+      asanBuild: ${{ parameters.asanBuild }}
   - template: run-tests.yml
     parameters:
       hostArch: ${{ parameters.vsDevCmdArch }}

--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -525,6 +525,12 @@ else()
     string(APPEND CMAKE_CXX_STANDARD_LIBRARIES " Synchronization.lib")
 endif()
 
+if(STL_ASAN_BUILD)
+    set(DLL_ASAN_SOURCES ${ASAN_SOURCES})
+else()
+    set(DLL_ASAN_SOURCES "")
+endif()
+
 function(target_stl_compile_options tgt rel_or_dbg)
     if(rel_or_dbg STREQUAL "Release")
         target_compile_options(${tgt} PRIVATE ${VCLIBS_RELEASE_OPTIONS})
@@ -562,7 +568,7 @@ function(add_stl_dlls D_SUFFIX REL_OR_DBG)
     set(gl_flag_Debug "")
 
     # msvcp140.dll
-    add_library(msvcp${D_SUFFIX}_objects OBJECT ${DLL_SOURCES} ${SOURCES})
+    add_library(msvcp${D_SUFFIX}_objects OBJECT ${DLL_SOURCES} ${SOURCES} ${DLL_ASAN_SOURCES})
     target_compile_definitions(msvcp${D_SUFFIX}_objects PRIVATE CRTDLL2 _DLL)
     target_compile_options(msvcp${D_SUFFIX}_objects PRIVATE ${gl_flag_${REL_OR_DBG}} /EHsc)
     target_stl_compile_options(msvcp${D_SUFFIX}_objects ${REL_OR_DBG})

--- a/tests/libcxx/lit.site.cfg.in
+++ b/tests/libcxx/lit.site.cfg.in
@@ -25,6 +25,7 @@ lit_config.library_dirs     = getattr(lit_config, 'library_dirs', dict())
 lit_config.test_subdirs     = getattr(lit_config, 'test_subdirs', dict())
 
 lit_config.expected_results[config.name] = stl.test.file_parsing.parse_result_file('@LIBCXX_EXPECTED_RESULTS@')
+# TRANSITION, VSO-1913897: '@STL_SOURCE_DIR@/tests/std/include' is a workaround
 lit_config.include_dirs[config.name]     = ['@STL_TESTED_HEADERS_DIR@', '@LIBCXX_SOURCE_DIR@/test/support', '@STL_SOURCE_DIR@/tests/std/include']
 lit_config.library_dirs[config.name]     = ['@STL_LIBRARY_OUTPUT_DIRECTORY@', '@TOOLSET_LIB@']
 lit_config.test_subdirs[config.name]     = ['@LIBCXX_SOURCE_DIR@/test/std']

--- a/tests/libcxx/lit.site.cfg.in
+++ b/tests/libcxx/lit.site.cfg.in
@@ -25,7 +25,7 @@ lit_config.library_dirs     = getattr(lit_config, 'library_dirs', dict())
 lit_config.test_subdirs     = getattr(lit_config, 'test_subdirs', dict())
 
 lit_config.expected_results[config.name] = stl.test.file_parsing.parse_result_file('@LIBCXX_EXPECTED_RESULTS@')
-lit_config.include_dirs[config.name]     = ['@STL_TESTED_HEADERS_DIR@', '@LIBCXX_SOURCE_DIR@/test/support']
+lit_config.include_dirs[config.name]     = ['@STL_TESTED_HEADERS_DIR@', '@LIBCXX_SOURCE_DIR@/test/support', '@STL_SOURCE_DIR@/tests/std/include']
 lit_config.library_dirs[config.name]     = ['@STL_LIBRARY_OUTPUT_DIRECTORY@', '@TOOLSET_LIB@']
 lit_config.test_subdirs[config.name]     = ['@LIBCXX_SOURCE_DIR@/test/std']
 

--- a/tests/libcxx/usual_matrix.lst
+++ b/tests/libcxx/usual_matrix.lst
@@ -3,7 +3,7 @@
 
 RUNALL_INCLUDE ..\universal_prefix.lst
 RUNALL_CROSSLIST
-*	PM_CL="/EHsc /MTd /std:c++latest /permissive- /utf-8 /FImsvc_stdlib_force_include.h /wd4643 /D_STL_CALL_ABORT_INSTEAD_OF_INVALID_PARAMETER"
+*	PM_CL="/EHsc /MTd /std:c++latest /permissive- /utf-8 /FImsvc_stdlib_force_include.h /FIvso1913897.hpp /wd4643 /D_STL_CALL_ABORT_INSTEAD_OF_INVALID_PARAMETER"
 RUNALL_CROSSLIST
 PM_CL="/analyze:autolog- /Zc:preprocessor /wd6262"
 ASAN	PM_CL="-fsanitize=address /Zi" PM_LINK="/debug"

--- a/tests/std/include/force_include.hpp
+++ b/tests/std/include/force_include.hpp
@@ -14,6 +14,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "vso1913897.hpp"
+
 struct TestEnvironmentPreparer {
     TestEnvironmentPreparer() noexcept {
         // avoid assertion dialog boxes; see GH-781

--- a/tests/std/include/vso1913897.hpp
+++ b/tests/std/include/vso1913897.hpp
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <stdlib.h>
+
+// TRANSITION, dynamically initialize a thread_local to workaround VSO-1913897
+static thread_local int stl_asan_init_hack = ::rand();

--- a/tests/std/include/vso1913897.hpp
+++ b/tests/std/include/vso1913897.hpp
@@ -3,9 +3,13 @@
 
 #pragma once
 
+#ifndef _M_CEE
+
 // TRANSITION, dynamically initialize a thread_local to workaround VSO-1913897
 inline int __stl_asan_init_function() {
     static volatile int __stl_asan_init_volatile = 42;
     return __stl_asan_init_volatile;
 }
 static thread_local int __stl_asan_init_variable = __stl_asan_init_function();
+
+#endif // _M_CEE

--- a/tests/std/include/vso1913897.hpp
+++ b/tests/std/include/vso1913897.hpp
@@ -3,7 +3,9 @@
 
 #pragma once
 
-#include <stdlib.h>
-
 // TRANSITION, dynamically initialize a thread_local to workaround VSO-1913897
-static thread_local int stl_asan_init_hack = ::rand();
+inline int __stl_asan_init_function() {
+    static volatile int __stl_asan_init_volatile = 42;
+    return __stl_asan_init_volatile;
+}
+static thread_local int __stl_asan_init_variable = __stl_asan_init_function();

--- a/tests/std/tests/GH_002030_asan_annotate_string/env.lst
+++ b/tests/std/tests/GH_002030_asan_annotate_string/env.lst
@@ -3,7 +3,7 @@
 
 # This test matrix is the usual test matrix, with all currently unsupported options removed, crossed with the ASan flags.
 
-# TRANSITION, google/sanitizers#328 - clang-cl does not currently support targeting /MDd or /MTd.
+# TRANSITION, google/sanitizers#328: clang-cl does not support /MDd or /MTd with ASan
 RUNALL_INCLUDE ..\prefix.lst
 RUNALL_CROSSLIST
 PM_CL="/Zi /wd4611 /w14640 /Zc:threadSafeInit-" PM_LINK="/debug"

--- a/tests/std/tests/GH_002030_asan_annotate_vector/env.lst
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/env.lst
@@ -3,7 +3,7 @@
 
 # This test matrix is the usual test matrix, with all currently unsupported options removed, crossed with the ASan flags.
 
-# TRANSITION, google/sanitizers#328 - clang-cl does not currently support targeting /MDd or /MTd.
+# TRANSITION, google/sanitizers#328: clang-cl does not support /MDd or /MTd with ASan
 RUNALL_INCLUDE ..\prefix.lst
 RUNALL_CROSSLIST
 PM_CL="/Zi /wd4611 /w14640 /Zc:threadSafeInit-" PM_LINK="/debug"

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -79,7 +79,7 @@ class STLTest(Test):
             self.isenseRspPath = tmpBase + '.isense.rsp'
             self.compileFlags.extend(['/dE--write-isense-rsp', '/dE' + self.isenseRspPath])
 
-        # TRANSITION, google/sanitizers#328: clang-cl does not support targeting /MDd or /MTd with ASan
+        # TRANSITION, google/sanitizers#328: clang-cl does not support /MDd or /MTd with ASan
         if ('clang' in self.config.available_features and 'asan' in self.config.available_features and
             ('MTd' in self.config.available_features or 'MDd' in self.config.available_features)):
             return Result(UNSUPPORTED, 'clang does not support debug variants of the STL with ASan')

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -79,6 +79,11 @@ class STLTest(Test):
             self.isenseRspPath = tmpBase + '.isense.rsp'
             self.compileFlags.extend(['/dE--write-isense-rsp', '/dE' + self.isenseRspPath])
 
+        # TRANSITION, google/sanitizers#328: clang-cl does not support targeting /MDd or /MTd with ASan
+        if ('clang' in self.config.available_features and 'asan' in self.config.available_features and
+            ('MTd' in self.config.available_features or 'MDd' in self.config.available_features)):
+            return Result(UNSUPPORTED, 'clang does not support debug variants of the STL with ASan')
+
         self._configureTestType()
 
         forceFail = self.expectedResult and self.expectedResult.isFailure


### PR DESCRIPTION
Add support for instrumenting the STL with ASan by setting the `STL_ASAN_BUILD` cmake option and enable this support in the STL-ASan-CI pipeline. This lets us run "full ASan" tests with coverage of the header-only code and binary libraries. For now that requires client programs to be ASan instrumented since they statically link with either the entire STL (`/MT` or `/MTd`) or the contents of the import library (`/MD` or `/MDd`). 

This includes a fairly icky workaround for an initialization ordering bug (VSO-1913897) which injects a dynamically-initialized `thread_local` into each test TU. It's a matter of opinion whether it's more horrible to have ASan and non-ASan test coverage diverge by using this workaround only for ASan testing, or more horrible to have the ASan workaround affect non-ASan testing. I've chosen to use the workaround universally. This should truly be temporary since there's ongoing work to fix the issue with a coordinated change in the compiler and ASan runtime. 

Drive-by: increase paranoia around google/sanitizers#328. This change isn't strictly needed but would have saved me some time and confusion.

### ⚠️ Requires coordinated changes in the internal test infrastructure ⚠️ 
.. to add `tests/std/include` to the include path for the libc++ test suite to support the VSO-1913897 workaround.
