### PR TITLE
Toolset update: VS 2022 17.10 Preview 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.27.0)
+cmake_minimum_required(VERSION 3.28.0)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.9 Preview 2 or later.
+1. Install Visual Studio 2022 17.10 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
@@ -156,7 +156,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.9 Preview 2 or later.
+1. Install Visual Studio 2022 17.10 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.27.0 or later, and [Ninja][] 1.11.0 or later.
+    * Otherwise, install [CMake][] 3.28.0 or later, and [Ninja][] 1.11.0 or later.
     * Make sure [Python][] 3.12 or later is available to CMake.
 2. Open Visual Studio, and choose the "Clone or check out code" option. Enter the URL of this repository,
    `https://github.com/microsoft/STL`.
@@ -160,7 +160,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.27.0 or later, and [Ninja][] 1.11.0 or later.
+    * Otherwise, install [CMake][] 3.28.0 or later, and [Ninja][] 1.11.0 or later.
     * Make sure [Python][] 3.12 or later is available to CMake.
 2. Open a command prompt.
 3. Change directories to a location where you'd like a clone of this STL repository.

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,7 +5,7 @@
 
 variables:
 - name: poolName
-  value: 'StlBuild-2024-01-09T1215-Pool'
+  value: 'StlBuild-2024-02-13T1246-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals true'

--- a/azure-devops/cross-build.yml
+++ b/azure-devops/cross-build.yml
@@ -19,7 +19,7 @@ jobs:
 - job: '${{ parameters.targetPlatform }}'
   strategy:
     parallel: ${{ parameters.numShards }}
-  timeoutInMinutes: 25
+  timeoutInMinutes: 30
   steps:
   - script: |
       if exist "$(tmpDir)" (rmdir /S /Q $(tmpDir))

--- a/azure-devops/native-build-test.yml
+++ b/azure-devops/native-build-test.yml
@@ -24,7 +24,7 @@ jobs:
 - job: '${{ parameters.targetPlatform }}'
   strategy:
     parallel: ${{ parameters.numShards }}
-  timeoutInMinutes: 25
+  timeoutInMinutes: 30
   steps:
   - script: |
       if exist "$(tmpDir)" (rmdir /S /Q $(tmpDir))

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -136,7 +136,7 @@ $Workloads = @(
 )
 
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/17/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.12.1/python-3.12.1-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.12.2/python-3.12.2-amd64.exe'
 
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_511.23_windows.exe'
 

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -91,7 +91,7 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
   $PsExecPath = Join-Path $ExtractedPsToolsPath 'PsExec64.exe'
 
   # https://github.com/PowerShell/PowerShell/releases/latest
-  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.4.0/PowerShell-7.4.0-win-x64.zip'
+  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.4.1/PowerShell-7.4.1-win-x64.zip'
   Write-Host "Downloading: $PowerShellZipUrl"
   $ExtractedPowerShellPath = DownloadAndExtractZip -Url $PowerShellZipUrl
   $PwshPath = Join-Path $ExtractedPowerShellPath 'pwsh.exe'

--- a/azure-devops/run-tests.yml
+++ b/azure-devops/run-tests.yml
@@ -17,7 +17,7 @@ parameters:
 steps:
 - task: CmdLine@2
   displayName: ${{ parameters.displayName }}
-  timeoutInMinutes: 20
+  timeoutInMinutes: 30
   condition: succeeded()
   inputs:
     workingDirectory: $(buildOutputLocation)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.27.0)
+cmake_minimum_required(VERSION 3.28.0)
 project(msvc_standard_libraries_benchmarks LANGUAGES CXX)
 
 if(DEFINED STL_BINARY_DIR)

--- a/stl/inc/__msvc_all_public_headers.hpp
+++ b/stl/inc/__msvc_all_public_headers.hpp
@@ -24,7 +24,7 @@
 #include <mbctype.h>
 #endif // !defined(_MSVC_TESTING_NVCC)
 
-#if 1 // TRANSITION, OS-17090155 (UCRT)
+#if 1 // TRANSITION, ArchivedOS-17501595 (UCRT)
 #define _CRT_DECLARE_NONSTDC_NAMES 0
 #ifndef _MSVC_TESTING_NVCC
 #include <sys/stat.h>
@@ -32,7 +32,7 @@
 #include <sys/utime.h>
 #endif // !defined(_MSVC_TESTING_NVCC)
 #undef _CRT_DECLARE_NONSTDC_NAMES
-#endif // TRANSITION, OS-17090155 (UCRT)
+#endif // TRANSITION, ArchivedOS-17501595 (UCRT)
 
 #define _SILENCE_CXX17_C_HEADER_DEPRECATION_WARNING
 #define _SILENCE_CXX20_CISO646_REMOVED_WARNING

--- a/stl/inc/__msvc_all_public_headers.hpp
+++ b/stl/inc/__msvc_all_public_headers.hpp
@@ -24,16 +24,6 @@
 #include <mbctype.h>
 #endif // !defined(_MSVC_TESTING_NVCC)
 
-#if 1 // TRANSITION, ArchivedOS-17501595 (UCRT)
-#define _CRT_DECLARE_NONSTDC_NAMES 0
-#ifndef _MSVC_TESTING_NVCC
-#include <sys/stat.h>
-#include <sys/timeb.h>
-#include <sys/utime.h>
-#endif // !defined(_MSVC_TESTING_NVCC)
-#undef _CRT_DECLARE_NONSTDC_NAMES
-#endif // TRANSITION, ArchivedOS-17501595 (UCRT)
-
 #define _SILENCE_CXX17_C_HEADER_DEPRECATION_WARNING
 #define _SILENCE_CXX20_CISO646_REMOVED_WARNING
 #define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING

--- a/stl/inc/__msvc_iter_core.hpp
+++ b/stl/inc/__msvc_iter_core.hpp
@@ -405,11 +405,7 @@ concept weakly_incrementable = movable<_Ty>
         requires _Signed_integer_like<iter_difference_t<_Ty>>;
         { ++__i } -> same_as<_Ty&>;
         __i++;
