### PR TITLE
Tests: Extract `is_permissive.hpp`

### DIFF
--- a/tests/std/include/is_permissive.hpp
+++ b/tests/std/include/is_permissive.hpp
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <yvals_core.h>
+
+namespace detail {
+    constexpr bool permissive() {
+        return false;
+    }
+
+    template <class>
+    struct PermissiveTestBase {
+        static constexpr bool permissive() {
+            return true;
+        }
+    };
+
+    template <class T>
+    struct PermissiveTest : PermissiveTestBase<T> {
+        static constexpr bool test() {
+            return permissive();
+        }
+    };
+} // namespace detail
+
+template <class T>
+_INLINE_VAR constexpr bool is_permissive_v = detail::PermissiveTest<T>::test();
+
+_INLINE_VAR constexpr bool is_permissive = is_permissive_v<int>;

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -12,33 +12,14 @@
 #include <type_traits>
 #include <utility>
 
+#include <is_permissive.hpp>
+
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
 
 namespace ranges = std::ranges;
 
 template <class>
 inline constexpr bool always_false = false;
-
-namespace detail {
-    constexpr bool permissive() {
-        return false;
-    }
-
-    template <class>
-    struct DependentBase {
-        static constexpr bool permissive() {
-            return true;
-        }
-    };
-
-    template <class T>
-    struct Derived : DependentBase<T> {
-        static constexpr bool test() {
-            return permissive();
-        }
-    };
-} // namespace detail
-constexpr bool is_permissive = detail::Derived<int>::test();
 
 template <class T>
 inline constexpr T* nullptr_to = nullptr;

--- a/tests/std/tests/P0645R10_text_formatting_args/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_args/test.cpp
@@ -12,6 +12,8 @@
 #include <type_traits>
 #include <variant>
 
+#include <is_permissive.hpp>
+
 using namespace std;
 
 template <class CharType>
@@ -264,27 +266,6 @@ template <class Context>
 void test_lvalue_only_visitation() {
     visit_format_arg(lvalue_only_visitor{}, basic_format_arg<Context>{});
 }
-
-namespace detail {
-    constexpr bool permissive() {
-        return false;
-    }
-
-    template <class>
-    struct DependentBase {
-        static constexpr bool permissive() {
-            return true;
-        }
-    };
-
-    template <class T>
-    struct Derived : DependentBase<T> {
-        static constexpr bool test() {
-            return permissive();
-        }
-    };
-} // namespace detail
-constexpr bool is_permissive = detail::Derived<int>::test();
 
 template <class Context, class... Args>
 concept CanMakeFormatArgs = requires(Args&&... args) { make_format_args<Context>(static_cast<Args&&>(args)...); };

--- a/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.compile.pass.cpp
+++ b/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.compile.pass.cpp
@@ -11,32 +11,13 @@
 #include <type_traits>
 #include <utility>
 
+#include <is_permissive.hpp>
+
 #pragma warning(disable : 4793) // function compiled as native: non-clrcall vcall thunks must be compiled as native
 
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
 
 namespace ranges = std::ranges;
-
-namespace detail {
-    constexpr bool permissive() {
-        return false;
-    }
-
-    template <class>
-    struct DependentBase {
-        static constexpr bool permissive() {
-            return true;
-        }
-    };
-
-    template <class T>
-    struct Derived : DependentBase<T> {
-        static constexpr bool test() {
-            return permissive();
-        }
-    };
-} // namespace detail
-constexpr bool is_permissive = detail::Derived<int>::test();
 
 template <bool>
 struct borrowed { // borrowed<true> is a borrowed_range; borrowed<false> is not

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -22,6 +22,8 @@
 #include <type_traits>
 #include <utility>
 
+#include <is_permissive.hpp>
+
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
 
 template <class, class = void>
@@ -31,27 +33,6 @@ constexpr bool is_trait<T, std::void_t<typename T::type>> = true;
 
 template <class>
 constexpr bool always_false = false;
-
-namespace detail {
-    constexpr bool permissive() {
-        return false;
-    }
-
-    template <class>
-    struct DependentBase {
-        static constexpr bool permissive() {
-            return true;
-        }
-    };
-
-    template <class T>
-    struct Derived : DependentBase<T> {
-        static constexpr bool test() {
-            return permissive();
-        }
-    };
-} // namespace detail
-constexpr bool is_permissive = detail::Derived<int>::test();
 
 struct IncompleteClass;
 union IncompleteUnion;

--- a/tests/std/tests/P2136R3_invoke_r/test.cpp
+++ b/tests/std/tests/P2136R3_invoke_r/test.cpp
@@ -6,31 +6,11 @@
 #include <string>
 #include <type_traits>
 
+#include <is_permissive.hpp>
+
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
 
 using namespace std;
-
-// TRANSITION, DevCom-1457457
-namespace detail {
-    constexpr bool permissive() {
-        return false;
-    }
-
-    template <class>
-    struct DependentBase {
-        static constexpr bool permissive() {
-            return true;
-        }
-    };
-
-    template <class T>
-    struct Derived : DependentBase<T> {
-        static constexpr bool test() {
-            return permissive();
-        }
-    };
-} // namespace detail
-constexpr bool is_permissive = detail::Derived<int>::test();
 
 constexpr int square(int n) {
     return n * n;

--- a/tests/std/tests/VSO_0000000_type_traits/test.cpp
+++ b/tests/std/tests/VSO_0000000_type_traits/test.cpp
@@ -9,6 +9,8 @@
 #include <type_traits>
 #include <utility>
 
+#include <is_permissive.hpp>
+
 using namespace std;
 
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
@@ -1267,27 +1269,6 @@ namespace {
     constexpr bool is_trait = false;
     template <class T>
     constexpr bool is_trait<T, void_t<typename T::type>> = true;
-
-    namespace detail {
-        constexpr bool permissive() {
-            return false;
-        }
-
-        template <class>
-        struct DependentBase {
-            static constexpr bool permissive() {
-                return true;
-            }
-        };
-
-        template <class T>
-        struct Derived : DependentBase<T> {
-            static constexpr bool test() {
-                return permissive();
-            }
-        };
-    } // namespace detail
-    constexpr bool is_permissive = detail::Derived<int>::test();
 
     struct move_only {
         move_only()                       = default;


### PR DESCRIPTION
We've accumulated a bunch of test files copy-pasting the machinery used to detect `/permissive` mode. Let's centralize it.

This is based on `test_mdspan_support.hpp`, with `namespace details` renamed to `namespace detail` (see below). Its `PermissiveTestBase` and `PermissiveTest` were nicely named, and it was using `inline constexpr bool`. Also add `is_permissive_v<T>`, when we need it to be dependent on a template parameter. We need to include `<yvals_core.h>` for `_INLINE_VAR`, since there's some C++14 usage.

`test_mdspan_support.hpp`: Drive-by change, this file had both `namespace details` and `namespace detail`. Standardize on the latter, as it's used everywhere else.

`P2136R3_invoke_r`: `// TRANSITION, DevCom-1457457` is repeated where `is_permissive` is used, so we can drop the one next to the definition.