### PR TITLE
README.md: allow htmlLabels inside flowchart

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ vehicles.
 
 ```mermaid
 flowchart TB
+%%{ init: {"flowchart": {"htmlLabels": true}} }%%
     classDef default text-align:left
     subgraph VisualStudioSubgraph[Visual Studio]
         direction TB


### PR DESCRIPTION
Fixes #4381

It seems htmlLabels are disabled by default now for some reason. But we can enable them.

It seems it works:
https://github.com/fsb4000/STL/tree/patch-1
![изображение](https://github.com/microsoft/STL/assets/4289847/befbfe18-0542-4dfa-bae7-b05cafd04475)
