### PR TITLE
Modules workaround for `views::pairwise_transform`

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -8971,6 +8971,7 @@ namespace ranges {
     concept _Regular_invocable_with_repeated_type =
         _Regular_invocable_with_repeated_type_impl<_Fn, _Ty, make_index_sequence<_Nx>>;
 
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1975579
     template <class _Fn, class _Ty, class _Indices>
     struct _Invoke_result_with_repeated_type_impl;
 
@@ -8982,6 +8983,19 @@ namespace ranges {
     template <class _Fn, class _Ty, size_t _Nx>
     using _Invoke_result_with_repeated_type =
         _Invoke_result_with_repeated_type_impl<_Fn, _Ty, make_index_sequence<_Nx>>::type;
+#else // ^^^ no workaround / workaround vvv
+    template <class _Fn, class _Ty, size_t _Nx, class... _Types>
+    struct _Invoke_result_with_repeated_type_impl
+        : _Invoke_result_with_repeated_type_impl<_Fn, _Ty, _Nx - 1, _Ty, _Types...> {};
+
+    template <class _Fn, class _Ty, class... _Types>
+    struct _Invoke_result_with_repeated_type_impl<_Fn, _Ty, 0, _Types...> {
+        using type = invoke_result_t<_Fn, _Types...>;
+    };
+
+    template <class _Fn, class _Ty, size_t _Nx>
+    using _Invoke_result_with_repeated_type = _Invoke_result_with_repeated_type_impl<_Fn, _Ty, _Nx>::type;
+#endif // ^^^ workaround ^^^
 
     template <class _Vw, class _Fn, size_t _Nx>
     concept _Adjacent_transform_constraints =

--- a/tests/std/include/test_header_units_and_modules.hpp
+++ b/tests/std/include/test_header_units_and_modules.hpp
@@ -596,9 +596,29 @@ void test_random() {
 void test_ranges() {
     using namespace std;
     puts("Testing <ranges>.");
-    constexpr int arr[]{11, 0, 22, 0, 33, 0, 44, 0, 55};
-    assert(ranges::distance(views::filter(arr, [](int x) { return x == 0; })) == 4);
-    static_assert(ranges::distance(views::filter(arr, [](int x) { return x != 0; })) == 5);
+
+    {
+        constexpr int arr[]{11, 0, 22, 0, 33, 0, 44, 0, 55};
+        assert(ranges::distance(views::filter(arr, [](int x) { return x == 0; })) == 4);
+        static_assert(ranges::distance(views::filter(arr, [](int x) { return x != 0; })) == 5);
+    }
+
+#if TEST_STANDARD >= 23
+    // Also test GH-4404 "unrecoverable error importing module 'std' with std::ranges::views::pairwise_transform"
+    {
+        constexpr array arr{10, 2, 30, 4, 50};
+
+        constexpr auto pairwise_plus = views::pairwise_transform(plus{});
+        const auto vec2              = ranges::to<vector>(arr | pairwise_plus);
+        const vector correct2{12, 32, 34, 54};
+        assert(vec2 == correct2);
+
+        constexpr auto triplewise_plus = views::adjacent_transform<3>([](int x, int y, int z) { return x + y + z; });
+        const auto vec3                = ranges::to<vector>(arr | triplewise_plus);
+        const vector correct3{42, 36, 84};
+        assert(vec3 == correct3);
+    }
+#endif // TEST_STANDARD >= 23
 }
 
 void test_ratio() {


### PR DESCRIPTION
Fixes #4404 by working around VSO-1975579 "Standard Library Modules: fatal error C1116: unrecoverable error importing module `'std'`. Specialization of `'std::invoke_result_t'` with arguments `'_Fn, _Ty...'`".

I don't trust the behavior of pack expansions here until @cdacamar fixes the compiler, so I've chosen to use a classical countdown for the workaround.

I checked our other usage of `_Repeat_type` and it didn't appear to be affected, presumably because it doesn't involve `invoke_result_t`.