### PR TITLE
Test coarse-grained `_HAS_CXXnn` instead of fine-grained `__cpp_lib_MEOW`

### DIFF
--- a/stl/inc/__msvc_filebuf.hpp
+++ b/stl/inc/__msvc_filebuf.hpp
@@ -383,7 +383,7 @@ public:
         }
     }
 
-#if defined(__cpp_lib_print) && defined(_CPPRTTI)
+#if _HAS_CXX23 && defined(_CPPRTTI)
     template <class _Filebuf_type>
     friend ios_base::iostate _Print_noformat_unicode(ostream&, string_view);
 #endif

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -9,11 +9,11 @@
 #if _STL_COMPILER_PREPROCESSOR
 #include <ios>
 
-#ifdef __cpp_lib_print
+#if _HAS_CXX23
 #include <__msvc_filebuf.hpp>
 #include <__msvc_print.hpp>
 #include <format>
-#endif // ^^^ defined(__cpp_lib_print) ^^^
+#endif // ^^^ _HAS_CXX23 ^^^
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
@@ -1088,7 +1088,7 @@ basic_ostream<_Elem, _Traits>& operator<<(basic_ostream<_Elem, _Traits>& _Ostr, 
     return _Ostr << _Errcode.category().name() << ':' << _Errcode.value();
 }
 
-#ifdef __cpp_lib_print
+#if _HAS_CXX23
 #ifdef _CPPRTTI
 template <int = 0>
 ios_base::iostate _Print_noformat_nonunicode(ostream& _Ostr, const string_view _Str) {
@@ -1289,7 +1289,7 @@ void println(ostream&, format_string<_Types...>, _Types&&...) = delete; // requi
 _EXPORT_STD void vprint_unicode(ostream&, string_view, format_args)    = delete; // requires /GR option
 _EXPORT_STD void vprint_nonunicode(ostream&, string_view, format_args) = delete; // requires /GR option
 #endif // ^^^ !defined(_CPPRTTI) ^^^
-#endif // defined(__cpp_lib_print)
+#endif // _HAS_CXX23
 
 _STD_END
 

--- a/stl/inc/print
+++ b/stl/inc/print
@@ -7,9 +7,9 @@
 #define _PRINT_
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
-#ifndef __cpp_lib_print
+#if !_HAS_CXX23
 _EMIT_STL_WARNING(STL4038, "The contents of <print> are available only with C++23 or later.");
-#else // ^^^ !defined(__cpp_lib_print) / defined(__cpp_lib_print) vvv
+#else // ^^^ !_HAS_CXX23 / _HAS_CXX23 vvv
 
 #include <__msvc_print.hpp>
 #include <cstdio>
@@ -163,6 +163,6 @@ _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)
 #pragma pack(pop)
 
-#endif // ^^^ defined(__cpp_lib_print) ^^^
+#endif // ^^^ _HAS_CXX23 ^^^
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _PRINT_

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -7,9 +7,9 @@
 #define _RANGES_
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
-#ifndef __cpp_lib_ranges
+#if !_HAS_CXX20
 _EMIT_STL_WARNING(STL4038, "The contents of <ranges> are available only with C++20 or later.");
-#else // ^^^ !defined(__cpp_lib_ranges) / defined(__cpp_lib_ranges) vvv
+#else // ^^^ !_HAS_CXX20 / _HAS_CXX20 vvv
 #include <__msvc_int128.hpp>
 #include <iosfwd>
 #include <iterator>
@@ -10427,6 +10427,6 @@ _STD_END
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)
 #pragma pack(pop)
-#endif // ^^^ defined(__cpp_lib_ranges) ^^^
+#endif // ^^^ _HAS_CXX20 ^^^
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _RANGES_

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -10261,7 +10261,6 @@ namespace ranges {
         _EXPORT_STD inline constexpr _Cartesian_product_fn cartesian_product;
     } // namespace views
 
-#ifdef __cpp_lib_ranges_to_container
     template <class _Range, class _Container>
     concept _Sized_and_reservable = sized_range<_Range> && sized_range<_Container>
                                  && requires(_Container& _Cont, const range_size_t<_Container> _Count) {
@@ -10415,7 +10414,6 @@ namespace ranges {
     _NODISCARD constexpr auto to(_Types&&... _Args) {
         return _Range_closure<_To_template_fn<_Container>, decay_t<_Types>...>{_STD forward<_Types>(_Args)...};
     }
-#endif // defined(__cpp_lib_ranges_to_container)
 #endif // _HAS_CXX23
 } // namespace ranges
 

--- a/tests/std/tests/Dev11_0000000_tuple_cat/test.cpp
+++ b/tests/std/tests/Dev11_0000000_tuple_cat/test.cpp
@@ -10,12 +10,12 @@
 #include <type_traits>
 #include <utility>
 
-#ifdef __cpp_lib_ranges
+#if _HAS_CXX20
 #include <iterator>
 #include <list>
 #include <ranges>
 #include <vector>
-#endif // __cpp_lib_ranges
+#endif // _HAS_CXX20
 
 using namespace std;
 
@@ -231,7 +231,7 @@ int main() {
         }
     }
 
