### PR TITLE
ADL-proof implementation of `function`, `move_only_function`, `packaged_task`, `promise`, and `optional`

### DIFF
--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -824,6 +824,22 @@ private:
 };
 #endif // _HAS_FUNCTION_ALLOCATOR_SUPPORT
 
+template <class _Ty, class... _Types>
+_Ty* _Global_new(_Types&&... _Args) { // acts as "new" while disallowing user overload selection
+    struct _NODISCARD _Guard_type {
+        void* _Result;
+        ~_Guard_type() {
+            if (_Result) {
+                _STD _Deallocate<_New_alignof<_Ty>>(_Result, sizeof(_Ty));
+            }
+        }
+    };
+
+    _Guard_type _Guard{_Allocate<_New_alignof<_Ty>>(sizeof(_Ty))};
+    ::new (_Guard._Result) _Ty(_STD forward<_Types>(_Args)...);
+    return static_cast<_Ty*>(_STD exchange(_Guard._Result, nullptr));
+}
+
 template <class _Callable, class _Rx, class... _Types>
 class _Func_impl_no_alloc final : public _Func_base<_Rx, _Types...> {
     // derived class for specific implementation types that don't use allocators

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -771,11 +771,11 @@ private:
             _Myalty _Rebound(_Myax);
             _Alloc_construct_ptr<_Myalty> _Constructor{_Rebound};
             _Constructor._Allocate();
-            _Construct_in_place(*_Constructor._Ptr, _Mypair._Myval2, _Myax);
+            _STD _Construct_in_place(*_Constructor._Ptr, _Mypair._Myval2, _Myax);
             return _Constructor._Release();
         } else {
             const auto _Ptr = static_cast<_Func_impl*>(_Where);
-            _Construct_in_place(*_Ptr, _Mypair._Myval2, _Myax);
+            _STD _Construct_in_place(*_Ptr, _Mypair._Myval2, _Myax);
             return _Ptr;
         }
     }
@@ -785,7 +785,7 @@ private:
             return nullptr;
         } else {
             const auto _Ptr = static_cast<_Func_impl*>(_Where);
-            _Construct_in_place(*_Ptr, _STD move(_Mypair._Myval2), _STD move(_Mypair._Get_first()));
+            _STD _Construct_in_place(*_Ptr, _STD move(_Mypair._Myval2), _STD move(_Mypair._Get_first()));
             return _Ptr;
         }
     }
@@ -814,9 +814,9 @@ private:
 
     void _Delete_this(bool _Deallocate) noexcept override { // destroy self
         _Myalty _Al(_Mypair._Get_first());
-        _Destroy_in_place(*this);
+        _STD _Destroy_in_place(*this);
         if (_Deallocate) {
-            _Deallocate_plain(_Al, this);
+            _STD _Deallocate_plain(_Al, this);
         }
     }
 
