### PR TITLE
`<random>`: Implement Mandates for `seed_seq::generate`

### DIFF
--- a/stl/inc/random
+++ b/stl/inc/random
@@ -179,6 +179,11 @@ public:
 
     template <class _RanIt>
     void generate(_RanIt _First, _RanIt _Last) const { // generate randomized interval from seeds
+        static_assert(_Is_any_of_v<remove_cv_t<typename iterator_traits<_RanIt>::value_type>, //
+                          unsigned int, unsigned long, unsigned long long>,
+            "N4971 [rand.util.seedseq]/7 requires the value type of the iterator to be an unsigned type that is at "
+            "least 32-bit.");
+
         _Adl_verify_range(_First, _Last);
         auto _UFirst   = _Get_unwrapped(_First);
         const auto _Nx = static_cast<size_t>(_Get_unwrapped(_Last) - _UFirst);


### PR DESCRIPTION
Fixes #4434.

Notes:
- Extended unsigned integer types are not supported (through the whole MSVC STL).
- `char32_t` is excluded because it's not an "unsigned integer type" in the core language.
- `remove_cv_t` is used, which is related to CWG-251 (still open).
- `_Iter_value_t` is intentionally not used, see #4436.