### PR TITLE
Add permissions to the Update Status Chart action

### DIFF
--- a/.github/workflows/update-status-chart.yml
+++ b/.github/workflows/update-status-chart.yml
@@ -6,6 +6,8 @@ on:
   schedule:
     - cron: "0 7 * * *"
   workflow_dispatch:
+permissions:
+  contents: write
 jobs:
   build:
     if: ${{ github.repository == 'microsoft/STL' }}


### PR DESCRIPTION
Followup to #4223 where I said:

> `.github/workflows/update-status-chart.yml` mentions `github.token` for the GraphQL API, but all it needs is public read-only access, so I don't think that it'll need to be changed.

Wrong! It autonomously commits changes:

https://github.com/microsoft/STL/blob/1bc5ca60fcb41c2ed87a721d6ca2f77844cf6dc6/.github/workflows/update-status-chart.yml#L31-L37

So the workflow runs [started failing](https://github.com/microsoft/STL/actions/runs/7752540972/job/21142220750) with:

```
remote: Permission to microsoft/STL.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/microsoft/STL/': The requested URL returned error: 403
Error: Process completed with exit code 128.
```

I've verified in my fork that granting the `contents: write` permission is sufficient - we don't need to grant `issues: read` and `pull-requests: read`.