### PR TITLE
Fix the incorrect width that occurred when formatting a floating number in the locale specific form

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -3111,6 +3111,7 @@ _NODISCARD _OutputIt _Fmt_write(
             if (_Specs._Localized) {
                 _Groups     = _STD use_facet<numpunct<_CharT>>(_Locale._Get()).grouping();
                 _Separators = _Count_separators(static_cast<size_t>(_Integral_end - _Buffer_start), _Groups);
+                _Width += _Separators;
             }
         }
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -568,10 +568,6 @@ std/input.output/string.streams/stringbuf/stringbuf.members/view.pass.cpp FAIL
 std/input.output/syncstream/syncbuf/syncstream.syncbuf.cons/dtor.pass.cpp FAIL
 std/input.output/syncstream/syncbuf/syncstream.syncbuf.members/emit.pass.cpp FAIL
 
-# GH-4316: <format>: The width of output is miscalculated when formatting a floating-point number in the locale-specific form
-std/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/locale-specific_form.pass.cpp FAIL
-std/utilities/format/format.functions/locale-specific_form.pass.cpp FAIL
-
 
 # *** VCRUNTIME BUGS ***
 # DevCom-10373274 VSO-1824997 "vcruntime nothrow array operator new falls back on the wrong function"

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1506,6 +1506,8 @@ constexpr bool test_format_string() {
     return true;
 }
 
+// Also test GH-4316 <format>: The width of output is miscalculated
+// when formatting a floating-point number in the locale-specific form
 template <class charT>
 void test_gh_4316() {
     assert(format(locale{"en-US"}, STR("{:@>8L}"), 12345) == STR("@@12,345"));

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1506,6 +1506,12 @@ constexpr bool test_format_string() {
     return true;
 }
 
+template <class charT>
+void test_gh_4316() {
+    assert(format(locale{"en-US"}, STR("{:@>8L}"), 12345) == STR("@@12,345"));
+    assert(format(locale{"en-US"}, STR("{:@>8L}"), 12345.0) == STR("@@12,345"));
+}
+
 // Also test GH-4319: incorrect output for some floating-point values
 template <class charT>
 void test_gh_4319() {
@@ -1588,6 +1594,11 @@ void test() {
     test_localized_char<char, char>();
     test_localized_char<wchar_t, char>();
     test_localized_char<wchar_t, wchar_t>();
+
+#if !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
+    test_gh_4316<char>();
+    test_gh_4316<wchar_t>();
+#endif // !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
 
     test_gh_4319<char>();
     test_gh_4319<wchar_t>();


### PR DESCRIPTION
Fixes #4316 