### PR TITLE
Move libc++'s `ascii` tests to "LIKELY BOGUS TESTS"

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -712,6 +712,11 @@ std/iterators/iterator.requirements/iterator.concepts/iterator.concept.random.ac
 # Bogus test expects to_address() to SFINAE away for int.
 std/utilities/memory/pointer.conversion/to_address_without_pointer_traits.pass.cpp FAIL
 
+# libc++'s "ascii" mode considers every code unit to represent a valid printable narrow character.
+# We don't support such a mode.
+std/utilities/format/format.functions/ascii.pass.cpp FAIL
+std/utilities/format/format.functions/escaped_output.ascii.pass.cpp FAIL
+
 
 # *** LIKELY STL BUGS ***
 # Not analyzed, likely STL bugs. Various assertions.
@@ -947,9 +952,6 @@ std/algorithms/alg.modifying.operations/alg.unique/ranges_unique.pass.cpp:1 SKIP
 std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_long_double.hex.pass.cpp SKIPPED
 std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_double.hex.pass.cpp SKIPPED
 
-# Not analyzed. These tests use characters that cannot be represented in legacy character encodings
-std/utilities/format/format.functions/ascii.pass.cpp FAIL
-
 # Not analyzed. Failing assert(swaps <= expected).
 std/algorithms/alg.modifying.operations/alg.rotate/ranges_rotate.pass.cpp FAIL
 
@@ -1029,7 +1031,6 @@ std/ranges/range.adaptors/range.lazy.split/range.lazy.split.inner/iter_swap.pass
 std/thread/futures/futures.task/futures.task.members/ctor2.compile.pass.cpp FAIL
 
 # Not analyzed. MSVC emits truncation warnings, Clang fails a runtime assertion.
-std/utilities/format/format.functions/escaped_output.ascii.pass.cpp FAIL
 std/utilities/format/format.functions/locale-specific_form.pass.cpp FAIL
 
 # Not analyzed.


### PR DESCRIPTION
libc++'s "ascii" mode (`_LIBCPP_HAS_NO_UNICODE`) means "every code unit outside ASCII is treated as a valid printable character". AFAIK we don't support such a mode.

For `char`, MSVC STL uses the code page specified by `_MSVC_EXECUTION_CHARACTER_SET`. Some code pages might consider most code units printable, but even Windows 1252 has a couple of non-printable characters.

For `wchar_t`, we don't have a way to opt-out UTF-16, and I don't see a need to do so.