### PR TITLE
Remove attempt on unsized find vectorization...

### DIFF
--- a/benchmarks/src/find_and_count.cpp
+++ b/benchmarks/src/find_and_count.cpp
@@ -42,31 +42,12 @@ BENCHMARK(bm<uint8_t, 8021, 3056, Op::FindUnsized>);
 BENCHMARK(bm<uint8_t, 8021, 3056, Op::Count>);
 
 BENCHMARK(bm<uint16_t, 8021, 3056, Op::FindSized>);
-BENCHMARK(bm<uint16_t, 8021, 3056, Op::FindUnsized>);
 BENCHMARK(bm<uint16_t, 8021, 3056, Op::Count>);
 
 BENCHMARK(bm<uint32_t, 8021, 3056, Op::FindSized>);
-BENCHMARK(bm<uint32_t, 8021, 3056, Op::FindUnsized>);
 BENCHMARK(bm<uint32_t, 8021, 3056, Op::Count>);
 
 BENCHMARK(bm<uint64_t, 8021, 3056, Op::FindSized>);
-BENCHMARK(bm<uint64_t, 8021, 3056, Op::FindUnsized>);
 BENCHMARK(bm<uint64_t, 8021, 3056, Op::Count>);
-
-BENCHMARK(bm<int8_t, 8021, 3056, Op::FindSized>);
-BENCHMARK(bm<int8_t, 8021, 3056, Op::FindUnsized>);
-BENCHMARK(bm<int8_t, 8021, 3056, Op::Count>);
-
-BENCHMARK(bm<int16_t, 8021, 3056, Op::FindSized>);
-BENCHMARK(bm<int16_t, 8021, 3056, Op::FindUnsized>);
-BENCHMARK(bm<int16_t, 8021, 3056, Op::Count>);
-
-BENCHMARK(bm<int32_t, 8021, 3056, Op::FindSized>);
-BENCHMARK(bm<int32_t, 8021, 3056, Op::FindUnsized>);
-BENCHMARK(bm<int32_t, 8021, 3056, Op::Count>);
-
-BENCHMARK(bm<int64_t, 8021, 3056, Op::FindSized>);
-BENCHMARK(bm<int64_t, 8021, 3056, Op::FindUnsized>);
-BENCHMARK(bm<int64_t, 8021, 3056, Op::Count>);
 
 BENCHMARK_MAIN();

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5950,7 +5950,7 @@ namespace ranges {
         requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
     _NODISCARD constexpr _It _Find_unchecked(_It _First, const _Se _Last, const _Ty& _Val, _Pj _Proj = {}) {
         // TRANSITION, DevCom-1614562: not trying wmemchr
-        // Only one-byte elements are suitable for unsized optimization
+        // Only single-byte elements are suitable for unsized optimization
         constexpr bool _Single_byte_elements = sizeof(_Iter_value_t<_It>) == 1;
         constexpr bool _Is_sized             = sized_sentinel_for<_Se, _It>;
 
@@ -5973,8 +5973,8 @@ namespace ranges {
 
                 _Ptr_t _Result;
 #if _USE_STD_VECTOR_ALGORITHMS
-                if constexpr (!_Single_byte_elements) {
-                    _STL_INTERNAL_STATIC_ASSERT(_Is_sized);
+                if constexpr (_Is_sized) {
+                    // When _Is_sized && _Single_byte_elements, prefer this over memchr() for performance
                     const auto _Last_ptr = _First_ptr + (_Last - _First);
                     _Result              = _STD __std_find_trivial(_First_ptr, _Last_ptr, _Val);
                 } else

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5956,7 +5956,7 @@ namespace ranges {
         constexpr bool _Is_memchr_sized_elements = sizeof(_Iter_value_t<_It>) == 1;
 
         if constexpr (_Vector_alg_in_find_is_safe<_It, _Ty>
-                      && (_Is_sized && (_USE_STD_VECTOR_ALGORITHMS || _Is_memchr_sized_elements)
+                      && ((_Is_sized && (_USE_STD_VECTOR_ALGORITHMS || _Is_memchr_sized_elements))
                           || same_as<_Se, unreachable_sentinel_t> && _Is_memchr_sized_elements)
                       && same_as<_Pj, identity>) {
             if (!_STD is_constant_evaluated()) {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5957,7 +5957,7 @@ namespace ranges {
 
         if constexpr (_Vector_alg_in_find_is_safe<_It, _Ty>
                       && ((_Is_sized && (_USE_STD_VECTOR_ALGORITHMS || _Is_memchr_sized_elements))
-                          ||( same_as<_Se, unreachable_sentinel_t> && _Is_memchr_sized_elements))
+                          || (same_as<_Se, unreachable_sentinel_t> && _Is_memchr_sized_elements))
                       && same_as<_Pj, identity>) {
             if (!_STD is_constant_evaluated()) {
                 if (!_STD _Could_compare_equal_to_value_type<_It>(_Val)) {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5989,6 +5989,12 @@ namespace ranges {
                     }
 
                     _Result = static_cast<_Ptr_t>(_CSTD memchr(_First_ptr, static_cast<unsigned char>(_Val), _Count));
+
+                    if constexpr (_Is_sized) {
+                        if (_Result == nullptr) {
+                            return _RANGES next(_STD move(_First), _Last);
+                        }
+                    }
                 }
 
                 if constexpr (is_pointer_v<_It>) {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5973,26 +5973,23 @@ namespace ranges {
 
                 _Ptr_t _Result;
 #if _USE_STD_VECTOR_ALGORITHMS
-                if constexpr (_Is_sized) {
+                if constexpr (!_Single_byte_elements) {
+                    _STL_INTERNAL_STATIC_ASSERT(_Is_sized);
                     const auto _Last_ptr = _First_ptr + (_Last - _First);
                     _Result              = _STD __std_find_trivial(_First_ptr, _Last_ptr, _Val);
-                } else {
+                } else
+#endif // ^^^ _USE_STD_VECTOR_ALGORITHMS ^^^
+                {
                     _STL_INTERNAL_STATIC_ASSERT(_Single_byte_elements);
+                    size_t _Count;
+                    if constexpr (_Is_sized) {
+                        _Count = static_cast<size_t>(_Last - _First);
+                    } else {
+                        _Count = SIZE_MAX;
+                    }
 
-                    _Result = static_cast<_Ptr_t>(_CSTD memchr(_First_ptr, static_cast<unsigned char>(_Val), SIZE_MAX));
+                    _Result = static_cast<_Ptr_t>(_CSTD memchr(_First_ptr, static_cast<unsigned char>(_Val), _Count));
                 }
-#else // ^^^ _USE_STD_VECTOR_ALGORITHMS / !_USE_STD_VECTOR_ALGORITHMS vvv
-                _STL_INTERNAL_STATIC_ASSERT(_Single_byte_elements);
-
-                size_t _Count;
-                if constexpr (_Is_sized) {
-                    _Count = static_cast<size_t>(_Last - _First);
-                } else {
-                    _Count = SIZE_MAX;
-                }
-
-                _Result = static_cast<_Ptr_t>(_CSTD memchr(_First_ptr, static_cast<unsigned char>(_Val), _Count));
-#endif // ^^^ !_USE_STD_VECTOR_ALGORITHMS ^^^
 
                 if constexpr (is_pointer_v<_It>) {
                     return _Result;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5950,13 +5950,13 @@ namespace ranges {
         requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
     _NODISCARD constexpr _It _Find_unchecked(_It _First, const _Se _Last, const _Ty& _Val, _Pj _Proj = {}) {
         // TRANSITION, DevCom-1614562: not trying wmemchr
-        // Only byte sized elements are suitable for unsized optimization
-        constexpr bool _Is_memchr_sized_elements = sizeof(_Iter_value_t<_It>) == 1;
-        constexpr bool _Is_sized                 = sized_sentinel_for<_Se, _It>;
+        // Only one-byte elements are suitable for unsized optimization
+        constexpr bool _Single_byte_elements = sizeof(_Iter_value_t<_It>) == 1;
+        constexpr bool _Is_sized             = sized_sentinel_for<_Se, _It>;
 
         if constexpr (_Vector_alg_in_find_is_safe<_It, _Ty>
-                      && ((_Is_sized && (_USE_STD_VECTOR_ALGORITHMS || _Is_memchr_sized_elements))
-                          || (same_as<_Se, unreachable_sentinel_t> && _Is_memchr_sized_elements))
+                      && ((_Is_sized && (_USE_STD_VECTOR_ALGORITHMS || _Single_byte_elements))
+                          || (same_as<_Se, unreachable_sentinel_t> && _Single_byte_elements))
                       && same_as<_Pj, identity>) {
             if (!_STD is_constant_evaluated()) {
                 if (!_STD _Could_compare_equal_to_value_type<_It>(_Val)) {
@@ -5977,12 +5977,12 @@ namespace ranges {
                     const auto _Last_ptr = _First_ptr + (_Last - _First);
                     _Result              = _STD __std_find_trivial(_First_ptr, _Last_ptr, _Val);
                 } else {
-                    _STL_INTERNAL_STATIC_ASSERT(_Is_memchr_sized_elements);
+                    _STL_INTERNAL_STATIC_ASSERT(_Single_byte_elements);
 
                     _Result = static_cast<_Ptr_t>(_CSTD memchr(_First_ptr, static_cast<unsigned char>(_Val), SIZE_MAX));
                 }
 #else // ^^^ _USE_STD_VECTOR_ALGORITHMS / !_USE_STD_VECTOR_ALGORITHMS vvv
-                _STL_INTERNAL_STATIC_ASSERT(_Is_memchr_sized_elements);
+                _STL_INTERNAL_STATIC_ASSERT(_Single_byte_elements);
 
                 size_t _Count;
                 if constexpr (_Is_sized) {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5949,7 +5949,7 @@ namespace ranges {
     template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity>
         requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
     _NODISCARD constexpr _It _Find_unchecked(_It _First, const _Se _Last, const _Ty& _Val, _Pj _Proj = {}) {
-        // TRANSITION, DevCom - 1614562 : not trying wmemchr
+        // TRANSITION, DevCom-1614562: not trying wmemchr
         // Only byte sized elements are suitable for unsized optimization
         constexpr bool _Is_memchr_sized_elements = sizeof(_Iter_value_t<_It>) == 1;
         constexpr bool _Is_sized                 = sized_sentinel_for<_Se, _It>;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5957,7 +5957,7 @@ namespace ranges {
 
         if constexpr (_Vector_alg_in_find_is_safe<_It, _Ty>
                       && ((_Is_sized && (_USE_STD_VECTOR_ALGORITHMS || _Is_memchr_sized_elements))
-                          || same_as<_Se, unreachable_sentinel_t> && _Is_memchr_sized_elements)
+                          ||( same_as<_Se, unreachable_sentinel_t> && _Is_memchr_sized_elements))
                       && same_as<_Pj, identity>) {
             if (!_STD is_constant_evaluated()) {
                 if (!_STD _Could_compare_equal_to_value_type<_It>(_Val)) {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -90,11 +90,6 @@ const void* __stdcall __std_find_trivial_2(const void* _First, const void* _Last
 const void* __stdcall __std_find_trivial_4(const void* _First, const void* _Last, uint32_t _Val) noexcept;
 const void* __stdcall __std_find_trivial_8(const void* _First, const void* _Last, uint64_t _Val) noexcept;
 
-const void* __stdcall __std_find_trivial_unsized_1(const void* _First, uint8_t _Val) noexcept;
-const void* __stdcall __std_find_trivial_unsized_2(const void* _First, uint16_t _Val) noexcept;
-const void* __stdcall __std_find_trivial_unsized_4(const void* _First, uint32_t _Val) noexcept;
-const void* __stdcall __std_find_trivial_unsized_8(const void* _First, uint64_t _Val) noexcept;
-
 const void* __stdcall __std_min_element_1(const void* _First, const void* _Last, bool _Signed) noexcept;
 const void* __stdcall __std_min_element_2(const void* _First, const void* _Last, bool _Signed) noexcept;
 const void* __stdcall __std_min_element_4(const void* _First, const void* _Last, bool _Signed) noexcept;
@@ -165,27 +160,6 @@ _Ty* __std_find_trivial(_Ty* const _First, _Ty* const _Last, const _TVal _Val) n
     } else if constexpr (sizeof(_Ty) == 8) {
         return const_cast<_Ty*>(
             static_cast<const _Ty*>(::__std_find_trivial_8(_First, _Last, static_cast<uint64_t>(_Val))));
-    } else {
-        static_assert(_Always_false<_Ty>, "Unexpected size");
-    }
-}
-
-template <class _Ty, class _TVal>
-_Ty* __std_find_trivial_unsized(_Ty* const _First, const _TVal _Val) noexcept {
-    if constexpr (is_pointer_v<_TVal> || is_null_pointer_v<_TVal>) {
-        return _STD __std_find_trivial_unsized(_First, reinterpret_cast<uintptr_t>(_Val));
-    } else if constexpr (sizeof(_Ty) == 1) {
-        return const_cast<_Ty*>(
-            static_cast<const _Ty*>(::__std_find_trivial_unsized_1(_First, static_cast<uint8_t>(_Val))));
-    } else if constexpr (sizeof(_Ty) == 2) {
-        return const_cast<_Ty*>(
-            static_cast<const _Ty*>(::__std_find_trivial_unsized_2(_First, static_cast<uint16_t>(_Val))));
-    } else if constexpr (sizeof(_Ty) == 4) {
-        return const_cast<_Ty*>(
-            static_cast<const _Ty*>(::__std_find_trivial_unsized_4(_First, static_cast<uint32_t>(_Val))));
-    } else if constexpr (sizeof(_Ty) == 8) {
-        return const_cast<_Ty*>(
-            static_cast<const _Ty*>(::__std_find_trivial_unsized_8(_First, static_cast<uint64_t>(_Val))));
     } else {
         static_assert(_Always_false<_Ty>, "Unexpected size");
     }
@@ -5976,7 +5950,14 @@ namespace ranges {
         requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
     _NODISCARD constexpr _It _Find_unchecked(_It _First, const _Se _Last, const _Ty& _Val, _Pj _Proj = {}) {
         constexpr bool _Is_sized = sized_sentinel_for<_Se, _It>;
-        if constexpr (_Vector_alg_in_find_is_safe<_It, _Ty> && _Sized_or_unreachable_sentinel_for<_Se, _It>
+
+        // TRANSITION, DevCom - 1614562 : not trying wmemchr
+        // Only byte sized elements are suitable for unsized optimization
+        constexpr bool _Is_memchr_sized_elements = sizeof(_Iter_value_t<_It>) == 1;
+
+        if constexpr (_Vector_alg_in_find_is_safe<_It, _Ty>
+                      && (_Is_sized && (_USE_STD_VECTOR_ALGORITHMS || _Is_memchr_sized_elements)
+                          || same_as<_Se, unreachable_sentinel_t> && _Is_memchr_sized_elements)
                       && same_as<_Pj, identity>) {
             if (!_STD is_constant_evaluated()) {
                 if (!_STD _Could_compare_equal_to_value_type<_It>(_Val)) {
@@ -5989,48 +5970,37 @@ namespace ranges {
                 }
 
                 using _Ptr_t = remove_reference_t<_Iter_ref_t<_It>>*;
-#if _USE_STD_VECTOR_ALGORITHMS
+
                 const auto _First_ptr = _STD _To_address(_First);
 
                 _Ptr_t _Result;
-
+#if _USE_STD_VECTOR_ALGORITHMS
                 if constexpr (_Is_sized) {
                     const auto _Last_ptr = _First_ptr + (_Last - _First);
-
-                    _Result = _STD __std_find_trivial(_First_ptr, _Last_ptr, _Val);
+                    _Result              = _STD __std_find_trivial(_First_ptr, _Last_ptr, _Val);
                 } else {
-                    _Result = _STD __std_find_trivial_unsized(_First_ptr, _Val);
+                    _STL_INTERNAL_STATIC_ASSERT(_Is_memchr_sized_elements);
+
+                    _Result = static_cast<_Ptr_t>(_CSTD memchr(_First_ptr, static_cast<unsigned char>(_Val), SIZE_MAX));
                 }
+#else // ^^^ _USE_STD_VECTOR_ALGORITHMS / !_USE_STD_VECTOR_ALGORITHMS vvv
+                _STL_INTERNAL_STATIC_ASSERT(_Is_memchr_sized_elements);
+
+                size_t _Count;
+                if constexpr (_Is_sized) {
+                    _Count = static_cast<size_t>(_Last - _First);
+                } else {
+                    _Count = SIZE_MAX;
+                }
+
+                _Result = static_cast<_Ptr_t>(_CSTD memchr(_First_ptr, static_cast<unsigned char>(_Val), _Count));
+#endif // ^^^ !_USE_STD_VECTOR_ALGORITHMS ^^^
 
                 if constexpr (is_pointer_v<_It>) {
                     return _Result;
                 } else {
                     return _RANGES next(_STD move(_First), _Result - _First_ptr);
                 }
-#else // ^^^ _USE_STD_VECTOR_ALGORITHMS / !_USE_STD_VECTOR_ALGORITHMS vvv
-                if constexpr (sizeof(_Iter_value_t<_It>) == 1) {
-                    size_t _Count;
-                    if constexpr (_Is_sized) {
-                        _Count = static_cast<size_t>(_Last - _First);
-                    } else {
-                        _Count = SIZE_MAX;
-                    }
-
-                    const auto _First_ptr = _STD to_address(_First);
-                    const auto _Result =
-                        static_cast<_Ptr_t>(_CSTD memchr(_First_ptr, static_cast<unsigned char>(_Val), _Count));
-                    if (_Result) {
-                        if constexpr (is_pointer_v<_It>) {
-                            return _Result;
-                        } else {
-                            return _RANGES next(_STD move(_First), _Result - _First_ptr);
-                        }
-                    } else {
-                        return _RANGES next(_STD move(_First), _Last);
-                    }
-                }
-                // TRANSITION, DevCom-1614562: not trying wmemchr
-#endif // ^^^ !_USE_STD_VECTOR_ALGORITHMS ^^^
             }
         }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5949,11 +5949,10 @@ namespace ranges {
     template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity>
         requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
     _NODISCARD constexpr _It _Find_unchecked(_It _First, const _Se _Last, const _Ty& _Val, _Pj _Proj = {}) {
-        constexpr bool _Is_sized = sized_sentinel_for<_Se, _It>;
-
         // TRANSITION, DevCom - 1614562 : not trying wmemchr
         // Only byte sized elements are suitable for unsized optimization
         constexpr bool _Is_memchr_sized_elements = sizeof(_Iter_value_t<_It>) == 1;
+        constexpr bool _Is_sized                 = sized_sentinel_for<_Se, _It>;
 
         if constexpr (_Vector_alg_in_find_is_safe<_It, _Ty>
                       && ((_Is_sized && (_USE_STD_VECTOR_ALGORITHMS || _Is_memchr_sized_elements))
@@ -5969,8 +5968,7 @@ namespace ranges {
                     }
                 }
 
-                using _Ptr_t = remove_reference_t<_Iter_ref_t<_It>>*;
-
+                using _Ptr_t          = remove_reference_t<_Iter_ref_t<_It>>*;
                 const auto _First_ptr = _STD _To_address(_First);
 
                 _Ptr_t _Result;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5955,8 +5955,8 @@ namespace ranges {
         constexpr bool _Is_sized             = sized_sentinel_for<_Se, _It>;
 
         if constexpr (_Vector_alg_in_find_is_safe<_It, _Ty>
-                      && ((_Is_sized && (_USE_STD_VECTOR_ALGORITHMS || _Single_byte_elements))
-                          || (same_as<_Se, unreachable_sentinel_t> && _Single_byte_elements))
+                      && (_Single_byte_elements ? _Is_sized || same_as<_Se, unreachable_sentinel_t>
+                                                : _Is_sized && _USE_STD_VECTOR_ALGORITHMS)
                       && same_as<_Pj, identity>) {
             if (!_STD is_constant_evaluated()) {
                 if (!_STD _Could_compare_equal_to_value_type<_It>(_Val)) {

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -1839,7 +1839,7 @@ namespace {
 
     // TRANSITION, ABI: used only in functions preserved for binary compatibility
     template <class _Ty>
-    const void* __std_find_trivial_unsized_impl(const void* _First, const _Ty _Val) noexcept {
+    const void* __std_find_trivial_unsized_impl(const void* const _First, const _Ty _Val) noexcept {
         auto _Ptr = static_cast<const _Ty*>(_First);
         while (*_Ptr != _Val) {
             ++_Ptr;

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -1847,6 +1847,10 @@ namespace {
         return _Ptr;
     }
 
+    // The below functions have exactly the same signature as the extern "C" functions, up to calling convention.
+    // This makes sure the template specialization can be fused with the extern "C" function.
+    // In optimized builds it avoids an extra call, as these functions are too large to inline.
+
     template <class _Traits, class _Ty>
     const void* __stdcall __std_find_trivial_impl(const void* _First, const void* _Last, _Ty _Val) noexcept {
 #ifndef _M_ARM64EC


### PR DESCRIPTION
... except for 1-byte element, where we can still yield to `memchr` 

Fixes #4485

Drive-by: signed coverage doesn't make difference here