### PR TITLE
Enforce `std::time_base::mdy` for "C" locale

### DIFF
--- a/stl/src/xdateord.cpp
+++ b/stl/src/xdateord.cpp
@@ -10,14 +10,14 @@
 _EXTERN_C_UNLESS_PURE
 
 _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Getdateorder() noexcept { // return date order for current locale
-    wchar_t buf[2]                   = {0};
     const wchar_t* const locale_name = ___lc_locale_name_func()[LC_TIME];
     if (locale_name == nullptr) {
         // Enforce std::time_base::mdy for "C" locale
         return std::time_base::mdy;
-    } else {
-        GetLocaleInfoEx(locale_name, LOCALE_ILDATE, buf, static_cast<int>(std::size(buf)));
     }
+
+    wchar_t buf[2] = {0};
+    GetLocaleInfoEx(locale_name, LOCALE_ILDATE, buf, static_cast<int>(std::size(buf)));
 
     switch (buf[0]) {
     case L'0':

--- a/stl/src/xdateord.cpp
+++ b/stl/src/xdateord.cpp
@@ -10,8 +10,14 @@
 _EXTERN_C_UNLESS_PURE
 
 _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Getdateorder() noexcept { // return date order for current locale
-    wchar_t buf[2] = {0};
-    GetLocaleInfoEx(___lc_locale_name_func()[LC_TIME], LOCALE_ILDATE, buf, static_cast<int>(std::size(buf)));
+    wchar_t buf[2]             = {0};
+    const wchar_t* locale_name = ___lc_locale_name_func()[LC_TIME];
+    if (locale_name == nullptr) {
+        // Enforce std::time_base::mdy for "C" locale
+        buf[0] = L'0';
+    } else {
+        GetLocaleInfoEx(locale_name, LOCALE_ILDATE, buf, static_cast<int>(std::size(buf)));
+    }
 
     switch (buf[0]) {
     case L'0':

--- a/stl/src/xdateord.cpp
+++ b/stl/src/xdateord.cpp
@@ -14,7 +14,7 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Getdateorder() noexcept { // return d
     const wchar_t* const locale_name = ___lc_locale_name_func()[LC_TIME];
     if (locale_name == nullptr) {
         // Enforce std::time_base::mdy for "C" locale
-        buf[0] = L'0';
+        return std::time_base::mdy;
     } else {
         GetLocaleInfoEx(locale_name, LOCALE_ILDATE, buf, static_cast<int>(std::size(buf)));
     }

--- a/stl/src/xdateord.cpp
+++ b/stl/src/xdateord.cpp
@@ -11,8 +11,7 @@ _EXTERN_C_UNLESS_PURE
 
 _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Getdateorder() noexcept { // return date order for current locale
     const wchar_t* const locale_name = ___lc_locale_name_func()[LC_TIME];
-    if (locale_name == nullptr) {
-        // Enforce std::time_base::mdy for "C" locale
+    if (locale_name == nullptr) { // Indicates "C" locale; GetLocaleInfoEx would see this as LOCALE_NAME_USER_DEFAULT
         return std::time_base::mdy;
     }
 

--- a/stl/src/xdateord.cpp
+++ b/stl/src/xdateord.cpp
@@ -10,8 +10,8 @@
 _EXTERN_C_UNLESS_PURE
 
 _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Getdateorder() noexcept { // return date order for current locale
-    wchar_t buf[2]             = {0};
-    const wchar_t* locale_name = ___lc_locale_name_func()[LC_TIME];
+    wchar_t buf[2]                   = {0};
+    const wchar_t* const locale_name = ___lc_locale_name_func()[LC_TIME];
     if (locale_name == nullptr) {
         // Enforce std::time_base::mdy for "C" locale
         buf[0] = L'0';


### PR DESCRIPTION
Fixes #3346

1) I found out that the tests work on libc++. 
2) I looked how libc++ detect date_order. It has a some date and run `std::strftime(mbstr, sizeof(mbstr), "%x", std::localtime(&t));` and analyse its output.
3) I looked at `strftime` implementation. It creates `_LocaleUpdate` object. and passes `nullptr` to it.
`_LocaleUpdate` constructor looks like that (pseudo-code)
```C
if (locale)
{
    _locale_pointers = *locale;
}
else if (is_it_C_locale())
{
    _locale_pointers = some_predefined_values;
}
else
{
   query runtime data to fill _locale_pointers from the current locale.
}
```
4) So  `std::strftime` uses `mdy` for "C" locale and we can do too. I found another places where we did a special case for "C" locale.
https://github.com/microsoft/STL/blob/8b081e26ba016970ce3338cb483ff10f2ade30a5/stl/src/xstrcoll.cpp#L57-L69
https://github.com/microsoft/STL/blob/8b081e26ba016970ce3338cb483ff10f2ade30a5/stl/src/_tolower.cpp#L52-L58
https://github.com/microsoft/STL/blob/8b081e26ba016970ce3338cb483ff10f2ade30a5/stl/src/_toupper.cpp#L51-L57