### PR TITLE
`<xiosbase>`: Deprecate non-conforming extension `ios_base::hexfloat`

### DIFF
--- a/stl/inc/ios
+++ b/stl/inc/ios
@@ -206,8 +206,8 @@ _EXPORT_STD inline ios_base& __CLRCALL_OR_CDECL hex(ios_base& _Iosbase) { // set
     return _Iosbase;
 }
 
-_EXPORT_STD inline ios_base& __CLRCALL_OR_CDECL hexfloat(ios_base& _Iosbase) { // set floatfield to hexfloat
-    _Iosbase.setf(ios_base::hexfloat, ios_base::floatfield);
+_EXPORT_STD inline ios_base& __CLRCALL_OR_CDECL hexfloat(ios_base& _Iosbase) { // set floatfield to (scientific | fixed)
+    _Iosbase.setf(ios_base::scientific | ios_base::fixed, ios_base::floatfield);
     return _Iosbase;
 }
 

--- a/stl/inc/xiosbase
+++ b/stl/inc/xiosbase
@@ -42,7 +42,7 @@ public:
     static constexpr int scientific = 0x1000;
     static constexpr int fixed      = 0x2000;
 
-    static constexpr int hexfloat = 0x3000; // TRANSITION, ABI, GH-3296
+    _DEPRECATE_IOS_BASE_HEXFLOAT static constexpr int hexfloat = 0x3000; // TRANSITION, ABI, GH-3296
 
     static constexpr int boolalpha   = 0x4000;
     static constexpr int adjustfield = left | right | internal;

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -1441,7 +1441,7 @@ private:
         if (_Flags & ios_base::uppercase) {
             if (_Ffl == ios_base::fixed) {
                 _Ch = 'f';
-            } else if (_Ffl == ios_base::hexfloat) {
+            } else if (_Ffl == (ios_base::scientific | ios_base::fixed)) {
                 _Ch = 'A'; // added with TR1
             } else if (_Ffl == ios_base::scientific) {
                 _Ch = 'E';
@@ -1451,7 +1451,7 @@ private:
         } else {
             if (_Ffl == ios_base::fixed) {
                 _Ch = 'f';
-            } else if (_Ffl == ios_base::hexfloat) {
+            } else if (_Ffl == (ios_base::scientific | ios_base::fixed)) {
                 _Ch = 'a'; // added with TR1
             } else if (_Ffl == ios_base::scientific) {
                 _Ch = 'e';
@@ -1475,7 +1475,7 @@ private:
         bool _Is_finite_val) const { // put formatted floating-point to _Dest
         auto _Prefix = static_cast<size_t>(0 < _Count && (*_Buf == '+' || *_Buf == '-'));
         const char* _Exps;
-        if ((_Iosbase.flags() & ios_base::floatfield) != ios_base::hexfloat) {
+        if ((_Iosbase.flags() & ios_base::floatfield) != (ios_base::scientific | ios_base::fixed)) {
             _Exps = "eE";
         } else { // correct for hexadecimal floating-point
             _Exps = "pP";

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1537,7 +1537,18 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define _DEPRECATE_TR1_RANDOM
 #endif // ^^^ warning disabled ^^^
 
-// next warning number: STL4047
+#if _HAS_CXX17 && !defined(_SILENCE_IOS_BASE_HEXFLOAT_DEPRECATION_WARNING) \
+    && !defined(_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS)
+#define _DEPRECATE_IOS_BASE_HEXFLOAT                                                                                \
+    [[deprecated("warning STL4047: std::ios_base::hexfloat is a non-Standard extension and will be removed. "       \
+                 "(std::ios_base::scientific | std::ios_base::fixed) or std::hexfloat should be used instead. You " \
+                 "can define _SILENCE_IOS_BASE_HEXFLOAT_DEPRECATION_WARNING or "                                    \
+                 "_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS to suppress this warning.")]]
+#else // ^^^ warning enabled / warning disabled vvv
+#define _DEPRECATE_IOS_BASE_HEXFLOAT
+#endif // ^^^ warning disabled ^^^
+
+// next warning number: STL4048
 
 // next error number: STL1006
 

--- a/tests/tr1/tests/ios/test.cpp
+++ b/tests/tr1/tests/ios/test.cpp
@@ -12,11 +12,11 @@
 #include <string.h>
 
 // static data
-static const STD ios_base::fmtflags ffl[] = {STD ios_base::hexfloat, STD ios_base::dec, STD ios_base::fixed,
-    STD ios_base::hex, STD ios_base::internal, STD ios_base::left, STD ios_base::oct, STD ios_base::right,
-    STD ios_base::scientific, STD ios_base::showbase, STD ios_base::showpoint, STD ios_base::showpos,
-    STD ios_base::skipws, STD ios_base::unitbuf, STD ios_base::uppercase, STD ios_base::boolalpha,
-    STD ios_base::adjustfield, STD ios_base::basefield, STD ios_base::floatfield};
+static const STD ios_base::fmtflags ffl[] = {STD ios_base::dec, STD ios_base::fixed, STD ios_base::hex,
+    STD ios_base::internal, STD ios_base::left, STD ios_base::oct, STD ios_base::right, STD ios_base::scientific,
+    STD ios_base::showbase, STD ios_base::showpoint, STD ios_base::showpos, STD ios_base::skipws, STD ios_base::unitbuf,
+    STD ios_base::uppercase, STD ios_base::boolalpha, STD ios_base::adjustfield, STD ios_base::basefield,
+    STD ios_base::floatfield};
 
 static const STD ios_base::iostate ifl[] = {
     STD ios_base::badbit, STD ios_base::eofbit, STD ios_base::failbit, STD ios_base::goodbit};
@@ -85,8 +85,6 @@ void test_main() { // test basic workings of ios definitions
     CHECK_INT(STD ios_base::left | STD ios_base::right | STD ios_base::internal, STD ios_base::adjustfield);
     CHECK_INT(STD ios_base::dec | STD ios_base::oct | STD ios_base::hex, STD ios_base::basefield);
     CHECK_INT(STD ios_base::scientific | STD ios_base::fixed, STD ios_base::floatfield);
-
-    CHECK_INT(STD ios_base::scientific | STD ios_base::fixed, STD ios_base::hexfloat);
 
     // test assignment and control functions
     CHECK(x && true);
@@ -170,7 +168,7 @@ void test_main() { // test basic workings of ios definitions
     CHECK_INT(x.flags(), STD ios_base::scientific | STD ios_base::unitbuf);
 
     x.clear(STD ios_base::floatfield);
-    x.setf(STD ios_base::hexfloat);
+    x.setf(STD ios_base::scientific | STD ios_base::fixed);
     CHECK_INT(x.flags(), STD ios_base::scientific | STD ios_base::fixed | STD ios_base::unitbuf);
 
     CHECK_INT(x.precision(INT_MIN), 6);
@@ -216,13 +214,13 @@ void test_main() { // test basic workings of ios definitions
     CHECK_INT(po->flags(), STD ios_base::oct | STD ios_base::right | STD ios_base::scientific);
 
     STD hexfloat(*po);
-    CHECK_INT(po->flags(), STD ios_base::oct | STD ios_base::right | STD ios_base::hexfloat);
+    CHECK_INT(po->flags(), STD ios_base::oct | STD ios_base::right | STD ios_base::scientific | STD ios_base::fixed);
 
     STD defaultfloat(*po);
     CHECK_INT(po->flags(), STD ios_base::oct | STD ios_base::right);
 
     STD hexfloat(*po);
-    CHECK_INT(po->flags(), STD ios_base::oct | STD ios_base::right | STD ios_base::hexfloat);
+    CHECK_INT(po->flags(), STD ios_base::oct | STD ios_base::right | STD ios_base::scientific | STD ios_base::fixed);
 
     STD error_code ec1 = STD make_error_code(STD io_errc::stream);
     CHECK(ec1.value() == (int) STD io_errc::stream);


### PR DESCRIPTION
Towards #3296.

All uses of `ios_base::float` are replaced with `ios_base::scientific | ios_base::fixed`. Also, It seems to me that we should no longer test `ios_base::float`.