### PR TITLE
Mirror internal MSBuild changes

### DIFF
--- a/stl/msbuild/stl_1/md/msvcp_1_app/msvcp_1.vcxproj
+++ b/stl/msbuild/stl_1/md/msvcp_1_app/msvcp_1.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{AC581714-5C34-43F1-88AA-F239723F751F}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_1/md/msvcp_1_kernel32/msvcp_1.vcxproj
+++ b/stl/msbuild/stl_1/md/msvcp_1_kernel32/msvcp_1.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{58C30DB7-35C9-432D-8490-66F6E5901B8F}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_1/md/msvcp_1_netfx/msvcp_1.vcxproj
+++ b/stl/msbuild/stl_1/md/msvcp_1_netfx/msvcp_1.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CAA5F16A-A6C1-4450-981D-E3BF0F0A7B5B}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_1/md/msvcp_1_onecore/msvcp_1.vcxproj
+++ b/stl/msbuild/stl_1/md/msvcp_1_onecore/msvcp_1.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{2BD1256B-3615-4061-AD30-4F5E1E092381}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_1/msvcp_1.settings.targets
+++ b/stl/msbuild/stl_1/msvcp_1.settings.targets
@@ -60,7 +60,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
             <DestFolder2>$(IntermediateOutputDirectory)</DestFolder2>
             <DestFile>$(DllDefName)</DestFile>
         </DefFromI>
-        <RCResourceFile Include="$(MSBuildThisFileDirectory)\msvcprt_1.rc"/>
+        <ResourceCompile Include="$(MSBuildThisFileDirectory)\msvcprt_1.rc"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/stl/msbuild/stl_1/xmd/msvcp_1_app/msvcp_1.vcxproj
+++ b/stl/msbuild/stl_1/xmd/msvcp_1_app/msvcp_1.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{E30D9740-AD72-4A90-B8A9-A1CABCC52EB9}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_1/xmd/msvcp_1_kernel32/msvcp_1.vcxproj
+++ b/stl/msbuild/stl_1/xmd/msvcp_1_kernel32/msvcp_1.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A90AB3DB-494B-4ECD-AEFB-E880F9C58F74}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_1/xmd/msvcp_1_netfx/msvcp_1.vcxproj
+++ b/stl/msbuild/stl_1/xmd/msvcp_1_netfx/msvcp_1.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B37B087A-D591-472E-8E73-396CD32F5E77}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_1/xmd/msvcp_1_onecore/msvcp_1.vcxproj
+++ b/stl/msbuild/stl_1/xmd/msvcp_1_onecore/msvcp_1.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{6E55B52D-472B-4A51-AC94-B1E391ECAAD7}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_2/md/msvcp_2_app/msvcp_2.vcxproj
+++ b/stl/msbuild/stl_2/md/msvcp_2_app/msvcp_2.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{451BB540-FBE3-4BFC-B3FC-1D118E6D44ED}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_2/md/msvcp_2_kernel32/msvcp_2.vcxproj
+++ b/stl/msbuild/stl_2/md/msvcp_2_kernel32/msvcp_2.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{219EFF3E-A40D-46E4-86DC-887AF90330CA}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_2/md/msvcp_2_netfx/msvcp_2.vcxproj
+++ b/stl/msbuild/stl_2/md/msvcp_2_netfx/msvcp_2.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{DEC67AC5-1EF2-4745-BAFF-28484A23477E}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_2/md/msvcp_2_onecore/msvcp_2.vcxproj
+++ b/stl/msbuild/stl_2/md/msvcp_2_onecore/msvcp_2.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{24C78BD7-AED7-4090-BE81-8E3247ECC5A3}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_2/msvcp_2.settings.targets
+++ b/stl/msbuild/stl_2/msvcp_2.settings.targets
@@ -60,7 +60,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
             <DestFolder2>$(IntermediateOutputDirectory)</DestFolder2>
             <DestFile>$(DllDefName)</DestFile>
         </DefFromI>
