### PR TITLE
Fix vectorized `ranges::find` with `unreachable_sentinel` to properly mask the beginning and handle unaligned pointers

### DIFF
--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -1862,16 +1862,8 @@ namespace {
             unsigned int _Bingo = static_cast<unsigned int>(_mm256_movemask_epi8(_Traits::_Cmp_avx(_Data, _Comparand)));
 
             _Bingo &= _Mask;
-            if (_Bingo != 0) {
-                unsigned long _Offset = _tzcnt_u32(_Bingo);
-                _Advance_bytes(_First, _Offset);
-                return _First;
-            }
 
             for (;;) {
-                _Data  = _mm256_load_si256(static_cast<const __m256i*>(_First));
-                _Bingo = static_cast<unsigned int>(_mm256_movemask_epi8(_Traits::_Cmp_avx(_Data, _Comparand)));
-
                 if (_Bingo != 0) {
                     unsigned long _Offset = _tzcnt_u32(_Bingo);
                     _Advance_bytes(_First, _Offset);
@@ -1879,6 +1871,9 @@ namespace {
                 }
 
                 _Advance_bytes(_First, 32);
+
+                _Data  = _mm256_load_si256(static_cast<const __m256i*>(_First));
+                _Bingo = static_cast<unsigned int>(_mm256_movemask_epi8(_Traits::_Cmp_avx(_Data, _Comparand)));
             }
         }
 
@@ -1898,17 +1893,8 @@ namespace {
             unsigned int _Bingo = static_cast<unsigned int>(_mm_movemask_epi8(_Traits::_Cmp_sse(_Data, _Comparand)));
 
             _Bingo &= _Mask;
-            if (_Bingo != 0) {
-                unsigned long _Offset;
-                _BitScanForward(&_Offset, _Bingo); // lgtm [cpp/conditionallyuninitializedvariable]
-                _Advance_bytes(_First, _Offset);
-                return _First;
-            }
 
             for (;;) {
-                _Data  = _mm_load_si128(static_cast<const __m128i*>(_First));
-                _Bingo = static_cast<unsigned int>(_mm_movemask_epi8(_Traits::_Cmp_sse(_Data, _Comparand)));
-
                 if (_Bingo != 0) {
                     unsigned long _Offset;
                     _BitScanForward(&_Offset, _Bingo); // lgtm [cpp/conditionallyuninitializedvariable]
@@ -1917,6 +1903,9 @@ namespace {
                 }
 
                 _Advance_bytes(_First, 16);
+
+                _Data  = _mm_load_si128(static_cast<const __m128i*>(_First));
+                _Bingo = static_cast<unsigned int>(_mm_movemask_epi8(_Traits::_Cmp_sse(_Data, _Comparand)));
             }
         }
 #endif // !_M_ARM64EC

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -1844,7 +1844,10 @@ namespace {
     template <class _Traits, class _Ty>
     const void* __stdcall __std_find_trivial_unsized_impl(const void* _First, const _Ty _Val) noexcept {
 #ifndef _M_ARM64EC
-        if (_Use_avx2()) {
+        if ((reinterpret_cast<uintptr_t>(_First) & (sizeof(_Ty) - 1)) != 0) {
+            // _First isn't aligned to sizeof(_Ty), so we need to use the scalar fallback below.
+            // This can happen with 8-byte elements on x86's 4-aligned stack. It can also happen with packed structs.
+        } else if (_Use_avx2()) {
             _Zeroupper_on_exit _Guard; // TRANSITION, DevCom-10331414
 
             // We read by vector-sized pieces, and we align pointers to vector-sized boundary.
@@ -1875,9 +1878,7 @@ namespace {
                 _Data  = _mm256_load_si256(static_cast<const __m256i*>(_First));
                 _Bingo = static_cast<unsigned int>(_mm256_movemask_epi8(_Traits::_Cmp_avx(_Data, _Comparand)));
             }
-        }
-
-        if (_Traits::_Sse_available()) {
+        } else if (_Traits::_Sse_available()) {
             // We read by vector-sized pieces, and we align pointers to vector-sized boundary.
             // From start partial piece we mask out matches that don't belong to the range.
             // This makes sure we never cross page boundary, thus we read 'as if' sequentially.

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -140,6 +140,32 @@ void test_find(mt19937_64& gen) {
     }
 }
 
+#if _HAS_CXX20
+// GH-4449 <xutility>: ranges::find with unreachable_sentinel / __std_find_trivial_unsized_1 gives wrong result
+template <class T>
+void test_gh_4449() {
+    constexpr T desired_val{11};
+    constexpr T unwanted_val{22};
+
+    T arr[256];
+
+    constexpr int mid1 = 64;
+    constexpr int mid2 = 192;
+
+    ranges::fill(arr, arr + mid1, desired_val);
+    ranges::fill(arr + mid1, arr + mid2, unwanted_val);
+    ranges::fill(arr + mid2, end(arr), desired_val);
+
+    for (int idx = mid1; idx <= mid2; ++idx) { // when idx == mid2, the value is immediately found
+        const auto where = ranges::find(arr + idx, unreachable_sentinel, desired_val);
+
+        assert(where == arr + mid2);
+
+        arr[idx] = desired_val; // get ready for the next iteration
+    }
+}
+#endif // _HAS_CXX20
+
 #if _HAS_CXX23
 template <class T>
 void test_case_find_last(const vector<T>& input, T v) {
@@ -370,6 +396,13 @@ void test_vector_algorithms(mt19937_64& gen) {
     test_find<unsigned int>(gen);
     test_find<long long>(gen);
     test_find<unsigned long long>(gen);
+
+#if _HAS_CXX20
+    test_gh_4449<uint8_t>();
+    test_gh_4449<uint16_t>();
+    test_gh_4449<uint32_t>();
+    test_gh_4449<uint64_t>();
+#endif // _HAS_CXX20
 
 #if _HAS_CXX23
     test_find_last<char>(gen);


### PR DESCRIPTION
Fixes #4449.

For unsized `ranges::find`, `vector_algorithms.cpp` reads elements "before the beginning", although (hopefully) not in a way that annoys memory page protection or ASAN. Then we "we mask out matches that don't belong to the range", pretending that they weren't there. This allows us to use vectorized loads for the entire unbounded loop, instead of starting with classic scalar code until we get to a nicely-aligned boundary.

However, we had a control flow bug. We started with "load" a vector chunk, "mask" away matches before the beginning, "check" if we found anything (and return if so). Then we started our infinite loop: `for (;;) { load; check; advance; }`. But this repeated the initial load and check, *without the mask!* It was also unnecessary extra work.

A minimal correctness fix would be to cycle around the "advance" step: `load; mask; check; for (;;) { advance; load; check; }`. But we can do even better - the "check" steps are exactly identical between the first part and the infinite loop. So we can cycle the loop a bit more: `load; mask; for (;;) { check; advance; load; }` avoids having to repeat the "check". (The "load" steps are also exactly identical, but there's no easy way to fuse them, given that we want to mask only the first one.)

Also fixes #4454.

Unlike the other vectorized algorithms, find-unsized uses aligned loads, so it requires that its N-byte elements are N-aligned. This is notoriously untrue on x86, where 8-byte elements can appear on a 4-aligned stack. Packed structs can also subvert this assumption.

We can simply test whether the pointer is properly aligned. I was able to fix this with the following control flow:

```cpp
#ifndef _M_ARM64EC
if (unaligned) {
    // use the scalar fallback below
} else if (_Use_avx2()) {
    always return AVX2 result;
} else if (_Traits::_Sse_available()) {
    always return SSE-n result;
}
#endif // !_M_ARM64EC
return scalar fallback;
```

Note that (unlike some other vectorized algorithms) our AVX2 and SSE-n codepaths here are always-return, so chaining them with `else if` is fine. I thought this was less disruptive than increasing the level of control flow nesting.