### PR TITLE
<xutility>, <algorithm>: Add top level const on pointer parameters

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -141,7 +141,7 @@ auto __std_minmax(_Ty* const _First, _Ty* const _Last) noexcept {
 }
 
 template <class _Ty, class _TVal>
-_Ty* __std_find_last_trivial(_Ty* _First, _Ty* _Last, const _TVal _Val) noexcept {
+_Ty* __std_find_last_trivial(_Ty* const _First, _Ty* const _Last, const _TVal _Val) noexcept {
     if constexpr (_STD is_pointer_v<_TVal> || _STD is_null_pointer_v<_TVal>) {
         return _STD __std_find_last_trivial(_First, _Last, reinterpret_cast<uintptr_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 1) {

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -72,7 +72,7 @@ __declspec(noalias) _Min_max_d __stdcall __std_minmax_d(const void* _First, cons
 
 _STD_BEGIN
 template <class _Ty>
-_STD pair<_Ty*, _Ty*> __std_minmax_element(_Ty* _First, _Ty* _Last) noexcept {
+_STD pair<_Ty*, _Ty*> __std_minmax_element(_Ty* const _First, _Ty* const _Last) noexcept {
     constexpr bool _Signed = _STD is_signed_v<_Ty>;
 
     _Min_max_element_t _Res;

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -97,7 +97,7 @@ _STD pair<_Ty*, _Ty*> __std_minmax_element(_Ty* const _First, _Ty* const _Last) 
 }
 
 template <class _Ty>
-auto __std_minmax(_Ty* _First, _Ty* _Last) noexcept {
+auto __std_minmax(_Ty* const _First, _Ty* const _Last) noexcept {
     constexpr bool _Signed = _STD is_signed_v<_Ty>;
 
     if constexpr (_STD is_pointer_v<_Ty>) {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -133,7 +133,7 @@ __declspec(noalias) double __stdcall __std_max_d(const void* _First, const void*
 
 _STD_BEGIN
 template <class _Ty, class _TVal>
-__declspec(noalias) size_t __std_count_trivial(_Ty* _First, _Ty* _Last, const _TVal _Val) noexcept {
+__declspec(noalias) size_t __std_count_trivial(_Ty* const _First, _Ty* const _Last, const _TVal _Val) noexcept {
     if constexpr (_STD is_pointer_v<_TVal> || _STD is_null_pointer_v<_TVal>) {
         return _STD __std_count_trivial(_First, _Last, reinterpret_cast<uintptr_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 1) {
@@ -150,7 +150,7 @@ __declspec(noalias) size_t __std_count_trivial(_Ty* _First, _Ty* _Last, const _T
 }
 
 template <class _Ty, class _TVal>
-_Ty* __std_find_trivial(_Ty* _First, _Ty* _Last, const _TVal _Val) noexcept {
+_Ty* __std_find_trivial(_Ty* const _First, _Ty* const _Last, const _TVal _Val) noexcept {
     if constexpr (_STD is_pointer_v<_TVal> || _STD is_null_pointer_v<_TVal>) {
         return _STD __std_find_trivial(_First, _Last, reinterpret_cast<uintptr_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 1) {
@@ -192,7 +192,7 @@ _Ty* __std_find_trivial_unsized(_Ty* const _First, const _TVal _Val) noexcept {
 }
 
 template <class _Ty>
-_Ty* __std_min_element(_Ty* _First, _Ty* _Last) noexcept {
+_Ty* __std_min_element(_Ty* const _First, _Ty* const _Last) noexcept {
     constexpr bool _Signed = _STD is_signed_v<_Ty>;
 
     if constexpr (_STD is_same_v<_STD remove_const_t<_Ty>, float>) {
@@ -213,7 +213,7 @@ _Ty* __std_min_element(_Ty* _First, _Ty* _Last) noexcept {
 }
 
 template <class _Ty>
-_Ty* __std_max_element(_Ty* _First, _Ty* _Last) noexcept {
+_Ty* __std_max_element(_Ty* const _First, _Ty* const _Last) noexcept {
     constexpr bool _Signed = _STD is_signed_v<_Ty>;
 
     if constexpr (_STD is_same_v<_STD remove_const_t<_Ty>, float>) {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -234,7 +234,7 @@ _Ty* __std_max_element(_Ty* _First, _Ty* _Last) noexcept {
 }
 
 template <class _Ty>
-auto __std_min(_Ty* _First, _Ty* _Last) noexcept {
+auto __std_min(_Ty* const _First, _Ty* const _Last) noexcept {
     constexpr bool _Signed = _STD is_signed_v<_Ty>;
 
     if constexpr (_STD is_pointer_v<_Ty>) {
@@ -277,7 +277,7 @@ auto __std_min(_Ty* _First, _Ty* _Last) noexcept {
 }
 
 template <class _Ty>
-auto __std_max(_Ty* _First, _Ty* _Last) noexcept {
+auto __std_max(_Ty* const _First, _Ty* const _Last) noexcept {
     constexpr bool _Signed = _STD is_signed_v<_Ty>;
 
     if constexpr (_STD is_pointer_v<_Ty>) {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -171,7 +171,7 @@ _Ty* __std_find_trivial(_Ty* _First, _Ty* _Last, const _TVal _Val) noexcept {
 }
 
 template <class _Ty, class _TVal>
-_Ty* __std_find_trivial_unsized(_Ty* _First, const _TVal _Val) noexcept {
+_Ty* __std_find_trivial_unsized(_Ty* const _First, const _TVal _Val) noexcept {
     if constexpr (_STD is_pointer_v<_TVal> || _STD is_null_pointer_v<_TVal>) {
         return _STD __std_find_trivial_unsized(_First, reinterpret_cast<uintptr_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 1) {


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
Closes #4385 

This PR adds the top-level `const` to the `_Ty* _First, _Ty* _Last ` parameters for the following functions
`<algorithm>` : `__std_minmax_element`, `__std_minmax`
`<xutility>`: `__std_find_trivial_unsized`, `__std_min`, `__std_max`