### PR TITLE
Export VCRuntime entities properly

### DIFF
--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -35,8 +35,8 @@ _STD_END
 
 _STD_BEGIN
 
-_EXPORT_STD class exception;
-_EXPORT_STD class bad_exception;
+_EXPORT_STD using exception     = exception;
+_EXPORT_STD using bad_exception = bad_exception;
 
 _EXPORT_STD using ::terminate;
 

--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -35,9 +35,11 @@ _STD_END
 
 _STD_BEGIN
 
+#ifndef _VCRT_EXPORT_STD // TRANSITION, VCRuntime update expected in 17.10 Preview 3
 // Follow N4971 [module.interface]/6 by exporting aliases (a type alias is not an entity, N4971 [basic.pre]/3):
 _EXPORT_STD using exception     = exception;
 _EXPORT_STD using bad_exception = bad_exception;
+#endif // ^^^ workaround ^^^
 
 _EXPORT_STD using ::terminate;
 

--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -35,7 +35,7 @@ _STD_END
 
 _STD_BEGIN
 
-// Follow N4971 [module.interface]/6 by exporting aliases:
+// Follow N4971 [module.interface]/6 by exporting aliases (a type alias is not an entity, N4971 [basic.pre]/3):
 _EXPORT_STD using exception     = exception;
 _EXPORT_STD using bad_exception = bad_exception;
 

--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -35,6 +35,7 @@ _STD_END
 
 _STD_BEGIN
 
+// Follow N4971 [module.interface]/6 by exporting aliases:
 _EXPORT_STD using exception     = exception;
 _EXPORT_STD using bad_exception = bad_exception;
 

--- a/stl/inc/new
+++ b/stl/inc/new
@@ -23,11 +23,6 @@ _STL_DISABLE_CLANG_WARNINGS
 
 // Mirroring <vcruntime_new.h> declarations:
 
-_STD_BEGIN
-_EXPORT_STD using nothrow_t = nothrow_t;
-_EXPORT_STD extern "C++" const nothrow_t nothrow;
-_STD_END
-
 _EXPORT_STD extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new(size_t);
 _EXPORT_STD extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new(
     size_t, const _STD nothrow_t&) noexcept;

--- a/stl/inc/new
+++ b/stl/inc/new
@@ -24,7 +24,7 @@ _STL_DISABLE_CLANG_WARNINGS
 // Mirroring <vcruntime_new.h> declarations:
 
 _STD_BEGIN
-_EXPORT_STD extern "C++" struct nothrow_t;
+_EXPORT_STD using nothrow_t = nothrow_t;
 _EXPORT_STD extern "C++" const nothrow_t nothrow;
 _STD_END
 
@@ -76,8 +76,8 @@ _EXPORT_STD extern "C++" void __CRTDECL operator delete[](void*, void*) noexcept
 
 _STD_BEGIN
 #if _HAS_EXCEPTIONS
-_EXPORT_STD class bad_alloc;
-_EXPORT_STD class bad_array_new_length;
+_EXPORT_STD using bad_alloc            = bad_alloc;
+_EXPORT_STD using bad_array_new_length = bad_array_new_length;
 #else // ^^^ _HAS_EXCEPTIONS / !_HAS_EXCEPTIONS vvv
 // <exception> exports bad_alloc and bad_array_new_length.
 #endif // ^^^ !_HAS_EXCEPTIONS ^^^

