### PR TITLE
Implement P2875R4 Undeprecate `polymorphic_allocator::destroy`

### DIFF
--- a/stl/inc/xpolymorphic_allocator.h
+++ b/stl/inc/xpolymorphic_allocator.h
@@ -296,8 +296,8 @@ namespace pmr {
         }
 
         template <class _Uty>
-        _CXX17_DEPRECATE_POLYMORPHIC_ALLOCATOR_DESTROY void destroy(_Uty* const _Ptr) noexcept /* strengthened */ {
-            _STD _Destroy_in_place(*_Ptr);
+        void destroy(_Uty* const _Ptr) noexcept /* strengthened */ {
+            _Ptr->~_Uty();
         }
 
         _NODISCARD polymorphic_allocator select_on_container_copy_construction() const noexcept /* strengthened */ {

--- a/stl/inc/xpolymorphic_allocator.h
+++ b/stl/inc/xpolymorphic_allocator.h
@@ -269,7 +269,7 @@ namespace pmr {
 
         template <class _Uty>
         void delete_object(_Uty* const _Ptr) noexcept /* strengthened */ {
-            _STD _Destroy_in_place(*_Ptr);
+            _Ptr->~_Uty();
             deallocate_object(_Ptr);
         }
 #endif // _HAS_CXX20

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -132,6 +132,7 @@
 // P2338R4 Freestanding Library: Character Primitives And The C Library
 //     (including __cpp_lib_freestanding_charconv)
 // P2517R1 Conditional noexcept For apply()
+// P2875R4 Undeprecate polymorphic_allocator::destroy
 
 // _HAS_CXX17 indirectly controls:
 // N4190 Removing auto_ptr, random_shuffle(), And Old <functional> Stuff
@@ -1386,17 +1387,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define _CXX20_DEPRECATE_MOVE_ITERATOR_ARROW
 #endif // ^^^ warning disabled ^^^
 
-#if _HAS_CXX17 && !defined(_SILENCE_CXX17_POLYMORPHIC_ALLOCATOR_DESTROY_DEPRECATION_WARNING) \
-    && !defined(_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS)
-#define _CXX17_DEPRECATE_POLYMORPHIC_ALLOCATOR_DESTROY                                                   \
-    [[deprecated("warning STL4032: "                                                                     \
-                 "std::pmr::polymorphic_allocator::destroy() is deprecated in C++17 by LWG-3036. "       \
-                 "Prefer std::destroy_at() or std::allocator_traits<polymorphic_allocator>::destroy(). " \
-                 "You can define _SILENCE_CXX17_POLYMORPHIC_ALLOCATOR_DESTROY_DEPRECATION_WARNING "      \
-                 "or _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS to suppress this warning.")]]
-#else // ^^^ warning enabled / warning disabled vvv
-#define _CXX17_DEPRECATE_POLYMORPHIC_ALLOCATOR_DESTROY
-#endif // ^^^ warning disabled ^^^
+// STL4032 was "std::pmr::polymorphic_allocator::destroy() is deprecated in C++17 by LWG-3036." (reverted by P2875R4)
 
 #if _HAS_CXX20 && !defined(_SILENCE_CXX20_IS_ALWAYS_EQUAL_DEPRECATION_WARNING) \
     && !defined(_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS)

--- a/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
+++ b/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#define _SILENCE_CXX17_POLYMORPHIC_ALLOCATOR_DESTROY_DEPRECATION_WARNING
 #define _SILENCE_CXX23_ALIGNED_UNION_DEPRECATION_WARNING
 
 #include <algorithm>


### PR DESCRIPTION
Fixes #4521. Also makes MSVC STL's `polymorphic_allocator::destroy` reject arrays (which is implicitly required by the standard wording).