### PR TITLE
`download_unicode_data_files.py`: Select latest or a specific version

### DIFF
--- a/tools/unicode_properties_parse/download_unicode_data_files.py
+++ b/tools/unicode_properties_parse/download_unicode_data_files.py
@@ -3,6 +3,7 @@
 
 from pathlib import PurePosixPath
 import sys
+from urllib.error import HTTPError
 from urllib.request import urlretrieve
 
 
@@ -36,7 +37,10 @@ def download_unicode_data_files():
         url = base_url + data_file
         filename = PurePosixPath(data_file).name
         print(f"Downloading: {url}")
-        urlretrieve(url, filename)
+        try:
+            urlretrieve(url, filename)
+        except HTTPError as http_error:
+            sys.exit(f"{http_error}")
 
 
 if __name__ == "__main__":

--- a/tools/unicode_properties_parse/download_unicode_data_files.py
+++ b/tools/unicode_properties_parse/download_unicode_data_files.py
@@ -1,21 +1,41 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from pathlib import PurePosixPath
+import sys
 from urllib.request import urlretrieve
 
 
-Unicode_data_files = {
-    "DerivedCoreProperties.txt": "https://www.unicode.org/Public/UCD/latest/ucd/DerivedCoreProperties.txt",
-    "DerivedGeneralCategory.txt": "https://www.unicode.org/Public/UCD/latest/ucd/extracted/DerivedGeneralCategory.txt",
-    "EastAsianWidth.txt": "https://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt",
-    "GraphemeBreakProperty.txt": "https://www.unicode.org/Public/UCD/latest/ucd/auxiliary/GraphemeBreakProperty.txt",
-    "GraphemeBreakTest.txt": "https://www.unicode.org/Public/UCD/latest/ucd/auxiliary/GraphemeBreakTest.txt",
-    "emoji-data.txt": "https://www.unicode.org/Public/UCD/latest/ucd/emoji/emoji-data.txt",
-}
+def get_base_url():
+    if len(sys.argv) != 2:
+        sys.exit(f"Usage: python {sys.argv[0]} [latest|<VERSION LIKE 15.0.0>]")
+
+    version = sys.argv[1]
+
+    if version == "latest":
+        return "https://unicode.org/Public/UCD/latest/"
+
+    return f"https://unicode.org/Public/{version}/"
+
+
+Unicode_data_files = [
+    "ucd/DerivedCoreProperties.txt",
+    "ucd/extracted/DerivedGeneralCategory.txt",
+    "ucd/EastAsianWidth.txt",
+    "ucd/auxiliary/GraphemeBreakProperty.txt",
+    "ucd/auxiliary/GraphemeBreakTest.txt",
+    "ucd/emoji/emoji-data.txt",
+]
+
 
 def download_unicode_data_files():
-    for filename, url in Unicode_data_files.items():
-        print(f"downloading {filename} from {url}")
+    base_url = get_base_url()
+    print(f"   Base URL: {base_url}")
+
+    for data_file in Unicode_data_files:
+        url = base_url + data_file
+        filename = PurePosixPath(data_file).name
+        print(f"Downloading: {url}")
         urlretrieve(url, filename)
 
 


### PR DESCRIPTION
Followup to #4435, addressing @tahonermann's https://github.com/microsoft/STL/pull/4435#discussion_r1518638817.

Usage examples:

```
D:\GitHub\STL\tools\unicode_properties_parse>python download_unicode_data_files.py
Usage: python download_unicode_data_files.py [latest|<VERSION LIKE 15.0.0>]

D:\GitHub\STL\tools\unicode_properties_parse>python download_unicode_data_files.py x y
Usage: python download_unicode_data_files.py [latest|<VERSION LIKE 15.0.0>]

D:\GitHub\STL\tools\unicode_properties_parse>python download_unicode_data_files.py latest
   Base URL: https://unicode.org/Public/UCD/latest/
Downloading: https://unicode.org/Public/UCD/latest/ucd/DerivedCoreProperties.txt
Downloading: https://unicode.org/Public/UCD/latest/ucd/extracted/DerivedGeneralCategory.txt
Downloading: https://unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt
Downloading: https://unicode.org/Public/UCD/latest/ucd/auxiliary/GraphemeBreakProperty.txt
Downloading: https://unicode.org/Public/UCD/latest/ucd/auxiliary/GraphemeBreakTest.txt
Downloading: https://unicode.org/Public/UCD/latest/ucd/emoji/emoji-data.txt

D:\GitHub\STL\tools\unicode_properties_parse>dir *.txt
[...]
03/10/2024  05:30 PM         1,072,686 DerivedCoreProperties.txt
03/10/2024  05:30 PM           268,498 DerivedGeneralCategory.txt
03/10/2024  05:30 PM           194,188 EastAsianWidth.txt
03/10/2024  05:30 PM           111,505 emoji-data.txt
03/10/2024  05:30 PM            96,863 GraphemeBreakProperty.txt
03/10/2024  05:30 PM           188,211 GraphemeBreakTest.txt
               6 File(s)      1,931,951 bytes
[...]

D:\GitHub\STL\tools\unicode_properties_parse>python download_unicode_data_files.py 15.0.0
   Base URL: https://unicode.org/Public/15.0.0/
Downloading: https://unicode.org/Public/15.0.0/ucd/DerivedCoreProperties.txt
Downloading: https://unicode.org/Public/15.0.0/ucd/extracted/DerivedGeneralCategory.txt
Downloading: https://unicode.org/Public/15.0.0/ucd/EastAsianWidth.txt
Downloading: https://unicode.org/Public/15.0.0/ucd/auxiliary/GraphemeBreakProperty.txt
Downloading: https://unicode.org/Public/15.0.0/ucd/auxiliary/GraphemeBreakTest.txt
Downloading: https://unicode.org/Public/15.0.0/ucd/emoji/emoji-data.txt

D:\GitHub\STL\tools\unicode_properties_parse>dir *.txt
[...]
03/10/2024  05:30 PM         1,053,943 DerivedCoreProperties.txt
03/10/2024  05:30 PM           268,339 DerivedGeneralCategory.txt
03/10/2024  05:30 PM           186,337 EastAsianWidth.txt
03/10/2024  05:30 PM           111,505 emoji-data.txt
03/10/2024  05:30 PM            96,863 GraphemeBreakProperty.txt
03/10/2024  05:30 PM            83,691 GraphemeBreakTest.txt
               6 File(s)      1,800,678 bytes
[...]

D:\GitHub\STL\tools\unicode_properties_parse>python download_unicode_data_files.py peppermint
   Base URL: https://unicode.org/Public/peppermint/
Downloading: https://unicode.org/Public/peppermint/ucd/DerivedCoreProperties.txt
HTTP Error 404: Not Found
```