### PR TITLE
Implement LWG-3984 `ranges::to`'s recursion branch may be ill-formed

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -10372,7 +10372,7 @@ namespace ranges {
             const auto _Xform = [](auto&& _Elem) _STATIC_CALL_OPERATOR {
                 return _RANGES to<range_value_t<_Container>>(_STD forward<decltype(_Elem)>(_Elem));
             };
-            return _RANGES to<_Container>(views::transform(_Range, _Xform), _STD forward<_Types>(_Args)...);
+            return _RANGES to<_Container>(views::transform(ref_view{_Range}, _Xform), _STD forward<_Types>(_Args)...);
         } else {
             static_assert(_Always_false<_Container>, "the program is ill-formed per N4950 [range.utility.conv.to]/2.3");
         }


### PR DESCRIPTION
Fixes #4501.