### PR TITLE
Issue #4320 Fixes handling of exponent positioning in <format> to pre…

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -3106,9 +3106,11 @@ _NODISCARD _OutputIt _Fmt_write(
         case chars_format::hex:
         case chars_format::scientific:
             if (_Extra_precision != 0) {
+                 if (!(_Specs._Alt || _Specs._Localized)){
                 // Trailing zeroes are in front of the exponent
                 while (*--_Exponent_start != _Exponent) {
                 }
+             }     
             }
             [[fallthrough]];
         case chars_format::fixed:


### PR DESCRIPTION
…vent out-of-bound access and crashes. When _Specs._Alt || _Specs._Localized is true, the correct position is already stored in _Exponent_start, eliminating the need for unnecessary loop execution. This modification ensures code stability and prevents issues related to trailing zeroes insertion.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
