### PR TITLE
Dedicated `ranges::minmax` vectorization that does not unnecessarily track element pointer

### DIFF
--- a/benchmarks/src/minmax_element.cpp
+++ b/benchmarks/src/minmax_element.cpp
@@ -13,6 +13,9 @@ enum class Op {
     Min,
     Max,
     Both,
+    Min_el,
+    Max_el,
+    Both_el,
 };
 
 using namespace std;
@@ -38,6 +41,12 @@ void bm(benchmark::State& state) {
             benchmark::DoNotOptimize(ranges::max_element(a));
         } else if constexpr (Operation == Op::Both) {
             benchmark::DoNotOptimize(ranges::minmax_element(a));
+        } else if constexpr (Operation == Op::Min_el) {
+            benchmark::DoNotOptimize(ranges::min(a));
+        } else if constexpr (Operation == Op::Max_el) {
+            benchmark::DoNotOptimize(ranges::max(a));
+        } else if constexpr (Operation == Op::Both_el) {
+            benchmark::DoNotOptimize(ranges::minmax(a));
         }
     }
 }
@@ -45,42 +54,72 @@ void bm(benchmark::State& state) {
 BENCHMARK(bm<uint8_t, 8021, Op::Min>);
 BENCHMARK(bm<uint8_t, 8021, Op::Max>);
 BENCHMARK(bm<uint8_t, 8021, Op::Both>);
+BENCHMARK(bm<uint8_t, 8021, Op::Min_el>);
+BENCHMARK(bm<uint8_t, 8021, Op::Max_el>);
+BENCHMARK(bm<uint8_t, 8021, Op::Both_el>);
 
 BENCHMARK(bm<uint16_t, 8021, Op::Min>);
 BENCHMARK(bm<uint16_t, 8021, Op::Max>);
 BENCHMARK(bm<uint16_t, 8021, Op::Both>);
+BENCHMARK(bm<uint16_t, 8021, Op::Min_el>);
+BENCHMARK(bm<uint16_t, 8021, Op::Max_el>);
+BENCHMARK(bm<uint16_t, 8021, Op::Both_el>);
 
 BENCHMARK(bm<uint32_t, 8021, Op::Min>);
 BENCHMARK(bm<uint32_t, 8021, Op::Max>);
 BENCHMARK(bm<uint32_t, 8021, Op::Both>);
+BENCHMARK(bm<uint32_t, 8021, Op::Min_el>);
+BENCHMARK(bm<uint32_t, 8021, Op::Max_el>);
+BENCHMARK(bm<uint32_t, 8021, Op::Both_el>);
 
 BENCHMARK(bm<uint64_t, 8021, Op::Min>);
 BENCHMARK(bm<uint64_t, 8021, Op::Max>);
 BENCHMARK(bm<uint64_t, 8021, Op::Both>);
+BENCHMARK(bm<uint64_t, 8021, Op::Min_el>);
+BENCHMARK(bm<uint64_t, 8021, Op::Max_el>);
+BENCHMARK(bm<uint64_t, 8021, Op::Both_el>);
 
 BENCHMARK(bm<int8_t, 8021, Op::Min>);
 BENCHMARK(bm<int8_t, 8021, Op::Max>);
 BENCHMARK(bm<int8_t, 8021, Op::Both>);
+BENCHMARK(bm<int8_t, 8021, Op::Min_el>);
+BENCHMARK(bm<int8_t, 8021, Op::Max_el>);
+BENCHMARK(bm<int8_t, 8021, Op::Both_el>);
 
 BENCHMARK(bm<int16_t, 8021, Op::Min>);
 BENCHMARK(bm<int16_t, 8021, Op::Max>);
 BENCHMARK(bm<int16_t, 8021, Op::Both>);
+BENCHMARK(bm<int16_t, 8021, Op::Min_el>);
+BENCHMARK(bm<int16_t, 8021, Op::Max_el>);
+BENCHMARK(bm<int16_t, 8021, Op::Both_el>);
 
 BENCHMARK(bm<int32_t, 8021, Op::Min>);
 BENCHMARK(bm<int32_t, 8021, Op::Max>);
 BENCHMARK(bm<int32_t, 8021, Op::Both>);
+BENCHMARK(bm<int16_t, 8021, Op::Min_el>);
+BENCHMARK(bm<int16_t, 8021, Op::Max_el>);
+BENCHMARK(bm<int16_t, 8021, Op::Both_el>);
 
 BENCHMARK(bm<int64_t, 8021, Op::Min>);
 BENCHMARK(bm<int64_t, 8021, Op::Max>);
 BENCHMARK(bm<int64_t, 8021, Op::Both>);
+BENCHMARK(bm<int64_t, 8021, Op::Min_el>);
+BENCHMARK(bm<int64_t, 8021, Op::Max_el>);
+BENCHMARK(bm<int64_t, 8021, Op::Both_el>);
 
 BENCHMARK(bm<float, 8021, Op::Min>);
 BENCHMARK(bm<float, 8021, Op::Max>);
 BENCHMARK(bm<float, 8021, Op::Both>);
+BENCHMARK(bm<float, 8021, Op::Min_el>);
+BENCHMARK(bm<float, 8021, Op::Max_el>);
+BENCHMARK(bm<float, 8021, Op::Both_el>);
 
 BENCHMARK(bm<double, 8021, Op::Min>);
 BENCHMARK(bm<double, 8021, Op::Max>);
 BENCHMARK(bm<double, 8021, Op::Both>);
+BENCHMARK(bm<double, 8021, Op::Min_el>);
+BENCHMARK(bm<double, 8021, Op::Max_el>);
+BENCHMARK(bm<double, 8021, Op::Both_el>);
 
 
 BENCHMARK_MAIN();

--- a/benchmarks/src/minmax_element.cpp
+++ b/benchmarks/src/minmax_element.cpp
@@ -13,9 +13,9 @@ enum class Op {
     Min,
     Max,
     Both,
-    Min_el,
-    Max_el,
-    Both_el,
+    Min_val,
+    Max_val,
+    Both_val,
 };
 
 using namespace std;
@@ -36,16 +36,16 @@ void bm(benchmark::State& state) {
 
     for (auto _ : state) {
         if constexpr (Operation == Op::Min) {
-            benchmark::DoNotOptimize(ranges::min_element(a));
+            benchmark::DoNotOptimize(ranges::min_valement(a));
         } else if constexpr (Operation == Op::Max) {
-            benchmark::DoNotOptimize(ranges::max_element(a));
+            benchmark::DoNotOptimize(ranges::max_valement(a));
         } else if constexpr (Operation == Op::Both) {
-            benchmark::DoNotOptimize(ranges::minmax_element(a));
-        } else if constexpr (Operation == Op::Min_el) {
+            benchmark::DoNotOptimize(ranges::minmax_valement(a));
+        } else if constexpr (Operation == Op::Min_val) {
             benchmark::DoNotOptimize(ranges::min(a));
-        } else if constexpr (Operation == Op::Max_el) {
+        } else if constexpr (Operation == Op::Max_val) {
             benchmark::DoNotOptimize(ranges::max(a));
-        } else if constexpr (Operation == Op::Both_el) {
+        } else if constexpr (Operation == Op::Both_val) {
             benchmark::DoNotOptimize(ranges::minmax(a));
         }
     }
@@ -54,72 +54,72 @@ void bm(benchmark::State& state) {
 BENCHMARK(bm<uint8_t, 8021, Op::Min>);
 BENCHMARK(bm<uint8_t, 8021, Op::Max>);
 BENCHMARK(bm<uint8_t, 8021, Op::Both>);
-BENCHMARK(bm<uint8_t, 8021, Op::Min_el>);
-BENCHMARK(bm<uint8_t, 8021, Op::Max_el>);
-BENCHMARK(bm<uint8_t, 8021, Op::Both_el>);
+BENCHMARK(bm<uint8_t, 8021, Op::Min_val>);
+BENCHMARK(bm<uint8_t, 8021, Op::Max_val>);
+BENCHMARK(bm<uint8_t, 8021, Op::Both_val>);
 
 BENCHMARK(bm<uint16_t, 8021, Op::Min>);
 BENCHMARK(bm<uint16_t, 8021, Op::Max>);
 BENCHMARK(bm<uint16_t, 8021, Op::Both>);
-BENCHMARK(bm<uint16_t, 8021, Op::Min_el>);
-BENCHMARK(bm<uint16_t, 8021, Op::Max_el>);
-BENCHMARK(bm<uint16_t, 8021, Op::Both_el>);
+BENCHMARK(bm<uint16_t, 8021, Op::Min_val>);
+BENCHMARK(bm<uint16_t, 8021, Op::Max_val>);
+BENCHMARK(bm<uint16_t, 8021, Op::Both_val>);
 
 BENCHMARK(bm<uint32_t, 8021, Op::Min>);
 BENCHMARK(bm<uint32_t, 8021, Op::Max>);
 BENCHMARK(bm<uint32_t, 8021, Op::Both>);
-BENCHMARK(bm<uint32_t, 8021, Op::Min_el>);
-BENCHMARK(bm<uint32_t, 8021, Op::Max_el>);
-BENCHMARK(bm<uint32_t, 8021, Op::Both_el>);
+BENCHMARK(bm<uint32_t, 8021, Op::Min_val>);
+BENCHMARK(bm<uint32_t, 8021, Op::Max_val>);
+BENCHMARK(bm<uint32_t, 8021, Op::Both_val>);
 
 BENCHMARK(bm<uint64_t, 8021, Op::Min>);
 BENCHMARK(bm<uint64_t, 8021, Op::Max>);
 BENCHMARK(bm<uint64_t, 8021, Op::Both>);
-BENCHMARK(bm<uint64_t, 8021, Op::Min_el>);
-BENCHMARK(bm<uint64_t, 8021, Op::Max_el>);
-BENCHMARK(bm<uint64_t, 8021, Op::Both_el>);
+BENCHMARK(bm<uint64_t, 8021, Op::Min_val>);
+BENCHMARK(bm<uint64_t, 8021, Op::Max_val>);
+BENCHMARK(bm<uint64_t, 8021, Op::Both_val>);
 
 BENCHMARK(bm<int8_t, 8021, Op::Min>);
 BENCHMARK(bm<int8_t, 8021, Op::Max>);
 BENCHMARK(bm<int8_t, 8021, Op::Both>);
-BENCHMARK(bm<int8_t, 8021, Op::Min_el>);
-BENCHMARK(bm<int8_t, 8021, Op::Max_el>);
-BENCHMARK(bm<int8_t, 8021, Op::Both_el>);
+BENCHMARK(bm<int8_t, 8021, Op::Min_val>);
+BENCHMARK(bm<int8_t, 8021, Op::Max_val>);
+BENCHMARK(bm<int8_t, 8021, Op::Both_val>);
 
 BENCHMARK(bm<int16_t, 8021, Op::Min>);
 BENCHMARK(bm<int16_t, 8021, Op::Max>);
 BENCHMARK(bm<int16_t, 8021, Op::Both>);
-BENCHMARK(bm<int16_t, 8021, Op::Min_el>);
-BENCHMARK(bm<int16_t, 8021, Op::Max_el>);
-BENCHMARK(bm<int16_t, 8021, Op::Both_el>);
+BENCHMARK(bm<int16_t, 8021, Op::Min_val>);
+BENCHMARK(bm<int16_t, 8021, Op::Max_val>);
+BENCHMARK(bm<int16_t, 8021, Op::Both_val>);
 
 BENCHMARK(bm<int32_t, 8021, Op::Min>);
 BENCHMARK(bm<int32_t, 8021, Op::Max>);
 BENCHMARK(bm<int32_t, 8021, Op::Both>);
-BENCHMARK(bm<int32_t, 8021, Op::Min_el>);
-BENCHMARK(bm<int32_t, 8021, Op::Max_el>);
-BENCHMARK(bm<int32_t, 8021, Op::Both_el>);
+BENCHMARK(bm<int32_t, 8021, Op::Min_val>);
+BENCHMARK(bm<int32_t, 8021, Op::Max_val>);
+BENCHMARK(bm<int32_t, 8021, Op::Both_val>);
 
 BENCHMARK(bm<int64_t, 8021, Op::Min>);
 BENCHMARK(bm<int64_t, 8021, Op::Max>);
 BENCHMARK(bm<int64_t, 8021, Op::Both>);
-BENCHMARK(bm<int64_t, 8021, Op::Min_el>);
-BENCHMARK(bm<int64_t, 8021, Op::Max_el>);
-BENCHMARK(bm<int64_t, 8021, Op::Both_el>);
+BENCHMARK(bm<int64_t, 8021, Op::Min_val>);
+BENCHMARK(bm<int64_t, 8021, Op::Max_val>);
+BENCHMARK(bm<int64_t, 8021, Op::Both_val>);
 
 BENCHMARK(bm<float, 8021, Op::Min>);
 BENCHMARK(bm<float, 8021, Op::Max>);
 BENCHMARK(bm<float, 8021, Op::Both>);
-BENCHMARK(bm<float, 8021, Op::Min_el>);
-BENCHMARK(bm<float, 8021, Op::Max_el>);
-BENCHMARK(bm<float, 8021, Op::Both_el>);
+BENCHMARK(bm<float, 8021, Op::Min_val>);
+BENCHMARK(bm<float, 8021, Op::Max_val>);
+BENCHMARK(bm<float, 8021, Op::Both_val>);
 
 BENCHMARK(bm<double, 8021, Op::Min>);
 BENCHMARK(bm<double, 8021, Op::Max>);
 BENCHMARK(bm<double, 8021, Op::Both>);
-BENCHMARK(bm<double, 8021, Op::Min_el>);
-BENCHMARK(bm<double, 8021, Op::Max_el>);
-BENCHMARK(bm<double, 8021, Op::Both_el>);
+BENCHMARK(bm<double, 8021, Op::Min_val>);
+BENCHMARK(bm<double, 8021, Op::Max_val>);
+BENCHMARK(bm<double, 8021, Op::Both_val>);
 
 
 BENCHMARK_MAIN();

--- a/benchmarks/src/minmax_element.cpp
+++ b/benchmarks/src/minmax_element.cpp
@@ -96,9 +96,9 @@ BENCHMARK(bm<int16_t, 8021, Op::Both_el>);
 BENCHMARK(bm<int32_t, 8021, Op::Min>);
 BENCHMARK(bm<int32_t, 8021, Op::Max>);
 BENCHMARK(bm<int32_t, 8021, Op::Both>);
-BENCHMARK(bm<int16_t, 8021, Op::Min_el>);
-BENCHMARK(bm<int16_t, 8021, Op::Max_el>);
-BENCHMARK(bm<int16_t, 8021, Op::Both_el>);
+BENCHMARK(bm<int32_t, 8021, Op::Min_el>);
+BENCHMARK(bm<int32_t, 8021, Op::Max_el>);
+BENCHMARK(bm<int32_t, 8021, Op::Both_el>);
 
 BENCHMARK(bm<int64_t, 8021, Op::Min>);
 BENCHMARK(bm<int64_t, 8021, Op::Max>);

--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -15,6 +15,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/inc/__msvc_formatter.hpp
     ${CMAKE_CURRENT_LIST_DIR}/inc/__msvc_int128.hpp
     ${CMAKE_CURRENT_LIST_DIR}/inc/__msvc_iter_core.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/inc/__msvc_minmax.hpp
     ${CMAKE_CURRENT_LIST_DIR}/inc/__msvc_print.hpp
     ${CMAKE_CURRENT_LIST_DIR}/inc/__msvc_sanitizer_annotate_container.hpp
     ${CMAKE_CURRENT_LIST_DIR}/inc/__msvc_system_error_abi.hpp

--- a/stl/inc/__msvc_minmax.hpp
+++ b/stl/inc/__msvc_minmax.hpp
@@ -1,0 +1,86 @@
+// __msvc_minmax.hpp internal header (core)
+
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef __MSVC_MINMAX_HPP
+#define __MSVC_MINMAX_HPP
+#include <yvals_core.h>
+#if _STL_COMPILER_PREPROCESSOR
+#include <stdint.h>
+
+#pragma pack(push, _CRT_PACKING)
+#pragma warning(push, _STL_WARNING_LEVEL)
+#pragma warning(disable : _STL_DISABLED_WARNINGS)
+_STL_DISABLE_CLANG_WARNINGS
+#pragma push_macro("new")
+#undef new
+
+extern "C" {
+struct _Min_max_element_t {
+    const void* _Min;
+    const void* _Max;
+};
+
+struct _Min_max_1i {
+    int8_t _Min;
+    int8_t _Max;
+};
+
+struct _Min_max_1u {
+    uint8_t _Min;
+    uint8_t _Max;
+};
+
+struct _Min_max_2i {
+    int16_t _Min;
+    int16_t _Max;
+};
+
+struct _Min_max_2u {
+    uint16_t _Min;
+    uint16_t _Max;
+};
+
+struct _Min_max_4i {
+    int32_t _Min;
+    int32_t _Max;
+};
+
+struct _Min_max_4u {
+    uint32_t _Min;
+    uint32_t _Max;
+};
+
+struct _Min_max_8i {
+    int64_t _Min;
+    int64_t _Max;
+};
+
+struct _Min_max_8u {
+    uint64_t _Min;
+    uint64_t _Max;
+};
+
+struct _Min_max_f {
+    float _Min;
+    float _Max;
+};
+
+struct _Min_max_d {
+    double _Min;
+    double _Max;
+};
+
+struct _Min_max_p {
+    void* _Min;
+    void* _Max;
+};
+} // extern "C"
+
+#pragma pop_macro("new")
+_STL_RESTORE_CLANG_WARNINGS
+#pragma warning(pop)
+#pragma pack(pop)
+#endif // _STL_COMPILER_PREPROCESSOR
+#endif // __MSVC_MINMAX_HPP

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -7,6 +7,7 @@
 #define _ALGORITHM_
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
+#include <__msvc_minmax.hpp>
 #include <xmemory>
 
 #if _HAS_CXX23
@@ -29,11 +30,6 @@ _STL_DISABLE_CLANG_WARNINGS
 #if _USE_STD_VECTOR_ALGORITHMS
 
 extern "C" {
-struct _Min_max_element_t {
-    const void* _Min;
-    const void* _Max;
-};
-
 // The "noalias" attribute tells the compiler optimizer that pointers going into these hand-vectorized algorithms
 // won't be stored beyond the lifetime of the function, and that the function will only reference arrays denoted by
 // those pointers. The optimizer also assumes in that case that a pointer parameter is not returned to the caller via
@@ -61,6 +57,17 @@ const void* __stdcall __std_find_last_trivial_1(const void* _First, const void* 
 const void* __stdcall __std_find_last_trivial_2(const void* _First, const void* _Last, uint16_t _Val) noexcept;
 const void* __stdcall __std_find_last_trivial_4(const void* _First, const void* _Last, uint32_t _Val) noexcept;
 const void* __stdcall __std_find_last_trivial_8(const void* _First, const void* _Last, uint64_t _Val) noexcept;
+
+__declspec(noalias) _Min_max_1i __stdcall __std_minmax_1i(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) _Min_max_1u __stdcall __std_minmax_1u(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) _Min_max_2i __stdcall __std_minmax_2i(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) _Min_max_2u __stdcall __std_minmax_2u(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) _Min_max_4i __stdcall __std_minmax_4i(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) _Min_max_4u __stdcall __std_minmax_4u(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) _Min_max_8i __stdcall __std_minmax_8i(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) _Min_max_8u __stdcall __std_minmax_8u(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) _Min_max_f __stdcall __std_minmax_f(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) _Min_max_d __stdcall __std_minmax_d(const void* const _First, const void* const _Last) noexcept;
 } // extern "C"
 
 _STD_BEGIN
@@ -87,6 +94,53 @@ _STD pair<_Ty*, _Ty*> __std_minmax_element(_Ty* _First, _Ty* _Last) noexcept {
     }
 
     return {const_cast<_Ty*>(static_cast<const _Ty*>(_Res._Min)), const_cast<_Ty*>(static_cast<const _Ty*>(_Res._Max))};
+}
+
+template <class _Ty>
+auto __std_minmax(_Ty* _First, _Ty* _Last) noexcept {
+    constexpr bool _Signed = _STD is_signed_v<_Ty>;
+
+    if constexpr (_STD is_pointer_v<_Ty>) {
+        if constexpr (sizeof(_Ty) == 4) {
+            auto _Result = ::__std_minmax_4u(_First, _Last);
+            return _Min_max_p{reinterpret_cast<void*>(_Result._Min), reinterpret_cast<void*>(_Result._Max)};
+        } else if constexpr (sizeof(_Ty) == 8) {
+            auto _Result = ::__std_minmax_8u(_First, _Last);
+            return _Min_max_p{reinterpret_cast<void*>(_Result._Min), reinterpret_cast<void*>(_Result._Max)};
+        } else {
+            static_assert(_STD _Always_false<_Ty>, "Unexpected size");
+        }
+    } else if constexpr (_STD is_same_v<_STD remove_const_t<_Ty>, float>) {
+        return ::__std_minmax_f(_First, _Last);
+    } else if constexpr (_STD _Is_any_of_v<_STD remove_const_t<_Ty>, double, long double>) {
+        return ::__std_minmax_d(_First, _Last);
+    } else if constexpr (sizeof(_Ty) == 1) {
+        if constexpr (_Signed) {
+            return ::__std_minmax_1i(_First, _Last);
+        } else {
+            return ::__std_minmax_1u(_First, _Last);
+        }
+    } else if constexpr (sizeof(_Ty) == 2) {
+        if constexpr (_Signed) {
+            return ::__std_minmax_2i(_First, _Last);
+        } else {
+            return ::__std_minmax_2u(_First, _Last);
+        }
+    } else if constexpr (sizeof(_Ty) == 4) {
+        if constexpr (_Signed) {
+            return ::__std_minmax_4i(_First, _Last);
+        } else {
+            return ::__std_minmax_4u(_First, _Last);
+        }
+    } else if constexpr (sizeof(_Ty) == 8) {
+        if constexpr (_Signed) {
+            return ::__std_minmax_8i(_First, _Last);
+        } else {
+            return ::__std_minmax_8u(_First, _Last);
+        }
+    } else {
+        static_assert(_STD _Always_false<_Ty>, "Unexpected size");
+    }
 }
 
 template <class _Ty, class _TVal>
@@ -10070,6 +10124,14 @@ _NODISCARD constexpr pair<const _Ty&, const _Ty&> minmax(const _Ty& _Left _MSVC_
 _EXPORT_STD template <class _Ty, class _Pr>
 _NODISCARD constexpr pair<_Ty, _Ty> minmax(initializer_list<_Ty> _Ilist, _Pr _Pred) {
     // return {leftmost/smallest, rightmost/largest}
+#if _USE_STD_VECTOR_ALGORITHMS
+    if constexpr (_Is_min_max_optimization_safe<const _Ty*, _Pr>) {
+        if (!_STD _Is_constant_evaluated()) {
+            const auto _Result = _STD __std_minmax(_STD _To_address(_Ilist.begin()), _STD _To_address(_Ilist.end()));
+            return {static_cast<_Ty>(_Result._Min), static_cast<_Ty>(_Result._Max)};
+        }
+    }
+#endif // _USE_STD_VECTOR_ALGORITHMS
     pair<const _Ty*, const _Ty*> _Res =
         _STD _Minmax_element_unchecked(_Ilist.begin(), _Ilist.end(), _STD _Pass_fn(_Pred));
     return pair<_Ty, _Ty>(*_Res.first, *_Res.second);
@@ -10197,8 +10259,8 @@ namespace ranges {
                 if (!_STD is_constant_evaluated()) {
                     const auto _First_ptr = _STD to_address(_First);
                     const auto _Last_ptr  = _First_ptr + (_Last - _First);
-                    const auto _Result    = _STD __std_minmax_element(_First_ptr, _Last_ptr);
-                    return {static_cast<_Vty>(*_Result.first), static_cast<_Vty>(*_Result.second)};
+                    const auto _Result    = _STD __std_minmax(_First_ptr, _Last_ptr);
+                    return {static_cast<_Vty>(_Result._Min), static_cast<_Vty>(_Result._Max)};
                 }
             }
 #endif // _USE_STD_VECTOR_ALGORITHMS

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -108,6 +108,27 @@ const void* __stdcall __std_max_element_4(const void* _First, const void* _Last,
 const void* __stdcall __std_max_element_8(const void* _First, const void* _Last, bool _Signed) noexcept;
 const void* __stdcall __std_max_element_f(const void* _First, const void* _Last, bool _Unused) noexcept;
 const void* __stdcall __std_max_element_d(const void* _First, const void* _Last, bool _Unused) noexcept;
+
+__declspec(noalias) int8_t __stdcall __std_min_1i(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) uint8_t __stdcall __std_min_1u(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) int16_t __stdcall __std_min_2i(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) uint16_t __stdcall __std_min_2u(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) int32_t __stdcall __std_min_4i(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) uint32_t __stdcall __std_min_4u(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) int64_t __stdcall __std_min_8i(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) uint64_t __stdcall __std_min_8u(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) float __stdcall __std_min_f(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) double __stdcall __std_min_d(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) int8_t __stdcall __std_max_1i(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) uint8_t __stdcall __std_max_1u(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) int16_t __stdcall __std_max_2i(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) uint16_t __stdcall __std_max_2u(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) int32_t __stdcall __std_max_4i(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) uint32_t __stdcall __std_max_4u(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) int64_t __stdcall __std_max_8i(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) uint64_t __stdcall __std_max_8u(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) float __stdcall __std_max_f(const void* const _First, const void* const _Last) noexcept;
+__declspec(noalias) double __stdcall __std_max_d(const void* const _First, const void* const _Last) noexcept;
 } // extern "C"
 
 _STD_BEGIN
@@ -207,6 +228,96 @@ _Ty* __std_max_element(_Ty* _First, _Ty* _Last) noexcept {
         return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_max_element_4(_First, _Last, _Signed)));
     } else if constexpr (sizeof(_Ty) == 8) {
         return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_max_element_8(_First, _Last, _Signed)));
+    } else {
+        static_assert(_STD _Always_false<_Ty>, "Unexpected size");
+    }
+}
+
+template <class _Ty>
+auto __std_min(_Ty* _First, _Ty* _Last) noexcept {
+    constexpr bool _Signed = _STD is_signed_v<_Ty>;
+
+    if constexpr (_STD is_pointer_v<_Ty>) {
+        if constexpr (sizeof(_Ty) == 4) {
+            return reinterpret_cast<void*>(::__std_min_4u(_First, _Last));
+        } else if constexpr (sizeof(_Ty) == 8) {
+            return reinterpret_cast<void*>(::__std_min_8u(_First, _Last));
+        } else {
+            static_assert(_STD _Always_false<_Ty>, "Unexpected size");
+        }
+    } else if constexpr (_STD is_same_v<_STD remove_const_t<_Ty>, float>) {
+        return ::__std_min_f(_First, _Last);
+    } else if constexpr (_STD _Is_any_of_v<_STD remove_const_t<_Ty>, double, long double>) {
+        return ::__std_min_d(_First, _Last);
+    } else if constexpr (sizeof(_Ty) == 1) {
+        if constexpr (_Signed) {
+            return ::__std_min_1i(_First, _Last);
+        } else {
+            return ::__std_min_1u(_First, _Last);
+        }
+    } else if constexpr (sizeof(_Ty) == 2) {
+        if constexpr (_Signed) {
+            return ::__std_min_2i(_First, _Last);
+        } else {
+            return ::__std_min_2u(_First, _Last);
+        }
+    } else if constexpr (sizeof(_Ty) == 4) {
+        if constexpr (_Signed) {
+            return ::__std_min_4i(_First, _Last);
+        } else {
+            return ::__std_min_4u(_First, _Last);
+        }
+    } else if constexpr (sizeof(_Ty) == 8) {
+        if constexpr (_Signed) {
+            return ::__std_min_8i(_First, _Last);
+        } else {
+            return ::__std_min_8u(_First, _Last);
+        }
+    } else {
+        static_assert(_STD _Always_false<_Ty>, "Unexpected size");
+    }
+}
+
+template <class _Ty>
+auto __std_max(_Ty* _First, _Ty* _Last) noexcept {
+    constexpr bool _Signed = _STD is_signed_v<_Ty>;
+
+    if constexpr (_STD is_pointer_v<_Ty>) {
+        if constexpr (sizeof(_Ty) == 4) {
+            return reinterpret_cast<void*>(::__std_max_4u(_First, _Last));
+        } else if constexpr (sizeof(_Ty) == 8) {
+            return reinterpret_cast<void*>(::__std_max_8u(_First, _Last));
+        } else {
+            static_assert(_STD _Always_false<_Ty>, "Unexpected size");
+        }
+    } else if constexpr (_STD is_same_v<_STD remove_const_t<_Ty>, float>) {
+        return ::__std_max_f(_First, _Last);
+    } else if constexpr (_STD _Is_any_of_v<_STD remove_const_t<_Ty>, double, long double>) {
+        return ::__std_max_d(_First, _Last);
+    } else if constexpr (sizeof(_Ty) == 1) {
+        if constexpr (_Signed) {
+            return ::__std_max_1i(_First, _Last);
+        } else {
+            return ::__std_max_1u(_First, _Last);
+        }
+    } else if constexpr (sizeof(_Ty) == 2) {
+        if constexpr (_Signed) {
+            return ::__std_max_2i(_First, _Last);
+        } else {
+            return ::__std_max_2u(_First, _Last);
+        }
+    } else if constexpr (sizeof(_Ty) == 4) {
+        if constexpr (_Signed) {
+            return ::__std_max_4i(_First, _Last);
+        } else {
+            return ::__std_max_4u(_First, _Last);
+        }
+    } else if constexpr (sizeof(_Ty) == 8) {
+        if constexpr (_Signed) {
+            return ::__std_max_8i(_First, _Last);
+        } else {
+            return ::__std_max_8u(_First, _Last);
+        }
     } else {
         static_assert(_STD _Always_false<_Ty>, "Unexpected size");
     }
@@ -6971,6 +7082,13 @@ namespace ranges {
 _EXPORT_STD template <class _Ty, class _Pr>
 _NODISCARD constexpr _Ty(min)(initializer_list<_Ty> _Ilist, _Pr _Pred) {
     // return leftmost/smallest
+#if _USE_STD_VECTOR_ALGORITHMS
+    if constexpr (_Is_min_max_optimization_safe<const _Ty*, _Pr>) {
+        if (!_Is_constant_evaluated()) {
+            return static_cast<_Ty>(_STD __std_min(_To_address(_Ilist.begin()), _STD _To_address(_Ilist.end())));
+        }
+    }
+#endif // _USE_STD_VECTOR_ALGORITHMS
     const _Ty* _Res = _STD _Min_element_unchecked(_Ilist.begin(), _Ilist.end(), _STD _Pass_fn(_Pred));
     return *_Res;
 }
@@ -7004,6 +7122,13 @@ namespace ranges {
             const auto _Last  = _Range.end();
             _STL_ASSERT(_First != _Last,
                 "An initializer_list passed to std::ranges::min must not be empty. (N4950 [alg.min.max]/5)");
+#if _USE_STD_VECTOR_ALGORITHMS
+            if constexpr (_Is_min_max_optimization_safe<const _Ty*, _Pr>) {
+                if (!_Is_constant_evaluated()) {
+                    return static_cast<_Ty>(_STD __std_min(_STD _To_address(_First), _STD _To_address(_Last)));
+                }
+            }
+#endif // _USE_STD_VECTOR_ALGORITHMS
             return *_RANGES _Min_element_unchecked(_First, _Last, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
         }
 
@@ -7017,6 +7142,16 @@ namespace ranges {
             _STL_ASSERT(
                 _UFirst != _ULast, "A range passed to std::ranges::min must not be empty. (N4950 [alg.min.max]/5)");
             if constexpr (forward_range<_Rng> && _Prefer_iterator_copies<iterator_t<_Rng>>) {
+#if _USE_STD_VECTOR_ALGORITHMS
+                if constexpr (is_same_v<_Pj, identity> && _Is_min_max_optimization_safe<decltype(_UFirst), _Pr>
+                              && sized_sentinel_for<decltype(_ULast), decltype(_UFirst)>) {
+                    if (!_STD is_constant_evaluated()) {
+                        const auto _First_ptr = _STD to_address(_UFirst);
+                        const auto _Last_ptr  = _First_ptr + (_ULast - _UFirst);
+                        return static_cast<range_value_t<_Rng>>(_STD __std_min(_First_ptr, _Last_ptr));
+                    }
+                }
+#endif // _USE_STD_VECTOR_ALGORITHMS
                 return static_cast<range_value_t<_Rng>>(*_RANGES _Min_element_unchecked(
                     _STD move(_UFirst), _STD move(_ULast), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj)));
             } else {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -7141,17 +7141,17 @@ namespace ranges {
             auto _ULast  = _Uend(_Range);
             _STL_ASSERT(
                 _UFirst != _ULast, "A range passed to std::ranges::min must not be empty. (N4950 [alg.min.max]/5)");
-            if constexpr (forward_range<_Rng> && _Prefer_iterator_copies<iterator_t<_Rng>>) {
 #if _USE_STD_VECTOR_ALGORITHMS
-                if constexpr (is_same_v<_Pj, identity> && _Is_min_max_optimization_safe<decltype(_UFirst), _Pr>
-                              && sized_sentinel_for<decltype(_ULast), decltype(_UFirst)>) {
-                    if (!_STD is_constant_evaluated()) {
-                        const auto _First_ptr = _STD to_address(_UFirst);
-                        const auto _Last_ptr  = _First_ptr + (_ULast - _UFirst);
-                        return static_cast<range_value_t<_Rng>>(_STD __std_min(_First_ptr, _Last_ptr));
-                    }
+            if constexpr (is_same_v<_Pj, identity> && _Is_min_max_optimization_safe<decltype(_UFirst), _Pr>
+                          && sized_sentinel_for<decltype(_ULast), decltype(_UFirst)>) {
+                if (!_STD is_constant_evaluated()) {
+                    const auto _First_ptr = _STD to_address(_UFirst);
+                    const auto _Last_ptr  = _First_ptr + (_ULast - _UFirst);
+                    return static_cast<range_value_t<_Rng>>(_STD __std_min(_First_ptr, _Last_ptr));
                 }
+            }
 #endif // _USE_STD_VECTOR_ALGORITHMS
+            if constexpr (forward_range<_Rng> && _Prefer_iterator_copies<iterator_t<_Rng>>) {
                 return static_cast<range_value_t<_Rng>>(*_RANGES _Min_element_unchecked(
                     _STD move(_UFirst), _STD move(_ULast), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj)));
             } else {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6884,6 +6884,13 @@ namespace ranges {
 _EXPORT_STD template <class _Ty, class _Pr>
 _NODISCARD constexpr _Ty(max)(initializer_list<_Ty> _Ilist, _Pr _Pred) {
     // return leftmost/largest
+#if _USE_STD_VECTOR_ALGORITHMS
+    if constexpr (_Is_min_max_optimization_safe<const _Ty*, _Pr>) {
+        if (!_Is_constant_evaluated()) {
+            return static_cast<_Ty>(_STD __std_max(_To_address(_Ilist.begin()), _STD _To_address(_Ilist.end())));
+        }
+    }
+#endif // _USE_STD_VECTOR_ALGORITHMS
     const _Ty* _Res = _STD _Max_element_unchecked(_Ilist.begin(), _Ilist.end(), _STD _Pass_fn(_Pred));
     return *_Res;
 }
@@ -6923,6 +6930,13 @@ namespace ranges {
             const auto _Last  = _Range.end();
             _STL_ASSERT(_First != _Last,
                 "An initializer_list passed to std::ranges::max must not be empty. (N4950 [alg.min.max]/13)");
+#if _USE_STD_VECTOR_ALGORITHMS
+            if constexpr (_Is_min_max_optimization_safe<const _Ty*, _Pr>) {
+                if (!_Is_constant_evaluated()) {
+                    return static_cast<_Ty>(_STD __std_max(_STD _To_address(_First), _STD _To_address(_Last)));
+                }
+            }
+#endif // _USE_STD_VECTOR_ALGORITHMS
             return *_RANGES _Max_element_unchecked(_First, _Last, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
         }
 
@@ -6935,6 +6949,16 @@ namespace ranges {
             auto _ULast  = _Uend(_Range);
             _STL_ASSERT(
                 _UFirst != _ULast, "A range passed to std::ranges::max must not be empty. (N4950 [alg.min.max]/13)");
+#if _USE_STD_VECTOR_ALGORITHMS
+            if constexpr (is_same_v<_Pj, identity> && _Is_min_max_optimization_safe<decltype(_UFirst), _Pr>
+                          && sized_sentinel_for<decltype(_ULast), decltype(_UFirst)>) {
+                if (!_STD is_constant_evaluated()) {
+                    const auto _First_ptr = _STD to_address(_UFirst);
+                    const auto _Last_ptr  = _First_ptr + (_ULast - _UFirst);
+                    return static_cast<range_value_t<_Rng>>(_STD __std_max(_First_ptr, _Last_ptr));
+                }
+            }
+#endif // _USE_STD_VECTOR_ALGORITHMS
             if constexpr (forward_range<_Rng> && _Prefer_iterator_copies<iterator_t<_Rng>>) {
                 return static_cast<range_value_t<_Rng>>(*_RANGES _Max_element_unchecked(
                     _STD move(_UFirst), _STD move(_ULast), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj)));

--- a/tests/std/include/test_min_max_element_support.hpp
+++ b/tests/std/include/test_min_max_element_support.hpp
@@ -107,5 +107,15 @@ void test_case_min_max_element(const std::vector<T>& input) {
     assert(expected_max == actual_max_sized_range);
     assert(expected_minmax.first == actual_minmax_sized_range.min);
     assert(expected_minmax.second == actual_minmax_sized_range.max);
+
+    if (input.begin() != input.end()) {
+        auto actual_min_value    = std::ranges::min(input);
+        auto actual_max_value    = std::ranges::max(input);
+        auto actual_minmax_value = std::ranges::minmax(input);     
+        assert(*expected_min == actual_min_value);
+        assert(*expected_max == actual_max_value);
+        assert(*expected_minmax.first == actual_minmax_value.min);
+        assert(*expected_minmax.second == actual_minmax_value.max);
+    }
 #endif // _HAS_CXX20
 }

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -572,6 +572,11 @@ constexpr bool test_constexpr() {
     assert(ranges::minmax_element(a).min == begin(a) + 1);
     assert(ranges::minmax_element(a).max == end(a) - 2);
 
+    assert(ranges::min(a) == 10);
+    assert(ranges::max(a) == 60);
+    assert(ranges::minmax(a).min == 10);
+    assert(ranges::minmax(a).max == 60);
+
     int b[size(a)];
     reverse_copy(begin(a), end(a), begin(b));
     assert(equal(rbegin(a), rend(a), begin(b), end(b)));


### PR DESCRIPTION
Towards #2803

## New header

Can't have `extert "C"` functions that use templates, so the new header accommodates non-template `minmax` structure variations.

## Sign handing

Unlike `_element` counterpart, the integer signedness affects function selection rather than passed as runtime parameter. 

Computing element pointer requires index, so `cmpgt`+ `blendv` pair is needed to capture it. `cmpgt` is only available in signed form, so unsigned types are supported by adjustment of the input values. 

Computing only vertical min/max without the index for most of types doesn't need the `cmpgt`+ `blendv` pair,  as there are signed and unsigned `min`/`max` operation. The only exception is 64-bit integer support: there are no `min`/`max` ops, so still using `blendv`. For consistency, enforced also by the template use, even for 64-bit integers the sign is still passed as function selection

# Benchmark

`_val` are new results, we indirect for value there

<details>
<summary>I put output of the benchmark before and after in a single table</summary>

```
--------------------------------------------------------------------------------------------------
Benchmark                                old time        old CPU        new time       new CPU   
--------------------------------------------------------------------------------------------------
bm<uint8_t, 8021, Op::Min>                1345 ns         1350 ns       1336 ns         1350 ns   
bm<uint8_t, 8021, Op::Max>                1192 ns         1193 ns       2146 ns         1842 ns   
bm<uint8_t, 8021, Op::Both>               1675 ns         1674 ns       1883 ns         1918 ns   
bm<uint8_t, 8021, Op::Min_el>             8482 ns         8370 ns        665 ns          666 ns   
bm<uint8_t, 8021, Op::Max_el>             7954 ns         8022 ns        567 ns          578 ns   
bm<uint8_t, 8021, Op::Both_el>           27377 ns        27623 ns      30814 ns        30691 ns   
bm<uint16_t, 8021, Op::Min>               1841 ns         1814 ns       2091 ns         2100 ns   
bm<uint16_t, 8021, Op::Max>               1840 ns         1859 ns       1826 ns         1859 ns   
bm<uint16_t, 8021, Op::Both>              1819 ns         1842 ns       1999 ns         2009 ns   
bm<uint16_t, 8021, Op::Min_el>           10433 ns        10498 ns        591 ns          600 ns   
bm<uint16_t, 8021, Op::Max_el>           10183 ns        10254 ns        619 ns          614 ns   
bm<uint16_t, 8021, Op::Both_el>          22395 ns        21973 ns      23348 ns        23438 ns   
bm<uint32_t, 8021, Op::Min>               2455 ns         2455 ns       2283 ns         2288 ns   
bm<uint32_t, 8021, Op::Max>               3746 ns         3749 ns       3977 ns         4011 ns   
bm<uint32_t, 8021, Op::Both>              4417 ns         4443 ns       4784 ns         4649 ns   
bm<uint32_t, 8021, Op::Min_el>            2182 ns         2176 ns       1107 ns         1099 ns   
bm<uint32_t, 8021, Op::Max_el>            3453 ns         3453 ns       1688 ns         1674 ns   
bm<uint32_t, 8021, Op::Both_val>          4251 ns         4248 ns       1075 ns         1099 ns   
bm<uint64_t, 8021, Op::Min>               6909 ns         6801 ns       6827 ns         6801 ns   
bm<uint64_t, 8021, Op::Max>               6867 ns         6801 ns       6985 ns         6975 ns   
bm<uint64_t, 8021, Op::Both>              7646 ns         7499 ns       7570 ns         7499 ns   
bm<uint64_t, 8021, Op::Min_val>           6619 ns         6696 ns       5925 ns         5938 ns   
bm<uint64_t, 8021, Op::Max_val>           6942 ns         6975 ns       5912 ns         5859 ns   
bm<uint64_t, 8021, Op::Both_val>          8901 ns         8789 ns       6103 ns         5999 ns   
bm<int8_t, 8021, Op::Min>                  901 ns          907 ns        915 ns          921 ns   
bm<int8_t, 8021, Op::Max>                  833 ns          837 ns        885 ns          889 ns   
bm<int8_t, 8021, Op::Both>                1091 ns         1099 ns       1148 ns         1147 ns   
bm<int8_t, 8021, Op::Min_val>             6150 ns         6278 ns        398 ns          394 ns   
bm<int8_t, 8021, Op::Max_val>             6979 ns         6975 ns        414 ns          419 ns   
bm<int8_t, 8021, Op::Both_val>           26893 ns        26681 ns      23398 ns        23542 ns   
bm<int16_t, 8021, Op::Min>                1626 ns         1639 ns       1764 ns         1765 ns   
bm<int16_t, 8021, Op::Max>                1701 ns         1660 ns       1729 ns         1709 ns   
bm<int16_t, 8021, Op::Both>               1690 ns         1709 ns       1720 ns         1744 ns   
bm<int16_t, 8021, Op::Min_val>            9462 ns         9277 ns        858 ns          865 ns   
bm<int16_t, 8021, Op::Max_val>            9000 ns         8998 ns        856 ns          858 ns   
bm<int16_t, 8021, Op::Both_val>          19110 ns        19043 ns      18287 ns        18415 ns   
bm<int32_t, 8021, Op::Min>                2164 ns         2176 ns       3264 ns         3191 ns   
bm<int32_t, 8021, Op::Max>                3370 ns         3418 ns       3489 ns         3488 ns   
bm<int32_t, 8021, Op::Both>               4296 ns         4238 ns       4274 ns         4332 ns   
bm<int32_t, 8021, Op::Min_val>            2115 ns         2086 ns       1619 ns         1639 ns   
bm<int32_t, 8021, Op::Max_val>            3439 ns         3376 ns        928 ns          924 ns   
bm<int32_t, 8021, Op::Both_val>           4079 ns         4049 ns       1025 ns         1025 ns   
bm<int64_t, 8021, Op::Min>                6861 ns         6836 ns       6842 ns         6801 ns   
bm<int64_t, 8021, Op::Max>                6898 ns         6801 ns       6989 ns         6975 ns   
bm<int64_t, 8021, Op::Both>               8925 ns         8789 ns       8976 ns         8998 ns   
bm<int64_t, 8021, Op::Min_val>            6714 ns         6696 ns       5947 ns         5859 ns   
bm<int64_t, 8021, Op::Max_val>            6853 ns         6975 ns       5860 ns         5859 ns   
bm<int64_t, 8021, Op::Both_val>           7852 ns         7743 ns       6108 ns         6138 ns   
bm<float, 8021, Op::Min>                  3662 ns         3683 ns       3260 ns         3296 ns   
bm<float, 8021, Op::Max>                  3477 ns         3449 ns       3548 ns         3530 ns   
bm<float, 8021, Op::Both>                 5127 ns         5190 ns       5140 ns         5190 ns   
bm<float, 8021, Op::Min_val>              3375 ns         3376 ns       2873 ns         2916 ns   
bm<float, 8021, Op::Max_val>              3534 ns         3610 ns       2848 ns         2888 ns   
bm<float, 8021, Op::Both_val>             4958 ns         4743 ns       2916 ns         2916 ns   
bm<double, 8021, Op::Min>                 6103 ns         6138 ns       6017 ns         5999 ns   
bm<double, 8021, Op::Max>                 6001 ns         5999 ns       6292 ns         6278 ns   
bm<double, 8021, Op::Both>                7307 ns         7324 ns       7773 ns         7847 ns   
bm<double, 8021, Op::Min_val>             6021 ns         5999 ns       5963 ns         5999 ns   
bm<double, 8021, Op::Max_val>             5984 ns         5999 ns       5768 ns         5781 ns   
bm<double, 8021, Op::Both_val>            7120 ns         7150 ns       6024 ns         5999 ns   

```
</details>

Some rows show order of magnitude improvement.
Some show difference within results variation.

I interpret these results as the change being pure improvement, and the row that don't show it are memory-bound rather than CPU bound, and this can change on a different machine or by reducing input data amount.