### PR TITLE
`<new>`: `SRWLOCK` to protect the `new` handler instead of an indexed `CRITICAL_SECTION`

### DIFF
--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -310,7 +310,6 @@ _EMIT_STL_WARNING(STL4001, "/clr:pure is deprecated and will be REMOVED.");
 #endif // !defined(_CRTDATA2_IMPORT)
 
 #define _LOCK_LOCALE         0
-#define _LOCK_MALLOC         1
 #define _LOCK_STREAM         2
 #define _LOCK_DEBUG          3
 #define _LOCK_AT_THREAD_EXIT 4

--- a/stl/src/stdhndlr.cpp
+++ b/stl/src/stdhndlr.cpp
@@ -20,7 +20,7 @@ namespace {
 _STD_BEGIN
 
 _CRTIMP2 new_handler __cdecl set_new_handler(_In_opt_ new_handler pnew) noexcept { // remove current handler
-    unique_lock _Lock{_New_handler_mutex};
+    lock_guard _Lock{_New_handler_mutex};
     new_handler pold = _New_handler;
     _New_handler     = pnew;
     _set_new_handler(pnew ? _New_handler_interface : nullptr);
@@ -28,7 +28,7 @@ _CRTIMP2 new_handler __cdecl set_new_handler(_In_opt_ new_handler pnew) noexcept
 }
 
 _CRTIMP2 new_handler __cdecl get_new_handler() noexcept { // get current new handler
-    unique_lock _Lock{_New_handler_mutex};
+    lock_guard _Lock{_New_handler_mutex};
     return _New_handler;
 }
 

--- a/stl/src/stdhndlr.cpp
+++ b/stl/src/stdhndlr.cpp
@@ -5,9 +5,11 @@
 
 #include <new.h>
 #include <new>
+#include <mutex>
 
 namespace {
     _STD new_handler _New_handler;
+    constinit std::mutex _New_handler_mutex;
 
     int __cdecl _New_handler_interface(size_t) { // interface to existing Microsoft _callnewh mechanism
         _New_handler();
@@ -18,18 +20,16 @@ namespace {
 _STD_BEGIN
 
 _CRTIMP2 new_handler __cdecl set_new_handler(_In_opt_ new_handler pnew) noexcept { // remove current handler
-    _BEGIN_LOCK(_LOCK_MALLOC) // lock thread to ensure atomicity
+    unique_lock _Lock{_New_handler_mutex};
     new_handler pold = _New_handler;
     _New_handler     = pnew;
     _set_new_handler(pnew ? _New_handler_interface : nullptr);
     return pold;
-    _END_LOCK()
 }
 
 _CRTIMP2 new_handler __cdecl get_new_handler() noexcept { // get current new handler
-    _BEGIN_LOCK(_LOCK_MALLOC) // lock thread to ensure atomicity
+    unique_lock _Lock{_New_handler_mutex};
     return _New_handler;
-    _END_LOCK()
 }
 
 _STD_END

--- a/stl/src/stdhndlr.cpp
+++ b/stl/src/stdhndlr.cpp
@@ -3,9 +3,9 @@
 
 // set_new_handler
 
+#include <mutex>
 #include <new.h>
 #include <new>
-#include <mutex>
 
 namespace {
     _STD new_handler _New_handler;

--- a/stl/src/stdhndlr.cpp
+++ b/stl/src/stdhndlr.cpp
@@ -9,7 +9,7 @@
 
 namespace {
     _STD new_handler _New_handler;
-    constinit std::mutex _New_handler_mutex;
+    constinit _STD mutex _New_handler_mutex;
 
     int __cdecl _New_handler_interface(size_t) { // interface to existing Microsoft _callnewh mechanism
         _New_handler();


### PR DESCRIPTION
Towards #3521

After finally making both constructor of `std::mutex` `constexpr` and its destructor trivial, it is should be fine to use usual mutexes everywhere!