### PR TITLE
Implement LWG-3950 `std::basic_string_view` comparison operators are overspecified

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1643,119 +1643,13 @@ namespace ranges {
 } // namespace ranges
 #endif // _HAS_CXX20
 
-_EXPORT_STD template <class _Elem, class _Traits>
-_NODISCARD constexpr bool operator==(
-    const basic_string_view<_Elem, _Traits> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
-    return _Lhs._Equal(_Rhs);
-}
-
-#if !_HAS_CXX20
-template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO-409326
-_NODISCARD constexpr bool operator==(
-    const _Identity_t<basic_string_view<_Elem, _Traits>> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
-    return _Lhs._Equal(_Rhs);
-}
-#endif // !_HAS_CXX20
-
-_EXPORT_STD template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO-409326
-_NODISCARD constexpr bool operator==(
-    const basic_string_view<_Elem, _Traits> _Lhs, const _Identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
-    return _Lhs._Equal(_Rhs);
-}
-
-#if !_HAS_CXX20
-template <class _Elem, class _Traits>
-_NODISCARD constexpr bool operator!=(
-    const basic_string_view<_Elem, _Traits> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
-    return !_Lhs._Equal(_Rhs);
-}
-
-template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO-409326
-_NODISCARD constexpr bool operator!=(
-    const _Identity_t<basic_string_view<_Elem, _Traits>> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
-    return !_Lhs._Equal(_Rhs);
-}
-
-template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO-409326
-_NODISCARD constexpr bool operator!=(
-    const basic_string_view<_Elem, _Traits> _Lhs, const _Identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
-    return !_Lhs._Equal(_Rhs);
-}
-
-template <class _Elem, class _Traits>
-_NODISCARD constexpr bool operator<(
-    const basic_string_view<_Elem, _Traits> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
-    return _Lhs.compare(_Rhs) < 0;
-}
-
-template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO-409326
-_NODISCARD constexpr bool operator<(
-    const _Identity_t<basic_string_view<_Elem, _Traits>> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
-    return _Lhs.compare(_Rhs) < 0;
-}
-
-template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO-409326
-_NODISCARD constexpr bool operator<(
-    const basic_string_view<_Elem, _Traits> _Lhs, const _Identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
-    return _Lhs.compare(_Rhs) < 0;
-}
-
-template <class _Elem, class _Traits>
-_NODISCARD constexpr bool operator>(
-    const basic_string_view<_Elem, _Traits> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
-    return _Lhs.compare(_Rhs) > 0;
-}
-
-template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO-409326
-_NODISCARD constexpr bool operator>(
-    const _Identity_t<basic_string_view<_Elem, _Traits>> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
-    return _Lhs.compare(_Rhs) > 0;
-}
-
-template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO-409326
-_NODISCARD constexpr bool operator>(
-    const basic_string_view<_Elem, _Traits> _Lhs, const _Identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
-    return _Lhs.compare(_Rhs) > 0;
-}
-
-template <class _Elem, class _Traits>
-_NODISCARD constexpr bool operator<=(
-    const basic_string_view<_Elem, _Traits> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
-    return _Lhs.compare(_Rhs) <= 0;
-}
-
-template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO-409326
-_NODISCARD constexpr bool operator<=(
-    const _Identity_t<basic_string_view<_Elem, _Traits>> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
-    return _Lhs.compare(_Rhs) <= 0;
-}
-
-template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO-409326
-_NODISCARD constexpr bool operator<=(
-    const basic_string_view<_Elem, _Traits> _Lhs, const _Identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
-    return _Lhs.compare(_Rhs) <= 0;
-}
-
-template <class _Elem, class _Traits>
-_NODISCARD constexpr bool operator>=(
-    const basic_string_view<_Elem, _Traits> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
-    return _Lhs.compare(_Rhs) >= 0;
-}
-
-template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO-409326
-_NODISCARD constexpr bool operator>=(
-    const _Identity_t<basic_string_view<_Elem, _Traits>> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
-    return _Lhs.compare(_Rhs) >= 0;
-}
-
-template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO-409326
-_NODISCARD constexpr bool operator>=(
-    const basic_string_view<_Elem, _Traits> _Lhs, const _Identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
-    return _Lhs.compare(_Rhs) >= 0;
-}
-#endif // !_HAS_CXX20
-
 #if _HAS_CXX20
