### PR TITLE
`<generator>`: Test `generator::promise_type`

### DIFF
--- a/stl/inc/generator
+++ b/stl/inc/generator
@@ -40,18 +40,19 @@ concept _Has_real_pointers = same_as<_Alloc, void> || is_pointer_v<typename allo
 template <class _Allocator = void>
 class _Promise_allocator { // statically specified allocator type
 private:
-    using _Alloc = _Rebind_alloc_t<_Allocator, _Aligned_block>;
+    using _Alloc           = _Rebind_alloc_t<_Allocator, _Aligned_block>;
+    using _Alloc_size_type = allocator_traits<_Alloc>::size_type;
 
     static void* _Allocate(_Alloc _Al, const size_t _Size) {
         if constexpr (default_initializable<_Alloc> && allocator_traits<_Alloc>::is_always_equal::value) {
             // do not store stateless allocator
             const size_t _Count = (_Size + sizeof(_Aligned_block) - 1) / sizeof(_Aligned_block);
-            return _Al.allocate(_Count);
+            return _Al.allocate(static_cast<_Alloc_size_type>(_Count));
         } else {
             // store stateful allocator
             constexpr size_t _Align = (_STD max)(alignof(_Alloc), sizeof(_Aligned_block));
             const size_t _Count     = (_Size + sizeof(_Alloc) + _Align - 1) / sizeof(_Aligned_block);
-            void* const _Ptr        = _Al.allocate(_Count);
+            void* const _Ptr        = _Al.allocate(static_cast<_Alloc_size_type>(_Count));
             const auto _Al_address =
                 (reinterpret_cast<uintptr_t>(_Ptr) + _Size + alignof(_Alloc) - 1) & ~(alignof(_Alloc) - 1);
             ::new (reinterpret_cast<void*>(_Al_address)) _Alloc(_STD move(_Al));
@@ -83,7 +84,7 @@ public:
             // make stateless allocator
             _Alloc _Al{};
             const size_t _Count = (_Size + sizeof(_Aligned_block) - 1) / sizeof(_Aligned_block);
-            _Al.deallocate(static_cast<_Aligned_block*>(_Ptr), _Count);
+            _Al.deallocate(static_cast<_Aligned_block*>(_Ptr), static_cast<_Alloc_size_type>(_Count));
         } else {
             // retrieve stateful allocator
             const auto _Al_address =
@@ -94,7 +95,7 @@ public:
 
             constexpr size_t _Align = (_STD max)(alignof(_Alloc), sizeof(_Aligned_block));
             const size_t _Count     = (_Size + sizeof(_Alloc) + _Align - 1) / sizeof(_Aligned_block);
-            _Al.deallocate(static_cast<_Aligned_block*>(_Ptr), _Count);
+            _Al.deallocate(static_cast<_Aligned_block*>(_Ptr), static_cast<_Alloc_size_type>(_Count));
         }
     }
 };
@@ -108,7 +109,7 @@ private:
     static void __stdcall _Dealloc_stateless(void* const _Ptr, const size_t _Size) noexcept {
         _Alloc _Al{};
         const size_t _Count = (_Size + sizeof(_Dealloc_fn) + sizeof(_Aligned_block) - 1) / sizeof(_Aligned_block);
-        _Al.deallocate(static_cast<_Aligned_block*>(_Ptr), _Count);
+        _Al.deallocate(static_cast<_Aligned_block*>(_Ptr), static_cast<allocator_traits<_Alloc>::size_type>(_Count));
     }
 
     template <class _Alloc>
@@ -123,7 +124,7 @@ private:
         _Stored_al.~_Alloc();
 
         const size_t _Count = (_Size + sizeof(_Al) + _Align - 1) / sizeof(_Aligned_block);
