### PR TITLE
Enable warnings for the benchmarks, and fix them

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -61,6 +61,9 @@ endif()
 
 set(CMAKE_BUILD_TYPE RelWithDebInfo)
 
+# /utf-8 affects <format>.
+add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/diagnostics:caret;/W4;/WX;/w14265;/w15038;/w15262;/utf-8>")
+
 if(NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/google-benchmark/.git")
     message(FATAL_ERROR "google-benchmark is not checked out; make sure to run\n    git submodule update --init benchmarks/google-benchmark")
 endif()

--- a/benchmarks/inc/udt.hpp
+++ b/benchmarks/inc/udt.hpp
@@ -3,18 +3,18 @@
 
 #pragma once
 
-template <typename Contained>
+template <typename Data>
 struct aggregate {
-    Contained c;
+    Data c;
 
     friend bool operator==(const aggregate&, const aggregate&) = default;
 };
 
-template <typename Contained>
+template <typename Data>
 struct non_trivial {
-    Contained c;
+    Data c;
     non_trivial() : c() {}
-    non_trivial(const Contained& src) : c(src) {}
+    non_trivial(const Data& src) : c(src) {}
     non_trivial(const non_trivial& other) : c(other.c) {}
     non_trivial& operator=(const non_trivial& other) {
         c = other.c;

--- a/benchmarks/inc/utility.hpp
+++ b/benchmarks/inc/utility.hpp
@@ -18,6 +18,15 @@ std::vector<Contained> random_vector(size_t n) {
     xoshiro256ss prng{id64(rd), id64(rd), id64(rd), id64(rd)};
 
     std::vector<Contained> res(n);
+
+// Here, the type Contained can be char, int, aggregate<Data>, or non_trivial<Data> where Data is char or int.
+// (aggregate<Data> and non_trivial<Data> are defined in udt.hpp.)
+// static_cast<Contained> silences truncation warnings when Contained is directly char or int,
+// but is insufficient for aggregate<Data> or non_trivial<Data>.
+#pragma warning(push)
+#pragma warning(disable : 4244) // warning C4244: conversion from 'uint64_t' to 'Data', possible loss of data
     std::generate(res.begin(), res.end(), [&prng] { return static_cast<Contained>(prng.next()); });
+#pragma warning(pop)
+
     return res;
 }

--- a/benchmarks/src/std/containers/sequences/vector.bool/copy/test.cpp
+++ b/benchmarks/src/std/containers/sequences/vector.bool/copy/test.cpp
@@ -4,6 +4,7 @@
 #include <benchmark/benchmark.h>
 //
 #include <algorithm>
+#include <cstddef>
 #include <random>
 #include <vector>
 
@@ -17,7 +18,7 @@ static vector<bool> createRandomVector(const size_t size) {
 }
 
 static void copy_block_aligned(benchmark::State& state) {
-    const auto size           = state.range(0);
+    const auto size           = static_cast<size_t>(state.range(0));
     const vector<bool> source = createRandomVector(size);
     vector<bool> dest(size, false);
 
@@ -27,7 +28,7 @@ static void copy_block_aligned(benchmark::State& state) {
 }
 
 static void copy_source_misaligned(benchmark::State& state) {
-    const auto size           = state.range(0);
+    const auto size           = static_cast<size_t>(state.range(0));
     const vector<bool> source = createRandomVector(size);
     vector<bool> dest(size, false);
 
@@ -37,7 +38,7 @@ static void copy_source_misaligned(benchmark::State& state) {
 }
 
 static void copy_dest_misaligned(benchmark::State& state) {
-    const auto size           = state.range(0);
+    const auto size           = static_cast<size_t>(state.range(0));
     const vector<bool> source = createRandomVector(size);
     vector<bool> dest(size, false);
 
@@ -48,7 +49,7 @@ static void copy_dest_misaligned(benchmark::State& state) {
 
 // Special benchmark for matching char alignment
 static void copy_matching_alignment(benchmark::State& state) {
-    const auto size           = state.range(0);
+    const auto size           = static_cast<size_t>(state.range(0));
     const vector<bool> source = createRandomVector(size);
     vector<bool> dest(size, false);
 

--- a/benchmarks/src/std/containers/sequences/vector.bool/copy_n/test.cpp
+++ b/benchmarks/src/std/containers/sequences/vector.bool/copy_n/test.cpp
@@ -4,6 +4,7 @@
 #include <benchmark/benchmark.h>
 //
 #include <algorithm>
+#include <cstddef>
 #include <random>
 #include <vector>
 
@@ -17,7 +18,7 @@ static vector<bool> createRandomVector(const size_t size) {
 }
 
 static void copy_n_block_aligned(benchmark::State& state) {
-    const auto size           = state.range(0);
+    const auto size           = static_cast<size_t>(state.range(0));
     const vector<bool> source = createRandomVector(size);
     vector<bool> dest(size, false);
 
@@ -27,7 +28,7 @@ static void copy_n_block_aligned(benchmark::State& state) {
 }
 
 static void copy_n_source_misaligned(benchmark::State& state) {
-    const auto size           = state.range(0);
+    const auto size           = static_cast<size_t>(state.range(0));
     const vector<bool> source = createRandomVector(size);
     vector<bool> dest(size, false);
 
@@ -37,7 +38,7 @@ static void copy_n_source_misaligned(benchmark::State& state) {
 }
 
 static void copy_n_dest_misaligned(benchmark::State& state) {
-    const auto size           = state.range(0);
+    const auto size           = static_cast<size_t>(state.range(0));
     const vector<bool> source = createRandomVector(size);
     vector<bool> dest(size, false);
 
@@ -48,7 +49,7 @@ static void copy_n_dest_misaligned(benchmark::State& state) {
 
 // Special benchmark for matching char alignment
 static void copy_n_matching_alignment(benchmark::State& state) {
-    const auto size           = state.range(0);
+    const auto size           = static_cast<size_t>(state.range(0));
     const vector<bool> source = createRandomVector(size);
     vector<bool> dest(size, false);
 

--- a/benchmarks/src/std/containers/sequences/vector.bool/move/test.cpp
+++ b/benchmarks/src/std/containers/sequences/vector.bool/move/test.cpp
@@ -4,6 +4,7 @@
 #include <benchmark/benchmark.h>
 //
 #include <algorithm>
+#include <cstddef>
 #include <random>
 #include <vector>
 
@@ -17,7 +18,7 @@ static vector<bool> createRandomVector(const size_t size) {
 }
 
 static void move_block_aligned(benchmark::State& state) {
-    const auto size           = state.range(0);
+    const auto size           = static_cast<size_t>(state.range(0));
     const vector<bool> source = createRandomVector(size);
     vector<bool> dest(size, false);
 
@@ -27,7 +28,7 @@ static void move_block_aligned(benchmark::State& state) {
 }
 
 static void move_source_misaligned(benchmark::State& state) {
-    const auto size           = state.range(0);
+    const auto size           = static_cast<size_t>(state.range(0));
     const vector<bool> source = createRandomVector(size);
     vector<bool> dest(size, false);
 
@@ -37,7 +38,7 @@ static void move_source_misaligned(benchmark::State& state) {
 }
 
 static void move_dest_misaligned(benchmark::State& state) {
-    const auto size           = state.range(0);
+    const auto size           = static_cast<size_t>(state.range(0));
     const vector<bool> source = createRandomVector(size);
     vector<bool> dest(size, false);
 
@@ -48,7 +49,7 @@ static void move_dest_misaligned(benchmark::State& state) {
 
 // Special benchmark for matching char alignment
 static void move_matching_alignment(benchmark::State& state) {
-    const auto size           = state.range(0);
+    const auto size           = static_cast<size_t>(state.range(0));
     const vector<bool> source = createRandomVector(size);
     vector<bool> dest(size, false);
 


### PR DESCRIPTION
Discovered while reviewing #3928, but this has been lurking since the addition of the benchmarks in #2780. No stealth merge conflicts - #3928's new benchmark has been fixed to be warning-clean.

* Enable warnings when building the benchmarks.
  + Start with the usual: `/diagnostics:caret /W4 /WX`
  + I'm enabling the same off-by-default warnings as the STL's build (C4265 (non-virtual dtor), C5038 (data member init order)) and adding C5262 (implicit fallthrough).
  + Finally, let's add `/utf-8` in case we ever benchmark `<format>`.
* Fix x86 `size_t` truncation warnings in the vector.bool benchmarks.
* `udt.hpp`: Rename template parameters from `Contained` to `Data`, avoiding REALLY confusing diagnostics.
* `utility.hpp`: Silence truncation warnings with a big comment.
