### PR TITLE
`<xmemory>`: Unify overloads of `_Allocate` and `_Deallocate` with `if constexpr`

### DIFF
--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -217,13 +217,13 @@ __declspec(allocator) _CONSTEXPR20 void* _Allocate(const size_t _Bytes) {
     {
 #if defined(_M_IX86) || defined(_M_X64)
 #if _HAS_CXX20 // TRANSITION, GH-1532
-        if (!_STD is_constant_evaluated())
+        if (_STD is_constant_evaluated()) {
+            return _Traits::_Allocate(_Bytes);
+        }
 #endif // _HAS_CXX20
-        {
-            if (_Bytes >= _Big_allocation_threshold) {
-                // boost the alignment of big allocations to help autovectorization
-                return _Allocate_manually_vector_aligned<_Traits>(_Bytes);
-            }
+        if (_Bytes >= _Big_allocation_threshold) {
+            // boost the alignment of big allocations to help autovectorization
+            return _Allocate_manually_vector_aligned<_Traits>(_Bytes);
         }
 #endif // defined(_M_IX86) || defined(_M_X64)
         return _Traits::_Allocate(_Bytes);

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -240,40 +240,33 @@ __declspec(allocator) _CONSTEXPR20 void* _Allocate(const size_t _Bytes) {
 template <size_t _Align>
 _CONSTEXPR20 void _Deallocate(void* _Ptr, size_t _Bytes) noexcept {
     // deallocate storage allocated by _Allocate
+#if _HAS_CXX20 // TRANSITION, GH-1532
+    if (_STD is_constant_evaluated()) {
+        ::operator delete(_Ptr);
+        return;
+    }
+#endif // _HAS_CXX20
+
 #ifdef __cpp_aligned_new
     if constexpr (_Align > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
-#if _HAS_CXX20 // TRANSITION, GH-1532
-        if (_STD is_constant_evaluated()) {
-            ::operator delete(_Ptr);
-        } else
-#endif // _HAS_CXX20
-        {
-            size_t _Passed_align = _Align;
+        size_t _Passed_align = _Align;
 #if defined(_M_IX86) || defined(_M_X64)
-            if (_Bytes >= _Big_allocation_threshold) {
-                // boost the alignment of big allocations to help autovectorization
-                _Passed_align = (_STD max)(_Align, _Big_allocation_alignment);
-            }
-#endif // defined(_M_IX86) || defined(_M_X64)
-            ::operator delete(_Ptr, _Bytes, align_val_t{_Passed_align});
+        if (_Bytes >= _Big_allocation_threshold) {
+            // boost the alignment of big allocations to help autovectorization
+            _Passed_align = (_STD max)(_Align, _Big_allocation_alignment);
         }
+#endif // defined(_M_IX86) || defined(_M_X64)
+        ::operator delete(_Ptr, _Bytes, align_val_t{_Passed_align});
     } else
 #endif // defined(__cpp_aligned_new)
     {
-#if _HAS_CXX20 // TRANSITION, GH-1532
-        if (_STD is_constant_evaluated()) {
-            ::operator delete(_Ptr);
-        } else
-#endif // _HAS_CXX20
-        {
 #if defined(_M_IX86) || defined(_M_X64)
-            if (_Bytes >= _Big_allocation_threshold) {
-                // boost the alignment of big allocations to help autovectorization
-                _Adjust_manually_vector_aligned(_Ptr, _Bytes);
-            }
-#endif // defined(_M_IX86) || defined(_M_X64)
-            ::operator delete(_Ptr, _Bytes);
+        if (_Bytes >= _Big_allocation_threshold) {
+            // boost the alignment of big allocations to help autovectorization
+            _Adjust_manually_vector_aligned(_Ptr, _Bytes);
         }
+#endif // defined(_M_IX86) || defined(_M_X64)
+        ::operator delete(_Ptr, _Bytes);
     }
 }
 

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -190,97 +190,92 @@ inline void _Adjust_manually_vector_aligned(void*& _Ptr, size_t& _Bytes) {
 }
 #endif // defined(_M_IX86) || defined(_M_X64)
 
-#ifdef __cpp_aligned_new
-template <size_t _Align, class _Traits = _Default_allocate_traits,
-    enable_if_t<(_Align > __STDCPP_DEFAULT_NEW_ALIGNMENT__), int> = 0>
+template <size_t _Align, class _Traits = _Default_allocate_traits>
 __declspec(allocator) _CONSTEXPR20 void* _Allocate(const size_t _Bytes) {
-    // allocate _Bytes when __cpp_aligned_new && _Align > __STDCPP_DEFAULT_NEW_ALIGNMENT__
-    if (_Bytes == 0) {
+    // allocate _Bytes
+#ifdef __cpp_aligned_new
+    if constexpr (_Align > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
+        if (_Bytes == 0) {
+            return nullptr;
+        }
+
+#if _HAS_CXX20 // TRANSITION, GH-1532
+        if (_STD is_constant_evaluated()) {
+            return _Traits::_Allocate(_Bytes);
+        } else
+#endif // _HAS_CXX20
+        {
+            size_t _Passed_align = _Align;
+#if defined(_M_IX86) || defined(_M_X64)
+            if (_Bytes >= _Big_allocation_threshold) {
+                // boost the alignment of big allocations to help autovectorization
+                _Passed_align = (_STD max)(_Align, _Big_allocation_alignment);
+            }
+#endif // defined(_M_IX86) || defined(_M_X64)
+            return _Traits::_Allocate_aligned(_Bytes, _Passed_align);
+        }
+    } else
+#endif // defined(__cpp_aligned_new)
+    {
+#if defined(_M_IX86) || defined(_M_X64)
+#if _HAS_CXX20 // TRANSITION, GH-1532
+        if (!_STD is_constant_evaluated())
+#endif // _HAS_CXX20
+        {
+            if (_Bytes >= _Big_allocation_threshold) {
+                // boost the alignment of big allocations to help autovectorization
+                return _Allocate_manually_vector_aligned<_Traits>(_Bytes);
+            }
+        }
+#endif // defined(_M_IX86) || defined(_M_X64)
+
+        if (_Bytes != 0) {
+            return _Traits::_Allocate(_Bytes);
+        }
+
         return nullptr;
     }
-
-#if _HAS_CXX20 // TRANSITION, GH-1532
-    if (_STD is_constant_evaluated()) {
-        return _Traits::_Allocate(_Bytes);
-    } else
-#endif // _HAS_CXX20
-    {
-        size_t _Passed_align = _Align;
-#if defined(_M_IX86) || defined(_M_X64)
-        if (_Bytes >= _Big_allocation_threshold) {
-            // boost the alignment of big allocations to help autovectorization
-            _Passed_align = (_STD max)(_Align, _Big_allocation_alignment);
-        }
-#endif // defined(_M_IX86) || defined(_M_X64)
-        return _Traits::_Allocate_aligned(_Bytes, _Passed_align);
-    }
 }
 
-template <size_t _Align, enable_if_t<(_Align > __STDCPP_DEFAULT_NEW_ALIGNMENT__), int> = 0>
-_CONSTEXPR20 void _Deallocate(void* _Ptr, const size_t _Bytes) noexcept {
-    // deallocate storage allocated by _Allocate when __cpp_aligned_new && _Align > __STDCPP_DEFAULT_NEW_ALIGNMENT__
-#if _HAS_CXX20 // TRANSITION, GH-1532
-    if (_STD is_constant_evaluated()) {
-        ::operator delete(_Ptr);
-    } else
-#endif // _HAS_CXX20
-    {
-        size_t _Passed_align = _Align;
-#if defined(_M_IX86) || defined(_M_X64)
-        if (_Bytes >= _Big_allocation_threshold) { // boost the alignment of big allocations to help autovectorization
-            _Passed_align = (_STD max)(_Align, _Big_allocation_alignment);
-        }
-#endif // defined(_M_IX86) || defined(_M_X64)
-        ::operator delete(_Ptr, _Bytes, align_val_t{_Passed_align});
-    }
-}
-
-#define _HAS_ALIGNED_NEW 1
-#else // ^^^ defined(__cpp_aligned_new) / !defined(__cpp_aligned_new) vvv
-#define _HAS_ALIGNED_NEW 0
-#endif // ^^^ !defined(__cpp_aligned_new) ^^^
-
-template <size_t _Align, class _Traits = _Default_allocate_traits,
-    enable_if_t<(!_HAS_ALIGNED_NEW || _Align <= __STDCPP_DEFAULT_NEW_ALIGNMENT__), int> = 0>
-__declspec(allocator) _CONSTEXPR20 void* _Allocate(const size_t _Bytes) {
-    // allocate _Bytes when !_HAS_ALIGNED_NEW || _Align <= __STDCPP_DEFAULT_NEW_ALIGNMENT__
-#if defined(_M_IX86) || defined(_M_X64)
-#if _HAS_CXX20 // TRANSITION, GH-1532
-    if (!_STD is_constant_evaluated())
-#endif // _HAS_CXX20
-    {
-        if (_Bytes >= _Big_allocation_threshold) { // boost the alignment of big allocations to help autovectorization
-            return _Allocate_manually_vector_aligned<_Traits>(_Bytes);
-        }
-    }
-#endif // defined(_M_IX86) || defined(_M_X64)
-
-    if (_Bytes != 0) {
-        return _Traits::_Allocate(_Bytes);
-    }
-
-    return nullptr;
-}
-
-template <size_t _Align, enable_if_t<(!_HAS_ALIGNED_NEW || _Align <= __STDCPP_DEFAULT_NEW_ALIGNMENT__), int> = 0>
+template <size_t _Align>
 _CONSTEXPR20 void _Deallocate(void* _Ptr, size_t _Bytes) noexcept {
-    // deallocate storage allocated by _Allocate when !_HAS_ALIGNED_NEW || _Align <= __STDCPP_DEFAULT_NEW_ALIGNMENT__
+    // deallocate storage allocated by _Allocate
+#ifdef __cpp_aligned_new
+    if constexpr (_Align > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
 #if _HAS_CXX20 // TRANSITION, GH-1532
-    if (_STD is_constant_evaluated()) {
-        ::operator delete(_Ptr);
-    } else
+        if (_STD is_constant_evaluated()) {
+            ::operator delete(_Ptr);
+        } else
 #endif // _HAS_CXX20
-    {
+        {
+            size_t _Passed_align = _Align;
 #if defined(_M_IX86) || defined(_M_X64)
-        if (_Bytes >= _Big_allocation_threshold) { // boost the alignment of big allocations to help autovectorization
-            _Adjust_manually_vector_aligned(_Ptr, _Bytes);
-        }
+            if (_Bytes >= _Big_allocation_threshold) {
+                // boost the alignment of big allocations to help autovectorization
+                _Passed_align = (_STD max)(_Align, _Big_allocation_alignment);
+            }
 #endif // defined(_M_IX86) || defined(_M_X64)
-        ::operator delete(_Ptr, _Bytes);
+            ::operator delete(_Ptr, _Bytes, align_val_t{_Passed_align});
+        }
+    } else
+#endif // defined(__cpp_aligned_new)
+    {
+#if _HAS_CXX20 // TRANSITION, GH-1532
+        if (_STD is_constant_evaluated()) {
+            ::operator delete(_Ptr);
+        } else
+#endif // _HAS_CXX20
+        {
+#if defined(_M_IX86) || defined(_M_X64)
+            if (_Bytes >= _Big_allocation_threshold) {
+                // boost the alignment of big allocations to help autovectorization
+                _Adjust_manually_vector_aligned(_Ptr, _Bytes);
+            }
+#endif // defined(_M_IX86) || defined(_M_X64)
+            ::operator delete(_Ptr, _Bytes);
+        }
     }
 }
-
-#undef _HAS_ALIGNED_NEW
 
 template <class _Ty, class... _Types>
 _Ty* _Global_new(_Types&&... _Args) { // acts as "new" while disallowing user overload selection

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -197,13 +197,14 @@ __declspec(allocator) _CONSTEXPR20 void* _Allocate(const size_t _Bytes) {
         return nullptr;
     }
 
+#if _HAS_CXX20 // TRANSITION, GH-1532
+    if (_STD is_constant_evaluated()) {
+        return _Traits::_Allocate(_Bytes);
+    }
+#endif // _HAS_CXX20
+
 #ifdef __cpp_aligned_new
     if constexpr (_Align > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
-#if _HAS_CXX20 // TRANSITION, GH-1532
-        if (_STD is_constant_evaluated()) {
-            return _Traits::_Allocate(_Bytes);
-        }
-#endif // _HAS_CXX20
         size_t _Passed_align = _Align;
 #if defined(_M_IX86) || defined(_M_X64)
         if (_Bytes >= _Big_allocation_threshold) {
@@ -216,11 +217,6 @@ __declspec(allocator) _CONSTEXPR20 void* _Allocate(const size_t _Bytes) {
 #endif // defined(__cpp_aligned_new)
     {
 #if defined(_M_IX86) || defined(_M_X64)
-#if _HAS_CXX20 // TRANSITION, GH-1532
-        if (_STD is_constant_evaluated()) {
-            return _Traits::_Allocate(_Bytes);
-        }
-#endif // _HAS_CXX20
         if (_Bytes >= _Big_allocation_threshold) {
             // boost the alignment of big allocations to help autovectorization
             return _Allocate_manually_vector_aligned<_Traits>(_Bytes);

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -202,18 +202,16 @@ __declspec(allocator) _CONSTEXPR20 void* _Allocate(const size_t _Bytes) {
 #if _HAS_CXX20 // TRANSITION, GH-1532
         if (_STD is_constant_evaluated()) {
             return _Traits::_Allocate(_Bytes);
-        } else
-#endif // _HAS_CXX20
-        {
-            size_t _Passed_align = _Align;
-#if defined(_M_IX86) || defined(_M_X64)
-            if (_Bytes >= _Big_allocation_threshold) {
-                // boost the alignment of big allocations to help autovectorization
-                _Passed_align = (_STD max)(_Align, _Big_allocation_alignment);
-            }
-#endif // defined(_M_IX86) || defined(_M_X64)
-            return _Traits::_Allocate_aligned(_Bytes, _Passed_align);
         }
+#endif // _HAS_CXX20
+        size_t _Passed_align = _Align;
+#if defined(_M_IX86) || defined(_M_X64)
+        if (_Bytes >= _Big_allocation_threshold) {
+            // boost the alignment of big allocations to help autovectorization
+            _Passed_align = (_STD max)(_Align, _Big_allocation_alignment);
+        }
+#endif // defined(_M_IX86) || defined(_M_X64)
+        return _Traits::_Allocate_aligned(_Bytes, _Passed_align);
     } else
 #endif // defined(__cpp_aligned_new)
     {

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -193,12 +193,12 @@ inline void _Adjust_manually_vector_aligned(void*& _Ptr, size_t& _Bytes) {
 template <size_t _Align, class _Traits = _Default_allocate_traits>
 __declspec(allocator) _CONSTEXPR20 void* _Allocate(const size_t _Bytes) {
     // allocate _Bytes
+    if (_Bytes == 0) {
+        return nullptr;
+    }
+
 #ifdef __cpp_aligned_new
     if constexpr (_Align > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
-        if (_Bytes == 0) {
-            return nullptr;
-        }
-
 #if _HAS_CXX20 // TRANSITION, GH-1532
         if (_STD is_constant_evaluated()) {
             return _Traits::_Allocate(_Bytes);
@@ -228,12 +228,7 @@ __declspec(allocator) _CONSTEXPR20 void* _Allocate(const size_t _Bytes) {
             }
         }
 #endif // defined(_M_IX86) || defined(_M_X64)
-
-        if (_Bytes != 0) {
-            return _Traits::_Allocate(_Bytes);
-        }
-
-        return nullptr;
+        return _Traits::_Allocate(_Bytes);
     }
 }
 


### PR DESCRIPTION
Currently, both `_Allocate` and `_Deallocate` have multiple overloads that are dispatched by SFINAE.
It seems that we should dispatch overaligned and normal branches with `if constexpr` instead (see #189).