### PR TITLE
`<flat_map>` Fix compile errors

### DIFF
--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -757,6 +757,28 @@ protected:
         return _Old_size - size();
     }
 
+    template <class _KeyTy, class... _MappedArgTypes>
+    pair<iterator, bool> _Try_emplace(_KeyTy&& _Key_val, _MappedArgTypes&&... _Mapped_args) {
+        auto _Key_it = _STD lower_bound(_Data.keys.begin(), _Data.keys.end(), _Key_val, _Key_compare);
+        if (_Key_it != _Data.keys.end() && _Key_equal(*_Key_it, _STD forward<_KeyTy>(_Key_val))) {
+            // Already exists
+            return {this->begin() + _STD distance(_Data.keys.begin(), _Key_it), false};
+        } else {
+            // Need to insert
+            auto _Index = _STD distance(_Data.keys.begin(), _Key_it);
+            this->_Insert_exact(this->cbegin() + _Index, key_type{_STD forward<_KeyTy>(_Key_val)},
+                mapped_type{_STD forward<_MappedArgTypes>(_Mapped_args)...});
+            return {this->begin() + _Index, true};
+        }
+    }
+
+    void _Insert_exact(const_iterator _Position, key_type&& _Key_val, mapped_type&& _Mapped_val) {
+        _Clear_flat_map_scope_guard _Guard{this};
+        _Data.keys.insert(_Position._Key_it, _STD move(_Key_val));
+        _Data.values.insert(_Position._Mapped_it, _STD move(_Mapped_val));
+        _Guard._Clearable = nullptr;
+    }
+
 private:
     template <class _KeyTy1, class _KeyTy2>
         requires (same_as<remove_cvref_t<_KeyTy1 &&>, key_type> && same_as<remove_cvref_t<_KeyTy2 &&>, key_type>)
@@ -789,13 +811,6 @@ private:
         auto _Remaining_count = _STD distance(_Sorted_view.begin(), _Subrange.begin());
         _Data.keys.erase(_Data.keys.begin() + _Remaining_count, _Data.keys.end());
         _Data.values.erase(_Data.values.begin() + _Remaining_count, _Data.values.end());
-        _Guard._Clearable = nullptr;
-    }
-
-    void _Insert_exact(const_iterator _Position, key_type&& _Key_val, mapped_type&& _Mapped_val) {
-        _Clear_flat_map_scope_guard _Guard{this};
-        _Data.keys.insert(_Position._Key_it, _STD move(_Key_val));
-        _Data.values.insert(_Position._Mapped_it, _STD move(_Mapped_val));
         _Guard._Clearable = nullptr;
     }
 
@@ -1161,6 +1176,7 @@ public:
 
 private:
     using _MyBase::_Erase_if;
+    using _MyBase::_Try_emplace;
 
     template <class _KTy, class _MTy, class _Comp, class _KeyCont, class _MappedCont, class _Pred>
     friend typename flat_map<_KTy, _MTy, _Comp, _KeyCont, _MappedCont>::size_type erase_if(
@@ -1187,21 +1203,6 @@ private:
             _Xout_of_range("std::flat_map::at: the specified key does not exist.");
         } else {
             return _Position->second;
-        }
-    }
-
-    template <class _KeyTy, class... _MappedArgTypes>
-    pair<iterator, bool> _Try_emplace(_KeyTy&& _Key_val, _MappedArgTypes&&... _Mapped_args) {
-        auto _Key_it = _STD lower_bound(_Data.keys.begin(), _Data.keys.end(), _Key_val, _Key_compare);
-        if (_Key_it != _Data.keys.end() && _Key_equal(*_Key_it, _STD forward<_KeyTy>(_Key_val))) {
-            // Already exists
-            return {this->begin() + _STD distance(_Data.keys.begin(), _Key_it), false};
-        } else {
-            // Need to insert
-            auto _Index = _STD distance(_Data.keys.begin(), _Key_it);
-            this->_Insert_exact(this->cbegin() + _Index, key_type{_STD forward<_KeyTy>(_Key_val)},
-                mapped_type{_STD forward<_MappedArgTypes>(_Mapped_args)...});
-            return {this->begin() + _Index, true};
         }
     }
 
@@ -1328,6 +1329,7 @@ public:
 
 private:
     using _MyBase::_Erase_if;
+    using _MyBase::_Insert_exact
 
     template <class _KTy, class _MTy, class _Comp, class _KeyCont, class _MappedCont, class _Pred>
     friend typename flat_multimap<_KTy, _MTy, _Comp, _KeyCont, _MappedCont>::size_type erase_if(

--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -1329,7 +1329,7 @@ public:
 
 private:
     using _MyBase::_Erase_if;
-    using _MyBase::_Insert_exact
+    using _MyBase::_Insert_exact;
 
     template <class _KTy, class _MTy, class _Comp, class _KeyCont, class _MappedCont, class _Pred>
     friend typename flat_multimap<_KTy, _MTy, _Comp, _KeyCont, _MappedCont>::size_type erase_if(

--- a/tests/std/tests/P0429R9_flat_map/env.lst
+++ b/tests/std/tests/P0429R9_flat_map/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst

--- a/tests/std/tests/P0429R9_flat_map/test.cpp
+++ b/tests/std/tests/P0429R9_flat_map/test.cpp
@@ -300,8 +300,42 @@ namespace scary_test {
     static_assert(is_same_v<flat_map<int, int>::value_compare, flat_multimap<int, int>::value_compare>);
 } // namespace scary_test
 
+// GH-4344 <flat_map> Fix compile errors
+void test_gh_4344() {
+    flat_map<int, char> fm;
+
+    const auto p1 = fm.try_emplace(10, 'm');
+    assert(p1.first->first == 10);
+    assert(p1.first->second == 'm');
+    assert(p1.second);
+
+    const auto p2 = fm.try_emplace(70, 'e');
+    assert(p2.first->first == 70);
+    assert(p2.first->second == 'e');
+    assert(p2.second);
+
+    const auto p3 = fm.try_emplace(20, 'o');
+    assert(p3.first->first == 20);
+    assert(p3.first->second == 'o');
+    assert(p3.second);
+
+    const auto p4 = fm.try_emplace(90, 'w');
+    assert(p4.first->first == 90);
+    assert(p4.first->second == 'w');
+    assert(p4.second);
+
+    const auto p5 = fm.try_emplace(70, 'X');
+    assert(p5.first->first == 70);
+    assert(p5.first->second == 'e');
+    assert(!p5.second);
+
+    assert(check_key_content(fm, {10, 20, 70, 90}));
+    assert(check_value_content(fm, {'m', 'o', 'e', 'w'}));
+}
+
 int main() {
     test_construction();
     test_pointer_to_incomplete_type();
     test_erase_if();
+    test_gh_4344();
 }


### PR DESCRIPTION
As mentioned in a [comment](https://github.com/microsoft/STL/commit/00c23249b9580512990722e3a0494fe61866c3fe#commitcomment-137907936), I've been testing out the `flat_map` implementation in my personal project but after the last commit I'm getting the following error:
`flat_map.h(1196,44): '_Key_equal': function was not declared in the template definition context and can be found only via argument-dependent lookup in the instantiation context`

Previous version compiled fine though.

It seems the `_Try_emplace` function here depends on the private `_Key_equal`. I moved that back to the base implementation similar to `_Erase_if`.

I've also moved `_Insert_exact` to the protected section as the `flat_multimap::_Emplace_key_mapped()` uses that function.