### PR TITLE
Make `~mutex` trivial

### DIFF
--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -45,10 +45,6 @@ public:
     }
 #endif // ^^^ !defined(_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR) ^^^
 
-    ~_Mutex_base() noexcept {
-        _Mtx_destroy_in_situ(_Mymtx());
-    }
-
     _Mutex_base(const _Mutex_base&)            = delete;
     _Mutex_base& operator=(const _Mutex_base&) = delete;
 

--- a/stl/inc/xthreads.h
+++ b/stl/inc/xthreads.h
@@ -101,7 +101,6 @@ _CRTIMP2_PURE _Thrd_result __cdecl _Mtx_init(_Mtx_t*, int) noexcept;
 _CRTIMP2_PURE void __cdecl _Mtx_destroy(_Mtx_t) noexcept;
 #endif // _CRTBLD
 _CRTIMP2_PURE void __cdecl _Mtx_init_in_situ(_Mtx_t, int) noexcept;
-_CRTIMP2_PURE void __cdecl _Mtx_destroy_in_situ(_Mtx_t) noexcept;
 _CRTIMP2_PURE int __cdecl _Mtx_current_owns(_Mtx_t) noexcept;
 _CRTIMP2_PURE _Thrd_result __cdecl _Mtx_lock(_Mtx_t) noexcept;
 _CRTIMP2_PURE _Thrd_result __cdecl _Mtx_trylock(_Mtx_t) noexcept;

--- a/stl/src/mutex.cpp
+++ b/stl/src/mutex.cpp
@@ -44,6 +44,7 @@ _CRTIMP2_PURE void __cdecl _Mtx_init_in_situ(_Mtx_t mtx, int type) noexcept { //
     mtx->_Count     = 0;
 }
 
+// TRANSITION, ABI: preserved for binary compatibility
 _CRTIMP2_PURE void __cdecl _Mtx_destroy_in_situ(_Mtx_t mtx) noexcept { // destroy mutex in situ
     _THREAD_ASSERT(mtx->_Count == 0, "mutex destroyed while busy");
     (void) mtx;
@@ -64,6 +65,7 @@ _CRTIMP2_PURE _Thrd_result __cdecl _Mtx_init(_Mtx_t* mtx, int type) noexcept { /
     return _Thrd_result::_Success;
 }
 
+// TRANSITION, ABI: preserved for binary compatibility
 _CRTIMP2_PURE void __cdecl _Mtx_destroy(_Mtx_t mtx) noexcept { // destroy mutex
     if (mtx) { // something to do, do it
         _Mtx_destroy_in_situ(mtx);


### PR DESCRIPTION
By simply removing `~_Mutex_base`. This destructor has been only a debug check since GH-3770. Losing the debug check is a small price to pay to elide the destructor call, doubly so for static storage duration mutexes that now won't need dynamic initializers to register with `at_exit`.

`_Mtx_destroy` and `_Mtx_destroy_in_situ` are only called by APIs preserved for binary compatibility, so mark them as also "preserved for binary compatibility".
