### PR TITLE
Implement LWG-3919 `enumerate_view` may invoke UB for sized common non-forward underlying ranges

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -6386,7 +6386,7 @@ namespace ranges {
         _NODISCARD constexpr auto end() noexcept(_Is_end_nothrow_v<_Vw>) // strengthened
             requires (!_Simple_view<_Vw>)
         {
-            if constexpr (common_range<_Vw> && sized_range<_Vw>) {
+            if constexpr (forward_range<_Vw> && common_range<_Vw> && sized_range<_Vw>) {
                 return _Iterator<false>{_RANGES end(_Range), _RANGES distance(_Range)};
             } else {
                 return _Sentinel<false>{_RANGES end(_Range)};
@@ -6396,7 +6396,7 @@ namespace ranges {
         _NODISCARD constexpr auto end() const noexcept(_Is_end_nothrow_v<const _Vw>) // strengthened
             requires _Range_with_movable_references<const _Vw>
         {
-            if constexpr (common_range<const _Vw> && sized_range<const _Vw>) {
+            if constexpr (forward_range<const _Vw> && common_range<const _Vw> && sized_range<const _Vw>) {
                 return _Iterator<true>{_RANGES end(_Range), _RANGES distance(_Range)};
             } else {
                 return _Sentinel<true>{_RANGES end(_Range)};

--- a/tests/std/tests/P2164R9_views_enumerate/test.cpp
+++ b/tests/std/tests/P2164R9_views_enumerate/test.cpp
@@ -203,7 +203,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
             assert((as_const(r).begin() == s) == is_empty);
         }
 
-        STATIC_ASSERT(common_range<R> == (common_range<V> && sized_range<V>) );
+        STATIC_ASSERT(common_range<R> == (forward_range<V> && common_range<V> && sized_range<V>) );
         if constexpr (common_range<V> && sized_range<V> && bidirectional_range<V>) {
             if (!is_empty) {
                 assert(*prev(s) == *prev(end(expected)));
@@ -228,7 +228,8 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
             assert((r.begin() == cs) == is_empty);
         }
 
-        STATIC_ASSERT(common_range<const R> == (common_range<const V> && sized_range<const V>) );
+        STATIC_ASSERT(
+            common_range<const R> == (forward_range<const V> && common_range<const V> && sized_range<const V>) );
         if constexpr (common_range<const V> && sized_range<const V> && bidirectional_range<const V>) {
             if (!is_empty) {
                 assert(*prev(cs) == *prev(end(expected)));


### PR DESCRIPTION
Fixes #4499.