### PR TITLE
libcxx `stol.pass.cpp` is now passing for ASAN

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -209,9 +209,6 @@ std/language.support/support.dynamic/new.delete/new.delete.array/new.size_nothro
 std/language.support/support.dynamic/new.delete/new.delete.single/new.size_align_nothrow.pass.cpp:1 FAIL
 std/language.support/support.dynamic/new.delete/new.delete.single/new.size_nothrow.pass.cpp:1 FAIL
 
-# ASAN runtime intercepts `strtol` and breaks LWG-2009 (VSO-1875597)
-std/strings/string.conversions/stol.pass.cpp:1 FAIL
-
 # Not analyzed. SKIPPED because this is x86-specific.
 # ERROR: AddressSanitizer: allocator is out of memory trying to allocate NNNN bytes
 std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_strong.pass.cpp:1 SKIPPED


### PR DESCRIPTION
Followup to the VS 2022 17.10 Preview 2 toolset update #4475.

This toolset fixed VSO-1875597 "\[ASAN\]\[STL\] Interception breaks strtol: TEST 'libc++ std/strings/string.conversions/stol.pass.cpp:1' FAILED". @CaseyCarter explained the bug:

> The implementation of `std::stol` expects `::strtol` to set `errno` to `ERANGE` when given an unrepresentable input, which it does normally, but not with ASAN

We can now un-skip the affected test.

(We missed a few opportunities to discover this during the toolset update; I should have run ASAN, etc. I'll try to improve our development practices in the future.)