### PR TITLE
fix formatting floating-point values without type and precision provided

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2967,6 +2967,7 @@ _NODISCARD _OutputIt _Fmt_write(
     auto _Format    = chars_format::general;
     auto _Exponent  = 'e';
     auto _Precision = _Specs._Precision;
+    auto _None_Type = false;
 
     switch (_Specs._Type) {
     case 'A':
@@ -3002,6 +3003,9 @@ _NODISCARD _OutputIt _Fmt_write(
             _Precision = 6;
         }
         _Format = chars_format::general;
+        break;
+    default:
+        _None_Type = true;
         break;
     }
 
@@ -3043,7 +3047,11 @@ _NODISCARD _OutputIt _Fmt_write(
         _Result.ptr += 3;
     } else {
         if (_Precision == -1) {
-            _Result = _STD to_chars(_Buffer, _STD end(_Buffer), _Value, _Format);
+            if (_None_Type) {
+                _Result = _STD to_chars(_Buffer, _STD end(_Buffer), _Value);
+            } else {
+                _Result = _STD to_chars(_Buffer, _STD end(_Buffer), _Value, _Format);
+            }
         } else {
             _Result = _STD to_chars(_Buffer, _STD end(_Buffer), _Value, _Format, _Precision);
         }

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2967,7 +2967,7 @@ _NODISCARD _OutputIt _Fmt_write(
     auto _Format    = chars_format::general;
     auto _Exponent  = 'e';
     auto _Precision = _Specs._Precision;
-    auto _None_Type = false;
+    auto _None_type = false;
 
     switch (_Specs._Type) {
     case 'A':
@@ -3005,7 +3005,7 @@ _NODISCARD _OutputIt _Fmt_write(
         _Format = chars_format::general;
         break;
     default:
-        _None_Type = true;
+        _None_type = true;
         break;
     }
 
@@ -3047,7 +3047,7 @@ _NODISCARD _OutputIt _Fmt_write(
         _Result.ptr += 3;
     } else {
         if (_Precision == -1) {
-            if (_None_Type) {
+            if (_None_type) {
                 _Result = _STD to_chars(_Buffer, _STD end(_Buffer), _Value);
             } else {
                 _Result = _STD to_chars(_Buffer, _STD end(_Buffer), _Value, _Format);

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1506,6 +1506,12 @@ constexpr bool test_format_string() {
     return true;
 }
 
+// Also test GH-4319: incorrect output for some floating-point values
+template <class charT>
+void test_gh_4319() {
+    assert(format(STR("{:}"), 12345678.0) == STR("12345678"));
+}
+
 void test() {
     test_simple_formatting<char>();
     test_simple_formatting<wchar_t>();
@@ -1582,6 +1588,9 @@ void test() {
     test_localized_char<char, char>();
     test_localized_char<wchar_t, char>();
     test_localized_char<wchar_t, wchar_t>();
+
+    test_gh_4319<char>();
+    test_gh_4319<wchar_t>();
 }
 
 int main() {


### PR DESCRIPTION
Fixes #4319

`libcxx\test\std\utilities\format\format.functions\locale-specific_form.pass.cpp` is still failing after this fix.

```
Format string   {:$<11.6Lg}
Expected output 1,234.57$$$
Actual output   1,234.57$$$$
```

I guess, it's a different bug, isn't it?