### PR TITLE
Various cleanups: product code

### DIFF
--- a/stl/inc/__msvc_bit_utils.hpp
+++ b/stl/inc/__msvc_bit_utils.hpp
@@ -202,17 +202,19 @@ _NODISCARD constexpr int _Popcount_fallback(_Ty _Val) noexcept {
         // hence we split the value so that it fits in 32-bit registers
         return _Popcount_fallback(static_cast<unsigned long>(_Val))
              + _Popcount_fallback(static_cast<unsigned long>(_Val >> 32));
-    }
+    } else
 #endif // (defined(_M_IX86) && !defined(_M_HYBRID_X86_ARM64)) || defined(_M_ARM)
-    // we static_cast these bit patterns in order to truncate them to the correct size
-    _Val = static_cast<_Ty>(_Val - ((_Val >> 1) & static_cast<_Ty>(0x5555'5555'5555'5555ull)));
-    _Val = static_cast<_Ty>((_Val & static_cast<_Ty>(0x3333'3333'3333'3333ull))
-                            + ((_Val >> 2) & static_cast<_Ty>(0x3333'3333'3333'3333ull)));
-    _Val = static_cast<_Ty>((_Val + (_Val >> 4)) & static_cast<_Ty>(0x0F0F'0F0F'0F0F'0F0Full));
-    // Multiply by one in each byte, so that it will have the sum of all source bytes in the highest byte
-    _Val = static_cast<_Ty>(_Val * static_cast<_Ty>(0x0101'0101'0101'0101ull));
-    // Extract highest byte
-    return static_cast<int>(_Val >> (_Digits - 8));
+    {
+        // we static_cast these bit patterns in order to truncate them to the correct size
+        _Val = static_cast<_Ty>(_Val - ((_Val >> 1) & static_cast<_Ty>(0x5555'5555'5555'5555ull)));
+        _Val = static_cast<_Ty>((_Val & static_cast<_Ty>(0x3333'3333'3333'3333ull))
+                                + ((_Val >> 2) & static_cast<_Ty>(0x3333'3333'3333'3333ull)));
+        _Val = static_cast<_Ty>((_Val + (_Val >> 4)) & static_cast<_Ty>(0x0F0F'0F0F'0F0F'0F0Full));
+        // Multiply by one in each byte, so that it will have the sum of all source bytes in the highest byte
+        _Val = static_cast<_Ty>(_Val * static_cast<_Ty>(0x0101'0101'0101'0101ull));
+        // Extract highest byte
+        return static_cast<int>(_Val >> (_Digits - 8));
+    }
 }
 
 #if ((defined(_M_IX86) && !defined(_M_HYBRID_X86_ARM64)) || (defined(_M_X64) && !defined(_M_ARM64EC))) \

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -72,14 +72,14 @@ __declspec(noalias) _Min_max_d __stdcall __std_minmax_d(const void* _First, cons
 
 _STD_BEGIN
 template <class _Ty>
-_STD pair<_Ty*, _Ty*> __std_minmax_element(_Ty* const _First, _Ty* const _Last) noexcept {
-    constexpr bool _Signed = _STD is_signed_v<_Ty>;
+pair<_Ty*, _Ty*> __std_minmax_element(_Ty* const _First, _Ty* const _Last) noexcept {
+    constexpr bool _Signed = is_signed_v<_Ty>;
 
     _Min_max_element_t _Res;
 
-    if constexpr (_STD is_same_v<_STD remove_const_t<_Ty>, float>) {
+    if constexpr (is_same_v<remove_const_t<_Ty>, float>) {
         _Res = ::__std_minmax_element_f(_First, _Last, false);
-    } else if constexpr (_STD _Is_any_of_v<_STD remove_const_t<_Ty>, double, long double>) {
+    } else if constexpr (_Is_any_of_v<remove_const_t<_Ty>, double, long double>) {
         _Res = ::__std_minmax_element_d(_First, _Last, false);
     } else if constexpr (sizeof(_Ty) == 1) {
         _Res = ::__std_minmax_element_1(_First, _Last, _Signed);
@@ -90,7 +90,7 @@ _STD pair<_Ty*, _Ty*> __std_minmax_element(_Ty* const _First, _Ty* const _Last) 
     } else if constexpr (sizeof(_Ty) == 8) {
         _Res = ::__std_minmax_element_8(_First, _Last, _Signed);
     } else {
-        static_assert(_STD _Always_false<_Ty>, "Unexpected size");
+        static_assert(_Always_false<_Ty>, "Unexpected size");
     }
 
     return {const_cast<_Ty*>(static_cast<const _Ty*>(_Res._Min)), const_cast<_Ty*>(static_cast<const _Ty*>(_Res._Max))};
@@ -98,18 +98,18 @@ _STD pair<_Ty*, _Ty*> __std_minmax_element(_Ty* const _First, _Ty* const _Last) 
 
 template <class _Ty>
 auto __std_minmax(_Ty* const _First, _Ty* const _Last) noexcept {
-    constexpr bool _Signed = _STD is_signed_v<_Ty>;
+    constexpr bool _Signed = is_signed_v<_Ty>;
 
-    if constexpr (_STD is_pointer_v<_Ty>) {
+    if constexpr (is_pointer_v<_Ty>) {
 #ifdef _WIN64
         const auto _Result = ::__std_minmax_8u(_First, _Last);
 #else
         const auto _Result = ::__std_minmax_4u(_First, _Last);
 #endif
         return _Min_max_p{reinterpret_cast<void*>(_Result._Min), reinterpret_cast<void*>(_Result._Max)};
-    } else if constexpr (_STD is_same_v<_STD remove_const_t<_Ty>, float>) {
+    } else if constexpr (is_same_v<remove_const_t<_Ty>, float>) {
         return ::__std_minmax_f(_First, _Last);
-    } else if constexpr (_STD _Is_any_of_v<_STD remove_const_t<_Ty>, double, long double>) {
+    } else if constexpr (_Is_any_of_v<remove_const_t<_Ty>, double, long double>) {
         return ::__std_minmax_d(_First, _Last);
     } else if constexpr (sizeof(_Ty) == 1) {
         if constexpr (_Signed) {
@@ -136,13 +136,13 @@ auto __std_minmax(_Ty* const _First, _Ty* const _Last) noexcept {
             return ::__std_minmax_8u(_First, _Last);
         }
     } else {
-        static_assert(_STD _Always_false<_Ty>, "Unexpected size");
+        static_assert(_Always_false<_Ty>, "Unexpected size");
     }
 }
 
 template <class _Ty, class _TVal>
 _Ty* __std_find_last_trivial(_Ty* const _First, _Ty* const _Last, const _TVal _Val) noexcept {
-    if constexpr (_STD is_pointer_v<_TVal> || _STD is_null_pointer_v<_TVal>) {
+    if constexpr (is_pointer_v<_TVal> || is_null_pointer_v<_TVal>) {
         return _STD __std_find_last_trivial(_First, _Last, reinterpret_cast<uintptr_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 1) {
         return const_cast<_Ty*>(
@@ -157,7 +157,7 @@ _Ty* __std_find_last_trivial(_Ty* const _First, _Ty* const _Last, const _TVal _V
         return const_cast<_Ty*>(
             static_cast<const _Ty*>(::__std_find_last_trivial_8(_First, _Last, static_cast<uint64_t>(_Val))));
     } else {
-        static_assert(_STD _Always_false<_Ty>, "Unexpected size");
+        static_assert(_Always_false<_Ty>, "Unexpected size");
     }
 }
 _STD_END

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -134,7 +134,7 @@ __declspec(noalias) double __stdcall __std_max_d(const void* _First, const void*
 _STD_BEGIN
 template <class _Ty, class _TVal>
 __declspec(noalias) size_t __std_count_trivial(_Ty* const _First, _Ty* const _Last, const _TVal _Val) noexcept {
-    if constexpr (_STD is_pointer_v<_TVal> || _STD is_null_pointer_v<_TVal>) {
+    if constexpr (is_pointer_v<_TVal> || is_null_pointer_v<_TVal>) {
         return _STD __std_count_trivial(_First, _Last, reinterpret_cast<uintptr_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 1) {
         return ::__std_count_trivial_1(_First, _Last, static_cast<uint8_t>(_Val));
@@ -145,13 +145,13 @@ __declspec(noalias) size_t __std_count_trivial(_Ty* const _First, _Ty* const _La
     } else if constexpr (sizeof(_Ty) == 8) {
         return ::__std_count_trivial_8(_First, _Last, static_cast<uint64_t>(_Val));
     } else {
-        static_assert(_STD _Always_false<_Ty>, "Unexpected size");
+        static_assert(_Always_false<_Ty>, "Unexpected size");
     }
 }
 
 template <class _Ty, class _TVal>
 _Ty* __std_find_trivial(_Ty* const _First, _Ty* const _Last, const _TVal _Val) noexcept {
-    if constexpr (_STD is_pointer_v<_TVal> || _STD is_null_pointer_v<_TVal>) {
+    if constexpr (is_pointer_v<_TVal> || is_null_pointer_v<_TVal>) {
         return _STD __std_find_trivial(_First, _Last, reinterpret_cast<uintptr_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 1) {
         return const_cast<_Ty*>(
@@ -166,13 +166,13 @@ _Ty* __std_find_trivial(_Ty* const _First, _Ty* const _Last, const _TVal _Val) n
         return const_cast<_Ty*>(
             static_cast<const _Ty*>(::__std_find_trivial_8(_First, _Last, static_cast<uint64_t>(_Val))));
     } else {
-        static_assert(_STD _Always_false<_Ty>, "Unexpected size");
+        static_assert(_Always_false<_Ty>, "Unexpected size");
     }
 }
 
 template <class _Ty, class _TVal>
 _Ty* __std_find_trivial_unsized(_Ty* const _First, const _TVal _Val) noexcept {
-    if constexpr (_STD is_pointer_v<_TVal> || _STD is_null_pointer_v<_TVal>) {
+    if constexpr (is_pointer_v<_TVal> || is_null_pointer_v<_TVal>) {
         return _STD __std_find_trivial_unsized(_First, reinterpret_cast<uintptr_t>(_Val));
     } else if constexpr (sizeof(_Ty) == 1) {
         return const_cast<_Ty*>(
@@ -187,17 +187,17 @@ _Ty* __std_find_trivial_unsized(_Ty* const _First, const _TVal _Val) noexcept {
         return const_cast<_Ty*>(
             static_cast<const _Ty*>(::__std_find_trivial_unsized_8(_First, static_cast<uint64_t>(_Val))));
     } else {
-        static_assert(_STD _Always_false<_Ty>, "Unexpected size");
+        static_assert(_Always_false<_Ty>, "Unexpected size");
     }
 }
 
 template <class _Ty>
 _Ty* __std_min_element(_Ty* const _First, _Ty* const _Last) noexcept {
-    constexpr bool _Signed = _STD is_signed_v<_Ty>;
+    constexpr bool _Signed = is_signed_v<_Ty>;
 
-    if constexpr (_STD is_same_v<_STD remove_const_t<_Ty>, float>) {
+    if constexpr (is_same_v<remove_const_t<_Ty>, float>) {
         return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_min_element_f(_First, _Last, false)));
-    } else if constexpr (_STD _Is_any_of_v<_STD remove_const_t<_Ty>, double, long double>) {
+    } else if constexpr (_Is_any_of_v<remove_const_t<_Ty>, double, long double>) {
         return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_min_element_d(_First, _Last, false)));
     } else if constexpr (sizeof(_Ty) == 1) {
         return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_min_element_1(_First, _Last, _Signed)));
@@ -208,17 +208,17 @@ _Ty* __std_min_element(_Ty* const _First, _Ty* const _Last) noexcept {
     } else if constexpr (sizeof(_Ty) == 8) {
         return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_min_element_8(_First, _Last, _Signed)));
     } else {
-        static_assert(_STD _Always_false<_Ty>, "Unexpected size");
+        static_assert(_Always_false<_Ty>, "Unexpected size");
     }
 }
 
 template <class _Ty>
 _Ty* __std_max_element(_Ty* const _First, _Ty* const _Last) noexcept {
-    constexpr bool _Signed = _STD is_signed_v<_Ty>;
+    constexpr bool _Signed = is_signed_v<_Ty>;
 
-    if constexpr (_STD is_same_v<_STD remove_const_t<_Ty>, float>) {
+    if constexpr (is_same_v<remove_const_t<_Ty>, float>) {
         return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_max_element_f(_First, _Last, false)));
-    } else if constexpr (_STD _Is_any_of_v<_STD remove_const_t<_Ty>, double, long double>) {
+    } else if constexpr (_Is_any_of_v<remove_const_t<_Ty>, double, long double>) {
         return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_max_element_d(_First, _Last, false)));
     } else if constexpr (sizeof(_Ty) == 1) {
         return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_max_element_1(_First, _Last, _Signed)));
@@ -229,23 +229,23 @@ _Ty* __std_max_element(_Ty* const _First, _Ty* const _Last) noexcept {
     } else if constexpr (sizeof(_Ty) == 8) {
         return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_max_element_8(_First, _Last, _Signed)));
     } else {
-        static_assert(_STD _Always_false<_Ty>, "Unexpected size");
+        static_assert(_Always_false<_Ty>, "Unexpected size");
     }
 }
 
 template <class _Ty>
 auto __std_min(_Ty* const _First, _Ty* const _Last) noexcept {
-    constexpr bool _Signed = _STD is_signed_v<_Ty>;
+    constexpr bool _Signed = is_signed_v<_Ty>;
 
-    if constexpr (_STD is_pointer_v<_Ty>) {
+    if constexpr (is_pointer_v<_Ty>) {
 #ifdef _WIN64
         return reinterpret_cast<void*>(::__std_min_8u(_First, _Last));
 #else
         return reinterpret_cast<void*>(::__std_min_4u(_First, _Last));
 #endif
-    } else if constexpr (_STD is_same_v<_STD remove_const_t<_Ty>, float>) {
+    } else if constexpr (is_same_v<remove_const_t<_Ty>, float>) {
         return ::__std_min_f(_First, _Last);
-    } else if constexpr (_STD _Is_any_of_v<_STD remove_const_t<_Ty>, double, long double>) {
+    } else if constexpr (_Is_any_of_v<remove_const_t<_Ty>, double, long double>) {
         return ::__std_min_d(_First, _Last);
     } else if constexpr (sizeof(_Ty) == 1) {
         if constexpr (_Signed) {
@@ -272,23 +272,23 @@ auto __std_min(_Ty* const _First, _Ty* const _Last) noexcept {
             return ::__std_min_8u(_First, _Last);
         }
     } else {
-        static_assert(_STD _Always_false<_Ty>, "Unexpected size");
+        static_assert(_Always_false<_Ty>, "Unexpected size");
     }
 }
 
 template <class _Ty>
 auto __std_max(_Ty* const _First, _Ty* const _Last) noexcept {
-    constexpr bool _Signed = _STD is_signed_v<_Ty>;
+    constexpr bool _Signed = is_signed_v<_Ty>;
 
-    if constexpr (_STD is_pointer_v<_Ty>) {
+    if constexpr (is_pointer_v<_Ty>) {
 #ifdef _WIN64
         return reinterpret_cast<void*>(::__std_max_8u(_First, _Last));
 #else
         return reinterpret_cast<void*>(::__std_max_4u(_First, _Last));
 #endif
-    } else if constexpr (_STD is_same_v<_STD remove_const_t<_Ty>, float>) {
+    } else if constexpr (is_same_v<remove_const_t<_Ty>, float>) {
         return ::__std_max_f(_First, _Last);
-    } else if constexpr (_STD _Is_any_of_v<_STD remove_const_t<_Ty>, double, long double>) {
+    } else if constexpr (_Is_any_of_v<remove_const_t<_Ty>, double, long double>) {
         return ::__std_max_d(_First, _Last);
     } else if constexpr (sizeof(_Ty) == 1) {
         if constexpr (_Signed) {
@@ -315,7 +315,7 @@ auto __std_max(_Ty* const _First, _Ty* const _Last) noexcept {
             return ::__std_max_8u(_First, _Last);
         }
     } else {
-        static_assert(_STD _Always_false<_Ty>, "Unexpected size");
+        static_assert(_Always_false<_Ty>, "Unexpected size");
     }
 }
 _STD_END

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -18,12 +18,9 @@
 
 #if _STL_COMPILER_PREPROCESSOR
 
-// This does not use `_EMIT_STL_ERROR`, as it needs to be checked before we include anything else.
-#define _STL_STRINGIZE_(S) #S
-#define _STL_STRINGIZE(S)  _STL_STRINGIZE_(S)
+// This does not use `_EMIT_STL_ERROR`, as it is checking the language itself.
 #ifndef __cplusplus
-#pragma message(__FILE__ "(" _STL_STRINGIZE(__LINE__) "): STL1003: Unexpected compiler, expected C++ compiler.")
-#error Error in C++ Standard Library usage
+#error error STL1003: Unexpected compiler, expected C++ compiler.
 #endif // !defined(__cplusplus)
 
 // Implemented unconditionally:
@@ -503,6 +500,9 @@
 
 #include <vcruntime.h>
 #include <xkeycheck.h> // The _HAS_CXX tags must be defined before including this.
+
+#define _STL_STRINGIZE_(S) #S
+#define _STL_STRINGIZE(S)  _STL_STRINGIZE_(S)
 
 // Note that _STL_PRAGMA is load-bearing;
 // it still needs to exist even once CUDA and ICC support _Pragma.


### PR DESCRIPTION
* In `_Popcount_fallback()`, after `if constexpr ... return` add `else` to avoid dead code.
  + We always follow this convention for `if constexpr`.
* Remove unnecessary `_STD` qualification on types, variable templates, and alias templates.
  + This became possible after my #4146 moved these functions into `namespace std`.
* `yvals_core.h`: Improve "error STL1003: Unexpected compiler, expected C++ compiler." like #4020.
  + Then we can move `_STL_STRINGIZE` down to its point of use, near our other macros.
  + Result:
    ```
    D:\GitHub\STL\out\x64>type woof.c
    #include <vector>
    
    D:\GitHub\STL\out\x64>cl /EHsc /nologo /W4 /c woof.c
    woof.c
    D:\GitHub\STL\out\x64\out\inc\yvals_core.h(23): fatal error C1189: #error:  error STL1003: Unexpected compiler, expected C++ compiler.
    ```