### PR TITLE
ADL-proof implementation of uninitialized memory algorithms

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -75,8 +75,8 @@ namespace ranges {
         _STATIC_CALL_OPERATOR uninitialized_copy_result<borrowed_iterator_t<_Rng1>, borrowed_iterator_t<_Rng2>>
             operator()(_Rng1&& _Range1, _Rng2&& _Range2) _CONST_CALL_OPERATOR {
             auto _First1  = _RANGES begin(_Range1);
-            auto _UResult = _Uninitialized_copy_unchecked(
-                _RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2));
+            auto _UResult = _Uninitialized_copy_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)),
+                _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2));
 
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in));
             return {_STD move(_First1), _RANGES _Rewrap_iterator(_Range2, _STD move(_UResult.out))};
@@ -101,9 +101,11 @@ namespace ranges {
                     return _RANGES _Copy_memcpy_common(_IFirst, _RANGES next(_IFirst, _STD move(_ILast)), _OFirst,
                         _RANGES next(_OFirst, _STD move(_OLast)));
                 } else if constexpr (_Is_sized1) {
-                    return _RANGES _Copy_memcpy_distance(_IFirst, _OFirst, _IFirst, _RANGES next(_IFirst, _STD move(_ILast)));
+                    return _RANGES _Copy_memcpy_distance(
+                        _IFirst, _OFirst, _IFirst, _RANGES next(_IFirst, _STD move(_ILast)));
                 } else if constexpr (_Is_sized2) {
-                    return _RANGES _Copy_memcpy_distance(_IFirst, _OFirst, _OFirst, _RANGES next(_OFirst, _STD move(_OLast)));
+                    return _RANGES _Copy_memcpy_distance(
+                        _IFirst, _OFirst, _OFirst, _RANGES next(_OFirst, _STD move(_OLast)));
                 } else {
                     _STL_ASSERT(false, "Tried to uninitialized_copy two ranges with unreachable sentinels");
                 }
@@ -263,8 +265,8 @@ namespace ranges {
         _STATIC_CALL_OPERATOR uninitialized_move_result<borrowed_iterator_t<_Rng1>, borrowed_iterator_t<_Rng2>>
             operator()(_Rng1&& _Range1, _Rng2&& _Range2) _CONST_CALL_OPERATOR {
             auto _First1  = _RANGES begin(_Range1);
-            auto _UResult = _RANGES _Uninitialized_move_unchecked(
-                _RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2));
+            auto _UResult = _RANGES _Uninitialized_move_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)),
+                _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2));
 
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in));
             return {_STD move(_First1), _RANGES _Rewrap_iterator(_Range2, _STD move(_UResult.out))};
@@ -393,7 +395,8 @@ namespace ranges {
             requires constructible_from<range_value_t<_Rng>, const _Ty&>
         _STATIC_CALL_OPERATOR borrowed_iterator_t<_Rng> operator()(
             _Rng&& _Range, const _Ty& _Val) _CONST_CALL_OPERATOR {
-            return _RANGES _Rewrap_iterator(_Range, _Uninitialized_fill_unchecked(_Ubegin(_Range), _Uend(_Range), _Val));
+            return _RANGES _Rewrap_iterator(
+                _Range, _Uninitialized_fill_unchecked(_Ubegin(_Range), _Uend(_Range), _Val));
         }
 
     private:
@@ -593,8 +596,8 @@ namespace ranges {
             requires destructible<iter_value_t<_It>>
         _STATIC_CALL_OPERATOR constexpr _It operator()(_It _First, _Se _Last) _CONST_CALL_OPERATOR noexcept {
             _STD _Adl_verify_range(_First, _Last);
-            _STD _Seek_wrapped(_First,
-                _RANGES _Destroy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last))));
+            _STD _Seek_wrapped(_First, _RANGES _Destroy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                                           _RANGES _Unwrap_sent<_It>(_STD move(_Last))));
             return _First;
         }
 
@@ -875,7 +878,8 @@ _NoThrowFwdIt uninitialized_value_construct_n(_NoThrowFwdIt _First, const _Diff 
         return _First;
     }
 
-    _STD _Seek_wrapped(_First, _STD _Uninitialized_value_construct_n_unchecked1(_STD _Get_unwrapped_n(_First, _Count), _Count));
+    _STD _Seek_wrapped(
+        _First, _STD _Uninitialized_value_construct_n_unchecked1(_STD _Get_unwrapped_n(_First, _Count), _Count));
     return _First;
 }
 

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -59,14 +59,14 @@ namespace ranges {
             requires constructible_from<iter_value_t<_Out>, iter_reference_t<_It>>
         _STATIC_CALL_OPERATOR uninitialized_copy_result<_It, _Out> operator()(
             _It _First1, _Se _Last1, _Out _First2, _OSe _Last2) _CONST_CALL_OPERATOR {
-            _Adl_verify_range(_First1, _Last1);
-            _Adl_verify_range(_First2, _Last2);
-            auto _UResult = _Uninitialized_copy_unchecked(_Unwrap_iter<_Se>(_STD move(_First1)),
-                _Unwrap_sent<_It>(_STD move(_Last1)), _Unwrap_iter<_OSe>(_STD move(_First2)),
-                _Unwrap_sent<_Out>(_STD move(_Last2)));
+            _STD _Adl_verify_range(_First1, _Last1);
+            _STD _Adl_verify_range(_First2, _Last2);
+            auto _UResult = _Uninitialized_copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First1)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last1)), _RANGES _Unwrap_iter<_OSe>(_STD move(_First2)),
+                _RANGES _Unwrap_sent<_Out>(_STD move(_Last2)));
 
-            _Seek_wrapped(_First1, _STD move(_UResult.in));
-            _Seek_wrapped(_First2, _STD move(_UResult.out));
+            _STD _Seek_wrapped(_First1, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_First2, _STD move(_UResult.out));
             return {_STD move(_First1), _STD move(_First2)};
         }
 
