### PR TITLE
Comment cleanups

### DIFF
--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -305,9 +305,9 @@ concept three_way_comparable_with =
     three_way_comparable<_Ty1, _Cat> && three_way_comparable<_Ty2, _Cat>
 #if _HAS_CXX23
     && _Comparison_common_type_with<_Ty1, _Ty2>
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
     && common_reference_with<const remove_reference_t<_Ty1>&, const remove_reference_t<_Ty2>&>
-#endif // C++20
+#endif // ^^^ !_HAS_CXX23 ^^^
     && three_way_comparable<common_reference_t<const remove_reference_t<_Ty1>&, const remove_reference_t<_Ty2>&>, _Cat>
     && _Weakly_equality_comparable_with<_Ty1, _Ty2> && _Partially_ordered_with<_Ty1, _Ty2>
     && requires(const remove_reference_t<_Ty1>& __t, const remove_reference_t<_Ty2>& __u) {

--- a/stl/inc/concepts
+++ b/stl/inc/concepts
@@ -212,9 +212,9 @@ _EXPORT_STD template <class _Ty1, class _Ty2>
 concept equality_comparable_with = equality_comparable<_Ty1> && equality_comparable<_Ty2>
 #if _HAS_CXX23
     && _Comparison_common_type_with<_Ty1, _Ty2>
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
     && common_reference_with<const remove_reference_t<_Ty1>&, const remove_reference_t<_Ty2>&>
-#endif // C++20
+#endif // ^^^ !_HAS_CXX23 ^^^
     && equality_comparable<common_reference_t<const remove_reference_t<_Ty1>&, const remove_reference_t<_Ty2>&>>
     && _Weakly_equality_comparable_with<_Ty1, _Ty2>;
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -105,9 +105,9 @@ namespace ranges {
     concept _Valid_movable_box_object =
 #if _HAS_CXX23
         move_constructible<_Ty>
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
         copy_constructible<_Ty>
-#endif // ^^^ C++20 ^^^
+#endif // ^^^ !_HAS_CXX23 ^^^
         && _Destructible_object<_Ty>;
 
     template <class _It>
@@ -5696,14 +5696,14 @@ namespace ranges {
     concept _Has_tuple_element =
 #if _HAS_CXX23
         _Tuple_like<_Tuple> && _Index < tuple_size_v<_Tuple>;
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
         requires(_Tuple __t) {
             typename tuple_size<_Tuple>::type;
             requires _Index < tuple_size_v<_Tuple>;
             typename tuple_element_t<_Index, _Tuple>;
             { _STD get<_Index>(__t) } -> convertible_to<const tuple_element_t<_Index, _Tuple>&>;
         };
-#endif // ^^^ C++20 ^^^
+#endif // ^^^ !_HAS_CXX23 ^^^
 
     template <class _Tuple, size_t _Index>
     concept _Returnable_element = is_reference_v<_Tuple> || move_constructible<tuple_element_t<_Index, _Tuple>>;

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -1032,9 +1032,9 @@ struct _Tuple_cat2<_Ty, index_sequence<_Kx...>, index_sequence<_Ix...>, _Ix_next
 
 #if _HAS_CXX23
 template <_Tuple_like... _Tuples>
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
 template <class... _Tuples>
-#endif // ^^^ C++20 ^^^
+#endif // ^^^ !_HAS_CXX23 ^^^
 using _Tuple_cat1 = _Tuple_cat2<tuple<_Tuples&&...>, index_sequence<>, index_sequence<>, 0,
     make_index_sequence<tuple_size_v<_Remove_cvref_t<_Tuples>>>...>;
 
@@ -1045,9 +1045,9 @@ constexpr _Ret _Tuple_cat(index_sequence<_Kx...>, index_sequence<_Ix...>, _Ty _A
 
 #if _HAS_CXX23
 _EXPORT_STD template <_Tuple_like... _Tuples>
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
 _EXPORT_STD template <class... _Tuples>
-#endif // ^^^ C++20 ^^^
+#endif // ^^^ !_HAS_CXX23 ^^^
 _NODISCARD constexpr typename _Tuple_cat1<_Tuples...>::_Ret tuple_cat(_Tuples&&... _Tpls) { // concatenate tuples
     using _Cat1   = _Tuple_cat1<_Tuples...>;
     using _Ret    = typename _Cat1::_Ret;
@@ -1059,9 +1059,9 @@ _NODISCARD constexpr typename _Tuple_cat1<_Tuples...>::_Ret tuple_cat(_Tuples&&.
 #if _HAS_CXX17
 #if _HAS_CXX23
 template <class _Callable, _Tuple_like _Tuple, size_t... _Indices>
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
 template <class _Callable, class _Tuple, size_t... _Indices>
-#endif // ^^^ C++20 ^^^
+#endif // ^^^ !_HAS_CXX23 ^^^
 constexpr decltype(auto) _Apply_impl(_Callable&& _Obj, _Tuple&& _Tpl, index_sequence<_Indices...>) noexcept(
     noexcept(_STD invoke(_STD forward<_Callable>(_Obj), _STD get<_Indices>(_STD forward<_Tuple>(_Tpl))...))) {
     return _STD invoke(_STD forward<_Callable>(_Obj), _STD get<_Indices>(_STD forward<_Tuple>(_Tpl))...);
@@ -1069,9 +1069,9 @@ constexpr decltype(auto) _Apply_impl(_Callable&& _Obj, _Tuple&& _Tpl, index_sequ
 
 #if _HAS_CXX23
 _EXPORT_STD template <class _Callable, _Tuple_like _Tuple>
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
 _EXPORT_STD template <class _Callable, class _Tuple>
-#endif // ^^^ C++20 ^^^
+#endif // ^^^ !_HAS_CXX23 ^^^
 constexpr decltype(auto) apply(_Callable&& _Obj, _Tuple&& _Tpl) noexcept(
     noexcept(_Apply_impl(_STD forward<_Callable>(_Obj), _STD forward<_Tuple>(_Tpl),
         make_index_sequence<tuple_size_v<remove_reference_t<_Tuple>>>{}))) {
@@ -1081,9 +1081,9 @@ constexpr decltype(auto) apply(_Callable&& _Obj, _Tuple&& _Tpl) noexcept(
 
 #if _HAS_CXX23
 template <class _Ty, _Tuple_like _Tuple, size_t... _Indices>
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
 template <class _Ty, class _Tuple, size_t... _Indices>
-#endif // ^^^ C++20 ^^^
+#endif // ^^^ !_HAS_CXX23 ^^^
 constexpr _Ty _Make_from_tuple_impl(_Tuple&& _Tpl, index_sequence<_Indices...>) noexcept(
     is_nothrow_constructible_v<_Ty, decltype(_STD get<_Indices>(_STD forward<_Tuple>(_Tpl)))...>) {
     // construct _Ty from the elements of _Tpl
@@ -1094,9 +1094,9 @@ constexpr _Ty _Make_from_tuple_impl(_Tuple&& _Tpl, index_sequence<_Indices...>) 
 
 #if _HAS_CXX23
 _EXPORT_STD template <class _Ty, _Tuple_like _Tuple>
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
 _EXPORT_STD template <class _Ty, class _Tuple>
-#endif // ^^^ C++20 ^^^
+#endif // ^^^ !_HAS_CXX23 ^^^
 _NODISCARD constexpr _Ty make_from_tuple(_Tuple&& _Tpl) noexcept(noexcept(_Make_from_tuple_impl<_Ty>(
     _STD forward<_Tuple>(_Tpl), make_index_sequence<tuple_size_v<remove_reference_t<_Tuple>>>{}))) /* strengthened */ {
     // construct _Ty from the elements of _Tpl

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1423,27 +1423,27 @@ template <class _Iter>
 using _Guide_key_t =
 #if _HAS_CXX23
     remove_const_t<tuple_element_t<0, typename iterator_traits<_Iter>::value_type>>;
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
     remove_const_t<typename iterator_traits<_Iter>::value_type::first_type>;
-#endif // ^^^ C++20 ^^^
+#endif // ^^^ !_HAS_CXX23 ^^^
 
 template <class _Iter>
 using _Guide_val_t =
 #if _HAS_CXX23
     tuple_element_t<1, typename iterator_traits<_Iter>::value_type>;
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
     typename iterator_traits<_Iter>::value_type::second_type;
-#endif // ^^^ C++20 ^^^
+#endif // ^^^ !_HAS_CXX23 ^^^
 
 template <class _Iter>
 using _Guide_pair_t =
 #if _HAS_CXX23
     pair<add_const_t<tuple_element_t<0, typename iterator_traits<_Iter>::value_type>>,
         tuple_element_t<1, typename iterator_traits<_Iter>::value_type>>;
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
     pair<add_const_t<typename iterator_traits<_Iter>::value_type::first_type>,
         typename iterator_traits<_Iter>::value_type::second_type>;
-#endif // ^^^ C++20 ^^^
+#endif // ^^^ !_HAS_CXX23 ^^^
 
 _EXPORT_STD template <class _Ty>
 struct is_execution_policy : false_type {};
@@ -2840,7 +2840,7 @@ namespace ranges {
             noexcept(const_iterator<_Begin_on_const<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))})) {
             return const_iterator<_Begin_on_const<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))};
         }
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
         _NODISCARD _STATIC_CALL_OPERATOR constexpr auto operator()(_Ty&& _Val) _CONST_CALL_OPERATOR
             noexcept(noexcept(_RANGES begin(static_cast<_CTy&&>(_Val))))
@@ -2848,7 +2848,7 @@ namespace ranges {
         {
             return _RANGES begin(static_cast<_CTy&&>(_Val));
         }
-#endif // ^^^ C++20 ^^^
+#endif // ^^^ !_HAS_CXX23 ^^^
     };
 
     inline namespace _Cpos {
@@ -2870,7 +2870,7 @@ namespace ranges {
             noexcept(noexcept(const_sentinel<_End_on_const<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))})) {
             return const_sentinel<_End_on_const<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))};
         }
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
         _NODISCARD _STATIC_CALL_OPERATOR constexpr auto operator()(_Ty&& _Val) _CONST_CALL_OPERATOR
             noexcept(noexcept(_RANGES end(static_cast<_CTy&&>(_Val))))
@@ -2878,7 +2878,7 @@ namespace ranges {
         {
             return _RANGES end(static_cast<_CTy&&>(_Val));
         }
-#endif // ^^^ C++20 ^^^
+#endif // ^^^ !_HAS_CXX23 ^^^
     };
 
     inline namespace _Cpos {
@@ -3040,7 +3040,7 @@ namespace ranges {
             noexcept(const_iterator<_Rbegin_on_const<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))})) {
             return const_iterator<_Rbegin_on_const<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))};
         }
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
         _NODISCARD _STATIC_CALL_OPERATOR constexpr auto operator()(_Ty&& _Val) _CONST_CALL_OPERATOR
             noexcept(noexcept(_RANGES rbegin(static_cast<_CTy&&>(_Val))))
