### PR TITLE
Handle paths case-insensitively when running tests

### DIFF
--- a/tests/utils/stl/test/format.py
+++ b/tests/utils/stl/test/format.py
@@ -65,7 +65,7 @@ def _getEnvLst(sourcePath, localConfig):
 def _isLegalDirectory(sourcePath, test_subdirs):
     for prefix in test_subdirs:
         common = os.path.normpath(os.path.commonpath((sourcePath, prefix)))
-        if common == sourcePath or common == prefix:
+        if os.path.samefile(common, sourcePath) or os.path.samefile(common, prefix):
             return True
 
     return False


### PR DESCRIPTION
Fixes #4393.

@AlexGuteniev discovered that attempting to run tests with a drive letter of a different case would fail (see lowercase `d:`):

```
D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py d:\GitHub\STL\tests\std\tests\VSO_0157762_feature_test_macros
stl-lit.py: D:\GitHub\STL\llvm-project\llvm\utils\lit\lit\discovery.py:276: warning: input 'd:\\GitHub\\STL\\tests\\std\\tests\\VSO_0157762_feature_test_macros' contained no tests
error: did not discover any tests for provided path(s)
```

Later, I discovered that case variation in the middle of the path would also fail (see uppercase `STD`):

```
D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py D:\GitHub\STL\tests\STD\tests\VSO_0157762_feature_test_macros
stl-lit.py: D:\GitHub\STL\llvm-project\llvm\utils\lit\lit\discovery.py:276: warning: input 'D:\\GitHub\\STL\\tests\\STD\\tests\\VSO_0157762_feature_test_macros' contained no tests
error: did not discover any tests for provided path(s)
```

