### PR TITLE
Silence warning C4324: structure was padded due to alignment specifier

### DIFF
--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -542,8 +542,6 @@ struct alignas(_Ty) alignas(size_t) alignas(_Atomic_counter_t) _Circular_buffer 
     }
 };
 
-#pragma warning(push)
-#pragma warning(disable : 4324) // structure was padded due to alignment specifier
 template <class _Ty>
 class alignas(hardware_destructive_interference_size) _Work_stealing_deque {
     // thread-local work-stealing deque, which allows efficient access from a single owner thread at the "bottom"
@@ -657,7 +655,6 @@ private:
     _Guarded_by_(_Segment_lock) _Circular_buffer<_Ty>* _Segment{_Circular_buffer<_Ty>::_New_circular_buffer()};
     mutex _Segment_lock{};
 };
-#pragma warning(pop)
 
 enum class _Steal_result { _Success, _Abort, _Done };
 
@@ -2495,13 +2492,10 @@ struct _Static_partitioned_remove_if2 {
         // may transition from _Serial directly to _Done, doing the moving step implicitly.
     };
 
-#pragma warning(push)
-#pragma warning(disable : 4324) // structure was padded due to alignment specifier
     struct alignas(hardware_destructive_interference_size) alignas(_FwdIt) _Chunk_local_data {
         atomic<_Chunk_state> _State;
         _FwdIt _New_end;
     };
-#pragma warning(pop)
 
     _Static_partition_team<_Iter_diff_t<_FwdIt>> _Team;
     _Static_partition_range<_FwdIt> _Basis;
@@ -3457,14 +3451,11 @@ struct _Static_partitioned_partition2 {
         _Done // when a chunk becomes _Done, it is complete / will never need to touch _Results again
     };
 
-#pragma warning(push)
-#pragma warning(disable : 4324) // structure was padded due to alignment specifier
     struct alignas(hardware_destructive_interference_size) alignas(_FwdIt) _Chunk_local_data {
         atomic<_Chunk_state> _State;
         _FwdIt _Beginning_of_falses;
         _Diff _Chunk_trues;
     };
-#pragma warning(pop)
 
     _Static_partition_team<_Diff> _Team;
     _Static_partition_range<_FwdIt> _Basis;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3862,10 +3862,6 @@ namespace ranges {
         constexpr explicit _Subrange_base(const _Size_type& _Size_) noexcept : _Size(_Size_) {}
     };
 
-#if 1 // TRANSITION, VSO-1695918 - Warning C4324 incorrectly firing in the presence of `pragma pack`
-#pragma warning(push)
-#pragma warning(disable : 4324) // structure was padded due to alignment specifier
-#endif // ^^^ workaround ^^^
     _EXPORT_STD template <input_or_output_iterator _It, sentinel_for<_It> _Se, subrange_kind _Ki>
         requires (_Ki == subrange_kind::sized || !sized_sentinel_for<_Se, _It>)
     class subrange : public _Subrange_base<_It, _Se, _Ki> {
@@ -4029,9 +4025,6 @@ namespace ranges {
             return *this;
         }
     };
-#if 1 // TRANSITION, VSO-1695918 - Warning C4324 incorrectly firing in the presence of `pragma pack`
-#pragma warning(pop)
-#endif // ^^^ workaround ^^^
 
     template <input_or_output_iterator _It, sentinel_for<_It> _Se>
     subrange(_It, _Se) -> subrange<_It, _Se>;

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -780,6 +780,7 @@
 #endif // !defined(_STL_EXTRA_DISABLED_WARNINGS)
 
 // warning C4180: qualifier applied to function type has no meaning; ignored
+// warning C4324: structure was padded due to alignment specifier
 // warning C4412: function signature contains type 'meow'; C++ objects are unsafe to pass between pure code
 //                and mixed or native. (/Wall)
 // warning C4455: literal suffix identifiers that do not start with an underscore are reserved
@@ -811,9 +812,9 @@
 #ifndef _STL_DISABLED_WARNINGS
 // clang-format off
 #define _STL_DISABLED_WARNINGS                        \
-    4180 4412 4455 4494 4514 4574 4582 4583 4587 4588 \
-    4619 4623 4625 4626 4643 4648 4702 4793 4820 4868 \
-    4988 5026 5027 5045 5220 6294                     \
+    4180 4324 4412 4455 4494 4514 4574 4582 4583 4587 \
+    4588 4619 4623 4625 4626 4643 4648 4702 4793 4820 \
+    4868 4988 5026 5027 5045 5220 6294                \
     _STL_DISABLED_WARNING_C4577                       \
     _STL_DISABLED_WARNING_C4984                       \
     _STL_DISABLED_WARNING_C5053                       \

--- a/tests/std/tests/P2374R4_views_cartesian_product/test.cpp
+++ b/tests/std/tests/P2374R4_views_cartesian_product/test.cpp
@@ -934,6 +934,20 @@ constexpr void test_gh_3733() {
     assert(as_const(cart).size() == 0);
 }
 
+// GH-4425 <ranges>: views::cartesian_product and views::filter emit
+// spurious warning C4324 'structure was padded due to alignment specifier'
+constexpr void test_gh_4425() {
+    const vector<int> vec{11, 22, 33, 44};
+
+    const auto strictly_ascending = [](const auto& t) { return get<0>(t) < get<1>(t); };
+
+    const auto result = ranges::to<vector>(views::cartesian_product(vec, vec) | views::filter(strictly_ascending));
+
+    const vector<tuple<int, int>> correct{{11, 22}, {11, 33}, {11, 44}, {22, 33}, {22, 44}, {33, 44}};
+
+    assert(result == correct);
+}
+
 int main() {
     // Check views
 #ifndef __EDG__ // TRANSITION, VSO-1900293
@@ -997,4 +1011,7 @@ int main() {
 
     STATIC_ASSERT((test_gh_3733(), true));
     test_gh_3733();
+
+    STATIC_ASSERT((test_gh_4425(), true));
+    test_gh_4425();
 }


### PR DESCRIPTION
Fixes #4425.

This globally silences the warning because I don't think it's ever useful for the STL to emit it. If the user gives us a highly-aligned type, and we have to build another type with it, warning about padding is unlikely to be productive - presumably they had reasons for making their type highly-aligned, and it's not like they can change the layout of our type. (Yeah, in theory maybe they could request a different order of `tuple` elements or something, but most of the time it's not going to be actionable.) And if the warning is emitted purely from STL code, as in my test case, it's extremely annoying. Finally, this is just a performance warning - it has no impact on correctness.