-        <RCResourceFile Include="$(MSBuildThisFileDirectory)\msvcprt_2.rc"/>
+        <ResourceCompile Include="$(MSBuildThisFileDirectory)\msvcprt_2.rc"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/stl/msbuild/stl_2/xmd/msvcp_2_app/msvcp_2.vcxproj
+++ b/stl/msbuild/stl_2/xmd/msvcp_2_app/msvcp_2.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{EFC70BD7-F82E-4951-8F60-468B164BF419}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_2/xmd/msvcp_2_kernel32/msvcp_2.vcxproj
+++ b/stl/msbuild/stl_2/xmd/msvcp_2_kernel32/msvcp_2.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3CFB766B-CCA6-4078-9A03-CAE24FF65373}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_2/xmd/msvcp_2_netfx/msvcp_2.vcxproj
+++ b/stl/msbuild/stl_2/xmd/msvcp_2_netfx/msvcp_2.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4A10E59B-BC11-478F-A911-4985F503B489}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_2/xmd/msvcp_2_onecore/msvcp_2.vcxproj
+++ b/stl/msbuild/stl_2/xmd/msvcp_2_onecore/msvcp_2.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4897703D-D42F-4CF6-B4C1-B7CFD3D9F054}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_asan/stl_asan.vcxproj
+++ b/stl/msbuild/stl_asan/stl_asan.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B8236181-0F0C-465B-8729-36944CBF324A}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_atomic_wait/md/msvcp_atomic_wait_app/msvcp_atomic_wait.vcxproj
+++ b/stl/msbuild/stl_atomic_wait/md/msvcp_atomic_wait_app/msvcp_atomic_wait.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{99C61FE5-793F-4D49-82F6-27938575B058}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_atomic_wait/md/msvcp_atomic_wait_kernel32/msvcp_atomic_wait.vcxproj
+++ b/stl/msbuild/stl_atomic_wait/md/msvcp_atomic_wait_kernel32/msvcp_atomic_wait.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{2C785D3F-9961-46E9-A202-D410DAD6269D}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_atomic_wait/md/msvcp_atomic_wait_netfx/msvcp_atomic_wait.vcxproj
+++ b/stl/msbuild/stl_atomic_wait/md/msvcp_atomic_wait_netfx/msvcp_atomic_wait.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B0D8709C-8649-43DF-AB53-AA05134A9B83}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_atomic_wait/md/msvcp_atomic_wait_onecore/msvcp_atomic_wait.vcxproj
+++ b/stl/msbuild/stl_atomic_wait/md/msvcp_atomic_wait_onecore/msvcp_atomic_wait.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{22F86914-609E-4BF5-A1DA-2804C1251044}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_atomic_wait/msvcp_atomic_wait.settings.targets
+++ b/stl/msbuild/stl_atomic_wait/msvcp_atomic_wait.settings.targets
@@ -60,7 +60,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
             <DestFolder2>$(IntermediateOutputDirectory)</DestFolder2>
             <DestFile>$(DllDefName)</DestFile>
         </DefFromI>
-        <RCResourceFile Include="$(MSBuildThisFileDirectory)\msvcprt_atomic_wait.rc"/>
+        <ResourceCompile Include="$(MSBuildThisFileDirectory)\msvcprt_atomic_wait.rc"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/stl/msbuild/stl_atomic_wait/xmd/msvcp_atomic_wait_app/msvcp_atomic_wait.vcxproj
+++ b/stl/msbuild/stl_atomic_wait/xmd/msvcp_atomic_wait_app/msvcp_atomic_wait.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3AEA1ADF-5AA1-4BAB-B0AA-104B622C75B5}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_atomic_wait/xmd/msvcp_atomic_wait_kernel32/msvcp_atomic_wait.vcxproj
+++ b/stl/msbuild/stl_atomic_wait/xmd/msvcp_atomic_wait_kernel32/msvcp_atomic_wait.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D771D7D3-3021-4CBE-A966-68CD817D0C04}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_atomic_wait/xmd/msvcp_atomic_wait_netfx/msvcp_atomic_wait.vcxproj
+++ b/stl/msbuild/stl_atomic_wait/xmd/msvcp_atomic_wait_netfx/msvcp_atomic_wait.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{31EE7F7B-CF43-489D-8419-EDB8F2C152EE}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_atomic_wait/xmd/msvcp_atomic_wait_onecore/msvcp_atomic_wait.vcxproj
+++ b/stl/msbuild/stl_atomic_wait/xmd/msvcp_atomic_wait_onecore/msvcp_atomic_wait.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{57A6A807-C9DC-4ADF-8128-3589FCDAA2E4}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_base/md/msvcp_app/msvcp.vcxproj
+++ b/stl/msbuild/stl_base/md/msvcp_app/msvcp.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{26CFD97A-BD12-4347-ACEA-3B13904E59DA}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_base/md/msvcp_kernel32/msvcp.vcxproj
+++ b/stl/msbuild/stl_base/md/msvcp_kernel32/msvcp.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{00EE32E2-A705-4D07-A967-60092E13F497}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_base/md/msvcp_netfx/msvcp.vcxproj
+++ b/stl/msbuild/stl_base/md/msvcp_netfx/msvcp.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{98CE2EB2-F428-4C28-9186-8D614658A1BE}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_base/md/msvcp_onecore/msvcp.vcxproj
+++ b/stl/msbuild/stl_base/md/msvcp_onecore/msvcp.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3318F9FE-FD4A-4D16-82F6-7DBC8007D1B6}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_base/msvcp.settings.targets
+++ b/stl/msbuild/stl_base/msvcp.settings.targets
@@ -64,7 +64,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
             <DestFolder2>$(IntermediateOutputDirectory)</DestFolder2>
             <DestFile>$(DllDefName)</DestFile>
         </DefFromI>
