### PR TITLE
Make implicit conversion to `bool` ADL-proof (except for views)

### DIFF
--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -95,7 +95,7 @@ public:
     // [expected.un.eq]
     template <class _UErr>
     _NODISCARD_FRIEND constexpr bool operator==(const unexpected& _Left, const unexpected<_UErr>& _Right) noexcept(
-        noexcept(_Fake_copy_init<bool>(_Left._Unexpected == _Right.error()))) /* strengthened */ {
+        noexcept(_STD _Fake_copy_init<bool>(_Left._Unexpected == _Right.error()))) /* strengthened */ {
         return _Left._Unexpected == _Right.error();
     }
 
@@ -1096,8 +1096,8 @@ public:
     template <class _Uty, class _UErr>
         requires (!is_void_v<_Uty>)
     _NODISCARD_FRIEND constexpr bool operator==(const expected& _Left, const expected<_Uty, _UErr>& _Right) noexcept(
-        noexcept(_Fake_copy_init<bool>(_Left._Value == *_Right)) && noexcept(
-            _Fake_copy_init<bool>(_Left._Unexpected == _Right.error()))) /* strengthened */ {
+        noexcept(_STD _Fake_copy_init<bool>(_Left._Value == *_Right)) && noexcept(
+            _STD _Fake_copy_init<bool>(_Left._Unexpected == _Right.error()))) /* strengthened */ {
         if (_Left._Has_value != _Right.has_value()) {
             return false;
         } else if (_Left._Has_value) {

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -623,7 +623,7 @@ optional(_Ty) -> optional<_Ty>;
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 _NODISCARD constexpr bool operator==(const optional<_Ty1>& _Left, const optional<_Ty2>& _Right) noexcept(
-    noexcept(_Fake_copy_init<bool>(*_Left == *_Right))) /* strengthened */
+    noexcept(_STD _Fake_copy_init<bool>(*_Left == *_Right))) /* strengthened */
 #ifdef __cpp_lib_concepts
     requires requires {
         { *_Left == *_Right } -> _Implicitly_convertible_to<bool>;
@@ -640,7 +640,7 @@ _NODISCARD constexpr bool operator==(const optional<_Ty1>& _Left, const optional
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 _NODISCARD constexpr bool operator!=(const optional<_Ty1>& _Left, const optional<_Ty2>& _Right) noexcept(
-    noexcept(_Fake_copy_init<bool>(*_Left != *_Right))) /* strengthened */
+    noexcept(_STD _Fake_copy_init<bool>(*_Left != *_Right))) /* strengthened */
 #ifdef __cpp_lib_concepts
     requires requires {
         { *_Left != *_Right } -> _Implicitly_convertible_to<bool>;
@@ -657,7 +657,7 @@ _NODISCARD constexpr bool operator!=(const optional<_Ty1>& _Left, const optional
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 _NODISCARD constexpr bool operator<(const optional<_Ty1>& _Left, const optional<_Ty2>& _Right) noexcept(
-    noexcept(_Fake_copy_init<bool>(*_Left < *_Right))) /* strengthened */
+    noexcept(_STD _Fake_copy_init<bool>(*_Left < *_Right))) /* strengthened */
 #ifdef __cpp_lib_concepts
     requires requires {
         { *_Left < *_Right } -> _Implicitly_convertible_to<bool>;
@@ -674,7 +674,7 @@ _NODISCARD constexpr bool operator<(const optional<_Ty1>& _Left, const optional<
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 _NODISCARD constexpr bool operator>(const optional<_Ty1>& _Left, const optional<_Ty2>& _Right) noexcept(
-    noexcept(_Fake_copy_init<bool>(*_Left > *_Right))) /* strengthened */
+    noexcept(_STD _Fake_copy_init<bool>(*_Left > *_Right))) /* strengthened */
 #ifdef __cpp_lib_concepts
     requires requires {
         { *_Left > *_Right } -> _Implicitly_convertible_to<bool>;
@@ -691,7 +691,7 @@ _NODISCARD constexpr bool operator>(const optional<_Ty1>& _Left, const optional<
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 _NODISCARD constexpr bool operator<=(const optional<_Ty1>& _Left, const optional<_Ty2>& _Right) noexcept(
-    noexcept(_Fake_copy_init<bool>(*_Left <= *_Right))) /* strengthened */
+    noexcept(_STD _Fake_copy_init<bool>(*_Left <= *_Right))) /* strengthened */
 #ifdef __cpp_lib_concepts
     requires requires {
         { *_Left <= *_Right } -> _Implicitly_convertible_to<bool>;
@@ -708,7 +708,7 @@ _NODISCARD constexpr bool operator<=(const optional<_Ty1>& _Left, const optional
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 _NODISCARD constexpr bool operator>=(const optional<_Ty1>& _Left, const optional<_Ty2>& _Right) noexcept(
-    noexcept(_Fake_copy_init<bool>(*_Left >= *_Right))) /* strengthened */
+    noexcept(_STD _Fake_copy_init<bool>(*_Left >= *_Right))) /* strengthened */
 #ifdef __cpp_lib_concepts
     requires requires {
         { *_Left >= *_Right } -> _Implicitly_convertible_to<bool>;
@@ -828,7 +828,7 @@ using _Enable_if_comparable_with_greater_equal =
 
 _EXPORT_STD template <class _Ty1, class _Ty2, _Enable_if_comparable_with_equal<_Ty1, _Ty2> = 0>
 _NODISCARD constexpr bool operator==(const optional<_Ty1>& _Left, const _Ty2& _Right) noexcept(
-    noexcept(_Fake_copy_init<bool>(*_Left == _Right))) /* strengthened */ {
+    noexcept(_STD _Fake_copy_init<bool>(*_Left == _Right))) /* strengthened */ {
     if (_Left) {
         return *_Left == _Right;
     }
@@ -837,7 +837,7 @@ _NODISCARD constexpr bool operator==(const optional<_Ty1>& _Left, const _Ty2& _R
 
 _EXPORT_STD template <class _Ty1, class _Ty2, _Enable_if_comparable_with_equal<_Ty1, _Ty2> = 0>
 _NODISCARD constexpr bool operator==(const _Ty1& _Left, const optional<_Ty2>& _Right) noexcept(
-    noexcept(_Fake_copy_init<bool>(_Left == *_Right))) /* strengthened */ {
+    noexcept(_STD _Fake_copy_init<bool>(_Left == *_Right))) /* strengthened */ {
     if (_Right) {
         return _Left == *_Right;
     }
@@ -846,7 +846,7 @@ _NODISCARD constexpr bool operator==(const _Ty1& _Left, const optional<_Ty2>& _R
 
 _EXPORT_STD template <class _Ty1, class _Ty2, _Enable_if_comparable_with_not_equal<_Ty1, _Ty2> = 0>
 _NODISCARD constexpr bool operator!=(const optional<_Ty1>& _Left, const _Ty2& _Right) noexcept(
-    noexcept(_Fake_copy_init<bool>(*_Left != _Right))) /* strengthened */ {
+    noexcept(_STD _Fake_copy_init<bool>(*_Left != _Right))) /* strengthened */ {
     if (_Left) {
         return *_Left != _Right;
     }
@@ -854,7 +854,7 @@ _NODISCARD constexpr bool operator!=(const optional<_Ty1>& _Left, const _Ty2& _R
 }
 _EXPORT_STD template <class _Ty1, class _Ty2, _Enable_if_comparable_with_not_equal<_Ty1, _Ty2> = 0>
 _NODISCARD constexpr bool operator!=(const _Ty1& _Left, const optional<_Ty2>& _Right) noexcept(
-    noexcept(_Fake_copy_init<bool>(_Left != *_Right))) /* strengthened */ {
+    noexcept(_STD _Fake_copy_init<bool>(_Left != *_Right))) /* strengthened */ {
     if (_Right) {
         return _Left != *_Right;
     }
@@ -863,7 +863,7 @@ _NODISCARD constexpr bool operator!=(const _Ty1& _Left, const optional<_Ty2>& _R
 
 _EXPORT_STD template <class _Ty1, class _Ty2, _Enable_if_comparable_with_less<_Ty1, _Ty2> = 0>
 _NODISCARD constexpr bool operator<(const optional<_Ty1>& _Left, const _Ty2& _Right) noexcept(
-    noexcept(_Fake_copy_init<bool>(*_Left < _Right))) /* strengthened */ {
+    noexcept(_STD _Fake_copy_init<bool>(*_Left < _Right))) /* strengthened */ {
     if (_Left) {
         return *_Left < _Right;
     }
@@ -871,7 +871,7 @@ _NODISCARD constexpr bool operator<(const optional<_Ty1>& _Left, const _Ty2& _Ri
 }
 _EXPORT_STD template <class _Ty1, class _Ty2, _Enable_if_comparable_with_less<_Ty1, _Ty2> = 0>
 _NODISCARD constexpr bool operator<(const _Ty1& _Left, const optional<_Ty2>& _Right) noexcept(
-    noexcept(_Fake_copy_init<bool>(_Left < *_Right))) /* strengthened */ {
+    noexcept(_STD _Fake_copy_init<bool>(_Left < *_Right))) /* strengthened */ {
     if (_Right) {
         return _Left < *_Right;
     }
@@ -880,7 +880,7 @@ _NODISCARD constexpr bool operator<(const _Ty1& _Left, const optional<_Ty2>& _Ri
 
 _EXPORT_STD template <class _Ty1, class _Ty2, _Enable_if_comparable_with_greater<_Ty1, _Ty2> = 0>
 _NODISCARD constexpr bool operator>(const optional<_Ty1>& _Left, const _Ty2& _Right) noexcept(
-    noexcept(_Fake_copy_init<bool>(*_Left > _Right))) /* strengthened */ {
+    noexcept(_STD _Fake_copy_init<bool>(*_Left > _Right))) /* strengthened */ {
     if (_Left) {
         return *_Left > _Right;
     }
@@ -888,7 +888,7 @@ _NODISCARD constexpr bool operator>(const optional<_Ty1>& _Left, const _Ty2& _Ri
 }
 _EXPORT_STD template <class _Ty1, class _Ty2, _Enable_if_comparable_with_greater<_Ty1, _Ty2> = 0>
 _NODISCARD constexpr bool operator>(const _Ty1& _Left, const optional<_Ty2>& _Right) noexcept(
-    noexcept(_Fake_copy_init<bool>(_Left > *_Right))) /* strengthened */ {
+    noexcept(_STD _Fake_copy_init<bool>(_Left > *_Right))) /* strengthened */ {
     if (_Right) {
         return _Left > *_Right;
     }
@@ -897,7 +897,7 @@ _NODISCARD constexpr bool operator>(const _Ty1& _Left, const optional<_Ty2>& _Ri
 
 _EXPORT_STD template <class _Ty1, class _Ty2, _Enable_if_comparable_with_less_equal<_Ty1, _Ty2> = 0>
 _NODISCARD constexpr bool operator<=(const optional<_Ty1>& _Left, const _Ty2& _Right) noexcept(
-    noexcept(_Fake_copy_init<bool>(*_Left <= _Right))) /* strengthened */ {
+    noexcept(_STD _Fake_copy_init<bool>(*_Left <= _Right))) /* strengthened */ {
     if (_Left) {
         return *_Left <= _Right;
     }
@@ -905,7 +905,7 @@ _NODISCARD constexpr bool operator<=(const optional<_Ty1>& _Left, const _Ty2& _R
 }
 _EXPORT_STD template <class _Ty1, class _Ty2, _Enable_if_comparable_with_less_equal<_Ty1, _Ty2> = 0>
 _NODISCARD constexpr bool operator<=(const _Ty1& _Left, const optional<_Ty2>& _Right) noexcept(
-    noexcept(_Fake_copy_init<bool>(_Left <= *_Right))) /* strengthened */ {
+    noexcept(_STD _Fake_copy_init<bool>(_Left <= *_Right))) /* strengthened */ {
     if (_Right) {
         return _Left <= *_Right;
     }
@@ -914,7 +914,7 @@ _NODISCARD constexpr bool operator<=(const _Ty1& _Left, const optional<_Ty2>& _R
 
 _EXPORT_STD template <class _Ty1, class _Ty2, _Enable_if_comparable_with_greater_equal<_Ty1, _Ty2> = 0>
 _NODISCARD constexpr bool operator>=(const optional<_Ty1>& _Left, const _Ty2& _Right) noexcept(
-    noexcept(_Fake_copy_init<bool>(*_Left >= _Right))) /* strengthened */ {
+    noexcept(_STD _Fake_copy_init<bool>(*_Left >= _Right))) /* strengthened */ {
     if (_Left) {
         return *_Left >= _Right;
     }
@@ -922,7 +922,7 @@ _NODISCARD constexpr bool operator>=(const optional<_Ty1>& _Left, const _Ty2& _R
 }
 _EXPORT_STD template <class _Ty1, class _Ty2, _Enable_if_comparable_with_greater_equal<_Ty1, _Ty2> = 0>
 _NODISCARD constexpr bool operator>=(const _Ty1& _Left, const optional<_Ty2>& _Right) noexcept(
-    noexcept(_Fake_copy_init<bool>(_Left >= *_Right))) /* strengthened */ {
+    noexcept(_STD _Fake_copy_init<bool>(_Left >= *_Right))) /* strengthened */ {
     if (_Right) {
         return _Left >= *_Right;
     }

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -2441,7 +2441,7 @@ struct less {
     using _RESULT_TYPE_NAME _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS          = bool;
 
     _NODISCARD constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const
-        noexcept(noexcept(_Fake_copy_init<bool>(_Left < _Right))) /* strengthened */ {
+        noexcept(noexcept(_STD _Fake_copy_init<bool>(_Left < _Right))) /* strengthened */ {
         return _Left < _Right;
     }
 };

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -391,7 +391,7 @@ struct equal_to {
     using _RESULT_TYPE_NAME _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS          = bool;
 
     _NODISCARD constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const
-        noexcept(noexcept(_Fake_copy_init<bool>(_Left == _Right))) /* strengthened */ {
+        noexcept(noexcept(_STD _Fake_copy_init<bool>(_Left == _Right))) /* strengthened */ {
         return _Left == _Right;
     }
 };
@@ -403,7 +403,7 @@ struct not_equal_to {
     using _RESULT_TYPE_NAME _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS          = bool;
 
     _NODISCARD constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const
-        noexcept(noexcept(_Fake_copy_init<bool>(_Left != _Right))) /* strengthened */ {
+        noexcept(noexcept(_STD _Fake_copy_init<bool>(_Left != _Right))) /* strengthened */ {
         return _Left != _Right;
     }
 };
@@ -415,7 +415,7 @@ struct greater {
     using _RESULT_TYPE_NAME _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS          = bool;
 
     _NODISCARD constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const
-        noexcept(noexcept(_Fake_copy_init<bool>(_Left > _Right))) /* strengthened */ {
+        noexcept(noexcept(_STD _Fake_copy_init<bool>(_Left > _Right))) /* strengthened */ {
         return _Left > _Right;
     }
 };
@@ -427,7 +427,7 @@ struct greater_equal {
     using _RESULT_TYPE_NAME _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS          = bool;
 
     _NODISCARD constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const
-        noexcept(noexcept(_Fake_copy_init<bool>(_Left >= _Right))) /* strengthened */ {
+        noexcept(noexcept(_STD _Fake_copy_init<bool>(_Left >= _Right))) /* strengthened */ {
         return _Left >= _Right;
     }
 };
@@ -439,7 +439,7 @@ struct less_equal {
     using _RESULT_TYPE_NAME _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS          = bool;
 
     _NODISCARD constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const
-        noexcept(noexcept(_Fake_copy_init<bool>(_Left <= _Right))) /* strengthened */ {
+        noexcept(noexcept(_STD _Fake_copy_init<bool>(_Left <= _Right))) /* strengthened */ {
         return _Left <= _Right;
     }
 };
@@ -1491,7 +1491,7 @@ _INLINE_VAR constexpr bool _Has_nothrow_operator_arrow = _Is_nothrow_convertible
 
 template <class _Iter, class _Pointer>
 _INLINE_VAR constexpr bool _Has_nothrow_operator_arrow<_Iter, _Pointer, false> =
-    noexcept(_Fake_copy_init<_Pointer>(_STD declval<_Iter>().operator->()));
+    noexcept(_STD _Fake_copy_init<_Pointer>(_STD declval<_Iter>().operator->()));
 
 _EXPORT_STD template <class _BidIt>
 class reverse_iterator {
@@ -1614,7 +1614,7 @@ public:
     }
 
     _NODISCARD _CONSTEXPR17 reference operator[](const difference_type _Off) const
-        noexcept(noexcept(_Fake_copy_init<reference>(current[_Off]))) /* strengthened */ {
+        noexcept(noexcept(_STD _Fake_copy_init<reference>(current[_Off]))) /* strengthened */ {
         return current[static_cast<difference_type>(-_Off - 1)];
     }
 
@@ -1683,7 +1683,7 @@ protected:
 _EXPORT_STD template <class _BidIt1, class _BidIt2>
 _NODISCARD _CONSTEXPR17 bool
     operator==(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
-        noexcept(_Fake_copy_init<bool>(_Left._Get_current() == _Right._Get_current()))) /* strengthened */
+        noexcept(_STD _Fake_copy_init<bool>(_Left._Get_current() == _Right._Get_current()))) /* strengthened */
 #ifdef __cpp_lib_concepts
     requires requires {
         { _Left._Get_current() == _Right._Get_current() } -> _Implicitly_convertible_to<bool>;
@@ -1696,7 +1696,7 @@ _NODISCARD _CONSTEXPR17 bool
 _EXPORT_STD template <class _BidIt1, class _BidIt2>
 _NODISCARD _CONSTEXPR17 bool
     operator!=(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
-        noexcept(_Fake_copy_init<bool>(_Left._Get_current() != _Right._Get_current()))) /* strengthened */
+        noexcept(_STD _Fake_copy_init<bool>(_Left._Get_current() != _Right._Get_current()))) /* strengthened */
 #ifdef __cpp_lib_concepts
     requires requires {
         { _Left._Get_current() != _Right._Get_current() } -> _Implicitly_convertible_to<bool>;
@@ -1709,7 +1709,7 @@ _NODISCARD _CONSTEXPR17 bool
 _EXPORT_STD template <class _BidIt1, class _BidIt2>
 _NODISCARD _CONSTEXPR17 bool
     operator<(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
-        noexcept(_Fake_copy_init<bool>(_Left._Get_current() > _Right._Get_current()))) /* strengthened */
+        noexcept(_STD _Fake_copy_init<bool>(_Left._Get_current() > _Right._Get_current()))) /* strengthened */
 #ifdef __cpp_lib_concepts
     requires requires {
         { _Left._Get_current() > _Right._Get_current() } -> _Implicitly_convertible_to<bool>;
@@ -1722,7 +1722,7 @@ _NODISCARD _CONSTEXPR17 bool
 _EXPORT_STD template <class _BidIt1, class _BidIt2>
 _NODISCARD _CONSTEXPR17 bool
     operator>(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
-        noexcept(_Fake_copy_init<bool>(_Left._Get_current() < _Right._Get_current()))) /* strengthened */
+        noexcept(_STD _Fake_copy_init<bool>(_Left._Get_current() < _Right._Get_current()))) /* strengthened */
 #ifdef __cpp_lib_concepts
     requires requires {
         { _Left._Get_current() < _Right._Get_current() } -> _Implicitly_convertible_to<bool>;
@@ -1735,7 +1735,7 @@ _NODISCARD _CONSTEXPR17 bool
 _EXPORT_STD template <class _BidIt1, class _BidIt2>
 _NODISCARD _CONSTEXPR17 bool
     operator<=(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
-        noexcept(_Fake_copy_init<bool>(_Left._Get_current() >= _Right._Get_current()))) /* strengthened */
+        noexcept(_STD _Fake_copy_init<bool>(_Left._Get_current() >= _Right._Get_current()))) /* strengthened */
 #ifdef __cpp_lib_concepts
     requires requires {
         { _Left._Get_current() >= _Right._Get_current() } -> _Implicitly_convertible_to<bool>;
@@ -1748,7 +1748,7 @@ _NODISCARD _CONSTEXPR17 bool
 _EXPORT_STD template <class _BidIt1, class _BidIt2>
 _NODISCARD _CONSTEXPR17 bool
     operator>=(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
-        noexcept(_Fake_copy_init<bool>(_Left._Get_current() <= _Right._Get_current()))) /* strengthened */
+        noexcept(_STD _Fake_copy_init<bool>(_Left._Get_current() <= _Right._Get_current()))) /* strengthened */
 #ifdef __cpp_lib_concepts
     requires requires {
         { _Left._Get_current() <= _Right._Get_current() } -> _Implicitly_convertible_to<bool>;
@@ -2132,7 +2132,7 @@ public:
 
     template <sentinel_for<_Iter> _Sent>
     _NODISCARD constexpr bool operator==(const _Sent& _Se) const
-        noexcept(noexcept(_Fake_copy_init<bool>(_Current == _Se))) /* strengthened */ {
+        noexcept(noexcept(_STD _Fake_copy_init<bool>(_Current == _Se))) /* strengthened */ {
         return _Current == _Se;
     }
 
@@ -2150,28 +2150,28 @@ public:
     }
 
     _NODISCARD constexpr bool operator<(const basic_const_iterator& _Right) const
-        noexcept(noexcept(_Fake_copy_init<bool>(_Current < _Right._Current))) // strengthened
+        noexcept(noexcept(_STD _Fake_copy_init<bool>(_Current < _Right._Current))) // strengthened
         requires random_access_iterator<_Iter>
     {
         return _Current < _Right._Current;
     }
 
     _NODISCARD constexpr bool operator>(const basic_const_iterator& _Right) const
-        noexcept(noexcept(_Fake_copy_init<bool>(_Current > _Right._Current))) // strengthened
+        noexcept(noexcept(_STD _Fake_copy_init<bool>(_Current > _Right._Current))) // strengthened
         requires random_access_iterator<_Iter>
     {
         return _Current > _Right._Current;
     }
 
     _NODISCARD constexpr bool operator<=(const basic_const_iterator& _Right) const
-        noexcept(noexcept(_Fake_copy_init<bool>(_Current <= _Right._Current))) // strengthened
+        noexcept(noexcept(_STD _Fake_copy_init<bool>(_Current <= _Right._Current))) // strengthened
         requires random_access_iterator<_Iter>
     {
         return _Current <= _Right._Current;
     }
 
     _NODISCARD constexpr bool operator>=(const basic_const_iterator& _Right) const
-        noexcept(noexcept(_Fake_copy_init<bool>(_Current >= _Right._Current))) // strengthened
+        noexcept(noexcept(_STD _Fake_copy_init<bool>(_Current >= _Right._Current))) // strengthened
         requires random_access_iterator<_Iter>
     {
         return _Current >= _Right._Current;
@@ -2187,28 +2187,28 @@ public:
     template <_Different_from<basic_const_iterator> _Other>
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD constexpr bool operator<(const _Other& _Right) const
-        noexcept(noexcept(_Fake_copy_init<bool>(_Current < _Right))) /* strengthened */ {
+        noexcept(noexcept(_STD _Fake_copy_init<bool>(_Current < _Right))) /* strengthened */ {
         return _Current < _Right;
     }
 
     template <_Different_from<basic_const_iterator> _Other>
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD constexpr bool operator>(const _Other& _Right) const
-        noexcept(noexcept(_Fake_copy_init<bool>(_Current > _Right))) /* strengthened */ {
+        noexcept(noexcept(_STD _Fake_copy_init<bool>(_Current > _Right))) /* strengthened */ {
         return _Current > _Right;
     }
 
     template <_Different_from<basic_const_iterator> _Other>
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD constexpr bool operator<=(const _Other& _Right) const
-        noexcept(noexcept(_Fake_copy_init<bool>(_Current <= _Right))) /* strengthened */ {
+        noexcept(noexcept(_STD _Fake_copy_init<bool>(_Current <= _Right))) /* strengthened */ {
         return _Current <= _Right;
     }
 
     template <_Different_from<basic_const_iterator> _Other>
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD constexpr bool operator>=(const _Other& _Right) const
-        noexcept(noexcept(_Fake_copy_init<bool>(_Current >= _Right))) /* strengthened */ {
+        noexcept(noexcept(_STD _Fake_copy_init<bool>(_Current >= _Right))) /* strengthened */ {
         return _Current >= _Right;
     }
 
@@ -2223,28 +2223,28 @@ public:
     template <_Not_a_const_iterator _Other>
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD_FRIEND constexpr bool operator<(const _Other& _Left, const basic_const_iterator& _Right) noexcept(
-        noexcept(_Fake_copy_init<bool>(_Left < _Right._Current))) /* strengthened */ {
+        noexcept(_STD _Fake_copy_init<bool>(_Left < _Right._Current))) /* strengthened */ {
         return _Left < _Right._Current;
     }
 
     template <_Not_a_const_iterator _Other>
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD_FRIEND constexpr bool operator>(const _Other& _Left, const basic_const_iterator& _Right) noexcept(
-        noexcept(_Fake_copy_init<bool>(_Left > _Right._Current))) /* strengthened */ {
+        noexcept(_STD _Fake_copy_init<bool>(_Left > _Right._Current))) /* strengthened */ {
         return _Left > _Right._Current;
     }
 
     template <_Not_a_const_iterator _Other>
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD_FRIEND constexpr bool operator<=(const _Other& _Left, const basic_const_iterator& _Right) noexcept(
-        noexcept(_Fake_copy_init<bool>(_Left <= _Right._Current))) /* strengthened */ {
+        noexcept(_STD _Fake_copy_init<bool>(_Left <= _Right._Current))) /* strengthened */ {
         return _Left <= _Right._Current;
     }
 
     template <_Not_a_const_iterator _Other>
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD_FRIEND constexpr bool operator>=(const _Other& _Left, const basic_const_iterator& _Right) noexcept(
-        noexcept(_Fake_copy_init<bool>(_Left >= _Right._Current))) /* strengthened */ {
+        noexcept(_STD _Fake_copy_init<bool>(_Left >= _Right._Current))) /* strengthened */ {
         return _Left >= _Right._Current;
     }
 
@@ -2342,12 +2342,12 @@ namespace ranges {
 
         template <class _Ty>
         concept _Has_member = requires(_Ty __t) {
-            { _Fake_copy_init(__t.begin()) } -> input_or_output_iterator;
+            { _STD _Fake_copy_init(__t.begin()) } -> input_or_output_iterator;
         };
 
         template <class _Ty>
         concept _Has_ADL = _Has_class_or_enum_type<_Ty> && requires(_Ty __t) {
-            { _Fake_copy_init(begin(__t)) } -> input_or_output_iterator; // intentional ADL
+            { _STD _Fake_copy_init(begin(__t)) } -> input_or_output_iterator; // intentional ADL
         };
 
         class _Cpo {
@@ -2364,9 +2364,10 @@ namespace ranges {
                         "and std::ranges::data do not accept arrays with incomplete element types.");
                     return {_St::_Array, true};
                 } else if constexpr (_Has_member<_Ty>) {
-                    return {_St::_Member, noexcept(_Fake_copy_init(_STD declval<_Ty>().begin()))};
+                    return {_St::_Member, noexcept(_STD _Fake_copy_init(_STD declval<_Ty>().begin()))};
                 } else if constexpr (_Has_ADL<_Ty>) {
-                    return {_St::_Non_member, noexcept(_Fake_copy_init(begin(_STD declval<_Ty>())))}; // intentional ADL
+                    return {_St::_Non_member,
+                        noexcept(_STD _Fake_copy_init(begin(_STD declval<_Ty>())))}; // intentional ADL
                 } else {
                     return {_St::_None};
                 }
@@ -2410,12 +2411,12 @@ namespace ranges {
 
         template <class _Ty>
         concept _Has_member = requires(_Ty __t) {
-            { _Fake_copy_init(__t.end()) } -> sentinel_for<iterator_t<_Ty>>;
+            { _STD _Fake_copy_init(__t.end()) } -> sentinel_for<iterator_t<_Ty>>;
         };
 
         template <class _Ty>
         concept _Has_ADL = _Has_class_or_enum_type<_Ty> && requires(_Ty __t) {
-            { _Fake_copy_init(end(__t)) } -> sentinel_for<iterator_t<_Ty>>; // intentional ADL
+            { _STD _Fake_copy_init(end(__t)) } -> sentinel_for<iterator_t<_Ty>>; // intentional ADL
         };
 
         class _Cpo {
@@ -2438,9 +2439,10 @@ namespace ranges {
                         return {_St::_None};
                     }
                 } else if constexpr (_Has_member<_Ty>) {
-                    return {_St::_Member, noexcept(_Fake_copy_init(_STD declval<_Ty>().end()))};
+                    return {_St::_Member, noexcept(_STD _Fake_copy_init(_STD declval<_Ty>().end()))};
                 } else if constexpr (_Has_ADL<_Ty>) {
-                    return {_St::_Non_member, noexcept(_Fake_copy_init(end(_STD declval<_Ty>())))}; // intentional ADL
+                    return {
+                        _St::_Non_member, noexcept(_STD _Fake_copy_init(end(_STD declval<_Ty>())))}; // intentional ADL
                 } else {
                     return {_St::_None};
                 }
@@ -2764,12 +2766,12 @@ namespace ranges {
 
         template <class _Ty>
         concept _Has_member = requires(_Ty __t) {
-            { _Fake_copy_init(__t.rbegin()) } -> input_or_output_iterator;
+            { _STD _Fake_copy_init(__t.rbegin()) } -> input_or_output_iterator;
         };
 
         template <class _Ty>
         concept _Has_ADL = _Has_class_or_enum_type<_Ty> && requires(_Ty __t) {
-            { _Fake_copy_init(rbegin(__t)) } -> input_or_output_iterator; // intentional ADL
+            { _STD _Fake_copy_init(rbegin(__t)) } -> input_or_output_iterator; // intentional ADL
         };
 
         template <class _Ty>
@@ -2786,10 +2788,10 @@ namespace ranges {
             _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 if constexpr (_Has_member<_Ty>) {
-                    return {_St::_Member, noexcept(_Fake_copy_init(_STD declval<_Ty>().rbegin()))};
+                    return {_St::_Member, noexcept(_STD _Fake_copy_init(_STD declval<_Ty>().rbegin()))};
                 } else if constexpr (_Has_ADL<_Ty>) {
-                    return {
-                        _St::_Non_member, noexcept(_Fake_copy_init(rbegin(_STD declval<_Ty>())))}; // intentional ADL
+                    return {_St::_Non_member,
+                        noexcept(_STD _Fake_copy_init(rbegin(_STD declval<_Ty>())))}; // intentional ADL
                 } else if constexpr (_Can_make_reverse<_Ty>) {
                     return {_St::_Make_reverse, noexcept(_STD make_reverse_iterator(_RANGES end(_STD declval<_Ty>())))};
                 } else {
@@ -2832,13 +2834,13 @@ namespace ranges {
 
         template <class _Ty>
         concept _Has_member = requires(_Ty __t) {
-            { _Fake_copy_init(__t.rend()) } -> sentinel_for<decltype(_RANGES rbegin(__t))>;
+            { _STD _Fake_copy_init(__t.rend()) } -> sentinel_for<decltype(_RANGES rbegin(__t))>;
         };
 
         template <class _Ty>
         concept _Has_ADL = _Has_class_or_enum_type<_Ty> && requires(_Ty __t) {
             // intentional ADL
-            { _Fake_copy_init(rend(__t)) } -> sentinel_for<decltype(_RANGES rbegin(__t))>;
+            { _STD _Fake_copy_init(rend(__t)) } -> sentinel_for<decltype(_RANGES rbegin(__t))>;
         };
 
         template <class _Ty>
@@ -2855,9 +2857,10 @@ namespace ranges {
             _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 if constexpr (_Has_member<_Ty>) {
-                    return {_St::_Member, noexcept(_Fake_copy_init(_STD declval<_Ty>().rend()))};
+                    return {_St::_Member, noexcept(_STD _Fake_copy_init(_STD declval<_Ty>().rend()))};
                 } else if constexpr (_Has_ADL<_Ty>) {
-                    return {_St::_Non_member, noexcept(_Fake_copy_init(rend(_STD declval<_Ty>())))}; // intentional ADL
+                    return {
+                        _St::_Non_member, noexcept(_STD _Fake_copy_init(rend(_STD declval<_Ty>())))}; // intentional ADL
                 } else if constexpr (_Can_make_reverse<_Ty>) {
                     return {
                         _St::_Make_reverse, noexcept(_STD make_reverse_iterator(_RANGES begin(_STD declval<_Ty>())))};
@@ -2964,12 +2967,12 @@ namespace ranges {
 
         template <class _Ty, class _UnCV>
         concept _Has_member = !disable_sized_range<_UnCV> && requires(_Ty __t) {
-            { _Fake_copy_init(__t.size()) } -> _Integer_like;
+            { _STD _Fake_copy_init(__t.size()) } -> _Integer_like;
         };
 
         template <class _Ty, class _UnCV>
         concept _Has_ADL = _Has_class_or_enum_type<_Ty> && !disable_sized_range<_UnCV> && requires(_Ty __t) {
-            { _Fake_copy_init(size(__t)) } -> _Integer_like; // intentional ADL
+            { _STD _Fake_copy_init(size(__t)) } -> _Integer_like; // intentional ADL
         };
 
         template <class _Ty>
@@ -2994,9 +2997,10 @@ namespace ranges {
                         return {_St::_None};
                     }
                 } else if constexpr (_Has_member<_Ty, _UnCV>) {
-                    return {_St::_Member, noexcept(_Fake_copy_init(_STD declval<_Ty>().size()))};
+                    return {_St::_Member, noexcept(_STD _Fake_copy_init(_STD declval<_Ty>().size()))};
                 } else if constexpr (_Has_ADL<_Ty, _UnCV>) {
-                    return {_St::_Non_member, noexcept(_Fake_copy_init(size(_STD declval<_Ty>())))}; // intentional ADL
+                    return {
+                        _St::_Non_member, noexcept(_STD _Fake_copy_init(size(_STD declval<_Ty>())))}; // intentional ADL
                 } else if constexpr (_Can_difference<_Ty>) {
                     return {_St::_Subtract,
                         noexcept(_RANGES end(_STD declval<_Ty>()) - _RANGES begin(_STD declval<_Ty>()))};
@@ -3102,7 +3106,7 @@ namespace ranges {
 
         template <class _Ty>
         concept _Has_member = requires(_Ty __t) {
-            { _Fake_copy_init(__t.data()) } -> _Points_to_object;
+            { _STD _Fake_copy_init(__t.data()) } -> _Points_to_object;
         };
 
         template <class _Ty>
@@ -4132,7 +4136,7 @@ public:
     template <sentinel_for<_Iter> _Sent>
     _NODISCARD_FRIEND constexpr bool
         operator==(const move_iterator& _Left, const move_sentinel<_Sent>& _Right) noexcept(
-            noexcept(_Fake_copy_init<bool>(_Left._Current == _Right._Get_last()))) /* strengthened */ {
+            noexcept(_STD _Fake_copy_init<bool>(_Left._Current == _Right._Get_last()))) /* strengthened */ {
         return _Left._Current == _Right._Get_last();
     }
 
@@ -4215,7 +4219,7 @@ private:
 _EXPORT_STD template <class _Iter1, class _Iter2>
 _NODISCARD _CONSTEXPR17 bool
     operator==(const move_iterator<_Iter1>& _Left, const move_iterator<_Iter2>& _Right) noexcept(
-        noexcept(_Fake_copy_init<bool>(_Left.base() == _Right.base()))) /* strengthened */
+        noexcept(_STD _Fake_copy_init<bool>(_Left.base() == _Right.base()))) /* strengthened */
 #ifdef __cpp_lib_concepts
     requires requires {
         { _Left.base() == _Right.base() } -> _Implicitly_convertible_to<bool>;
@@ -4236,7 +4240,7 @@ _NODISCARD _CONSTEXPR17 bool operator!=(const move_iterator<_Iter1>& _Left,
 _EXPORT_STD template <class _Iter1, class _Iter2>
 _NODISCARD _CONSTEXPR17 bool
     operator<(const move_iterator<_Iter1>& _Left, const move_iterator<_Iter2>& _Right) noexcept(
-        noexcept(_Fake_copy_init<bool>(_Left.base() < _Right.base()))) /* strengthened */
+        noexcept(_STD _Fake_copy_init<bool>(_Left.base() < _Right.base()))) /* strengthened */
 #ifdef __cpp_lib_concepts
     requires requires {
         { _Left.base() < _Right.base() } -> _Implicitly_convertible_to<bool>;

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -155,6 +155,7 @@ tests\Dev11_1140665_unique_ptr_array_conversions
 tests\Dev11_1150223_shared_mutex
 tests\Dev11_1158803_regex_thread_safety
 tests\Dev11_1180290_filesystem_error_code
+tests\GH_000140_adl_proof_comparison
 tests\GH_000177_forbidden_aliasing
 tests\GH_000178_uniform_int
 tests\GH_000342_filebuf_close

--- a/tests/std/tests/GH_000140_adl_proof_comparison/env.lst
+++ b/tests/std/tests/GH_000140_adl_proof_comparison/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/GH_000140_adl_proof_comparison/test.compile.pass.cpp
+++ b/tests/std/tests/GH_000140_adl_proof_comparison/test.compile.pass.cpp
@@ -1,0 +1,353 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef _M_CEE // TRANSITION, VSO-1659496
+#include <cstddef>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#if _HAS_CXX17
+#include <optional>
+#endif // _HAS_CXX17
+
+#if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#include <ranges>
+#endif // _HAS_CXX20 && defined(__cpp_lib_concepts)
+
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#include <expected>
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+
+using namespace std;
+
+template <class T>
+struct tagged_bool_like {
+    bool val_;
+    constexpr operator bool() const noexcept {
+        return val_;
+    }
+};
+
+template <class T>
+struct holder {
+    T t;
+};
+
+struct incomplete;
+
+using validating_bool_like = tagged_bool_like<holder<incomplete>>;
+
+constexpr holder<incomplete>* placeholder             = nullptr;
+constexpr holder<incomplete>* const* placeholder_addr = std::addressof(placeholder);
+
+struct test_comparable {
+    friend constexpr validating_bool_like operator==(const test_comparable&, const test_comparable&) noexcept {
+        return {true};
+    }
+    friend constexpr validating_bool_like operator!=(const test_comparable&, const test_comparable&) noexcept {
+        return {false};
+    }
+    friend constexpr validating_bool_like operator<(const test_comparable&, const test_comparable&) noexcept {
+        return {false};
+    }
+    friend constexpr validating_bool_like operator>(const test_comparable&, const test_comparable&) noexcept {
+        return {false};
+    }
+    friend constexpr validating_bool_like operator<=(const test_comparable&, const test_comparable&) noexcept {
+        return {true};
+    }
+    friend constexpr validating_bool_like operator>=(const test_comparable&, const test_comparable&) noexcept {
+        return {true};
+    }
+};
+
+template <class T>
+struct validating_iterator_provider {
+    struct iterator;
+};
+
+template <class, class = void>
+constexpr bool is_validating_iterator = false;
+template <class I>
+constexpr bool is_validating_iterator<I, void_t<typename I::reference>> =
+    is_same_v<I, typename validating_iterator_provider<remove_reference_t<typename I::reference>>::iterator>;
+
+template <class T>
+struct validating_iterator_provider<T>::iterator {
+    using value_type        = remove_cv_t<T>;
+    using pointer           = T*;
+    using reference         = T&;
+    using difference_type   = ptrdiff_t;
+    using iterator_category = random_access_iterator_tag;
+#if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+    using iterator_concept = contiguous_iterator_tag;
+#endif // _HAS_CXX20 && defined(__cpp_lib_concepts)
+
+    constexpr T& operator*() const noexcept {
+        return *ptr_;
+    }
+
+    constexpr T* operator->() const noexcept {
+        return ptr_;
+    }
+
+    constexpr T& operator[](const ptrdiff_t n) const noexcept {
+        return ptr_[n];
+    }
+
+    constexpr iterator& operator++() noexcept {
+        ++ptr_;
+        return *this;
+    }
+    constexpr iterator operator++(int) noexcept {
+        auto old = *this;
+        ++*this;
+        return old;
+    }
+
+    constexpr iterator& operator--() noexcept {
+        --ptr_;
+        return *this;
+    }
+    constexpr iterator operator--(int) noexcept {
+        auto old = *this;
+        --*this;
+        return old;
+    }
+
+    constexpr iterator& operator+=(const ptrdiff_t n) noexcept {
+        ptr_ += n;
+        return *this;
+    }
+
+    constexpr iterator& operator-=(const ptrdiff_t n) noexcept {
+        ptr_ -= n;
+        return *this;
+    }
+
+    friend constexpr iterator operator+(const iterator i, const ptrdiff_t n) noexcept {
+        return {i.ptr_ + n};
+    }
+    friend constexpr iterator operator+(const ptrdiff_t n, const iterator i) noexcept {
+        return {i.ptr_ + n};
+    }
+
+    friend constexpr ptrdiff_t operator-(const iterator i, const iterator j) noexcept {
+        return i.ptr_ - j.ptr_;
+    }
+    friend constexpr iterator operator-(const iterator i, const ptrdiff_t n) noexcept {
+        return iterator{i.ptr_ - n};
+    }
+
+    template <class OtherIter, enable_if_t<is_validating_iterator<OtherIter>, int> = 0>
+    friend constexpr auto operator==(iterator i, OtherIter j) noexcept
+        -> decltype(pointer{} == typename OtherIter::pointer{} ? placeholder_addr : nullptr) {
+        return i.operator->() == j.operator->() ? placeholder_addr : nullptr;
+    }
+    template <class OtherIter, enable_if_t<is_validating_iterator<OtherIter>, int> = 0>
+    friend constexpr auto operator!=(iterator i, OtherIter j) noexcept
+        -> decltype(pointer{} != typename OtherIter::pointer{} ? placeholder_addr : nullptr) {
+        return i.operator->() != j.operator->() ? placeholder_addr : nullptr;
+    }
+
+    template <class OtherIter, enable_if_t<is_validating_iterator<OtherIter>, int> = 0>
+    friend constexpr auto operator<(iterator i, OtherIter j) noexcept
+        -> decltype(pointer{} < typename OtherIter::pointer{} ? placeholder_addr : nullptr) {
+        return i.operator->() < j.operator->() ? placeholder_addr : nullptr;
+    }
+    template <class OtherIter, enable_if_t<is_validating_iterator<OtherIter>, int> = 0>
+    friend constexpr auto operator>(iterator i, OtherIter j) noexcept
+        -> decltype(pointer{} > typename OtherIter::pointer{} ? placeholder_addr : nullptr) {
+        return i.operator->() > j.operator->() ? placeholder_addr : nullptr;
+    }
+    template <class OtherIter, enable_if_t<is_validating_iterator<OtherIter>, int> = 0>
+    friend constexpr auto operator<=(iterator i, OtherIter j) noexcept
+        -> decltype(pointer{} <= typename OtherIter::pointer{} ? placeholder_addr : nullptr) {
+        return i.operator->() <= j.operator->() ? placeholder_addr : nullptr;
+    }
+    template <class OtherIter, enable_if_t<is_validating_iterator<OtherIter>, int> = 0>
+    friend constexpr auto operator>=(iterator i, OtherIter j) noexcept
+        -> decltype(pointer{} >= typename OtherIter::pointer{} ? placeholder_addr : nullptr) {
+        return i.operator->() >= j.operator->() ? placeholder_addr : nullptr;
+    }
+
+    template <class OtherIter, enable_if_t<!is_same_v<OtherIter, iterator> //
+                                               && is_validating_iterator<OtherIter> //
+                                               && is_convertible_v<T*, typename OtherIter::pointer>,
+                                   int> = 0>
+    constexpr operator OtherIter() const noexcept {
+        return {ptr_};
+    }
+
+    T* ptr_;
+};
+
+void test_adl_proof_legacy_comparison_functors() {
+    (void) equal_to<test_comparable>{}(test_comparable{}, test_comparable{});
+    (void) not_equal_to<test_comparable>{}(test_comparable{}, test_comparable{});
+    (void) less<test_comparable>{}(test_comparable{}, test_comparable{});
+    (void) greater<test_comparable>{}(test_comparable{}, test_comparable{});
+    (void) less_equal<test_comparable>{}(test_comparable{}, test_comparable{});
+    (void) greater_equal<test_comparable>{}(test_comparable{}, test_comparable{});
+}
+
+void test_adl_proof_reverse_iterator_comparison() {
+    using validating_iter = validating_iterator_provider<holder<incomplete>*>::iterator;
+    holder<incomplete>* p{};
+
+    reverse_iterator<validating_iter> rit{validating_iter{&p + 1}};
+    (void) rit.operator->();
+    (void) rit[0];
+
+    reverse_iterator<validating_iterator_provider<int>::iterator> i{};
+    reverse_iterator<validating_iterator_provider<const int>::iterator> j{};
+
+    (void) (i == j);
+    (void) (i != j);
+    (void) (i < j);
+    (void) (i > j);
+    (void) (i <= j);
+    (void) (i >= j);
+
+    (void) (j == i);
+    (void) (j != i);
+    (void) (j < i);
+    (void) (j > i);
+    (void) (j <= i);
+    (void) (j >= i);
+}
+
+void test_adl_proof_move_iterator_comparison() {
+    move_iterator<validating_iterator_provider<int>::iterator> i{};
+    move_iterator<validating_iterator_provider<const int>::iterator> j{};
+
+    (void) (i == j);
+    (void) (i != j);
+    (void) (i < j);
+    (void) (i > j);
+    (void) (i <= j);
+    (void) (i >= j);
+
+    (void) (j == i);
+    (void) (j != i);
+    (void) (j < i);
+    (void) (j > i);
+    (void) (j <= i);
+    (void) (j >= i);
+
+#if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+    move_sentinel<validating_iterator_provider<int>::iterator> s{};
+
+    (void) (i == s);
+    (void) (i != s);
+#endif // _HAS_CXX20 && defined(__cpp_lib_concepts)
+}
+
+#if _HAS_CXX17
+void test_adl_proof_optional_comparison() {
+    test_comparable v{};
+    optional<test_comparable> op{v};
+
+    (void) (op == op);
+    (void) (op != op);
+    (void) (op < op);
+    (void) (op > op);
+    (void) (op <= op);
+    (void) (op >= op);
+    (void) (op == op);
+
+    (void) (op == v);
+    (void) (op != v);
+    (void) (op < v);
+    (void) (op > v);
+    (void) (op <= v);
+    (void) (op >= v);
+
+    (void) (v == op);
+    (void) (v != op);
+    (void) (v < op);
+    (void) (v > op);
+    (void) (v <= op);
+    (void) (v >= op);
+}
+#endif // _HAS_CXX17
+
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+void test_adl_proof_expected_comparison() {
+    expected<test_comparable, test_comparable> ex;
+    (void) (ex == ex);
+    (void) (ex != ex);
+
+    expected<void, test_comparable> vex;
+    (void) (vex == vex);
+    (void) (vex != vex);
+
+    unexpected<test_comparable> unex{test_comparable{}};
+    (void) (unex == unex);
+    (void) (unex != unex);
+}
+
+void test_adl_proof_basic_constant_iterator_comparison() {
+    validating_iterator_provider<int>::iterator i{};
+    validating_iterator_provider<const int>::iterator j{};
+
+    basic_const_iterator<validating_iterator_provider<int>::iterator> ci{};
+    basic_const_iterator<validating_iterator_provider<const int>::iterator> cj{};
+
+    (void) (ci == ci);
+    (void) (ci != ci);
+    (void) (ci < ci);
+    (void) (ci > ci);
+    (void) (ci <= ci);
+    (void) (ci >= ci);
+
+    (void) (ci == cj);
+    (void) (ci != cj);
+
+    (void) (cj == ci);
+    (void) (cj != ci);
+    (void) (cj < ci);
+    (void) (cj > ci);
+    (void) (cj <= ci);
+    (void) (cj >= ci);
+
+    (void) (ci == i);
+    (void) (ci != i);
+    (void) (ci < i);
+    (void) (ci > i);
+    (void) (ci <= i);
+    (void) (ci >= i);
+
+    (void) (ci == j);
+    (void) (ci != j);
+
+    (void) (cj == i);
+    (void) (cj != i);
+    (void) (cj < i);
+    (void) (cj > i);
+    (void) (cj <= i);
+    (void) (cj >= i);
+
+    (void) (i == ci);
+    (void) (i != ci);
+    (void) (i < ci);
+    (void) (i > ci);
+    (void) (i <= ci);
+    (void) (i >= ci);
+
+    (void) (i == cj);
+    (void) (i != cj);
+
+    (void) (j == ci);
+    (void) (j != ci);
+    (void) (j < ci);
+    (void) (j > ci);
+    (void) (j <= ci);
+    (void) (j >= ci);
+}
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+
+#endif // _M_CEE

--- a/tests/std/tests/GH_000140_adl_proof_comparison/test.compile.pass.cpp
+++ b/tests/std/tests/GH_000140_adl_proof_comparison/test.compile.pass.cpp
@@ -5,7 +5,6 @@
 #include <cstddef>
 #include <functional>
 #include <iterator>
-#include <memory>
 #include <type_traits>
 #include <utility>
 
@@ -41,7 +40,7 @@ struct incomplete;
 using validating_bool_like = tagged_bool_like<holder<incomplete>>;
 
 constexpr holder<incomplete>* placeholder             = nullptr;
-constexpr holder<incomplete>* const* placeholder_addr = std::addressof(placeholder);
+constexpr holder<incomplete>* const* placeholder_addr = &placeholder;
 
 struct test_comparable {
     friend constexpr validating_bool_like operator==(const test_comparable&, const test_comparable&) noexcept {

--- a/tests/std/tests/GH_000140_adl_proof_comparison/test.compile.pass.cpp
+++ b/tests/std/tests/GH_000140_adl_proof_comparison/test.compile.pass.cpp
@@ -194,6 +194,19 @@ void test_adl_proof_legacy_comparison_functors() {
     (void) greater_equal<test_comparable>{}(test_comparable{}, test_comparable{});
 }
 
+template <class L, class R>
+void test_adl_proof_comparison() {
+    L l{};
+    R r{};
+
+    (void) (l == r);
+    (void) (l != r);
+    (void) (l < r);
+    (void) (l > r);
+    (void) (l <= r);
+    (void) (l >= r);
+}
+
 void test_adl_proof_reverse_iterator_comparison() {
     using validating_iter = validating_iterator_provider<holder<incomplete>*>::iterator;
     holder<incomplete>* p{};
@@ -202,43 +215,22 @@ void test_adl_proof_reverse_iterator_comparison() {
     (void) rit.operator->();
     (void) rit[0];
 
-    reverse_iterator<validating_iterator_provider<int>::iterator> i{};
-    reverse_iterator<validating_iterator_provider<const int>::iterator> j{};
+    using I = reverse_iterator<validating_iterator_provider<int>::iterator>;
+    using J = reverse_iterator<validating_iterator_provider<const int>::iterator>;
 
-    (void) (i == j);
-    (void) (i != j);
-    (void) (i < j);
-    (void) (i > j);
-    (void) (i <= j);
-    (void) (i >= j);
-
-    (void) (j == i);
-    (void) (j != i);
-    (void) (j < i);
-    (void) (j > i);
-    (void) (j <= i);
-    (void) (j >= i);
+    test_adl_proof_comparison<I, J>();
+    test_adl_proof_comparison<J, I>();
 }
 
 void test_adl_proof_move_iterator_comparison() {
-    move_iterator<validating_iterator_provider<int>::iterator> i{};
-    move_iterator<validating_iterator_provider<const int>::iterator> j{};
+    using I = move_iterator<validating_iterator_provider<int>::iterator>;
+    using J = move_iterator<validating_iterator_provider<const int>::iterator>;
 
-    (void) (i == j);
-    (void) (i != j);
-    (void) (i < j);
-    (void) (i > j);
-    (void) (i <= j);
-    (void) (i >= j);
-
-    (void) (j == i);
-    (void) (j != i);
-    (void) (j < i);
-    (void) (j > i);
-    (void) (j <= i);
-    (void) (j >= i);
+    test_adl_proof_comparison<I, J>();
+    test_adl_proof_comparison<J, I>();
 
 #if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+    I i{};
     move_sentinel<validating_iterator_provider<int>::iterator> s{};
 
     (void) (i == s);
@@ -248,29 +240,12 @@ void test_adl_proof_move_iterator_comparison() {
 
 #if _HAS_CXX17
 void test_adl_proof_optional_comparison() {
-    test_comparable v{};
-    optional<test_comparable> op{v};
+    using V = test_comparable;
+    using O = optional<test_comparable>;
 
-    (void) (op == op);
-    (void) (op != op);
-    (void) (op < op);
-    (void) (op > op);
-    (void) (op <= op);
-    (void) (op >= op);
-
-    (void) (op == v);
-    (void) (op != v);
-    (void) (op < v);
-    (void) (op > v);
-    (void) (op <= v);
-    (void) (op >= v);
-
-    (void) (v == op);
-    (void) (v != op);
-    (void) (v < op);
-    (void) (v > op);
-    (void) (v <= op);
-    (void) (v >= op);
+    test_adl_proof_comparison<O, O>();
+    test_adl_proof_comparison<O, V>();
+    test_adl_proof_comparison<V, O>();
 }
 #endif // _HAS_CXX17
 
@@ -290,62 +265,27 @@ void test_adl_proof_expected_comparison() {
 }
 
 void test_adl_proof_basic_const_iterator_comparison() {
-    validating_iterator_provider<int>::iterator i{};
-    validating_iterator_provider<const int>::iterator j{};
+    using I = validating_iterator_provider<int>::iterator;
+    using J = validating_iterator_provider<const int>::iterator;
 
-    basic_const_iterator<validating_iterator_provider<int>::iterator> ci{};
-    basic_const_iterator<validating_iterator_provider<const int>::iterator> cj{};
+    using CI = basic_const_iterator<validating_iterator_provider<int>::iterator>;
+    using CJ = basic_const_iterator<validating_iterator_provider<const int>::iterator>;
 
-    (void) (ci == ci);
-    (void) (ci != ci);
-    (void) (ci < ci);
-    (void) (ci > ci);
-    (void) (ci <= ci);
-    (void) (ci >= ci);
+    test_adl_proof_comparison<CI, I>();
+    test_adl_proof_comparison<CI, J>();
+    test_adl_proof_comparison<CI, CI>();
+    test_adl_proof_comparison<CI, CJ>();
 
-    (void) (ci == cj);
-    (void) (ci != cj);
+    test_adl_proof_comparison<CJ, I>();
+    test_adl_proof_comparison<CJ, J>();
+    test_adl_proof_comparison<CJ, CI>();
+    test_adl_proof_comparison<CJ, CJ>();
 
-    (void) (cj == ci);
-    (void) (cj != ci);
-    (void) (cj < ci);
-    (void) (cj > ci);
-    (void) (cj <= ci);
-    (void) (cj >= ci);
+    test_adl_proof_comparison<I, CI>();
+    test_adl_proof_comparison<J, CI>();
 
-    (void) (ci == i);
-    (void) (ci != i);
-    (void) (ci < i);
-    (void) (ci > i);
-    (void) (ci <= i);
-    (void) (ci >= i);
-
-    (void) (ci == j);
-    (void) (ci != j);
-
-    (void) (cj == i);
-    (void) (cj != i);
-    (void) (cj < i);
-    (void) (cj > i);
-    (void) (cj <= i);
-    (void) (cj >= i);
-
-    (void) (i == ci);
-    (void) (i != ci);
-    (void) (i < ci);
-    (void) (i > ci);
-    (void) (i <= ci);
-    (void) (i >= ci);
-
-    (void) (i == cj);
-    (void) (i != cj);
-
-    (void) (j == ci);
-    (void) (j != ci);
-    (void) (j < ci);
-    (void) (j > ci);
-    (void) (j <= ci);
-    (void) (j >= ci);
+    test_adl_proof_comparison<I, CJ>();
+    test_adl_proof_comparison<J, CJ>();
 }
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 

--- a/tests/std/tests/GH_000140_adl_proof_comparison/test.compile.pass.cpp
+++ b/tests/std/tests/GH_000140_adl_proof_comparison/test.compile.pass.cpp
@@ -257,7 +257,6 @@ void test_adl_proof_optional_comparison() {
     (void) (op > op);
     (void) (op <= op);
     (void) (op >= op);
-    (void) (op == op);
 
     (void) (op == v);
     (void) (op != v);
@@ -290,7 +289,7 @@ void test_adl_proof_expected_comparison() {
     (void) (unex != unex);
 }
 
-void test_adl_proof_basic_constant_iterator_comparison() {
+void test_adl_proof_basic_const_iterator_comparison() {
     validating_iterator_provider<int>::iterator i{};
     validating_iterator_provider<const int>::iterator j{};
 

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -2001,6 +2001,142 @@ namespace poison_pill_test {
     STATIC_ASSERT(CanSize<some_type const&>);
 } // namespace poison_pill_test
 
+#ifndef _M_CEE // TRANSITION, VSO-1659496
+// N.B. reverse_iterator<value_holder<incomplet>*> can't be made ADL-proof and doesn't model bidirectional_iterator,
+// so the rbegin()/rend() member functions return the same iterators as begin()/end().
+namespace adl_proof_test {
+    struct validating_member_range {
+        value_holder<incomplet>* elems_[1];
+
+        constexpr value_holder<incomplet>** begin() noexcept {
+            return elems_;
+        }
+        constexpr value_holder<incomplet>* const* begin() const noexcept {
+            return elems_;
+        }
+
+        constexpr value_holder<incomplet>** end() noexcept {
+            return elems_ + 1;
+        }
+        constexpr value_holder<incomplet>* const* end() const noexcept {
+            return elems_ + 1;
+        }
+
+        constexpr value_holder<incomplet>** rbegin() noexcept {
+            return elems_;
+        }
+        constexpr value_holder<incomplet>* const* rbegin() const noexcept {
+            return elems_;
+        }
+
+        constexpr value_holder<incomplet>** rend() noexcept {
+            return elems_ + 1;
+        }
+        constexpr value_holder<incomplet>* const* rend() const noexcept {
+            return elems_ + 1;
+        }
+
+        constexpr value_holder<incomplet>** data() noexcept {
+            return elems_;
+        }
+        constexpr value_holder<incomplet>* const* data() const noexcept {
+            return elems_;
+        }
+    };
+
+    STATIC_ASSERT(CanBegin<validating_member_range&>);
+    STATIC_ASSERT(CanBegin<const validating_member_range&>);
+    STATIC_ASSERT(CanCBegin<validating_member_range&>);
+    STATIC_ASSERT(CanCBegin<const validating_member_range&>);
+
+    STATIC_ASSERT(CanEnd<validating_member_range&>);
+    STATIC_ASSERT(CanEnd<const validating_member_range&>);
+    STATIC_ASSERT(CanCEnd<validating_member_range&>);
+    STATIC_ASSERT(CanCEnd<const validating_member_range&>);
+
+    STATIC_ASSERT(CanRBegin<validating_member_range&>);
+    STATIC_ASSERT(CanRBegin<const validating_member_range&>);
+    STATIC_ASSERT(CanCRBegin<validating_member_range&>);
+    STATIC_ASSERT(CanCRBegin<const validating_member_range&>);
+
+    STATIC_ASSERT(CanREnd<validating_member_range&>);
+    STATIC_ASSERT(CanREnd<const validating_member_range&>);
+    STATIC_ASSERT(CanCREnd<validating_member_range&>);
+    STATIC_ASSERT(CanCREnd<const validating_member_range&>);
+
+    STATIC_ASSERT(CanData<validating_member_range&>);
+    STATIC_ASSERT(CanData<const validating_member_range&>);
+    STATIC_ASSERT(CanCData<validating_member_range&>);
+    STATIC_ASSERT(CanCData<const validating_member_range&>);
+
+    struct validating_nonmember_range {
+        value_holder<incomplet>* elems_[1];
+
+        friend constexpr value_holder<incomplet>** begin(validating_nonmember_range& r) noexcept {
+            return r.elems_;
+        }
+        friend constexpr value_holder<incomplet>* const* begin(const validating_nonmember_range& r) noexcept {
+            return r.elems_;
+        }
+
+        friend constexpr value_holder<incomplet>** end(validating_nonmember_range& r) noexcept {
+            return r.elems_ + 1;
+        }
+        friend constexpr value_holder<incomplet>* const* end(const validating_nonmember_range& r) noexcept {
+            return r.elems_ + 1;
+        }
+
+        friend constexpr value_holder<incomplet>** rbegin(validating_nonmember_range& r) noexcept {
+            return r.elems_;
+        }
+        friend constexpr value_holder<incomplet>* const* rbegin(const validating_nonmember_range& r) noexcept {
+            return r.elems_;
+        }
+
+        friend constexpr value_holder<incomplet>** rend(validating_nonmember_range& r) noexcept {
+            return r.elems_ + 1;
+        }
+        friend constexpr value_holder<incomplet>* const* rend(const validating_nonmember_range& r) noexcept {
+            return r.elems_ + 1;
+        }
+    };
+
+    STATIC_ASSERT(CanBegin<validating_nonmember_range&>);
+    STATIC_ASSERT(CanBegin<const validating_nonmember_range&>);
+    STATIC_ASSERT(CanCBegin<validating_nonmember_range&>);
+    STATIC_ASSERT(CanCBegin<const validating_nonmember_range&>);
+
+    STATIC_ASSERT(CanEnd<validating_nonmember_range&>);
+    STATIC_ASSERT(CanEnd<const validating_nonmember_range&>);
+    STATIC_ASSERT(CanCEnd<validating_nonmember_range&>);
+    STATIC_ASSERT(CanCEnd<const validating_nonmember_range&>);
+
+    STATIC_ASSERT(CanRBegin<validating_nonmember_range&>);
+    STATIC_ASSERT(CanRBegin<const validating_nonmember_range&>);
+    STATIC_ASSERT(CanCRBegin<validating_nonmember_range&>);
+    STATIC_ASSERT(CanCRBegin<const validating_nonmember_range&>);
+
+    STATIC_ASSERT(CanREnd<validating_nonmember_range&>);
+    STATIC_ASSERT(CanREnd<const validating_nonmember_range&>);
+    STATIC_ASSERT(CanCREnd<validating_nonmember_range&>);
+    STATIC_ASSERT(CanCREnd<const validating_nonmember_range&>);
+
+    struct nonsizable_type {
+        constexpr value_holder<incomplet>* size() const noexcept {
+            return nullptr;
+        }
+
+        friend constexpr value_holder<incomplet>* size(nonsizable_type) noexcept {
+            return nullptr;
+        }
+    };
+
+    STATIC_ASSERT(CanSize<validating_member_range>);
+    STATIC_ASSERT(CanSize<validating_nonmember_range>);
+    STATIC_ASSERT(!CanSize<nonsizable_type>);
+} // namespace adl_proof_test
+#endif // _M_CEE
+
 namespace unwrapped_begin_end {
     // Validate the iterator-unwrapping range access CPOs ranges::_Ubegin and ranges::_Uend
     using test::CanCompare, test::CanDifference, test::Common, test::ProxyRef, test::Sized, test::WrappedState;


### PR DESCRIPTION
... by `_STD`-qualifying `_Fake_copy_init`. Towards #140.

While dealing with #4318, I found that most, if not all, occurrences of `_Fake_copy_init` in MSVC STL needed to be qualified.

Fixed components:
- "legacy" comparison function objects: `equal_to`, `not_equal_to`, `less`, `greater`, `less_equal`, and `greater_equal`
- iterator adaptors: `reverse_iterator`, `move_iterator` (together with `move_sentinel`), and `basic_const_iterator`
- `optional`
- `expected` (together with `unexpected`)

Views (in `<ranges>`) are not yet touched since I haven't come up with testing examples, but I think occurrences of `_Fake_copy_init` in views also need to be qualified.