### PR TITLE
`<condition_variable>`: Avoid squirrelly forward declaration of `_Cnd_internal_imp_t`

### DIFF
--- a/stl/inc/__msvc_threads_core.hpp
+++ b/stl/inc/__msvc_threads_core.hpp
@@ -71,12 +71,11 @@ _INLINE_VAR constexpr size_t _Cnd_internal_imp_alignment = alignof(void*);
 
 using _Mtx_t = _Mtx_internal_imp_t*;
 
-#ifdef _M_CEE // avoid warning LNK4248: unresolved typeref token for '_Cnd_internal_imp_t'; image may not run
-using _Cnd_t = void*;
-#else // ^^^ defined(_M_CEE) / !defined(_M_CEE) vvv
-struct _Cnd_internal_imp_t;
+struct _Cnd_internal_imp_t {
+    _STD _Aligned_storage_t<_Cnd_internal_imp_size, _Cnd_internal_imp_alignment> _Cv_storage;
+};
+
 using _Cnd_t = _Cnd_internal_imp_t*;
-#endif // ^^^ !defined(_M_CEE) ^^^
 } // extern "C"
 
 #pragma pop_macro("new")

--- a/stl/inc/__msvc_threads_core.hpp
+++ b/stl/inc/__msvc_threads_core.hpp
@@ -58,20 +58,19 @@ struct _Mtx_internal_imp_t {
     int _Count{};
 };
 
-// Size and alignment for _Cnd_internal_imp_t
-#if defined(_CRT_WINDOWS) // for Windows-internal code
-_INLINE_VAR constexpr size_t _Cnd_internal_imp_size = 2 * sizeof(void*);
-#elif defined(_WIN64) // ordinary 64-bit code
-_INLINE_VAR constexpr size_t _Cnd_internal_imp_size = 72;
-#else // vvv ordinary 32-bit code vvv
-_INLINE_VAR constexpr size_t _Cnd_internal_imp_size = 40;
-#endif // ^^^ ordinary 32-bit code ^^^
-
-_INLINE_VAR constexpr size_t _Cnd_internal_imp_alignment = alignof(void*);
-
 using _Mtx_t = _Mtx_internal_imp_t*;
 
 struct _Cnd_internal_imp_t {
+#if defined(_CRT_WINDOWS) // for Windows-internal code
+    static constexpr size_t _Cnd_internal_imp_size = 2 * sizeof(void*);
+#elif defined(_WIN64) // ordinary 64-bit code
+    static constexpr size_t _Cnd_internal_imp_size = 72;
+#else // vvv ordinary 32-bit code vvv
+    static constexpr size_t _Cnd_internal_imp_size = 40;
+#endif // ^^^ ordinary 32-bit code ^^^
+
+    static constexpr size_t _Cnd_internal_imp_alignment = alignof(void*);
+
     _STD _Aligned_storage_t<_Cnd_internal_imp_size, _Cnd_internal_imp_alignment> _Cv_storage;
 };
 