-        <RCResourceFile Include="$(CrtRoot)\crtw32\msvcprt.rc"/>
+        <ResourceCompile Include="$(CrtRoot)\crtw32\msvcprt.rc"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/stl/msbuild/stl_base/mt/libcpmt_kernel32/libcpmt.vcxproj
+++ b/stl/msbuild/stl_base/mt/libcpmt_kernel32/libcpmt.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B56C39F9-89BF-486F-9C5E-B88FD82E2AA7}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_base/mt/libcpmt_onecore/libcpmt.vcxproj
+++ b/stl/msbuild/stl_base/mt/libcpmt_onecore/libcpmt.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{5F515BBF-E680-4553-B38E-0C125D2A6455}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_base/mt1/libcpmt_kernel32/libcpmt.vcxproj
+++ b/stl/msbuild/stl_base/mt1/libcpmt_kernel32/libcpmt.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{027B5024-5996-4645-BC46-8FEF2E2A4E71}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_base/mt1/libcpmt_onecore/libcpmt.vcxproj
+++ b/stl/msbuild/stl_base/mt1/libcpmt_onecore/libcpmt.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{0824A200-D996-41C0-87D8-62CF1D7483C6}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_base/stl.files.settings.targets
+++ b/stl/msbuild/stl_base/stl.files.settings.targets
@@ -16,9 +16,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
             $(CrtRoot)\github\stl\src\tzdb.cpp;
             $(CrtRoot)\github\stl\src\ulocale.cpp;
             ">
-            <IncludeInLink>false</IncludeInLink>
-            <IncludeInLib>true</IncludeInLib>
-            <IncludeInImportLib>false</IncludeInImportLib>
+            <LinkCompiled>false</LinkCompiled>
+            <LibCompiled>true</LibCompiled>
+            <ImpLibCompiled>false</ImpLibCompiled>
         </ClCompile>
 
         <ClCompile Include="$(CrtRoot)\github\stl\src\excptptr.cpp;">
@@ -149,7 +149,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         </ClCompile>
 
         <!-- Objs that exist in both libcpmt[d][01].lib and msvcprt[d].lib
-             (controlled by IncludeInLink and IncludeInImportLib). -->
+             (controlled by ExtraImpLibCompiled). -->
         <ClCompile Include="
             $(CrtRoot)\github\stl\src\asan_noop.cpp;
             $(CrtRoot)\github\stl\src\charconv.cpp;
@@ -167,22 +167,20 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
             $(CrtRoot)\github\stl\src\xcharconv_tables_float.cpp;
             $(CrtRoot)\github\stl\src\xonce2.cpp;
             ">
-            <IncludeInLink>false</IncludeInLink>
-            <IncludeInImportLib>true</IncludeInImportLib>
+            <ExtraImpLibCompiled>true</ExtraImpLibCompiled>
             <PreprocessorDefinitions>$(ClDefines);_ENFORCE_ONLY_CORE_HEADERS</PreprocessorDefinitions>
         </ClCompile>
     </ItemGroup>
 
     <ItemGroup Condition="'$(BuildArchitecture)' == 'i386' or '$(BuildArchitecture)' == 'amd64'">
         <!-- Objs that exist in both libcpmt[d][01].lib and msvcprt[d].lib
-             (controlled by IncludeInLink and IncludeInImportLib). -->
+             (controlled by ExtraImpLibCompiled). -->
         <BuildFiles Include="
             $(CrtRoot)\github\stl\src\alias_init_once_begin_initialize.asm;
             $(CrtRoot)\github\stl\src\alias_init_once_complete.asm;
             ">
             <BuildAs>asm</BuildAs>
