### PR TITLE
Change _Literal_zero constructor to use pointer to _Literal_zero

### DIFF
--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -35,7 +35,7 @@ struct _Literal_zero {
         }
     }
     template <class _Ty, enable_if_t<!is_same_v<_Ty, int>, int> = 0>
-    _Literal_zero( _Ty ) = delete;
+    _Literal_zero(_Ty) = delete;
 };
 
 using _Compare_t = signed char;

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -28,13 +28,14 @@ _STD_BEGIN
 void _Literal_zero_is_expected();
 
 struct _Literal_zero {
-    template <class _Ty, enable_if_t<is_same_v<_Ty, int>, int> = 0>
-    consteval _Literal_zero(_Ty _Zero) noexcept {
+    consteval _Literal_zero(_Literal_zero* _Zero) noexcept {
         // Can't use _STL_VERIFY because this is a core header
         if (_Zero != 0) {
             _Literal_zero_is_expected();
         }
     }
+    template <class _Ty, enable_if_t<!is_same_v<_Ty, int>, int> = 0>
+    _Literal_zero( _Ty ) = delete;
 };
 
 using _Compare_t = signed char;


### PR DESCRIPTION
This means that `std::is_constructible_v<_Literal_zero, int>` is now false, and thus libraries like Catch2 can detect the difference between a type comparable with `int`, and type comparable only with literal `0`. This then lets it handle expressions like `(a <=> b) == 0` inside `REQUIRE`.