@@ -3048,7 +3048,7 @@ namespace ranges {
         {
             return _RANGES rbegin(static_cast<_CTy&&>(_Val));
         }
-#endif // ^^^ C++20 ^^^
+#endif // ^^^ !_HAS_CXX23 ^^^
     };
 
     inline namespace _Cpos {
@@ -3070,7 +3070,7 @@ namespace ranges {
             noexcept(noexcept(const_sentinel<_Rend_on_const<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))})) {
             return const_sentinel<_Rend_on_const<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))};
         }
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
         _NODISCARD _STATIC_CALL_OPERATOR constexpr auto operator()(_Ty&& _Val) _CONST_CALL_OPERATOR
             noexcept(noexcept(_RANGES rend(static_cast<_CTy&&>(_Val))))
@@ -3078,7 +3078,7 @@ namespace ranges {
         {
             return _RANGES rend(static_cast<_CTy&&>(_Val));
         }
-#endif // ^^^ C++20 ^^^
+#endif // ^^^ !_HAS_CXX23 ^^^
     };
 
     inline namespace _Cpos {
@@ -3297,7 +3297,7 @@ namespace ranges {
             noexcept(noexcept(_RANGES data(_RANGES _Possibly_const_range(_Val)))) {
             return _RANGES _As_const_pointer(_RANGES data(_RANGES _Possibly_const_range(_Val)));
         }
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
         _NODISCARD _STATIC_CALL_OPERATOR constexpr auto operator()(_Ty&& _Val) _CONST_CALL_OPERATOR
             noexcept(noexcept(_RANGES data(static_cast<_CTy&&>(_Val))))
@@ -3305,7 +3305,7 @@ namespace ranges {
         {
             return _RANGES data(static_cast<_CTy&&>(_Val));
         }
-#endif // ^^^ C++20 ^^^
+#endif // ^^^ !_HAS_CXX23 ^^^
     };
 
     inline namespace _Cpos {

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -976,7 +976,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 
 // P0298R3 std::byte
 #ifndef _HAS_STD_BYTE
-#define _HAS_STD_BYTE _HAS_CXX17 // inspected by GSL, do not remove
+#define _HAS_STD_BYTE _HAS_CXX17
 #endif // !defined(_HAS_STD_BYTE)
 
 // P0302R1 Removing Allocator Support In std::function

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1842,29 +1842,29 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 // macros with language mode sensitivity
 #if _HAS_CXX20
 #define __cpp_lib_array_constexpr 201811L // P1032R1 Miscellaneous constexpr
-#elif _HAS_CXX17 // ^^^ _HAS_CXX20 / _HAS_CXX17 vvv
+#elif _HAS_CXX17
 #define __cpp_lib_array_constexpr 201803L // P0858R0 Constexpr Iterator Requirements
-#endif // _HAS_CXX17
+#endif
 
 #if _HAS_CXX20
 #define __cpp_lib_chrono 201907L // P1466R3 Miscellaneous Minor Fixes For <chrono>
 #elif _HAS_CXX17
 #define __cpp_lib_chrono 201611L // P0505R0 constexpr For <chrono> (Again)
-#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
+#else
 #define __cpp_lib_chrono 201510L // P0092R1 <chrono> floor(), ceil(), round(), abs()
-#endif // ^^^ !_HAS_CXX17 ^^^
+#endif
 
 #if _HAS_CXX23
 #define __cpp_lib_concepts 202207L // P2404R3 Move-Only Types For Comparison Concepts
-#elif _HAS_CXX20 // ^^^ C++23 / C++20 vvv
+#elif _HAS_CXX20
 #define __cpp_lib_concepts 202002L // P1964R2 Replacing boolean With boolean-testable
-#endif // C++20
+#endif
 
 #if _HAS_CXX23
 #define __cpp_lib_constexpr_memory 202202L // P2273R3 constexpr unique_ptr
 #elif _HAS_CXX20
 #define __cpp_lib_constexpr_memory 201811L // P1006R1 constexpr For pointer_traits<T*>::pointer_to()
-#endif // _HAS_CXX20
+#endif
 
 #ifndef _M_CEE_PURE
 #if _HAS_CXX20
@@ -1876,17 +1876,17 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 
 #if _HAS_CXX23
 #define __cpp_lib_optional 202110L // P0798R8 Monadic Operations For optional
-#elif _HAS_CXX20 // ^^^ _HAS_CXX23 / _HAS_CXX20 vvv
+#elif _HAS_CXX20
 #define __cpp_lib_optional 202106L // P2231R1 Completing constexpr In optional And variant
-#elif _HAS_CXX17 // ^^^ _HAS_CXX20 / _HAS_CXX17 vvv
+#elif _HAS_CXX17
 #define __cpp_lib_optional 201606L // P0307R2 Making Optional Greater Equal Again
-#endif // _HAS_CXX17
+#endif
 
 #if _HAS_CXX23
 #define __cpp_lib_ranges 202302L // P2609R3 Relaxing Ranges Just A Smidge
-#elif _HAS_CXX20 // ^^^ _HAS_CXX23 / _HAS_CXX20 vvv
+#elif _HAS_CXX20
 #define __cpp_lib_ranges 202110L // P2415R2 What Is A view?
-#endif // _HAS_CXX20
+#endif
 
 #if _HAS_CXX20
 #define __cpp_lib_shared_ptr_arrays 201707L // P0674R1 make_shared() For Arrays
@@ -1896,15 +1896,15 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 
 #if _HAS_CXX23
 #define __cpp_lib_shift 202202L // P2440R1 ranges::shift_left, ranges::shift_right
-#elif _HAS_CXX20 // ^^^ _HAS_CXX23 / _HAS_CXX20 vvv
+#elif _HAS_CXX20
 #define __cpp_lib_shift 201806L // P0769R2 shift_left(), shift_right()
-#endif // _HAS_CXX20
+#endif
 
 #if _HAS_CXX20
 #define __cpp_lib_variant 202106L // P2231R1 Completing constexpr In optional And variant
-#elif _HAS_CXX17 // ^^^ _HAS_CXX20 / _HAS_CXX17 vvv
+#elif _HAS_CXX17
 #define __cpp_lib_variant 202102L // P2162R2 Inheriting From variant
-#endif // _HAS_CXX17
+#endif
 
 #define __cpp_lib_experimental_erase_if   201411L
 #define __cpp_lib_experimental_filesystem 201406L

--- a/tests/std/tests/GH_000431_equal_memcmp_is_safe/test.compile.pass.cpp
+++ b/tests/std/tests/GH_000431_equal_memcmp_is_safe/test.compile.pass.cpp
@@ -175,7 +175,7 @@ STATIC_ASSERT(test_equal_memcmp_is_safe_for_types<true, char8_t, char8_t>());
 STATIC_ASSERT(test_equal_memcmp_is_safe_for_types<true, char16_t, char16_t>());
 STATIC_ASSERT(test_equal_memcmp_is_safe_for_types<true, char32_t, char32_t>());
 
-// Don't allow diffrent size integrals
+// Don't allow different size integrals
 STATIC_ASSERT(test_equal_memcmp_is_safe_for_types<false, short, int>());
 STATIC_ASSERT(test_equal_memcmp_is_safe_for_types<false, long long, int>());
 

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -6528,11 +6528,11 @@ int run_test() {
 
   return 0;
 }
-#else // ^^ real test / vv workaround
+#else // ^^^ no workaround / workaround vvv
 int run_test() {
   return 0;
 }
-#endif // _HAS_CXX20 && !defined(__EDG__) && !defined(TEST_PERMISSIVE)
+#endif // ^^^ workaround ^^^
 
 } // namespace visit
 // -- END: test/std/utilities/variant/variant.visit/visit.pass.cpp
@@ -7058,11 +7058,11 @@ int run_test() {
 
   return 0;
 }
-#else // ^^ real tests / vv workaround
+#else // ^^^ no workaround / workaround vvv
 int run_test() {
   return 0;
 }
-#endif // _HAS_CXX20 && !defined(__EDG__) && !defined(TEST_PERMISSIVE)
+#endif // ^^^ workaround ^^^
 } // namespace visit::return_type
 // -- END: test/std/utilities/variant/variant.visit/visit_return_type.pass.cpp
 

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -1036,11 +1036,11 @@ int run_test() {
   static_assert(test());
   return 0;
 }
-#else
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
 int run_test() {
     return 0;
 }
-#endif // _HAS_CXX23
+#endif // ^^^ !_HAS_CXX23 ^^^
 } // namespace and_then
 // -- END: test/std/utilities/optional/optional.monadic/and_then.pass.cpp
 