According to my understanding, this is happening because LLVM's lit machinery isn't performing case normalization before ultimately calling our code, which is performing exact equality checks with `==`. We can fix this on our side by using [`os.path.samefile`](https://docs.python.org/3/library/os.path.html#os.path.samefile):

> Return `True` if both pathname arguments refer to the same file or directory. This is determined by the device number and i-node number and raises an exception if an `os.stat()` call on either pathname fails.

This fixes the problematic scenarios, while not affecting what happens if the user specifies a totally nonexistent test.

<details><summary>Click to expand <code>main</code>'s behavior:</summary>

```
D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py D:\GitHub\STL\tests\std\tests\VSO_0157762_feature_test_macros
-- Testing: 35 tests, 32 workers --
[...]

D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py d:\GitHub\STL\tests\std\tests\VSO_0157762_feature_test_macros
stl-lit.py: D:\GitHub\STL\llvm-project\llvm\utils\lit\lit\discovery.py:276: warning: input 'd:\\GitHub\\STL\\tests\\std\\tests\\VSO_0157762_feature_test_macros' contained no tests
error: did not discover any tests for provided path(s)

D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py ..\..\tests\std\tests\VSO_0157762_feature_test_macros
-- Testing: 35 tests, 32 workers --
[...]

D:\GitHub\STL\out\x64>:: Change the middle to STD:
D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py D:\GitHub\STL\tests\STD\tests\VSO_0157762_feature_test_macros
stl-lit.py: D:\GitHub\STL\llvm-project\llvm\utils\lit\lit\discovery.py:276: warning: input 'D:\\GitHub\\STL\\tests\\STD\\tests\\VSO_0157762_feature_test_macros' contained no tests
error: did not discover any tests for provided path(s)

D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py d:\GitHub\STL\tests\STD\tests\VSO_0157762_feature_test_macros
stl-lit.py: D:\GitHub\STL\llvm-project\llvm\utils\lit\lit\discovery.py:276: warning: input 'd:\\GitHub\\STL\\tests\\STD\\tests\\VSO_0157762_feature_test_macros' contained no tests
error: did not discover any tests for provided path(s)

D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py ..\..\tests\STD\tests\VSO_0157762_feature_test_macros
stl-lit.py: D:\GitHub\STL\llvm-project\llvm\utils\lit\lit\discovery.py:276: warning: input '..\\..\\tests\\STD\\tests\\VSO_0157762_feature_test_macros' contained no tests
error: did not discover any tests for provided path(s)

D:\GitHub\STL\out\x64>:: Change the end to vso_0157762_FEATURE_TEST_MACROS:
D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py D:\GitHub\STL\tests\std\tests\vso_0157762_FEATURE_TEST_MACROS
-- Testing: 35 tests, 32 workers --
[...]

D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py d:\GitHub\STL\tests\std\tests\vso_0157762_FEATURE_TEST_MACROS
stl-lit.py: D:\GitHub\STL\llvm-project\llvm\utils\lit\lit\discovery.py:276: warning: input 'd:\\GitHub\\STL\\tests\\std\\tests\\vso_0157762_FEATURE_TEST_MACROS' contained no tests
error: did not discover any tests for provided path(s)

D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py ..\..\tests\std\tests\vso_0157762_FEATURE_TEST_MACROS
-- Testing: 35 tests, 32 workers --
[...]

D:\GitHub\STL\out\x64>:: Nonexistent test:
D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py D:\GitHub\STL\tests\std\tests\UNATCO_0451_helios
stl-lit.py: D:\GitHub\STL\llvm-project\llvm\utils\lit\lit\discovery.py:276: warning: input 'D:\\GitHub\\STL\\tests\\std\\tests\\UNATCO_0451_helios' contained no tests
error: did not discover any tests for provided path(s)

D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py d:\GitHub\STL\tests\std\tests\UNATCO_0451_helios
stl-lit.py: D:\GitHub\STL\llvm-project\llvm\utils\lit\lit\discovery.py:276: warning: input 'd:\\GitHub\\STL\\tests\\std\\tests\\UNATCO_0451_helios' contained no tests
error: did not discover any tests for provided path(s)

D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py ..\..\tests\std\tests\UNATCO_0451_helios
stl-lit.py: D:\GitHub\STL\llvm-project\llvm\utils\lit\lit\discovery.py:276: warning: input '..\\..\\tests\\std\\tests\\UNATCO_0451_helios' contained no tests
error: did not discover any tests for provided path(s)
```
</details>

<details><summary>Click to expand this PR's behavior:</summary>

```
D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py D:\GitHub\STL\tests\std\tests\VSO_0157762_feature_test_macros
-- Testing: 35 tests, 32 workers --
[...]

D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py d:\GitHub\STL\tests\std\tests\VSO_0157762_feature_test_macros
-- Testing: 35 tests, 32 workers --
[...]

D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py ..\..\tests\std\tests\VSO_0157762_feature_test_macros
-- Testing: 35 tests, 32 workers --
[...]

D:\GitHub\STL\out\x64>:: Change the middle to STD:
D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py D:\GitHub\STL\tests\STD\tests\VSO_0157762_feature_test_macros
-- Testing: 35 tests, 32 workers --
[...]

D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py d:\GitHub\STL\tests\STD\tests\VSO_0157762_feature_test_macros
-- Testing: 35 tests, 32 workers --
[...]

D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py ..\..\tests\STD\tests\VSO_0157762_feature_test_macros
-- Testing: 35 tests, 32 workers --
[...]

D:\GitHub\STL\out\x64>:: Change the end to vso_0157762_FEATURE_TEST_MACROS:
D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py D:\GitHub\STL\tests\std\tests\vso_0157762_FEATURE_TEST_MACROS
-- Testing: 35 tests, 32 workers --
[...]

D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py d:\GitHub\STL\tests\std\tests\vso_0157762_FEATURE_TEST_MACROS
-- Testing: 35 tests, 32 workers --
[...]

D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py ..\..\tests\std\tests\vso_0157762_FEATURE_TEST_MACROS
-- Testing: 35 tests, 32 workers --
[...]

D:\GitHub\STL\out\x64>:: Nonexistent test:
D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py D:\GitHub\STL\tests\std\tests\UNATCO_0451_helios
stl-lit.py: D:\GitHub\STL\llvm-project\llvm\utils\lit\lit\discovery.py:276: warning: input 'D:\\GitHub\\STL\\tests\\std\\tests\\UNATCO_0451_helios' contained no tests
error: did not discover any tests for provided path(s)

D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py d:\GitHub\STL\tests\std\tests\UNATCO_0451_helios
stl-lit.py: D:\GitHub\STL\llvm-project\llvm\utils\lit\lit\discovery.py:276: warning: input 'd:\\GitHub\\STL\\tests\\std\\tests\\UNATCO_0451_helios' contained no tests
error: did not discover any tests for provided path(s)

D:\GitHub\STL\out\x64>python tests\utils\stl-lit\stl-lit.py ..\..\tests\std\tests\UNATCO_0451_helios
stl-lit.py: D:\GitHub\STL\llvm-project\llvm\utils\lit\lit\discovery.py:276: warning: input '..\\..\\tests\\std\\tests\\UNATCO_0451_helios' contained no tests
error: did not discover any tests for provided path(s)
```
</details>