@@ -76,10 +76,10 @@ namespace ranges {
             operator()(_Rng1&& _Range1, _Rng2&& _Range2) _CONST_CALL_OPERATOR {
             auto _First1  = _RANGES begin(_Range1);
             auto _UResult = _Uninitialized_copy_unchecked(
-                _Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2));
+                _RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2));
 
-            _Seek_wrapped(_First1, _STD move(_UResult.in));
-            return {_STD move(_First1), _Rewrap_iterator(_Range2, _STD move(_UResult.out))};
+            _STD _Seek_wrapped(_First1, _STD move(_UResult.in));
+            return {_STD move(_First1), _RANGES _Rewrap_iterator(_Range2, _STD move(_UResult.out))};
         }
 
     private:
@@ -98,12 +98,12 @@ namespace ranges {
                           && _Sized_or_unreachable_sentinel_for<_Se, _It>
                           && _Sized_or_unreachable_sentinel_for<_OSe, _Out>) {
                 if constexpr (_Is_sized1 && _Is_sized2) {
-                    return _Copy_memcpy_common(_IFirst, _RANGES next(_IFirst, _STD move(_ILast)), _OFirst,
+                    return _RANGES _Copy_memcpy_common(_IFirst, _RANGES next(_IFirst, _STD move(_ILast)), _OFirst,
                         _RANGES next(_OFirst, _STD move(_OLast)));
                 } else if constexpr (_Is_sized1) {
-                    return _Copy_memcpy_distance(_IFirst, _OFirst, _IFirst, _RANGES next(_IFirst, _STD move(_ILast)));
+                    return _RANGES _Copy_memcpy_distance(_IFirst, _OFirst, _IFirst, _RANGES next(_IFirst, _STD move(_ILast)));
                 } else if constexpr (_Is_sized2) {
-                    return _Copy_memcpy_distance(_IFirst, _OFirst, _OFirst, _RANGES next(_OFirst, _STD move(_OLast)));
+                    return _RANGES _Copy_memcpy_distance(_IFirst, _OFirst, _OFirst, _RANGES next(_OFirst, _STD move(_OLast)));
                 } else {
                     _STL_ASSERT(false, "Tried to uninitialized_copy two ranges with unreachable sentinels");
                 }
@@ -131,10 +131,10 @@ _NoThrowFwdIt uninitialized_copy_n(const _InIt _First, const _Diff _Count_raw, _
         return _Dest;
     }
 
-    auto _UFirst = _Get_unwrapped_n(_First, _Count);
-    auto _UDest  = _Get_unwrapped_n(_Dest, _Count);
+    auto _UFirst = _STD _Get_unwrapped_n(_First, _Count);
+    auto _UDest  = _STD _Get_unwrapped_n(_Dest, _Count);
     if constexpr (_Iter_copy_cat<decltype(_UFirst), decltype(_UDest)>::_Bitcopy_constructible) {
-        _UDest = _Copy_memmove_n(_UFirst, static_cast<size_t>(_Count), _UDest);
+        _UDest = _STD _Copy_memmove_n(_UFirst, static_cast<size_t>(_Count), _UDest);
     } else {
         _Uninitialized_backout<decltype(_UDest)> _Backout{_UDest};
 
@@ -145,7 +145,7 @@ _NoThrowFwdIt uninitialized_copy_n(const _InIt _First, const _Diff _Count_raw, _
         _UDest = _Backout._Release();
     }
 
-    _Seek_wrapped(_Dest, _UDest);
+    _STD _Seek_wrapped(_Dest, _UDest);
     return _Dest;
 }
 
@@ -179,19 +179,19 @@ namespace ranges {
                 return {_STD move(_First1), _STD move(_First2)};
             }
 
-            _Adl_verify_range(_First2, _Last2);
-            auto _IFirst = _Get_unwrapped_n(_STD move(_First1), _Count);
-            auto _OFirst = _Unwrap_iter<_OSe>(_STD move(_First2));
-            auto _OLast  = _Unwrap_sent<_Out>(_STD move(_Last2));
+            _STD _Adl_verify_range(_First2, _Last2);
+            auto _IFirst = _STD _Get_unwrapped_n(_STD move(_First1), _Count);
+            auto _OFirst = _RANGES _Unwrap_iter<_OSe>(_STD move(_First2));
+            auto _OLast  = _RANGES _Unwrap_sent<_Out>(_STD move(_Last2));
             if constexpr (_Iter_copy_cat<_It, _Out>::_Bitcopy_constructible
                           && _Sized_or_unreachable_sentinel_for<_OSe, _Out>) {
                 if constexpr (sized_sentinel_for<_OSe, _Out>) {
-                    auto _UResult = _Copy_memcpy_common(
+                    auto _UResult = _RANGES _Copy_memcpy_common(
                         _IFirst, _IFirst + _Count, _OFirst, _RANGES next(_OFirst, _STD move(_OLast)));
                     _IFirst = _STD move(_UResult.in);
                     _OFirst = _STD move(_UResult.out);
                 } else {
-                    auto _UResult = _Copy_memcpy_count(_IFirst, _OFirst, static_cast<size_t>(_Count));
+                    auto _UResult = _RANGES _Copy_memcpy_count(_IFirst, _OFirst, static_cast<size_t>(_Count));
                     _IFirst       = _STD move(_UResult.in);
                     _OFirst       = _STD move(_UResult.out);
                 }
@@ -205,8 +205,8 @@ namespace ranges {
                 _OFirst = _Backout._Release();
             }
 
-            _Seek_wrapped(_First1, _STD move(_IFirst));
-            _Seek_wrapped(_First2, _STD move(_OFirst));
+            _STD _Seek_wrapped(_First1, _STD move(_IFirst));
+            _STD _Seek_wrapped(_First2, _STD move(_OFirst));
             return {_STD move(_First1), _STD move(_First2)};
         }
     };
@@ -219,11 +219,11 @@ namespace ranges {
 _EXPORT_STD template <class _InIt, class _NoThrowFwdIt>
 _NoThrowFwdIt uninitialized_move(const _InIt _First, const _InIt _Last, _NoThrowFwdIt _Dest) {
     // move [_First, _Last) to raw [_Dest, ...)
-    _Adl_verify_range(_First, _Last);
-    const auto _UFirst = _Get_unwrapped(_First);
-    const auto _ULast  = _Get_unwrapped(_Last);
-    const auto _UDest  = _Get_unwrapped_n(_Dest, _Idl_distance<_InIt>(_UFirst, _ULast));
-    _Seek_wrapped(_Dest, _STD _Uninitialized_move_unchecked(_UFirst, _ULast, _UDest));
+    _STD _Adl_verify_range(_First, _Last);
+    const auto _UFirst = _STD _Get_unwrapped(_First);
+    const auto _ULast  = _STD _Get_unwrapped(_Last);
+    const auto _UDest  = _STD _Get_unwrapped_n(_Dest, _STD _Idl_distance<_InIt>(_UFirst, _ULast));
+    _STD _Seek_wrapped(_Dest, _STD _Uninitialized_move_unchecked(_UFirst, _ULast, _UDest));
     return _Dest;
 }
 
@@ -247,14 +247,14 @@ namespace ranges {
             requires constructible_from<iter_value_t<_Out>, iter_rvalue_reference_t<_It>>
         _STATIC_CALL_OPERATOR uninitialized_move_result<_It, _Out> operator()(
             _It _First1, _Se _Last1, _Out _First2, _OSe _Last2) _CONST_CALL_OPERATOR {
-            _Adl_verify_range(_First1, _Last1);
-            _Adl_verify_range(_First2, _Last2);
-            auto _UResult = _RANGES _Uninitialized_move_unchecked(_Unwrap_iter<_Se>(_STD move(_First1)),
-                _Unwrap_sent<_It>(_STD move(_Last1)), _Unwrap_iter<_OSe>(_STD move(_First2)),
-                _Unwrap_sent<_Out>(_STD move(_Last2)));
+            _STD _Adl_verify_range(_First1, _Last1);
+            _STD _Adl_verify_range(_First2, _Last2);
+            auto _UResult = _RANGES _Uninitialized_move_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First1)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last1)), _RANGES _Unwrap_iter<_OSe>(_STD move(_First2)),
+                _RANGES _Unwrap_sent<_Out>(_STD move(_Last2)));
 
-            _Seek_wrapped(_First1, _STD move(_UResult.in));
-            _Seek_wrapped(_First2, _STD move(_UResult.out));
+            _STD _Seek_wrapped(_First1, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_First2, _STD move(_UResult.out));
             return {_STD move(_First1), _STD move(_First2)};
         }
 
