### PR TITLE
`vector_algorithms.cpp`, `*minmax*`: invert the condition to improve `*_element` cases a bit more

### DIFF
--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -1197,7 +1197,37 @@ namespace {
                 // Increment vertical indices. Will stop at exactly wrap around, if not reach the end before
                 _Cur_idx = _Traits::_Inc(_Cur_idx);
 
-                if (_First == _Stop_at) {
+                if (_First != _Stop_at) {
+                    // This is the main part, finding vertical minimum/maximum
+
+                    // Load values and if unsigned adjust them to be signed (for signed vector comparisons)
+                    _Cur_vals = _Traits::_Sign_correction(_Traits::_Load(_First), _Sign);
+
+                    if constexpr ((_Mode & _Mode_min) != 0) {
+                        // Looking for the first occurrence of minimum, don't overwrite with newly found occurrences
+                        const auto _Is_less = _Traits::_Cmp_gt(_Cur_vals_min, _Cur_vals); // _Cur_vals < _Cur_vals_min
+                        _Cur_idx_min        = _mm_blendv_epi8(
+                            _Cur_idx_min, _Cur_idx, _Traits::_Mask_cast(_Is_less)); // Remember their vertical indices
+                        _Cur_vals_min = _Traits::_Min(_Cur_vals_min, _Cur_vals, _Is_less); // Update the current minimum
+                    }
+
+                    if constexpr (_Mode == _Mode_max) {
+                        // Looking for the first occurrence of maximum, don't overwrite with newly found occurrences
+                        const auto _Is_greater =
+                            _Traits::_Cmp_gt(_Cur_vals, _Cur_vals_max); // _Cur_vals > _Cur_vals_max
+                        _Cur_idx_max = _mm_blendv_epi8(_Cur_idx_max, _Cur_idx,
+                            _Traits::_Mask_cast(_Is_greater)); // Remember their vertical indices
+                        _Cur_vals_max =
+                            _Traits::_Max(_Cur_vals_max, _Cur_vals, _Is_greater); // Update the current maximum
+                    } else if constexpr (_Mode == _Mode_both) {
+                        // Looking for the last occurrence of maximum, do overwrite with newly found occurrences
+                        const auto _Is_less =
+                            _Traits::_Cmp_gt(_Cur_vals_max, _Cur_vals); // !(_Cur_vals >= _Cur_vals_max)
+                        _Cur_idx_max  = _mm_blendv_epi8(_Cur_idx, _Cur_idx_max,
+                             _Traits::_Mask_cast(_Is_less)); // Remember their vertical indices
+                        _Cur_vals_max = _Traits::_Max(_Cur_vals, _Cur_vals_max, _Is_less); // Update the current maximum
+                    }
+                } else {
                     // Reached end or indices wrap around point.
                     // Compute horizontal min and/or max. Determine horizontal and vertical position of it.
 
@@ -1309,32 +1339,6 @@ namespace {
                         break; // No wrapping, so it was the only portion
                     }
                 }
-                // This is the main part, finding vertical minimum/maximum
-
-                // Load values and if unsigned adjust them to be signed (for signed vector comparisons)
-                _Cur_vals = _Traits::_Sign_correction(_Traits::_Load(_First), _Sign);
-
-                if constexpr ((_Mode & _Mode_min) != 0) {
-                    // Looking for the first occurrence of minimum, don't overwrite with newly found occurrences
-                    const auto _Is_less = _Traits::_Cmp_gt(_Cur_vals_min, _Cur_vals); // _Cur_vals < _Cur_vals_min
-                    _Cur_idx_min        = _mm_blendv_epi8(
-                        _Cur_idx_min, _Cur_idx, _Traits::_Mask_cast(_Is_less)); // Remember their vertical indices
-                    _Cur_vals_min = _Traits::_Min(_Cur_vals_min, _Cur_vals, _Is_less); // Update the current minimum
-                }
-
-                if constexpr (_Mode == _Mode_max) {
-                    // Looking for the first occurrence of maximum, don't overwrite with newly found occurrences
-                    const auto _Is_greater = _Traits::_Cmp_gt(_Cur_vals, _Cur_vals_max); // _Cur_vals > _Cur_vals_max
-                    _Cur_idx_max           = _mm_blendv_epi8(
-                        _Cur_idx_max, _Cur_idx, _Traits::_Mask_cast(_Is_greater)); // Remember their vertical indices
-                    _Cur_vals_max = _Traits::_Max(_Cur_vals_max, _Cur_vals, _Is_greater); // Update the current maximum
-                } else if constexpr (_Mode == _Mode_both) {
-                    // Looking for the last occurrence of maximum, do overwrite with newly found occurrences
-                    const auto _Is_less = _Traits::_Cmp_gt(_Cur_vals_max, _Cur_vals); // !(_Cur_vals >= _Cur_vals_max)
-                    _Cur_idx_max        = _mm_blendv_epi8(_Cur_idx, _Cur_idx_max,
-                               _Traits::_Mask_cast(_Is_less)); // Remember their vertical indices
-                    _Cur_vals_max = _Traits::_Max(_Cur_vals, _Cur_vals_max, _Is_less); // Update the current maximum
-                }
             }
         }
 #endif // !_M_ARM64EC
