### PR TITLE
`create-1es-hosted-pool.ps1`: Avoid `ConvertTo-SecureString`

### DIFF
--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -79,9 +79,9 @@ function New-Password {
     }
   }
 
-  $result = ''
+  [SecureString] $result = [SecureString]::new()
   for ($idx = 0; $idx -lt $Length; $idx++) {
-    $result += $alphabet[$randomData[$idx] -band $mask]
+    $result.AppendChar($alphabet[$randomData[$idx] -band $mask])
   }
 
   return $result
@@ -143,8 +143,7 @@ New-AzResourceGroup `
 ####################################################################################################
 Display-ProgressBar -Status 'Creating credentials'
 
-$AdminPW = New-Password
-$AdminPWSecure = ConvertTo-SecureString $AdminPW -AsPlainText -Force
+$AdminPWSecure = New-Password
 $Credential = New-Object System.Management.Automation.PSCredential ('AdminUser', $AdminPWSecure)
 
 ####################################################################################################


### PR DESCRIPTION
This mirrors MSVC-PR-539935, which @joemmett will be merging into MSVC `main`.

New codebase scanning tools are hissing at how `create-1es-hosted-pool.ps1` builds up a plaintext password before converting it into a `SecureString` with `ConvertTo-SecureString`.

Jonathan's fix is to start with a `SecureString` and build it up character-by-character. Of course, this still leaves each character in normal memory for a fraction of a nanosecond, but that's unavoidable. This avoids mentioning `ConvertTo-SecureString`, thereby making the tools happy. Later in this script, we redact the generated password from appearing in any console output (my innovation back in #1577), and we discard it entirely after creating the pool, so we're touching it as little as possible.

I verified that the updated function works in PowerShell 7.4.1, but I haven't done a full test drive of the updated script.

:warning: I eventually noticed that it'll be broken because of this leftover mention of `$AdminPW`:

https://github.com/microsoft/STL/blob/fbdcee4978d733ab5bd231fea207c887f80e4e17/azure-devops/create-1es-hosted-pool.ps1#L236

@joemmett's MSVC-PR is high priority so I want to merge this as-is, then I'll figure out how to fix the script during April Patch Tuesday.