--- a/stl/inc/new
+++ b/stl/inc/new
@@ -43,13 +43,7 @@ _EXPORT_STD extern "C++" void __CRTDECL operator delete[](void*, const _STD noth
 
 #ifdef __cpp_aligned_new
 _STD_BEGIN
-#ifdef __EDG__ // TRANSITION, VSO-1618988
-extern "C++" {
-_EXPORT_STD enum class align_val_t : size_t;
-}
-#else // ^^^ workaround / no workaround vvv
-_EXPORT_STD extern "C++" enum class align_val_t : size_t;
-#endif // ^^^ no workaround ^^^
+_EXPORT_STD using align_val_t = align_val_t;
 _STD_END
 
 _EXPORT_STD extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new(size_t, _STD align_val_t);

--- a/stl/inc/new
+++ b/stl/inc/new
@@ -18,6 +18,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 
 _STD_BEGIN
+#ifndef _VCRT_EXPORT_STD // TRANSITION, VCRuntime update expected in 17.10 Preview 3
 #if _HAS_EXCEPTIONS
 // Follow N4971 [module.interface]/6 by exporting aliases (a type alias is not an entity, N4971 [basic.pre]/3):
 _EXPORT_STD using bad_alloc            = bad_alloc;
@@ -25,6 +26,7 @@ _EXPORT_STD using bad_array_new_length = bad_array_new_length;
 #else // ^^^ _HAS_EXCEPTIONS / !_HAS_EXCEPTIONS vvv
 // <exception> exports bad_alloc and bad_array_new_length.
 #endif // ^^^ !_HAS_EXCEPTIONS ^^^
+#endif // ^^^ workaround ^^^
 
 #if _HAS_CXX20
 _EXPORT_STD struct destroying_delete_t {

--- a/stl/inc/new
+++ b/stl/inc/new
@@ -38,6 +38,7 @@ _EXPORT_STD extern "C++" void __CRTDECL operator delete[](void*, const _STD noth
 
 #ifdef __cpp_aligned_new
 _STD_BEGIN
+// Follow N4971 [module.interface]/6 by exporting aliases:
 _EXPORT_STD using align_val_t = align_val_t;
 _STD_END
 
@@ -65,6 +66,7 @@ _EXPORT_STD extern "C++" void __CRTDECL operator delete[](void*, void*) noexcept
 
 _STD_BEGIN
 #if _HAS_EXCEPTIONS
+// Follow N4971 [module.interface]/6 by exporting aliases:
 _EXPORT_STD using bad_alloc            = bad_alloc;
 _EXPORT_STD using bad_array_new_length = bad_array_new_length;
 #else // ^^^ _HAS_EXCEPTIONS / !_HAS_EXCEPTIONS vvv

--- a/stl/inc/new
+++ b/stl/inc/new
@@ -17,53 +17,6 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-#ifdef _BUILD_STD_MODULE
-#pragma warning(push)
-#pragma warning(disable : 28251) // Inconsistent annotation for 'new': this instance has no annotations.
-
-// Mirroring <vcruntime_new.h> declarations:
-
-_EXPORT_STD extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new(size_t);
-_EXPORT_STD extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new(
-    size_t, const _STD nothrow_t&) noexcept;
-_EXPORT_STD extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new[](size_t);
-_EXPORT_STD extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new[](
-    size_t, const _STD nothrow_t&) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete(void*) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete(void*, size_t) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete(void*, const _STD nothrow_t&) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete[](void*) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete[](void*, size_t) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete[](void*, const _STD nothrow_t&) noexcept;
-
-#ifdef __cpp_aligned_new
-_STD_BEGIN
-// Follow N4971 [module.interface]/6 by exporting aliases:
-_EXPORT_STD using align_val_t = align_val_t;
-_STD_END
-
-_EXPORT_STD extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new(size_t, _STD align_val_t);
-_EXPORT_STD extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new(
-    size_t, _STD align_val_t, const _STD nothrow_t&) noexcept;
-_EXPORT_STD extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new[](size_t, _STD align_val_t);
-_EXPORT_STD extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new[](
-    size_t, _STD align_val_t, const _STD nothrow_t&) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete(void*, _STD align_val_t) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete(void*, size_t, _STD align_val_t) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete(void*, _STD align_val_t, const _STD nothrow_t&) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete[](void*, _STD align_val_t) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete[](void*, size_t, _STD align_val_t) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete[](void*, _STD align_val_t, const _STD nothrow_t&) noexcept;
-#endif // defined(__cpp_aligned_new)
-
-_EXPORT_STD extern "C++" _NODISCARD void* __CRTDECL operator new(size_t, void*) noexcept;
-_EXPORT_STD extern "C++" _NODISCARD void* __CRTDECL operator new[](size_t, void*) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete(void*, void*) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete[](void*, void*) noexcept;
-
-#pragma warning(pop)
-#endif // defined(_BUILD_STD_MODULE)
-
 _STD_BEGIN
 #if _HAS_EXCEPTIONS
 // Follow N4971 [module.interface]/6 by exporting aliases:

--- a/stl/inc/new
+++ b/stl/inc/new
@@ -19,7 +19,7 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 #if _HAS_EXCEPTIONS
-// Follow N4971 [module.interface]/6 by exporting aliases:
+// Follow N4971 [module.interface]/6 by exporting aliases (a type alias is not an entity, N4971 [basic.pre]/3):
 _EXPORT_STD using bad_alloc            = bad_alloc;
 _EXPORT_STD using bad_array_new_length = bad_array_new_length;
 #else // ^^^ _HAS_EXCEPTIONS / !_HAS_EXCEPTIONS vvv

--- a/stl/inc/typeinfo
+++ b/stl/inc/typeinfo
@@ -23,20 +23,26 @@ _STL_DISABLE_CLANG_WARNINGS
 #include <vcruntime_typeinfo.h>
 #pragma pop_macro("raw_name")
 
+#ifndef _VCRT_EXPORT_STD // TRANSITION, VCRuntime update expected in 17.10 Preview 3
 // Follow N4971 [module.interface]/6 by exporting aliases (a type alias is not an entity, N4971 [basic.pre]/3):
 _EXPORT_STD using type_info = type_info; // for typeid, MSVC looks for type_info in the global namespace
+#endif // ^^^ workaround ^^^
 
 _STD_BEGIN
 
 // size in pointers of std::function and std::any (roughly 3 pointers larger than std::string when building debug)
 _INLINE_VAR constexpr int _Small_object_num_ptrs = 6 + 16 / sizeof(void*);
 
+#ifndef _VCRT_EXPORT_STD // TRANSITION, VCRuntime update expected in 17.10 Preview 3
 _EXPORT_STD using ::type_info;
+#endif // ^^^ workaround ^^^
 
 #if _HAS_EXCEPTIONS
+#ifndef _VCRT_EXPORT_STD // TRANSITION, VCRuntime update expected in 17.10 Preview 3
 // Follow N4971 [module.interface]/6 by exporting aliases (a type alias is not an entity, N4971 [basic.pre]/3):
 _EXPORT_STD using bad_cast   = bad_cast;
 _EXPORT_STD using bad_typeid = bad_typeid;
+#endif // ^^^ workaround ^^^
 #else // ^^^ _HAS_EXCEPTIONS / !_HAS_EXCEPTIONS vvv
 _EXPORT_STD class bad_cast : public exception { // base of all bad cast exceptions
 public:

--- a/stl/inc/typeinfo
+++ b/stl/inc/typeinfo
@@ -23,7 +23,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #include <vcruntime_typeinfo.h>
 #pragma pop_macro("raw_name")
 
-_EXPORT_STD extern "C++" class type_info; // for typeid, MSVC looks for type_info in the global namespace
+_EXPORT_STD using type_info = type_info; // for typeid, MSVC looks for type_info in the global namespace
 
 _STD_BEGIN
 
@@ -33,8 +33,8 @@ _INLINE_VAR constexpr int _Small_object_num_ptrs = 6 + 16 / sizeof(void*);
 _EXPORT_STD using ::type_info;
 
 #if _HAS_EXCEPTIONS
-_EXPORT_STD class bad_cast;
-_EXPORT_STD class bad_typeid;
+_EXPORT_STD using bad_cast   = bad_cast;
+_EXPORT_STD using bad_typeid = bad_typeid;
 #else // ^^^ _HAS_EXCEPTIONS / !_HAS_EXCEPTIONS vvv
 _EXPORT_STD class bad_cast : public exception { // base of all bad cast exceptions
 public:

--- a/stl/inc/typeinfo
+++ b/stl/inc/typeinfo
@@ -23,6 +23,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #include <vcruntime_typeinfo.h>
 #pragma pop_macro("raw_name")
 
+// Follow N4971 [module.interface]/6 by exporting aliases:
 _EXPORT_STD using type_info = type_info; // for typeid, MSVC looks for type_info in the global namespace
 
 _STD_BEGIN
@@ -33,6 +34,7 @@ _INLINE_VAR constexpr int _Small_object_num_ptrs = 6 + 16 / sizeof(void*);
 _EXPORT_STD using ::type_info;
 
 #if _HAS_EXCEPTIONS
+// Follow N4971 [module.interface]/6 by exporting aliases:
 _EXPORT_STD using bad_cast   = bad_cast;
 _EXPORT_STD using bad_typeid = bad_typeid;
 #else // ^^^ _HAS_EXCEPTIONS / !_HAS_EXCEPTIONS vvv

--- a/stl/inc/typeinfo
+++ b/stl/inc/typeinfo
@@ -23,7 +23,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #include <vcruntime_typeinfo.h>
 #pragma pop_macro("raw_name")
 
-// Follow N4971 [module.interface]/6 by exporting aliases:
+// Follow N4971 [module.interface]/6 by exporting aliases (a type alias is not an entity, N4971 [basic.pre]/3):
 _EXPORT_STD using type_info = type_info; // for typeid, MSVC looks for type_info in the global namespace
 
 _STD_BEGIN
@@ -34,7 +34,7 @@ _INLINE_VAR constexpr int _Small_object_num_ptrs = 6 + 16 / sizeof(void*);
 _EXPORT_STD using ::type_info;
 
 #if _HAS_EXCEPTIONS
-// Follow N4971 [module.interface]/6 by exporting aliases:
+// Follow N4971 [module.interface]/6 by exporting aliases (a type alias is not an entity, N4971 [basic.pre]/3):
 _EXPORT_STD using bad_cast   = bad_cast;
 _EXPORT_STD using bad_typeid = bad_typeid;
 #else // ^^^ _HAS_EXCEPTIONS / !_HAS_EXCEPTIONS vvv

--- a/stl/modules/std.ixx
+++ b/stl/modules/std.ixx
@@ -61,36 +61,49 @@ export extern "C++" enum class align_val_t : size_t;
 #endif // ^^^ defined(__cpp_aligned_new) ^^^
 _STD_END
 
-#pragma warning(disable : 28251) // Inconsistent annotation for 'new': this instance has no annotations.
-
-export extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new(size_t);
-export extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new(size_t, const _STD nothrow_t&) noexcept;
-export extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new[](size_t);
-export extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new[](size_t, const _STD nothrow_t&) noexcept;
-export extern "C++" void __CRTDECL operator delete(void*) noexcept;
-export extern "C++" void __CRTDECL operator delete(void*, size_t) noexcept;
-export extern "C++" void __CRTDECL operator delete(void*, const _STD nothrow_t&) noexcept;
-export extern "C++" void __CRTDECL operator delete[](void*) noexcept;
-export extern "C++" void __CRTDECL operator delete[](void*, size_t) noexcept;
-export extern "C++" void __CRTDECL operator delete[](void*, const _STD nothrow_t&) noexcept;
+export extern "C++" _NODISCARD _Ret_notnull_ _Post_writable_byte_size_(_Size)
+_VCRT_ALLOCATOR void* __CRTDECL operator new(size_t _Size);
+export extern "C++" _NODISCARD _Ret_maybenull_ _Success_(return != NULL)
+    _Post_writable_byte_size_(_Size) _VCRT_ALLOCATOR void* __CRTDECL
+    operator new(size_t _Size, const _STD nothrow_t&) noexcept;
+export extern "C++" _NODISCARD _Ret_notnull_ _Post_writable_byte_size_(_Size)
+_VCRT_ALLOCATOR void* __CRTDECL operator new[](size_t _Size);
+export extern "C++" _NODISCARD _Ret_maybenull_ _Success_(return != NULL)
+    _Post_writable_byte_size_(_Size) _VCRT_ALLOCATOR void* __CRTDECL
+    operator new[](size_t _Size, const _STD nothrow_t&) noexcept;
+export extern "C++" void __CRTDECL operator delete(void* _Block) noexcept;
+export extern "C++" void __CRTDECL operator delete(void* _Block, size_t _Size) noexcept;
+export extern "C++" void __CRTDECL operator delete(void* _Block, const _STD nothrow_t&) noexcept;
+export extern "C++" void __CRTDECL operator delete[](void* _Block) noexcept;
+export extern "C++" void __CRTDECL operator delete[](void* _Block, size_t _Size) noexcept;
+export extern "C++" void __CRTDECL operator delete[](void* _Block, const _STD nothrow_t&) noexcept;
 
 #ifdef __cpp_aligned_new
-export extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new(size_t, _STD align_val_t);
-export extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new(
-    size_t, _STD align_val_t, const _STD nothrow_t&) noexcept;
-export extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new[](size_t, _STD align_val_t);
-export extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new[](
-    size_t, _STD align_val_t, const _STD nothrow_t&) noexcept;
-export extern "C++" void __CRTDECL operator delete(void*, _STD align_val_t) noexcept;
-export extern "C++" void __CRTDECL operator delete(void*, size_t, _STD align_val_t) noexcept;
-export extern "C++" void __CRTDECL operator delete(void*, _STD align_val_t, const _STD nothrow_t&) noexcept;
-export extern "C++" void __CRTDECL operator delete[](void*, _STD align_val_t) noexcept;
-export extern "C++" void __CRTDECL operator delete[](void*, size_t, _STD align_val_t) noexcept;
-export extern "C++" void __CRTDECL operator delete[](void*, _STD align_val_t, const _STD nothrow_t&) noexcept;
+export extern "C++" _NODISCARD _Ret_notnull_ _Post_writable_byte_size_(_Size)
+_VCRT_ALLOCATOR void* __CRTDECL operator new(size_t _Size, _STD align_val_t _Al);
+export extern "C++" _NODISCARD _Ret_maybenull_ _Success_(return != NULL)
+    _Post_writable_byte_size_(_Size) _VCRT_ALLOCATOR void* __CRTDECL
+    operator new(size_t _Size, _STD align_val_t _Al, const _STD nothrow_t&) noexcept;
+export extern "C++" _NODISCARD _Ret_notnull_ _Post_writable_byte_size_(_Size)
+_VCRT_ALLOCATOR void* __CRTDECL operator new[](size_t _Size, _STD align_val_t _Al);
+export extern "C++" _NODISCARD _Ret_maybenull_ _Success_(return != NULL)
+    _Post_writable_byte_size_(_Size) _VCRT_ALLOCATOR void* __CRTDECL
+    operator new[](size_t _Size, _STD align_val_t _Al, const _STD nothrow_t&) noexcept;
+export extern "C++" void __CRTDECL operator delete(void* _Block, _STD align_val_t _Al) noexcept;
+export extern "C++" void __CRTDECL operator delete(void* _Block, size_t _Size, _STD align_val_t _Al) noexcept;
+export extern "C++" void __CRTDECL operator delete(void* _Block, _STD align_val_t _Al, const _STD nothrow_t&) noexcept;
+export extern "C++" void __CRTDECL operator delete[](void* _Block, _STD align_val_t _Al) noexcept;
+export extern "C++" void __CRTDECL operator delete[](void* _Block, size_t _Size, _STD align_val_t _Al) noexcept;
+export extern "C++" void __CRTDECL operator delete[](
+    void* _Block, _STD align_val_t _Al, const _STD nothrow_t&) noexcept;
 #endif // ^^^ defined(__cpp_aligned_new) ^^^
 
-export extern "C++" _NODISCARD void* __CRTDECL operator new(size_t, void*) noexcept;
-export extern "C++" _NODISCARD void* __CRTDECL operator new[](size_t, void*) noexcept;
+export extern "C++" _NODISCARD _MSVC_CONSTEXPR _Ret_notnull_ _Post_writable_byte_size_(_Size)
+    _Post_satisfies_(return == _Where) void* __CRTDECL
+    operator new(size_t _Size, _Writable_bytes_(_Size) void* _Where) noexcept;
+export extern "C++" _NODISCARD _Ret_notnull_ _Post_writable_byte_size_(_Size)
+    _Post_satisfies_(return == _Where) void* __CRTDECL
+    operator new[](size_t _Size, _Writable_bytes_(_Size) void* _Where) noexcept;
 export extern "C++" void __CRTDECL operator delete(void*, void*) noexcept;
 export extern "C++" void __CRTDECL operator delete[](void*, void*) noexcept;
 

--- a/stl/modules/std.ixx
+++ b/stl/modules/std.ixx
@@ -37,7 +37,7 @@ export module std;
 #pragma warning(disable : 5244) // '#include <meow>' in the purview of module 'std' appears erroneous.
 
 #include <yvals_core.h>
-#ifndef _EXPORT_VCR // TRANSITION, VCRuntime update expected in 17.10 Preview 3
+#ifndef _VCRT_EXPORT_STD // TRANSITION, VCRuntime update expected in 17.10 Preview 3
 
 // N4971 [module.interface]/6: "A redeclaration of an entity X is implicitly exported
 // if X was introduced by an exported declaration; otherwise it shall not be exported."

--- a/stl/modules/std.ixx
+++ b/stl/modules/std.ixx
@@ -52,49 +52,47 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 
 _STD_BEGIN
-_EXPORT_STD extern "C++" struct nothrow_t;
+export extern "C++" struct nothrow_t;
 
-_EXPORT_STD extern "C++" const nothrow_t nothrow;
+export extern "C++" const nothrow_t nothrow;
 
 #ifdef __cpp_aligned_new
-_EXPORT_STD extern "C++" enum class align_val_t : size_t;
+export extern "C++" enum class align_val_t : size_t;
 #endif // ^^^ defined(__cpp_aligned_new) ^^^
 _STD_END
 
 #pragma warning(disable : 28251) // Inconsistent annotation for 'new': this instance has no annotations.
 
-_EXPORT_STD extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new(size_t);
-_EXPORT_STD extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new(
-    size_t, const _STD nothrow_t&) noexcept;
-_EXPORT_STD extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new[](size_t);
-_EXPORT_STD extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new[](
-    size_t, const _STD nothrow_t&) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete(void*) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete(void*, size_t) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete(void*, const _STD nothrow_t&) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete[](void*) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete[](void*, size_t) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete[](void*, const _STD nothrow_t&) noexcept;
+export extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new(size_t);
+export extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new(size_t, const _STD nothrow_t&) noexcept;
+export extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new[](size_t);
+export extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new[](size_t, const _STD nothrow_t&) noexcept;
+export extern "C++" void __CRTDECL operator delete(void*) noexcept;
+export extern "C++" void __CRTDECL operator delete(void*, size_t) noexcept;
+export extern "C++" void __CRTDECL operator delete(void*, const _STD nothrow_t&) noexcept;
+export extern "C++" void __CRTDECL operator delete[](void*) noexcept;
+export extern "C++" void __CRTDECL operator delete[](void*, size_t) noexcept;
+export extern "C++" void __CRTDECL operator delete[](void*, const _STD nothrow_t&) noexcept;
 
 #ifdef __cpp_aligned_new
-_EXPORT_STD extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new(size_t, _STD align_val_t);
-_EXPORT_STD extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new(
+export extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new(size_t, _STD align_val_t);
+export extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new(
     size_t, _STD align_val_t, const _STD nothrow_t&) noexcept;
-_EXPORT_STD extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new[](size_t, _STD align_val_t);
-_EXPORT_STD extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new[](
+export extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new[](size_t, _STD align_val_t);
+export extern "C++" _NODISCARD _VCRT_ALLOCATOR void* __CRTDECL operator new[](
     size_t, _STD align_val_t, const _STD nothrow_t&) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete(void*, _STD align_val_t) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete(void*, size_t, _STD align_val_t) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete(void*, _STD align_val_t, const _STD nothrow_t&) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete[](void*, _STD align_val_t) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete[](void*, size_t, _STD align_val_t) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete[](void*, _STD align_val_t, const _STD nothrow_t&) noexcept;
+export extern "C++" void __CRTDECL operator delete(void*, _STD align_val_t) noexcept;
+export extern "C++" void __CRTDECL operator delete(void*, size_t, _STD align_val_t) noexcept;
+export extern "C++" void __CRTDECL operator delete(void*, _STD align_val_t, const _STD nothrow_t&) noexcept;
+export extern "C++" void __CRTDECL operator delete[](void*, _STD align_val_t) noexcept;
+export extern "C++" void __CRTDECL operator delete[](void*, size_t, _STD align_val_t) noexcept;
+export extern "C++" void __CRTDECL operator delete[](void*, _STD align_val_t, const _STD nothrow_t&) noexcept;
 #endif // ^^^ defined(__cpp_aligned_new) ^^^
 
-_EXPORT_STD extern "C++" _NODISCARD void* __CRTDECL operator new(size_t, void*) noexcept;
-_EXPORT_STD extern "C++" _NODISCARD void* __CRTDECL operator new[](size_t, void*) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete(void*, void*) noexcept;
-_EXPORT_STD extern "C++" void __CRTDECL operator delete[](void*, void*) noexcept;
+export extern "C++" _NODISCARD void* __CRTDECL operator new(size_t, void*) noexcept;
+export extern "C++" _NODISCARD void* __CRTDECL operator new[](size_t, void*) noexcept;
+export extern "C++" void __CRTDECL operator delete(void*, void*) noexcept;
+export extern "C++" void __CRTDECL operator delete[](void*, void*) noexcept;
 
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/stl/modules/std.ixx
+++ b/stl/modules/std.ixx
@@ -7,6 +7,12 @@ module;
 // This named module expects to be built with classic headers, not header units.
 #define _BUILD_STD_MODULE
 
+// N4971 [module.interface]/6: "A redeclaration of an entity X is implicitly exported
+// if X was introduced by an exported declaration; otherwise it shall not be exported."
+// Therefore, we'll need to introduce the `nothrow` object with an exported declaration,
+// instead of allowing <vcruntime_new.h> to declare it.
+#define __NOTHROW_T_DEFINED
+
 // The subset of "C headers" [tab:c.headers] corresponding to
 // the "C++ headers for C library facilities" [tab:headers.cpp.c]
 #include <assert.h>
@@ -35,6 +41,16 @@ export module std;
 
 #pragma warning(push)
 #pragma warning(disable : 5244) // '#include <meow>' in the purview of module 'std' appears erroneous.
+
+#include <yvals_core.h>
+#pragma pack(push, _CRT_PACKING)
+_STD_BEGIN
+_EXPORT_STD extern "C++" struct nothrow_t {
+    explicit nothrow_t() = default;
+};
+_EXPORT_STD extern "C++" const nothrow_t nothrow;
+_STD_END
+#pragma pack(pop)
 
 // "C++ library headers" [tab:headers.cpp]
 #include <algorithm>

--- a/tests/std/include/test_header_units_and_modules.hpp
+++ b/tests/std/include/test_header_units_and_modules.hpp
@@ -204,6 +204,10 @@ void test_deque() {
 void test_exception() {
     using namespace std;
     puts("Testing <exception>.");
+
+    static_assert(is_class_v<exception>);
+    static_assert(is_class_v<bad_exception>);
+
     assert(uncaught_exceptions() == 0);
     const exception_ptr ep = current_exception();
     assert(!ep);
@@ -471,6 +475,11 @@ void test_mutex() {
 void test_new() {
     using namespace std;
     puts("Testing <new>.");
+
+    static_assert(is_class_v<bad_alloc>);
+    static_assert(is_class_v<bad_array_new_length>);
+    static_assert(is_class_v<nothrow_t>);
+
     bool caught_bad_alloc = false;
 
     try {
@@ -988,6 +997,11 @@ void test_typeindex() {
 void test_typeinfo() {
     using namespace std;
     puts("Testing <typeinfo>.");
+
+    static_assert(is_class_v<type_info>);
+    static_assert(is_class_v<bad_cast>);
+    static_assert(is_class_v<bad_typeid>);
+
     const type_info& t1 = typeid(int);
     const type_info& t2 = typeid(const int&);
     const type_info& t3 = typeid(double);

--- a/tests/std/include/test_header_units_and_modules.hpp
+++ b/tests/std/include/test_header_units_and_modules.hpp
@@ -478,6 +478,7 @@ void test_new() {
 
     static_assert(is_class_v<bad_alloc>);
     static_assert(is_class_v<bad_array_new_length>);
+    static_assert(is_same_v<underlying_type_t<align_val_t>, size_t>);
     static_assert(is_class_v<nothrow_t>);
 
     bool caught_bad_alloc = false;


### PR DESCRIPTION
Fixes #4350. Mirrored as MSVC-PR-527804 with VCRuntime changes.

# :lady_beetle: The Problem
The Standard has a rule WG21-N4971 \[module.interface\]/6: "A redeclaration of an entity *X* is implicitly exported if *X* was introduced by an exported declaration; otherwise it shall not be exported." followed by an example:

```cpp
export module M;
struct S { int n; };
typedef S S;
export typedef S S; // OK, does not redeclare an entity
export struct S;    // error: exported declaration follows non-exported declaration
```

[Clang enforces this rule](https://godbolt.org/z/bcG9b4hzv), but MSVC let me be a bad kitty :smirk_cat:, jumping up on the table where I'm not allowed, reported as VSO-1953157 "Modules: MSVC should emit an error when an exported declaration follows a non-exported declaration".

# :adhesive_bandage: The Short-Term Fix
For types, we can export aliases, which also avoids the need to mention `extern "C++"`. This technique looks unusual, so we'll comment it with Standard citations.

The `std::nothrow` object and `::operator new/new[]/delete/delete[]` functions are subject to the same rule, but they're trickier to handle because we can't just alias them. So, I'm fusing `<new>`'s `#ifdef _BUILD_STD_MODULE` machinery directly into `std.ixx` (it expanded to nothing elsewhere).

In `std.ixx`, we have to wait for the exact right moment. We begin with the Global Module Fragment, we define `_BUILD_STD_MODULE` immediately after, and then include CRT headers. (These won't drag in VCRuntime machinery.) Then we say `export module std;` to start the party, and we silence the warning about including headers within a named module.

Now, before we include any STL headers (which will drag in VCRuntime headers), we include `<yvals_core.h>`. This will observe the definition of `_BUILD_STD_MODULE` above (we're assuming classic headers, as commented), and drags in `<vcruntime.h>` (but not any `<vcruntime_MEOW.h>`).

We check whether that emits `_VCRT_EXPORT_STD` (see the long-term fix below). If not, we're working with an older VCRuntime that won't export its own machinery, so we need to introduce exported declarations first.

For laziness, I'm using the full set of push/pop guards, even though `std.ixx` isn't a header and all we really need is the packing. Then I can declare the `nothrow_t` type, the `nothrow` object, and the `align_val_t` type. Finally, I need to replicate the (incredibly verbose) declarations of all of the global allocation/deallocation operators, complete with SAL annotations (we're the first declarations, so we can't omit them). They mention `NULL` which I need to preserve :vomiting_face: because VCRuntime says that and they need to match. I adjusted the declarations to use our `_STD` and west `const`.

Because this is `std.ixx` itself, I'm saying `export` directly, there's no reason to `_EXPORT_STD` here.

# :hammer_and_wrench: The Long-Term Fix
This is an unusual PR because it takes two forms simultaneously. The GitHub portion is the short-term fix, but it'll be simultaneously merged with VCRuntime changes that are the long-term fix. The VCRuntime changes will make `<vcruntime.h>` detect `_BUILD_STD_MODULE` and define `_VCRT_EXPORT_STD`, so it'll export its own machinery. When this happens, the presence of the `_VCRT_EXPORT_STD` macro will automatically disable the STL's workarounds, so it won't try to redundantly `export` things. In `std.ixx`, we'll be left with an unguarded inclusion of `<yvals_core.h>` which is harmless (it's immediately followed by including `<algorithm>`).

After this PR is merged, and ships in (expected) VS 2022 17.10 Preview 3, I'll be able to remove all of the workarounds in the STL. Having VCRuntime export its own machinery is what I should have done in the first place, and this will finally get us there.