--- a/stl/inc/__msvc_threads_core.hpp
+++ b/stl/inc/__msvc_threads_core.hpp
@@ -47,12 +47,10 @@ struct _Mtx_internal_imp_t {
 #endif // ^^^ !defined(_WIN64) ^^^
 #endif // ^^^ public STL ^^^
 
-    static constexpr size_t _Critical_section_align = alignof(void*);
-
     int _Type{};
     union {
         _Stl_critical_section _Critical_section{};
-        _STD _Aligned_storage_t<_Critical_section_size, _Critical_section_align> _Cs_storage;
+        _STD _Aligned_storage_t<_Critical_section_size, alignof(void*)> _Cs_storage;
     };
     long _Thread_id{};
     int _Count{};
@@ -69,9 +67,7 @@ struct _Cnd_internal_imp_t {
     static constexpr size_t _Cnd_internal_imp_size = 40;
 #endif // ^^^ ordinary 32-bit code ^^^
 
-    static constexpr size_t _Cnd_internal_imp_alignment = alignof(void*);
-
-    _STD _Aligned_storage_t<_Cnd_internal_imp_size, _Cnd_internal_imp_alignment> _Cv_storage;
+    _STD _Aligned_storage_t<_Cnd_internal_imp_size, alignof(void*)> _Cv_storage;
 };
 
 using _Cnd_t = _Cnd_internal_imp_t*;

--- a/stl/inc/__msvc_threads_core.hpp
+++ b/stl/inc/__msvc_threads_core.hpp
@@ -33,19 +33,13 @@ struct _Stl_critical_section {
 };
 
 struct _Mtx_internal_imp_t {
-#if defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT)
-#ifdef _WIN64
-    static constexpr size_t _Critical_section_size = 16;
-#else // ^^^ defined(_WIN64) / !defined(_WIN64) vvv
-    static constexpr size_t _Critical_section_size = 8;
-#endif // ^^^ !defined(_WIN64) ^^^
-#else // ^^^ Windows private STL / public STL vvv
-#ifdef _WIN64
+#if defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT) // for Windows-internal code
+    static constexpr size_t _Critical_section_size = 2 * sizeof(void*);
+#elif defined(_WIN64) // ordinary 64-bit code
     static constexpr size_t _Critical_section_size = 64;
-#else // ^^^ defined(_WIN64) / !defined(_WIN64) vvv
+#else // vvv ordinary 32-bit code vvv
     static constexpr size_t _Critical_section_size = 36;
-#endif // ^^^ !defined(_WIN64) ^^^
-#endif // ^^^ public STL ^^^
+#endif // ^^^ ordinary 32-bit code ^^^
 
     int _Type{};
     union {

--- a/stl/inc/condition_variable
+++ b/stl/inc/condition_variable
@@ -220,10 +220,10 @@ public:
 private:
     shared_ptr<mutex> _Myptr;
 
-    _Aligned_storage_t<_Cnd_internal_imp_size, _Cnd_internal_imp_alignment> _Cnd_storage;
+    _Cnd_internal_imp_t _Cnd_storage;
 
-    _NODISCARD _Cnd_t _Mycnd() noexcept { // get pointer to _Cnd_internal_imp_t inside _Cnd_storage
-        return reinterpret_cast<_Cnd_t>(&_Cnd_storage);
+    _NODISCARD _Cnd_t _Mycnd() noexcept {
+        return &_Cnd_storage;
     }
 
     template <class _Lock>

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -637,10 +637,10 @@ public:
     }
 
 private:
-    _Aligned_storage_t<_Cnd_internal_imp_size, _Cnd_internal_imp_alignment> _Cnd_storage;
+    _Cnd_internal_imp_t _Cnd_storage;
 
-    _Cnd_t _Mycnd() noexcept { // get pointer to _Cnd_internal_imp_t inside _Cnd_storage
-        return reinterpret_cast<_Cnd_t>(&_Cnd_storage);
+    _Cnd_t _Mycnd() noexcept {
+        return &_Cnd_storage;
     }
 };
 

--- a/stl/src/primitives.hpp
+++ b/stl/src/primitives.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <__msvc_threads_core.hpp>
 #include <cstdlib>
 #include <type_traits>
 

--- a/stl/src/primitives.hpp
+++ b/stl/src/primitives.hpp
@@ -49,11 +49,3 @@ namespace Concurrency {
         }
     } // namespace details
 } // namespace Concurrency
-
-extern "C" {
-
-struct _Cnd_internal_imp_t {
-    std::_Aligned_storage_t<_Cnd_internal_imp_size, _Cnd_internal_imp_alignment> _Cv_storage;
-};
-
-} // extern "C"

--- a/stl/src/primitives.hpp
+++ b/stl/src/primitives.hpp
@@ -50,11 +50,11 @@ namespace Concurrency {
 extern "C" {
 
 struct _Cnd_internal_imp_t {
-    std::_Aligned_storage_t<_Cnd_internal_imp_size, _Cnd_internal_imp_alignment> cv;
+    std::_Aligned_storage_t<_Cnd_internal_imp_size, _Cnd_internal_imp_alignment> _Cv_storage;
 
     [[nodiscard]] Concurrency::details::stl_condition_variable_win7* _get_cv() noexcept {
         // get pointer to implementation
-        return reinterpret_cast<Concurrency::details::stl_condition_variable_win7*>(&cv);
+        return reinterpret_cast<Concurrency::details::stl_condition_variable_win7*>(&_Cv_storage);
     }
 };
 

--- a/stl/src/primitives.hpp
+++ b/stl/src/primitives.hpp
@@ -44,6 +44,9 @@ namespace Concurrency {
             CONDITION_VARIABLE m_condition_variable = CONDITION_VARIABLE_INIT;
         };
 
+        [[nodiscard]] inline stl_condition_variable_win7* _Get_cond_var(::_Cnd_internal_imp_t* _Cond) noexcept {
+            return reinterpret_cast<stl_condition_variable_win7*>(&_Cond->_Cv_storage);
+        }
     } // namespace details
 } // namespace Concurrency
 
@@ -51,11 +54,6 @@ extern "C" {
 
 struct _Cnd_internal_imp_t {
     std::_Aligned_storage_t<_Cnd_internal_imp_size, _Cnd_internal_imp_alignment> _Cv_storage;
-
-    [[nodiscard]] Concurrency::details::stl_condition_variable_win7* _get_cv() noexcept {
-        // get pointer to implementation
-        return reinterpret_cast<Concurrency::details::stl_condition_variable_win7*>(&_Cv_storage);
-    }
 };
 
 } // extern "C"

--- a/stl/src/sharedmutex.cpp
+++ b/stl/src/sharedmutex.cpp
@@ -50,7 +50,7 @@ _Thrd_result __stdcall _Cnd_timedwait_for(const _Cnd_t cond, const _Mtx_t mtx, c
     mtx->_Thread_id = -1;
     --mtx->_Count;
 
-    if (!cond->_get_cv()->wait_for(cs, target_ms)) { // report timeout
+    if (!Concurrency::details::_Get_cond_var(cond)->wait_for(cs, target_ms)) { // report timeout
         const auto end_ms = GetTickCount64();
         if (end_ms - start_ms >= target_ms) {
             res = _Thrd_result::_Timedout;


### PR DESCRIPTION
Followup to https://github.com/microsoft/STL/pull/4457#issuecomment-1995780996. I performed this as a series of well-structured commits.

# Commits

`primitives.hpp`: Include `__msvc_threads_core.hpp`.

This will allow us to move the definition of `_Cnd_internal_imp_t` into `__msvc_threads_core.hpp`.

This is a safe transformation because only 3 files include `primitives.hpp` and they already drag in `__msvc_threads_core.hpp` (`sharedmutex.cpp` directly; `cond.cpp` and `mutex.cpp` via `xthreads.h`).

---

In `_Cnd_internal_imp_t`, rename its `_Aligned_storage_t` data member `cv` to `_Cv_storage`.

This will allow us to move the definition into `stl/inc/__msvc_threads_core.hpp`.

The new name is consistent with how `_Mtx_internal_imp_t` names its `_Aligned_storage_t` data member `_Cs_storage`.

---

Change definition: `_Cnd_internal_imp_t::_get_cv` => `Concurrency::details::_Get_cond_var`

Change the member function `_Cnd_internal_imp_t::_get_cv` into the non-member function `Concurrency::details::_Get_cond_var`, renamed to be more descriptive.

Drop the unnecessary comment `// get pointer to implementation`.

Now we don't need to qualify `stl_condition_variable_win7`, defined immediately above.

We need to take a parameter `::_Cnd_internal_imp_t* _Cond`, qualified for clarity.

We need `inline` for the non-member function.

---

Replace calls: `cond->_get_cv()` => `Concurrency::details::_Get_cond_var(cond)`

---

Move the definition of `_Cnd_internal_imp_t` from `primitives.hpp` to `__msvc_threads_core.hpp`.

This is still within `extern "C"`.

Change `std::` => `_STD`.

We no longer need the wacky `/clr` forward declaration workaround.

---

Directly store `_Cnd_internal_imp_t _Cnd_storage`.

We can do this because its only data member is exactly `_Aligned_storage_t<_Cnd_internal_imp_size, _Cnd_internal_imp_alignment>`, so the representation is unchanged.

Then we can simplify the `_Mycnd()` member function.

This follows the same pattern as `_Mutex_base`'s `_Mtx_internal_imp_t _Mtx_storage` and `_Mymtx()`.

---

Move `_Cnd_internal_imp_size`/`_Cnd_internal_imp_alignment` within `_Cnd_internal_imp_t`.

This changes `_INLINE_VAR` to `static`.

The comment `// Size and alignment for _Cnd_internal_imp_t` is now unnecessary and can be dropped.

---

Fuse `_Critical_section_align` and `_Cnd_internal_imp_alignment` into their only uses.

---

Follow `_Cnd_internal_imp_t`'s simpler pattern in `_Mtx_internal_imp_t`.

This expresses "16 or 8 bytes" as `2 * sizeof(void*)`.


# Note

After this, I believe that we should apply a similar bugfix as #4294, checking `UNDOCKED_WINDOWS_UCRT` when determining `_Cnd_internal_imp_size`, but I'm not doing that here (mixing functional changes with cleanups is bad).