@@ -264,10 +264,10 @@ namespace ranges {
             operator()(_Rng1&& _Range1, _Rng2&& _Range2) _CONST_CALL_OPERATOR {
             auto _First1  = _RANGES begin(_Range1);
             auto _UResult = _RANGES _Uninitialized_move_unchecked(
-                _Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2));
+                _RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2));
 
-            _Seek_wrapped(_First1, _STD move(_UResult.in));
-            return {_STD move(_First1), _Rewrap_iterator(_Range2, _STD move(_UResult.out))};
+            _STD _Seek_wrapped(_First1, _STD move(_UResult.in));
+            return {_STD move(_First1), _RANGES _Rewrap_iterator(_Range2, _STD move(_UResult.out))};
         }
     };
 
@@ -283,10 +283,10 @@ pair<_InIt, _NoThrowFwdIt> uninitialized_move_n(_InIt _First, const _Diff _Count
         return {_First, _Dest};
     }
 
-    auto _UFirst = _Get_unwrapped_n(_First, _Count);
-    auto _UDest  = _Get_unwrapped_n(_Dest, _Count);
+    auto _UFirst = _STD _Get_unwrapped_n(_First, _Count);
+    auto _UDest  = _STD _Get_unwrapped_n(_Dest, _Count);
     if constexpr (_Iter_move_cat<decltype(_UFirst), decltype(_UDest)>::_Bitcopy_constructible) {
-        _UDest = _Copy_memmove_n(_UFirst, static_cast<size_t>(_Count), _UDest);
+        _UDest = _STD _Copy_memmove_n(_UFirst, static_cast<size_t>(_Count), _UDest);
         _UFirst += _Count;
     } else {
         _Uninitialized_backout<decltype(_UDest)> _Backout{_UDest};
@@ -298,8 +298,8 @@ pair<_InIt, _NoThrowFwdIt> uninitialized_move_n(_InIt _First, const _Diff _Count
         _UDest = _Backout._Release();
     }
 
-    _Seek_wrapped(_Dest, _UDest);
-    _Seek_wrapped(_First, _UFirst);
+    _STD _Seek_wrapped(_Dest, _UDest);
+    _STD _Seek_wrapped(_First, _UFirst);
     return {_First, _Dest};
 }
 
@@ -342,19 +342,19 @@ namespace ranges {
                 return {_STD move(_First1), _STD move(_First2)};
             }
 