+_EXPORT_STD template <class _Elem, class _Traits>
+_NODISCARD constexpr bool operator==(const basic_string_view<_Elem, _Traits> _Lhs,
+    const type_identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
+    return _Lhs._Equal(_Rhs);
+}
+
 template <class _Traits, class = void>
 struct _Get_comparison_category {
     using type = weak_ordering;
@@ -1766,24 +1660,126 @@ struct _Get_comparison_category<_Traits, void_t<typename _Traits::comparison_cat
     using type = _Traits::comparison_category;
 
     static_assert(_Is_any_of_v<type, partial_ordering, weak_ordering, strong_ordering>,
-        "N4950 [string.view.comparison]/4: Mandates: R denotes a comparison category type.");
+        "N4971 [string.view.comparison]/4: Mandates: R denotes a comparison category type.");
 };
 
 template <class _Traits>
 using _Get_comparison_category_t = _Get_comparison_category<_Traits>::type;
 
 _EXPORT_STD template <class _Elem, class _Traits>
-_NODISCARD constexpr _Get_comparison_category_t<_Traits> operator<=>(
-    const basic_string_view<_Elem, _Traits> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
+_NODISCARD constexpr _Get_comparison_category_t<_Traits> operator<=>(const basic_string_view<_Elem, _Traits> _Lhs,
+    const type_identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
     return static_cast<_Get_comparison_category_t<_Traits>>(_Lhs.compare(_Rhs) <=> 0);
+}
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
+template <class _Elem, class _Traits>
+_NODISCARD constexpr bool operator==(
+    const basic_string_view<_Elem, _Traits> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
+    return _Lhs._Equal(_Rhs);
 }
 
-_EXPORT_STD template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO-409326
-_NODISCARD constexpr _Get_comparison_category_t<_Traits> operator<=>(
-    const basic_string_view<_Elem, _Traits> _Lhs, const _Identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
-    return static_cast<_Get_comparison_category_t<_Traits>>(_Lhs.compare(_Rhs) <=> 0);
+template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO-409326
+_NODISCARD constexpr bool operator==(
+    const _Identity_t<basic_string_view<_Elem, _Traits>> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
+    return _Lhs._Equal(_Rhs);
 }
-#endif // _HAS_CXX20
+
+template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO-409326
+_NODISCARD constexpr bool operator==(
+    const basic_string_view<_Elem, _Traits> _Lhs, const _Identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
+    return _Lhs._Equal(_Rhs);
+}
+
+template <class _Elem, class _Traits>
+_NODISCARD constexpr bool operator!=(
+    const basic_string_view<_Elem, _Traits> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
+    return !_Lhs._Equal(_Rhs);
+}
+
+template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO-409326
+_NODISCARD constexpr bool operator!=(
+    const _Identity_t<basic_string_view<_Elem, _Traits>> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
+    return !_Lhs._Equal(_Rhs);
+}
+
+template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO-409326
+_NODISCARD constexpr bool operator!=(
+    const basic_string_view<_Elem, _Traits> _Lhs, const _Identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
+    return !_Lhs._Equal(_Rhs);
+}
+
+template <class _Elem, class _Traits>
+_NODISCARD constexpr bool operator<(
+    const basic_string_view<_Elem, _Traits> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
+    return _Lhs.compare(_Rhs) < 0;
+}
+
+template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO-409326
+_NODISCARD constexpr bool operator<(
+    const _Identity_t<basic_string_view<_Elem, _Traits>> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
+    return _Lhs.compare(_Rhs) < 0;
+}
+
+template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO-409326
+_NODISCARD constexpr bool operator<(
+    const basic_string_view<_Elem, _Traits> _Lhs, const _Identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
+    return _Lhs.compare(_Rhs) < 0;
+}
+
+template <class _Elem, class _Traits>
+_NODISCARD constexpr bool operator>(
+    const basic_string_view<_Elem, _Traits> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
+    return _Lhs.compare(_Rhs) > 0;
+}
+
+template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO-409326
+_NODISCARD constexpr bool operator>(
+    const _Identity_t<basic_string_view<_Elem, _Traits>> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
+    return _Lhs.compare(_Rhs) > 0;
+}
+
+template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO-409326
+_NODISCARD constexpr bool operator>(
+    const basic_string_view<_Elem, _Traits> _Lhs, const _Identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
+    return _Lhs.compare(_Rhs) > 0;
+}
+
+template <class _Elem, class _Traits>
+_NODISCARD constexpr bool operator<=(
+    const basic_string_view<_Elem, _Traits> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
+    return _Lhs.compare(_Rhs) <= 0;
+}
+
+template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO-409326
+_NODISCARD constexpr bool operator<=(
+    const _Identity_t<basic_string_view<_Elem, _Traits>> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
+    return _Lhs.compare(_Rhs) <= 0;
+}
+
+template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO-409326
+_NODISCARD constexpr bool operator<=(
+    const basic_string_view<_Elem, _Traits> _Lhs, const _Identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
+    return _Lhs.compare(_Rhs) <= 0;
+}
+
+template <class _Elem, class _Traits>
+_NODISCARD constexpr bool operator>=(
+    const basic_string_view<_Elem, _Traits> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
+    return _Lhs.compare(_Rhs) >= 0;
+}
+
+template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO-409326
+_NODISCARD constexpr bool operator>=(
+    const _Identity_t<basic_string_view<_Elem, _Traits>> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
+    return _Lhs.compare(_Rhs) >= 0;
+}
+
+template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO-409326
+_NODISCARD constexpr bool operator>=(
+    const basic_string_view<_Elem, _Traits> _Lhs, const _Identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
+    return _Lhs.compare(_Rhs) >= 0;
+}
+#endif // ^^^ !_HAS_CXX20 ^^^
 
 _EXPORT_STD using string_view = basic_string_view<char>;
 #ifdef __cpp_lib_char8_t

--- a/tests/std/tests/P0220R1_string_view/test.cpp
+++ b/tests/std/tests/P0220R1_string_view/test.cpp
@@ -1261,6 +1261,79 @@ void test_C6510_warning() { // compile-only
     (void) sv;
 }
 
+#if _HAS_CXX20
+// LWG-3950 "std::basic_string_view comparison operators are overspecified"
+namespace test_lwg_3950 {
+    template <class _Traits>
+    struct get_string_comparison_category {
+        using type = weak_ordering;
+    };
+
+    template <class Traits>
+        requires requires { typename Traits::comparison_category; }
+    struct get_string_comparison_category<Traits> {
+        using type = Traits::comparison_category;
+
+        static_assert(disjunction_v<is_same<type, partial_ordering>, is_same<type, weak_ordering>,
+            is_same<type, strong_ordering>>);
+    };
+
+    template <class Traits>
+    using get_string_comparison_category_t = get_string_comparison_category<Traits>::type;
+
+    template <class Traits>
+    concept characterized_traits = requires { typename Traits::is_characterized; };
+
+#ifdef __clang__ // TRANSITION, LLVM-75404
+#define CONST_PARAM const
+#else // ^^^ workaround / no workaround vvv
+#define CONST_PARAM
+#endif // ^^^ no workaround ^^^
+
+    template <class CharT, characterized_traits Traits>
+    constexpr bool operator==(CONST_PARAM basic_string_view<CharT, Traits> x,
+        CONST_PARAM type_identity_t<basic_string_view<CharT, Traits>> y) noexcept {
+        return x.size() == y.size() && x.compare(y) == 0;
+    }
+    template <class CharT, characterized_traits Traits>
+    constexpr get_string_comparison_category_t<Traits> operator<=>(CONST_PARAM basic_string_view<CharT, Traits> x,
+        CONST_PARAM type_identity_t<basic_string_view<CharT, Traits>> y) noexcept {
+        return static_cast<get_string_comparison_category_t<Traits>>(x.compare(y) <=> 0);
+    }
+
+    template <class CharT>
+    struct test_traits : char_traits<CharT> {
+        using is_characterized = void;
+    };
+
+    using test_string_view = basic_string_view<char, test_traits<char>>;
+
+    static_assert(test_string_view{} == test_string_view{});
+    static_assert(!(test_string_view{} != test_string_view{}));
+    static_assert(!(test_string_view{} < test_string_view{}));
+    static_assert(!(test_string_view{} > test_string_view{}));
+    static_assert(test_string_view{} <= test_string_view{});
+    static_assert(test_string_view{} >= test_string_view{});
+    static_assert(test_string_view{} <=> test_string_view{} == strong_ordering::equal);
+
+    static_assert(test_string_view{} == "");
+    static_assert(!(test_string_view{} != ""));
+    static_assert(!(test_string_view{} < ""));
+    static_assert(!(test_string_view{} > ""));
+    static_assert(test_string_view{} <= "");
+    static_assert(test_string_view{} >= "");
+    static_assert(test_string_view{} <=> "" == strong_ordering::equal);
+
+    static_assert("" == test_string_view{});
+    static_assert(!("" != test_string_view{}));
+    static_assert(!("" < test_string_view{}));
+    static_assert(!("" > test_string_view{}));
+    static_assert("" <= test_string_view{});
+    static_assert("" >= test_string_view{});
+    static_assert("" <=> test_string_view{} == strong_ordering::equal);
+} // namespace test_lwg_3950
+#endif // _HAS_CXX20
+
 int main() {
     test_case_default_constructor();
     test_case_ntcts_constructor();

--- a/tests/std/tests/P0220R1_string_view/test.cpp
+++ b/tests/std/tests/P0220R1_string_view/test.cpp
@@ -1264,7 +1264,7 @@ void test_C6510_warning() { // compile-only
 #if _HAS_CXX20
 // LWG-3950 "std::basic_string_view comparison operators are overspecified"
 namespace test_lwg_3950 {
-    template <class _Traits>
+    template <class Traits>
     struct get_string_comparison_category {
         using type = weak_ordering;
     };


### PR DESCRIPTION
Fixes #4500.

Tests whether `std::type_identity_t` is exactly used, see #4249.