-    }
-#ifdef __clang__ // TRANSITION, LLVM-48173
-    && !same_as<_Ty, bool>
-#endif // ^^^ workaround ^^^
-    ;
+    };
 
 _EXPORT_STD template <class _It>
 concept input_or_output_iterator = requires(_It __i) { { *__i } -> _Can_reference; }

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2696,27 +2696,23 @@ _Ty atomic_fetch_xor_explicit(
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _Ty>
-void atomic_wait(const volatile atomic<_Ty>* const _Mem,
-    const typename atomic<_Ty>::value_type _Expected) noexcept { // TRANSITION, VSO-1854115, omit typename
+void atomic_wait(const volatile atomic<_Ty>* const _Mem, const typename atomic<_Ty>::value_type _Expected) noexcept {
     _Mem->wait(_Expected);
 }
 
 _EXPORT_STD template <class _Ty>
-void atomic_wait(const atomic<_Ty>* const _Mem,
-    const typename atomic<_Ty>::value_type _Expected) noexcept { // TRANSITION, VSO-1854115, omit typename
+void atomic_wait(const atomic<_Ty>* const _Mem, const typename atomic<_Ty>::value_type _Expected) noexcept {
     _Mem->wait(_Expected);
 }
 
 _EXPORT_STD template <class _Ty>
-void atomic_wait_explicit(const volatile atomic<_Ty>* const _Mem,
-    const typename atomic<_Ty>::value_type _Expected, // TRANSITION, VSO-1854115, omit typename
+void atomic_wait_explicit(const volatile atomic<_Ty>* const _Mem, const typename atomic<_Ty>::value_type _Expected,
     const memory_order _Order) noexcept {
     _Mem->wait(_Expected, _Order);
 }
 
 _EXPORT_STD template <class _Ty>
-void atomic_wait_explicit(const atomic<_Ty>* const _Mem,
-    const typename atomic<_Ty>::value_type _Expected, // TRANSITION, VSO-1854115, omit typename
+void atomic_wait_explicit(const atomic<_Ty>* const _Mem, const typename atomic<_Ty>::value_type _Expected,
     const memory_order _Order) noexcept {
     _Mem->wait(_Expected, _Order);
 }

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -3459,7 +3459,7 @@ namespace chrono {
                 // 86,400*INTMAX_MAX ~= 7.97e23. This is representable by float and double, so they can always represent
                 // at least one day. On the other hand, one second with the largest possible _Period1 needs a tick count
                 // of 1/(INTMAX_MAX) ~= 1.08e-19, which is also representable in both float and double. So, both
-                // floating point types can represent durations between one second and one day, regardless of _Period1.
+                // floating-point types can represent durations between one second and one day, regardless of _Period1.
                 return true;
             } else {
                 // TRANSITION: user-defined arithmetic-like types

--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -292,12 +292,12 @@ public:
         return !(_Lhs == _Rhs);
     }
 
-    _NODISCARD_FRIEND bool operator!=(const exception_ptr& _Lhs, nullptr_t _Rhs) noexcept {
-        return !(_Lhs == _Rhs);
+    _NODISCARD_FRIEND bool operator!=(const exception_ptr& _Lhs, nullptr_t) noexcept {
+        return !(_Lhs == nullptr);
     }
 
-    _NODISCARD_FRIEND bool operator!=(nullptr_t _Lhs, const exception_ptr& _Rhs) noexcept {
-        return !(_Lhs == _Rhs);
+    _NODISCARD_FRIEND bool operator!=(nullptr_t, const exception_ptr& _Rhs) noexcept {
+        return !(nullptr == _Rhs);
     }
 #endif // !_HAS_CXX20
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -722,8 +722,11 @@ public:
         }
     };
 
-    // TRANSITION, LLVM-49072
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, LLVM-81774 (Clang), VSO-1956558 (EDG)
     basic_format_arg() noexcept : _Active_state(_Basic_format_arg_type::_None), _No_state() {}
+#else // ^^^ workaround / no workaround vvv
+    basic_format_arg() noexcept = default;
+#endif // ^^^ no workaround ^^^
 
     explicit operator bool() const noexcept {
         return _Active_state != _Basic_format_arg_type::_None;

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -3687,56 +3687,56 @@ _NODISCARD bool operator==(nullptr_t, const unique_ptr<_Ty, _Dx>& _Right) noexce
 }
 
 template <class _Ty, class _Dx>
-_NODISCARD bool operator!=(const unique_ptr<_Ty, _Dx>& _Left, nullptr_t _Right) noexcept {
-    return !(_Left == _Right);
+_NODISCARD bool operator!=(const unique_ptr<_Ty, _Dx>& _Left, nullptr_t) noexcept {
+    return !(_Left == nullptr);
 }
 
 template <class _Ty, class _Dx>
-_NODISCARD bool operator!=(nullptr_t _Left, const unique_ptr<_Ty, _Dx>& _Right) noexcept {
-    return !(_Left == _Right);
+_NODISCARD bool operator!=(nullptr_t, const unique_ptr<_Ty, _Dx>& _Right) noexcept {
+    return !(nullptr == _Right);
 }
 #endif // !_HAS_CXX20
 
 _EXPORT_STD template <class _Ty, class _Dx>
-_NODISCARD _CONSTEXPR23 bool operator<(const unique_ptr<_Ty, _Dx>& _Left, nullptr_t _Right) {
+_NODISCARD _CONSTEXPR23 bool operator<(const unique_ptr<_Ty, _Dx>& _Left, nullptr_t) {
     using _Ptr = typename unique_ptr<_Ty, _Dx>::pointer;
-    return less<_Ptr>{}(_Left.get(), _Right);
+    return less<_Ptr>{}(_Left.get(), nullptr);
 }
 
 _EXPORT_STD template <class _Ty, class _Dx>
-_NODISCARD _CONSTEXPR23 bool operator<(nullptr_t _Left, const unique_ptr<_Ty, _Dx>& _Right) {
+_NODISCARD _CONSTEXPR23 bool operator<(nullptr_t, const unique_ptr<_Ty, _Dx>& _Right) {
     using _Ptr = typename unique_ptr<_Ty, _Dx>::pointer;
-    return less<_Ptr>{}(_Left, _Right.get());
+    return less<_Ptr>{}(nullptr, _Right.get());
 }
 
 _EXPORT_STD template <class _Ty, class _Dx>
-_NODISCARD _CONSTEXPR23 bool operator>=(const unique_ptr<_Ty, _Dx>& _Left, nullptr_t _Right) {
-    return !(_Left < _Right);
+_NODISCARD _CONSTEXPR23 bool operator>=(const unique_ptr<_Ty, _Dx>& _Left, nullptr_t) {
+    return !(_Left < nullptr);
 }
 
 _EXPORT_STD template <class _Ty, class _Dx>
-_NODISCARD _CONSTEXPR23 bool operator>=(nullptr_t _Left, const unique_ptr<_Ty, _Dx>& _Right) {
-    return !(_Left < _Right);
+_NODISCARD _CONSTEXPR23 bool operator>=(nullptr_t, const unique_ptr<_Ty, _Dx>& _Right) {
+    return !(nullptr < _Right);
 }
 
 _EXPORT_STD template <class _Ty, class _Dx>
-_NODISCARD _CONSTEXPR23 bool operator>(const unique_ptr<_Ty, _Dx>& _Left, nullptr_t _Right) {
-    return _Right < _Left;
+_NODISCARD _CONSTEXPR23 bool operator>(const unique_ptr<_Ty, _Dx>& _Left, nullptr_t) {
+    return nullptr < _Left;
 }
 
 _EXPORT_STD template <class _Ty, class _Dx>
-_NODISCARD _CONSTEXPR23 bool operator>(nullptr_t _Left, const unique_ptr<_Ty, _Dx>& _Right) {
-    return _Right < _Left;
+_NODISCARD _CONSTEXPR23 bool operator>(nullptr_t, const unique_ptr<_Ty, _Dx>& _Right) {
+    return _Right < nullptr;
 }
 
 _EXPORT_STD template <class _Ty, class _Dx>
-_NODISCARD _CONSTEXPR23 bool operator<=(const unique_ptr<_Ty, _Dx>& _Left, nullptr_t _Right) {
-    return !(_Right < _Left);
+_NODISCARD _CONSTEXPR23 bool operator<=(const unique_ptr<_Ty, _Dx>& _Left, nullptr_t) {
+    return !(nullptr < _Left);
 }
 
 _EXPORT_STD template <class _Ty, class _Dx>
-_NODISCARD _CONSTEXPR23 bool operator<=(nullptr_t _Left, const unique_ptr<_Ty, _Dx>& _Right) {
-    return !(_Right < _Left);
+_NODISCARD _CONSTEXPR23 bool operator<=(nullptr_t, const unique_ptr<_Ty, _Dx>& _Right) {
+    return !(_Right < nullptr);
 }
 
 #if _HAS_CXX20

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1483,26 +1483,14 @@ struct _SP_convertible : is_convertible<_Yty*, _Ty*>::type {};
 
 template <class _Yty, class _Uty, class _Void>
 struct _SP_convertible<_Yty, _Uty[], _Void> : false_type {};
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10548086
 template <class _Yty, class _Uty>
 struct _SP_convertible<_Yty, _Uty[], void_t<_Yty (*)[]>> : is_convertible<_Yty (*)[], _Uty (*)[]>::type {};
-#else // ^^^ no workaround / workaround vvv
-template <class _Yty, class _Uty>
-struct _SP_convertible<_Yty, _Uty[], void_t<decltype(static_cast<_Yty (*)[]>(nullptr))>>
-    : is_convertible<_Yty (*)[], _Uty (*)[]>::type {};
-#endif // ^^^ workaround ^^^
 
 template <class _Yty, class _Uty, size_t _Ext, class _Void>
 struct _SP_convertible<_Yty, _Uty[_Ext], _Void> : false_type {};
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10548086
 template <class _Yty, class _Uty, size_t _Ext>
 struct _SP_convertible<_Yty, _Uty[_Ext], void_t<_Yty (*)[_Ext]>>
     : is_convertible<_Yty (*)[_Ext], _Uty (*)[_Ext]>::type {};
-#else // ^^^ no workaround / workaround vvv
-template <class _Yty, class _Uty, size_t _Ext>
-struct _SP_convertible<_Yty, _Uty[_Ext], void_t<decltype(static_cast<_Yty (*)[_Ext]>(nullptr))>>
-    : is_convertible<_Yty (*)[_Ext], _Uty (*)[_Ext]>::type {};
-#endif // ^^^ workaround ^^^
 
 template <class _Yty, class _Ty>
 struct _SP_pointer_compatible : is_convertible<_Yty*, _Ty*>::type {

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -146,12 +146,10 @@ namespace ranges {
             void operator()(auto&&) &&      = delete;
             void operator()(auto&&) const&& = delete;
 
-            // TRANSITION, DevCom-10519736, explicit `this->` shouldn't be needed.
-
             template <class _Ty>
             _NODISCARD constexpr decltype(auto) operator()(_Ty && _Val) & noexcept(
                 noexcept(_Right(_Left(_STD forward<_Ty>(_Val)))))
-                requires requires { this->_Right(this->_Left(_STD forward<_Ty>(_Val))); }
+                requires requires { _Right(_Left(_STD forward<_Ty>(_Val))); }
             {
                 return _Right(_Left(_STD forward<_Ty>(_Val)));
             }
@@ -159,7 +157,7 @@ namespace ranges {
             template <class _Ty>
             _NODISCARD constexpr decltype(auto) operator()(_Ty && _Val) const& noexcept(
                 noexcept(_Right(_Left(_STD forward<_Ty>(_Val)))))
-                requires requires { this->_Right(this->_Left(_STD forward<_Ty>(_Val))); }
+                requires requires { _Right(_Left(_STD forward<_Ty>(_Val))); }
             {
                 return _Right(_Left(_STD forward<_Ty>(_Val)));
             }
@@ -167,7 +165,7 @@ namespace ranges {
             template <class _Ty>
             _NODISCARD constexpr decltype(auto) operator()(_Ty && _Val) && noexcept(
                 noexcept(_STD move(_Right)(_STD move(_Left)(_STD forward<_Ty>(_Val)))))
-                requires requires { _STD move(this->_Right)(_STD move(this->_Left)(_STD forward<_Ty>(_Val))); }
+                requires requires { _STD move(_Right)(_STD move(_Left)(_STD forward<_Ty>(_Val))); }
             {
                 return _STD move(_Right)(_STD move(_Left)(_STD forward<_Ty>(_Val)));
             }
@@ -175,7 +173,7 @@ namespace ranges {
             template <class _Ty>
             _NODISCARD constexpr decltype(auto) operator()(_Ty && _Val) const&& noexcept(
                 noexcept(_STD move(_Right)(_STD move(_Left)(_STD forward<_Ty>(_Val)))))
-                requires requires { _STD move(this->_Right)(_STD move(this->_Left)(_STD forward<_Ty>(_Val))); }
+                requires requires { _STD move(_Right)(_STD move(_Left)(_STD forward<_Ty>(_Val))); }
             {
                 return _STD move(_Right)(_STD move(_Left)(_STD forward<_Ty>(_Val)));
             }

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1746,7 +1746,7 @@ constexpr auto invoke(_Callable&& _Obj, _Ty1&& _Arg1, _Types2&&... _Args2) noexc
     } else if constexpr (_Invoker1<_Callable, _Ty1>::_Strategy == _Invoker_strategy::_Pmd_object) {
         return static_cast<_Ty1&&>(_Arg1).*_Obj;
     } else if constexpr (_Invoker1<_Callable, _Ty1>::_Strategy == _Invoker_strategy::_Pmd_refwrap) {
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10543093
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1956799
         return _Arg1.get().*_Obj;
 #else // ^^^ no workaround / workaround vvv
         auto& _Ref = _Arg1.get();

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1409,33 +1409,9 @@ struct _Add_qualifiers<_Ty1&&> {
     using _Apply = add_rvalue_reference_t<_Copy_cv<_Ty1, _Ty2>>;
 };
 
-#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, DevCom-10095944
-template <class _Ty1, class _Ty2>
-using _Cond_res_if_right = // N4950 [meta.trans.other]/2.4
-    decltype(false ? _Returns_exactly<_Ty1>() : _Returns_exactly<_Ty2>());
-
-template <class _Ty>
-using _Is_scalar_or_array = disjunction<is_scalar<_Ty>, is_array<_Ty>>;
-
-template <class _Ty1, class _Ty2, class = void>
-struct _Cond_res_workaround {};
-
-template <class _Ty1, class _Ty2>
-struct _Cond_res_workaround<_Ty1, _Ty2, void_t<_Cond_res_if_right<_Ty1, _Ty2>>> {
-    using _Uty = remove_cvref_t<_Ty1>;
-    using type = conditional_t<conjunction_v<is_same<_Uty, remove_cvref_t<_Ty2>>, _Is_scalar_or_array<_Uty>,
-                                   disjunction<conjunction<is_lvalue_reference<_Ty1>, is_rvalue_reference<_Ty2>>,
-                                       conjunction<is_rvalue_reference<_Ty1>, is_lvalue_reference<_Ty2>>>>,
-        decay_t<_Copy_cv<remove_reference_t<_Ty1>, remove_reference_t<_Ty2>>>, _Cond_res_if_right<_Ty1, _Ty2>>;
-};
-
-template <class _Ty1, class _Ty2>
-using _Cond_res = _Cond_res_workaround<_Ty1, _Ty2>::type;
-#else // ^^^ workaround / no workaround vvv
 template <class _Ty1, class _Ty2>
 using _Cond_res = // N4950 [meta.trans.other]/2.4
     decltype(false ? _Returns_exactly<_Ty1>() : _Returns_exactly<_Ty2>());
-#endif // ^^^ no workaround ^^^
 
 _EXPORT_STD template <class...>
 struct common_reference;

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -1085,7 +1085,7 @@ public:
     using _Mybase::index;
     using _Mybase::valueless_by_exception;
 
-#ifdef __clang__ // TRANSITION, LLVM-45398
+#ifdef __clang__ // TRANSITION, LLVM-35450
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-lambda-capture"
 #endif // ^^^ workaround ^^^
@@ -1147,7 +1147,7 @@ public:
             }
         }
     }
-#ifdef __clang__ // TRANSITION, LLVM-45398
+#ifdef __clang__ // TRANSITION, LLVM-35450
 #pragma clang diagnostic pop
 #endif // ^^^ workaround ^^^
 

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -228,7 +228,7 @@ public:
 template <class _Myvec>
 struct pointer_traits<_Vector_const_iterator<_Myvec>> {
     using pointer         = _Vector_const_iterator<_Myvec>;
-    using element_type    = const typename pointer::value_type; // TRANSITION, VSO-1854115, omit typename
+    using element_type    = const pointer::value_type;
     using difference_type = pointer::difference_type;
 
     _NODISCARD static constexpr element_type* to_address(const pointer _Iter) noexcept {

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -1442,7 +1442,7 @@ private:
             if (_Ffl == ios_base::fixed) {
                 _Ch = 'f';
             } else if (_Ffl == (ios_base::scientific | ios_base::fixed)) {
-                _Ch = 'A'; // added with TR1
+                _Ch = 'A';
             } else if (_Ffl == ios_base::scientific) {
                 _Ch = 'E';
             } else {
@@ -1452,7 +1452,7 @@ private:
             if (_Ffl == ios_base::fixed) {
                 _Ch = 'f';
             } else if (_Ffl == (ios_base::scientific | ios_base::fixed)) {
-                _Ch = 'a'; // added with TR1
+                _Ch = 'a';
             } else if (_Ffl == ios_base::scientific) {
                 _Ch = 'e';
             } else {

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2552,7 +2552,7 @@ template <_RANGES input_range _Rng>
 using _Range_key_type = remove_const_t<typename _RANGES range_value_t<_Rng>::first_type>;
 
 template <_RANGES input_range _Rng>
-using _Range_mapped_type = typename _RANGES range_value_t<_Rng>::second_type; // TRANSITION, VSO-1854035, omit typename
+using _Range_mapped_type = _RANGES range_value_t<_Rng>::second_type;
 
 template <_RANGES input_range _Rng>
 using _Range_to_alloc_type =

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1150,7 +1150,7 @@ private:
 template <class _Traits>
 struct pointer_traits<_String_view_iterator<_Traits>> {
     using pointer         = _String_view_iterator<_Traits>;
-    using element_type    = const typename pointer::value_type; // TRANSITION, VSO-1854115, omit typename
+    using element_type    = const pointer::value_type;
     using difference_type = pointer::difference_type;
 
     _NODISCARD static constexpr element_type* to_address(const pointer& _Iter) noexcept {
@@ -2044,7 +2044,7 @@ public:
 template <class _Mystr>
 struct pointer_traits<_String_const_iterator<_Mystr>> {
     using pointer         = _String_const_iterator<_Mystr>;
-    using element_type    = const typename pointer::value_type; // TRANSITION, VSO-1854115, omit typename
+    using element_type    = const pointer::value_type;
     using difference_type = pointer::difference_type;
 
     _NODISCARD static constexpr element_type* to_address(const pointer _Iter) noexcept {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6636,7 +6636,7 @@ _INLINE_VAR constexpr bool _Is_min_max_optimization_safe = // Activate the vecto
 #if defined(__LDBL_DIG__) && __LDBL_DIG__ == 18
                          is_same<_Elem, float>, is_same<_Elem, double>,
 #else // ^^^ 80-bit long double (not supported by MSVC in general, see GH-1316) / 64-bit long double vvv
-                         is_floating_point<_Elem>, // Element is floating point or...
+                         is_floating_point<_Elem>, // Element is floating-point or...
 #endif // ^^^ 64-bit long double ^^^
 #endif // _USE_STD_VECTOR_FLOATING_ALGORITHMS
                          is_integral<_Elem>, is_pointer<_Elem>>, // ... integral or pointer type.

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -899,8 +899,8 @@ _EMIT_STL_ERROR(STL1002, "Unexpected compiler version, expected CUDA 11.6 or new
 _EMIT_STL_ERROR(STL1000, "Unexpected compiler version, expected Clang 17.0.0 or newer.");
 #endif // ^^^ old Clang ^^^
 #elif defined(_MSC_VER)
-#if _MSC_VER < 1939 // Coarse-grained, not inspecting _MSC_FULL_VER
-_EMIT_STL_ERROR(STL1001, "Unexpected compiler version, expected MSVC 19.39 or newer.");
+#if _MSC_VER < 1940 // Coarse-grained, not inspecting _MSC_FULL_VER
+_EMIT_STL_ERROR(STL1001, "Unexpected compiler version, expected MSVC 19.40 or newer.");
 #endif // ^^^ old MSVC ^^^
 #else // vvv other compilers vvv
 // not attempting to detect other compilers

--- a/stl/modules/std.ixx
+++ b/stl/modules/std.ixx
@@ -42,7 +42,7 @@ export module std;
 // N4971 [module.interface]/6: "A redeclaration of an entity X is implicitly exported
 // if X was introduced by an exported declaration; otherwise it shall not be exported."
 
-// Therefore, we'll need to introduce exported declarations of <vcruntime_new.h> machinery before including it.
+// Therefore, we need to introduce exported declarations of <vcruntime_new.h> machinery before including it.
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -1351,12 +1351,12 @@ const void* __stdcall __std_min_element_8(
     return _Minmax_element<_Mode_min, _Minmax_traits_8>(_First, _Last, _Signed);
 }
 
-const void* __stdcall __std_min_element_f(
+const void* __stdcall __std_min_element_f( // _Minmax_element's "signature" comment explains `bool _Unused`
     const void* const _First, const void* const _Last, const bool _Unused) noexcept {
     return _Minmax_element<_Mode_min, _Minmax_traits_f>(_First, _Last, _Unused);
 }
 
-const void* __stdcall __std_min_element_d(
+const void* __stdcall __std_min_element_d( // _Minmax_element's "signature" comment explains `bool _Unused`
     const void* const _First, const void* const _Last, const bool _Unused) noexcept {
     return _Minmax_element<_Mode_min, _Minmax_traits_d>(_First, _Last, _Unused);
 }
@@ -1381,12 +1381,12 @@ const void* __stdcall __std_max_element_8(
     return _Minmax_element<_Mode_max, _Minmax_traits_8>(_First, _Last, _Signed);
 }
 
-const void* __stdcall __std_max_element_f(
+const void* __stdcall __std_max_element_f( // _Minmax_element's "signature" comment explains `bool _Unused`
     const void* const _First, const void* const _Last, const bool _Unused) noexcept {
     return _Minmax_element<_Mode_max, _Minmax_traits_f>(_First, _Last, _Unused);
 }
 
-const void* __stdcall __std_max_element_d(
+const void* __stdcall __std_max_element_d( // _Minmax_element's "signature" comment explains `bool _Unused`
     const void* const _First, const void* const _Last, const bool _Unused) noexcept {
     return _Minmax_element<_Mode_max, _Minmax_traits_d>(_First, _Last, _Unused);
 }
@@ -1411,12 +1411,12 @@ _Min_max_element_t __stdcall __std_minmax_element_8(
     return _Minmax_element<_Mode_both, _Minmax_traits_8>(_First, _Last, _Signed);
 }
 
-_Min_max_element_t __stdcall __std_minmax_element_f(
+_Min_max_element_t __stdcall __std_minmax_element_f( // _Minmax_element's "signature" comment explains `bool _Unused`
     const void* const _First, const void* const _Last, const bool _Unused) noexcept {
     return _Minmax_element<_Mode_both, _Minmax_traits_f>(_First, _Last, _Unused);
 }
 
-_Min_max_element_t __stdcall __std_minmax_element_d(
+_Min_max_element_t __stdcall __std_minmax_element_d( // _Minmax_element's "signature" comment explains `bool _Unused`
     const void* const _First, const void* const _Last, const bool _Unused) noexcept {
     return _Minmax_element<_Mode_both, _Minmax_traits_d>(_First, _Last, _Unused);
 }

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -581,7 +581,7 @@ std/language.support/support.dynamic/new.delete/new.delete.array/new.size_nothro
 std/depr/depr.c.headers/stdlib_h.aligned_alloc.compile.pass.cpp FAIL
 std/language.support/support.runtime/cstdlib.aligned_alloc.compile.pass.cpp FAIL
 
-# OS-11107628 "_Exit allows cleanup in other DLLs"
+# ArchivedOS-12440914 "_Exit allows cleanup in other DLLs"
 std/thread/thread.threads/thread.thread.class/thread.thread.assign/move2.pass.cpp SKIPPED
 std/thread/thread.threads/thread.thread.class/thread.thread.member/join.pass.cpp SKIPPED
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -459,6 +459,10 @@ std/algorithms/alg.modifying.operations/alg.move/move_backward.pass.cpp:1 FAIL
 std/algorithms/alg.modifying.operations/alg.move/move.pass.cpp:0 FAIL
 std/algorithms/alg.modifying.operations/alg.move/move.pass.cpp:1 FAIL
 
+# VSO-1948221 x86chk ICE with constexpr type_info: Assertion failed: isIndirection()
+std/language.support/support.rtti/type.info/type_info.equal.pass.cpp:0 FAIL
+std/language.support/support.rtti/type.info/type_info.equal.pass.cpp:1 FAIL
+
 
 # *** CLANG COMPILER BUGS ***
 # LLVM-46207 Clang's tgmath.h interferes with the UCRT's tgmath.h
@@ -1403,9 +1407,6 @@ std/input.output/string.streams/stringstream/stringstream.members/gcount.pass.cp
 
 # Similarly, this test is marked as `REQUIRES: 32-bit-pointer`.
 std/iterators/iterator.container/ssize.LWG3207.compile.pass.cpp:9 SKIPPED
-
-# VSO-1948221 x86chk ICE with constexpr type_info: Assertion failed: isIndirection()
-std/language.support/support.rtti/type.info/type_info.equal.pass.cpp:9 SKIPPED
 
 # These tests are marked as "UNSUPPORTED: !has-unix-headers" with comments saying:
 # "`check_assertion.h` requires Unix headers".

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -183,7 +183,7 @@ std/modules/std.pass.cpp FAIL
 
 # *** ASAN FAILURES ***
 # Even with `allocator_may_return_null=1`, ASan kills oversized allocations instead of throwing `bad_alloc`.
-# (https://github.com/google/sanitizers/issues/295)
+# (google/sanitizers#295)
 std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align_nothrow.except.pass.cpp:1 FAIL
 std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align.except.pass.cpp:1 FAIL
 std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align.pass.cpp:1 FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1020,11 +1020,6 @@ std/containers/sequences/vector/vector.cons/construct_size_value_alloc.pass.cpp:
 std/containers/sequences/vector.bool/enabled_hash.pass.cpp FAIL
 std/containers/sequences/vector.bool/vector_bool.pass.cpp FAIL
 
-# Not analyzed. Appears to involve constexpr dynamic allocation.
-# note: failure was caused by a read of an uninitialized symbol
-std/containers/sequences/vector/iterators.pass.cpp:0 FAIL
-std/containers/sequences/vector/iterators.pass.cpp:1 FAIL
-
 # Not analyzed. Inspecting shift operators for quoted().
 std/input.output/iostream.format/quoted.manip/quoted_traits.compile.pass.cpp FAIL
 
@@ -1220,24 +1215,6 @@ std/ranges/range.adaptors/range.join/range.join.iterator/star.pass.cpp:1 FAIL
 # Not analyzed. constexpr evaluation fails in ranges::swap.
 std/ranges/range.adaptors/range.join/range.join.iterator/iter.swap.pass.cpp:0 FAIL
 std/ranges/range.adaptors/range.join/range.join.iterator/iter.swap.pass.cpp:1 FAIL
-
-# Not analyzed. constexpr evaluation fails in assert(element_moved == 1).
-std/ranges/range.adaptors/range.lazy.split/ctor.range.pass.cpp:0 FAIL
-std/ranges/range.adaptors/range.lazy.split/ctor.range.pass.cpp:1 FAIL
-std/ranges/range.adaptors/range.split/ctor.range.pass.cpp:0 FAIL
-std/ranges/range.adaptors/range.split/ctor.range.pass.cpp:1 FAIL
-
-# Not analyzed. constexpr evaluation fails in assert(view_moved == 1).
-std/ranges/range.adaptors/range.lazy.split/ctor.view.pass.cpp:0 FAIL
-std/ranges/range.adaptors/range.lazy.split/ctor.view.pass.cpp:1 FAIL
-std/ranges/range.adaptors/range.split/ctor.view.pass.cpp:0 FAIL
-std/ranges/range.adaptors/range.split/ctor.view.pass.cpp:1 FAIL
-
-# Not analyzed. Testing split_view with an empty pattern, might be an MSVC constexpr bug.
-std/ranges/range.adaptors/range.split/begin.pass.cpp:0 FAIL
-std/ranges/range.adaptors/range.split/begin.pass.cpp:1 FAIL
-std/ranges/range.adaptors/range.split/general.pass.cpp:0 FAIL
-std/ranges/range.adaptors/range.split/general.pass.cpp:1 FAIL
 
 # Not analyzed. Likely MSVC constexpr bug with negative chars passed to __builtin_memcmp.
 std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/compare.pass.cpp:0 FAIL

--- a/tests/std/include/test_header_units_and_modules.hpp
+++ b/tests/std/include/test_header_units_and_modules.hpp
@@ -715,11 +715,9 @@ constexpr bool impl_test_source_location() {
 
 #ifdef __EDG__ // TRANSITION, DevCom-10199227
 #define TEST_DETAILED_FUNCTION_NAME 0
-#elif defined(__clang__) // TRANSITION, Clang 17 has this builtin
-#define TEST_DETAILED_FUNCTION_NAME __has_builtin(__builtin_FUNCSIG)
-#else // ^^^ Clang / MSVC vvv
+#else // ^^^ workaround / no workaround vvv
 #define TEST_DETAILED_FUNCTION_NAME 1
-#endif // ^^^ MSVC ^^^
+#endif // ^^^ no workaround ^^^
 
 #if TEST_DETAILED_FUNCTION_NAME
     assert(sl.function_name() == "bool __cdecl impl_test_source_location(void)"sv);

--- a/tests/std/tests/GH_000639_nvcc_include_all/env.lst
+++ b/tests/std/tests/GH_000639_nvcc_include_all/env.lst
@@ -1,7 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-PM_COMPILER="nvcc" PM_CL="--x cu -Xcompiler -Od,-EHsc,-nologo,-W4,-WX,-openmp"
+# TRANSITION, CUDA 11.6 rejected VS 2022 17.10 as unsupported, so we need --allow-unsupported-compiler
+PM_COMPILER="nvcc" PM_CL="--x cu -Xcompiler -Od,-EHsc,-nologo,-W4,-WX,-openmp --allow-unsupported-compiler"
 RUNALL_CROSSLIST
 PM_CL="-Xcompiler -MT"
 PM_CL="--debug -Xcompiler -MTd"

--- a/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
@@ -876,26 +876,20 @@ constexpr void check_multidimensional_subscript_operator() {
             unsigned long long>);
         static_assert(CanCallMultidimSubscriptOp<Mds, unsigned char, short, unsigned int, long, unsigned long long>);
         static_assert(CanCallMultidimSubscriptOp<Mds, ConvertibleToInt<int>, int, int, int, int>);
-#ifndef __clang__ // TRANSITION, Clang 17
         static_assert(!CanCallMultidimSubscriptOp<Mds, int, int, int, int, NonConvertibleToAnything>);
-#endif // __clang__
     }
 
     { // Check constraint: '(is_nothrow_constructible_v<index_type, OtherIndexTypes> && ...)'
         using Mds = mdspan<char, dextents<signed char, 2>>;
         static_assert(CanCallMultidimSubscriptOp<Mds, ConvertibleToInt<int, IsNothrow::yes>, int>);
-#ifndef __clang__ // TRANSITION, Clang 17
         static_assert(!CanCallMultidimSubscriptOp<Mds, ConvertibleToInt<int, IsNothrow::no>, int>);
-#endif // __clang__
     }
 
     { // Check constraint: 'sizeof...(OtherIndexTypes) == rank()'
         using Mds = mdspan<float, dextents<unsigned short, 3>>;
         static_assert(CanCallMultidimSubscriptOp<Mds, int, int, int>);
-#ifndef __clang__ // TRANSITION, Clang 17
         static_assert(!CanCallMultidimSubscriptOp<Mds, int, int>);
         static_assert(!CanCallMultidimSubscriptOp<Mds, int, int, int, int>);
-#endif // __clang__
     }
 
     { // Check correctness
@@ -908,10 +902,8 @@ constexpr void check_multidimensional_subscript_operator() {
         same_as<vector<bool>::reference> decltype(auto) r2 = as_const(mds)[0, 1];
         assert(!r2);
 
-#ifndef __clang__ // TRANSITION, Clang 17
         static_assert(noexcept(mds[1, 1])); // strengthened
         static_assert(noexcept(as_const(mds)[0, 1])); // strengthened
-#endif // __clang__
     }
 
     { // Check that indices are moved and then casted to 'index_type'

--- a/tests/std/tests/P0339R6_polymorphic_allocator/test.cpp
+++ b/tests/std/tests/P0339R6_polymorphic_allocator/test.cpp
@@ -69,7 +69,7 @@ void allocate_object_overflow_test() {
 
     polymorphic_allocator<> alloc{};
 
-#ifndef __SANITIZE_ADDRESS__ // TRANSITION, VSO-1854243
+#ifndef __SANITIZE_ADDRESS__ // TRANSITION, google/sanitizers#295
     try {
         int* vp = alloc.allocate_object<int>(threshold);
         alloc.deallocate_object(vp, threshold);

--- a/tests/std/tests/P0660R10_jthread_and_cv_any/test.cpp
+++ b/tests/std/tests/P0660R10_jthread_and_cv_any/test.cpp
@@ -139,7 +139,7 @@ int main() {
         assert(source.stop_possible());
     }
 
-    // TRANSITION, OS-11107628 "_Exit allows cleanup in other DLLs"
+    // TRANSITION, ArchivedOS-12440914 "_Exit allows cleanup in other DLLs"
     // detach() is intentionally not tested
 
     // get_id, get_stop_source, get_stop_token tested above

--- a/tests/std/tests/P0896R4_views_iota/test.cpp
+++ b/tests/std/tests/P0896R4_views_iota/test.cpp
@@ -359,9 +359,7 @@ int main() {
     test_integral<unsigned long long>();
 
     // Validate other integer types
-#ifndef __clang__ // TRANSITION, LLVM-48173
     static_assert(!CanViewIota<bool, bool>);
-#endif // ^^^ no workaround ^^^
     static_assert((test_integral<char>(), true));
     test_integral<char>();
     static_assert((test_integral<wchar_t>(), true));

--- a/tests/std/tests/P0896R4_views_split/test.cpp
+++ b/tests/std/tests/P0896R4_views_split/test.cpp
@@ -355,9 +355,7 @@ int main() {
     STATIC_ASSERT(instantiation_test());
     instantiation_test();
 
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-1516290
     STATIC_ASSERT(test_devcom_1559808());
-#endif // ^^^ no workaround ^^^
     test_devcom_1559808();
 
     STATIC_ASSERT(test_LWG_3590());

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -3037,7 +3037,7 @@ namespace test_predicate {
                 using Fn = NotCallableWithInt;
                 STATIC_ASSERT(predicate<Fn, tag>);
                 STATIC_ASSERT(!predicate<Fn, int>);
-            }; // TRANSITION, semicolon needed to make clang-format happy (LLVM-48305)
+            }
         }
 
         { // function object

--- a/tests/std/tests/P1208R6_source_location/test.cpp
+++ b/tests/std/tests/P1208R6_source_location/test.cpp
@@ -181,11 +181,7 @@ constexpr void lambda_test() {
     assert(x1.column() == 53);
     assert(x2.column() == 58);
 #else // ^^^ EDG / C1XX vvv
-#ifdef _MSVC_INTERNAL_TESTING // TRANSITION, VS 2022 17.10 Preview 1
     assert(x1.column() == 45);
-#else // ^^^ no workaround / workaround vvv
-    assert(x1.column() == 52);
-#endif // ^^^ workaround ^^^
     assert(x2.column() == 50);
 #endif // ^^^ C1XX ^^^
 #if _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION

--- a/tests/std/tests/P2273R3_constexpr_unique_ptr/test.compile.pass.cpp
+++ b/tests/std/tests/P2273R3_constexpr_unique_ptr/test.compile.pass.cpp
@@ -36,7 +36,6 @@ constexpr bool test_P2273R3_constexpr_unique_ptr() {
         assert(nullptr == p5);
         assert(!(p5 != nullptr));
         assert(!(nullptr != p5));
-#ifndef __EDG__ // TRANSITION, DevCom-1670927
         assert(!(p5 < nullptr));
         assert(!(nullptr < p5));
         assert(p5 <= nullptr);
@@ -47,7 +46,6 @@ constexpr bool test_P2273R3_constexpr_unique_ptr() {
         assert(nullptr >= p5);
         assert((p5 <=> nullptr) == strong_ordering::equal);
         assert((nullptr <=> p5) == strong_ordering::equal);
-#endif // ^^^ no workaround ^^^
     }
 
     // changes in [unique.ptr.dltr.dflt] and [unique.ptr.dltr.dflt1]

--- a/tests/std/tests/P2278R4_views_as_const/test.cpp
+++ b/tests/std/tests/P2278R4_views_as_const/test.cpp
@@ -641,10 +641,8 @@ int main() {
     }
 
     { // Validate non-views
-#ifndef __EDG__ // TRANSITION, VSO-1900291
         STATIC_ASSERT(test_one(some_ints, some_ints));
         test_one(some_ints, some_ints);
-#endif // ^^^ no workaround ^^^
 
         // Test with lvalue, rvalue, and wrapped in ref_view non-views
         auto vec = some_ints | ranges::to<vector>();
@@ -659,11 +657,9 @@ int main() {
     }
 
     { // Validate single_view
-#ifndef __EDG__ // TRANSITION, VSO-1900291
         static constexpr int one_int[1] = {333};
         STATIC_ASSERT(test_one(views::single(333), one_int));
         test_one(views::single(333), one_int);
-#endif // ^^^ no workaround ^^^
     }
 
     { // Validate empty_view

--- a/tests/std/tests/P2374R4_views_cartesian_product_recommended_practices/test.compile.pass.cpp
+++ b/tests/std/tests/P2374R4_views_cartesian_product_recommended_practices/test.compile.pass.cpp
@@ -53,12 +53,10 @@ constexpr void check_array() {
     static_assert(sizeof(cpv_difference_t<A1, A1>) <= sizeof(ptrdiff_t));
     static_assert(sizeof(cpv_difference_t<A1, A1, A1>) <= sizeof(ptrdiff_t));
 
-#ifndef __clang__ // TRANSITION, Clang 17
     // Computing cartesian product for big arrays requires bigger types
     using A2 = all_t<int(&)[500'000'000]>;
     static_assert(sizeof(cpv_size_t<A2, A2, A2>) > sizeof(size_t));
     static_assert(sizeof(cpv_difference_t<A2, A2, A2>) > sizeof(ptrdiff_t));
-#endif // __clang__
 }
 
 constexpr void check_std_array() {

--- a/tests/std/tests/P2465R3_standard_library_modules/test3.cpp
+++ b/tests/std/tests/P2465R3_standard_library_modules/test3.cpp
@@ -1,11 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifdef _MSVC_INTERNAL_TESTING // TRANSITION, VS 2022 17.10 Preview 1
 #include <__msvc_all_public_headers.hpp>
-#else // ^^^ no workaround / workaround vvv
-#include <assert.h> // intentionally not <cassert>
-#endif // ^^^ workaround ^^^
 
 import std;
 

--- a/tests/std/tests/P2465R3_standard_library_modules/test4.cpp
+++ b/tests/std/tests/P2465R3_standard_library_modules/test4.cpp
@@ -1,11 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifdef _MSVC_INTERNAL_TESTING // TRANSITION, VS 2022 17.10 Preview 1
 #include <__msvc_all_public_headers.hpp>
-#else // ^^^ no workaround / workaround vvv
-#include <assert.h> // intentionally not <cassert>
-#endif // ^^^ workaround ^^^
 
 import std.compat;
 

--- a/tests/utils/stl/util.py
+++ b/tests/utils/stl/util.py
@@ -77,7 +77,7 @@ def decodeOutput(bytes):
     try:
         return bytes.decode()
     except UnicodeError:
-        # Use 'backslashreplace' to avoid throwing another exception for unrecognized characters.
+        # Use 'backslashreplace' to avoid throwing another exception when tests emit garbage bytes.
         import locale
         return bytes.decode(locale.getpreferredencoding(do_setlocale=False), 'backslashreplace')
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.27.0)
+cmake_minimum_required(VERSION 3.28.0)
 project(msvc_standard_libraries_tools LANGUAGES CXX)
 
 add_subdirectory(format)

--- a/tools/format/CMakeLists.txt
+++ b/tools/format/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.27.0)
+cmake_minimum_required(VERSION 3.28.0)
 project(msvc_standard_libraries_format NONE)
 
 set(did_search OFF)

--- a/tools/validate/CMakeLists.txt
+++ b/tools/validate/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.27.0)
+cmake_minimum_required(VERSION 3.28.0)
 project(msvc_standard_libraries_validate LANGUAGES CXX)
 
 add_executable(validate-binary validate.cpp)


### PR DESCRIPTION
# Overview
- Code cleanups:
  * Removed compiler bug workarounds.
- Infrastructure improvements:
  * Updated dependencies.
    + Updated build compiler to VS 2022 17.10 Preview 1 (now required).
    + Updated CMake to 3.28 (now required).
    + Updated Python to 3.12.2.

# Commits
* Use PowerShell 7.4.1.
* Python 3.12.2.
* New pool.
* VS 2022 17.10 Preview 1.
* CMake 3.28.
* Require VS 2022 17.10 (aka MSVC 19.40).
* Require CMake 3.28.
* Update citations: DevCom-10543093 (not entirely fixed) => VSO-1956799
  + Reported VSO-1956799 "C1XX `constexpr` ICE when invoking a base PMD on a `reference_wrapper<Derived>`".
* Update citations: LLVM-45398 llvm/llvm-project#44743 (resolved as duplicate) => LLVM-35450 llvm/llvm-project#34798
* Update citations: VSO-1854243 (duplicate of upstream) => google/sanitizers#295
* Update citations: URL => `google/sanitizers#295`
  + To be more searchable.
* Update citations: OS-11107628 (archived) => ArchivedOS-12440914
* Update citations: OS-17090155 (archived) => ArchivedOS-17501595
* Remove UCRT workaround for ArchivedOS-17501595.
  + On 2018-04-20, @amyw-msft noted: "We actually fixed this in RS1"
* Remove Clang workarounds for LLVM-48173 llvm/llvm-project#47517.
* Remove Clang workaround for LLVM-48305 llvm/llvm-project#47649.
* Remove Clang workaround in `test_header_units_and_modules.hpp`.
  + We aren't testing Clang with header units and modules yet, but we require Clang 17, and this aligns with how we changed `<source_location>` in #4259.
* Remove Clang workarounds in `P0009R18_mdspan_mdspan`.
* Remove Clang workaround in `P2374R4_views_cartesian_product_recommended_practices`.
* Remove MSVC FAILs for tests that are passing now.
* Remove `_MSVC_INTERNAL_TESTING` workaround in `P1208R6_source_location`.
* Remove `_MSVC_INTERNAL_TESTING` workarounds in `P2465R3_standard_library_modules`.
  + This activates `#include`-then-`import` coverage.
* Remove MSVC workaround for DevCom-1516290.
* Remove MSVC workaround for DevCom-10095944.
* Remove MSVC workarounds for DevCom-10519736.
* Remove MSVC workarounds for DevCom-10548086.
* Remove MSVC workaround for VSO-1854035.
* Remove some MSVC workarounds for VSO-1854115.
  + Not all - only the `using` scenario was fixed. We were wrong about the other scenario.
* Remove incorrect citations of VSO-1854115.
  + `std::atomic_wait()` and `std::atomic_wait_explicit()` are top-level (namespace-scope) functions, so C++20 Down With Typename doesn't apply to them, regardless of the `const`. MSVC, Clang, and EDG all agree.
* Remove EDG workarounds for VSO-1900291.
* Remove EDG workaround for DevCom-1670927, add perma-workaround for VSO-1956627.
  + Reported VSO-1956627 "EDG emits bogus error 'expression must have a constant value' when using a named `nullptr_t` parameter".
  + I'm changing all operators for consistency, even when they aren't `constexpr`.
* Extend MSVC workaround for VSO-1948221 (`constexpr type_info` ICE) which just shipped.
* Update workaround in `basic_format_arg`: Clang and EDG still need it, MSVC doesn't.
  + Clang fixed LLVM-49072 llvm/llvm-project#48416.
  + Reported LLVM-81774 llvm/llvm-project#81774.
  + Reported VSO-1956558 "EDG incorrectly rejects default construction of union with nontrivial member".
* Add CUDA workaround `--allow-unsupported-compiler` to `GH_000639_nvcc_include_all`.
* Increase overall and test timeouts to 30 minutes.
  + Not motivated by anything in this toolset update, but with the recent addition of ASan and expansion of EDG coverage, we'd like to have a bit more breathing room. This is somewhat over 2x the time that the tests usually take.
* Comment cleanup requested in review of #4366.
* Comment cleanup requested in review of #4375.
* Comment additions requested in review of #3928.
* Comment cleanups: Hexfloat machinery doesn't need to say "added with TR1".
* Comment cleanups: Consistently hyphenate "floating-point" in headers.
