### PR TITLE
Implement LWG-4016 `container-insertable` checks do not match what `container-inserter` does

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -10329,25 +10329,24 @@ namespace ranges {
         && constructible_from<_Container, iterator_t<_Rng>, iterator_t<_Rng>, _Types...>;
 
     template <class _Container, class _Reference>
+    concept _Can_emplace_back = requires(_Container& _Cont) { _Cont.emplace_back(_STD declval<_Reference>()); };
+
+    template <class _Container, class _Reference>
     concept _Can_push_back = requires(_Container& _Cont) { _Cont.push_back(_STD declval<_Reference>()); };
+
+    template <class _Container, class _Reference>
+    concept _Can_emplace_end = requires(_Container& _Cont) { _Cont.emplace(_Cont.end(), _STD declval<_Reference>()); };
 
     template <class _Container, class _Reference>
     concept _Can_insert_end = requires(_Container& _Cont) { _Cont.insert(_Cont.end(), _STD declval<_Reference>()); };
 
     template <class _Rng, class _Container, class... _Types>
-    concept _Converts_constructible_insertable =
+    concept _Converts_constructible_appendable =
         _Ref_converts<_Rng, _Container> && constructible_from<_Container, _Types...>
-        && (_Can_push_back<_Container, range_reference_t<_Rng>>
+        && (_Can_emplace_back<_Container, range_reference_t<_Rng>>
+            || _Can_push_back<_Container, range_reference_t<_Rng>>
+            || _Can_emplace_end<_Container, range_reference_t<_Rng>>
             || _Can_insert_end<_Container, range_reference_t<_Rng>>);
-
-    template <class _Reference, class _Container>
-    _NODISCARD constexpr auto _Container_inserter(_Container& _Cont) {
-        if constexpr (_Can_push_back<_Container, _Reference>) {
-            return back_insert_iterator{_Cont};
-        } else {
-            return insert_iterator{_Cont, _Cont.end()};
-        }
-    }
 
     _EXPORT_STD template <class _Container, input_range _Rng, class... _Types>
         requires (!view<_Container>)
@@ -10361,12 +10360,24 @@ namespace ranges {
             return _Container(from_range, _STD forward<_Rng>(_Range), _STD forward<_Types>(_Args)...);
         } else if constexpr (_Converts_and_common_constructible<_Rng, _Container, _Types...>) {
             return _Container(_RANGES begin(_Range), _RANGES end(_Range), _STD forward<_Types>(_Args)...);
-        } else if constexpr (_Converts_constructible_insertable<_Rng, _Container, _Types...>) {
+        } else if constexpr (_Converts_constructible_appendable<_Rng, _Container, _Types...>) {
             _Container _Cont(_STD forward<_Types>(_Args)...);
             if constexpr (_Sized_and_reservable<_Rng, _Container>) {
                 _Cont.reserve(static_cast<range_size_t<_Container>>(_RANGES size(_Range)));
             }
-            _RANGES copy(_Range, _Container_inserter<range_reference_t<_Rng>>(_Cont));
+            for (auto&& _Elem : _Range) {
+                using _ElemTy = decltype(_Elem);
+                if constexpr (_Can_emplace_back<_Container, _ElemTy>) {
+                    _Cont.emplace_back(_STD forward<_ElemTy>(_Elem));
+                } else if constexpr (_Can_push_back<_Container, _ElemTy>) {
+                    _Cont.push_back(_STD forward<_ElemTy>(_Elem));
+                } else if constexpr (_Can_emplace_end<_Container, _ElemTy>) {
+                    _Cont.emplace(_Cont.end(), _STD forward<_ElemTy>(_Elem));
+                } else {
+                    _STL_INTERNAL_STATIC_ASSERT(_Can_insert_end<_Container, _ElemTy>);
+                    _Cont.insert(_Cont.end(), _STD forward<_ElemTy>(_Elem));
+                }
+            }
             return _Cont;
         } else if constexpr (!_Ref_converts<_Rng, _Container> && input_range<range_reference_t<_Rng>>) {
             const auto _Xform = [](auto&& _Elem) _STATIC_CALL_OPERATOR {


### PR DESCRIPTION
Fixes #4504.

Notes:
- the call to `ranges::for_each` in the proposed resolution is "manually inlined" to avoid inclusion dependency;
- the Standard requires `<ranges>` to include `<concepts>`, so the test code doesn't explicitly include it.