@@ -1410,7 +1414,31 @@ namespace {
             for (;;) {
                 _Advance_bytes(_First, 16);
 
-                if (_First == _Stop_at) {
+                if (_First != _Stop_at) {
+                    // This is the main part, finding vertical minimum/maximum
+
+                    _Cur_vals = _Traits::_Load(_First);
+
+                    if constexpr (_Sign_correction) {
+                        _Cur_vals = _Traits::_Sign_correction(_Cur_vals, false);
+                    }
+
+                    if constexpr ((_Mode & _Mode_min) != 0) {
+                        if constexpr (_Sign || _Sign_correction) {
+                            _Cur_vals_min = _Traits::_Min(_Cur_vals_min, _Cur_vals); // Update the current minimum
+                        } else {
+                            _Cur_vals_min = _Traits::_Min_u(_Cur_vals_min, _Cur_vals); // Update the current minimum
+                        }
+                    }
+
+                    if constexpr ((_Mode & _Mode_max) != 0) {
+                        if constexpr (_Sign || _Sign_correction) {
+                            _Cur_vals_max = _Traits::_Max(_Cur_vals_max, _Cur_vals); // Update the current maximum
+                        } else {
+                            _Cur_vals_max = _Traits::_Max_u(_Cur_vals_max, _Cur_vals); // Update the current maximum
+                        }
+                    }
+                } else {
                     // Reached end. Compute horizontal min and/or max.
 
                     if constexpr ((_Mode & _Mode_min) != 0) {
@@ -1450,29 +1478,6 @@ namespace {
                     }
 
                     break;
-                }
-                // This is the main part, finding vertical minimum/maximum
-
-                _Cur_vals = _Traits::_Load(_First);
-
-                if constexpr (_Sign_correction) {
-                    _Cur_vals = _Traits::_Sign_correction(_Cur_vals, false);
-                }
-
-                if constexpr ((_Mode & _Mode_min) != 0) {
-                    if constexpr (_Sign || _Sign_correction) {
-                        _Cur_vals_min = _Traits::_Min(_Cur_vals_min, _Cur_vals); // Update the current minimum
-                    } else {
-                        _Cur_vals_min = _Traits::_Min_u(_Cur_vals_min, _Cur_vals); // Update the current minimum
-                    }
-                }
-
-                if constexpr ((_Mode & _Mode_max) != 0) {
-                    if constexpr (_Sign || _Sign_correction) {
-                        _Cur_vals_max = _Traits::_Max(_Cur_vals_max, _Cur_vals); // Update the current maximum
-                    } else {
-                        _Cur_vals_max = _Traits::_Max_u(_Cur_vals_max, _Cur_vals); // Update the current maximum
-                    }
                 }
             }
         } else

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -1333,8 +1333,6 @@ namespace {
                             _Cur_vals_max = _Cur_vals;
                             _Cur_idx_max  = _mm_setzero_si128();
                         }
-
-                        continue;
                     } else {
                         break; // No wrapping, so it was the only portion
                     }


### PR DESCRIPTION
The possibility was realized when working on #4384. 

I observed that the compiler swaps branches to make the `_Minmax` loop more local.
Applying the same change to the `_Minmax_element` loop gives significant improvement: 1.6 or 1.8 times for some cases.
Also made that change to `_Minmax` loop to maintain consistency (with both its counterpart and how it being compiled).

<details>
<summary>Benchmark results</summary>

```
--------------------------------------------------------------------------------------------
Benchmark                              Old Time        Old CPU    New Time         New CPU  
--------------------------------------------------------------------------------------------
bm<uint8_t, 8021, Op::Min>              647 ns          642 ns      361 ns          361 ns  
bm<uint8_t, 8021, Op::Max>              598 ns          586 ns      368 ns          369 ns  
bm<uint8_t, 8021, Op::Both>             679 ns          684 ns      556 ns          562 ns  
bm<uint8_t, 8021, Op::Min_val>          278 ns          279 ns      272 ns          273 ns  
bm<uint8_t, 8021, Op::Max_val>          285 ns          285 ns      279 ns          276 ns  
bm<uint8_t, 8021, Op::Both_val>       20891 ns        20996 ns    20642 ns        20403 ns  
bm<uint16_t, 8021, Op::Min>            1093 ns         1099 ns      791 ns          785 ns  
bm<uint16_t, 8021, Op::Max>            1104 ns         1099 ns      659 ns          670 ns  
bm<uint16_t, 8021, Op::Both>           1595 ns         1604 ns     1050 ns         1050 ns  
bm<uint16_t, 8021, Op::Min_val>         332 ns          330 ns      326 ns          322 ns  
bm<uint16_t, 8021, Op::Max_val>         331 ns          337 ns      324 ns          322 ns  
bm<uint16_t, 8021, Op::Both_val>      12045 ns        12207 ns    11841 ns        11719 ns  
bm<uint32_t, 8021, Op::Min>            2135 ns         2093 ns     1294 ns         1287 ns  
bm<uint32_t, 8021, Op::Max>            1356 ns         1350 ns     1304 ns         1311 ns  
bm<uint32_t, 8021, Op::Both>           2117 ns         2131 ns     2092 ns         2086 ns  
bm<uint32_t, 8021, Op::Min_val>         627 ns          641 ns      618 ns          625 ns  
bm<uint32_t, 8021, Op::Max_val>        1041 ns         1050 ns     1049 ns         1050 ns  
bm<uint32_t, 8021, Op::Both_val>        666 ns          670 ns      693 ns          698 ns  
bm<uint64_t, 8021, Op::Min>            4629 ns         4604 ns     4615 ns         4604 ns  
bm<uint64_t, 8021, Op::Max>            4745 ns         4757 ns     4735 ns         4708 ns  
bm<uint64_t, 8021, Op::Both>           5065 ns         5156 ns     4925 ns         5000 ns  
bm<uint64_t, 8021, Op::Min_val>        4068 ns         4081 ns     4068 ns         4081 ns  
bm<uint64_t, 8021, Op::Max_val>        4068 ns         4081 ns     4058 ns         3990 ns  
bm<uint64_t, 8021, Op::Both_val>       4103 ns         4081 ns     4082 ns         4081 ns  
bm<int8_t, 8021, Op::Min>               551 ns          547 ns      358 ns          357 ns  
bm<int8_t, 8021, Op::Max>               578 ns          578 ns      364 ns          368 ns  
bm<int8_t, 8021, Op::Both>              708 ns          711 ns      553 ns          562 ns  
bm<int8_t, 8021, Op::Min_val>           275 ns          279 ns      268 ns          267 ns  
bm<int8_t, 8021, Op::Max_val>           274 ns          273 ns      269 ns          264 ns  
bm<int8_t, 8021, Op::Both_val>        20376 ns        20403 ns    20147 ns        19950 ns  
bm<int16_t, 8021, Op::Min>             1046 ns         1050 ns      783 ns          785 ns  
bm<int16_t, 8021, Op::Max>             1041 ns         1050 ns      675 ns          684 ns  
bm<int16_t, 8021, Op::Both>            1609 ns         1604 ns     1084 ns         1088 ns  
bm<int16_t, 8021, Op::Min_val>          535 ns          544 ns      530 ns          531 ns  
bm<int16_t, 8021, Op::Max_val>          571 ns          572 ns      545 ns          544 ns  
bm<int16_t, 8021, Op::Both_val>       13254 ns        13393 ns    13141 ns        13114 ns  
bm<int32_t, 8021, Op::Min>             2071 ns         2086 ns     1292 ns         1287 ns  
bm<int32_t, 8021, Op::Max>             1356 ns         1350 ns     1312 ns         1311 ns  
bm<int32_t, 8021, Op::Both>            2153 ns         2148 ns     2066 ns         2086 ns  
bm<int32_t, 8021, Op::Min_val>         1052 ns         1067 ns     1033 ns         1025 ns  
bm<int32_t, 8021, Op::Max_val>          622 ns          628 ns      620 ns          614 ns  
bm<int32_t, 8021, Op::Both_val>        1030 ns         1046 ns     1045 ns         1050 ns  
bm<int64_t, 8021, Op::Min>             4628 ns         4604 ns     4672 ns         4604 ns  
bm<int64_t, 8021, Op::Max>             4746 ns         4708 ns     4763 ns         4743 ns  
bm<int64_t, 8021, Op::Both>            5013 ns         5000 ns     5013 ns         5000 ns  
bm<int64_t, 8021, Op::Min_val>         4065 ns         4081 ns     4157 ns         4171 ns  
bm<int64_t, 8021, Op::Max_val>         4071 ns         4098 ns     4136 ns         4143 ns  
bm<int64_t, 8021, Op::Both_val>        4090 ns         4081 ns     4159 ns         4143 ns  
bm<float, 8021, Op::Min>               2219 ns         2197 ns     2423 ns         2459 ns  
bm<float, 8021, Op::Max>               2469 ns         2455 ns     2409 ns         2407 ns  
bm<float, 8021, Op::Both>              2558 ns         2567 ns     3202 ns         3209 ns  
bm<float, 8021, Op::Min_val>           2001 ns         1995 ns     2031 ns         1995 ns  
bm<float, 8021, Op::Max_val>           1998 ns         1995 ns     2038 ns         2040 ns  
bm<float, 8021, Op::Both_val>          2034 ns         2040 ns     2039 ns         2040 ns  
bm<double, 8021, Op::Min>              4206 ns         4262 ns     4084 ns         4081 ns  
bm<double, 8021, Op::Max>              4378 ns         4395 ns     4347 ns         4395 ns  
bm<double, 8021, Op::Both>             5433 ns         5301 ns     5139 ns         5162 ns  
bm<double, 8021, Op::Min_val>          4027 ns         3990 ns     4028 ns         3990 ns  
bm<double, 8021, Op::Max_val>          4032 ns         4081 ns     4037 ns         4081 ns  
bm<double, 8021, Op::Both_val>         4113 ns         4081 ns     4065 ns         4081 ns  
```
</details>