### PR TITLE
`<format>`: Always enable compile-time format string checking for `wchar_t`

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -3682,7 +3682,7 @@ public:
     template <class _Ty>
         requires convertible_to<const _Ty&, basic_string_view<_CharT>>
     consteval basic_format_string(const _Ty& _Str_val) : _Str(_Str_val) {
-        if (_Is_execution_charset_self_synchronizing()) {
+        if constexpr (!is_same_v<_CharT, char> || _Is_execution_charset_self_synchronizing()) {
             using _Context             = basic_format_context<back_insert_iterator<_Fmt_buffer<_CharT>>, _CharT>;
             constexpr size_t _Num_args = sizeof...(_Args);
             constexpr _Basic_format_arg_type _Arg_types[_Num_args > 0 ? _Num_args : 1] = {


### PR DESCRIPTION
We've been enabling compiler-time format string checking for self-synchronizing execution character sets (see #2221 and #2493). 

However, when the character type is `wchar_t`, the checking may also be skipped for certain execution character sets ([Godbolt link](https://godbolt.org/z/oh1K3fPcq)), although, IIUC, the supported execution _wide_ character set should always be Unicode and MSVC STL only supports `wchar_t` of the UTF-16 encoding.

This PR unconditionally enables compiler-time format string checking when the character type is `wchar_t` (or is not `char`, if formatting for `charN_t` is supported in the future).