-            <IncludeInLink>false</IncludeInLink>
-            <IncludeInImportLib>true</IncludeInImportLib>
+            <ExtraImpLibCompiled>true</ExtraImpLibCompiled>
         </BuildFiles>
     </ItemGroup>
 

--- a/stl/msbuild/stl_base/xmd/msvcp_app/msvcp.vcxproj
+++ b/stl/msbuild/stl_base/xmd/msvcp_app/msvcp.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3DFFE995-1592-4D71-A088-65B5E90829E3}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_base/xmd/msvcp_kernel32/msvcp.vcxproj
+++ b/stl/msbuild/stl_base/xmd/msvcp_kernel32/msvcp.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{19B72B03-37A8-4ED7-85D9-26031335269E}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_base/xmd/msvcp_netfx/msvcp.vcxproj
+++ b/stl/msbuild/stl_base/xmd/msvcp_netfx/msvcp.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{9E0C069E-C345-4977-9753-16CEE50029D8}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_base/xmd/msvcp_onecore/msvcp.vcxproj
+++ b/stl/msbuild/stl_base/xmd/msvcp_onecore/msvcp.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{617D60ED-BAB2-45FA-8FAF-B0E7F9304403}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_base/xmt/libcpmt_kernel32/libcpmt.vcxproj
+++ b/stl/msbuild/stl_base/xmt/libcpmt_kernel32/libcpmt.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{ECA62467-8F67-4F70-953D-0916472878AA}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_base/xmt/libcpmt_onecore/libcpmt.vcxproj
+++ b/stl/msbuild/stl_base/xmt/libcpmt_onecore/libcpmt.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{02DA6861-AC66-4EA6-B558-9D0E0F1073A8}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_base/xmt0/libcpmt_kernel32/libcpmt.vcxproj
+++ b/stl/msbuild/stl_base/xmt0/libcpmt_kernel32/libcpmt.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C9715C5F-41D3-472B-AC8D-4E374105FD6B}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_base/xmt0/libcpmt_onecore/libcpmt.vcxproj
+++ b/stl/msbuild/stl_base/xmt0/libcpmt_onecore/libcpmt.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{5B4429AE-5436-4C16-A6D6-998D76182CF1}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_base/xmt1/libcpmt_kernel32/libcpmt.vcxproj
+++ b/stl/msbuild/stl_base/xmt1/libcpmt_kernel32/libcpmt.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C5C4581F-36C6-4327-BB54-6C1DFF52A60F}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_base/xmt1/libcpmt_onecore/libcpmt.vcxproj
+++ b/stl/msbuild/stl_base/xmt1/libcpmt_onecore/libcpmt.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4B156573-7D78-4FDA-B365-320A91AE8916}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_codecvt_ids/md/msvcp_codecvt_ids_app/msvcp_codecvt_ids.vcxproj
+++ b/stl/msbuild/stl_codecvt_ids/md/msvcp_codecvt_ids_app/msvcp_codecvt_ids.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CD1E3105-704A-4D91-B49A-4D6E96546ED5}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_codecvt_ids/md/msvcp_codecvt_ids_kernel32/msvcp_codecvt_ids.vcxproj
+++ b/stl/msbuild/stl_codecvt_ids/md/msvcp_codecvt_ids_kernel32/msvcp_codecvt_ids.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{ED7C0741-B3D2-4EAD-AA7E-BDF1B0948ECC}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_codecvt_ids/md/msvcp_codecvt_ids_netfx/msvcp_codecvt_ids.vcxproj
+++ b/stl/msbuild/stl_codecvt_ids/md/msvcp_codecvt_ids_netfx/msvcp_codecvt_ids.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{5F6F2FF5-EFED-4CF7-8F44-810DB15F32CD}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_codecvt_ids/md/msvcp_codecvt_ids_onecore/msvcp_codecvt_ids.vcxproj
+++ b/stl/msbuild/stl_codecvt_ids/md/msvcp_codecvt_ids_onecore/msvcp_codecvt_ids.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{32352E48-0D6E-4BCA-935A-76DAFDD4239D}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_codecvt_ids/msvcp_codecvt_ids.settings.targets
+++ b/stl/msbuild/stl_codecvt_ids/msvcp_codecvt_ids.settings.targets
@@ -60,7 +60,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
             <DestFolder2>$(IntermediateOutputDirectory)</DestFolder2>
             <DestFile>$(DllDefName)</DestFile>
         </DefFromI>
