### PR TITLE
Expand old test coverage

### DIFF
--- a/benchmarks/inc/utility.hpp
+++ b/benchmarks/inc/utility.hpp
@@ -14,7 +14,7 @@
 template <class Contained>
 std::vector<Contained> random_vector(size_t n) {
     std::random_device rd;
-    std::uniform_int_distribution<uint64_t> id64;
+    std::uniform_int_distribution<std::uint64_t> id64;
     xoshiro256ss prng{id64(rd), id64(rd), id64(rd), id64(rd)};
 
     std::vector<Contained> res(n);

--- a/benchmarks/inc/xoshiro.hpp
+++ b/benchmarks/inc/xoshiro.hpp
@@ -10,16 +10,17 @@ SPDX-License-Identifier: CC0-1.0 */
 #pragma once
 
 #include <bit>
-#include <stdint.h>
+#include <cstdint>
 
 struct xoshiro256ss {
     xoshiro256ss() = delete;
-    xoshiro256ss(uint64_t s0, uint64_t s1, uint64_t s2, uint64_t s3) : s0_(s0), s1_(s1), s2_(s2), s3_(s3) {}
+    xoshiro256ss(std::uint64_t s0, std::uint64_t s1, std::uint64_t s2, std::uint64_t s3)
+        : s0_(s0), s1_(s1), s2_(s2), s3_(s3) {}
 
-    uint64_t next() {
+    std::uint64_t next() {
         auto result = std::rotl(s1_ * 5, 7) * 9;
 
-        const uint64_t t = s1_ << 17;
+        const std::uint64_t t = s1_ << 17;
 
         s2_ ^= s0_;
         s3_ ^= s1_;
@@ -34,8 +35,8 @@ struct xoshiro256ss {
     }
 
 private:
-    uint64_t s0_;
-    uint64_t s1_;
-    uint64_t s2_;
-    uint64_t s3_;
+    std::uint64_t s0_;
+    std::uint64_t s1_;
+    std::uint64_t s2_;
+    std::uint64_t s3_;
 };

--- a/tests/std/tests/Dev09_172497_tr1_mem_fn_const_correctness/test.cpp
+++ b/tests/std/tests/Dev09_172497_tr1_mem_fn_const_correctness/test.cpp
@@ -37,10 +37,23 @@ struct Cat {
     double purr_cv(int) const volatile {
         return 22.2;
     }
+
+    long double hiss(int, int) {
+        return 33.3l;
+    }
+    long double hiss_c(int, int) const {
+        return 33.3l;
+    }
+    long double hiss_v(int, int) volatile {
+        return 33.3l;
+    }
+    long double hiss_cv(int, int) const volatile {
+        return 33.3l;
+    }
 };
 
-// FDIS 20.8.10 [func.memfn]/2: "The simple call wrapper shall define two nested types named
-// argument_type and result_type as synonyms for cv T* and Ret, respectively, when pm is a pointer to
+// N4659 [depr.func.adaptor.typedefs]/10: "The simple call wrapper returned from a call to mem_fn(pm) shall define two
+// nested types named argument_type and result_type as synonyms for cv T* and Ret, respectively, when pm is a pointer to
 // member function with cv-qualifier cv and taking no arguments, where Ret is pm's return type."
 template <typename Ptr, typename F>
 void test_unary(F) {
@@ -48,8 +61,8 @@ void test_unary(F) {
     STATIC_ASSERT(is_same_v<typename F::result_type, float>);
 }
 
-// FDIS 20.8.10 [func.memfn]/3: "The simple call wrapper shall define three nested types named
-// first_argument_type, second_argument_type, and result_type as synonyms for cv T*, T1, and Ret,
+// N4659 [depr.func.adaptor.typedefs]/11: "The simple call wrapper returned from a call to mem_fn(pm) shall define three
+// nested types named first_argument_type, second_argument_type, and result_type as synonyms for cv T*, T1, and Ret,
 // respectively, when pm is a pointer to member function with cv-qualifier cv and taking one argument
 // of type T1, where Ret is pm's return type."
 template <typename Ptr, typename F>
@@ -57,6 +70,13 @@ void test_binary(F) {
     STATIC_ASSERT(is_same_v<typename F::first_argument_type, Ptr>);
     STATIC_ASSERT(is_same_v<typename F::second_argument_type, int>);
     STATIC_ASSERT(is_same_v<typename F::result_type, double>);
+}
+
+// N4659 [depr.func.adaptor.typedefs]/9: "The simple call wrapper returned from a call to mem_fn(pm) shall have a
+// nested type result_type that is a synonym for the return type of pm when pm is a pointer to member function."
+template <typename F>
+void test_ternary(F) {
+    STATIC_ASSERT(is_same_v<typename F::result_type, long double>);
 }
 
 int main() {
@@ -69,4 +89,9 @@ int main() {
     test_binary<const Cat*>(mem_fn(&Cat::purr_c));
     test_binary<volatile Cat*>(mem_fn(&Cat::purr_v));
     test_binary<const volatile Cat*>(mem_fn(&Cat::purr_cv));
+
+    test_ternary(mem_fn(&Cat::hiss));
+    test_ternary(mem_fn(&Cat::hiss_c));
+    test_ternary(mem_fn(&Cat::hiss_v));
+    test_ternary(mem_fn(&Cat::hiss_cv));
 }

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -6114,7 +6114,7 @@ int run_test()
 #include "variant_test_helpers.h"
 
 namespace visit {
-#if _HAS_CXX20 && !defined(__EDG__) && !defined(TEST_PERMISSIVE)
+#if _HAS_CXX20 && !defined(TEST_PERMISSIVE)
 void test_call_operator_forwarding() {
   using Fn = ForwardingCallObject;
   Fn obj{};
@@ -6563,7 +6563,7 @@ int run_test() {
 #include "variant_test_helpers.h"
 
 namespace visit::return_type {
-#if _HAS_CXX20 && !defined(__EDG__) && !defined(TEST_PERMISSIVE)
+#if _HAS_CXX20 && !defined(TEST_PERMISSIVE)
 template <typename ReturnType>
 void test_call_operator_forwarding() {
   using Fn = ForwardingCallObject;


### PR DESCRIPTION
* Overhaul FDIS citation and extend test coverage for `std::function` PMFs/PMDs.
  + FDIS citations were so old, they escaped our scans for outdated WPs. We don't need to quote `INVOKE`'s Standardese at length, we just need to summarize it. It used to be really confusing, now it's easy mode.
  + A couple of things have changed: derived values are now covered by the Standardese, and `reference_wrapper` support was added. This is tested elsewhere, e.g. in `Dev11_0535636_functional_overhaul`, but we can easily add comprehensive test coverage here.
  + I chose `f1x` and `g1x` to avoid renumbering everything.
* Update FDIS citations and add test coverage for `mem_fn` typedefs.
  + These typedefs were deprecated in C++17 and removed in C++20, so I'm citing WG21-N4659, the C++17 WP.
  + We were also missing test coverage for when `mem_fn` provides only `result_type`. Even though this is deprecated/removed, we may as well be comprehensive.
* `P0088R3_variant`: Activate EDG test coverage.
  + Now that concepts are available.
  + The preprocessor comments aren't being changed here because #4439 is cleaning them up better.
* Drive-by cleanup: In `benchmarks/inc`, include `<cstdint>` and qualify `std::`.