-#ifdef __cpp_lib_ranges
+#if _HAS_CXX20
     {
         using ranges::subrange, ranges::subrange_kind;
 
@@ -252,7 +252,7 @@ int main() {
         STATIC_ASSERT(is_same_v<decltype(cat7), tuple<LstIter, LstIter, VecIter, VecConstIter>>);
         assert(cat7 == make_tuple(next(lst.begin()), prev(lst.end()), vec.begin() + 1, vec.cend() - 1));
     }
-#endif // __cpp_lib_ranges
+#endif // _HAS_CXX20
 
 // Also test C++17 apply() and make_from_tuple().
 #if _HAS_CXX17

--- a/tests/std/tests/GH_000545_include_compare/test_stacktrace.cpp
+++ b/tests/std/tests/GH_000545_include_compare/test_stacktrace.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <version>
-#ifdef __cpp_lib_stacktrace
+#if _HAS_CXX23
 
 #include <stacktrace>
 
@@ -10,6 +10,6 @@
 
 static_assert(std::is_eq(std::partial_ordering::equivalent));
 
-#endif // __cpp_lib_stacktrace
+#endif // _HAS_CXX23
 
 void test_stacktrace() {}

--- a/tests/std/tests/GH_000690_overaligned_function/test.cpp
+++ b/tests/std/tests/GH_000690_overaligned_function/test.cpp
@@ -64,7 +64,7 @@ void test() {
 
 int main() {
     test<std::function<void(const void* storage, std::size_t storage_size)>>();
-#ifdef __cpp_lib_move_only_function
+#if _HAS_CXX23
     test<std::move_only_function<void(const void* storage, std::size_t storage_size)>>();
 #endif
 }

--- a/tests/std/tests/GH_001411_core_headers/test.cpp
+++ b/tests/std/tests/GH_001411_core_headers/test.cpp
@@ -51,11 +51,11 @@ void test_gh_2699() {
     assert(cats[1] == 50);
     assert(dogs[1] == 20);
 
-#ifdef __cpp_lib_ranges
+#if _HAS_CXX20
     std::ranges::swap(cats, dogs);
     assert(cats[1] == 20);
     assert(dogs[1] == 50);
-#endif // __cpp_lib_ranges
+#endif // _HAS_CXX20
 }
 
 int main() {

--- a/tests/std/tests/P0769R2_shift_left_shift_right/test.cpp
+++ b/tests/std/tests/P0769R2_shift_left_shift_right/test.cpp
@@ -105,7 +105,7 @@ void test_case_shift_left(const ptrdiff_t tmpSize) {
         fill_iota(tmp, tmpSize);
         test_iota(tmp.begin(), shift_left(tmp.begin(), tmp.end(), pos_to_shift), pos_to_shift + 1, tmpSize);
 
-#if __cpp_lib_shift >= 202202L
+#if _HAS_CXX23
         {
             fill_iota(tmp, tmpSize);
             auto [first, last] = ranges::shift_left(tmp.begin(), tmp.end(), pos_to_shift);
@@ -119,7 +119,7 @@ void test_case_shift_left(const ptrdiff_t tmpSize) {
             assert(first == tmp.begin());
             test_iota(first, last, pos_to_shift + 1, tmpSize);
         }
-#endif // __cpp_lib_shift >= 202202L
+#endif // _HAS_CXX23
     }
 
     fill_iota(tmp, tmpSize);
@@ -127,7 +127,7 @@ void test_case_shift_left(const ptrdiff_t tmpSize) {
         test_iota(shift_left(tmp.begin(), tmp.end(), tmpSize + i), tmp.end(), 1, tmpSize);
     }
 
-#if __cpp_lib_shift >= 202202L
+#if _HAS_CXX23
     fill_iota(tmp, tmpSize);
     for (int i = 0; i < 3; ++i) {
         auto [first, last] = ranges::shift_left(tmp.begin(), tmp.end(), tmpSize + i);
@@ -141,7 +141,7 @@ void test_case_shift_left(const ptrdiff_t tmpSize) {
         assert(first == tmp.begin());
         test_iota(last, tmp.end(), 1, tmpSize);
     }
-#endif // __cpp_lib_shift >= 202202L
+#endif // _HAS_CXX23
 }
 
 template <typename Container>
@@ -153,7 +153,7 @@ void test_case_shift_right(const ptrdiff_t tmpSize) {
         fill_iota(tmp, tmpSize);
         test_iota(shift_right(tmp.begin(), tmp.end(), pos_to_shift), tmp.end(), 1, tmpSize - pos_to_shift);
 
-#if __cpp_lib_shift >= 202202L
+#if _HAS_CXX23
         {
             fill_iota(tmp, tmpSize);
             auto [first, last] = ranges::shift_right(tmp.begin(), tmp.end(), pos_to_shift);
@@ -167,7 +167,7 @@ void test_case_shift_right(const ptrdiff_t tmpSize) {
             assert(last == tmp.end());
             test_iota(first, last, 1, tmpSize - pos_to_shift);
         }
-#endif // __cpp_lib_shift >= 202202L
+#endif // _HAS_CXX23
     }
 
     fill_iota(tmp, tmpSize);
@@ -175,7 +175,7 @@ void test_case_shift_right(const ptrdiff_t tmpSize) {
         test_iota(tmp.begin(), shift_right(tmp.begin(), tmp.end(), tmpSize + i), 1, tmpSize);
     }
 
-#if __cpp_lib_shift >= 202202L
+#if _HAS_CXX23
     fill_iota(tmp, tmpSize);
     for (int i = 0; i < 3; ++i) {
         auto [first, last] = ranges::shift_right(tmp.begin(), tmp.end(), tmpSize + i);
@@ -189,7 +189,7 @@ void test_case_shift_right(const ptrdiff_t tmpSize) {
         assert(last == tmp.end());
         test_iota(tmp.begin(), first, 1, tmpSize);
     }
-#endif // __cpp_lib_shift >= 202202L
+#endif // _HAS_CXX23
 }
 
 int main() {


### PR DESCRIPTION
From https://github.com/microsoft/STL/pull/4298#issuecomment-1923382041:

> in general, we prefer to test coarse-grained `_HAS_CXXnn` instead of fine-grained `__cpp_lib_MEOW`, once there are no compiler or mode dependencies.