-        _Al.deallocate(static_cast<_Aligned_block*>(_Ptr), _Count);
+        _Al.deallocate(static_cast<_Aligned_block*>(_Ptr), static_cast<allocator_traits<_Alloc>::size_type>(_Count));
     }
 
     static void __stdcall _Dealloc_delete(void* const _Ptr, const size_t _Size) noexcept {
@@ -132,15 +133,16 @@ private:
 
     template <class _ProtoAlloc>
     static void* _Allocate(const _ProtoAlloc& _Proto, size_t _Size) {
-        using _Alloc = _Rebind_alloc_t<_ProtoAlloc, _Aligned_block>;
-        auto _Al     = static_cast<_Alloc>(_Proto);
+        using _Alloc           = _Rebind_alloc_t<_ProtoAlloc, _Aligned_block>;
+        using _Alloc_size_type = allocator_traits<_Alloc>::size_type;
+        auto _Al               = static_cast<_Alloc>(_Proto);
 
         if constexpr (default_initializable<_Alloc> && allocator_traits<_Alloc>::is_always_equal::value) {
             // don't store stateless allocator
             const _Dealloc_fn _Dealloc = _Dealloc_stateless<_Alloc>;
 
             const size_t _Count = (_Size + sizeof(_Dealloc_fn) + sizeof(_Aligned_block) - 1) / sizeof(_Aligned_block);
-            void* const _Ptr    = _Al.allocate(_Count);
+            void* const _Ptr    = _Al.allocate(static_cast<_Alloc_size_type>(_Count));
             _CSTD memcpy(static_cast<char*>(_Ptr) + _Size, &_Dealloc, sizeof(_Dealloc));
             return _Ptr;
         } else {
@@ -150,7 +152,7 @@ private:
             const _Dealloc_fn _Dealloc = _Dealloc_stateful<_Alloc>;
 
             const size_t _Count = (_Size + sizeof(_Dealloc_fn) + sizeof(_Al) + _Align - 1) / sizeof(_Aligned_block);
-            void* const _Ptr    = _Al.allocate(_Count);
+            void* const _Ptr    = _Al.allocate(static_cast<_Alloc_size_type>(_Count));
             _CSTD memcpy(static_cast<char*>(_Ptr) + _Size, &_Dealloc, sizeof(_Dealloc));
             _Size += sizeof(_Dealloc_fn);
             const auto _Al_address =
@@ -215,7 +217,7 @@ public:
 #ifndef _PREFAST_ // TRANSITION, VSO-1662733
     _NODISCARD
 #endif // ^^^ no workaround ^^^
-    suspend_always initial_suspend() noexcept {
+    suspend_always initial_suspend() const noexcept {
         return {};
     }
 
@@ -446,6 +448,8 @@ private:
     friend _Gen_promise_base<_Gen_yield_t<_Ref>>;
 
 public:
+    using yielded = _Gen_yield_t<_Ref>;
+
     struct __declspec(empty_bases) promise_type : _Promise_allocator<_Alloc>, _Gen_promise_base<_Gen_yield_t<_Ref>> {
         _NODISCARD generator get_return_object() noexcept {
             return generator{_Gen_secret_tag{}, coroutine_handle<promise_type>::from_promise(*this)};

--- a/stl/inc/generator
+++ b/stl/inc/generator
@@ -47,12 +47,12 @@ private:
         if constexpr (default_initializable<_Alloc> && allocator_traits<_Alloc>::is_always_equal::value) {
             // do not store stateless allocator
             const size_t _Count = (_Size + sizeof(_Aligned_block) - 1) / sizeof(_Aligned_block);
-            return _Al.allocate(static_cast<_Alloc_size_type>(_Count));
+            return _Al.allocate(_Convert_size<_Alloc_size_type>(_Count));
         } else {
             // store stateful allocator
             constexpr size_t _Align = (_STD max)(alignof(_Alloc), sizeof(_Aligned_block));
             const size_t _Count     = (_Size + sizeof(_Alloc) + _Align - 1) / sizeof(_Aligned_block);
-            void* const _Ptr        = _Al.allocate(static_cast<_Alloc_size_type>(_Count));
+            void* const _Ptr        = _Al.allocate(_Convert_size<_Alloc_size_type>(_Count));
             const auto _Al_address =
                 (reinterpret_cast<uintptr_t>(_Ptr) + _Size + alignof(_Alloc) - 1) & ~(alignof(_Alloc) - 1);
             ::new (reinterpret_cast<void*>(_Al_address)) _Alloc(_STD move(_Al));
@@ -142,7 +142,7 @@ private:
             const _Dealloc_fn _Dealloc = _Dealloc_stateless<_Alloc>;
 
             const size_t _Count = (_Size + sizeof(_Dealloc_fn) + sizeof(_Aligned_block) - 1) / sizeof(_Aligned_block);
-            void* const _Ptr    = _Al.allocate(static_cast<_Alloc_size_type>(_Count));
+            void* const _Ptr    = _Al.allocate(_Convert_size<_Alloc_size_type>(_Count));
             _CSTD memcpy(static_cast<char*>(_Ptr) + _Size, &_Dealloc, sizeof(_Dealloc));
             return _Ptr;
         } else {
@@ -152,7 +152,7 @@ private:
             const _Dealloc_fn _Dealloc = _Dealloc_stateful<_Alloc>;
 
             const size_t _Count = (_Size + sizeof(_Dealloc_fn) + sizeof(_Al) + _Align - 1) / sizeof(_Aligned_block);
-            void* const _Ptr    = _Al.allocate(static_cast<_Alloc_size_type>(_Count));
+            void* const _Ptr    = _Al.allocate(_Convert_size<_Alloc_size_type>(_Count));
             _CSTD memcpy(static_cast<char*>(_Ptr) + _Size, &_Dealloc, sizeof(_Dealloc));
             _Size += sizeof(_Dealloc_fn);
             const auto _Al_address =

--- a/stl/inc/generator
+++ b/stl/inc/generator
@@ -37,7 +37,7 @@ struct alignas(__STDCPP_DEFAULT_NEW_ALIGNMENT__) _Aligned_block {
 template <class _Alloc>
 concept _Has_real_pointers = same_as<_Alloc, void> || is_pointer_v<typename allocator_traits<_Alloc>::pointer>;
 
-template <class _Allocator = void>
+template <class _Allocator>
 class _Promise_allocator { // statically specified allocator type
 private:
     using _Alloc           = _Rebind_alloc_t<_Allocator, _Aligned_block>;

--- a/stl/inc/generator
+++ b/stl/inc/generator
@@ -445,20 +445,19 @@ private:
     static_assert(_Has_real_pointers<_Alloc>, "generator allocators must use raw pointers "
                                               "(N4971 [coro.generator.class]/1.1)");
 
-    friend _Gen_promise_base<_Gen_yield_t<_Ref>>;
-
 public:
     using yielded = _Gen_yield_t<_Ref>;
 
-    struct __declspec(empty_bases) promise_type : _Promise_allocator<_Alloc>, _Gen_promise_base<_Gen_yield_t<_Ref>> {
+    friend _Gen_promise_base<yielded>;
+
+    struct __declspec(empty_bases) promise_type : _Promise_allocator<_Alloc>, _Gen_promise_base<yielded> {
         _NODISCARD generator get_return_object() noexcept {
             return generator{_Gen_secret_tag{}, coroutine_handle<promise_type>::from_promise(*this)};
         }
     };
     _STL_INTERNAL_STATIC_ASSERT(is_standard_layout_v<promise_type>);
 #ifdef __cpp_lib_is_pointer_interconvertible // TRANSITION, LLVM-48860
-    _STL_INTERNAL_STATIC_ASSERT(
-        is_pointer_interconvertible_base_of_v<_Gen_promise_base<_Gen_yield_t<_Ref>>, promise_type>);
+    _STL_INTERNAL_STATIC_ASSERT(is_pointer_interconvertible_base_of_v<_Gen_promise_base<yielded>, promise_type>);
 #endif // ^^^ no workaround ^^^
 
     generator(generator&& _That) noexcept : _Coro(_STD exchange(_That._Coro, {})) {}
@@ -479,7 +478,7 @@ public:
         _STL_ASSERT(_Coro, "Can't call begin on moved-from generator");
         _Coro.resume();
         return typename _Gen_iter_provider<_Value, _Ref>::_Iterator{
-            _Gen_secret_tag{}, coroutine_handle<_Gen_promise_base<_Gen_yield_t<_Ref>>>::from_address(_Coro.address())};
+            _Gen_secret_tag{}, coroutine_handle<_Gen_promise_base<yielded>>::from_address(_Coro.address())};
     }
 
     _NODISCARD default_sentinel_t end() const noexcept {

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -649,6 +649,7 @@ tests\P2474R2_views_repeat
 tests\P2474R2_views_repeat_death
 tests\P2494R2_move_only_range_adaptors
 tests\P2502R2_generator
+tests\P2502R2_generator_promise
 tests\P2505R5_monadic_functions_for_std_expected
 tests\P2510R3_text_formatting_pointers
 tests\P2517R1_apply_conditional_noexcept

--- a/tests/std/tests/P2502R2_generator_promise/env.lst
+++ b/tests/std/tests/P2502R2_generator_promise/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P2502R2_generator_promise/test.cpp
+++ b/tests/std/tests/P2502R2_generator_promise/test.cpp
@@ -1,0 +1,257 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cassert>
+#include <coroutine>
+#include <forward_list>
+#include <generator>
+#include <list>
+#include <memory_resource>
+#include <new>
+#include <ranges>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "range_algorithm_support.hpp"
+
+using namespace std;
+
+template <class T, class AlwaysEqual = true_type, signed_integral DifferenceType = ptrdiff_t>
+class TestAllocator : public allocator<T> {
+public:
+    using value_type      = T;
+    using is_always_equal = AlwaysEqual;
+    using difference_type = DifferenceType;
+    using size_type       = make_unsigned_t<difference_type>;
+
+    TestAllocator() = default;
+
+    template <class U>
+    TestAllocator(const TestAllocator<U, AlwaysEqual, DifferenceType>&) {}
+
+    T* allocate(const size_type s) {
+        return static_cast<T*>(::operator new(static_cast<size_t>(s * sizeof(T)), align_val_t{alignof(T)}));
+    }
+
+    void deallocate(T* const p, size_type s) {
+        ::operator delete(p, s * sizeof(T), align_val_t{alignof(T)});
+    }
+
+    operator pmr::polymorphic_allocator<void>() const {
+        return {};
+    }
+
+    bool operator==(const TestAllocator&) const = default;
+};
+
+template <class Promise, class... Args>
+concept HasOperatorNew = requires(Args&&... args) {
+    { Promise::operator new(forward<Args>(args)...) } -> same_as<void*>;
+};
+
+template <class Gen>
+struct generator_allocator {};
+
+template <class Ref, class V, class Alloc>
+struct generator_allocator<generator<Ref, V, Alloc>> {
+    using type = Alloc;
+};
+
+struct MoveOnly {
+    MoveOnly(const MoveOnly&)            = delete;
+    MoveOnly& operator=(const MoveOnly&) = delete;
+    MoveOnly(MoveOnly&&)                 = default;
+    MoveOnly& operator=(MoveOnly&&)      = default;
+};
+
+static_assert(movable<MoveOnly>);
+static_assert(!copyable<MoveOnly>);
+
+struct Immovable {
+    Immovable(Immovable&&)            = delete;
+    Immovable& operator=(Immovable&&) = delete;
+};
+
+static_assert(!movable<Immovable>);
+
+template <class T>
+struct Proxy {
+    Proxy(const T&); // not defined
+};
+
+template <class Gen, class Range>
+    requires convertible_to<ranges::range_reference_t<Range&>, typename Gen::yielded>
+void test_yield_elements_of_range(typename Gen::promise_type& p) {
+    using Alloc = generator_allocator<Gen>::type;
+
+    {
+        using Awaitable = decltype(p.yield_value(ranges::elements_of{declval<Range&>()}));
+        static_assert(convertible_to<decltype(declval<Awaitable&>().await_ready()), bool>);
+    }
+
+    if constexpr (!is_void_v<Alloc>) {
+        using Awaitable = decltype(p.yield_value(ranges::elements_of{declval<Range&>(), declval<Alloc&>()}));
+        static_assert(convertible_to<decltype(declval<Awaitable&>().await_ready()), bool>);
+    }
+}
+
+template <class Gen, class Alloc2>
+void test_operator_new(typename Gen::promise_type& p, const Alloc2& alloc2 = {}) {
+    using Promise = Gen::promise_type;
+    using Alloc   = generator_allocator<Gen>::type;
+
+    // Test 'operator new(size_t)'
+    constexpr bool has_op_new1 = HasOperatorNew<Promise, size_t>;
+    static_assert(has_op_new1 == (same_as<Alloc, void> || default_initializable<Alloc>) );
+    if constexpr (has_op_new1) {
+        const size_t size = __STDCPP_DEFAULT_NEW_ALIGNMENT__;
+        void* const mem   = p.operator new(size);
+        assert(reinterpret_cast<intptr_t>(mem) % __STDCPP_DEFAULT_NEW_ALIGNMENT__ == 0);
+        p.operator delete(mem, size);
+    }
+
+    // Test 'operator new(size_t, allocator_arg_t, const Alloc2&, const Args&...)'
+    constexpr bool has_op_new2 = HasOperatorNew<Promise, size_t, allocator_arg_t, const Alloc2&, int, int>;
+    static_assert(has_op_new2 == (same_as<Alloc, void> || convertible_to<const Alloc2&, Alloc>) );
+    if constexpr (has_op_new2) {
+        const size_t size = __STDCPP_DEFAULT_NEW_ALIGNMENT__;
+        void* const mem   = p.operator new(size, allocator_arg, alloc2, 0, 0);
+        assert(reinterpret_cast<intptr_t>(mem) % __STDCPP_DEFAULT_NEW_ALIGNMENT__ == 0);
+        p.operator delete(mem, size);
+    }
+
+    // Test 'operator new(size_t, const This&, allocator_arg_t, const Alloc2&, const Args&...)'
+    struct S {};
+    constexpr bool has_op_new3 = HasOperatorNew<Promise, size_t, const S&, allocator_arg_t, const Alloc2&, int, int>;
+    static_assert(has_op_new3 == (same_as<Alloc, void> || convertible_to<const Alloc2&, Alloc>) );
+    if constexpr (has_op_new3) {
+        const size_t size = __STDCPP_DEFAULT_NEW_ALIGNMENT__;
+        const S s;
+        void* const mem = p.operator new(size, s, allocator_arg, alloc2, 0, 0);
+        assert(reinterpret_cast<intptr_t>(mem) % __STDCPP_DEFAULT_NEW_ALIGNMENT__ == 0);
+        p.operator delete(mem, size);
+    }
+}
+
+template <class Ref, class V = void, class Alloc = void>
+void test_one() {
+    using Gen     = generator<Ref, V, Alloc>;
+    using Promise = Gen::promise_type;
+    using Yielded = Gen::yielded;
+    static_assert(semiregular<Promise>);
+
+    Promise p;
+
+    // Test 'get_return_object'
+    static_assert(same_as<decltype(p.get_return_object()), Gen>);
+    static_assert(noexcept(p.get_return_object()));
+
+    // Test 'initial_suspend'
+    static_assert(same_as<decltype(p.initial_suspend()), suspend_always>);
+    static_assert(same_as<decltype(as_const(p).initial_suspend()), suspend_always>);
+    static_assert(noexcept(p.initial_suspend()));
+    static_assert(noexcept(as_const(p).initial_suspend()));
+
+    // Test 'final_suspend'
+    using FinalAwaitable = decltype(p.final_suspend());
+    static_assert(convertible_to<decltype(declval<FinalAwaitable&>().await_ready()), bool>);
+    static_assert(noexcept(p.final_suspend()));
+
+    // Test 'yield_value(yielded)'
+    static_assert(same_as<decltype(p.yield_value(declval<Yielded>())), suspend_always>);
+    static_assert(noexcept(p.yield_value(declval<Yielded>())));
+
+    // Test 'yield_value(const remove_reference_t<yielded>&)'
+    if constexpr (is_rvalue_reference_v<Yielded>
+                  && constructible_from<remove_cvref_t<Yielded>, const remove_reference_t<Yielded>&>) {
+        using Lval      = const remove_reference_t<Yielded>&;
+        using Awaitable = decltype(p.yield_value(declval<Lval>()));
+
+        static_assert(convertible_to<decltype(declval<Awaitable&>().await_ready()), bool>);
+        static_assert(is_void_v<decltype(declval<Awaitable&>().await_resume())>);
+        static_assert(noexcept(p.yield_value(declval<Lval>()))
+                      == is_nothrow_constructible_v<remove_cvref_t<Yielded>,
+                          const remove_reference_t<Yielded>&>); // strengthened
+    }
+
+    { // Test 'yield_value(elements_of<generator>)'
+        {
+            using Awaitable = decltype(p.yield_value(ranges::elements_of{declval<Gen&>()}));
+            static_assert(convertible_to<decltype(declval<Awaitable&>().await_ready()), bool>);
+        }
+
+        if constexpr (!is_void_v<Alloc>) {
+            using Awaitable = decltype(p.yield_value(ranges::elements_of{declval<Gen&>(), declval<Alloc&>()}));
+            static_assert(convertible_to<decltype(declval<Awaitable&>().await_ready()), bool>);
+        }
+    }
+
+    using ValTy = conditional_t<is_void_v<V>, remove_cvref_t<Ref>, V>;
+    if constexpr (convertible_to<ValTy&, Yielded>) { // Test 'yield_value(ranges::elements_of<range>)'
+        test_yield_elements_of_range<Gen, vector<ValTy>>(p);
+        test_yield_elements_of_range<Gen, list<ValTy>>(p);
+        test_yield_elements_of_range<Gen, forward_list<ValTy>>(p);
+        test_yield_elements_of_range<Gen,
+            test::range<input_iterator_tag, ValTy, test::Sized::no, test::CanDifference::no, test::Common::no,
+                test::CanCompare::no, test::ProxyRef::no>>(p);
+    }
+
+    // Test 'await_transform'
+    static_assert(!requires(Promise& p) { p.await_transform(); });
+
+    // Test 'return_void'
+    static_assert(is_void_v<decltype(p.return_void())>);
+    static_assert(is_void_v<decltype(as_const(p).return_void())>);
+    static_assert(noexcept(p.return_void()));
+    static_assert(noexcept(as_const(p).return_void()));
+
+    // Test 'unhandled_exception'
+    static_assert(is_void_v<decltype(p.unhandled_exception())>);
+
+    // Test 'operator new(size_t, ARGS...)'
+    test_operator_new<Gen, allocator<void>>(p);
+    test_operator_new<Gen, pmr::polymorphic_allocator<void>>(p);
+    test_operator_new<Gen, TestAllocator<void, false_type, int>>(p);
+    if constexpr (same_as<Alloc, void>) {
+        test_operator_new<Gen, TestAllocator<void>>(p);
+        test_operator_new<Gen, TestAllocator<void, false_type>>(p);
+        test_operator_new<Gen, TestAllocator<void, true_type, int>>(p);
+    }
+}
+
+template <class Ref, class V = void>
+void test_with_allocator() {
+    test_one<Ref, V>();
+    test_one<Ref, V, allocator<void>>();
+    test_one<Ref, V, pmr::polymorphic_allocator<void>>();
+    test_one<Ref, V, TestAllocator<void>>();
+    test_one<Ref, V, TestAllocator<void, false_type>>();
+    test_one<Ref, V, TestAllocator<void, true_type, int>>();
+    test_one<Ref, V, TestAllocator<void, false_type, int>>();
+}
+
+template <class T>
+void test_with_type() {
+    test_with_allocator<T>();
+    test_with_allocator<T&>();
+    test_with_allocator<const T&>();
+    test_with_allocator<T&&>();
+    test_with_allocator<const T&&>();
+
+    test_with_allocator<Proxy<T>, T>();
+    test_with_allocator<Proxy<T>&, T>();
+    test_with_allocator<const Proxy<T>&, T>();
+    test_with_allocator<Proxy<T>&&, T>();
+    test_with_allocator<const Proxy<T>&&, T>();
+}
+
+int main() {
+    test_with_type<int>();
+    test_with_type<float>();
+    test_with_type<string>();
+    test_with_type<MoveOnly>();
+    test_with_type<Immovable>();
+    test_with_allocator<vector<bool>::reference, bool>();
+}

--- a/tests/std/tests/P2502R2_generator_promise/test.cpp
+++ b/tests/std/tests/P2502R2_generator_promise/test.cpp
@@ -3,9 +3,12 @@
 
 #include <cassert>
 #include <coroutine>
+#include <cstddef>
+#include <cstdint>
 #include <forward_list>
 #include <generator>
 #include <list>
+#include <memory>
 #include <memory_resource>
 #include <new>
 #include <ranges>


### PR DESCRIPTION
* Add tests for `generator::promise_type`
* Fix issues detected by new tests:
  * `generator::promise_type::initial_suspend` should be marked with `const`
  * Add missing `generator::yielded` type alias
  * Ad hoc: add `static_cast`s in `_Promise_allocator` since custom allocator's `size_type` might be smaller than `size_t`