@@ -1119,11 +1119,11 @@ int run_test() {
   static_assert(test());
   return 0;
 }
-#else // ^^ _HAS_CXX23 / vv no _HAS_CXX23
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
 int run_test() {
     return 0;
 }
-#endif // _HAS_CXX23
+#endif // ^^^ !_HAS_CXX23 ^^^
 } // namespace or_else
 // -- END: test/std/utilities/optional/optional.monadic/or_else.pass.cpp
 // -- BEGIN: test/std/utilities/optional/optional.monadic/transform.pass.cpp
@@ -1337,11 +1337,11 @@ int run_test() {
   static_assert(test());
   return 0;
 }
-#else // ^^ _HAS_CXX23 / vv no _HAS_CXX23
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
 int run_test() {
     return 0;
 }
-#endif // _HAS_CXX23
+#endif // ^^^ !_HAS_CXX23 ^^^
 } // namespace transform
 // -- END: test/std/utilities/optional/optional.monadic/transform.pass.cpp
 

--- a/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.compile.pass.cpp
+++ b/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.compile.pass.cpp
@@ -1108,7 +1108,7 @@ namespace special_memory_concepts {
     STATIC_ASSERT(ranges::range<range_archetype<range_status::input>>);
     STATIC_ASSERT(ranges::range<range_archetype<range_status::forward>>);
 
-    // Validate _No_throw_input_range; note that the distinction betweeen range<R> and
+    // Validate _No_throw_input_range; note that the distinction between range<R> and
     // no-throw-sentinel-for<sentinel_t<R>, iterator_t<R>> is purely semantic, so we can't test them separately.
     STATIC_ASSERT(!_No_throw_input_range<range_archetype<range_status::not_range>>);
     STATIC_ASSERT(!_No_throw_input_range<range_archetype<range_status::not_input>>);

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -613,11 +613,11 @@ STATIC_ASSERT(!ranges::view<int (&)[]>);
 #if _HAS_CXX23 // ranges::cbegin and ranges::cdata behavior differs in C++20 and C++23 modes
 STATIC_ASSERT(test_cbegin<int (&)[]>());
 STATIC_ASSERT(test_cdata<int (&)[]>());
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
 STATIC_ASSERT(test_cbegin<int (&)[], int const*>());
 // Can't use test_cdata here because it uses range_value_t and this isn't a range
 STATIC_ASSERT(std::same_as<decltype(ranges::cdata(std::declval<int (&)[]>())), int const*>);
-#endif // C++20
+#endif // ^^^ !_HAS_CXX23 ^^^
 
 STATIC_ASSERT(test_begin<int const (&)[], int const*>());
 STATIC_ASSERT(test_end<int const (&)[]>());
@@ -636,11 +636,11 @@ STATIC_ASSERT(!ranges::view<int const (&)[]>);
 #if _HAS_CXX23 // ranges::cbegin and ranges::cdata behavior differs in C++20 and C++23 modes
 STATIC_ASSERT(test_cbegin<int const (&)[]>());
 STATIC_ASSERT(test_cdata<int const (&)[]>());
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
 STATIC_ASSERT(test_cbegin<int const (&)[], int const*>());
 // Can't use test_cdata here because it uses range_value_t and this isn't a range
 STATIC_ASSERT(std::same_as<decltype(ranges::cdata(std::declval<int const (&)[]>())), int const*>);
-#endif // C++20
+#endif // ^^^ !_HAS_CXX23 ^^^
 
 // Validate behavior before/after completing the bound of an array
 extern int initially_unbounded[];
@@ -658,10 +658,10 @@ STATIC_ASSERT(ranges::data(initially_unbounded) == initially_unbounded);
 #if _HAS_CXX23 // ranges::cbegin and ranges::cdata behavior differs in C++20 and C++23 modes
 STATIC_ASSERT(!CanCBegin<decltype((initially_unbounded))>);
 STATIC_ASSERT(!CanCData<decltype((initially_unbounded))>);
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
 STATIC_ASSERT(ranges::cbegin(initially_unbounded) == initially_unbounded);
 STATIC_ASSERT(ranges::cdata(initially_unbounded) == initially_unbounded);
-#endif // C++20
+#endif // ^^^ !_HAS_CXX23 ^^^
 
 int initially_unbounded[42];
 STATIC_ASSERT(ranges::begin(initially_unbounded) == initially_unbounded);
@@ -1046,13 +1046,13 @@ STATIC_ASSERT(test_cend<std::span<int>, std::span<int>::const_iterator>());
 STATIC_ASSERT(test_crbegin<std::span<int>, std::span<int>::const_reverse_iterator>());
 STATIC_ASSERT(test_crend<std::span<int>, std::span<int>::const_reverse_iterator>());
 STATIC_ASSERT(test_cdata<std::span<int>, const int*>());
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
 STATIC_ASSERT(test_cbegin<std::span<int>, std::span<int>::iterator>());
 STATIC_ASSERT(test_cend<std::span<int>, std::span<int>::iterator>());
 STATIC_ASSERT(test_crbegin<std::span<int>, std::reverse_iterator<std::span<int>::iterator>>());
 STATIC_ASSERT(test_crend<std::span<int>, std::reverse_iterator<std::span<int>::iterator>>());
 STATIC_ASSERT(test_cdata<std::span<int>, int*>());
-#endif // C++20
+#endif // ^^^ !_HAS_CXX23 ^^^
 
 STATIC_ASSERT(test_begin<std::span<int> const, std::span<int>::iterator>());
 STATIC_ASSERT(test_end<std::span<int> const, std::span<int>::iterator>());
@@ -1070,13 +1070,13 @@ STATIC_ASSERT(test_cend<std::span<int> const, std::span<int>::const_iterator>())
 STATIC_ASSERT(test_crbegin<std::span<int> const, std::span<int>::const_reverse_iterator>());
 STATIC_ASSERT(test_crend<std::span<int> const, std::span<int>::const_reverse_iterator>());
 STATIC_ASSERT(test_cdata<std::span<int> const, const int*>());
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
 STATIC_ASSERT(test_cbegin<std::span<int> const, std::span<int>::iterator>());
 STATIC_ASSERT(test_cend<std::span<int> const, std::span<int>::iterator>());
 STATIC_ASSERT(test_crbegin<std::span<int> const, std::reverse_iterator<std::span<int>::iterator>>());
 STATIC_ASSERT(test_crend<std::span<int> const, std::reverse_iterator<std::span<int>::iterator>>());
 STATIC_ASSERT(test_cdata<std::span<int> const, int*>());
-#endif // C++20
+#endif // ^^^ !_HAS_CXX23 ^^^
 
 STATIC_ASSERT(test_begin<std::span<int>&, std::span<int>::iterator>());
 STATIC_ASSERT(test_end<std::span<int>&, std::span<int>::iterator>());
@@ -1094,13 +1094,13 @@ STATIC_ASSERT(test_cend<std::span<int>&, std::span<int>::const_iterator>());
 STATIC_ASSERT(test_crbegin<std::span<int>&, std::span<int>::const_reverse_iterator>());
 STATIC_ASSERT(test_crend<std::span<int>&, std::span<int>::const_reverse_iterator>());
 STATIC_ASSERT(test_cdata<std::span<int>&, const int*>());
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
 STATIC_ASSERT(test_cbegin<std::span<int>&, std::span<int>::iterator>());
 STATIC_ASSERT(test_cend<std::span<int>&, std::span<int>::iterator>());
 STATIC_ASSERT(test_crbegin<std::span<int>&, std::reverse_iterator<std::span<int>::iterator>>());
 STATIC_ASSERT(test_crend<std::span<int>&, std::reverse_iterator<std::span<int>::iterator>>());
 STATIC_ASSERT(test_cdata<std::span<int>&, int*>());
-#endif // C++20
+#endif // ^^^ !_HAS_CXX23 ^^^
 
 STATIC_ASSERT(test_begin<std::span<int> const&, std::span<int>::iterator>());
 STATIC_ASSERT(test_end<std::span<int> const&, std::span<int>::iterator>());
@@ -1118,13 +1118,13 @@ STATIC_ASSERT(test_cend<std::span<int> const&, std::span<int>::const_iterator>()
 STATIC_ASSERT(test_crbegin<std::span<int> const&, std::span<int>::const_reverse_iterator>());
 STATIC_ASSERT(test_crend<std::span<int> const&, std::span<int>::const_reverse_iterator>());
 STATIC_ASSERT(test_cdata<std::span<int> const&, const int*>());
-#else // ^^^ C++23 / C++20 vvv
+#else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
 STATIC_ASSERT(test_cbegin<std::span<int> const&, std::span<int>::iterator>());
 STATIC_ASSERT(test_cend<std::span<int> const&, std::span<int>::iterator>());
 STATIC_ASSERT(test_crbegin<std::span<int> const&, std::reverse_iterator<std::span<int>::iterator>>());
 STATIC_ASSERT(test_crend<std::span<int> const&, std::reverse_iterator<std::span<int>::iterator>>());
 STATIC_ASSERT(test_cdata<std::span<int> const&, int*>());
-#endif // C++20
+#endif // ^^^ !_HAS_CXX23 ^^^
 
 using valarray_int_iterator       = decltype(std::begin(std::declval<std::valarray<int>&>()));
 using const_valarray_int_iterator = decltype(std::begin(std::declval<const std::valarray<int>&>()));


### PR DESCRIPTION
* Fix comment typos.
* Drop comment `// inspected by GSL, do not remove`.
  + This is no longer necessary after microsoft/GSL#822.
* Comments: `C++23 / C++20` => `_HAS_CXX23 / !_HAS_CXX23`
  + This is more conventional and more accurately descriptive.
* Comments: Replace weird `_HAS_CXX23` comments with conventional ones.
* Comments: Replace weird `^^ real test / vv workaround` comments with conventional ones.
* Comments: In `yvals_core.h`, drop most comments around "macros with language mode sensitivity".
  + This eliminates one last occurrence of `^^^ C++23 / C++20 vvv`. We were pretty inconsistent about the patterns here, and these comments were distracting from the actually useful paper citations. The regions here are all single line, so it's okay to skip preprocessor comments. The only comment I retained was `#endif // language mode` because it's next to `#endif // !defined(_M_CEE_PURE)`.