### PR TITLE
Clarify some ASan-related libcxx FAILs

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -191,17 +191,17 @@ std/modules/std.pass.cpp FAIL
 
 
 # *** ASAN FAILURES ***
-# ASAN runtime warns about an overlarge allocation and panics when it should throw bad_alloc instead
-# (VSO-1854252, VSO-1854240, VSO-1854255, VSO-1854247, VSO-1854256)
+# Even with `allocator_may_return_null=1`, ASan kills oversized allocations instead of throwing `bad_alloc`.
+# (https://github.com/google/sanitizers/issues/295)
+std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align.pass.cpp:1 FAIL
+std/language.support/support.dynamic/new.delete/new.delete.array/new.size.pass.cpp:1 FAIL
+std/language.support/support.dynamic/new.delete/new.delete.single/new.size_align.pass.cpp:1 FAIL
+std/language.support/support.dynamic/new.delete/new.delete.single/new.size.pass.cpp:1 FAIL
 std/strings/basic.string/string.capacity/max_size.pass.cpp:1 FAIL
 
-# ASAN runtime warns about an overlarge allocation and doesn't call new_handler (VSO-1854235, VSO-1854568, VSO-1854400, VSO-1854248)
-std/language.support/support.dynamic/new.delete/new.delete.array/new.size.pass.cpp:1 FAIL
-std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align.pass.cpp:1 FAIL
+# Even with `allocator_may_return_null=1`, ASan doesn't call `new_handler` on allocation failure. (LLVM-15544)
 std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align_nothrow.pass.cpp:1 FAIL
 std/language.support/support.dynamic/new.delete/new.delete.array/new.size_nothrow.pass.cpp:1 FAIL
-std/language.support/support.dynamic/new.delete/new.delete.single/new.size.pass.cpp:1 FAIL
-std/language.support/support.dynamic/new.delete/new.delete.single/new.size_align.pass.cpp:1 FAIL
 std/language.support/support.dynamic/new.delete/new.delete.single/new.size_align_nothrow.pass.cpp:1 FAIL
 std/language.support/support.dynamic/new.delete/new.delete.single/new.size_nothrow.pass.cpp:1 FAIL
 


### PR DESCRIPTION
... and update links to point at upstream issues instead of VSOs which I closed as "duplicates" of those upstream issues.