-            _Adl_verify_range(_First2, _Last2);
-            auto _IFirst      = _Get_unwrapped_n(_STD move(_First1), _Count);
-            auto _OFirst      = _Unwrap_iter<_OSe>(_STD move(_First2));
-            const auto _OLast = _Unwrap_sent<_Out>(_STD move(_Last2));
+            _STD _Adl_verify_range(_First2, _Last2);
+            auto _IFirst      = _STD _Get_unwrapped_n(_STD move(_First1), _Count);
+            auto _OFirst      = _RANGES _Unwrap_iter<_OSe>(_STD move(_First2));
+            const auto _OLast = _RANGES _Unwrap_sent<_Out>(_STD move(_Last2));
             if constexpr (_Iter_move_cat<_It, _Out>::_Bitcopy_constructible
                           && _Sized_or_unreachable_sentinel_for<_OSe, _Out>) {
                 if constexpr (sized_sentinel_for<_OSe, _Out>) {
-                    auto _UResult = _Copy_memcpy_common(
+                    auto _UResult = _RANGES _Copy_memcpy_common(
                         _IFirst, _IFirst + _Count, _OFirst, _RANGES next(_OFirst, _STD move(_OLast)));
                     _IFirst = _STD move(_UResult.in);
                     _OFirst = _STD move(_UResult.out);
                 } else {
-                    auto _UResult = _Copy_memcpy_count(_IFirst, _OFirst, static_cast<size_t>(_Count));
+                    auto _UResult = _RANGES _Copy_memcpy_count(_IFirst, _OFirst, static_cast<size_t>(_Count));
                     _IFirst       = _STD move(_UResult.in);
                     _OFirst       = _STD move(_UResult.out);
                 }
@@ -368,8 +368,8 @@ namespace ranges {
                 _OFirst = _Backout._Release();
             }
 
-            _Seek_wrapped(_First1, _STD move(_IFirst));
-            _Seek_wrapped(_First2, _STD move(_OFirst));
+            _STD _Seek_wrapped(_First1, _STD move(_IFirst));
+            _STD _Seek_wrapped(_First2, _STD move(_OFirst));
             return {_STD move(_First1), _STD move(_First2)};
         }
     };
@@ -381,11 +381,11 @@ namespace ranges {
         template <_No_throw_forward_iterator _It, _No_throw_sentinel_for<_It> _Se, class _Ty>
             requires constructible_from<iter_value_t<_It>, const _Ty&>
         _STATIC_CALL_OPERATOR _It operator()(_It _First, _Se _Last, const _Ty& _Val) _CONST_CALL_OPERATOR {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _Uninitialized_fill_unchecked(
-                _Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)), _Val);
+                _RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _Val);
 
-            _Seek_wrapped(_First, _STD move(_UResult));
+            _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
         }
 
@@ -393,7 +393,7 @@ namespace ranges {
             requires constructible_from<range_value_t<_Rng>, const _Ty&>
         _STATIC_CALL_OPERATOR borrowed_iterator_t<_Rng> operator()(
             _Rng&& _Range, const _Ty& _Val) _CONST_CALL_OPERATOR {
-            return _Rewrap_iterator(_Range, _Uninitialized_fill_unchecked(_Ubegin(_Range), _Uend(_Range), _Val));
+            return _RANGES _Rewrap_iterator(_Range, _Uninitialized_fill_unchecked(_Ubegin(_Range), _Uend(_Range), _Val));
         }
 
     private:
@@ -405,13 +405,13 @@ namespace ranges {
 
             if constexpr (_Fill_memset_is_safe<_It, _Ty>) {
                 const auto _OFinal = _RANGES next(_OFirst, _STD move(_OLast));
-                _Fill_memset(_OFirst, _Val, static_cast<size_t>(_OFinal - _OFirst));
+                _STD _Fill_memset(_OFirst, _Val, static_cast<size_t>(_OFinal - _OFirst));
                 return _OFinal;
             } else {
                 if constexpr (_Fill_zero_memset_is_safe<_It, _Ty>) {
-                    if (_Is_all_bits_zero(_Val)) {
+                    if (_STD _Is_all_bits_zero(_Val)) {
                         const auto _OFinal = _RANGES next(_OFirst, _STD move(_OLast));
-                        _Fill_zero_memset(_OFirst, static_cast<size_t>(_OFinal - _OFirst));
+                        _STD _Fill_zero_memset(_OFirst, static_cast<size_t>(_OFinal - _OFirst));
                         return _OFinal;
                     }
                 }
@@ -439,15 +439,15 @@ _NoThrowFwdIt uninitialized_fill_n(_NoThrowFwdIt _First, const _Diff _Count_raw,
         return _First;
     }
 
-    auto _UFirst = _Get_unwrapped_n(_First, _Count);
+    auto _UFirst = _STD _Get_unwrapped_n(_First, _Count);
     if constexpr (_Fill_memset_is_safe<decltype(_UFirst), _Tval>) {
-        _Fill_memset(_UFirst, _Val, static_cast<size_t>(_Count));
+        _STD _Fill_memset(_UFirst, _Val, static_cast<size_t>(_Count));
         _UFirst += _Count;
     } else {
         if constexpr (_Fill_zero_memset_is_safe<decltype(_UFirst), _Tval>) {
-            if (_Is_all_bits_zero(_Val)) {
-                _Fill_zero_memset(_UFirst, static_cast<size_t>(_Count));
-                _Seek_wrapped(_First, _UFirst + _Count);
+            if (_STD _Is_all_bits_zero(_Val)) {
+                _STD _Fill_zero_memset(_UFirst, static_cast<size_t>(_Count));
+                _STD _Seek_wrapped(_First, _UFirst + _Count);
                 return _First;
             }
         }
@@ -461,7 +461,7 @@ _NoThrowFwdIt uninitialized_fill_n(_NoThrowFwdIt _First, const _Diff _Count_raw,
         _UFirst = _Backout._Release();
     }
 
-    _Seek_wrapped(_First, _UFirst);
+    _STD _Seek_wrapped(_First, _UFirst);
     return _First;
 }
 
@@ -492,15 +492,15 @@ namespace ranges {
                 return _First;
             }
 
-            auto _UFirst = _Get_unwrapped_n(_STD move(_First), _Count);
+            auto _UFirst = _STD _Get_unwrapped_n(_STD move(_First), _Count);
             if constexpr (_Fill_memset_is_safe<decltype(_UFirst), _Ty>) {
-                _Fill_memset(_UFirst, _Val, static_cast<size_t>(_Count));
-                _Seek_wrapped(_First, _UFirst + _Count);
+                _STD _Fill_memset(_UFirst, _Val, static_cast<size_t>(_Count));
+                _STD _Seek_wrapped(_First, _UFirst + _Count);
             } else {
                 if constexpr (_Fill_zero_memset_is_safe<decltype(_UFirst), _Ty>) {
-                    if (_Is_all_bits_zero(_Val)) {
-                        _Fill_zero_memset(_UFirst, static_cast<size_t>(_Count));
-                        _Seek_wrapped(_First, _UFirst + _Count);
+                    if (_STD _Is_all_bits_zero(_Val)) {
+                        _STD _Fill_zero_memset(_UFirst, static_cast<size_t>(_Count));
+                        _STD _Seek_wrapped(_First, _UFirst + _Count);
                         return _First;
                     }
                 }
@@ -511,7 +511,7 @@ namespace ranges {
                     _Backout._Emplace_back(_Val);
                 }
 
-                _Seek_wrapped(_First, _Backout._Release());
+                _STD _Seek_wrapped(_First, _Backout._Release());
             }
             return _First;
         }
@@ -564,8 +564,8 @@ namespace ranges {
 _EXPORT_STD template <class _NoThrowFwdIt>
 _CONSTEXPR20 void destroy(const _NoThrowFwdIt _First, const _NoThrowFwdIt _Last) {
     // destroy all elements in [_First, _Last)
-    _Adl_verify_range(_First, _Last);
-    _Destroy_range(_Get_unwrapped(_First), _Get_unwrapped(_Last));
+    _STD _Adl_verify_range(_First, _Last);
+    _STD _Destroy_range(_STD _Get_unwrapped(_First), _STD _Get_unwrapped(_Last));
 }
 
 _EXPORT_STD template <class _ExPo, class _NoThrowFwdIt, _Enable_if_execution_policy_t<_ExPo> = 0>
@@ -592,9 +592,9 @@ namespace ranges {
         template <_No_throw_input_iterator _It, _No_throw_sentinel_for<_It> _Se>
             requires destructible<iter_value_t<_It>>
         _STATIC_CALL_OPERATOR constexpr _It operator()(_It _First, _Se _Last) _CONST_CALL_OPERATOR noexcept {
-            _Adl_verify_range(_First, _Last);
-            _Seek_wrapped(_First,
-                _RANGES _Destroy_unchecked(_Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last))));
+            _STD _Adl_verify_range(_First, _Last);
+            _STD _Seek_wrapped(_First,
+                _RANGES _Destroy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last))));
             return _First;
         }
 
@@ -603,8 +603,8 @@ namespace ranges {
         _STATIC_CALL_OPERATOR constexpr borrowed_iterator_t<_Rng> operator()(
             _Rng&& _Range) _CONST_CALL_OPERATOR noexcept {
             auto _First = _RANGES begin(_Range);
-            _Seek_wrapped(
-                _First, _RANGES _Destroy_unchecked(_Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range)));
+            _STD _Seek_wrapped(
+                _First, _RANGES _Destroy_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range)));
             return _First;
         }
     };
