### PR TITLE
Remove a `/clr` workaround in test code

### DIFF
--- a/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
+++ b/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
@@ -1063,13 +1063,11 @@ constexpr bool test_invoke_constexpr() {
 #endif // _HAS_CXX20
     assert(&invoke(&Thing::m_x, p) == &p->m_x);
 
-#ifndef _M_CEE // TRANSITION, DevCom-939490
     assert(invoke(&Thing::sum, *p, 3) == 1023);
 #if _HAS_CXX20
     assert(invoke(&Thing::sum, ref(*p), 4) == 1024);
 #endif // _HAS_CXX20
     assert(invoke(&Thing::sum, p, 5) == 1025);
-#endif // _M_CEE
 
     assert(invoke(square_constexpr, 6) == 36);
     assert(invoke(&cube_constexpr, 7) == 343);


### PR DESCRIPTION
@Codiferous's MSVC-PR-522996 fixed VSO-1078742 DevCom-939490 "Calling a pointer to member function at `constexpr` time in `/clr` triggers internal compiler error" reported on 2020-03-04, so we can finally remove this workaround. As this is `/clr`, we can do so immediately, no need to wait for a toolset update. I've verified this internally.
