### PR TITLE
Implement LWG-4054 Repeating a `repeat_view` should repeat the view

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1705,10 +1705,10 @@ namespace ranges {
         struct _Repeat_fn {
             template <class _Ty>
             _NODISCARD _STATIC_CALL_OPERATOR constexpr auto operator()(_Ty&& _Value) _CONST_CALL_OPERATOR
-                noexcept(noexcept(repeat_view(_STD forward<_Ty>(_Value))))
-                requires requires { repeat_view(_STD forward<_Ty>(_Value)); }
+                noexcept(noexcept(repeat_view<decay_t<_Ty>>(_STD forward<_Ty>(_Value))))
+                requires requires { repeat_view<decay_t<_Ty>>(_STD forward<_Ty>(_Value)); }
             {
-                return repeat_view(_STD forward<_Ty>(_Value));
+                return repeat_view<decay_t<_Ty>>(_STD forward<_Ty>(_Value));
             }
 
             template <class _Ty1, class _Ty2>

--- a/tests/std/tests/P2474R2_views_repeat/test.cpp
+++ b/tests/std/tests/P2474R2_views_repeat/test.cpp
@@ -363,14 +363,20 @@ constexpr bool test() {
     return true;
 }
 
-// Check LWG-3875
+// Check LWG-3875 "std::ranges::repeat_view<T, IntegerClass>::iterator may be ill-formed"
 static_assert(CanViewRepeat<string, long long>);
 static_assert(CanViewRepeat<string, unsigned long long>);
 static_assert(CanViewRepeat<string, _Signed128>);
 static_assert(
     !CanViewRepeat<string, _Unsigned128>); // _Unsigned128 does not satisfy 'integer-like-with-usable-difference-type'
 
-// Check GH-3392
+// Check LWG-4054 "Repeating a repeat_view should repeat the view"
+static_assert(
+    std::is_same_v<decltype(views::repeat(views::repeat(42))), ranges::repeat_view<ranges::repeat_view<int>>>);
+static_assert(std::is_same_v<decltype(views::repeat("Hello world!")), ranges::repeat_view<const char*>>);
+static_assert(std::is_same_v<decltype(views::repeat(test)), ranges::repeat_view<bool (*)()>>);
+
+// Check GH-3392 "<ranges>: views::repeat(...) | views::take(...) is not always a valid range"
 static_assert(ranges::range<decltype(views::repeat('3', 100ull) | views::take(3))>);
 static_assert(ranges::range<decltype(views::repeat('3', 100ull) | views::drop(3))>);
 

--- a/tests/std/tests/P2474R2_views_repeat/test.cpp
+++ b/tests/std/tests/P2474R2_views_repeat/test.cpp
@@ -371,10 +371,9 @@ static_assert(
     !CanViewRepeat<string, _Unsigned128>); // _Unsigned128 does not satisfy 'integer-like-with-usable-difference-type'
 
 // Check LWG-4054 "Repeating a repeat_view should repeat the view"
-static_assert(
-    std::is_same_v<decltype(views::repeat(views::repeat(42))), ranges::repeat_view<ranges::repeat_view<int>>>);
-static_assert(std::is_same_v<decltype(views::repeat("Hello world!")), ranges::repeat_view<const char*>>);
-static_assert(std::is_same_v<decltype(views::repeat(test)), ranges::repeat_view<bool (*)()>>);
+static_assert(is_same_v<decltype(views::repeat(views::repeat(42))), ranges::repeat_view<ranges::repeat_view<int>>>);
+static_assert(is_same_v<decltype(views::repeat("Hello world!")), ranges::repeat_view<const char*>>);
+static_assert(is_same_v<decltype(views::repeat(test)), ranges::repeat_view<bool (*)()>>);
 
 // Check GH-3392 "<ranges>: views::repeat(...) | views::take(...) is not always a valid range"
 static_assert(ranges::range<decltype(views::repeat('3', 100ull) | views::take(3))>);


### PR DESCRIPTION
Fixes #4508.

Drive-by changes: add previously missing titles of GH/LWG issues to comments.