### PR TITLE
`xnotify.cpp`: `SRWLOCK` to protect the at-thread-exit data instead of an indexed `CRITICAL_SECTION`

### DIFF
--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -309,10 +309,10 @@ _EMIT_STL_WARNING(STL4001, "/clr:pure is deprecated and will be REMOVED.");
 #endif
 #endif // !defined(_CRTDATA2_IMPORT)
 
-#define _LOCK_LOCALE         0
-#define _LOCK_MALLOC         1
-#define _LOCK_STREAM         2
-#define _LOCK_DEBUG          3
+#define _LOCK_LOCALE 0
+#define _LOCK_MALLOC 1
+#define _LOCK_STREAM 2
+#define _LOCK_DEBUG  3
 
 #ifndef _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B
 #if _STL_WIN32_WINNT >= _STL_WIN32_WINNT_WINBLUE && defined(_WIN64)

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -313,7 +313,6 @@ _EMIT_STL_WARNING(STL4001, "/clr:pure is deprecated and will be REMOVED.");
 #define _LOCK_MALLOC         1
 #define _LOCK_STREAM         2
 #define _LOCK_DEBUG          3
-#define _LOCK_AT_THREAD_EXIT 4
 
 #ifndef _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B
 #if _STL_WIN32_WINNT >= _STL_WIN32_WINNT_WINBLUE && defined(_WIN64)

--- a/stl/src/xlock.cpp
+++ b/stl/src/xlock.cpp
@@ -13,7 +13,7 @@
 
 _STD_BEGIN
 
-constexpr int _Max_lock = 8; // must be power of two
+constexpr int _Max_lock = 4; // must be power of two
 
 #pragma warning(disable : 4074)
 #pragma init_seg(compiler)
@@ -121,14 +121,4 @@ void __cdecl _Lockit::_Lockit_dtor(int kind) noexcept { // unlock the mutex
         _Mtxunlock(&mtx[kind & (_Max_lock - 1)]);
     }
 }
-
-extern "C" {
-void _Lock_at_thread_exit_mutex() noexcept { // lock the at-thread-exit mutex
-    _Mtxlock(&mtx[_LOCK_AT_THREAD_EXIT]);
-}
-void _Unlock_at_thread_exit_mutex() noexcept { // unlock the at-thread-exit mutex
-    _Mtxunlock(&mtx[_LOCK_AT_THREAD_EXIT]);
-}
-} // extern "C"
-
 _STD_END

--- a/stl/src/xlock.cpp
+++ b/stl/src/xlock.cpp
@@ -13,7 +13,7 @@
 
 _STD_BEGIN
 
-constexpr int _Max_lock = 4; // must be power of two
+constexpr int _Max_lock = 8; // must be power of two; TRANSITION, ABI: may be less now
 
 #pragma warning(disable : 4074)
 #pragma init_seg(compiler)


### PR DESCRIPTION
Towards #3521. Fixes #273.

After finally making mutex constructor and destructor constexpr, it is time that we start using usual mutexes!