### PR TITLE
Standard Library Modules: Fix warning C4365 (signed/unsigned mismatch) with `/ZI`

### DIFF
--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -172,8 +172,10 @@ _STL_DISABLE_CLANG_WARNINGS
 #ifndef _STL_CRT_SECURE_INVALID_PARAMETER
 #ifdef _STL_CALL_ABORT_INSTEAD_OF_INVALID_PARAMETER
 #define _STL_CRT_SECURE_INVALID_PARAMETER(expr) _CSTD abort()
-#elif defined(_DEBUG) // avoid emitting unused long strings for function names; see GH-1956
-#define _STL_CRT_SECURE_INVALID_PARAMETER(expr) ::_invalid_parameter(_CRT_WIDE(#expr), L"", __FILEW__, __LINE__, 0)
+#elif defined(_DEBUG) // Avoid emitting unused long strings for function names; see GH-1956.
+// static_cast<unsigned int>(__LINE__) avoids warning C4365 (signed/unsigned mismatch) with the /ZI compiler option.
+#define _STL_CRT_SECURE_INVALID_PARAMETER(expr) \
+    ::_invalid_parameter(_CRT_WIDE(#expr), L"", __FILEW__, static_cast<unsigned int>(__LINE__), 0)
 #else // ^^^ defined(_DEBUG) / !defined(_DEBUG) vvv
 #define _STL_CRT_SECURE_INVALID_PARAMETER(expr) _CRT_SECURE_INVALID_PARAMETER(expr)
 #endif // ^^^ !defined(_DEBUG) ^^^

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -467,11 +467,7 @@ private:
     }              \
     }
 
-#ifdef _DEBUG
-#define _RAISE(x) _invoke_watson(_CRT_WIDE(#x), __FUNCTIONW__, __FILEW__, __LINE__, 0)
-#else
 #define _RAISE(x) _invoke_watson(nullptr, nullptr, nullptr, 0, 0)
-#endif
 
 #define _RERAISE
 #define _THROW(...) (__VA_ARGS__)._Raise()


### PR DESCRIPTION
This fixes DevCom-10610863 "Importing module std warns on signed/unsigned mismatch" (internal VSO-1992367 / AB#1992367 ).

# Problem

The problem was that the [`/ZI` compiler option](https://learn.microsoft.com/en-us/cpp/build/reference/z7-zi-zi-debug-information-format?view=msvc-170) (debug info for Edit and Continue) messes with `__LINE__`, making it a variable of type `long` instead of an integer literal. This variable can emit sign conversion warnings when passed to functions taking unsigned types (whereas integer literals don't, regardless of their type, because the compiler can directly see that the value is unaffected).

# Fix

The fix is to `static_cast<unsigned int>`, matching what [`_invalid_parameter()`][invalid_parameter_and_invoke_watson] takes.

[invalid_parameter_and_invoke_watson]: https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/invalid-parameter-functions?view=msvc-170

I'm also slightly updating the previous comment, since `// sentence fragment` is fine by itself, but multiple sentences need punctuation for clarity.

# Extra fix/cleanup

There was one more potential occurrence of signed/unsigned mismatch warnings involving `__LINE__`, when we call [`_invoke_watson()`][invalid_parameter_and_invoke_watson] for `_HAS_EXCEPTIONS=0`. I couldn't actually repro a warning here, but we can eliminate any risk - it turns out that `_invoke_watson()` always ignores its parameters. See `C:\Program Files (x86)\Windows Kits\10\Source\10.0.22621.0\ucrt\misc\invalid_parameter.cpp`.

# Unchanged `__LINE__`s

The rest of our `__LINE__` usage is with [`_malloc_dbg`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/malloc-dbg?view=msvc-170) and [`_calloc_dbg`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/calloc-dbg?view=msvc-170):

https://github.com/microsoft/STL/blob/191d51bb56230069db531f94a02fe0987bf4db85/stl/inc/xlocale#L43

They take `int linenumber`, so a `long` will be fine.

# No test coverage

I've been testing with `/w14365` since the very beginning:

https://github.com/microsoft/STL/blob/191d51bb56230069db531f94a02fe0987bf4db85/tests/std/tests/P2465R3_standard_library_modules/env.lst#L6

However, we missed this for two reasons: (1) no `/ZI` coverage, and (2) we use `_STL_CALL_ABORT_INSTEAD_OF_INVALID_PARAMETER` in our tests, which inherently bypasses the affected code. So, adding `/ZI` wouldn't actually accomplish anything useful.

Since we're highly centralized (all of `_STL_ASSERT`, `_STL_VERIFY`, `_STL_REPORT_ERROR`, and `_INVALID_MEMORY_ORDER` ultimately lead to `_STL_CRT_SECURE_INVALID_PARAMETER`), I believe that manual testing of this fix is sufficient as we're unlikely to regress.