@@ -839,7 +839,7 @@ public:
 private:
     _Mybase* _Copy(void* _Where) const override {
         if constexpr (_Is_large<_Func_impl_no_alloc>) {
-            return _Global_new<_Func_impl_no_alloc>(_Callee);
+            return _STD _Global_new<_Func_impl_no_alloc>(_Callee);
         } else {
             return ::new (_Where) _Func_impl_no_alloc(_Callee);
         }
@@ -878,7 +878,7 @@ private:
     void _Delete_this(bool _Dealloc) noexcept override { // destroy self
         this->~_Func_impl_no_alloc();
         if (_Dealloc) {
-            _Deallocate<alignof(_Func_impl_no_alloc)>(this, sizeof(_Func_impl_no_alloc));
+            _STD _Deallocate<alignof(_Func_impl_no_alloc)>(this, sizeof(_Func_impl_no_alloc));
         }
     }
 
@@ -938,14 +938,14 @@ protected:
 
     template <class _Fx>
     void _Reset(_Fx&& _Val) { // store copy of _Val
-        if (!_Test_callable(_Val)) { // null member pointer/function pointer/std::function
+        if (!_STD _Test_callable(_Val)) { // null member pointer/function pointer/std::function
             return; // already empty
         }
 
         using _Impl = _Func_impl_no_alloc<decay_t<_Fx>, _Ret, _Types...>;
         if constexpr (_Is_large<_Impl>) {
             // dynamically allocate _Val
-            _Set(_Global_new<_Impl>(_STD forward<_Fx>(_Val)));
+            _Set(_STD _Global_new<_Impl>(_STD forward<_Fx>(_Val)));
         } else {
             // store _Val in-situ
             _Set(::new (static_cast<void*>(&_Mystorage)) _Impl(_STD forward<_Fx>(_Val)));
@@ -955,7 +955,7 @@ protected:
 #if _HAS_FUNCTION_ALLOCATOR_SUPPORT
     template <class _Fx, class _Alloc>
     void _Reset_alloc(_Fx&& _Val, const _Alloc& _Ax) { // store copy of _Val with allocator
-        if (!_Test_callable(_Val)) { // null member pointer/function pointer/std::function
+        if (!_STD _Test_callable(_Val)) { // null member pointer/function pointer/std::function
             return; // already empty
         }
 
@@ -966,12 +966,12 @@ protected:
             _Alimpl _Al(_Ax);
             _Alloc_construct_ptr<_Alimpl> _Constructor{_Al};
             _Constructor._Allocate();
-            _Construct_in_place(*_Constructor._Ptr, _STD forward<_Fx>(_Val), _Ax);
-            _Set(_Unfancy(_Constructor._Release()));
+            _STD _Construct_in_place(*_Constructor._Ptr, _STD forward<_Fx>(_Val), _Ax);
+            _Set(_STD _Unfancy(_Constructor._Release()));
         } else {
             // store _Val in-situ
             const auto _Ptr = reinterpret_cast<_Myimpl*>(&_Mystorage);
-            _Construct_in_place(*_Ptr, _STD forward<_Fx>(_Val), _Ax);
+            _STD _Construct_in_place(*_Ptr, _STD forward<_Fx>(_Val), _Ax);
             _Set(_Ptr);
         }
     }
@@ -1469,7 +1469,7 @@ public:
     void _Construct_with_fn(_CTypes&&... _Args) {
         _Data._Impl = _Create_impl_ptr<_Vt, _VtInvQuals>();
         if constexpr (_Large_function_engaged<_Vt>) {
-            _Data._Set_large_fn_ptr(_Function_new_large<_Vt>(_STD forward<_CTypes>(_Args)...));
+            _Data._Set_large_fn_ptr(_STD _Function_new_large<_Vt>(_STD forward<_CTypes>(_Args)...));
         } else {
             ::new (_Data._Buf_ptr<_Vt>()) _Vt(_STD forward<_CTypes>(_Args)...);
         }

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -605,7 +605,7 @@ _Associated_state<_Ty>* _Make_associated_state(const _Alloc& _Al) {
 
     _Aldelty _Del_alloc(_Al);
     _Alstate _State_alloc(_Al);
-    auto _Del = _Make_unique_alloc(_Del_alloc, _Al);
+    auto _Del = _STD _Make_unique_alloc(_Del_alloc, _Al);
     auto _Res = _STD _Make_unique_alloc(_State_alloc, _STD _Unfancy(_Del.get()));
     (void) _Del.release(); // ownership of _Del.get() now transferred to _Res
     return _STD _Unfancy(_Res.release()); // ownership transferred to caller
@@ -621,7 +621,7 @@ _Pack_state* _Make_packaged_state(_Fty2&& _Fnarg, const _Alloc& _Al) {
 
     _Aldelty _Del_alloc(_Al);
     _Alstate _State_alloc(_Al);
-    auto _Del = _Make_unique_alloc(_Del_alloc, _Al);
+    auto _Del = _STD _Make_unique_alloc(_Del_alloc, _Al);
     auto _Res = _STD _Make_unique_alloc(_State_alloc, _STD forward<_Fty2>(_Fnarg), _Al, _STD _Unfancy(_Del.get()));
     (void) _Del.release(); // ownership of _Del.get() now transferred to _Res
     return _STD _Unfancy(_Res.release()); // ownership transferred to caller

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -40,7 +40,7 @@ struct _Allocator_deleter {
 
     using pointer = typename allocator_traits<_Alloc>::pointer;
     void operator()(pointer _Ptr) noexcept { // delete the pointer
-        _Destroy_in_place(*_Ptr);
+        _STD _Destroy_in_place(*_Ptr);
         _Al.deallocate(_Ptr, 1);
     }
 };
@@ -53,7 +53,7 @@ _NODISCARD _Unique_ptr_alloc<_Alloc> _Make_unique_alloc(_Alloc& _Al, _Args&&... 
     // construct an object with an allocator and return it owned by a unique_ptr
     _Alloc_construct_ptr<_Alloc> _Constructor{_Al};
     _Constructor._Allocate();
-    _Construct_in_place(*_Constructor._Ptr, _STD forward<_Args>(_Vals)...);
+    _STD _Construct_in_place(*_Constructor._Ptr, _STD forward<_Args>(_Vals)...);
     return _Unique_ptr_alloc<_Alloc>(_Constructor._Release(), _Allocator_deleter<_Alloc>{_Al});
 }
 
@@ -455,8 +455,8 @@ void _State_deleter<_Ty, _Derived, _Alloc>::_Delete(_Associated_state<_Ty>* _Sta
 
     _Derived* _Ptr = static_cast<_Derived*>(_State);
 
-    _Delete_plain_internal(_St_alloc, _Ptr);
-    _Delete_plain_internal(_Del_alloc, this);
+    _STD _Delete_plain_internal(_St_alloc, _Ptr);
+    _STD _Delete_plain_internal(_Del_alloc, this);
 }
 
 template <class>
@@ -606,9 +606,9 @@ _Associated_state<_Ty>* _Make_associated_state(const _Alloc& _Al) {
     _Aldelty _Del_alloc(_Al);
     _Alstate _State_alloc(_Al);
     auto _Del = _Make_unique_alloc(_Del_alloc, _Al);
-    auto _Res = _Make_unique_alloc(_State_alloc, _Unfancy(_Del.get()));
+    auto _Res = _STD _Make_unique_alloc(_State_alloc, _STD _Unfancy(_Del.get()));
     (void) _Del.release(); // ownership of _Del.get() now transferred to _Res
-    return _Unfancy(_Res.release()); // ownership transferred to caller
+    return _STD _Unfancy(_Res.release()); // ownership transferred to caller
 }
 
 #if _HAS_FUNCTION_ALLOCATOR_SUPPORT
@@ -622,9 +622,9 @@ _Pack_state* _Make_packaged_state(_Fty2&& _Fnarg, const _Alloc& _Al) {
     _Aldelty _Del_alloc(_Al);
     _Alstate _State_alloc(_Al);
     auto _Del = _Make_unique_alloc(_Del_alloc, _Al);
-    auto _Res = _Make_unique_alloc(_State_alloc, _STD forward<_Fty2>(_Fnarg), _Al, _Unfancy(_Del.get()));
+    auto _Res = _STD _Make_unique_alloc(_State_alloc, _STD forward<_Fty2>(_Fnarg), _Al, _STD _Unfancy(_Del.get()));
     (void) _Del.release(); // ownership of _Del.get() now transferred to _Res
-    return _Unfancy(_Res.release()); // ownership transferred to caller
+    return _STD _Unfancy(_Res.release()); // ownership transferred to caller
 }
 #endif // _HAS_FUNCTION_ALLOCATOR_SUPPORT
 
@@ -1277,7 +1277,7 @@ public:
 #if _HAS_FUNCTION_ALLOCATOR_SUPPORT
     template <class _Fty2, class _Alloc, enable_if_t<!is_same_v<_Remove_cvref_t<_Fty2>, packaged_task>, int> = 0>
     packaged_task(allocator_arg_t, const _Alloc& _Al, _Fty2&& _Fnarg)
-        : _MyPromise(_Make_packaged_state<_MyStateType>(_STD forward<_Fty2>(_Fnarg), _Al)) {}
+        : _MyPromise(_STD _Make_packaged_state<_MyStateType>(_STD forward<_Fty2>(_Fnarg), _Al)) {}
 #endif // _HAS_FUNCTION_ALLOCATOR_SUPPORT
 
     ~packaged_task() noexcept {

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -3036,7 +3036,7 @@ _NODISCARD shared_ptr<_Ty> _Allocate_shared_unbounded_array(
     const size_t _Bytes         = _Calculate_bytes_for_flexible_array<_Refc, _Check_overflow::_Yes>(_Count);
     const size_t _Storage_units = _Bytes / sizeof(_Storage);
     _Allocate_n_ptr _Guard{_Rebound, _Storage_units};
-    const auto _Rx = reinterpret_cast<_Refc*>(_Unfancy(_Guard._Ptr));
+    const auto _Rx = reinterpret_cast<_Refc*>(_STD _Unfancy(_Guard._Ptr));
     ::new (static_cast<void*>(_Rx)) _Refc(_Al, _Count, _Args...);
     _Guard._Ptr = nullptr;
     shared_ptr<_Ty> _Ret;

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -143,7 +143,7 @@ struct _Optional_construct_base : _Optional_destruct_base<_Ty> {
     _CONSTEXPR20 _Ty& _Construct(_Types&&... _Args) noexcept(is_nothrow_constructible_v<_Ty, _Types...>) {
         // transition from the empty to the value-containing state
         _STL_INTERNAL_CHECK(!this->_Has_value);
-        _Construct_in_place(this->_Value, _STD forward<_Types>(_Args)...);
+        _STD _Construct_in_place(this->_Value, _STD forward<_Types>(_Args)...);
         this->_Has_value = true;
         return this->_Value;
     }

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -288,7 +288,7 @@ _Ty* _Global_new(_Types&&... _Args) { // acts as "new" while disallowing user ov
         void* _Result;
         ~_Guard_type() {
             if (_Result) {
-                _Deallocate<_New_alignof<_Ty>>(_Result, sizeof(_Ty));
+                _STD _Deallocate<_New_alignof<_Ty>>(_Result, sizeof(_Ty));
             }
         }
     };

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1152,7 +1152,7 @@ _CONSTEXPR20 void _Delete_plain_internal(_Alloc& _Al, typename _Alloc::value_typ
     // destroy *_Ptr in place, then deallocate _Ptr using _Al; used for internal container types the user didn't name
     using _Ty = typename _Alloc::value_type;
     _Ptr->~_Ty();
-    _Deallocate_plain(_Al, _Ptr);
+    _STD _Deallocate_plain(_Al, _Ptr);
 }
 
 template <class _Alloc>

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -327,7 +327,7 @@ _CONSTEXPR20 void _Destroy_range(_NoThrowFwdIt _First, _NoThrowSentinel _Last) n
 template <class _Ty>
 _CONSTEXPR20 void _Destroy_in_place(_Ty& _Obj) noexcept {
     if constexpr (is_array_v<_Ty>) {
-        _Destroy_range(_Obj, _Obj + extent_v<_Ty>);
+        _STD _Destroy_range(_Obj, _Obj + extent_v<_Ty>);
     } else {
         _Obj.~_Ty();
     }
@@ -338,7 +338,7 @@ _EXPORT_STD template <class _Ty>
 _CONSTEXPR20 void destroy_at(_Ty* const _Location) noexcept /* strengthened */ {
 #if _HAS_CXX20
     if constexpr (is_array_v<_Ty>) {
-        _Destroy_range(_STD begin(*_Location), _STD end(*_Location));
+        _STD _Destroy_range(_STD begin(*_Location), _STD end(*_Location));
     } else
 #endif // _HAS_CXX20
     {

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -282,22 +282,6 @@ _CONSTEXPR20 void _Deallocate(void* _Ptr, size_t _Bytes) noexcept {
 
 #undef _HAS_ALIGNED_NEW
 
-template <class _Ty, class... _Types>
-_Ty* _Global_new(_Types&&... _Args) { // acts as "new" while disallowing user overload selection
-    struct _NODISCARD _Guard_type {
-        void* _Result;
-        ~_Guard_type() {
-            if (_Result) {
-                _STD _Deallocate<_New_alignof<_Ty>>(_Result, sizeof(_Ty));
-            }
-        }
-    };
-
-    _Guard_type _Guard{_Allocate<_New_alignof<_Ty>>(sizeof(_Ty))};
-    ::new (_Guard._Result) _Ty(_STD forward<_Types>(_Args)...);
-    return static_cast<_Ty*>(_STD exchange(_Guard._Result, nullptr));
-}
-
 template <class _Ptr, class _Ty>
 using _Rebind_pointer_t = typename pointer_traits<_Ptr>::template rebind<_Ty>;
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -551,9 +551,6 @@ std/language.support/cmp/cmp.alg/partial_order.pass.cpp FAIL
 std/language.support/cmp/cmp.alg/strong_order.pass.cpp FAIL
 std/language.support/cmp/cmp.alg/weak_order.pass.cpp FAIL
 
-# GH-3100: <memory> etc.: ADL should be avoided when calling _Construct_in_place and its friends
-std/utilities/function.objects/func.wrap/func.wrap.func/robust_against_adl.pass.cpp FAIL
-
 # GH-4238: <chrono>: file_clock::to_utc() overflows for file_time<nanoseconds>
 # This test also has a bogus assumption about the file_time epoch, and file_time<nanoseconds> is doomed on Windows.
 std/time/time.clock/time.clock.file/ostream.pass.cpp FAIL

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -156,6 +156,7 @@ tests\Dev11_1150223_shared_mutex
 tests\Dev11_1158803_regex_thread_safety
 tests\Dev11_1180290_filesystem_error_code
 tests\GH_000140_adl_proof_comparison
+tests\GH_000140_adl_proof_construction
 tests\GH_000140_adl_proof_views
 tests\GH_000177_forbidden_aliasing
 tests\GH_000178_uniform_int

--- a/tests/std/tests/GH_000140_adl_proof_construction/env.lst
+++ b/tests/std/tests/GH_000140_adl_proof_construction/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/GH_000140_adl_proof_construction/test.compile.pass.cpp
+++ b/tests/std/tests/GH_000140_adl_proof_construction/test.compile.pass.cpp
@@ -1,0 +1,165 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef _M_CEE // TRANSITION, VSO-1659496
+#include <functional>
+#include <future>
+#include <memory>
+#include <type_traits>
+#if _HAS_CXX17
+#include <optional>
+#endif // _HAS_CXX17
+
+using namespace std;
+
+template <class T>
+struct adl_proof_allocator_provider {
+    struct alloc;
+};
+
+// adl_proof_allocator<T> is equality-comparable even if T is ADL-incompatible.
+template <class T>
+using adl_proof_allocator = typename adl_proof_allocator_provider<T>::alloc;
+
+template <class, class = void>
+constexpr bool is_adl_proof_allocator = false;
+
+template <class Alloc>
+constexpr bool
+    is_adl_proof_allocator<Alloc, void_t<typename adl_proof_allocator_provider<typename Alloc::value_type>::alloc>> =
+        is_same_v<typename adl_proof_allocator_provider<typename Alloc::value_type>::alloc, Alloc>;
+
+template <class T>
+struct adl_proof_allocator_provider<T>::alloc {
+    using value_type = T;
+
+    template <class U>
+    struct rebind {
+        using other = typename adl_proof_allocator_provider<U>::alloc;
+    };
+
+    alloc() = default;
+    template <class OtherAlloc, enable_if_t<is_adl_proof_allocator<OtherAlloc>, int> = 0>
+    constexpr alloc(const OtherAlloc&) noexcept {}
+
+    T* allocate(const size_t n) {
+        return allocator<T>{}.allocate(n);
+    }
+
+#if _HAS_CXX23
+    allocation_result<T*> allocate_at_least(const size_t n) {
+        return allocator<T>{}.allocate_at_least(n);
+    }
+#endif // _HAS_CXX23
+
+    void deallocate(T* const p, const size_t n) {
+        return allocator<T>{}.deallocate(p, n);
+    }
+
+    template <class OtherAlloc, enable_if_t<is_adl_proof_allocator<OtherAlloc>, int> = 0>
+    friend constexpr bool operator==(const alloc&, const OtherAlloc&) noexcept {
+        return true;
+    }
+#if !_HAS_CXX20
+    template <class OtherAlloc, enable_if_t<is_adl_proof_allocator<OtherAlloc>, int> = 0>
+    friend constexpr bool operator!=(const alloc&, const OtherAlloc&) noexcept {
+        return false;
+    }
+#endif // !_HAS_CXX20
+};
+
+template <class T>
+struct holder {
+    T t;
+};
+
+struct incomplete;
+
+template <class Tag>
+struct tagged_identity {
+    template <class U>
+    constexpr U&& operator()(U&& u) const noexcept {
+        return static_cast<U&&>(u);
+    }
+};
+
+template <class Tag>
+struct tagged_large_identity {
+    template <class U>
+    constexpr U&& operator()(U&& u) const noexcept {
+        return static_cast<U&&>(u);
+    }
+
+    alignas(64) unsigned char unused[64]{};
+};
+
+using validator                 = holder<incomplete>*;
+using validating_identity       = tagged_identity<holder<incomplete>>;
+using validating_large_identity = tagged_large_identity<holder<incomplete>>;
+
+using simple_identity       = tagged_identity<void>;
+using simple_large_identity = tagged_large_identity<void>;
+
+void test_function() {
+    function<void(validator)>{};
+    function<void(validator)>{nullptr};
+    function<void(validator)>{simple_identity{}};
+    function<void(validator)>{simple_large_identity{}};
+
+    function<void(int)>{validating_identity{}};
+    function<void(int)>{validating_large_identity{}};
+
+#if !_HAS_CXX17
+    function<void(validator)>{allocator_arg, adl_proof_allocator<unsigned char>{}};
+    function<void(validator)>{allocator_arg, adl_proof_allocator<unsigned char>{}, nullptr};
+    function<void(validator)>{allocator_arg, adl_proof_allocator<unsigned char>{}, simple_identity{}};
+    function<void(validator)>{allocator_arg, adl_proof_allocator<unsigned char>{}, simple_large_identity{}};
+
+    function<void(int)>{allocator_arg, adl_proof_allocator<unsigned char>{}, validating_identity{}};
+    function<void(int)>{allocator_arg, adl_proof_allocator<unsigned char>{}, validating_large_identity{}};
+#endif // !_HAS_CXX17
+}
+
+void test_packaged_task() {
+    packaged_task<void(validator)>{};
+    packaged_task<void(validator)>{nullptr};
+    packaged_task<void(validator)>{simple_identity{}};
+    packaged_task<void(validator)>{simple_large_identity{}};
+
+    packaged_task<void(int)>{validating_identity{}};
+    packaged_task<void(int)>{validating_large_identity{}};
+
+#if !_HAS_CXX17
+    packaged_task<void(validator)>{allocator_arg, adl_proof_allocator<unsigned char>{}, simple_identity{}};
+    packaged_task<void(validator)>{allocator_arg, adl_proof_allocator<unsigned char>{}, simple_large_identity{}};
+
+    packaged_task<void(int)>{allocator_arg, adl_proof_allocator<unsigned char>{}, validating_identity{}};
+    packaged_task<void(int)>{allocator_arg, adl_proof_allocator<unsigned char>{}, validating_large_identity{}};
+#endif // !_HAS_CXX17
+}
+
+void test_promise() {
+    promise<validator>{};
+    promise<validator>{allocator_arg, adl_proof_allocator<unsigned char>{}};
+
+    promise<validator&>{};
+    promise<validator&>{allocator_arg, adl_proof_allocator<unsigned char>{}};
+}
+
+#if _HAS_CXX17
+void test_optional() {
+    optional<validator> o{};
+    o.emplace();
+    o = optional<validator>{};
+}
+#endif // _HAS_CXX17
+
+#if _HAS_CXX23
+void test_move_only_function() {
+    move_only_function<void(validator) const>{simple_identity{}};
+    move_only_function<void(validator) const>{simple_large_identity{}};
+    move_only_function<void(int) const>{validating_identity{}};
+    move_only_function<void(int) const>{validating_large_identity{}};
+}
+#endif // _HAS_CXX23
+#endif // ^^^ no workaround ^^^

--- a/tests/std/tests/GH_001596_adl_proof_algorithms/test.compile.pass.cpp
+++ b/tests/std/tests/GH_001596_adl_proof_algorithms/test.compile.pass.cpp
@@ -533,6 +533,31 @@ void test_algorithms() {
     std::destroy_at(new (buffer) validator{});
     std::destroy_at(new (buffer) validating_nontrivial{});
 
+#if _HAS_CXX20
+    {
+        alignas(validator[1]) unsigned char buf[sizeof(validator[1])];
+        ::new (static_cast<void*>(buf)) validator[1]{};
+        const auto p_arr = std::launder(reinterpret_cast<validator(*)[1]>(buf));
+
+        std::destroy(p_arr, p_arr);
+
+        (void) std::destroy_n(p_arr, 0);
+
+        std::destroy_at(p_arr);
+    }
+    {
+        alignas(validating_nontrivial[1]) unsigned char buf[sizeof(validating_nontrivial[1])];
+        ::new (static_cast<void*>(buf)) validating_nontrivial[1]{};
+        const auto p_arr = std::launder(reinterpret_cast<validating_nontrivial(*)[1]>(buf));
+
+        std::destroy(p_arr, p_arr);
+
+        (void) std::destroy_n(p_arr, 0);
+
+        std::destroy_at(p_arr);
+    }
+#endif // _HAS_CXX20
+
     std::destroy(varr, varr);
     std::destroy(narr, narr);
 
@@ -822,6 +847,17 @@ void test_per_execution_policy() {
 
     (void) std::destroy_n(ExecutionPolicy, varr, 0);
     (void) std::destroy_n(ExecutionPolicy, narr, 0);
+
+#if _HAS_CXX20
+    validator varr_2d[1][1]{};
+    validating_nontrivial narr_2d[1][1]{};
+
+    std::destroy(ExecutionPolicy, varr_2d, varr_2d);
+    std::destroy(ExecutionPolicy, narr_2d, narr_2d);
+
+    (void) std::destroy_n(ExecutionPolicy, varr_2d, 0);
+    (void) std::destroy_n(ExecutionPolicy, narr_2d, 0);
+#endif // _HAS_CXX20
 }
 
 void test_parallel_algorithms() {
@@ -989,6 +1025,16 @@ void test_ranges_non_projected_algorithms() {
         alignas(validating_nontrivial) unsigned char buf[sizeof(validating_nontrivial)];
         const auto pn = construct_at(reinterpret_cast<validating_nontrivial*>(buf));
         destroy_at(pn);
+    }
+    {
+        alignas(validator[1]) unsigned char buf[sizeof(validator[1])];
+        ::new (static_cast<void*>(buf)) validator[1]{};
+        destroy_at(std::launder(reinterpret_cast<validator(*)[1]>(buf)));
+    }
+    {
+        alignas(validating_nontrivial[1]) unsigned char buf[sizeof(validating_nontrivial[1])];
+        ::new (static_cast<void*>(buf)) validating_nontrivial[1]{};
+        destroy_at(std::launder(reinterpret_cast<validating_nontrivial(*)[1]>(buf)));
     }
 
     {


### PR DESCRIPTION
Towards #140 and #3100.

Unblocks one libcxx test:
- `std/utilities/function.objects/func.wrap/func.wrap.func/robust_against_adl.pass.cpp`

Also contains some drive-by and previously missed changes.
- Handling for array destruction in algorithms (valid since C++20) was missed in #4374.
- `_STD`-qualification for one `shared_ptr`-related `_Unfancy` call (which is not strictly necessary).
- `_STD`-qualification for `_Deallocate` and `_Make_unique_alloc` calls (which are not strictly necessary IIUC).
- Moving `_Global_new` from `<xmemory>` to `<functional>` because it is only used for `function`.

Remaining unqualified `_Construct_in_place` and `_Destroy_in_place` calls after this PR are all in containers and `valarray`.