-        <RCResourceFile Include="$(MSBuildThisFileDirectory)\msvcprt_codecvt_ids.rc"/>
+        <ResourceCompile Include="$(MSBuildThisFileDirectory)\msvcprt_codecvt_ids.rc"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/stl/msbuild/stl_codecvt_ids/xmd/msvcp_codecvt_ids_app/msvcp_codecvt_ids.vcxproj
+++ b/stl/msbuild/stl_codecvt_ids/xmd/msvcp_codecvt_ids_app/msvcp_codecvt_ids.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{53AB0179-49FF-4620-9D42-45BD8ED71EA8}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_codecvt_ids/xmd/msvcp_codecvt_ids_kernel32/msvcp_codecvt_ids.vcxproj
+++ b/stl/msbuild/stl_codecvt_ids/xmd/msvcp_codecvt_ids_kernel32/msvcp_codecvt_ids.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{9D9D5B21-5342-4726-AA4F-ACDF4D028F28}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_codecvt_ids/xmd/msvcp_codecvt_ids_netfx/msvcp_codecvt_ids.vcxproj
+++ b/stl/msbuild/stl_codecvt_ids/xmd/msvcp_codecvt_ids_netfx/msvcp_codecvt_ids.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D561DC89-A909-478B-8566-41640F9F5B53}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_codecvt_ids/xmd/msvcp_codecvt_ids_onecore/msvcp_codecvt_ids.vcxproj
+++ b/stl/msbuild/stl_codecvt_ids/xmd/msvcp_codecvt_ids_onecore/msvcp_codecvt_ids.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{10C04DBD-4EB2-4590-BC8D-25DBA780905C}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_post/md/msvcp_post_app/msvcp_post.vcxproj
+++ b/stl/msbuild/stl_post/md/msvcp_post_app/msvcp_post.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{0E89DF6E-E7BA-44A1-841E-E6310F470211}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_post/md/msvcp_post_kernel32/msvcp_post.vcxproj
+++ b/stl/msbuild/stl_post/md/msvcp_post_kernel32/msvcp_post.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4BC58285-8BF8-4362-BE62-38CCBB34EA57}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_post/md/msvcp_post_netcore/msvcp_post.vcxproj
+++ b/stl/msbuild/stl_post/md/msvcp_post_netcore/msvcp_post.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{F6BF440E-AA43-48D1-A7BF-53ED43ED2C6F}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_post/md/msvcp_post_netfx/msvcp_post.vcxproj
+++ b/stl/msbuild/stl_post/md/msvcp_post_netfx/msvcp_post.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{9EAC2409-0DE5-465D-BEB2-08DD9221CDC7}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_post/md/msvcp_post_onecore/msvcp_post.vcxproj
+++ b/stl/msbuild/stl_post/md/msvcp_post_onecore/msvcp_post.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{8A1D8A23-DBBA-4356-816E-344F7956D497}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_post/xmd/msvcp_post_app/msvcp_post.vcxproj
+++ b/stl/msbuild/stl_post/xmd/msvcp_post_app/msvcp_post.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{687A5106-D6CE-4BC4-8BA1-27D84F895FF5}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_post/xmd/msvcp_post_kernel32/msvcp_post.vcxproj
+++ b/stl/msbuild/stl_post/xmd/msvcp_post_kernel32/msvcp_post.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{13998FA0-CBA7-4303-9212-879E17F69D53}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_post/xmd/msvcp_post_netcore/msvcp_post.vcxproj
+++ b/stl/msbuild/stl_post/xmd/msvcp_post_netcore/msvcp_post.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{EC379541-9453-4884-9250-3CDBA73E2C10}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_post/xmd/msvcp_post_netfx/msvcp_post.vcxproj
+++ b/stl/msbuild/stl_post/xmd/msvcp_post_netfx/msvcp_post.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{9FAAE4A7-D6CE-48C8-8B80-6EA96F508545}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>

--- a/stl/msbuild/stl_post/xmd/msvcp_post_onecore/msvcp_post.vcxproj
+++ b/stl/msbuild/stl_post/xmd/msvcp_post_onecore/msvcp_post.vcxproj
@@ -6,7 +6,6 @@
   -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{8DA22F7E-CE13-4885-AD01-D97B180E815C}</ProjectGuid>
-    <UseRetailTargets>true</UseRetailTargets>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Cpp.Default.props))" />
   <PropertyGroup>


### PR DESCRIPTION
This mirrors @d-winsor's internal MSVC-PR-522185 "Cleanup old DevDiv targets" which merged into `prod/be`. The changes are limited to `stl/msbuild` so we can easily tolerate this temporary divergence. (I verified that GitHub is currently binary-identical to `prod/fe`.)