@@ -621,16 +621,16 @@ _CONSTEXPR20 _NoThrowFwdIt destroy_n(_NoThrowFwdIt _First, const _Diff _Count_ra
         return _First;
     }
 
-    auto _UFirst = _Get_unwrapped_n(_First, _Count);
+    auto _UFirst = _STD _Get_unwrapped_n(_First, _Count);
     if constexpr (is_trivially_destructible_v<_Iter_value_t<_NoThrowFwdIt>>) {
         _STD advance(_UFirst, _Count);
     } else {
         for (; _Count > 0; --_Count, (void) ++_UFirst) {
-            _Destroy_in_place(*_UFirst);
+            _STD _Destroy_in_place(*_UFirst);
         }
     }
 
-    _Seek_wrapped(_First, _UFirst);
+    _STD _Seek_wrapped(_First, _UFirst);
     return _First;
 }
 
@@ -650,7 +650,7 @@ namespace ranges {
                 return _First;
             }
 
-            auto _UFirst = _Get_unwrapped_n(_STD move(_First), _Count);
+            auto _UFirst = _STD _Get_unwrapped_n(_STD move(_First), _Count);
             if constexpr (is_trivially_destructible_v<iter_value_t<_It>>) {
                 _RANGES advance(_UFirst, _Count);
             } else {
@@ -661,7 +661,7 @@ namespace ranges {
                 } while (_Count > 0);
             }
 
-            _Seek_wrapped(_First, _STD move(_UFirst));
+            _STD _Seek_wrapped(_First, _STD move(_UFirst));
             return _First;
         }
     };
@@ -674,12 +674,12 @@ _EXPORT_STD template <class _NoThrowFwdIt>
 void uninitialized_default_construct(const _NoThrowFwdIt _First, const _NoThrowFwdIt _Last) {
     // default-initialize all elements in [_First, _Last)
     using _Ty = remove_reference_t<_Iter_ref_t<_NoThrowFwdIt>>;
-    _Adl_verify_range(_First, _Last);
+    _STD _Adl_verify_range(_First, _Last);
     if constexpr (!is_trivially_default_constructible_v<_Ty>) {
-        _Uninitialized_backout _Backout{_Get_unwrapped(_First)};
+        _Uninitialized_backout _Backout{_STD _Get_unwrapped(_First)};
 
-        for (const auto _ULast = _Get_unwrapped(_Last); _Backout._Last != _ULast; ++_Backout._Last) {
-            _Default_construct_in_place(*_Backout._Last);
+        for (const auto _ULast = _STD _Get_unwrapped(_Last); _Backout._Last != _ULast; ++_Backout._Last) {
+            _STD _Default_construct_in_place(*_Backout._Last);
         }
 
         _Backout._Release();
@@ -696,11 +696,11 @@ namespace ranges {
         template <_No_throw_forward_iterator _It, _No_throw_sentinel_for<_It> _Se>
             requires default_initializable<iter_value_t<_It>>
         _STATIC_CALL_OPERATOR _It operator()(_It _First, _Se _Last) _CONST_CALL_OPERATOR {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _Uninitialized_default_construct_unchecked(
-                _Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)));
+                _RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)));
 
-            _Seek_wrapped(_First, _STD move(_UResult));
+            _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
         }
 
