### PR TITLE
`<regex>`: Limit capture groups

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -4153,9 +4153,13 @@ void _Parser<_FwdIt, _Elem, _RxTraits>::_CharacterClass() { // add bracket expre
 
 template <class _FwdIt, class _Elem, class _RxTraits>
 void _Parser<_FwdIt, _Elem, _RxTraits>::_Do_capture_group() { // add capture group
-    // if (_MAX_GRP <= ++_Grp_idx)
-    //     _Error(regex_constants::error_complexity);
-    _Node_base* _Pos1 = _Nfa._Begin_capture_group(++_Grp_idx);
+    ++_Grp_idx;
+
+    if (_Grp_idx >= 1000) { // hardcoded limit
+        _Xregex_error(regex_constants::error_stack);
+    }
+
+    _Node_base* _Pos1 = _Nfa._Begin_capture_group(_Grp_idx);
     _Disjunction();
     _Nfa._End_group(_Pos1);
     _Finished_grps.resize(_Grp_idx + 1);


### PR DESCRIPTION
In general, the STL cannot avoid all stack overflows. (We don't know how much stack has been consumed when the user calls us, so thinking *any* thoughts might be too much.) However, `<regex>` tries to throw exceptions instead of stack overflowing due to excessive recursion. We've had a long-standing struggle with exactly where to set this threshold during matching; right now our threshold detects most potential overflows before they happen, but not all.

However, we don't do anything during regex *construction*. It turns out that requesting an excessive number of capture groups can easily trigger a stack overflow. We even had commented-out legacy code, indicating that our predecessors thought about this scenario somewhat. This PR adds a hardcoded limit arbitrarily set at 1000, which is more than generous enough for realistic code, yet comfortably far away from where I begin to observe stack overflows.

Alternatively, we could have more comprehensive logic to track the number of nested function calls during regex construction (which I believe would be entirely ABI-safe), but I'd like to go with this targeted change for now.