@@ -709,7 +709,7 @@ namespace ranges {
         _STATIC_CALL_OPERATOR borrowed_iterator_t<_Rng> operator()(_Rng&& _Range) _CONST_CALL_OPERATOR {
             auto _UResult = _Uninitialized_default_construct_unchecked(_Ubegin(_Range), _Uend(_Range));
 
-            return _Rewrap_iterator(_Range, _STD move(_UResult));
+            return _RANGES _Rewrap_iterator(_Range, _STD move(_UResult));
         }
 
     private:
@@ -727,7 +727,7 @@ namespace ranges {
                 _Uninitialized_backout _Backout{_STD move(_OFirst)};
 
                 for (; _Backout._Last != _OLast; ++_Backout._Last) {
-                    _Default_construct_in_place(*_Backout._Last);
+                    _STD _Default_construct_in_place(*_Backout._Last);
                 }
 
                 return _Backout._Release();
@@ -751,13 +751,13 @@ _NoThrowFwdIt uninitialized_default_construct_n(_NoThrowFwdIt _First, const _Dif
     if constexpr (is_trivially_default_constructible_v<_Ty>) {
         _STD advance(_First, _Count);
     } else {
-        _Uninitialized_backout _Backout{_Get_unwrapped_n(_First, _Count)};
+        _Uninitialized_backout _Backout{_STD _Get_unwrapped_n(_First, _Count)};
 
         for (; _Count > 0; ++_Backout._Last, (void) --_Count) {
-            _Default_construct_in_place(*_Backout._Last);
+            _STD _Default_construct_in_place(*_Backout._Last);
         }
 
-        _Seek_wrapped(_First, _Backout._Release());
+        _STD _Seek_wrapped(_First, _Backout._Release());
     }
     return _First;
 }
@@ -781,13 +781,13 @@ namespace ranges {
             if constexpr (is_trivially_default_constructible_v<_Ty>) {
                 _RANGES advance(_First, _Count);
             } else {
-                _Uninitialized_backout _Backout{_Get_unwrapped_n(_STD move(_First), _Count)};
+                _Uninitialized_backout _Backout{_STD _Get_unwrapped_n(_STD move(_First), _Count)};
 
                 for (; _Count > 0; --_Count, (void) ++_Backout._Last) {
-                    _Default_construct_in_place(*_Backout._Last);
+                    _STD _Default_construct_in_place(*_Backout._Last);
                 }
 
-                _Seek_wrapped(_First, _Backout._Release());
+                _STD _Seek_wrapped(_First, _Backout._Release());
             }
             return _First;
         }
@@ -800,11 +800,11 @@ namespace ranges {
 _EXPORT_STD template <class _NoThrowFwdIt>
 void uninitialized_value_construct(const _NoThrowFwdIt _First, const _NoThrowFwdIt _Last) {
     // value-initialize all elements in [_First, _Last)
-    _Adl_verify_range(_First, _Last);
-    const auto _UFirst = _Get_unwrapped(_First);
-    const auto _ULast  = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    const auto _UFirst = _STD _Get_unwrapped(_First);
+    const auto _ULast  = _STD _Get_unwrapped(_Last);
     if constexpr (_Use_memset_value_construct_v<_Unwrapped_t<const _NoThrowFwdIt&>>) {
-        _Zero_range(_UFirst, _ULast);
+        _STD _Zero_range(_UFirst, _ULast);
     } else {
         _Uninitialized_backout _Backout{_UFirst};
 
@@ -826,11 +826,11 @@ namespace ranges {
         template <_No_throw_forward_iterator _It, _No_throw_sentinel_for<_It> _Se>
             requires default_initializable<iter_value_t<_It>>
         _STATIC_CALL_OPERATOR _It operator()(_It _First, _Se _Last) _CONST_CALL_OPERATOR {
-            _Adl_verify_range(_First, _Last);
+            _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _Uninitialized_value_construct_unchecked(
-                _Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)));
+                _RANGES _Unwrap_iter<_Se>(_STD move(_First)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)));
 
-            _Seek_wrapped(_First, _STD move(_UResult));
+            _STD _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
         }
 
@@ -839,7 +839,7 @@ namespace ranges {
         _STATIC_CALL_OPERATOR borrowed_iterator_t<_Rng> operator()(_Rng&& _Range) _CONST_CALL_OPERATOR {
             auto _UResult = _Uninitialized_value_construct_unchecked(_Ubegin(_Range), _Uend(_Range));
 
-            return _Rewrap_iterator(_Range, _STD move(_UResult));
+            return _RANGES _Rewrap_iterator(_Range, _STD move(_UResult));
         }
 
     private:
@@ -850,7 +850,7 @@ namespace ranges {
             _STL_INTERNAL_STATIC_ASSERT(default_initializable<iter_value_t<_It>>);
 
             if constexpr (_Use_memset_value_construct_v<_It>) {
-                return _Zero_range(_OFirst, _RANGES next(_OFirst, _STD move(_OLast)));
+                return _STD _Zero_range(_OFirst, _RANGES next(_OFirst, _STD move(_OLast)));
             } else {
                 _Uninitialized_backout _Backout{_STD move(_OFirst)};
 
@@ -875,7 +875,7 @@ _NoThrowFwdIt uninitialized_value_construct_n(_NoThrowFwdIt _First, const _Diff 
         return _First;
     }
 
-    _Seek_wrapped(_First, _Uninitialized_value_construct_n_unchecked1(_Get_unwrapped_n(_First, _Count), _Count));
+    _STD _Seek_wrapped(_First, _STD _Uninitialized_value_construct_n_unchecked1(_STD _Get_unwrapped_n(_First, _Count), _Count));
     return _First;
 }
 
@@ -894,9 +894,9 @@ namespace ranges {
                 return _First;
             }
 
-            auto _UFirst = _Get_unwrapped_n(_STD move(_First), _Count);
+            auto _UFirst = _STD _Get_unwrapped_n(_STD move(_First), _Count);
             if constexpr (_Use_memset_value_construct_v<_It>) {
-                _Seek_wrapped(_First, _Zero_range(_UFirst, _UFirst + _Count));
+                _STD _Seek_wrapped(_First, _STD _Zero_range(_UFirst, _UFirst + _Count));
             } else {
                 _Uninitialized_backout _Backout{_STD move(_UFirst)};
 
@@ -904,7 +904,7 @@ namespace ranges {
                     _Backout._Emplace_back();
                 }
 
-                _Seek_wrapped(_First, _Backout._Release());
+                _STD _Seek_wrapped(_First, _Backout._Release());
             }
             return _First;
         }

--- a/stl/inc/new
+++ b/stl/inc/new
@@ -94,7 +94,11 @@ _EXPORT_STD template <class _Ty>
 _NODISCARD_LAUNDER constexpr _Ty* launder(_Ty* _Ptr) noexcept {
     static_assert(!is_function_v<_Ty> && !is_void_v<_Ty>,
         "N4950 [ptr.launder]/1: Mandates: !is_function_v<T> && !is_void_v<T> is true.");
-    return ::__builtin_launder(_Ptr); // TRANSITION, DevCom-10456452, should not be qualified
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10456452
+    return __builtin_launder(_Ptr);
+#else // ^^^ no workaround / workaround vvv
+    return ::__builtin_launder(_Ptr);
+#endif // ^^^ workaround ^^^
 }
 
 #if defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM) || defined(_M_ARM64)

--- a/stl/inc/new
+++ b/stl/inc/new
@@ -94,7 +94,7 @@ _EXPORT_STD template <class _Ty>
 _NODISCARD_LAUNDER constexpr _Ty* launder(_Ty* _Ptr) noexcept {
     static_assert(!is_function_v<_Ty> && !is_void_v<_Ty>,
         "N4950 [ptr.launder]/1: Mandates: !is_function_v<T> && !is_void_v<T> is true.");
-    return __builtin_launder(_Ptr);
+    return ::__builtin_launder(_Ptr); // TRANSITION, DevCom-10456452, should not be qualified
 }
 
 #if defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM) || defined(_M_ARM64)

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1114,7 +1114,7 @@ _CONSTEXPR20 void _Destroy_range(_NoThrowFwdIt _First, const _NoThrowSentinel _L
     // note that this is an optimization for debug mode codegen; in release mode the BE removes all of this
     if constexpr (!is_trivially_destructible_v<_Iter_value_t<_NoThrowFwdIt>>) {
         for (; _First != _Last; ++_First) {
-            _Destroy_in_place(*_First);
+            _STD _Destroy_in_place(*_First);
         }
     }
 }
@@ -1686,8 +1686,8 @@ namespace ranges {
 
     template <class _InIt, class _OutIt>
     in_out_result<_InIt, _OutIt> _Copy_memcpy_count(_InIt _IFirst, _OutIt _OFirst, const size_t _Count) noexcept {
-        const auto _IFirstPtr     = _To_address(_IFirst);
-        const auto _OFirstPtr     = _To_address(_OFirst);
+        const auto _IFirstPtr     = _STD _To_address(_IFirst);
+        const auto _OFirstPtr     = _STD _To_address(_OFirst);
         const auto _IFirst_ch     = const_cast<char*>(reinterpret_cast<const volatile char*>(_IFirstPtr));
         const auto _OFirst_ch     = const_cast<char*>(reinterpret_cast<const volatile char*>(_OFirstPtr));
         const size_t _Count_bytes = _Count * sizeof(iter_value_t<_InIt>);
@@ -1710,10 +1710,10 @@ namespace ranges {
     in_out_result<_InIt, _OutIt> _Copy_memcpy_distance(
         _InIt _IFirst, _OutIt _OFirst, const _DistIt _DFirst, const _DistIt _DLast) noexcept {
         // equivalent to _Copy_memcpy_count(_IFirst, _OFirst, _DLast - _DFirst) but computes distance more efficiently
-        const auto _IFirstPtr   = _To_address(_IFirst);
-        const auto _OFirstPtr   = _To_address(_OFirst);
-        const auto _DFirstPtr   = _To_address(_DFirst);
-        const auto _DLastPtr    = _To_address(_DLast);
+        const auto _IFirstPtr   = _STD _To_address(_IFirst);
+        const auto _OFirstPtr   = _STD _To_address(_OFirst);
+        const auto _DFirstPtr   = _STD _To_address(_DFirst);
+        const auto _DLastPtr    = _STD _To_address(_DLast);
         const auto _IFirst_ch   = const_cast<char*>(reinterpret_cast<const volatile char*>(_IFirstPtr));
         const auto _OFirst_ch   = const_cast<char*>(reinterpret_cast<const volatile char*>(_OFirstPtr));
         const auto _DFirst_ch   = const_cast<char*>(reinterpret_cast<const volatile char*>(_DFirstPtr));
@@ -1916,7 +1916,7 @@ _CONSTEXPR20 _NoThrowFwdIt _Uninitialized_copy_unchecked(_InIt _First, const _In
         if (!_STD is_constant_evaluated())
 #endif // _HAS_CXX20
         {
-            return _Copy_memmove(_First, _Last, _Dest);
+            return _STD _Copy_memmove(_First, _Last, _Dest);
         }
     }
 
@@ -1931,11 +1931,11 @@ _CONSTEXPR20 _NoThrowFwdIt _Uninitialized_copy_unchecked(_InIt _First, const _In
 _EXPORT_STD template <class _InIt, class _NoThrowFwdIt>
 _NoThrowFwdIt uninitialized_copy(const _InIt _First, const _InIt _Last, _NoThrowFwdIt _Dest) {
     // copy [_First, _Last) to raw [_Dest, ...)
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
-    auto _UDest       = _Get_unwrapped_n(_Dest, _Idl_distance<_InIt>(_UFirst, _ULast));
-    _Seek_wrapped(_Dest, _Uninitialized_copy_unchecked(_UFirst, _ULast, _UDest));
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
+    auto _UDest       = _STD _Get_unwrapped_n(_Dest, _STD _Idl_distance<_InIt>(_UFirst, _ULast));
+    _STD _Seek_wrapped(_Dest, _STD _Uninitialized_copy_unchecked(_UFirst, _ULast, _UDest));
     return _Dest;
 }
 
@@ -2002,15 +2002,15 @@ _CONSTEXPR20 _Alloc_ptr_t<_Alloc> _Uninitialized_fill_n(
 _EXPORT_STD template <class _NoThrowFwdIt, class _Tval>
 void uninitialized_fill(const _NoThrowFwdIt _First, const _NoThrowFwdIt _Last, const _Tval& _Val) {
     // copy _Val throughout raw [_First, _Last)
-    _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
-    const auto _ULast = _Get_unwrapped(_Last);
+    _STD _Adl_verify_range(_First, _Last);
+    auto _UFirst      = _STD _Get_unwrapped(_First);
+    const auto _ULast = _STD _Get_unwrapped(_Last);
     if constexpr (_Fill_memset_is_safe<_Unwrapped_t<const _NoThrowFwdIt&>, _Tval>) {
-        _Fill_memset(_UFirst, _Val, static_cast<size_t>(_ULast - _UFirst));
+        _STD _Fill_memset(_UFirst, _Val, static_cast<size_t>(_ULast - _UFirst));
     } else {
         if constexpr (_Fill_zero_memset_is_safe<_Unwrapped_t<const _NoThrowFwdIt&>, _Tval>) {
-            if (_Is_all_bits_zero(_Val)) {
-                _Fill_zero_memset(_UFirst, static_cast<size_t>(_ULast - _UFirst));
+            if (_STD _Is_all_bits_zero(_Val)) {
+                _STD _Fill_zero_memset(_UFirst, static_cast<size_t>(_ULast - _UFirst));
                 return;
             }
         }
@@ -2032,8 +2032,8 @@ _INLINE_VAR constexpr bool _Use_memset_value_construct_v =
 
 template <class _Ptr>
 _Ptr _Zero_range(const _Ptr _First, const _Ptr _Last) { // fill [_First, _Last) with zeroes
-    char* const _First_ch = reinterpret_cast<char*>(_To_address(_First));
-    char* const _Last_ch  = reinterpret_cast<char*>(_To_address(_Last));
+    char* const _First_ch = reinterpret_cast<char*>(_STD _To_address(_First));
+    char* const _Last_ch  = reinterpret_cast<char*>(_STD _To_address(_Last));
     _CSTD memset(_First_ch, 0, static_cast<size_t>(_Last_ch - _First_ch));
     return _Last;
 }
@@ -2067,7 +2067,7 @@ _NoThrowFwdIt _Uninitialized_value_construct_n_unchecked1(_NoThrowFwdIt _UFirst,
     // value-initialize all elements in [_UFirst, _UFirst + _Count)
     _STL_INTERNAL_CHECK(_Count >= 0);
     if constexpr (_Use_memset_value_construct_v<_NoThrowFwdIt>) {
-        return _Zero_range(_UFirst, _UFirst + _Count);
+        return _STD _Zero_range(_UFirst, _UFirst + _Count);
     } else {
         _Uninitialized_backout<_NoThrowFwdIt> _Backout{_UFirst};
         for (; 0 < _Count; --_Count) {

--- a/tests/std/tests/GH_001596_adl_proof_algorithms/test.compile.pass.cpp
+++ b/tests/std/tests/GH_001596_adl_proof_algorithms/test.compile.pass.cpp
@@ -466,9 +466,6 @@ void test_algorithms() {
     (void) std::uninitialized_fill_n(varr, 0, validator{});
     (void) std::uninitialized_fill_n(narr, 0, validating_nontrivial{});
 
-    std::uninitialized_fill(varr, varr, validator{});
-    std::uninitialized_fill(narr, narr, validating_nontrivial{});
-
 #if _HAS_CXX20
     {
         validator vx{};

--- a/tests/std/tests/P2538R1_adl_proof_std_projected/test.compile.pass.cpp
+++ b/tests/std/tests/P2538R1_adl_proof_std_projected/test.compile.pass.cpp
@@ -104,9 +104,9 @@ using validating_derived         = tagged_derived<holder<incomplete>>;
 using validating_base            = tagged_base<holder<incomplete>>;
 
 static_assert(std::sentinel_for<validating_base*, validating_derived*>);
-#ifndef __EDG__
+#ifndef __EDG__ // TRANSITION, DevCom-10581519
 static_assert(!std::sized_sentinel_for<validating_base*, validating_derived*>);
-#endif // !defined(__EDG__)
+#endif // ^^^ no workaround ^^^
 
 template <class T>
 bool less_function(T lhs, T rhs) {

--- a/tests/std/tests/P2538R1_adl_proof_std_projected/test.compile.pass.cpp
+++ b/tests/std/tests/P2538R1_adl_proof_std_projected/test.compile.pass.cpp
@@ -268,6 +268,7 @@ void test_ranges_algorithms() {
     (void) ends_with(varr, varr);
     (void) ends_with(iarr, iarr, iarr, iarr, validating_equal{});
     (void) ends_with(iarr, iarr, validating_equal{});
+    (void) ends_with(dptr, bptr, dptr, bptr, validating_true_comparator{});
 #endif // _HAS_CXX23
 
     int iarr2[1]{};


### PR DESCRIPTION
Separated from #4004. Towards #140 and #1596.

There's a separated commit addressing cases noted in https://github.com/microsoft/STL/pull/4367#discussion_r1477975129. Note that EDG currently incorrectly thinks `Derived*` and `Base*` are subtractable under some conditions, which ~should be~ is reported as DevCom-10581519 and should be cited as VSO-XXXX.

Unfortunately, currently there doesn't seem possible to verify that `_Copy_memcpy_distance` and `_Copy_memcpy_count` calls are properly qualified, because the comparison between `tagged_derived<holder<incomplete>>*` and `unreachable_sentinel_t` is ill-formed due to ADL.

As a workaround for DevCom-10456452, the `__builtin_launder` call is qualified.

This PR changes one line `_Destroy_range` in the same way as #4373, which shouldn't raise merge conflict IIUC.