### PR TITLE
Drop `inline`/`_INLINE_VAR` from templated `constexpr` variables in product and test codes

### DIFF
--- a/stl/inc/__msvc_bit_utils.hpp
+++ b/stl/inc/__msvc_bit_utils.hpp
@@ -41,7 +41,7 @@ _INLINE_VAR constexpr int _Stl_isa_available_sse42 = 2; // equal to __ISA_AVAILA
 _INLINE_VAR constexpr int _Stl_isa_available_avx2  = 5; // equal to __ISA_AVAILABLE_AVX2
 
 template <class _UInt>
-_INLINE_VAR constexpr int _Unsigned_integer_digits = sizeof(_UInt) * CHAR_BIT;
+constexpr int _Unsigned_integer_digits = sizeof(_UInt) * CHAR_BIT;
 
 // Implementation of countl_zero without using specialized CPU instructions.
 // Used at compile time and when said instructions are not supported.
@@ -356,7 +356,7 @@ _NODISCARD inline int _Arm64_popcount(const unsigned long long _Val) noexcept {
 #endif // _HAS_NEON_INTRINSICS
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _Is_standard_unsigned_integer =
+constexpr bool _Is_standard_unsigned_integer =
     _Is_any_of_v<remove_cv_t<_Ty>, unsigned char, unsigned short, unsigned int, unsigned long, unsigned long long>;
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>

--- a/stl/inc/__msvc_chrono.hpp
+++ b/stl/inc/__msvc_chrono.hpp
@@ -31,7 +31,7 @@ namespace chrono {
     struct treat_as_floating_point : is_floating_point<_Rep> {}; // tests for floating-point type
 
     _EXPORT_STD template <class _Rep>
-    _INLINE_VAR constexpr bool treat_as_floating_point_v = treat_as_floating_point<_Rep>::value;
+    constexpr bool treat_as_floating_point_v = treat_as_floating_point<_Rep>::value;
 
     _EXPORT_STD template <class _Rep>
     struct duration_values { // gets arithmetic properties of a type
@@ -53,10 +53,10 @@ namespace chrono {
 
 #if _HAS_CXX20
     template <class _Clock, class = void>
-    inline constexpr bool _Is_clock_v = false;
+    constexpr bool _Is_clock_v = false;
 
     template <class _Clock>
-    inline constexpr bool
+    constexpr bool
         _Is_clock_v<_Clock, void_t<typename _Clock::rep, typename _Clock::period, typename _Clock::duration,
                                 typename _Clock::time_point, decltype(_Clock::is_steady), decltype(_Clock::now())>> =
             true; // TRANSITION, GH-602
@@ -64,14 +64,14 @@ namespace chrono {
     _EXPORT_STD template <class _Clock>
     struct is_clock : bool_constant<_Is_clock_v<_Clock>> {};
     _EXPORT_STD template <class _Clock>
-    inline constexpr bool is_clock_v = _Is_clock_v<_Clock>;
+    constexpr bool is_clock_v = _Is_clock_v<_Clock>;
 #endif // _HAS_CXX20
 
     _EXPORT_STD template <class _Rep, class _Period = ratio<1>>
     class duration;
 
     template <class _Ty>
-    _INLINE_VAR constexpr bool _Is_duration_v = _Is_specialization_v<_Ty, duration>;
+    constexpr bool _Is_duration_v = _Is_specialization_v<_Ty, duration>;
 
     _EXPORT_STD template <class _To, class _Rep, class _Period, enable_if_t<_Is_duration_v<_To>, int> = 0>
     constexpr _To duration_cast(const duration<_Rep, _Period>&) noexcept(
@@ -252,11 +252,10 @@ namespace chrono {
 } // namespace chrono
 
 template <class _Rep, class _Period>
-_INLINE_VAR constexpr bool _Is_trivially_swappable_v<chrono::duration<_Rep, _Period>> = _Is_trivially_swappable_v<_Rep>;
+constexpr bool _Is_trivially_swappable_v<chrono::duration<_Rep, _Period>> = _Is_trivially_swappable_v<_Rep>;
 
 template <class _Clock, class _Duration>
-_INLINE_VAR constexpr bool _Is_trivially_swappable_v<chrono::time_point<_Clock, _Duration>> =
-    _Is_trivially_swappable_v<_Duration>;
+constexpr bool _Is_trivially_swappable_v<chrono::time_point<_Clock, _Duration>> = _Is_trivially_swappable_v<_Duration>;
 
 _NODISCARD constexpr intmax_t _Lcm(const intmax_t _Ax, const intmax_t _Bx) noexcept {
     return (_Ax / _Gcd(_Ax, _Bx)) * _Bx;

--- a/stl/inc/__msvc_filebuf.hpp
+++ b/stl/inc/__msvc_filebuf.hpp
@@ -51,7 +51,7 @@ namespace experimental {
 
 // clang-format off
 template <class _Ty>
-_INLINE_VAR constexpr bool _Is_any_path = _Is_any_of_v<_Ty
+constexpr bool _Is_any_path = _Is_any_of_v<_Ty
 #if _FSTREAM_SUPPORTS_EXPERIMENTAL_FILESYSTEM
     , experimental::filesystem::path
 #endif // _FSTREAM_SUPPORTS_EXPERIMENTAL_FILESYSTEM

--- a/stl/inc/__msvc_iter_core.hpp
+++ b/stl/inc/__msvc_iter_core.hpp
@@ -34,7 +34,7 @@ _EXPORT_STD template <class _Ty, class _Alloc>
 struct uses_allocator : _Has_allocator_type<_Ty, _Alloc>::type {};
 
 _EXPORT_STD template <class _Ty, class _Alloc>
-_INLINE_VAR constexpr bool uses_allocator_v = uses_allocator<_Ty, _Alloc>::value;
+constexpr bool uses_allocator_v = uses_allocator<_Ty, _Alloc>::value;
 
 // from <iterator>
 _EXPORT_STD struct input_iterator_tag {};
@@ -386,7 +386,7 @@ struct iterator_traits<_Ty*> {
 };
 
 template <class _Ty>
-inline constexpr bool _Integer_class = requires {
+constexpr bool _Integer_class = requires {
     typename _Ty::_Signed_type;
     typename _Ty::_Unsigned_type;
 };
@@ -418,7 +418,7 @@ concept sentinel_for = semiregular<_Se>
 // clang-format on
 
 _EXPORT_STD template <class _Se, class _It>
-inline constexpr bool disable_sized_sentinel_for = false;
+constexpr bool disable_sized_sentinel_for = false;
 
 // clang-format off
 _EXPORT_STD template <class _Se, class _It>
@@ -454,7 +454,7 @@ namespace ranges {
 _EXPORT_STD using ranges::get;
 
 template <class _It, class _Se, ranges::subrange_kind _Ki>
-inline constexpr bool _Is_subrange_v<ranges::subrange<_It, _Se, _Ki>> = true;
+constexpr bool _Is_subrange_v<ranges::subrange<_It, _Se, _Ki>> = true;
 
 template <class _It, class _Se, ranges::subrange_kind _Ki>
 struct tuple_size<ranges::subrange<_It, _Se, _Ki>> : integral_constant<size_t, 2> {};

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -185,7 +185,7 @@ _INLINE_VAR constexpr ptrdiff_t _Threshold_find_first_of = 16;
 
 // Can we activate the vector algorithms for find_first_of?
 template <class _It1, class _It2, class _Pr>
-_INLINE_VAR constexpr bool _Vector_alg_in_find_first_of_is_safe =
+constexpr bool _Vector_alg_in_find_first_of_is_safe =
     _Equal_memcmp_is_safe<_It1, _It2, _Pr> // can replace value comparison with bitwise comparison
     && sizeof(_Iter_value_t<_It1>) <= 2; // pcmpestri compatible size
 _STD_END
@@ -202,7 +202,7 @@ _STD_BEGIN
 _INLINE_VAR constexpr int _ISORT_MAX = 32; // maximum size for insertion sort
 
 template <class _It>
-_INLINE_VAR constexpr _Iter_diff_t<_It> _Isort_max{_ISORT_MAX};
+constexpr _Iter_diff_t<_It> _Isort_max{_ISORT_MAX};
 
 template <class _Diff>
 constexpr ptrdiff_t _Temporary_buffer_size(const _Diff _Value) noexcept {
@@ -3516,11 +3516,11 @@ namespace ranges {
     _EXPORT_STD inline constexpr _Find_first_of_fn find_first_of;
 
     template <class _Ty>
-    inline constexpr bool _Is_trivially_ranges_swappable_v =
+    constexpr bool _Is_trivially_ranges_swappable_v =
         disjunction_v<conjunction<is_scalar<_Ty>, negation<is_enum<_Ty>>>, _Is_trivially_swappable<_Ty>>;
 
     template <class _Ty, size_t _Len>
-    inline constexpr bool _Is_trivially_ranges_swappable_v<_Ty[_Len]> = _Is_trivially_ranges_swappable_v<_Ty>;
+    constexpr bool _Is_trivially_ranges_swappable_v<_Ty[_Len]> = _Is_trivially_ranges_swappable_v<_Ty>;
 
     template <class _Ty>
     struct _Is_trivially_ranges_swappable : bool_constant<_Is_trivially_ranges_swappable_v<_Ty>> {};
@@ -3948,7 +3948,7 @@ namespace ranges {
 
 // TRANSITION, DevCom-10606350: help the compiler auto-vectorize for simple types
 template <class _UOutIt, class _InTy, class _NewTy, class _OutTy = remove_pointer_t<_UOutIt>>
-_INLINE_VAR constexpr bool _Can_vectorize_replace_copy = conjunction_v<is_pointer<_UOutIt>, is_same<_InTy, _NewTy>,
+constexpr bool _Can_vectorize_replace_copy = conjunction_v<is_pointer<_UOutIt>, is_same<_InTy, _NewTy>,
     disjunction<
 #ifdef __cpp_lib_byte
         conjunction<is_same<_InTy, byte>, is_same<_OutTy, byte>>,
@@ -4718,7 +4718,7 @@ template <class _InIt, class _OutIt>
 #if _HAS_CXX20
 concept
 #else
-_INLINE_VAR constexpr bool
+constexpr bool
 #endif
     _Can_reread_dest = _Is_cpp17_fwd_iter_v<_OutIt> && is_same_v<_Iter_value_t<_InIt>, _Iter_value_t<_OutIt>>;
 

--- a/stl/inc/any
+++ b/stl/inc/any
@@ -42,14 +42,14 @@ public:
 inline constexpr size_t _Any_trivial_space_size = (_Small_object_num_ptrs - 1) * sizeof(void*);
 
 template <class _Ty>
-inline constexpr bool _Any_is_trivial =
+constexpr bool _Any_is_trivial =
     alignof(_Ty) <= alignof(max_align_t) && is_trivially_copyable_v<_Ty> && sizeof(_Ty) <= _Any_trivial_space_size;
 
 inline constexpr size_t _Any_small_space_size = (_Small_object_num_ptrs - 2) * sizeof(void*);
 
 template <class _Ty>
-inline constexpr bool _Any_is_small = alignof(_Ty) <= alignof(max_align_t)
-                                   && is_nothrow_move_constructible_v<_Ty> && sizeof(_Ty) <= _Any_small_space_size;
+constexpr bool _Any_is_small = alignof(_Ty) <= alignof(max_align_t)
+                            && is_nothrow_move_constructible_v<_Ty> && sizeof(_Ty) <= _Any_small_space_size;
 
 enum class _Any_representation : uintptr_t { _Trivial, _Big, _Small };
 
@@ -97,11 +97,10 @@ struct _Any_small_RTTI { // Hand-rolled vtable for nontrivial types that can be 
 };
 
 template <class _Ty>
-inline constexpr _Any_big_RTTI _Any_big_RTTI_obj = {
-    &_Any_big_RTTI::_Destroy_impl<_Ty>, &_Any_big_RTTI::_Copy_impl<_Ty>};
+constexpr _Any_big_RTTI _Any_big_RTTI_obj = {&_Any_big_RTTI::_Destroy_impl<_Ty>, &_Any_big_RTTI::_Copy_impl<_Ty>};
 
 template <class _Ty>
-inline constexpr _Any_small_RTTI _Any_small_RTTI_obj = {
+constexpr _Any_small_RTTI _Any_small_RTTI_obj = {
     &_Any_small_RTTI::_Destroy_impl<_Ty>, &_Any_small_RTTI::_Copy_impl<_Ty>, &_Any_small_RTTI::_Move_impl<_Ty>};
 
 _EXPORT_STD class any { // storage for any (CopyConstructible) type

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -330,8 +330,7 @@ struct _Storage_for {
 
 #if _CMPXCHG_MASK_OUT_PADDING_BITS
 template <class _Ty>
-inline constexpr bool _Might_have_non_value_bits =
-    !has_unique_object_representations_v<_Ty> && !is_floating_point_v<_Ty>;
+constexpr bool _Might_have_non_value_bits = !has_unique_object_representations_v<_Ty> && !is_floating_point_v<_Ty>;
 #endif // _CMPXCHG_MASK_OUT_PADDING_BITS
 
 _EXPORT_STD extern "C" inline void atomic_thread_fence(const memory_order _Order) noexcept {
@@ -1648,22 +1647,22 @@ struct _Atomic_integral<_Ty, 8> : _Atomic_storage<_Ty> { // atomic integral oper
 
 #if 1 // TRANSITION, ABI
 template <size_t _TypeSize>
-_INLINE_VAR constexpr bool _Is_always_lock_free = _TypeSize <= 8 && (_TypeSize & (_TypeSize - 1)) == 0;
+constexpr bool _Is_always_lock_free = _TypeSize <= 8 && (_TypeSize & (_TypeSize - 1)) == 0;
 #else // ^^^ don't break ABI / break ABI vvv
 #if _ATOMIC_HAS_DCAS
 template <size_t _TypeSize>
-_INLINE_VAR constexpr bool _Is_always_lock_free = _TypeSize <= 2 * sizeof(void*);
+constexpr bool _Is_always_lock_free = _TypeSize <= 2 * sizeof(void*);
 #else // ^^^ _ATOMIC_HAS_DCAS / !_ATOMIC_HAS_DCAS vvv
 template <size_t _TypeSize>
-_INLINE_VAR constexpr bool _Is_always_lock_free = _TypeSize <= sizeof(void*);
+constexpr bool _Is_always_lock_free = _TypeSize <= sizeof(void*);
 #endif // ^^^ !_ATOMIC_HAS_DCAS ^^^
 #endif // ^^^ break ABI ^^^
 
 template <class _Ty, bool _Is_lock_free = _Is_always_lock_free<sizeof(_Ty)>>
-_INLINE_VAR constexpr bool _Deprecate_non_lock_free_volatile = true;
+constexpr bool _Deprecate_non_lock_free_volatile = true;
 
 template <class _Ty>
-_CXX20_DEPRECATE_VOLATILE _INLINE_VAR constexpr bool _Deprecate_non_lock_free_volatile<_Ty, false> = true;
+_CXX20_DEPRECATE_VOLATILE constexpr bool _Deprecate_non_lock_free_volatile<_Ty, false> = true;
 
 template <class _Ty>
 struct _Atomic_integral_facade : _Atomic_integral<_Ty> {

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -1543,7 +1543,7 @@ namespace chrono {
     }
 
     template <class _To, class _From>
-    inline constexpr bool
+    constexpr bool
         _Duration_underflows_with = !treat_as_floating_point_v<typename _From::rep>
                                  && _From::period::den / _Gcd(_From::period::den, _To::period::den)
                                         > INTMAX_MAX / (_To::period::num / _Gcd(_From::period::num, _To::period::num));
@@ -2872,10 +2872,10 @@ namespace chrono {
     // [time.clock.cast.sys]
 
     template <class _TimePoint, class _Clock>
-    inline constexpr bool _Is_time_point_for_clock = false;
+    constexpr bool _Is_time_point_for_clock = false;
 
     template <class _Clock, class _Duration>
-    inline constexpr bool _Is_time_point_for_clock<time_point<_Clock, _Duration>, _Clock> = true;
+    constexpr bool _Is_time_point_for_clock<time_point<_Clock, _Duration>, _Clock> = true;
 
     template <class _SourceClock>
     struct clock_time_conversion<system_clock, _SourceClock> {
@@ -2947,17 +2947,17 @@ namespace chrono {
     };
 
     template <class _Conv1, class _Conv2, class _Tp, class = void>
-    inline constexpr bool _Has_two_step_conversion = false;
+    constexpr bool _Has_two_step_conversion = false;
 
     template <class _Conv1, class _Conv2, class _Tp>
-    inline constexpr bool
+    constexpr bool
         _Has_two_step_conversion<_Conv1, _Conv2, _Tp, void_t<decltype(_Conv1{}(_Conv2{}(_STD declval<_Tp>())))>> = true;
 
     template <class _Conv1, class _Conv2, class _Conv3, class _Tp, class = void>
-    inline constexpr bool _Has_three_step_conversion = false;
+    constexpr bool _Has_three_step_conversion = false;
 
     template <class _Conv1, class _Conv2, class _Conv3, class _Tp>
-    inline constexpr bool _Has_three_step_conversion<_Conv1, _Conv2, _Conv3, _Tp,
+    constexpr bool _Has_three_step_conversion<_Conv1, _Conv2, _Conv3, _Tp,
         void_t<decltype(_Conv1{}(_Conv2{}(_Conv3{}(_STD declval<_Tp>()))))>> = true;
 
     template <class _DestClock, class _SourceClock, class _Duration>
@@ -3004,7 +3004,7 @@ namespace chrono {
     }
 
     template <class _DestClock, class _SourceClock, class _Duration>
-    inline constexpr auto _Clock_cast_choice = _Choose_clock_cast<_DestClock, _SourceClock, _Duration>();
+    constexpr auto _Clock_cast_choice = _Choose_clock_cast<_DestClock, _SourceClock, _Duration>();
 
     _EXPORT_STD template <class _DestClock, class _SourceClock, class _Duration,
         enable_if_t<_Clock_cast_choice<_DestClock, _SourceClock, _Duration> != _Clock_cast_strategy::_None, int> = 0>

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -268,7 +268,7 @@ enum _Comparison_category : unsigned char {
 };
 
 template <class... _Types>
-inline constexpr unsigned char _Classify_category =
+constexpr unsigned char _Classify_category =
     _Comparison_category{(_Classify_category<_Types> | ... | _Comparison_category_strong)};
 template <class _Ty>
 inline constexpr unsigned char _Classify_category<_Ty> = _Comparison_category_none;

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -271,7 +271,7 @@ template <class... _Types>
 constexpr unsigned char _Classify_category =
     _Comparison_category{(_Classify_category<_Types> | ... | _Comparison_category_strong)};
 template <class _Ty>
-inline constexpr unsigned char _Classify_category<_Ty> = _Comparison_category_none;
+constexpr unsigned char _Classify_category<_Ty> = _Comparison_category_none;
 template <>
 inline constexpr unsigned char _Classify_category<partial_ordering> = _Comparison_category_partial;
 template <>

--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -213,7 +213,7 @@ namespace _Math_algorithms {
         static constexpr float value{9.2233715e+18f};
     };
     template <class _Ty>
-    _INLINE_VAR constexpr _Ty _Hypot_leg_huge = _Hypot_leg_huge_helper<_Ty>::value;
+    constexpr _Ty _Hypot_leg_huge = _Hypot_leg_huge_helper<_Ty>::value;
 
     template <class _Ty>
     struct _Hypot_leg_tiny_helper {
@@ -224,7 +224,7 @@ namespace _Math_algorithms {
         static constexpr float value{4.440892e-16f};
     };
     template <class _Ty>
-    _INLINE_VAR constexpr _Ty _Hypot_leg_tiny = _Hypot_leg_tiny_helper<_Ty>::value;
+    constexpr _Ty _Hypot_leg_tiny = _Hypot_leg_tiny_helper<_Ty>::value;
 
     template <class _Ty>
     _NODISCARD _Ty _Norm_minus_one(const _Ty _Xval, const _Ty _Yval) noexcept {
@@ -912,7 +912,7 @@ public:
 };
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _Is_unqual_fp = _Is_any_of_v<_Ty, float, double, long double>;
+constexpr bool _Is_unqual_fp = _Is_any_of_v<_Ty, float, double, long double>;
 
 template <class _Ty>
 struct _Complex_value {

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -384,7 +384,7 @@ struct _Atomic_is_usually_lock_free : bool_constant<atomic<_Ty>::is_always_lock_
 };
 
 template <class _FwdIt>
-inline constexpr bool _Use_atomic_iterator = conjunction_v<bool_constant<_Is_ranges_random_iter_v<_FwdIt>>,
+constexpr bool _Use_atomic_iterator = conjunction_v<bool_constant<_Is_ranges_random_iter_v<_FwdIt>>,
     is_trivially_copyable<_FwdIt>, _Atomic_is_usually_lock_free<_FwdIt>>;
 
 template <class _Ty>

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -162,14 +162,14 @@ namespace filesystem {
     }
 
     template <class _Ty, class = void>
-    inline constexpr bool _Is_Source_impl = false;
+    constexpr bool _Is_Source_impl = false;
 
     template <class _Ty>
-    inline constexpr bool _Is_Source_impl<_Ty, void_t<typename iterator_traits<_Ty>::value_type>> =
+    constexpr bool _Is_Source_impl<_Ty, void_t<typename iterator_traits<_Ty>::value_type>> =
         _Is_EcharT<typename iterator_traits<_Ty>::value_type>;
 
     template <class _Ty>
-    inline constexpr bool _Is_Source = _Is_Source_impl<decay_t<_Ty>>;
+    constexpr bool _Is_Source = _Is_Source_impl<decay_t<_Ty>>;
 
     _EXPORT_STD class path;
 
@@ -178,10 +178,10 @@ namespace filesystem {
                                                     // iterator_traits when determining if path is copyable.
 
     template <class _Elem, class _Traits, class _Alloc>
-    inline constexpr bool _Is_Source<basic_string<_Elem, _Traits, _Alloc>> = _Is_EcharT<_Elem>;
+    constexpr bool _Is_Source<basic_string<_Elem, _Traits, _Alloc>> = _Is_EcharT<_Elem>;
 
     template <class _Elem, class _Traits>
-    inline constexpr bool _Is_Source<basic_string_view<_Elem, _Traits>> = _Is_EcharT<_Elem>;
+    constexpr bool _Is_Source<basic_string_view<_Elem, _Traits>> = _Is_EcharT<_Elem>;
 
     struct _Normal_conversion {};
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -667,13 +667,13 @@ concept _Formattable_with_non_const = semiregular<_Formatter>
                                       };
 
 template <class _Ty, class _CharT>
-inline constexpr bool _Is_basic_string_like_for = false;
+constexpr bool _Is_basic_string_like_for = false;
 
 template <class _CharT, class _Traits, class _Alloc>
-inline constexpr bool _Is_basic_string_like_for<basic_string<_CharT, _Traits, _Alloc>, _CharT> = true;
+constexpr bool _Is_basic_string_like_for<basic_string<_CharT, _Traits, _Alloc>, _CharT> = true;
 
 template <class _CharT, class _Traits>
-inline constexpr bool _Is_basic_string_like_for<basic_string_view<_CharT, _Traits>, _CharT> = true;
+constexpr bool _Is_basic_string_like_for<basic_string_view<_CharT, _Traits>, _CharT> = true;
 
 template <class _Context>
 struct _Format_arg_traits {
@@ -1612,7 +1612,7 @@ _NODISCARD constexpr basic_format_arg<_Context> _Get_arg(const _Context& _Ctx, c
 }
 
 template <class _Ty>
-inline constexpr bool _Is_signed_or_unsigned_large_integer_t =
+constexpr bool _Is_signed_or_unsigned_large_integer_t =
     _Is_any_of_v<remove_cv_t<_Ty>, int, unsigned int, long, unsigned long, long long, unsigned long long>;
 
 // Checks that the type and value of an argument associated with a dynamic
@@ -2464,20 +2464,20 @@ struct _Invalid_format_kind {
 };
 
 _EXPORT_STD template <class _Ty>
-inline constexpr _Invalid_format_kind<_Ty> format_kind;
+constexpr _Invalid_format_kind<_Ty> format_kind;
 
 template <class _Ty>
-inline constexpr bool _Is_two_tuple = false;
+constexpr bool _Is_two_tuple = false;
 
 template <class _Ty, class _Uty>
-inline constexpr bool _Is_two_tuple<pair<_Ty, _Uty>> = true;
+constexpr bool _Is_two_tuple<pair<_Ty, _Uty>> = true;
 
 template <class _Ty, class _Uty>
-inline constexpr bool _Is_two_tuple<tuple<_Ty, _Uty>> = true;
+constexpr bool _Is_two_tuple<tuple<_Ty, _Uty>> = true;
 
 template <_RANGES input_range _Rng>
     requires same_as<_Rng, remove_cvref_t<_Rng>>
-inline constexpr range_format format_kind<_Rng> = []() consteval {
+constexpr range_format format_kind<_Rng> = []() consteval {
     using _Ref_value_t = remove_cvref_t<_RANGES range_reference_t<_Rng>>;
     if constexpr (same_as<_Ref_value_t, _Rng>) {
         return range_format::disabled;

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -706,7 +706,7 @@ _EXPORT_STD template <class _Fty>
 class function;
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _Testable_callable_v =
+constexpr bool _Testable_callable_v =
     disjunction_v<is_pointer<_Ty>, _Is_specialization<_Ty, function>, is_member_pointer<_Ty>>;
 
 template <class _Ty>
@@ -745,8 +745,8 @@ private:
 _INLINE_VAR constexpr size_t _Space_size = (_Small_object_num_ptrs - 1) * sizeof(void*);
 
 template <class _Impl> // determine whether _Impl must be dynamically allocated
-_INLINE_VAR constexpr bool _Is_large = sizeof(_Impl) > _Space_size || alignof(_Impl) > alignof(max_align_t)
-                                    || !_Impl::_Nothrow_move::value;
+constexpr bool _Is_large = sizeof(_Impl) > _Space_size || alignof(_Impl) > alignof(max_align_t)
+                        || !_Impl::_Nothrow_move::value;
 
 #if _HAS_FUNCTION_ALLOCATOR_SUPPORT
 template <class _Callable, class _Alloc, class _Rx, class... _Types>
@@ -1391,7 +1391,7 @@ void __stdcall _Function_destroy_large(_Move_only_function_data& _Self) noexcept
 }
 
 template <class _Vt>
-inline constexpr size_t _Function_small_copy_size = // We copy Impl* and the functor data at once
+constexpr size_t _Function_small_copy_size = // We copy Impl* and the functor data at once
     _Move_only_function_data::_Buf_offset<_Vt> // Impl* plus possible alignment
     + (size_t{sizeof(_Vt) + sizeof(void*) - 1} & ~size_t{sizeof(void*) - 1}); // size in whole pointers
 
@@ -1972,7 +1972,7 @@ template <class _Tx>
 struct is_placeholder<const volatile _Tx> : is_placeholder<_Tx>::type {}; // ignore cv-qualifiers
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr int is_placeholder_v = is_placeholder<_Ty>::value;
+constexpr int is_placeholder_v = is_placeholder<_Ty>::value;
 
 template <class _Ret, class _Fx, class... _Types>
 class _Binder;
@@ -1993,7 +1993,7 @@ template <class _Tx>
 struct is_bind_expression<const volatile _Tx> : is_bind_expression<_Tx>::type {}; // ignore cv-qualifiers
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_bind_expression_v = is_bind_expression<_Ty>::value;
+constexpr bool is_bind_expression_v = is_bind_expression<_Ty>::value;
 
 template <class _Cv_TiD, bool = _Is_specialization_v<remove_cv_t<_Cv_TiD>, reference_wrapper>,
     bool = is_bind_expression_v<_Cv_TiD>, int = is_placeholder_v<_Cv_TiD>>
@@ -2102,10 +2102,10 @@ concept _Can_call_binder = requires(_CvFD& _Fx, _CvBoundTuple& _Bound_tuple, _Un
 };
 #else // ^^^ concept available / concept unavailable vvv
 template <class _Ret, class _CvFD, class _IntSeq, class _CvBoundTuple, class _UnboundTuple, class = void>
-_INLINE_VAR constexpr bool _Can_call_binder = false;
+constexpr bool _Can_call_binder = false;
 
 template <class _Ret, class _CvFD, class _IntSeq, class _CvBoundTuple, class _UnboundTuple>
-_INLINE_VAR constexpr bool _Can_call_binder<_Ret, _CvFD, _IntSeq, _CvBoundTuple, _UnboundTuple,
+constexpr bool _Can_call_binder<_Ret, _CvFD, _IntSeq, _CvBoundTuple, _UnboundTuple,
     void_t<decltype(_STD _Call_binder(_Invoker_ret<_Ret>{}, _IntSeq{}, _STD declval<_CvFD&>(),
         _STD declval<_CvBoundTuple&>(), _STD declval<_UnboundTuple>()))>> = true;
 #endif // ^^^ concept unavailable ^^^

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -37,7 +37,7 @@ template <class _IndexType>
 struct _Maybe_empty_array<_IndexType, 0> {};
 
 template <size_t... _Extents>
-inline constexpr size_t _Calculate_rank_dynamic = (static_cast<size_t>(_Extents == dynamic_extent) + ... + 0);
+constexpr size_t _Calculate_rank_dynamic = (static_cast<size_t>(_Extents == dynamic_extent) + ... + 0);
 
 struct _Extents_from_tuple {
     explicit _Extents_from_tuple() = default;
@@ -315,7 +315,7 @@ public:
 };
 
 template <class>
-inline constexpr size_t _Repeat_dynamic_extent = dynamic_extent;
+constexpr size_t _Repeat_dynamic_extent = dynamic_extent;
 
 template <class... _Integrals>
     requires (is_convertible_v<_Integrals, size_t> && ...)
@@ -333,10 +333,10 @@ _EXPORT_STD template <class _IndexType, size_t _Rank>
 using dextents = _Dextents_impl<_IndexType, make_index_sequence<_Rank>>::type;
 
 template <class _Ty>
-inline constexpr bool _Is_extents = false;
+constexpr bool _Is_extents = false;
 
 template <class _IndexType, size_t... _Args>
-inline constexpr bool _Is_extents<extents<_IndexType, _Args...>> = true;
+constexpr bool _Is_extents<extents<_IndexType, _Args...>> = true;
 
 template <class _Extents>
 class _Fwd_prod_of_extents {
@@ -425,7 +425,7 @@ public:
 };
 
 template <class _Layout, class _Mapping>
-inline constexpr bool _Is_mapping_of =
+constexpr bool _Is_mapping_of =
     is_same_v<typename _Layout::template mapping<typename _Mapping::extents_type>, _Mapping>;
 
 _EXPORT_STD struct layout_left {

--- a/stl/inc/numbers
+++ b/stl/inc/numbers
@@ -28,58 +28,58 @@ namespace numbers {
     };
 
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty e_v = _Invalid<_Ty>{};
+    constexpr _Ty e_v = _Invalid<_Ty>{};
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty log2e_v = _Invalid<_Ty>{};
+    constexpr _Ty log2e_v = _Invalid<_Ty>{};
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty log10e_v = _Invalid<_Ty>{};
+    constexpr _Ty log10e_v = _Invalid<_Ty>{};
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty pi_v = _Invalid<_Ty>{};
+    constexpr _Ty pi_v = _Invalid<_Ty>{};
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty inv_pi_v = _Invalid<_Ty>{};
+    constexpr _Ty inv_pi_v = _Invalid<_Ty>{};
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty inv_sqrtpi_v = _Invalid<_Ty>{};
+    constexpr _Ty inv_sqrtpi_v = _Invalid<_Ty>{};
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty ln2_v = _Invalid<_Ty>{};
+    constexpr _Ty ln2_v = _Invalid<_Ty>{};
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty ln10_v = _Invalid<_Ty>{};
+    constexpr _Ty ln10_v = _Invalid<_Ty>{};
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty sqrt2_v = _Invalid<_Ty>{};
+    constexpr _Ty sqrt2_v = _Invalid<_Ty>{};
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty sqrt3_v = _Invalid<_Ty>{};
+    constexpr _Ty sqrt3_v = _Invalid<_Ty>{};
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty inv_sqrt3_v = _Invalid<_Ty>{};
+    constexpr _Ty inv_sqrt3_v = _Invalid<_Ty>{};
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty egamma_v = _Invalid<_Ty>{};
+    constexpr _Ty egamma_v = _Invalid<_Ty>{};
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty phi_v = _Invalid<_Ty>{};
+    constexpr _Ty phi_v = _Invalid<_Ty>{};
 
     template <floating_point _Floating>
-    inline constexpr _Floating e_v<_Floating> = static_cast<_Floating>(2.718281828459045);
+    constexpr _Floating e_v<_Floating> = static_cast<_Floating>(2.718281828459045);
     template <floating_point _Floating>
-    inline constexpr _Floating log2e_v<_Floating> = static_cast<_Floating>(1.4426950408889634);
+    constexpr _Floating log2e_v<_Floating> = static_cast<_Floating>(1.4426950408889634);
     template <floating_point _Floating>
-    inline constexpr _Floating log10e_v<_Floating> = static_cast<_Floating>(0.4342944819032518);
+    constexpr _Floating log10e_v<_Floating> = static_cast<_Floating>(0.4342944819032518);
     template <floating_point _Floating>
-    inline constexpr _Floating pi_v<_Floating> = static_cast<_Floating>(3.141592653589793);
+    constexpr _Floating pi_v<_Floating> = static_cast<_Floating>(3.141592653589793);
     template <floating_point _Floating>
-    inline constexpr _Floating inv_pi_v<_Floating> = static_cast<_Floating>(0.3183098861837907);
+    constexpr _Floating inv_pi_v<_Floating> = static_cast<_Floating>(0.3183098861837907);
     template <floating_point _Floating>
-    inline constexpr _Floating inv_sqrtpi_v<_Floating> = static_cast<_Floating>(0.5641895835477563);
+    constexpr _Floating inv_sqrtpi_v<_Floating> = static_cast<_Floating>(0.5641895835477563);
     template <floating_point _Floating>
-    inline constexpr _Floating ln2_v<_Floating> = static_cast<_Floating>(0.6931471805599453);
+    constexpr _Floating ln2_v<_Floating> = static_cast<_Floating>(0.6931471805599453);
     template <floating_point _Floating>
-    inline constexpr _Floating ln10_v<_Floating> = static_cast<_Floating>(2.302585092994046);
+    constexpr _Floating ln10_v<_Floating> = static_cast<_Floating>(2.302585092994046);
     template <floating_point _Floating>
-    inline constexpr _Floating sqrt2_v<_Floating> = static_cast<_Floating>(1.4142135623730951);
+    constexpr _Floating sqrt2_v<_Floating> = static_cast<_Floating>(1.4142135623730951);
     template <floating_point _Floating>
-    inline constexpr _Floating sqrt3_v<_Floating> = static_cast<_Floating>(1.7320508075688772);
+    constexpr _Floating sqrt3_v<_Floating> = static_cast<_Floating>(1.7320508075688772);
     template <floating_point _Floating>
-    inline constexpr _Floating inv_sqrt3_v<_Floating> = static_cast<_Floating>(0.5773502691896257);
+    constexpr _Floating inv_sqrt3_v<_Floating> = static_cast<_Floating>(0.5773502691896257);
     template <floating_point _Floating>
-    inline constexpr _Floating egamma_v<_Floating> = static_cast<_Floating>(0.5772156649015329);
+    constexpr _Floating egamma_v<_Floating> = static_cast<_Floating>(0.5772156649015329);
     template <floating_point _Floating>
-    inline constexpr _Floating phi_v<_Floating> = static_cast<_Floating>(1.618033988749895);
+    constexpr _Floating phi_v<_Floating> = static_cast<_Floating>(1.618033988749895);
 
     _EXPORT_STD inline constexpr double e          = e_v<double>;
     _EXPORT_STD inline constexpr double log2e      = log2e_v<double>;

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -49,7 +49,7 @@ _NODISCARD _CONSTEXPR20 _Ty accumulate(const _InIt _First, const _InIt _Last, _T
 #if _HAS_CXX17
 #if _STD_VECTORIZE_WITH_FLOAT_CONTROL
 template <class _InIt, class _Ty, class _BinOp>
-inline constexpr bool _Plus_on_arithmetic_ranges_reduction_v =
+constexpr bool _Plus_on_arithmetic_ranges_reduction_v =
     conjunction_v<is_arithmetic<_Ty>, is_arithmetic<remove_pointer_t<_InIt>>, is_same<plus<>, _BinOp>>;
 
 #pragma float_control(precise, off, push)
@@ -150,7 +150,7 @@ _NODISCARD _CONSTEXPR20 _Ty inner_product(const _InIt1 _First1, const _InIt1 _La
 #if _HAS_CXX17
 #if _STD_VECTORIZE_WITH_FLOAT_CONTROL
 template <class _InIt1, class _InIt2, class _Ty, class _BinOp1, class _BinOp2>
-inline constexpr bool _Default_ops_transform_reduce_v =
+constexpr bool _Default_ops_transform_reduce_v =
     conjunction_v<is_arithmetic<_Ty>, is_arithmetic<remove_pointer_t<_InIt1>>, is_arithmetic<remove_pointer_t<_InIt2>>,
         is_same<plus<>, _BinOp1>, is_same<multiplies<>, _BinOp2>>;
 
@@ -646,7 +646,7 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> lcm(const _Mt _Mx, const _Nt _Nx) n
 
 #if _HAS_CXX20
 template <class _Flt>
-inline constexpr _Flt _Floating_max{};
+constexpr _Flt _Floating_max{};
 template <>
 inline constexpr float _Floating_max<float> = FLT_MAX;
 template <>
@@ -655,7 +655,7 @@ template <>
 inline constexpr long double _Floating_max<long double> = LDBL_MAX;
 
 template <class _Flt>
-inline constexpr _Flt _Floating_min{};
+constexpr _Flt _Floating_min{};
 template <>
 inline constexpr float _Floating_min<float> = FLT_MIN;
 template <>

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -35,7 +35,7 @@ namespace ranges {
     // MUCH machinery defined in <xutility>
 
     template <class _Ty>
-    inline constexpr bool _Is_initializer_list = _Is_specialization_v<remove_cvref_t<_Ty>, initializer_list>;
+    constexpr bool _Is_initializer_list = _Is_specialization_v<remove_cvref_t<_Ty>, initializer_list>;
 
     template <auto> // _Require_constant<E> is a valid template-id iff E is a constant expression of structural type
     struct _Require_constant;
@@ -51,40 +51,39 @@ namespace ranges {
     using range_const_reference_t = iter_const_reference_t<iterator_t<_Rng>>;
 
     template <range _Ty>
-    inline constexpr auto _Compile_time_max_size =
-        (numeric_limits<_Make_unsigned_like_t<range_difference_t<_Ty>>>::max)();
+    constexpr auto _Compile_time_max_size = (numeric_limits<_Make_unsigned_like_t<range_difference_t<_Ty>>>::max)();
 
     template <sized_range _Ty>
-    inline constexpr auto _Compile_time_max_size<_Ty> = (numeric_limits<range_size_t<_Ty>>::max)();
+    constexpr auto _Compile_time_max_size<_Ty> = (numeric_limits<range_size_t<_Ty>>::max)();
 
 #ifdef __EDG__ // TRANSITION, VSO-1898880
     template <class _Ty>
     concept _Constant_sized_range = sized_range<_Ty> && requires { typename _Require_constant<_Ty::size()>; };
 
     template <_Constant_sized_range _Ty>
-    inline constexpr auto _Compile_time_max_size<_Ty> = _Ty::size();
+    constexpr auto _Compile_time_max_size<_Ty> = _Ty::size();
 #else // ^^^ workaround / no workaround vvv
     template <sized_range _Ty>
         requires requires { typename _Require_constant<_Ty::size()>; }
-    inline constexpr auto _Compile_time_max_size<_Ty> = _Ty::size();
+    constexpr auto _Compile_time_max_size<_Ty> = _Ty::size();
 #endif // ^^^ no workaround ^^^
 
     template <class _Ty, size_t _Size>
-    inline constexpr auto _Compile_time_max_size<_Ty[_Size]> = _Size;
+    constexpr auto _Compile_time_max_size<_Ty[_Size]> = _Size;
 
     template <class _Ty, size_t _Size>
-    inline constexpr auto _Compile_time_max_size<array<_Ty, _Size>> = _Size;
+    constexpr auto _Compile_time_max_size<array<_Ty, _Size>> = _Size;
 
     template <class _Ty, size_t _Size>
-    inline constexpr auto _Compile_time_max_size<const array<_Ty, _Size>> = _Size;
+    constexpr auto _Compile_time_max_size<const array<_Ty, _Size>> = _Size;
 
     template <class _Ty, size_t _Extent>
         requires (_Extent != dynamic_extent)
-    inline constexpr auto _Compile_time_max_size<span<_Ty, _Extent>> = _Extent;
+    constexpr auto _Compile_time_max_size<span<_Ty, _Extent>> = _Extent;
 
     template <class _Ty, size_t _Extent>
         requires (_Extent != dynamic_extent)
-    inline constexpr auto _Compile_time_max_size<const span<_Ty, _Extent>> = _Extent;
+    constexpr auto _Compile_time_max_size<const span<_Ty, _Extent>> = _Extent;
 #endif // _HAS_CXX23
 
     // clang-format off
@@ -991,11 +990,11 @@ namespace ranges {
     };
 
     template <class _Ty>
-    inline constexpr bool enable_borrowed_range<empty_view<_Ty>> = true;
+    constexpr bool enable_borrowed_range<empty_view<_Ty>> = true;
 
     namespace views {
         _EXPORT_STD template <class _Ty>
-        inline constexpr empty_view<_Ty> empty;
+        constexpr empty_view<_Ty> empty;
     } // namespace views
 
     _EXPORT_STD template <_Valid_movable_box_object _Ty>
@@ -1444,7 +1443,7 @@ namespace ranges {
     // clang-format on
 
     template <class _Wi, class _Bo>
-    inline constexpr bool enable_borrowed_range<iota_view<_Wi, _Bo>> = true;
+    constexpr bool enable_borrowed_range<iota_view<_Wi, _Bo>> = true;
 
     namespace views {
         struct _Iota_fn {
@@ -1825,7 +1824,7 @@ namespace ranges {
         };
 
         _EXPORT_STD template <class _Ty>
-        inline constexpr _Istream_fn<_Ty> istream;
+        constexpr _Istream_fn<_Ty> istream;
     } // namespace views
 
     _EXPORT_STD template <range _Rng>
@@ -1883,14 +1882,14 @@ namespace ranges {
     ref_view(_Rng&) -> ref_view<_Rng>;
 
     template <class _Rng>
-    inline constexpr bool enable_borrowed_range<ref_view<_Rng>> = true;
+    constexpr bool enable_borrowed_range<ref_view<_Rng>> = true;
 
 #if _HAS_CXX23
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<ref_view<_Rng>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<ref_view<_Rng>> = _Compile_time_max_size<_Rng>;
 
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<const ref_view<_Rng>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<const ref_view<_Rng>> = _Compile_time_max_size<_Rng>;
 #endif // _HAS_CXX23
 
     _EXPORT_STD template <range _Rng>
@@ -1978,14 +1977,14 @@ namespace ranges {
     };
 
     template <class _Rng>
-    inline constexpr bool enable_borrowed_range<owning_view<_Rng>> = enable_borrowed_range<_Rng>;
+    constexpr bool enable_borrowed_range<owning_view<_Rng>> = enable_borrowed_range<_Rng>;
 
 #if _HAS_CXX23
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<owning_view<_Rng>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<owning_view<_Rng>> = _Compile_time_max_size<_Rng>;
 
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<const owning_view<_Rng>> = _Compile_time_max_size<const _Rng>;
+    constexpr auto _Compile_time_max_size<const owning_view<_Rng>> = _Compile_time_max_size<const _Rng>;
 #endif // _HAS_CXX23
 
     namespace views {
@@ -2122,14 +2121,14 @@ namespace ranges {
     as_rvalue_view(_Rng&&) -> as_rvalue_view<views::all_t<_Rng>>;
 
     template <class _Rng>
-    inline constexpr bool enable_borrowed_range<as_rvalue_view<_Rng>> = enable_borrowed_range<_Rng>;
+    constexpr bool enable_borrowed_range<as_rvalue_view<_Rng>> = enable_borrowed_range<_Rng>;
 
 #if _HAS_CXX23
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<as_rvalue_view<_Rng>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<as_rvalue_view<_Rng>> = _Compile_time_max_size<_Rng>;
 
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<const as_rvalue_view<_Rng>> = _Compile_time_max_size<const _Rng>;
+    constexpr auto _Compile_time_max_size<const as_rvalue_view<_Rng>> = _Compile_time_max_size<const _Rng>;
 #endif // _HAS_CXX23
 
     namespace views {
@@ -2411,7 +2410,7 @@ namespace ranges {
 
 #if _HAS_CXX23
     template <class _Rng, class _Pr>
-    inline constexpr auto _Compile_time_max_size<filter_view<_Rng, _Pr>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<filter_view<_Rng, _Pr>> = _Compile_time_max_size<_Rng>;
 #endif // _HAS_CXX23
 
     namespace views {
@@ -2837,10 +2836,10 @@ namespace ranges {
 
 #if _HAS_CXX23
     template <class _Rng, class _Fn>
-    inline constexpr auto _Compile_time_max_size<transform_view<_Rng, _Fn>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<transform_view<_Rng, _Fn>> = _Compile_time_max_size<_Rng>;
 
     template <class _Rng, class _Fn>
-    inline constexpr auto _Compile_time_max_size<const transform_view<_Rng, _Fn>> = _Compile_time_max_size<const _Rng>;
+    constexpr auto _Compile_time_max_size<const transform_view<_Rng, _Fn>> = _Compile_time_max_size<const _Rng>;
 #endif // _HAS_CXX23
 
     namespace views {
@@ -3048,14 +3047,14 @@ namespace ranges {
     take_view(_Rng&&, range_difference_t<_Rng>) -> take_view<views::all_t<_Rng>>;
 
     template <class _Rng>
-    inline constexpr bool enable_borrowed_range<take_view<_Rng>> = enable_borrowed_range<_Rng>;
+    constexpr bool enable_borrowed_range<take_view<_Rng>> = enable_borrowed_range<_Rng>;
 
 #if _HAS_CXX23
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<take_view<_Rng>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<take_view<_Rng>> = _Compile_time_max_size<_Rng>;
 
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<const take_view<_Rng>> = _Compile_time_max_size<const _Rng>;
+    constexpr auto _Compile_time_max_size<const take_view<_Rng>> = _Compile_time_max_size<const _Rng>;
 #endif // _HAS_CXX23
 
     namespace views {
@@ -3297,10 +3296,10 @@ namespace ranges {
 
 #if _HAS_CXX23
     template <class _Rng, class _Pr>
-    inline constexpr auto _Compile_time_max_size<take_while_view<_Rng, _Pr>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<take_while_view<_Rng, _Pr>> = _Compile_time_max_size<_Rng>;
 
     template <class _Rng, class _Pr>
-    inline constexpr auto _Compile_time_max_size<const take_while_view<_Rng, _Pr>> = _Compile_time_max_size<const _Rng>;
+    constexpr auto _Compile_time_max_size<const take_while_view<_Rng, _Pr>> = _Compile_time_max_size<const _Rng>;
 #endif // _HAS_CXX23
 
     namespace views {
@@ -3448,14 +3447,14 @@ namespace ranges {
     drop_view(_Rng&&, range_difference_t<_Rng>) -> drop_view<views::all_t<_Rng>>;
 
     template <class _Rng>
-    inline constexpr bool enable_borrowed_range<drop_view<_Rng>> = enable_borrowed_range<_Rng>;
+    constexpr bool enable_borrowed_range<drop_view<_Rng>> = enable_borrowed_range<_Rng>;
 
 #if _HAS_CXX23
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<drop_view<_Rng>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<drop_view<_Rng>> = _Compile_time_max_size<_Rng>;
 
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<const drop_view<_Rng>> = _Compile_time_max_size<const _Rng>;
+    constexpr auto _Compile_time_max_size<const drop_view<_Rng>> = _Compile_time_max_size<const _Rng>;
 #endif // _HAS_CXX23
 
     namespace views {
@@ -3621,11 +3620,11 @@ namespace ranges {
     drop_while_view(_Rng&&, _Pr) -> drop_while_view<views::all_t<_Rng>, _Pr>;
 
     template <class _Rng, class _Pr>
-    inline constexpr bool enable_borrowed_range<drop_while_view<_Rng, _Pr>> = enable_borrowed_range<_Rng>;
+    constexpr bool enable_borrowed_range<drop_while_view<_Rng, _Pr>> = enable_borrowed_range<_Rng>;
 
 #if _HAS_CXX23
     template <class _Rng, class _Pr>
-    inline constexpr auto _Compile_time_max_size<drop_while_view<_Rng, _Pr>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<drop_while_view<_Rng, _Pr>> = _Compile_time_max_size<_Rng>;
 #endif // _HAS_CXX23
 
     namespace views {
@@ -4052,11 +4051,10 @@ namespace ranges {
     }
 
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<join_view<_Rng>> = _Join_view_compile_time_max_size<_Rng>();
+    constexpr auto _Compile_time_max_size<join_view<_Rng>> = _Join_view_compile_time_max_size<_Rng>();
 
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<const join_view<_Rng>> =
-        _Join_view_compile_time_max_size<const _Rng>();
+    constexpr auto _Compile_time_max_size<const join_view<_Rng>> = _Join_view_compile_time_max_size<const _Rng>();
 #endif // _HAS_CXX23
 
     namespace views {
@@ -4585,11 +4583,11 @@ namespace ranges {
     }
 
     template <class _Rng, class _Pat>
-    inline constexpr auto _Compile_time_max_size<join_with_view<_Rng, _Pat>> =
+    constexpr auto _Compile_time_max_size<join_with_view<_Rng, _Pat>> =
         _Join_with_view_compile_time_max_size<_Rng, _Pat>();
 
     template <class _Rng, class _Pat>
-    inline constexpr auto _Compile_time_max_size<const join_with_view<_Rng, _Pat>> =
+    constexpr auto _Compile_time_max_size<const join_with_view<_Rng, _Pat>> =
         _Join_with_view_compile_time_max_size<const _Rng, const _Pat>();
 #endif // _HAS_CXX23
 
@@ -5005,11 +5003,10 @@ namespace ranges {
 
 #if _HAS_CXX23
     template <class _Rng, class _Pat>
-    inline constexpr auto _Compile_time_max_size<lazy_split_view<_Rng, _Pat>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<lazy_split_view<_Rng, _Pat>> = _Compile_time_max_size<_Rng>;
 
     template <class _Rng, class _Pat>
-    inline constexpr auto _Compile_time_max_size<const lazy_split_view<_Rng, _Pat>> =
-        _Compile_time_max_size<const _Rng>;
+    constexpr auto _Compile_time_max_size<const lazy_split_view<_Rng, _Pat>> = _Compile_time_max_size<const _Rng>;
 #endif // _HAS_CXX23
 
     namespace views {
@@ -5195,7 +5192,7 @@ namespace ranges {
 
 #if _HAS_CXX23
     template <class _Rng, class _Pat>
-    inline constexpr auto _Compile_time_max_size<split_view<_Rng, _Pat>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<split_view<_Rng, _Pat>> = _Compile_time_max_size<_Rng>;
 #endif // _HAS_CXX23
 
     namespace views {
@@ -5347,14 +5344,14 @@ namespace ranges {
     common_view(_Rng&&) -> common_view<views::all_t<_Rng>>;
 
     template <class _Rng>
-    inline constexpr bool enable_borrowed_range<common_view<_Rng>> = enable_borrowed_range<_Rng>;
+    constexpr bool enable_borrowed_range<common_view<_Rng>> = enable_borrowed_range<_Rng>;
 
 #if _HAS_CXX23
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<common_view<_Rng>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<common_view<_Rng>> = _Compile_time_max_size<_Rng>;
 
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<const common_view<_Rng>> = _Compile_time_max_size<const _Rng>;
+    constexpr auto _Compile_time_max_size<const common_view<_Rng>> = _Compile_time_max_size<const _Rng>;
 #endif // _HAS_CXX23
 
     namespace views {
@@ -5475,14 +5472,14 @@ namespace ranges {
     reverse_view(_Rng&&) -> reverse_view<views::all_t<_Rng>>;
 
     template <class _Rng>
-    inline constexpr bool enable_borrowed_range<reverse_view<_Rng>> = enable_borrowed_range<_Rng>;
+    constexpr bool enable_borrowed_range<reverse_view<_Rng>> = enable_borrowed_range<_Rng>;
 
 #if _HAS_CXX23
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<reverse_view<_Rng>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<reverse_view<_Rng>> = _Compile_time_max_size<_Rng>;
 
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<const reverse_view<_Rng>> = _Compile_time_max_size<const _Rng>;
+    constexpr auto _Compile_time_max_size<const reverse_view<_Rng>> = _Compile_time_max_size<const _Rng>;
 #endif // _HAS_CXX23
 
     namespace views {
@@ -5621,14 +5618,14 @@ namespace ranges {
     as_const_view(_Rng&&) -> as_const_view<views::all_t<_Rng>>;
 
     template <class _Rng>
-    inline constexpr bool enable_borrowed_range<as_const_view<_Rng>> = enable_borrowed_range<_Rng>;
+    constexpr bool enable_borrowed_range<as_const_view<_Rng>> = enable_borrowed_range<_Rng>;
 
 #if _HAS_CXX23
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<as_const_view<_Rng>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<as_const_view<_Rng>> = _Compile_time_max_size<_Rng>;
 
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<const as_const_view<_Rng>> = _Compile_time_max_size<const _Rng>;
+    constexpr auto _Compile_time_max_size<const as_const_view<_Rng>> = _Compile_time_max_size<const _Rng>;
 #endif // _HAS_CXX23
 
     namespace views {
@@ -6088,15 +6085,14 @@ namespace ranges {
     };
 
     template <class _Rng, size_t _Index>
-    inline constexpr bool enable_borrowed_range<elements_view<_Rng, _Index>> = enable_borrowed_range<_Rng>;
+    constexpr bool enable_borrowed_range<elements_view<_Rng, _Index>> = enable_borrowed_range<_Rng>;
 
 #if _HAS_CXX23
     template <class _Rng, size_t _Index>
-    inline constexpr auto _Compile_time_max_size<elements_view<_Rng, _Index>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<elements_view<_Rng, _Index>> = _Compile_time_max_size<_Rng>;
 
     template <class _Rng, size_t _Index>
-    inline constexpr auto _Compile_time_max_size<const elements_view<_Rng, _Index>> =
-        _Compile_time_max_size<const _Rng>;
+    constexpr auto _Compile_time_max_size<const elements_view<_Rng, _Index>> = _Compile_time_max_size<const _Rng>;
 #endif // _HAS_CXX23
 
     _EXPORT_STD template <class _Rng>
@@ -6118,7 +6114,7 @@ namespace ranges {
         };
 
         _EXPORT_STD template <size_t _Index>
-        inline constexpr _Elements_fn<_Index> elements;
+        constexpr _Elements_fn<_Index> elements;
         _EXPORT_STD inline constexpr auto keys   = elements<0>;
         _EXPORT_STD inline constexpr auto values = elements<1>;
     } // namespace views
@@ -6439,14 +6435,14 @@ namespace ranges {
     enumerate_view(_Rng&&) -> enumerate_view<views::all_t<_Rng>>;
 
     template <class _Rng>
-    inline constexpr bool enable_borrowed_range<enumerate_view<_Rng>> = enable_borrowed_range<_Rng>;
+    constexpr bool enable_borrowed_range<enumerate_view<_Rng>> = enable_borrowed_range<_Rng>;
 
 #if _HAS_CXX23
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<enumerate_view<_Rng>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<enumerate_view<_Rng>> = _Compile_time_max_size<_Rng>;
 
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<const enumerate_view<_Rng>> = _Compile_time_max_size<const _Rng>;
+    constexpr auto _Compile_time_max_size<const enumerate_view<_Rng>> = _Compile_time_max_size<const _Rng>;
 #endif // _HAS_CXX23
 
     namespace views {
@@ -7038,15 +7034,15 @@ namespace ranges {
     chunk_view(_Rng&&, range_difference_t<_Rng>) -> chunk_view<views::all_t<_Rng>>;
 
     template <class _Vw>
-    inline constexpr bool enable_borrowed_range<chunk_view<_Vw>> = enable_borrowed_range<_Vw> && forward_range<_Vw>;
+    constexpr bool enable_borrowed_range<chunk_view<_Vw>> = enable_borrowed_range<_Vw> && forward_range<_Vw>;
 
 #if _HAS_CXX23
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<chunk_view<_Rng>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<chunk_view<_Rng>> = _Compile_time_max_size<_Rng>;
 
     template <class _Rng>
         requires forward_range<_Rng>
-    inline constexpr auto _Compile_time_max_size<const chunk_view<_Rng>> = _Compile_time_max_size<const _Rng>;
+    constexpr auto _Compile_time_max_size<const chunk_view<_Rng>> = _Compile_time_max_size<const _Rng>;
 #endif // _HAS_CXX23
 
     namespace views {
@@ -7438,14 +7434,14 @@ namespace ranges {
     slide_view(_Rng&&, range_difference_t<_Rng>) -> slide_view<views::all_t<_Rng>>;
 
     template <class _Vw>
-    inline constexpr bool enable_borrowed_range<slide_view<_Vw>> = enable_borrowed_range<_Vw>;
+    constexpr bool enable_borrowed_range<slide_view<_Vw>> = enable_borrowed_range<_Vw>;
 
 #if _HAS_CXX23
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<slide_view<_Rng>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<slide_view<_Rng>> = _Compile_time_max_size<_Rng>;
 
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<const slide_view<_Rng>> = _Compile_time_max_size<const _Rng>;
+    constexpr auto _Compile_time_max_size<const slide_view<_Rng>> = _Compile_time_max_size<const _Rng>;
 #endif // _HAS_CXX23
 
     namespace views {
@@ -7648,7 +7644,7 @@ namespace ranges {
 
 #if _HAS_CXX23
     template <class _Rng, class _Pr>
-    inline constexpr auto _Compile_time_max_size<chunk_by_view<_Rng, _Pr>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<chunk_by_view<_Rng, _Pr>> = _Compile_time_max_size<_Rng>;
 #endif // _HAS_CXX23
 
     namespace views {
@@ -8036,14 +8032,14 @@ namespace ranges {
     stride_view(_Rng&&, range_difference_t<_Rng>) -> stride_view<views::all_t<_Rng>>;
 
     template <class _Vw>
-    inline constexpr bool enable_borrowed_range<stride_view<_Vw>> = enable_borrowed_range<_Vw>;
+    constexpr bool enable_borrowed_range<stride_view<_Vw>> = enable_borrowed_range<_Vw>;
 
 #if _HAS_CXX23
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<stride_view<_Rng>> = _Compile_time_max_size<_Rng>;
+    constexpr auto _Compile_time_max_size<stride_view<_Rng>> = _Compile_time_max_size<_Rng>;
 
     template <class _Rng>
-    inline constexpr auto _Compile_time_max_size<const stride_view<_Rng>> = _Compile_time_max_size<const _Rng>;
+    constexpr auto _Compile_time_max_size<const stride_view<_Rng>> = _Compile_time_max_size<const _Rng>;
 #endif // _HAS_CXX23
 
     namespace views {
@@ -8542,7 +8538,7 @@ namespace ranges {
     zip_view(_RangeTypes&&...) -> zip_view<views::all_t<_RangeTypes>...>;
 
     template <class... _ViewTypes>
-    inline constexpr bool enable_borrowed_range<zip_view<_ViewTypes...>> = (enable_borrowed_range<_ViewTypes> && ...);
+    constexpr bool enable_borrowed_range<zip_view<_ViewTypes...>> = (enable_borrowed_range<_ViewTypes> && ...);
 
 #if _HAS_CXX23
     template <class... _Rngs>
@@ -8552,11 +8548,10 @@ namespace ranges {
     }
 
     template <class... _Rngs>
-    inline constexpr auto _Compile_time_max_size<zip_view<_Rngs...>> = _Zip_view_compile_time_max_size<_Rngs...>();
+    constexpr auto _Compile_time_max_size<zip_view<_Rngs...>> = _Zip_view_compile_time_max_size<_Rngs...>();
 
     template <class... _Rngs>
-    inline constexpr auto _Compile_time_max_size<const zip_view<_Rngs...>> =
-        _Zip_view_compile_time_max_size<const _Rngs...>();
+    constexpr auto _Compile_time_max_size<const zip_view<_Rngs...>> = _Zip_view_compile_time_max_size<const _Rngs...>();
 #endif // _HAS_CXX23
 
     namespace views {
@@ -8899,11 +8894,11 @@ namespace ranges {
 
 #if _HAS_CXX23
     template <class _Fn, class... _Rngs>
-    inline constexpr auto _Compile_time_max_size<zip_transform_view<_Fn, _Rngs...>> =
+    constexpr auto _Compile_time_max_size<zip_transform_view<_Fn, _Rngs...>> =
         _Compile_time_max_size<zip_view<_Rngs...>>;
 
     template <class _Fn, class... _Rngs>
-    inline constexpr auto _Compile_time_max_size<const zip_transform_view<_Fn, _Rngs...>> =
+    constexpr auto _Compile_time_max_size<const zip_transform_view<_Fn, _Rngs...>> =
         _Compile_time_max_size<const zip_view<_Rngs...>>;
 #endif // _HAS_CXX23
 
@@ -8970,10 +8965,10 @@ namespace ranges {
     using _Repeated_tuple = _Repeated_tuple_impl<_Ty, make_index_sequence<_Nx>>::type;
 
     template <class _Fn, class _Ty, class _Indices>
-    inline constexpr bool _Regular_invocable_with_repeated_type_impl = false;
+    constexpr bool _Regular_invocable_with_repeated_type_impl = false;
 
     template <class _Fn, class _Ty, size_t... _Indices>
-    inline constexpr bool _Regular_invocable_with_repeated_type_impl<_Fn, _Ty, index_sequence<_Indices...>> =
+    constexpr bool _Regular_invocable_with_repeated_type_impl<_Fn, _Ty, index_sequence<_Indices...>> =
         regular_invocable<_Fn, _Repeat_type<_Ty, _Indices>...>;
 
     template <class _Fn, class _Ty, size_t _Nx>
@@ -9373,7 +9368,7 @@ namespace ranges {
     };
 
     template <class _Rng, size_t _Nx>
-    inline constexpr bool enable_borrowed_range<adjacent_view<_Rng, _Nx>> = enable_borrowed_range<_Rng>;
+    constexpr bool enable_borrowed_range<adjacent_view<_Rng, _Nx>> = enable_borrowed_range<_Rng>;
 
 #if _HAS_CXX23
     template <class _Rng, size_t _Nx>
@@ -9385,11 +9380,10 @@ namespace ranges {
     }
 
     template <class _Rng, size_t _Nx>
-    inline constexpr auto _Compile_time_max_size<adjacent_view<_Rng, _Nx>> =
-        _Adjacent_view_compile_time_max_size<_Rng, _Nx>();
+    constexpr auto _Compile_time_max_size<adjacent_view<_Rng, _Nx>> = _Adjacent_view_compile_time_max_size<_Rng, _Nx>();
 
     template <class _Rng, size_t _Nx>
-    inline constexpr auto _Compile_time_max_size<const adjacent_view<_Rng, _Nx>> =
+    constexpr auto _Compile_time_max_size<const adjacent_view<_Rng, _Nx>> =
         _Adjacent_view_compile_time_max_size<const _Rng, _Nx>();
 #endif // _HAS_CXX23
 
@@ -9414,7 +9408,7 @@ namespace ranges {
         };
 
         _EXPORT_STD template <size_t _Nx>
-        inline constexpr _Adjacent_fn<_Nx> adjacent;
+        constexpr _Adjacent_fn<_Nx> adjacent;
         _EXPORT_STD inline constexpr _Adjacent_fn<2> pairwise;
     } // namespace views
 
@@ -9730,11 +9724,11 @@ namespace ranges {
 
 #if _HAS_CXX23
     template <class _Rng, class _Fn, size_t _Nx>
-    inline constexpr auto _Compile_time_max_size<adjacent_transform_view<_Rng, _Fn, _Nx>> =
+    constexpr auto _Compile_time_max_size<adjacent_transform_view<_Rng, _Fn, _Nx>> =
         _Compile_time_max_size<adjacent_view<_Rng, _Nx>>;
 
     template <class _Rng, class _Fn, size_t _Nx>
-    inline constexpr auto _Compile_time_max_size<const adjacent_transform_view<_Rng, _Fn, _Nx>> =
+    constexpr auto _Compile_time_max_size<const adjacent_transform_view<_Rng, _Fn, _Nx>> =
         _Compile_time_max_size<const adjacent_view<_Rng, _Nx>>;
 #endif // _HAS_CXX23
 
@@ -9772,7 +9766,7 @@ namespace ranges {
         };
 
         _EXPORT_STD template <size_t _Nx>
-        inline constexpr _Adjacent_transform_fn<_Nx> adjacent_transform;
+        constexpr _Adjacent_transform_fn<_Nx> adjacent_transform;
         _EXPORT_STD inline constexpr _Adjacent_transform_fn<2> pairwise_transform;
     } // namespace views
 
@@ -10273,11 +10267,11 @@ namespace ranges {
     }
 
     template <class... _Rngs>
-    inline constexpr auto _Compile_time_max_size<cartesian_product_view<_Rngs...>> =
+    constexpr auto _Compile_time_max_size<cartesian_product_view<_Rngs...>> =
         _Cartesian_product_view_compile_time_max_size<_Rngs...>();
 
     template <class... _Rngs>
-    inline constexpr auto _Compile_time_max_size<const cartesian_product_view<_Rngs...>> =
+    constexpr auto _Compile_time_max_size<const cartesian_product_view<_Rngs...>> =
         _Cartesian_product_view_compile_time_max_size<const _Rngs...>();
 #endif // _HAS_CXX23
 

--- a/stl/inc/ratio
+++ b/stl/inc/ratio
@@ -76,10 +76,10 @@ struct ratio { // holds the ratio of _Nx to _Dx
 };
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _Is_ratio_v = false; // test for ratio type
+constexpr bool _Is_ratio_v = false; // test for ratio type
 
 template <intmax_t _Rx1, intmax_t _Rx2>
-_INLINE_VAR constexpr bool _Is_ratio_v<ratio<_Rx1, _Rx2>> = true;
+constexpr bool _Is_ratio_v<ratio<_Rx1, _Rx2>> = true;
 
 template <class _Rx1, class _Rx2>
 struct _Ratio_add { // add two ratios
@@ -167,7 +167,7 @@ struct ratio_equal : bool_constant<_Rx1::num == _Rx2::num && _Rx1::den == _Rx2::
 };
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
-_INLINE_VAR constexpr bool ratio_equal_v = ratio_equal<_Rx1, _Rx2>::value;
+constexpr bool ratio_equal_v = ratio_equal<_Rx1, _Rx2>::value;
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
 struct ratio_not_equal : bool_constant<!ratio_equal_v<_Rx1, _Rx2>> { // tests if ratio != ratio
@@ -175,7 +175,7 @@ struct ratio_not_equal : bool_constant<!ratio_equal_v<_Rx1, _Rx2>> { // tests if
 };
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
-_INLINE_VAR constexpr bool ratio_not_equal_v = ratio_not_equal<_Rx1, _Rx2>::value;
+constexpr bool ratio_not_equal_v = ratio_not_equal<_Rx1, _Rx2>::value;
 
 struct _Big_uint128 {
     uint64_t _Upper;
@@ -231,7 +231,7 @@ struct ratio_less : bool_constant<_Ratio_less(_Rx1::num, _Rx1::den, _Rx2::num, _
 };
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
-_INLINE_VAR constexpr bool ratio_less_v = ratio_less<_Rx1, _Rx2>::value;
+constexpr bool ratio_less_v = ratio_less<_Rx1, _Rx2>::value;
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
 struct ratio_less_equal : bool_constant<!ratio_less_v<_Rx2, _Rx1>> { // tests if ratio <= ratio
@@ -240,7 +240,7 @@ struct ratio_less_equal : bool_constant<!ratio_less_v<_Rx2, _Rx1>> { // tests if
 };
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
-_INLINE_VAR constexpr bool ratio_less_equal_v = ratio_less_equal<_Rx1, _Rx2>::value;
+constexpr bool ratio_less_equal_v = ratio_less_equal<_Rx1, _Rx2>::value;
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
 struct ratio_greater : ratio_less<_Rx2, _Rx1>::type { // tests if ratio > ratio
@@ -248,7 +248,7 @@ struct ratio_greater : ratio_less<_Rx2, _Rx1>::type { // tests if ratio > ratio
 };
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
-_INLINE_VAR constexpr bool ratio_greater_v = ratio_greater<_Rx1, _Rx2>::value;
+constexpr bool ratio_greater_v = ratio_greater<_Rx1, _Rx2>::value;
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
 struct ratio_greater_equal : bool_constant<!ratio_less_v<_Rx1, _Rx2>> { // tests if ratio >= ratio
@@ -257,7 +257,7 @@ struct ratio_greater_equal : bool_constant<!ratio_less_v<_Rx1, _Rx2>> { // tests
 };
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
-_INLINE_VAR constexpr bool ratio_greater_equal_v = ratio_greater_equal<_Rx1, _Rx2>::value;
+constexpr bool ratio_greater_equal_v = ratio_greater_equal<_Rx1, _Rx2>::value;
 
 _EXPORT_STD using atto  = ratio<1, 1000000000000000000LL>;
 _EXPORT_STD using femto = ratio<1, 1000000000000000LL>;

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -196,7 +196,7 @@ struct _Char_traits_lt {
 // library-provided char_traits::eq behaves like equal_to<_Elem>
 // TRANSITION: This should not be activated for user-defined specializations of char_traits
 template <class _Elem>
-_INLINE_VAR constexpr bool _Can_memcmp_elements_with_pred<_Elem, _Elem, _Char_traits_eq<char_traits<_Elem>>> =
+constexpr bool _Can_memcmp_elements_with_pred<_Elem, _Elem, _Char_traits_eq<char_traits<_Elem>>> =
     _Can_memcmp_elements<_Elem, _Elem>;
 
 // library-provided char_traits::lt behaves like less<make_unsigned_t<_Elem>>

--- a/stl/inc/span
+++ b/stl/inc/span
@@ -224,16 +224,16 @@ class span;
 
 namespace ranges {
     template <class _Ty, size_t _Extent>
-    inline constexpr bool enable_view<span<_Ty, _Extent>> = true;
+    constexpr bool enable_view<span<_Ty, _Extent>> = true;
     template <class _Ty, size_t _Extent>
-    inline constexpr bool enable_borrowed_range<span<_Ty, _Extent>> = true;
+    constexpr bool enable_borrowed_range<span<_Ty, _Extent>> = true;
 } // namespace ranges
 
 template <class>
-inline constexpr bool _Is_span_v = false;
+constexpr bool _Is_span_v = false;
 
 template <class _Ty, size_t _Extent>
-inline constexpr bool _Is_span_v<span<_Ty, _Extent>> = true;
+constexpr bool _Is_span_v<span<_Ty, _Extent>> = true;
 
 // clang-format off
 template <class _It, class _Ty>

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -46,7 +46,7 @@ template <>
 struct is_error_code_enum<io_errc> : true_type {};
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_error_code_enum_v = is_error_code_enum<_Ty>::value;
+constexpr bool is_error_code_enum_v = is_error_code_enum<_Ty>::value;
 
 _EXPORT_STD template <class _Enum>
 struct is_error_condition_enum : false_type {};
@@ -55,7 +55,7 @@ template <>
 struct is_error_condition_enum<errc> : true_type {};
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_error_condition_enum_v = is_error_condition_enum<_Ty>::value;
+constexpr bool is_error_condition_enum_v = is_error_condition_enum<_Ty>::value;
 
 _EXPORT_STD class error_code;
 _EXPORT_STD class error_condition;

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -22,76 +22,75 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 template <bool _Same, class _Dest, class... _Srcs>
-_INLINE_VAR constexpr bool _Tuple_conditional_explicit_v0 = false;
+constexpr bool _Tuple_conditional_explicit_v0 = false;
 
 template <class... _Dests, class... _Srcs>
-_INLINE_VAR constexpr bool _Tuple_conditional_explicit_v0<true, tuple<_Dests...>, _Srcs...> =
+constexpr bool _Tuple_conditional_explicit_v0<true, tuple<_Dests...>, _Srcs...> =
     !conjunction_v<is_convertible<_Srcs, _Dests>...>;
 
 template <class _Dest, class... _Srcs>
-_INLINE_VAR constexpr bool _Tuple_conditional_explicit_v =
+constexpr bool _Tuple_conditional_explicit_v =
     _Tuple_conditional_explicit_v0<tuple_size_v<_Dest> == sizeof...(_Srcs), _Dest, _Srcs...>;
 
 template <bool _Same, class _Dest, class... _Srcs>
-_INLINE_VAR constexpr bool _Tuple_constructible_v0 = false;
+constexpr bool _Tuple_constructible_v0 = false;
 
 template <class... _Dests, class... _Srcs>
-_INLINE_VAR constexpr bool _Tuple_constructible_v0<true, tuple<_Dests...>, _Srcs...> =
+constexpr bool _Tuple_constructible_v0<true, tuple<_Dests...>, _Srcs...> =
     conjunction_v<is_constructible<_Dests, _Srcs>...>;
 
 template <class _Dest, class... _Srcs>
-_INLINE_VAR constexpr bool _Tuple_constructible_v =
+constexpr bool _Tuple_constructible_v =
     _Tuple_constructible_v0<tuple_size_v<_Dest> == sizeof...(_Srcs), _Dest, _Srcs...>;
 
 template <class _Dest, class... _Srcs>
 struct _Tuple_constructible_val : bool_constant<_Tuple_constructible_v<_Dest, _Srcs...>> {};
 
 template <bool _Same, class _Dest, class... _Srcs>
-_INLINE_VAR constexpr bool _Tuple_nothrow_constructible_v0 = false;
+constexpr bool _Tuple_nothrow_constructible_v0 = false;
 
 template <class... _Dests, class... _Srcs>
-_INLINE_VAR constexpr bool _Tuple_nothrow_constructible_v0<true, tuple<_Dests...>, _Srcs...> =
+constexpr bool _Tuple_nothrow_constructible_v0<true, tuple<_Dests...>, _Srcs...> =
     conjunction_v<is_nothrow_constructible<_Dests, _Srcs>...>;
 
 template <class _Dest, class... _Srcs>
-_INLINE_VAR constexpr bool _Tuple_nothrow_constructible_v =
+constexpr bool _Tuple_nothrow_constructible_v =
     _Tuple_nothrow_constructible_v0<tuple_size_v<_Dest> == sizeof...(_Srcs), _Dest, _Srcs...>;
 
 template <bool _Same, class _Dest, class... _Srcs>
-_INLINE_VAR constexpr bool _Tuple_assignable_v0 = false;
+constexpr bool _Tuple_assignable_v0 = false;
 
 template <class... _Dests, class... _Srcs>
-_INLINE_VAR constexpr bool _Tuple_assignable_v0<true, tuple<_Dests...>, _Srcs...> =
+constexpr bool _Tuple_assignable_v0<true, tuple<_Dests...>, _Srcs...> =
     conjunction_v<is_assignable<_Dests&, _Srcs>...>; // note _Dests& instead of _Dests
 
 #if _HAS_CXX23
 template <class... _Dests, class... _Srcs>
-inline constexpr bool _Tuple_assignable_v0<true, const tuple<_Dests...>, _Srcs...> =
+constexpr bool _Tuple_assignable_v0<true, const tuple<_Dests...>, _Srcs...> =
     conjunction_v<is_assignable<const _Dests&, _Srcs>...>;
 #endif // _HAS_CXX23
 
 template <class _Dest, class... _Srcs>
-_INLINE_VAR constexpr bool _Tuple_assignable_v =
-    _Tuple_assignable_v0<tuple_size_v<_Dest> == sizeof...(_Srcs), _Dest, _Srcs...>;
+constexpr bool _Tuple_assignable_v = _Tuple_assignable_v0<tuple_size_v<_Dest> == sizeof...(_Srcs), _Dest, _Srcs...>;
 
 template <class _Dest, class... _Srcs>
 struct _Tuple_assignable_val : bool_constant<_Tuple_assignable_v<_Dest, _Srcs...>> {};
 
 template <bool _Same, class _Dest, class... _Srcs>
-_INLINE_VAR constexpr bool _Tuple_nothrow_assignable_v0 = false;
+constexpr bool _Tuple_nothrow_assignable_v0 = false;
 
 template <class... _Dests, class... _Srcs>
-_INLINE_VAR constexpr bool _Tuple_nothrow_assignable_v0<true, tuple<_Dests...>, _Srcs...> =
+constexpr bool _Tuple_nothrow_assignable_v0<true, tuple<_Dests...>, _Srcs...> =
     conjunction_v<is_nothrow_assignable<_Dests&, _Srcs>...>; // note _Dests& instead of _Dests
 
 #if _HAS_CXX23
 template <class... _Dests, class... _Srcs>
-inline constexpr bool _Tuple_nothrow_assignable_v0<true, const tuple<_Dests...>, _Srcs...> =
+constexpr bool _Tuple_nothrow_assignable_v0<true, const tuple<_Dests...>, _Srcs...> =
     conjunction_v<is_nothrow_assignable<const _Dests&, _Srcs>...>;
 #endif // _HAS_CXX23
 
 template <class _Dest, class... _Srcs>
-_INLINE_VAR constexpr bool _Tuple_nothrow_assignable_v =
+constexpr bool _Tuple_nothrow_assignable_v =
     _Tuple_nothrow_assignable_v0<tuple_size_v<_Dest> == sizeof...(_Srcs), _Dest, _Srcs...>;
 
 // Constrain tuple's converting constructors
@@ -180,10 +179,10 @@ struct _Alloc_unpack_tuple_t {
 
 #if _HAS_CXX23
 template <class _Tuple, class _Other, class _Indices = make_index_sequence<tuple_size_v<_Tuple>>>
-inline constexpr bool _Can_construct_values_from_tuple_like_v = false;
+constexpr bool _Can_construct_values_from_tuple_like_v = false;
 
 template <class... _Types, class _Other, size_t... _Indices>
-inline constexpr bool _Can_construct_values_from_tuple_like_v<tuple<_Types...>, _Other, index_sequence<_Indices...>> =
+constexpr bool _Can_construct_values_from_tuple_like_v<tuple<_Types...>, _Other, index_sequence<_Indices...>> =
     conjunction_v<is_constructible<_Types, decltype(_STD get<_Indices>(_STD declval<_Other>()))>...>;
 
 #if defined(__clang__) || defined(__EDG__) // TRANSITION, LLVM-59827 and VSO-1900279
@@ -1080,9 +1079,9 @@ constexpr decltype(auto) apply(_Callable&& _Obj, _Tuple&& _Tpl) noexcept(
 }
 
 template <class _Ty, class _Tuple, class _Seq = make_index_sequence<tuple_size_v<remove_reference_t<_Tuple>>>>
-inline constexpr bool _Can_make_from_tuple = false;
+constexpr bool _Can_make_from_tuple = false;
 template <class _Ty, class _Tuple, size_t... _Indices>
-inline constexpr bool _Can_make_from_tuple<_Ty, _Tuple, index_sequence<_Indices...>> =
+constexpr bool _Can_make_from_tuple<_Ty, _Tuple, index_sequence<_Indices...>> =
     is_constructible_v<_Ty, decltype(_STD get<_Indices>(_STD declval<_Tuple>()))...>;
 
 template <class _Ty, class _Tuple, size_t... _Indices>

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -29,7 +29,7 @@ _STL_DISABLE_CLANG_WARNINGS
 _STD_BEGIN
 template <class>
 // TRANSITION, CWG-2518: false value attached to a dependent name (for static_assert)
-_INLINE_VAR constexpr bool _Always_false = false;
+constexpr bool _Always_false = false;
 
 template <bool _First_value, class _First, class... _Rest>
 struct _Conjunction { // handle false trait or last trait
@@ -50,16 +50,16 @@ struct conjunction<_First, _Rest...> : _Conjunction<_First::value, _First, _Rest
 };
 
 _EXPORT_STD template <class... _Traits>
-_INLINE_VAR constexpr bool conjunction_v = conjunction<_Traits...>::value;
+constexpr bool conjunction_v = conjunction<_Traits...>::value;
 
 _EXPORT_STD template <class _Trait>
 struct negation : bool_constant<!static_cast<bool>(_Trait::value)> {}; // The negated result of _Trait
 
 _EXPORT_STD template <class _Trait>
-_INLINE_VAR constexpr bool negation_v = negation<_Trait>::value;
+constexpr bool negation_v = negation<_Trait>::value;
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_void_v = is_same_v<remove_cv_t<_Ty>, void>;
+constexpr bool is_void_v = is_same_v<remove_cv_t<_Ty>, void>;
 
 _EXPORT_STD template <class _Ty>
 struct is_void : bool_constant<is_void_v<_Ty>> {};
@@ -215,87 +215,87 @@ _EXPORT_STD template <class _Ty>
 using add_pointer_t = typename _Add_pointer<_Ty>::type;
 
 _EXPORT_STD template <class>
-_INLINE_VAR constexpr bool is_array_v = false; // determine whether type argument is an array
+constexpr bool is_array_v = false; // determine whether type argument is an array
 
 template <class _Ty, size_t _Nx>
-_INLINE_VAR constexpr bool is_array_v<_Ty[_Nx]> = true;
+constexpr bool is_array_v<_Ty[_Nx]> = true;
 
 template <class _Ty>
-_INLINE_VAR constexpr bool is_array_v<_Ty[]> = true;
+constexpr bool is_array_v<_Ty[]> = true;
 
 _EXPORT_STD template <class _Ty>
 struct is_array : bool_constant<is_array_v<_Ty>> {};
 
 #if _HAS_CXX20
 _EXPORT_STD template <class>
-inline constexpr bool is_bounded_array_v = false;
+constexpr bool is_bounded_array_v = false;
 
 template <class _Ty, size_t _Nx>
-inline constexpr bool is_bounded_array_v<_Ty[_Nx]> = true;
+constexpr bool is_bounded_array_v<_Ty[_Nx]> = true;
 
 _EXPORT_STD template <class _Ty>
 struct is_bounded_array : bool_constant<is_bounded_array_v<_Ty>> {};
 
 _EXPORT_STD template <class>
-inline constexpr bool is_unbounded_array_v = false;
+constexpr bool is_unbounded_array_v = false;
 
 template <class _Ty>
-inline constexpr bool is_unbounded_array_v<_Ty[]> = true;
+constexpr bool is_unbounded_array_v<_Ty[]> = true;
 
 _EXPORT_STD template <class _Ty>
 struct is_unbounded_array : bool_constant<is_unbounded_array_v<_Ty>> {};
 #endif // _HAS_CXX20
 
 _EXPORT_STD template <class>
-_INLINE_VAR constexpr bool is_lvalue_reference_v = false; // determine whether type argument is an lvalue reference
+constexpr bool is_lvalue_reference_v = false; // determine whether type argument is an lvalue reference
 
 template <class _Ty>
-_INLINE_VAR constexpr bool is_lvalue_reference_v<_Ty&> = true;
+constexpr bool is_lvalue_reference_v<_Ty&> = true;
 
 _EXPORT_STD template <class _Ty>
 struct is_lvalue_reference : bool_constant<is_lvalue_reference_v<_Ty>> {};
 
 _EXPORT_STD template <class>
-_INLINE_VAR constexpr bool is_rvalue_reference_v = false; // determine whether type argument is an rvalue reference
+constexpr bool is_rvalue_reference_v = false; // determine whether type argument is an rvalue reference
 
 template <class _Ty>
-_INLINE_VAR constexpr bool is_rvalue_reference_v<_Ty&&> = true;
+constexpr bool is_rvalue_reference_v<_Ty&&> = true;
 
 _EXPORT_STD template <class _Ty>
 struct is_rvalue_reference : bool_constant<is_rvalue_reference_v<_Ty>> {};
 
 _EXPORT_STD template <class>
-_INLINE_VAR constexpr bool is_reference_v = false; // determine whether type argument is a reference
+constexpr bool is_reference_v = false; // determine whether type argument is a reference
 
 template <class _Ty>
-_INLINE_VAR constexpr bool is_reference_v<_Ty&> = true;
+constexpr bool is_reference_v<_Ty&> = true;
 
 template <class _Ty>
-_INLINE_VAR constexpr bool is_reference_v<_Ty&&> = true;
+constexpr bool is_reference_v<_Ty&&> = true;
 
 _EXPORT_STD template <class _Ty>
 struct is_reference : bool_constant<is_reference_v<_Ty>> {};
 
 _EXPORT_STD template <class>
-_INLINE_VAR constexpr bool is_pointer_v = false; // determine whether _Ty is a pointer
+constexpr bool is_pointer_v = false; // determine whether _Ty is a pointer
 
 template <class _Ty>
-_INLINE_VAR constexpr bool is_pointer_v<_Ty*> = true;
+constexpr bool is_pointer_v<_Ty*> = true;
 
 template <class _Ty>
-_INLINE_VAR constexpr bool is_pointer_v<_Ty* const> = true;
+constexpr bool is_pointer_v<_Ty* const> = true;
 
 template <class _Ty>
-_INLINE_VAR constexpr bool is_pointer_v<_Ty* volatile> = true;
+constexpr bool is_pointer_v<_Ty* volatile> = true;
 
 template <class _Ty>
-_INLINE_VAR constexpr bool is_pointer_v<_Ty* const volatile> = true;
+constexpr bool is_pointer_v<_Ty* const volatile> = true;
 
 _EXPORT_STD template <class _Ty>
 struct is_pointer : bool_constant<is_pointer_v<_Ty>> {};
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_null_pointer_v =
+constexpr bool is_null_pointer_v =
     is_same_v<remove_cv_t<_Ty>, nullptr_t>; // determine whether _Ty is cv-qualified nullptr_t
 
 _EXPORT_STD template <class _Ty>
@@ -305,16 +305,16 @@ _EXPORT_STD template <class _Ty>
 struct is_union : bool_constant<__is_union(_Ty)> {}; // determine whether _Ty is a union
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_union_v = __is_union(_Ty);
+constexpr bool is_union_v = __is_union(_Ty);
 
 _EXPORT_STD template <class _Ty>
 struct is_class : bool_constant<__is_class(_Ty)> {}; // determine whether _Ty is a class
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_class_v = __is_class(_Ty);
+constexpr bool is_class_v = __is_class(_Ty);
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_fundamental_v = is_arithmetic_v<_Ty> || is_void_v<_Ty> || is_null_pointer_v<_Ty>;
+constexpr bool is_fundamental_v = is_arithmetic_v<_Ty> || is_void_v<_Ty> || is_null_pointer_v<_Ty>;
 
 _EXPORT_STD template <class _Ty>
 struct is_fundamental : bool_constant<is_fundamental_v<_Ty>> {}; // determine whether _Ty is a fundamental type
@@ -325,7 +325,7 @@ struct is_convertible : bool_constant<__is_convertible_to(_From, _To)> {
 };
 
 _EXPORT_STD template <class _From, class _To>
-_INLINE_VAR constexpr bool is_convertible_v = __is_convertible_to(_From, _To);
+constexpr bool is_convertible_v = __is_convertible_to(_From, _To);
 
 #if !defined(__clang__) && !defined(__EDG__) // TRANSITION, DevCom-1627396
 template <class _Ty>
@@ -341,27 +341,27 @@ template <class _Ty>
 struct is_convertible<volatile _Ty&, const volatile _Ty&> : true_type {};
 
 template <class _Ty>
-_INLINE_VAR constexpr bool is_convertible_v<_Ty&, volatile _Ty&> = true;
+constexpr bool is_convertible_v<_Ty&, volatile _Ty&> = true;
 
 template <class _Ty>
-_INLINE_VAR constexpr bool is_convertible_v<volatile _Ty&, volatile _Ty&> = true;
+constexpr bool is_convertible_v<volatile _Ty&, volatile _Ty&> = true;
 
 template <class _Ty>
-_INLINE_VAR constexpr bool is_convertible_v<_Ty&, const volatile _Ty&> = true;
+constexpr bool is_convertible_v<_Ty&, const volatile _Ty&> = true;
 
 template <class _Ty>
-_INLINE_VAR constexpr bool is_convertible_v<volatile _Ty&, const volatile _Ty&> = true;
+constexpr bool is_convertible_v<volatile _Ty&, const volatile _Ty&> = true;
 #endif // ^^^ workaround ^^^
 
 _EXPORT_STD template <class _Ty>
 struct is_enum : bool_constant<__is_enum(_Ty)> {}; // determine whether _Ty is an enumerated type
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_enum_v = __is_enum(_Ty);
+constexpr bool is_enum_v = __is_enum(_Ty);
 
 #if _HAS_CXX23
 _EXPORT_STD template <class _Ty>
-inline constexpr bool is_scoped_enum_v = conjunction_v<is_enum<_Ty>, negation<is_convertible<_Ty, int>>>;
+constexpr bool is_scoped_enum_v = conjunction_v<is_enum<_Ty>, negation<is_convertible<_Ty, int>>>;
 
 _EXPORT_STD template <class _Ty>
 struct is_scoped_enum : bool_constant<is_scoped_enum_v<_Ty>> {};
@@ -371,7 +371,7 @@ _EXPORT_STD template <class _Ty>
 struct is_compound : bool_constant<!is_fundamental_v<_Ty>> {}; // determine whether _Ty is a compound type
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_compound_v = !is_fundamental_v<_Ty>;
+constexpr bool is_compound_v = !is_fundamental_v<_Ty>;
 
 #define _EMIT_CDECL(FUNC, OPT1, OPT2, OPT3) FUNC(__cdecl, OPT1, OPT2, OPT3)
 
@@ -559,42 +559,42 @@ _NON_MEMBER_CALL(_IS_MEMFUNPTR_EXPLICIT_THIS_GUIDES, , , noexcept)
 
 #ifdef __clang__
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_member_function_pointer_v = __is_member_function_pointer(_Ty);
+constexpr bool is_member_function_pointer_v = __is_member_function_pointer(_Ty);
 #else // ^^^ Clang / Other vvv
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_member_function_pointer_v = _Is_memfunptr<remove_cv_t<_Ty>>::_Bool_type::value;
+constexpr bool is_member_function_pointer_v = _Is_memfunptr<remove_cv_t<_Ty>>::_Bool_type::value;
 #endif // ^^^ Other ^^^
 
 _EXPORT_STD template <class _Ty>
 struct is_member_function_pointer : bool_constant<is_member_function_pointer_v<_Ty>> {};
 
 _EXPORT_STD template <class>
-_INLINE_VAR constexpr bool is_const_v = false; // determine whether type argument is const qualified
+constexpr bool is_const_v = false; // determine whether type argument is const qualified
 
 template <class _Ty>
-_INLINE_VAR constexpr bool is_const_v<const _Ty> = true;
+constexpr bool is_const_v<const _Ty> = true;
 
 _EXPORT_STD template <class _Ty>
 struct is_const : bool_constant<is_const_v<_Ty>> {};
 
 _EXPORT_STD template <class>
-_INLINE_VAR constexpr bool is_volatile_v = false; // determine whether type argument is volatile qualified
+constexpr bool is_volatile_v = false; // determine whether type argument is volatile qualified
 
 template <class _Ty>
-_INLINE_VAR constexpr bool is_volatile_v<volatile _Ty> = true;
+constexpr bool is_volatile_v<volatile _Ty> = true;
 
 _EXPORT_STD template <class _Ty>
 struct is_volatile : bool_constant<is_volatile_v<_Ty>> {};
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_function_v = // only function types and reference types can't be const qualified
+constexpr bool is_function_v = // only function types and reference types can't be const qualified
     !is_const_v<const _Ty> && !is_reference_v<_Ty>;
 
 _EXPORT_STD template <class _Ty>
 struct is_function : bool_constant<is_function_v<_Ty>> {};
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_object_v = // only function types and reference types can't be const qualified
+constexpr bool is_object_v = // only function types and reference types can't be const qualified
     is_const_v<const _Ty> && !is_void_v<_Ty>;
 
 _EXPORT_STD template <class _Ty>
@@ -613,10 +613,10 @@ struct _Is_member_object_pointer<_Ty1 _Ty2::*> {
 
 #ifdef __clang__
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_member_object_pointer_v = __is_member_object_pointer(_Ty);
+constexpr bool is_member_object_pointer_v = __is_member_object_pointer(_Ty);
 #else // ^^^ Clang / Other vvv
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_member_object_pointer_v = _Is_member_object_pointer<remove_cv_t<_Ty>>::value;
+constexpr bool is_member_object_pointer_v = _Is_member_object_pointer<remove_cv_t<_Ty>>::value;
 #endif // ^^^ Other ^^^
 
 _EXPORT_STD template <class _Ty>
@@ -624,17 +624,17 @@ struct is_member_object_pointer : bool_constant<is_member_object_pointer_v<_Ty>>
 
 #ifdef __clang__
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_member_pointer_v = __is_member_pointer(_Ty);
+constexpr bool is_member_pointer_v = __is_member_pointer(_Ty);
 #else // ^^^ Clang / Other vvv
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_member_pointer_v = is_member_object_pointer_v<_Ty> || is_member_function_pointer_v<_Ty>;
+constexpr bool is_member_pointer_v = is_member_object_pointer_v<_Ty> || is_member_function_pointer_v<_Ty>;
 #endif // ^^^ Other ^^^
 
 _EXPORT_STD template <class _Ty>
 struct is_member_pointer : bool_constant<is_member_pointer_v<_Ty>> {}; // determine whether _Ty is a pointer to member
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_scalar_v = // determine whether _Ty is a scalar type
+constexpr bool is_scalar_v = // determine whether _Ty is a scalar type
     is_arithmetic_v<_Ty> || is_enum_v<_Ty> || is_pointer_v<_Ty> || is_member_pointer_v<_Ty> || is_null_pointer_v<_Ty>;
 
 _EXPORT_STD template <class _Ty>
@@ -644,37 +644,37 @@ _EXPORT_STD template <class _Ty>
 struct _CXX20_DEPRECATE_IS_POD is_pod : bool_constant<__is_pod(_Ty)> {}; // determine whether _Ty is a POD type
 
 _EXPORT_STD template <class _Ty>
-_CXX20_DEPRECATE_IS_POD _INLINE_VAR constexpr bool is_pod_v = __is_pod(_Ty);
+_CXX20_DEPRECATE_IS_POD constexpr bool is_pod_v = __is_pod(_Ty);
 
 _EXPORT_STD template <class _Ty>
 struct is_empty : bool_constant<__is_empty(_Ty)> {}; // determine whether _Ty is an empty class
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_empty_v = __is_empty(_Ty);
+constexpr bool is_empty_v = __is_empty(_Ty);
 
 _EXPORT_STD template <class _Ty>
 struct is_polymorphic : bool_constant<__is_polymorphic(_Ty)> {}; // determine whether _Ty is a polymorphic type
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_polymorphic_v = __is_polymorphic(_Ty);
+constexpr bool is_polymorphic_v = __is_polymorphic(_Ty);
 
 _EXPORT_STD template <class _Ty>
 struct is_abstract : bool_constant<__is_abstract(_Ty)> {}; // determine whether _Ty is an abstract class
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_abstract_v = __is_abstract(_Ty);
+constexpr bool is_abstract_v = __is_abstract(_Ty);
 
 _EXPORT_STD template <class _Ty>
 struct is_final : bool_constant<__is_final(_Ty)> {}; // determine whether _Ty is a final class
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_final_v = __is_final(_Ty);
+constexpr bool is_final_v = __is_final(_Ty);
 
 _EXPORT_STD template <class _Ty>
 struct is_standard_layout : bool_constant<__is_standard_layout(_Ty)> {}; // determine whether _Ty is standard layout
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_standard_layout_v = __is_standard_layout(_Ty);
+constexpr bool is_standard_layout_v = __is_standard_layout(_Ty);
 
 #if _HAS_DEPRECATED_IS_LITERAL_TYPE
 _EXPORT_STD template <class _Ty>
@@ -683,7 +683,7 @@ struct _CXX17_DEPRECATE_IS_LITERAL_TYPE is_literal_type : bool_constant<__is_lit
 };
 
 _EXPORT_STD template <class _Ty>
-_CXX17_DEPRECATE_IS_LITERAL_TYPE _INLINE_VAR constexpr bool is_literal_type_v = __is_literal_type(_Ty);
+_CXX17_DEPRECATE_IS_LITERAL_TYPE constexpr bool is_literal_type_v = __is_literal_type(_Ty);
 #endif // _HAS_DEPRECATED_IS_LITERAL_TYPE
 
 #if 1 // TRANSITION, VSO-119526 and LLVM-41915
@@ -693,13 +693,13 @@ struct is_trivial : bool_constant<__is_trivially_constructible(_Ty) && __is_triv
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_trivial_v = __is_trivially_constructible(_Ty) && __is_trivially_copyable(_Ty);
+constexpr bool is_trivial_v = __is_trivially_constructible(_Ty) && __is_trivially_copyable(_Ty);
 #else // ^^^ workaround / no workaround vvv
 _EXPORT_STD template <class _Ty>
 struct is_trivial : bool_constant<__is_trivial(_Ty)> {}; // determine whether _Ty is a trivial type
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_trivial_v = __is_trivial(_Ty);
+constexpr bool is_trivial_v = __is_trivial(_Ty);
 #endif // ^^^ no workaround ^^^
 
 _EXPORT_STD template <class _Ty>
@@ -708,7 +708,7 @@ struct is_trivially_copyable : bool_constant<__is_trivially_copyable(_Ty)> {
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_trivially_copyable_v = __is_trivially_copyable(_Ty);
+constexpr bool is_trivially_copyable_v = __is_trivially_copyable(_Ty);
 
 _EXPORT_STD template <class _Ty>
 struct has_virtual_destructor : bool_constant<__has_virtual_destructor(_Ty)> {
@@ -716,7 +716,7 @@ struct has_virtual_destructor : bool_constant<__has_virtual_destructor(_Ty)> {
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool has_virtual_destructor_v = __has_virtual_destructor(_Ty);
+constexpr bool has_virtual_destructor_v = __has_virtual_destructor(_Ty);
 
 #if _HAS_CXX17
 _EXPORT_STD template <class _Ty>
@@ -725,14 +725,14 @@ struct has_unique_object_representations : bool_constant<__has_unique_object_rep
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool has_unique_object_representations_v = __has_unique_object_representations(_Ty);
+constexpr bool has_unique_object_representations_v = __has_unique_object_representations(_Ty);
 
 #ifdef __EDG__ // TRANSITION, VSO-1690654
 template <class _Ty>
 struct _Is_aggregate_impl : bool_constant<__is_aggregate(_Ty)> {};
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_aggregate_v = disjunction_v<is_array<_Ty>, _Is_aggregate_impl<_Ty>>;
+constexpr bool is_aggregate_v = disjunction_v<is_array<_Ty>, _Is_aggregate_impl<_Ty>>;
 
 _EXPORT_STD template <class _Ty>
 struct is_aggregate : bool_constant<is_aggregate_v<_Ty>> {};
@@ -741,7 +741,7 @@ _EXPORT_STD template <class _Ty>
 struct is_aggregate : bool_constant<__is_aggregate(_Ty)> {};
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_aggregate_v = __is_aggregate(_Ty);
+constexpr bool is_aggregate_v = __is_aggregate(_Ty);
 #endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX17
 
@@ -751,7 +751,7 @@ struct is_constructible : bool_constant<__is_constructible(_Ty, _Args...)> {
 };
 
 _EXPORT_STD template <class _Ty, class... _Args>
-_INLINE_VAR constexpr bool is_constructible_v = __is_constructible(_Ty, _Args...);
+constexpr bool is_constructible_v = __is_constructible(_Ty, _Args...);
 
 _EXPORT_STD template <class _Ty>
 struct is_copy_constructible : bool_constant<__is_constructible(_Ty, add_lvalue_reference_t<const _Ty>)> {
@@ -759,7 +759,7 @@ struct is_copy_constructible : bool_constant<__is_constructible(_Ty, add_lvalue_
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_copy_constructible_v = __is_constructible(_Ty, add_lvalue_reference_t<const _Ty>);
+constexpr bool is_copy_constructible_v = __is_constructible(_Ty, add_lvalue_reference_t<const _Ty>);
 
 _EXPORT_STD template <class _Ty>
 struct is_default_constructible : bool_constant<__is_constructible(_Ty)> {
@@ -767,7 +767,7 @@ struct is_default_constructible : bool_constant<__is_constructible(_Ty)> {
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_default_constructible_v = __is_constructible(_Ty);
+constexpr bool is_default_constructible_v = __is_constructible(_Ty);
 
 template <class _Ty, class = void>
 struct _Is_implicitly_default_constructible : false_type {
@@ -787,13 +787,13 @@ struct is_move_constructible : bool_constant<__is_constructible(_Ty, _Ty)> {
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_move_constructible_v = __is_constructible(_Ty, _Ty);
+constexpr bool is_move_constructible_v = __is_constructible(_Ty, _Ty);
 
 _EXPORT_STD template <class _To, class _From>
 struct is_assignable : bool_constant<__is_assignable(_To, _From)> {}; // determine whether _From can be assigned to _To
 
 _EXPORT_STD template <class _To, class _From>
-_INLINE_VAR constexpr bool is_assignable_v = __is_assignable(_To, _From);
+constexpr bool is_assignable_v = __is_assignable(_To, _From);
 
 #if defined(_IS_ASSIGNABLE_NOCHECK_SUPPORTED) && !defined(__CUDACC__)
 template <class _To, class _From>
@@ -810,8 +810,7 @@ struct is_copy_assignable
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_copy_assignable_v =
-    __is_assignable(add_lvalue_reference_t<_Ty>, add_lvalue_reference_t<const _Ty>);
+constexpr bool is_copy_assignable_v = __is_assignable(add_lvalue_reference_t<_Ty>, add_lvalue_reference_t<const _Ty>);
 
 #if defined(_IS_ASSIGNABLE_NOCHECK_SUPPORTED) && !defined(__CUDACC__)
 template <class _Ty>
@@ -820,14 +819,14 @@ struct _Is_copy_assignable_no_precondition_check
           add_lvalue_reference_t<_Ty>, add_lvalue_reference_t<const _Ty>)> {};
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _Is_copy_assignable_unchecked_v =
+constexpr bool _Is_copy_assignable_unchecked_v =
     __is_assignable_no_precondition_check(add_lvalue_reference_t<_Ty>, add_lvalue_reference_t<const _Ty>);
 #else // ^^^ Use intrinsic / intrinsic not supported vvv
 template <class _Ty>
 using _Is_copy_assignable_no_precondition_check = is_copy_assignable<_Ty>;
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _Is_copy_assignable_unchecked_v = is_copy_assignable_v<_Ty>;
+constexpr bool _Is_copy_assignable_unchecked_v = is_copy_assignable_v<_Ty>;
 #endif // ^^^ intrinsic not supported ^^^
 
 _EXPORT_STD template <class _Ty>
@@ -836,7 +835,7 @@ struct is_move_assignable : bool_constant<__is_assignable(add_lvalue_reference_t
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_move_assignable_v = __is_assignable(add_lvalue_reference_t<_Ty>, _Ty);
+constexpr bool is_move_assignable_v = __is_assignable(add_lvalue_reference_t<_Ty>, _Ty);
 
 #if defined(_IS_ASSIGNABLE_NOCHECK_SUPPORTED) && !defined(__CUDACC__)
 template <class _Ty>
@@ -844,14 +843,14 @@ struct _Is_move_assignable_no_precondition_check
     : bool_constant<__is_assignable_no_precondition_check(add_lvalue_reference_t<_Ty>, _Ty)> {};
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _Is_move_assignable_unchecked_v =
+constexpr bool _Is_move_assignable_unchecked_v =
     __is_assignable_no_precondition_check(add_lvalue_reference_t<_Ty>, _Ty);
 #else // ^^^ Use intrinsic / intrinsic not supported vvv
 template <class _Ty>
 using _Is_move_assignable_no_precondition_check = is_move_assignable<_Ty>;
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _Is_move_assignable_unchecked_v = is_move_assignable_v<_Ty>;
+constexpr bool _Is_move_assignable_unchecked_v = is_move_assignable_v<_Ty>;
 #endif // ^^^ intrinsic not supported ^^^
 
 _EXPORT_STD template <class _Ty>
@@ -860,7 +859,7 @@ struct is_destructible : bool_constant<__is_destructible(_Ty)> {
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_destructible_v = __is_destructible(_Ty);
+constexpr bool is_destructible_v = __is_destructible(_Ty);
 
 _EXPORT_STD template <class _Ty, class... _Args>
 struct is_trivially_constructible : bool_constant<__is_trivially_constructible(_Ty, _Args...)> {
@@ -868,7 +867,7 @@ struct is_trivially_constructible : bool_constant<__is_trivially_constructible(_
 };
 
 _EXPORT_STD template <class _Ty, class... _Args>
-_INLINE_VAR constexpr bool is_trivially_constructible_v = __is_trivially_constructible(_Ty, _Args...);
+constexpr bool is_trivially_constructible_v = __is_trivially_constructible(_Ty, _Args...);
 
 _EXPORT_STD template <class _Ty>
 struct is_trivially_copy_constructible
@@ -877,8 +876,7 @@ struct is_trivially_copy_constructible
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_trivially_copy_constructible_v =
-    __is_trivially_constructible(_Ty, add_lvalue_reference_t<const _Ty>);
+constexpr bool is_trivially_copy_constructible_v = __is_trivially_constructible(_Ty, add_lvalue_reference_t<const _Ty>);
 
 _EXPORT_STD template <class _Ty>
 struct is_trivially_default_constructible : bool_constant<__is_trivially_constructible(_Ty)> {
@@ -886,7 +884,7 @@ struct is_trivially_default_constructible : bool_constant<__is_trivially_constru
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_trivially_default_constructible_v = __is_trivially_constructible(_Ty);
+constexpr bool is_trivially_default_constructible_v = __is_trivially_constructible(_Ty);
 
 _EXPORT_STD template <class _Ty>
 struct is_trivially_move_constructible : bool_constant<__is_trivially_constructible(_Ty, _Ty)> {
@@ -894,7 +892,7 @@ struct is_trivially_move_constructible : bool_constant<__is_trivially_constructi
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_trivially_move_constructible_v = __is_trivially_constructible(_Ty, _Ty);
+constexpr bool is_trivially_move_constructible_v = __is_trivially_constructible(_Ty, _Ty);
 
 _EXPORT_STD template <class _To, class _From>
 struct is_trivially_assignable : bool_constant<__is_trivially_assignable(_To, _From)> {
@@ -902,7 +900,7 @@ struct is_trivially_assignable : bool_constant<__is_trivially_assignable(_To, _F
 };
 
 _EXPORT_STD template <class _To, class _From>
-_INLINE_VAR constexpr bool is_trivially_assignable_v = __is_trivially_assignable(_To, _From);
+constexpr bool is_trivially_assignable_v = __is_trivially_assignable(_To, _From);
 
 _EXPORT_STD template <class _Ty>
 struct is_trivially_copy_assignable
@@ -911,7 +909,7 @@ struct is_trivially_copy_assignable
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_trivially_copy_assignable_v =
+constexpr bool is_trivially_copy_assignable_v =
     __is_trivially_assignable(add_lvalue_reference_t<_Ty>, add_lvalue_reference_t<const _Ty>);
 
 _EXPORT_STD template <class _Ty>
@@ -920,7 +918,7 @@ struct is_trivially_move_assignable : bool_constant<__is_trivially_assignable(ad
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_trivially_move_assignable_v = __is_trivially_assignable(add_lvalue_reference_t<_Ty>, _Ty);
+constexpr bool is_trivially_move_assignable_v = __is_trivially_assignable(add_lvalue_reference_t<_Ty>, _Ty);
 
 _EXPORT_STD template <class _Ty>
 struct is_trivially_destructible : bool_constant<__is_trivially_destructible(_Ty)> {
@@ -928,7 +926,7 @@ struct is_trivially_destructible : bool_constant<__is_trivially_destructible(_Ty
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_trivially_destructible_v = __is_trivially_destructible(_Ty);
+constexpr bool is_trivially_destructible_v = __is_trivially_destructible(_Ty);
 
 _EXPORT_STD template <class _Ty, class... _Args>
 struct is_nothrow_constructible : bool_constant<__is_nothrow_constructible(_Ty, _Args...)> {
@@ -936,7 +934,7 @@ struct is_nothrow_constructible : bool_constant<__is_nothrow_constructible(_Ty, 
 };
 
 _EXPORT_STD template <class _Ty, class... _Args>
-_INLINE_VAR constexpr bool is_nothrow_constructible_v = __is_nothrow_constructible(_Ty, _Args...);
+constexpr bool is_nothrow_constructible_v = __is_nothrow_constructible(_Ty, _Args...);
 
 _EXPORT_STD template <class _Ty>
 struct is_nothrow_copy_constructible
@@ -946,8 +944,7 @@ struct is_nothrow_copy_constructible
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_nothrow_copy_constructible_v =
-    __is_nothrow_constructible(_Ty, add_lvalue_reference_t<const _Ty>);
+constexpr bool is_nothrow_copy_constructible_v = __is_nothrow_constructible(_Ty, add_lvalue_reference_t<const _Ty>);
 
 _EXPORT_STD template <class _Ty>
 struct is_nothrow_default_constructible : bool_constant<__is_nothrow_constructible(_Ty)> {
@@ -955,7 +952,7 @@ struct is_nothrow_default_constructible : bool_constant<__is_nothrow_constructib
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_nothrow_default_constructible_v = __is_nothrow_constructible(_Ty);
+constexpr bool is_nothrow_default_constructible_v = __is_nothrow_constructible(_Ty);
 
 _EXPORT_STD template <class _Ty>
 struct is_nothrow_move_constructible : bool_constant<__is_nothrow_constructible(_Ty, _Ty)> {
@@ -963,7 +960,7 @@ struct is_nothrow_move_constructible : bool_constant<__is_nothrow_constructible(
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_nothrow_move_constructible_v = __is_nothrow_constructible(_Ty, _Ty);
+constexpr bool is_nothrow_move_constructible_v = __is_nothrow_constructible(_Ty, _Ty);
 
 _EXPORT_STD template <class _To, class _From>
 struct is_nothrow_assignable : bool_constant<__is_nothrow_assignable(_To, _From)> {
@@ -971,7 +968,7 @@ struct is_nothrow_assignable : bool_constant<__is_nothrow_assignable(_To, _From)
 };
 
 _EXPORT_STD template <class _To, class _From>
-_INLINE_VAR constexpr bool is_nothrow_assignable_v = __is_nothrow_assignable(_To, _From);
+constexpr bool is_nothrow_assignable_v = __is_nothrow_assignable(_To, _From);
 
 _EXPORT_STD template <class _Ty>
 struct is_nothrow_copy_assignable
@@ -980,7 +977,7 @@ struct is_nothrow_copy_assignable
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_nothrow_copy_assignable_v =
+constexpr bool is_nothrow_copy_assignable_v =
     __is_nothrow_assignable(add_lvalue_reference_t<_Ty>, add_lvalue_reference_t<const _Ty>);
 
 _EXPORT_STD template <class _Ty>
@@ -989,7 +986,7 @@ struct is_nothrow_move_assignable : bool_constant<__is_nothrow_assignable(add_lv
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_nothrow_move_assignable_v = __is_nothrow_assignable(add_lvalue_reference_t<_Ty>, _Ty);
+constexpr bool is_nothrow_move_assignable_v = __is_nothrow_assignable(add_lvalue_reference_t<_Ty>, _Ty);
 
 _EXPORT_STD template <class _Ty>
 struct is_nothrow_destructible : bool_constant<__is_nothrow_destructible(_Ty)> {
@@ -998,7 +995,7 @@ struct is_nothrow_destructible : bool_constant<__is_nothrow_destructible(_Ty)> {
 };
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_nothrow_destructible_v = __is_nothrow_destructible(_Ty);
+constexpr bool is_nothrow_destructible_v = __is_nothrow_destructible(_Ty);
 
 template <class _Ty, bool = is_integral_v<_Ty>>
 struct _Sign_base { // determine whether integral type _Ty is signed or unsigned
@@ -1019,16 +1016,16 @@ _EXPORT_STD template <class _Ty>
 struct is_signed : bool_constant<_Sign_base<_Ty>::_Signed> {}; // determine whether _Ty is a signed type
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_signed_v = _Sign_base<_Ty>::_Signed;
+constexpr bool is_signed_v = _Sign_base<_Ty>::_Signed;
 
 _EXPORT_STD template <class _Ty>
 struct is_unsigned : bool_constant<_Sign_base<_Ty>::_Unsigned> {}; // determine whether _Ty is an unsigned type
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_unsigned_v = _Sign_base<_Ty>::_Unsigned;
+constexpr bool is_unsigned_v = _Sign_base<_Ty>::_Unsigned;
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _Is_nonbool_integral = is_integral_v<_Ty> && !is_same_v<remove_cv_t<_Ty>, bool>;
+constexpr bool _Is_nonbool_integral = is_integral_v<_Ty> && !is_same_v<remove_cv_t<_Ty>, bool>;
 
 template <bool>
 struct _Select { // Select between aliases that extract either their first or second parameter
@@ -1140,7 +1137,7 @@ _EXPORT_STD template <class _Ty>
 struct alignment_of : integral_constant<size_t, alignof(_Ty)> {}; // determine alignment of _Ty
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr size_t alignment_of_v = alignof(_Ty);
+constexpr size_t alignment_of_v = alignof(_Ty);
 
 template <class _Ty, size_t _Len>
 union _Align_type { // union with size _Len bytes and alignment of _Ty
@@ -1261,28 +1258,28 @@ _EXPORT_STD template <class _Ty>
 using underlying_type_t = typename _Underlying_type<_Ty>::type;
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr size_t rank_v = 0; // determine number of dimensions of array _Ty
+constexpr size_t rank_v = 0; // determine number of dimensions of array _Ty
 
 template <class _Ty, size_t _Nx>
-_INLINE_VAR constexpr size_t rank_v<_Ty[_Nx]> = rank_v<_Ty> + 1;
+constexpr size_t rank_v<_Ty[_Nx]> = rank_v<_Ty> + 1;
 
 template <class _Ty>
-_INLINE_VAR constexpr size_t rank_v<_Ty[]> = rank_v<_Ty> + 1;
+constexpr size_t rank_v<_Ty[]> = rank_v<_Ty> + 1;
 
 _EXPORT_STD template <class _Ty>
 struct rank : integral_constant<size_t, rank_v<_Ty>> {};
 
 _EXPORT_STD template <class _Ty, unsigned int _Ix = 0>
-_INLINE_VAR constexpr size_t extent_v = 0; // determine extent of dimension _Ix of array _Ty
+constexpr size_t extent_v = 0; // determine extent of dimension _Ix of array _Ty
 
 template <class _Ty, size_t _Nx>
-_INLINE_VAR constexpr size_t extent_v<_Ty[_Nx], 0> = _Nx;
+constexpr size_t extent_v<_Ty[_Nx], 0> = _Nx;
 
 template <class _Ty, unsigned int _Ix, size_t _Nx>
-_INLINE_VAR constexpr size_t extent_v<_Ty[_Nx], _Ix> = extent_v<_Ty, _Ix - 1>;
+constexpr size_t extent_v<_Ty[_Nx], _Ix> = extent_v<_Ty, _Ix - 1>;
 
 template <class _Ty, unsigned int _Ix>
-_INLINE_VAR constexpr size_t extent_v<_Ty[], _Ix> = extent_v<_Ty, _Ix - 1>;
+constexpr size_t extent_v<_Ty[], _Ix> = extent_v<_Ty, _Ix - 1>;
 
 _EXPORT_STD template <class _Ty, unsigned int _Ix = 0>
 struct extent : integral_constant<size_t, extent_v<_Ty, _Ix>> {};
@@ -1293,7 +1290,7 @@ struct is_base_of : bool_constant<__is_base_of(_Base, _Derived)> {
 };
 
 _EXPORT_STD template <class _Base, class _Derived>
-_INLINE_VAR constexpr bool is_base_of_v = __is_base_of(_Base, _Derived);
+constexpr bool is_base_of_v = __is_base_of(_Base, _Derived);
 
 _EXPORT_STD template <class _Ty>
 struct decay { // determines decayed version of _Ty
@@ -1525,9 +1522,9 @@ using type_identity_t = type_identity<_Ty>::type;
 #endif // _HAS_CXX20
 
 template <class _Type, template <class...> class _Template>
-_INLINE_VAR constexpr bool _Is_specialization_v = false; // true if and only if _Type is a specialization of _Template
+constexpr bool _Is_specialization_v = false; // true if and only if _Type is a specialization of _Template
 template <template <class...> class _Template, class... _Types>
-_INLINE_VAR constexpr bool _Is_specialization_v<_Template<_Types...>, _Template> = true;
+constexpr bool _Is_specialization_v<_Template<_Types...>, _Template> = true;
 
 template <class _Type, template <class...> class _Template>
 struct _Is_specialization : bool_constant<_Is_specialization_v<_Type, _Template>> {};
@@ -1740,15 +1737,15 @@ constexpr auto invoke(_Callable&& _Obj, _Ty1&& _Arg1, _Types2&&... _Args2) noexc
 #pragma warning(disable : 4365) // '%s': conversion from '%s' to '%s', signed/unsigned mismatch (/Wall)
 
 template <class _From, class _To, bool = is_convertible_v<_From, _To>, bool = is_void_v<_To>>
-_INLINE_VAR constexpr bool _Is_nothrow_convertible_v = noexcept(_STD _Fake_copy_init<_To>(_STD declval<_From>()));
+constexpr bool _Is_nothrow_convertible_v = noexcept(_STD _Fake_copy_init<_To>(_STD declval<_From>()));
 
 #pragma warning(pop)
 
 template <class _From, class _To, bool _IsVoid>
-_INLINE_VAR constexpr bool _Is_nothrow_convertible_v<_From, _To, false, _IsVoid> = false;
+constexpr bool _Is_nothrow_convertible_v<_From, _To, false, _IsVoid> = false;
 
 template <class _From, class _To>
-_INLINE_VAR constexpr bool _Is_nothrow_convertible_v<_From, _To, true, true> = true;
+constexpr bool _Is_nothrow_convertible_v<_From, _To, true, true> = true;
 
 template <class _From, class _To>
 struct _Is_nothrow_convertible : bool_constant<_Is_nothrow_convertible_v<_From, _To>> {
@@ -1757,7 +1754,7 @@ struct _Is_nothrow_convertible : bool_constant<_Is_nothrow_convertible_v<_From, 
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _From, class _To>
-inline constexpr bool is_nothrow_convertible_v = _Is_nothrow_convertible_v<_From, _To>;
+constexpr bool is_nothrow_convertible_v = _Is_nothrow_convertible_v<_From, _To>;
 
 _EXPORT_STD template <class _From, class _To>
 struct is_nothrow_convertible : bool_constant<_Is_nothrow_convertible_v<_From, _To>> {};
@@ -1878,7 +1875,7 @@ struct is_invocable : _Select_invoke_traits<_Callable, _Args...>::_Is_invocable 
 };
 
 _EXPORT_STD template <class _Callable, class... _Args>
-inline constexpr bool is_invocable_v = _Select_invoke_traits<_Callable, _Args...>::_Is_invocable::value;
+constexpr bool is_invocable_v = _Select_invoke_traits<_Callable, _Args...>::_Is_invocable::value;
 
 _EXPORT_STD template <class _Callable, class... _Args>
 struct is_nothrow_invocable : _Select_invoke_traits<_Callable, _Args...>::_Is_nothrow_invocable {
@@ -1886,7 +1883,7 @@ struct is_nothrow_invocable : _Select_invoke_traits<_Callable, _Args...>::_Is_no
 };
 
 _EXPORT_STD template <class _Callable, class... _Args>
-inline constexpr bool is_nothrow_invocable_v = _Select_invoke_traits<_Callable, _Args...>::_Is_nothrow_invocable::value;
+constexpr bool is_nothrow_invocable_v = _Select_invoke_traits<_Callable, _Args...>::_Is_nothrow_invocable::value;
 
 _EXPORT_STD template <class _Rx, class _Callable, class... _Args>
 struct is_invocable_r : _Is_invocable_r_<_Rx, _Callable, _Args...> {
@@ -1894,7 +1891,7 @@ struct is_invocable_r : _Is_invocable_r_<_Rx, _Callable, _Args...> {
 };
 
 _EXPORT_STD template <class _Rx, class _Callable, class... _Args>
-inline constexpr bool is_invocable_r_v = _Is_invocable_r_<_Rx, _Callable, _Args...>::value;
+constexpr bool is_invocable_r_v = _Is_invocable_r_<_Rx, _Callable, _Args...>::value;
 
 _EXPORT_STD template <class _Rx, class _Callable, class... _Args>
 struct is_nothrow_invocable_r : _Select_invoke_traits<_Callable, _Args...>::template _Is_nothrow_invocable_r<_Rx> {
@@ -1902,7 +1899,7 @@ struct is_nothrow_invocable_r : _Select_invoke_traits<_Callable, _Args...>::temp
 };
 
 _EXPORT_STD template <class _Rx, class _Callable, class... _Args>
-inline constexpr bool is_nothrow_invocable_r_v =
+constexpr bool is_nothrow_invocable_r_v =
     _Select_invoke_traits<_Callable, _Args...>::template _Is_nothrow_invocable_r<_Rx>::value;
 #endif // _HAS_CXX17
 
@@ -1912,13 +1909,13 @@ _EXPORT_STD template <class _Ty1, class _Ty2>
 struct is_layout_compatible : bool_constant<__is_layout_compatible(_Ty1, _Ty2)> {};
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
-inline constexpr bool is_layout_compatible_v = __is_layout_compatible(_Ty1, _Ty2);
+constexpr bool is_layout_compatible_v = __is_layout_compatible(_Ty1, _Ty2);
 
 _EXPORT_STD template <class _Base, class _Derived>
 struct is_pointer_interconvertible_base_of : bool_constant<__is_pointer_interconvertible_base_of(_Base, _Derived)> {};
 
 _EXPORT_STD template <class _Base, class _Derived>
-inline constexpr bool is_pointer_interconvertible_base_of_v = __is_pointer_interconvertible_base_of(_Base, _Derived);
+constexpr bool is_pointer_interconvertible_base_of_v = __is_pointer_interconvertible_base_of(_Base, _Derived);
 
 _EXPORT_STD template <class _ClassTy, class _MemberTy>
 _NODISCARD constexpr bool is_pointer_interconvertible_with_class(_MemberTy _ClassTy::*_Pm) noexcept {
@@ -2157,14 +2154,14 @@ struct is_swappable_with : _Is_swappable_with<_Ty1, _Ty2>::type {
 };
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
-inline constexpr bool is_swappable_with_v =
+constexpr bool is_swappable_with_v =
     conjunction_v<_Swappable_with_helper<_Ty1, _Ty2>, _Swappable_with_helper<_Ty2, _Ty1>>;
 
 _EXPORT_STD template <class _Ty>
 struct is_swappable : _Is_swappable<_Ty>::type {}; // Determine if _Ty lvalues satisfy is_swappable_with
 
 _EXPORT_STD template <class _Ty>
-inline constexpr bool is_swappable_v = _Is_swappable<_Ty>::value;
+constexpr bool is_swappable_v = _Is_swappable<_Ty>::value;
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 struct is_nothrow_swappable_with : _Is_nothrow_swappable_with<_Ty1, _Ty2>::type {
@@ -2173,7 +2170,7 @@ struct is_nothrow_swappable_with : _Is_nothrow_swappable_with<_Ty1, _Ty2>::type 
 };
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
-inline constexpr bool is_nothrow_swappable_with_v = _Is_nothrow_swappable_with<_Ty1, _Ty2>::value;
+constexpr bool is_nothrow_swappable_with_v = _Is_nothrow_swappable_with<_Ty1, _Ty2>::value;
 
 _EXPORT_STD template <class _Ty>
 struct is_nothrow_swappable : _Is_nothrow_swappable<_Ty>::type {
@@ -2181,7 +2178,7 @@ struct is_nothrow_swappable : _Is_nothrow_swappable<_Ty>::type {
 };
 
 _EXPORT_STD template <class _Ty>
-inline constexpr bool is_nothrow_swappable_v = _Is_nothrow_swappable<_Ty>::value;
+constexpr bool is_nothrow_swappable_v = _Is_nothrow_swappable<_Ty>::value;
 #endif // _HAS_CXX17
 
 namespace _Has_ADL_swap_detail {
@@ -2199,7 +2196,7 @@ namespace _Has_ADL_swap_detail {
 using _Has_ADL_swap_detail::_Has_ADL_swap;
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _Is_trivially_swappable_v = conjunction_v<is_trivially_destructible<_Ty>,
+constexpr bool _Is_trivially_swappable_v = conjunction_v<is_trivially_destructible<_Ty>,
     is_trivially_move_constructible<_Ty>, is_trivially_move_assignable<_Ty>, negation<_Has_ADL_swap<_Ty>>>;
 
 #ifdef __cpp_lib_byte

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -147,7 +147,7 @@ _EXPORT_STD template <class _Tuple>
 struct tuple_size;
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr size_t tuple_size_v = tuple_size<_Ty>::value;
+constexpr size_t tuple_size_v = tuple_size<_Ty>::value;
 
 _EXPORT_STD template <size_t _Index, class _Tuple>
 struct tuple_element;
@@ -187,17 +187,17 @@ template <class _Ty1, class _Ty2>
 concept _Different_from = !same_as<remove_cvref_t<_Ty1>, remove_cvref_t<_Ty2>>;
 
 template <class>
-inline constexpr bool _Is_std_array_v = false;
+constexpr bool _Is_std_array_v = false;
 
 template <class _Ty, size_t _Size>
-inline constexpr bool _Is_std_array_v<array<_Ty, _Size>> = true;
+constexpr bool _Is_std_array_v<array<_Ty, _Size>> = true;
 
 template <class>
-inline constexpr bool _Is_subrange_v = false;
+constexpr bool _Is_subrange_v = false;
 
 #if _HAS_CXX23
 template <class _Ty>
-inline constexpr bool _Tuple_like_impl =
+constexpr bool _Tuple_like_impl =
     _Is_specialization_v<_Ty, tuple> || _Is_specialization_v<_Ty, pair> || _Is_std_array_v<_Ty> || _Is_subrange_v<_Ty>;
 
 template <class _Ty>
@@ -778,27 +778,27 @@ struct in_place_type_t { // tag that selects a type to construct in place
     explicit in_place_type_t() = default;
 };
 _EXPORT_STD template <class _Ty>
-inline constexpr in_place_type_t<_Ty> in_place_type{};
+constexpr in_place_type_t<_Ty> in_place_type{};
 
 _EXPORT_STD template <size_t>
 struct in_place_index_t { // tag that selects the index of a type to construct in place
     explicit in_place_index_t() = default;
 };
 _EXPORT_STD template <size_t _Idx>
-inline constexpr in_place_index_t<_Idx> in_place_index{};
+constexpr in_place_index_t<_Idx> in_place_index{};
 #endif // _HAS_CXX17
 
 #if _HAS_CXX20
 template <class _Ty>
-inline constexpr bool _Is_standard_integer = is_integral_v<_Ty>
-                                          && !_Is_any_of_v<remove_cv_t<_Ty>, bool, char,
+constexpr bool _Is_standard_integer = is_integral_v<_Ty>
+                                   && !_Is_any_of_v<remove_cv_t<_Ty>, bool, char,
 #ifdef _NATIVE_WCHAR_T_DEFINED
-                                              wchar_t,
+                                       wchar_t,
 #endif // _NATIVE_WCHAR_T_DEFINED
 #ifdef __cpp_char8_t
-                                              char8_t,
+                                       char8_t,
 #endif // defined(__cpp_char8_t)
-                                              char16_t, char32_t>;
+                                       char16_t, char32_t>;
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 _NODISCARD constexpr bool cmp_equal(const _Ty1 _Left, const _Ty2 _Right) noexcept {

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -333,7 +333,7 @@ struct _CXX20_DEPRECATE_VOLATILE variant_size<volatile _Ty> : variant_size<_Ty>:
 template <class _Ty>
 struct _CXX20_DEPRECATE_VOLATILE variant_size<const volatile _Ty> : variant_size<_Ty>::type {};
 _EXPORT_STD template <class _Ty>
-inline constexpr size_t variant_size_v = variant_size<_Ty>::value;
+constexpr size_t variant_size_v = variant_size<_Ty>::value;
 
 template <class... _Types>
 struct variant_size<variant<_Types...>> : integral_constant<size_t, sizeof...(_Types)> {};
@@ -580,10 +580,10 @@ _NODISCARD constexpr _Variant_raw_visit_t<_Fn, _Storage> _Variant_raw_visit_valu
 }
 
 template <class _Fn, class _Storage, class _Indices = make_index_sequence<remove_reference_t<_Storage>::_Size>>
-inline constexpr bool _Variant_raw_visit_noexcept = false;
+constexpr bool _Variant_raw_visit_noexcept = false;
 
 template <class _Fn, class _Storage, size_t... _Idxs>
-inline constexpr bool _Variant_raw_visit_noexcept<_Fn, _Storage, index_sequence<_Idxs...>> =
+constexpr bool _Variant_raw_visit_noexcept<_Fn, _Storage, index_sequence<_Idxs...>> =
     conjunction_v<is_nothrow_invocable<_Fn, _Tagged<_Storage&&, variant_npos>>,
         is_nothrow_invocable<_Fn, _Variant_tagged_ref_t<_Storage, _Idxs>>...>;
 
@@ -720,7 +720,7 @@ struct _Variant_construct_visitor { // visitor that constructs the same alternat
 };
 
 template <class _Target, class... _Types>
-inline constexpr bool _Variant_should_directly_construct_v =
+constexpr bool _Variant_should_directly_construct_v =
     disjunction_v<is_nothrow_constructible<_Target, _Types...>, negation<is_nothrow_move_constructible<_Target>>>;
 
 template <class... _Types>
@@ -957,9 +957,9 @@ using _Variant_init_index = _Meta_front<typename _Variant_init_helper<void, _Ty,
 #endif // ^^^ not Clang ^^^
 
 template <class>
-inline constexpr bool _Is_in_place_index_specialization = false;
+constexpr bool _Is_in_place_index_specialization = false;
 template <size_t _Idx>
-inline constexpr bool _Is_in_place_index_specialization<in_place_index_t<_Idx>> = true;
+constexpr bool _Is_in_place_index_specialization<in_place_index_t<_Idx>> = true;
 
 _EXPORT_STD template <class... _Types>
 class variant : private _SMF_control<_Variant_destroy_layer<_Types...>, _Types...> { // discriminated union
@@ -1399,7 +1399,7 @@ _NODISCARD constexpr common_comparison_category_t<compare_three_way_result_t<_Ty
 #endif // _HAS_CXX20
 
 template <class... _Variants>
-inline constexpr size_t _Variant_total_states =
+constexpr size_t _Variant_total_states =
     (size_t{1} * ... * (variant_size_v<_Variants> + 1)); // +1 to account for the valueless state
 
 _NODISCARD constexpr size_t _Variant_visit_index1(const size_t _Acc) noexcept {
@@ -1567,29 +1567,29 @@ constexpr _Ret _Visit_impl(_Callable&& _Obj, _Variants&&... _Args) {
 }
 
 template <class _Expected, class _Callable, class _ArgList, class... _Variants>
-inline constexpr bool _Variant_all_visit_results_same = false;
+constexpr bool _Variant_all_visit_results_same = false;
 
 template <class _Expected, class _Callable, class... _Args>
-inline constexpr bool _Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args...>> =
+constexpr bool _Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args...>> =
     is_same_v<decltype(_STD invoke(_STD declval<_Callable>(), _STD declval<_Args>()...)), _Expected>;
 
 template <class _Expected, class _Callable, class... _Args, class... _Types, class... _Rest>
-inline constexpr bool
+constexpr bool
     _Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args...>, variant<_Types...>&, _Rest...> =
         (_Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args..., _Types&>, _Rest...> && ...);
 
 template <class _Expected, class _Callable, class... _Args, class... _Types, class... _Rest>
-inline constexpr bool
+constexpr bool
     _Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args...>, const variant<_Types...>&, _Rest...> =
         (_Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args..., const _Types&>, _Rest...> && ...);
 
 template <class _Expected, class _Callable, class... _Args, class... _Types, class... _Rest>
-inline constexpr bool
+constexpr bool
     _Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args...>, variant<_Types...>&&, _Rest...> =
         (_Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args..., _Types>, _Rest...> && ...);
 
 template <class _Expected, class _Callable, class... _Args, class... _Types, class... _Rest>
-inline constexpr bool
+constexpr bool
     _Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args...>, const variant<_Types...>&&, _Rest...> =
         (_Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args..., const _Types>, _Rest...> && ...);
 
@@ -1612,30 +1612,30 @@ constexpr _Variant_visit_result_t<_Callable, _As_variant<_Variants>...> visit(_C
 
 #if _HAS_CXX20
 template <class _Expected, class _Callable, class _ArgList, class... _Variants>
-inline constexpr bool _Variant_all_visit_results_convertible = false;
+constexpr bool _Variant_all_visit_results_convertible = false;
 
 template <class _Expected, class _Callable, class... _Args>
-inline constexpr bool _Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args...>> =
+constexpr bool _Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args...>> =
     _Invoke_convertible<decltype(_STD invoke(_STD declval<_Callable>(), _STD declval<_Args>()...)), _Expected>::value;
 
 template <class _Expected, class _Callable, class... _Args, class... _Types, class... _Rest>
-inline constexpr bool
+constexpr bool
     _Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args...>, variant<_Types...>&, _Rest...> =
         (_Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args..., _Types&>, _Rest...> && ...);
 
 template <class _Expected, class _Callable, class... _Args, class... _Types, class... _Rest>
-inline constexpr bool _Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args...>,
+constexpr bool _Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args...>,
     const variant<_Types...>&, _Rest...> =
     (_Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args..., const _Types&>, _Rest...>
         && ...);
 
 template <class _Expected, class _Callable, class... _Args, class... _Types, class... _Rest>
-inline constexpr bool
+constexpr bool
     _Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args...>, variant<_Types...>&&, _Rest...> =
         (_Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args..., _Types>, _Rest...> && ...);
 
 template <class _Expected, class _Callable, class... _Args, class... _Types, class... _Rest>
-inline constexpr bool _Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args...>,
+constexpr bool _Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args...>,
     const variant<_Types...>&&, _Rest...> =
     (_Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args..., const _Types>, _Rest...> && ...);
 

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -3600,10 +3600,10 @@ public:
 #endif // _HAS_CXX23
 
 template <class _Alloc, bool _RequiresMutable>
-_INLINE_VAR constexpr bool _Is_vb_iterator<_Vb_iterator<_Alloc>, _RequiresMutable> = true;
+constexpr bool _Is_vb_iterator<_Vb_iterator<_Alloc>, _RequiresMutable> = true;
 
 template <class _Alloc>
-_INLINE_VAR constexpr bool _Is_vb_iterator<_Vb_const_iterator<_Alloc>, false> = true;
+constexpr bool _Is_vb_iterator<_Vb_const_iterator<_Alloc>, false> = true;
 
 template <class _VbIt>
 _CONSTEXPR20 void _Fill_vbool(_VbIt _First, const _VbIt _Last, const bool _Val) noexcept {

--- a/stl/inc/xcharconv_ryu_tables.h
+++ b/stl/inc/xcharconv_ryu_tables.h
@@ -62,7 +62,7 @@ _STD_BEGIN
 
 // A table of all two-digit numbers. This is used to speed up decimal digit
 // generation by copying pairs of digits into the final output.
-template <class _CharT> inline constexpr _CharT __DIGIT_TABLE[] = {_CharT{}};
+template <class _CharT> constexpr _CharT __DIGIT_TABLE[] = {_CharT{}};
 
 template <> inline constexpr char __DIGIT_TABLE<char>[200] = {
   '0','0','0','1','0','2','0','3','0','4','0','5','0','6','0','7','0','8','0','9',

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -116,7 +116,7 @@ struct _Uhash_choose_transparency<_Kty, _Hasher, _Keyeq,
 #endif // _HAS_CXX20
 
 template <class _Hasher, class _Kty>
-_INLINE_VAR constexpr bool _Nothrow_hash =
+constexpr bool _Nothrow_hash =
     noexcept(static_cast<size_t>(_STD declval<const _Hasher&>()(_STD declval<const _Kty&>())));
 
 template <class _Kty, class _Hasher, class _Keyeq>

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -653,7 +653,7 @@ protected:
 };
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _Is_one_byte_char_like_v = _Is_any_of_v<remove_cv_t<_Ty>, signed char, unsigned char,
+constexpr bool _Is_one_byte_char_like_v = _Is_any_of_v<remove_cv_t<_Ty>, signed char, unsigned char,
 #ifdef __cpp_lib_byte
     byte,
 #endif // defined(__cpp_lib_byte)
@@ -663,7 +663,7 @@ _INLINE_VAR constexpr bool _Is_one_byte_char_like_v = _Is_any_of_v<remove_cv_t<_
     char>;
 
 template <class _Elem, class _Byte>
-_INLINE_VAR constexpr bool _Is_codecvt_do_always_noconv_v =
+constexpr bool _Is_codecvt_do_always_noconv_v =
     is_same_v<_Byte, _Elem> || (_Is_one_byte_char_like_v<_Byte> && _Is_one_byte_char_like_v<_Elem>);
 
 _EXPORT_STD extern "C++" template <class _Elem, class _Byte, class _Statype>

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -68,7 +68,7 @@ struct _NODISCARD _Tidy_deallocate_guard { // class with destructor that calls _
 };
 
 template <class _Keycmp, class _Lhs, class _Rhs>
-_INLINE_VAR constexpr bool _Nothrow_compare = noexcept(
+constexpr bool _Nothrow_compare = noexcept(
     static_cast<bool>(_STD declval<const _Keycmp&>()(_STD declval<const _Lhs&>(), _STD declval<const _Rhs&>())));
 
 [[noreturn]] inline void _Throw_bad_array_new_length() {
@@ -90,7 +90,7 @@ _NODISCARD constexpr size_t _Get_size_of_n(const size_t _Count) {
 }
 
 template <class _Ty>
-_INLINE_VAR constexpr size_t _New_alignof = (_STD max)(alignof(_Ty), __STDCPP_DEFAULT_NEW_ALIGNMENT__);
+constexpr size_t _New_alignof = (_STD max)(alignof(_Ty), __STDCPP_DEFAULT_NEW_ALIGNMENT__);
 
 struct _Default_allocate_traits {
     __declspec(allocator) static
@@ -726,8 +726,8 @@ struct allocator_traits : conditional_t<_Is_default_allocator<_Alloc>::value, _D
 // _Choose_pocca_v returns whether an attempt to propagate allocators is necessary in copy assignment operations.
 // Note that even when false_type, callers should call _Pocca as we want to assign allocators even when equal.
 template <class _Alloc>
-_INLINE_VAR constexpr bool _Choose_pocca_v = allocator_traits<_Alloc>::propagate_on_container_copy_assignment::value
-                                          && !allocator_traits<_Alloc>::is_always_equal::value;
+constexpr bool _Choose_pocca_v = allocator_traits<_Alloc>::propagate_on_container_copy_assignment::value
+                              && !allocator_traits<_Alloc>::is_always_equal::value;
 
 enum class _Pocma_values {
     _Equal_allocators, // usually allows contents to be stolen (e.g. with swap)
@@ -736,12 +736,11 @@ enum class _Pocma_values {
 };
 
 template <class _Alloc>
-_INLINE_VAR constexpr _Pocma_values _Choose_pocma_v =
-    allocator_traits<_Alloc>::is_always_equal::value
-        ? _Pocma_values::_Equal_allocators
-        : (allocator_traits<_Alloc>::propagate_on_container_move_assignment::value
-                ? _Pocma_values::_Propagate_allocators
-                : _Pocma_values::_No_propagate_allocators);
+constexpr _Pocma_values _Choose_pocma_v = allocator_traits<_Alloc>::is_always_equal::value
+                                            ? _Pocma_values::_Equal_allocators
+                                            : (allocator_traits<_Alloc>::propagate_on_container_move_assignment::value
+                                                    ? _Pocma_values::_Propagate_allocators
+                                                    : _Pocma_values::_No_propagate_allocators);
 
 template <class _Alloc, class _Value_type>
 using _Rebind_alloc_t = typename allocator_traits<_Alloc>::template rebind_alloc<_Value_type>;
@@ -754,7 +753,7 @@ using _Maybe_rebind_alloc_t =
         _Rebind_alloc_t<_Alloc, _Value_type>>;
 
 template <class _Alloc> // tests if allocator has simple addressing
-_INLINE_VAR constexpr bool _Is_simple_alloc_v =
+constexpr bool _Is_simple_alloc_v =
     is_same_v<typename allocator_traits<_Alloc>::size_type, size_t>
     && is_same_v<typename allocator_traits<_Alloc>::difference_type, ptrdiff_t>
     && is_same_v<typename allocator_traits<_Alloc>::pointer, typename _Alloc::value_type*>
@@ -885,10 +884,10 @@ _NODISCARD inline const void* _Get_asan_aligned_after(const void* const _End) no
 }
 
 template <class _Container, class = void>
-_INLINE_VAR constexpr size_t _Container_allocation_minimum_asan_alignment = alignof(typename _Container::value_type);
+constexpr size_t _Container_allocation_minimum_asan_alignment = alignof(typename _Container::value_type);
 
 template <class _Container>
-_INLINE_VAR constexpr size_t _Container_allocation_minimum_asan_alignment<_Container,
+constexpr size_t _Container_allocation_minimum_asan_alignment<_Container,
     void_t<decltype(_Container::allocator_type::_Minimum_asan_allocation_alignment)>> =
     (_STD max)(
         alignof(typename _Container::value_type), _Container::allocator_type::_Minimum_asan_allocation_alignment);
@@ -1986,10 +1985,9 @@ void uninitialized_fill(const _NoThrowFwdIt _First, const _NoThrowFwdIt _Last, c
 }
 
 template <class _NoThrowFwdIt>
-_INLINE_VAR constexpr bool _Use_memset_value_construct_v =
-    conjunction_v<bool_constant<_Iterator_is_contiguous<_NoThrowFwdIt>>, is_scalar<_Iter_value_t<_NoThrowFwdIt>>,
-        negation<is_volatile<remove_reference_t<_Iter_ref_t<_NoThrowFwdIt>>>>,
-        negation<is_member_pointer<_Iter_value_t<_NoThrowFwdIt>>>>;
+constexpr bool _Use_memset_value_construct_v = conjunction_v<bool_constant<_Iterator_is_contiguous<_NoThrowFwdIt>>,
+    is_scalar<_Iter_value_t<_NoThrowFwdIt>>, negation<is_volatile<remove_reference_t<_Iter_ref_t<_NoThrowFwdIt>>>>,
+    negation<is_member_pointer<_Iter_value_t<_NoThrowFwdIt>>>>;
 
 template <class _Ptr>
 _Ptr _Zero_range(const _Ptr _First, const _Ptr _Last) { // fill [_First, _Last) with zeroes
@@ -2159,15 +2157,15 @@ _NODISCARD constexpr bool _Allocators_equal(const _Alloc& _Lhs, const _Alloc& _R
 
 #if _HAS_CXX23
 template <class _Ty, class = void>
-inline constexpr bool _Has_member_from_primary = false;
+constexpr bool _Has_member_from_primary = false;
 template <class _Ty>
-inline constexpr bool _Has_member_from_primary<_Ty, void_t<typename _Ty::_From_primary>> = true;
+constexpr bool _Has_member_from_primary<_Ty, void_t<typename _Ty::_From_primary>> = true;
 
 // Avoid using allocate_at_least when the allocator publicly derives from std::allocator:
 // "old" allocators might hide allocate and deallocate but fail to hide allocate_at_least.
 // Also avoid using allocate_at_least from std::allocator itself because it currently doesn't do anything useful.
 template <class _Alloc>
-inline constexpr bool _Should_allocate_at_least =
+constexpr bool _Should_allocate_at_least =
     !_Has_member_from_primary<_Alloc>
     && _Has_member_allocate_at_least<_Alloc, typename allocator_traits<_Alloc>::size_type>;
 #endif // _HAS_CXX23
@@ -2271,13 +2269,13 @@ template <class _Ty1, class _Ty2>
 void _Deduce_as_pair(const pair<_Ty1, _Ty2>&); // not defined
 
 template <class _Ty, class = void>
-_INLINE_VAR constexpr bool _Is_deducible_as_pair = false;
+constexpr bool _Is_deducible_as_pair = false;
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _Is_deducible_as_pair<_Ty, decltype(_STD _Deduce_as_pair(_STD declval<_Ty>()))> = true;
+constexpr bool _Is_deducible_as_pair<_Ty, decltype(_STD _Deduce_as_pair(_STD declval<_Ty>()))> = true;
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _Is_cv_pair = _Is_specialization_v<remove_cv_t<_Ty>, pair>;
+constexpr bool _Is_cv_pair = _Is_specialization_v<remove_cv_t<_Ty>, pair>;
 
 template <class _Ty>
 const _Ty& _Normally_bind(_Identity_t<const _Ty&>); // not defined
@@ -2289,10 +2287,10 @@ template <class _Ty, class _Uty>
 using _Normally_bound_ref = decltype(_STD _Normally_bind<_Ty>(_STD declval<_Uty>()));
 
 template <class _Ty, class _Uty, class = void>
-_INLINE_VAR constexpr bool _Is_normally_bindable = false;
+constexpr bool _Is_normally_bindable = false;
 
 template <class _Ty, class _Uty>
-_INLINE_VAR constexpr bool _Is_normally_bindable<_Ty, _Uty, void_t<_Normally_bound_ref<_Ty, _Uty>>> = true;
+constexpr bool _Is_normally_bindable<_Ty, _Uty, void_t<_Normally_bound_ref<_Ty, _Uty>>> = true;
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _Ty, class _Alloc, class... _Types, enable_if_t<!_Is_cv_pair<_Ty>, int> = 0>
@@ -2577,10 +2575,10 @@ _EXPORT_STD inline void* align(size_t _Bound, size_t _Size, void*& _Ptr, size_t&
 }
 
 template <class _Ty, class = void>
-_INLINE_VAR constexpr bool _Is_transparent_v = false;
+constexpr bool _Is_transparent_v = false;
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _Is_transparent_v<_Ty, void_t<typename _Ty::is_transparent>> = true;
+constexpr bool _Is_transparent_v<_Ty, void_t<typename _Ty::is_transparent>> = true;
 
 template <class _Ty>
 struct _Is_transparent : bool_constant<_Is_transparent_v<_Ty>> {};

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -886,7 +886,7 @@ constexpr size_t _Traits_rfind_not_ch(_In_reads_(_Hay_size) const _Traits_ptr_t<
 }
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _Is_EcharT = _Is_any_of_v<_Ty, char, wchar_t,
+constexpr bool _Is_EcharT = _Is_any_of_v<_Ty, char, wchar_t,
 #ifdef __cpp_char8_t
     char8_t,
 #endif // defined(__cpp_char8_t)
@@ -1637,9 +1637,9 @@ basic_string_view(_Range&&) -> basic_string_view<_RANGES range_value_t<_Range>>;
 
 namespace ranges {
     template <class _Elem, class _Traits>
-    inline constexpr bool enable_view<basic_string_view<_Elem, _Traits>> = true;
+    constexpr bool enable_view<basic_string_view<_Elem, _Traits>> = true;
     template <class _Elem, class _Traits>
-    inline constexpr bool enable_borrowed_range<basic_string_view<_Elem, _Traits>> = true;
+    constexpr bool enable_borrowed_range<basic_string_view<_Elem, _Traits>> = true;
 } // namespace ranges
 #endif // _HAS_CXX20
 
@@ -2307,7 +2307,7 @@ public:
 
 // get _Ty's size after being EBCO'd
 template <class _Ty>
-_INLINE_VAR constexpr size_t _Size_after_ebco_v = is_empty_v<_Ty> ? 0 : sizeof(_Ty);
+constexpr size_t _Size_after_ebco_v = is_empty_v<_Ty> ? 0 : sizeof(_Ty);
 
 struct _String_constructor_concat_tag {
     // tag to select constructors used by basic_string's concatenation operators (operator+)

--- a/stl/inc/xtr1common
+++ b/stl/inc/xtr1common
@@ -70,15 +70,15 @@ using conditional_t = typename conditional<_Test, _Ty1, _Ty2>::type;
 
 #ifdef __clang__
 _EXPORT_STD template <class _Ty1, class _Ty2>
-_INLINE_VAR constexpr bool is_same_v = __is_same(_Ty1, _Ty2);
+constexpr bool is_same_v = __is_same(_Ty1, _Ty2);
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 struct is_same : bool_constant<__is_same(_Ty1, _Ty2)> {};
 #else // ^^^ Clang / not Clang vvv
 _EXPORT_STD template <class, class>
-_INLINE_VAR constexpr bool is_same_v = false; // determine whether arguments are the same type
+constexpr bool is_same_v = false; // determine whether arguments are the same type
 template <class _Ty>
-_INLINE_VAR constexpr bool is_same_v<_Ty, _Ty> = true;
+constexpr bool is_same_v<_Ty, _Ty> = true;
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 struct is_same : bool_constant<is_same_v<_Ty1, _Ty2>> {};
@@ -164,10 +164,10 @@ struct disjunction<_First, _Rest...> : _Disjunction<_First::value, _First, _Rest
 };
 
 _EXPORT_STD template <class... _Traits>
-_INLINE_VAR constexpr bool disjunction_v = disjunction<_Traits...>::value;
+constexpr bool disjunction_v = disjunction<_Traits...>::value;
 
 template <class _Ty, class... _Types>
-_INLINE_VAR constexpr bool _Is_any_of_v = // true if and only if _Ty is in _Types
+constexpr bool _Is_any_of_v = // true if and only if _Ty is in _Types
 #if _HAS_CXX17
     (is_same_v<_Ty, _Types> || ...);
 #else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
@@ -185,8 +185,7 @@ _EXPORT_STD _NODISCARD constexpr bool is_constant_evaluated() noexcept {
 #endif // _HAS_CXX20
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_integral_v = _Is_any_of_v<remove_cv_t<_Ty>, bool, char, signed char, unsigned char,
-    wchar_t,
+constexpr bool is_integral_v = _Is_any_of_v<remove_cv_t<_Ty>, bool, char, signed char, unsigned char, wchar_t,
 #ifdef __cpp_char8_t
     char8_t,
 #endif // defined(__cpp_char8_t)
@@ -196,13 +195,13 @@ _EXPORT_STD template <class _Ty>
 struct is_integral : bool_constant<is_integral_v<_Ty>> {};
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_floating_point_v = _Is_any_of_v<remove_cv_t<_Ty>, float, double, long double>;
+constexpr bool is_floating_point_v = _Is_any_of_v<remove_cv_t<_Ty>, float, double, long double>;
 
 _EXPORT_STD template <class _Ty>
 struct is_floating_point : bool_constant<is_floating_point_v<_Ty>> {};
 
 _EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr bool is_arithmetic_v = // determine whether _Ty is an arithmetic type
+constexpr bool is_arithmetic_v = // determine whether _Ty is an arithmetic type
     is_integral_v<_Ty> || is_floating_point_v<_Ty>;
 
 _EXPORT_STD template <class _Ty>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5827,7 +5827,7 @@ struct _Vector_alg_in_find_is_safe_object_pointers<_Ty1*, _Ty2*>
 
 // Can we activate the vector algorithms for find/count?
 template <class _Iter, class _Ty, class _Elem = _Iter_value_t<_Iter>>
-constexpr bool _Vector_alg_in_find_is_safe =
+_INLINE_VAR constexpr bool _Vector_alg_in_find_is_safe =
     // The iterator must be contiguous so we can get raw pointers.
     _Iterator_is_contiguous<_Iter>
     // The iterator must not be volatile.

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -705,10 +705,10 @@ struct _Unused_parameter { // generic unused parameter struct
 };
 
 template <class _Ty, class = void> // checks whether a container/view is a non-customized specialization
-_INLINE_VAR constexpr bool _Has_unchecked_begin_end = false;
+constexpr bool _Has_unchecked_begin_end = false;
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _Has_unchecked_begin_end<_Ty,
+constexpr bool _Has_unchecked_begin_end<_Ty,
     void_t<decltype(_STD declval<_Ty&>()._Unchecked_begin()), decltype(_STD declval<_Ty&>()._Unchecked_end())>> = true;
 
 template <class _Ty>
@@ -1186,49 +1186,49 @@ template <class _Iter>
 using _Iter_cat_t = typename iterator_traits<_Iter>::iterator_category;
 
 template <class _Ty, class = void>
-_INLINE_VAR constexpr bool _Is_iterator_v = false;
+constexpr bool _Is_iterator_v = false;
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _Is_iterator_v<_Ty, void_t<_Iter_cat_t<_Ty>>> = true;
+constexpr bool _Is_iterator_v<_Ty, void_t<_Iter_cat_t<_Ty>>> = true;
 
 template <class _Ty>
 struct _Is_iterator : bool_constant<_Is_iterator_v<_Ty>> {};
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Is_cpp17_input_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, input_iterator_tag>;
+constexpr bool _Is_cpp17_input_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, input_iterator_tag>;
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Is_ranges_input_iter_v =
+constexpr bool _Is_ranges_input_iter_v =
 #if _HAS_CXX20
     (input_iterator<_Iter> && sentinel_for<_Iter, _Iter>) ||
 #endif
     _Is_cpp17_input_iter_v<_Iter>;
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Is_cpp17_fwd_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, forward_iterator_tag>;
+constexpr bool _Is_cpp17_fwd_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, forward_iterator_tag>;
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Is_ranges_fwd_iter_v =
+constexpr bool _Is_ranges_fwd_iter_v =
 #if _HAS_CXX20
     forward_iterator<_Iter> ||
 #endif
     _Is_cpp17_fwd_iter_v<_Iter>;
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Is_cpp17_bidi_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, bidirectional_iterator_tag>;
+constexpr bool _Is_cpp17_bidi_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, bidirectional_iterator_tag>;
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Is_ranges_bidi_iter_v =
+constexpr bool _Is_ranges_bidi_iter_v =
 #if _HAS_CXX20
     bidirectional_iterator<_Iter> ||
 #endif
     _Is_cpp17_bidi_iter_v<_Iter>;
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Is_cpp17_random_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, random_access_iterator_tag>;
+constexpr bool _Is_cpp17_random_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, random_access_iterator_tag>;
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Is_ranges_random_iter_v =
+constexpr bool _Is_ranges_random_iter_v =
 #if _HAS_CXX20
     random_access_iterator<_Iter> ||
 #endif
@@ -1254,17 +1254,17 @@ constexpr void _Verify_range(const _Ty* const _First, const _Ty* const _Last) no
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 
 template <class _Iter, class = void>
-_INLINE_VAR constexpr bool _Allow_inheriting_unwrap_v = true;
+constexpr bool _Allow_inheriting_unwrap_v = true;
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Allow_inheriting_unwrap_v<_Iter, void_t<typename _Iter::_Prevent_inheriting_unwrap>> =
+constexpr bool _Allow_inheriting_unwrap_v<_Iter, void_t<typename _Iter::_Prevent_inheriting_unwrap>> =
     is_same_v<_Iter, typename _Iter::_Prevent_inheriting_unwrap>;
 
 template <class _Iter, class _Sentinel = _Iter, class = void>
-_INLINE_VAR constexpr bool _Range_verifiable_v = false;
+constexpr bool _Range_verifiable_v = false;
 
 template <class _Iter, class _Sentinel>
-_INLINE_VAR constexpr bool _Range_verifiable_v<_Iter, _Sentinel,
+constexpr bool _Range_verifiable_v<_Iter, _Sentinel,
     void_t<decltype(_Verify_range(_STD declval<const _Iter&>(), _STD declval<const _Sentinel&>()))>> =
     _Allow_inheriting_unwrap_v<_Iter>;
 
@@ -1281,17 +1281,17 @@ constexpr void _Adl_verify_range(const _Iter& _First, const _Sentinel& _Last) {
 }
 
 template <class _Iter, class = void>
-_INLINE_VAR constexpr bool _Unwrappable_v = false;
+constexpr bool _Unwrappable_v = false;
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Unwrappable_v<_Iter,
+constexpr bool _Unwrappable_v<_Iter,
     void_t<decltype(_STD declval<_Remove_cvref_t<_Iter>&>()._Seek_to(_STD declval<_Iter>()._Unwrapped()))>> =
     _Allow_inheriting_unwrap_v<_Remove_cvref_t<_Iter>>;
 
 template <class _Iter, class = void>
-_INLINE_VAR constexpr bool _Has_nothrow_unwrapped = false;
+constexpr bool _Has_nothrow_unwrapped = false;
 template <class _Iter>
-_INLINE_VAR constexpr bool _Has_nothrow_unwrapped<_Iter, void_t<decltype(_STD declval<_Iter>()._Unwrapped())>> =
+constexpr bool _Has_nothrow_unwrapped<_Iter, void_t<decltype(_STD declval<_Iter>()._Unwrapped())>> =
     noexcept(_STD declval<_Iter>()._Unwrapped());
 
 template <class _Iter>
@@ -1311,15 +1311,14 @@ template <class _Iter>
 using _Unwrapped_t = _Remove_cvref_t<decltype(_STD _Get_unwrapped(_STD declval<_Iter>()))>;
 
 template <class _Iter, class = bool>
-_INLINE_VAR constexpr bool _Do_unwrap_when_unverified_v = false;
+constexpr bool _Do_unwrap_when_unverified_v = false;
 
 template <class _Iter>
-_INLINE_VAR constexpr bool
-    _Do_unwrap_when_unverified_v<_Iter, decltype(static_cast<bool>(_Iter::_Unwrap_when_unverified))> =
-        static_cast<bool>(_Iter::_Unwrap_when_unverified);
+constexpr bool _Do_unwrap_when_unverified_v<_Iter, decltype(static_cast<bool>(_Iter::_Unwrap_when_unverified))> =
+    static_cast<bool>(_Iter::_Unwrap_when_unverified);
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Unwrappable_for_unverified_v =
+constexpr bool _Unwrappable_for_unverified_v =
     _Unwrappable_v<_Iter> && _Do_unwrap_when_unverified_v<_Remove_cvref_t<_Iter>>;
 
 template <class _Iter>
@@ -1344,22 +1343,21 @@ struct _Distance_unknown {
 };
 
 template <class _Diff>
-_INLINE_VAR constexpr _Diff _Max_possible_v{static_cast<_Make_unsigned_like_t<_Diff>>(-1) >> 1};
+constexpr _Diff _Max_possible_v{static_cast<_Make_unsigned_like_t<_Diff>>(-1) >> 1};
 
 template <class _Diff>
-_INLINE_VAR constexpr _Diff _Min_possible_v{-_Max_possible_v<_Diff> - 1};
+constexpr _Diff _Min_possible_v{-_Max_possible_v<_Diff> - 1};
 
 template <class _Iter, class = void>
-_INLINE_VAR constexpr bool _Offset_verifiable_v = false;
+constexpr bool _Offset_verifiable_v = false;
 
 template <class _Iter>
-_INLINE_VAR constexpr bool
+constexpr bool
     _Offset_verifiable_v<_Iter, void_t<decltype(_STD declval<const _Iter&>()._Verify_offset(_Iter_diff_t<_Iter>{}))>> =
         true;
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Unwrappable_for_offset_v =
-    _Unwrappable_v<_Iter> && _Offset_verifiable_v<_Remove_cvref_t<_Iter>>;
+constexpr bool _Unwrappable_for_offset_v = _Unwrappable_v<_Iter> && _Offset_verifiable_v<_Remove_cvref_t<_Iter>>;
 
 template <class _Iter, class _Diff>
 _NODISCARD constexpr decltype(auto) _Get_unwrapped_n(_Iter&& _It, const _Diff _Off) {
@@ -1388,10 +1386,10 @@ _NODISCARD constexpr decltype(auto) _Get_unwrapped_n(_Iter&& _It, const _Diff _O
 }
 
 template <class _Iter, class _UIter, class = void>
-_INLINE_VAR constexpr bool _Wrapped_seekable_v = false;
+constexpr bool _Wrapped_seekable_v = false;
 
 template <class _Iter, class _UIter>
-_INLINE_VAR constexpr bool
+constexpr bool
     _Wrapped_seekable_v<_Iter, _UIter, void_t<decltype(_STD declval<_Iter&>()._Seek_to(_STD declval<_UIter>()))>> =
         true;
 
@@ -1444,7 +1442,7 @@ _EXPORT_STD template <class _Ty>
 struct is_execution_policy : false_type {};
 
 _EXPORT_STD template <class _Ty>
-inline constexpr bool is_execution_policy_v = is_execution_policy<_Ty>::value;
+constexpr bool is_execution_policy_v = is_execution_policy<_Ty>::value;
 
 // Note: The noexcept specifiers on all parallel algorithm overloads enforce termination as per
 // N4950 [execpol.seq]/2, [execpol.par]/2, [execpol.parunseq]/2, and [execpol.unseq]/2
@@ -1606,10 +1604,10 @@ _NODISCARD _CONSTEXPR17 _BidIt prev(
 }
 
 template <class _Iter, class _Pointer, bool = is_pointer_v<_Remove_cvref_t<_Iter>>>
-_INLINE_VAR constexpr bool _Has_nothrow_operator_arrow = _Is_nothrow_convertible_v<_Iter, _Pointer>;
+constexpr bool _Has_nothrow_operator_arrow = _Is_nothrow_convertible_v<_Iter, _Pointer>;
 
 template <class _Iter, class _Pointer>
-_INLINE_VAR constexpr bool _Has_nothrow_operator_arrow<_Iter, _Pointer, false> =
+constexpr bool _Has_nothrow_operator_arrow<_Iter, _Pointer, false> =
     noexcept(_STD _Fake_copy_init<_Pointer>(_STD declval<_Iter>().operator->()));
 
 _EXPORT_STD template <class _BidIt>
@@ -1909,7 +1907,7 @@ _NODISCARD _CONSTEXPR17 reverse_iterator<_BidIt> make_reverse_iterator(_BidIt _I
 #if _HAS_CXX20
 template <class _BidIt1, class _BidIt2>
     requires (!sized_sentinel_for<_BidIt1, _BidIt2>)
-inline constexpr bool disable_sized_sentinel_for<reverse_iterator<_BidIt1>, reverse_iterator<_BidIt2>> = true;
+constexpr bool disable_sized_sentinel_for<reverse_iterator<_BidIt1>, reverse_iterator<_BidIt2>> = true;
 #endif // _HAS_CXX20
 
 _EXPORT_STD template <class _Container>
@@ -2440,14 +2438,14 @@ _NODISCARD constexpr const_sentinel<_Sent> make_const_sentinel(_Sent _Se) noexce
 
 namespace ranges {
     template <class>
-    inline constexpr bool _Has_complete_elements = false;
+    constexpr bool _Has_complete_elements = false;
 
     template <class _Ty>
         requires requires(_Ty& __t) { sizeof(__t[0]); }
-    inline constexpr bool _Has_complete_elements<_Ty> = true;
+    constexpr bool _Has_complete_elements<_Ty> = true;
 
     _EXPORT_STD template <class>
-    inline constexpr bool enable_borrowed_range = false;
+    constexpr bool enable_borrowed_range = false;
 
     template <class _Rng>
     concept _Should_range_access = is_lvalue_reference_v<_Rng> || enable_borrowed_range<remove_cvref_t<_Rng>>;
@@ -3081,7 +3079,7 @@ namespace ranges {
     }
 
     _EXPORT_STD template <class>
-    inline constexpr bool disable_sized_range = false;
+    constexpr bool disable_sized_range = false;
 
     namespace _Size {
 #if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1681199
@@ -3324,7 +3322,7 @@ namespace ranges {
     class view_interface;
 
     _EXPORT_STD template <class _Ty>
-    inline constexpr bool enable_view =
+    constexpr bool enable_view =
         derived_from<_Ty, view_base> || _Strictly_derived_from_specialization_of<_Ty, view_interface>;
 
     _EXPORT_STD template <class _Ty>
@@ -4040,7 +4038,7 @@ namespace ranges {
         -> subrange<iterator_t<_Rng>, sentinel_t<_Rng>, subrange_kind::sized>;
 
     template <class _It, class _Se, subrange_kind _Ki>
-    inline constexpr bool enable_borrowed_range<subrange<_It, _Se, _Ki>> = true;
+    constexpr bool enable_borrowed_range<subrange<_It, _Se, _Ki>> = true;
 
     _EXPORT_STD template <size_t _Idx, class _It, class _Se, subrange_kind _Ki>
         requires ((_Idx == 0 && copyable<_It>) || _Idx == 1)
@@ -4448,7 +4446,7 @@ _NODISCARD _CONSTEXPR17 move_iterator<_Iter> make_move_iterator(_Iter _It) noexc
 #if _HAS_CXX20
 template <class _Iter1, class _Iter2>
     requires (!sized_sentinel_for<_Iter1, _Iter2>)
-inline constexpr bool disable_sized_sentinel_for<move_iterator<_Iter1>, move_iterator<_Iter2>> = true;
+constexpr bool disable_sized_sentinel_for<move_iterator<_Iter1>, move_iterator<_Iter2>> = true;
 
 _EXPORT_STD struct unreachable_sentinel_t;
 namespace _Unreachable_sentinel_detail {
@@ -4470,7 +4468,7 @@ _EXPORT_STD inline constexpr unreachable_sentinel_t unreachable_sentinel{};
 #if _HAS_CXX20
 // When concepts are available, we can detect arbitrary contiguous iterators.
 template <class _Iter>
-inline constexpr bool _Iterator_is_contiguous = contiguous_iterator<_Iter>;
+constexpr bool _Iterator_is_contiguous = contiguous_iterator<_Iter>;
 
 template <class _Iter>
 _NODISCARD constexpr auto _To_address(const _Iter& _Val) noexcept {
@@ -4480,7 +4478,7 @@ _NODISCARD constexpr auto _To_address(const _Iter& _Val) noexcept {
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 // When concepts aren't available, we can detect pointers. (Iterators should be unwrapped before using this.)
 template <class _Iter>
-_INLINE_VAR constexpr bool _Iterator_is_contiguous = is_pointer_v<_Iter>;
+constexpr bool _Iterator_is_contiguous = is_pointer_v<_Iter>;
 
 template <class _Iter>
 _NODISCARD constexpr auto _To_address(const _Iter& _Val) noexcept {
@@ -4497,19 +4495,18 @@ _NODISCARD constexpr auto _To_address(const move_iterator<_Iter>& _Val) noexcept
 // _Iterators_are_contiguous<_Iter1, _Iter2> reports whether both iterators are known to be contiguous.
 
 template <class _Iter1, class _Iter2>
-_INLINE_VAR constexpr bool _Iterators_are_contiguous =
-    _Iterator_is_contiguous<_Iter1> && _Iterator_is_contiguous<_Iter2>;
+constexpr bool _Iterators_are_contiguous = _Iterator_is_contiguous<_Iter1> && _Iterator_is_contiguous<_Iter2>;
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Iterator_is_volatile = is_volatile_v<remove_reference_t<_Iter_ref_t<_Iter>>>;
+constexpr bool _Iterator_is_volatile = is_volatile_v<remove_reference_t<_Iter_ref_t<_Iter>>>;
 
 template <class _Source, class _Dest>
-_INLINE_VAR constexpr bool _Is_pointer_address_convertible = is_void_v<_Source>
-                                                          || is_void_v<_Dest>
-                                                          // NOTE: is_same_v is required for function pointers to work
-                                                          || is_same_v<remove_cv_t<_Source>, remove_cv_t<_Dest>>
+constexpr bool _Is_pointer_address_convertible = is_void_v<_Source>
+                                              || is_void_v<_Dest>
+                                              // NOTE: is_same_v is required for function pointers to work
+                                              || is_same_v<remove_cv_t<_Source>, remove_cv_t<_Dest>>
 #ifdef __cpp_lib_is_pointer_interconvertible
-                                                          || is_pointer_interconvertible_base_of_v<_Dest, _Source>
+                                              || is_pointer_interconvertible_base_of_v<_Dest, _Source>
 #endif // defined(__cpp_lib_is_pointer_interconvertible)
     ;
 
@@ -4632,7 +4629,7 @@ _OutCtgIt _Copy_memmove_n(_CtgIt _First, const size_t _Count, _OutCtgIt _Dest) {
 }
 
 template <class _It, bool _RequiresMutable = false>
-_INLINE_VAR constexpr bool _Is_vb_iterator = false;
+constexpr bool _Is_vb_iterator = false;
 
 template <class _VbIt, class _OutIt>
 _CONSTEXPR20 _OutIt _Copy_vbool(_VbIt _First, _VbIt _Last, _OutIt _Dest);
@@ -5092,20 +5089,20 @@ struct _Is_character_or_byte_or_bool<byte> : true_type {};
 // _Fill_memset_is_safe determines if _FwdIt and _Ty are eligible for memset optimization in fill.
 // Need to explicitly test for volatile because _Unwrap_enum_t discards qualifiers.
 template <class _FwdIt, class _Ty, bool = _Iterator_is_contiguous<_FwdIt>>
-_INLINE_VAR constexpr bool _Fill_memset_is_safe = conjunction_v<is_scalar<_Ty>,
+constexpr bool _Fill_memset_is_safe = conjunction_v<is_scalar<_Ty>,
     _Is_character_or_byte_or_bool<_Unwrap_enum_t<remove_reference_t<_Iter_ref_t<_FwdIt>>>>,
     negation<is_volatile<remove_reference_t<_Iter_ref_t<_FwdIt>>>>, is_assignable<_Iter_ref_t<_FwdIt>, const _Ty&>>;
 
 template <class _FwdIt, class _Ty>
-_INLINE_VAR constexpr bool _Fill_memset_is_safe<_FwdIt, _Ty, false> = false;
+constexpr bool _Fill_memset_is_safe<_FwdIt, _Ty, false> = false;
 
 template <class _FwdIt, class _Ty, bool = _Iterator_is_contiguous<_FwdIt>>
-_INLINE_VAR constexpr bool _Fill_zero_memset_is_safe =
+constexpr bool _Fill_zero_memset_is_safe =
     conjunction_v<is_scalar<_Ty>, is_scalar<_Iter_value_t<_FwdIt>>, negation<is_member_pointer<_Iter_value_t<_FwdIt>>>,
         negation<is_volatile<remove_reference_t<_Iter_ref_t<_FwdIt>>>>, is_assignable<_Iter_ref_t<_FwdIt>, const _Ty&>>;
 
 template <class _FwdIt, class _Ty>
-_INLINE_VAR constexpr bool _Fill_zero_memset_is_safe<_FwdIt, _Ty, false> = false;
+constexpr bool _Fill_zero_memset_is_safe<_FwdIt, _Ty, false> = false;
 
 template <class _CtgIt, class _Ty>
 void _Fill_memset(_CtgIt _Dest, const _Ty _Val, const size_t _Count) {
@@ -5258,15 +5255,15 @@ namespace ranges {
 #endif // _HAS_CXX20
 
 template <class _Ty1, class _Ty2, class = void>
-_INLINE_VAR constexpr bool _Can_compare_with_operator_equal = false;
+constexpr bool _Can_compare_with_operator_equal = false;
 
 template <class _Ty1, class _Ty2>
-_INLINE_VAR constexpr bool
+constexpr bool
     _Can_compare_with_operator_equal<_Ty1, _Ty2, void_t<decltype(_STD declval<_Ty1&>() == _STD declval<_Ty2&>())>> =
         true;
 
 template <class _Ty1, class _Ty2>
-_INLINE_VAR constexpr bool _Is_pointer_address_comparable =
+constexpr bool _Is_pointer_address_comparable =
     _Can_compare_with_operator_equal<_Ty1*, _Ty2*>
     && (_Is_pointer_address_convertible<_Ty1, _Ty2> || _Is_pointer_address_convertible<_Ty2, _Ty1>);
 
@@ -5281,7 +5278,7 @@ _INLINE_VAR constexpr bool _Is_pointer_address_comparable =
 #pragma warning(disable : 4806) // no value of type 'bool' promoted to type 'char' can equal the given constant
 template <class _Elem1, class _Elem2,
     bool = sizeof(_Elem1) == sizeof(_Elem2) && is_integral_v<_Elem1> && is_integral_v<_Elem2>>
-_INLINE_VAR constexpr bool _Can_memcmp_elements =
+constexpr bool _Can_memcmp_elements =
     is_same_v<_Elem1, bool> || is_same_v<_Elem2, bool> || static_cast<_Elem1>(-1) == static_cast<_Elem2>(-1);
 #pragma warning(pop)
 
@@ -5296,46 +5293,44 @@ inline constexpr bool _Can_memcmp_elements<byte, byte, false> = true;
 // Pointer elements are eligible for memcmp when they point to the same type, ignoring cv-qualification.
 // This handles pointers to object types, pointers to void, and pointers to function types.
 template <class _Ty1, class _Ty2>
-_INLINE_VAR constexpr bool _Can_memcmp_elements<_Ty1*, _Ty2*, false> = _Is_pointer_address_comparable<_Ty1, _Ty2>;
+constexpr bool _Can_memcmp_elements<_Ty1*, _Ty2*, false> = _Is_pointer_address_comparable<_Ty1, _Ty2>;
 
 template <class _Elem1, class _Elem2>
-_INLINE_VAR constexpr bool _Can_memcmp_elements<_Elem1, _Elem2, false> = false;
+constexpr bool _Can_memcmp_elements<_Elem1, _Elem2, false> = false;
 
 // _Can_memcmp_elements_with_pred<_Elem1, _Elem2, _Pr> reports whether the memcmp optimization is applicable,
 // given contiguously stored elements. (This avoids having to repeat the metaprogramming that finds the element types.)
 // _Elem1 and _Elem2 aren't top-level const here.
 template <class _Elem1, class _Elem2, class _Pr>
-_INLINE_VAR constexpr bool _Can_memcmp_elements_with_pred = false;
+constexpr bool _Can_memcmp_elements_with_pred = false;
 
 // With equal_to<_Elem3> we need to make sure that both _Elem1 and _Elem2 are convertible to _Elem3 without changing
 // object representation (we use _Iter_copy_cat for this task) and _Elem3 can be safely memcmp'ed with itself
 template <class _Elem1, class _Elem2, class _Elem3>
-_INLINE_VAR constexpr bool _Can_memcmp_elements_with_pred<_Elem1, _Elem2, equal_to<_Elem3>> =
+constexpr bool _Can_memcmp_elements_with_pred<_Elem1, _Elem2, equal_to<_Elem3>> =
     _Iter_copy_cat<_Elem1*, _Elem3*>::_Bitcopy_constructible && _Iter_copy_cat<_Elem2*, _Elem3*>::_Bitcopy_constructible
     && _Can_memcmp_elements<remove_cv_t<_Elem3>, remove_cv_t<_Elem3>>;
 
 // equal_to<> is transparent.
 template <class _Elem1, class _Elem2>
-_INLINE_VAR constexpr bool _Can_memcmp_elements_with_pred<_Elem1, _Elem2, equal_to<>> =
-    _Can_memcmp_elements<_Elem1, _Elem2>;
+constexpr bool _Can_memcmp_elements_with_pred<_Elem1, _Elem2, equal_to<>> = _Can_memcmp_elements<_Elem1, _Elem2>;
 
 #if _HAS_CXX20
 // ranges::equal_to is also transparent.
 template <class _Elem1, class _Elem2>
-_INLINE_VAR constexpr bool _Can_memcmp_elements_with_pred<_Elem1, _Elem2, _RANGES equal_to> =
-    _Can_memcmp_elements<_Elem1, _Elem2>;
+constexpr bool _Can_memcmp_elements_with_pred<_Elem1, _Elem2, _RANGES equal_to> = _Can_memcmp_elements<_Elem1, _Elem2>;
 #endif // _HAS_CXX20
 
 // _Equal_memcmp_is_safe<_Iter1, _Iter2, _Pr> reports whether we can activate the memcmp optimization
 // for arbitrary iterators and predicates.
 // It ignores top-level constness on the iterators and on the elements.
 template <class _Iter1, class _Iter2, class _Pr>
-_INLINE_VAR constexpr bool _Equal_memcmp_is_safe_helper =
+constexpr bool _Equal_memcmp_is_safe_helper =
     _Iterators_are_contiguous<_Iter1, _Iter2> && !_Iterator_is_volatile<_Iter1> && !_Iterator_is_volatile<_Iter2>
     && _Can_memcmp_elements_with_pred<_Iter_value_t<_Iter1>, _Iter_value_t<_Iter2>, _Pr>;
 
 template <class _Iter1, class _Iter2, class _Pr>
-_INLINE_VAR constexpr bool _Equal_memcmp_is_safe =
+constexpr bool _Equal_memcmp_is_safe =
     _Equal_memcmp_is_safe_helper<remove_const_t<_Iter1>, remove_const_t<_Iter2>, _Pr>;
 
 template <class _CtgIt1, class _CtgIt2>
@@ -5609,7 +5604,7 @@ namespace ranges {
 #endif // _HAS_CXX20
 
 template <class _Elem1, class _Elem2>
-_INLINE_VAR constexpr bool _Lex_compare_memcmp_classify_elements = conjunction_v<_Is_character_or_bool<_Elem1>,
+constexpr bool _Lex_compare_memcmp_classify_elements = conjunction_v<_Is_character_or_bool<_Elem1>,
     _Is_character_or_bool<_Elem2>, is_unsigned<_Elem1>, is_unsigned<_Elem2>>;
 
 #ifdef __cpp_lib_byte
@@ -5832,7 +5827,7 @@ struct _Vector_alg_in_find_is_safe_object_pointers<_Ty1*, _Ty2*>
 
 // Can we activate the vector algorithms for find/count?
 template <class _Iter, class _Ty, class _Elem = _Iter_value_t<_Iter>>
-_INLINE_VAR constexpr bool _Vector_alg_in_find_is_safe =
+constexpr bool _Vector_alg_in_find_is_safe =
     // The iterator must be contiguous so we can get raw pointers.
     _Iterator_is_contiguous<_Iter>
     // The iterator must not be volatile.
@@ -6737,7 +6732,7 @@ namespace ranges {
 #endif // _HAS_CXX20
 
 template <class _Iter, class _Pr, class _Elem = _Iter_value_t<_Iter>>
-_INLINE_VAR constexpr bool _Is_min_max_optimization_safe = // Activate the vector algorithms for min_/max_element?
+constexpr bool _Is_min_max_optimization_safe = // Activate the vector algorithms for min_/max_element?
     _Iterator_is_contiguous<_Iter> // The iterator must be contiguous so we can get raw pointers.
     && !_Iterator_is_volatile<_Iter> // The iterator must not be volatile.
     && conjunction_v<disjunction<

--- a/tests/std/include/is_permissive.hpp
+++ b/tests/std/include/is_permissive.hpp
@@ -26,6 +26,6 @@ namespace detail {
 } // namespace detail
 
 template <class T>
-_INLINE_VAR constexpr bool is_permissive_v = detail::PermissiveTest<T>::test();
+constexpr bool is_permissive_v = detail::PermissiveTest<T>::test();
 
 _INLINE_VAR constexpr bool is_permissive = is_permissive_v<int>;

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -19,10 +19,10 @@
 namespace ranges = std::ranges;
 
 template <class>
-inline constexpr bool always_false = false;
+constexpr bool always_false = false;
 
 template <class T>
-inline constexpr T* nullptr_to = nullptr;
+constexpr T* nullptr_to = nullptr;
 
 template <bool>
 struct borrowed { // borrowed<true> is a borrowed_range; borrowed<false> is not
@@ -939,7 +939,7 @@ namespace test {
 
 template <class Category, class Element, test::Sized IsSized, test::CanDifference Diff, test::Common IsCommon,
     test::CanCompare Eq, test::ProxyRef Proxy, test::Copyability Copy>
-inline constexpr bool std::ranges::enable_view<
+constexpr bool std::ranges::enable_view<
     test::range<Category, Element, IsSized, Diff, IsCommon, Eq, Proxy, test::CanView::yes, Copy>> = true;
 
 template <class T>
@@ -953,7 +953,7 @@ template <ranges::contiguous_range R>
 basic_borrowed_range(R&) -> basic_borrowed_range<std::remove_reference_t<ranges::range_reference_t<R>>>;
 
 template <class T>
-inline constexpr bool ranges::enable_borrowed_range<::basic_borrowed_range<T>> = true;
+constexpr bool ranges::enable_borrowed_range<::basic_borrowed_range<T>> = true;
 
 template <int>
 struct unique_tag {};

--- a/tests/std/include/test_mdspan_support.hpp
+++ b/tests/std/include/test_mdspan_support.hpp
@@ -62,13 +62,13 @@ concept NotImplicitlyConstructibleFrom = std::constructible_from<T, Args...> && 
 
 namespace detail {
     template <class T>
-    inline constexpr bool is_extents_v = false;
+    constexpr bool is_extents_v = false;
 
     template <class T, size_t... E>
-    inline constexpr bool is_extents_v<std::extents<T, E...>> = true;
+    constexpr bool is_extents_v<std::extents<T, E...>> = true;
 
     template <class Layout, class Mapping>
-    inline constexpr bool is_mapping_of_v =
+    constexpr bool is_mapping_of_v =
         std::is_same_v<typename Layout::template mapping<typename Mapping::extents_type>, Mapping>;
 
     template <class M>

--- a/tests/std/tests/GH_000140_adl_proof_views/test.compile.pass.cpp
+++ b/tests/std/tests/GH_000140_adl_proof_views/test.compile.pass.cpp
@@ -177,10 +177,10 @@ struct tagged_ints_view {
 };
 
 template <class Tag>
-inline constexpr bool ranges::enable_view<tagged_ints_view<Tag>> = true;
+constexpr bool ranges::enable_view<tagged_ints_view<Tag>> = true;
 
 template <class Tag>
-inline constexpr bool ranges::enable_borrowed_range<tagged_ints_view<Tag>> = true;
+constexpr bool ranges::enable_borrowed_range<tagged_ints_view<Tag>> = true;
 
 struct validating_view_to_join_for_verification {
     constexpr const tagged_ints_view<holder<incomplete>>* begin() const noexcept {

--- a/tests/std/tests/GH_000935_complex_numerical_accuracy/floating_point_utils.hpp
+++ b/tests/std/tests/GH_000935_complex_numerical_accuracy/floating_point_utils.hpp
@@ -15,25 +15,25 @@ namespace fputil {
     using float_bits_t = typename _STD _Floating_type_traits<T>::_Uint_type;
 
     template <typename T>
-    _INLINE_VAR constexpr float_bits_t<T> sign_mask_v = _STD _Floating_type_traits<T>::_Shifted_sign_mask;
+    constexpr float_bits_t<T> sign_mask_v = _STD _Floating_type_traits<T>::_Shifted_sign_mask;
 
     template <typename T>
-    _INLINE_VAR constexpr float_bits_t<T> magnitude_mask_v = ~sign_mask_v<T>;
+    constexpr float_bits_t<T> magnitude_mask_v = ~sign_mask_v<T>;
 
     template <typename T>
-    _INLINE_VAR constexpr float_bits_t<T> exponent_mask_v = _STD _Floating_type_traits<T>::_Shifted_exponent_mask;
+    constexpr float_bits_t<T> exponent_mask_v = _STD _Floating_type_traits<T>::_Shifted_exponent_mask;
 
     template <typename T>
-    _INLINE_VAR constexpr float_bits_t<T> significand_mask_v = magnitude_mask_v<T> & ~exponent_mask_v<T>;
+    constexpr float_bits_t<T> significand_mask_v = magnitude_mask_v<T> & ~exponent_mask_v<T>;
 
     template <typename T>
-    _INLINE_VAR constexpr float_bits_t<T> norm_min_bits_v = significand_mask_v<T> + 1U;
+    constexpr float_bits_t<T> norm_min_bits_v = significand_mask_v<T> + 1U;
 
     template <typename T>
-    _INLINE_VAR constexpr float_bits_t<T> norm_max_bits_v = exponent_mask_v<T> - 1U;
+    constexpr float_bits_t<T> norm_max_bits_v = exponent_mask_v<T> - 1U;
 
     template <typename T>
-    _INLINE_VAR constexpr float_bits_t<T> infinity_bits_v = exponent_mask_v<T>;
+    constexpr float_bits_t<T> infinity_bits_v = exponent_mask_v<T>;
 
     // not affected by abrupt underflow
     template <typename T, std::enable_if_t<std::is_floating_point_v<T>, int> = 0>

--- a/tests/std/tests/LWG3528_make_from_tuple_impl/test.compile.pass.cpp
+++ b/tests/std/tests/LWG3528_make_from_tuple_impl/test.compile.pass.cpp
@@ -27,11 +27,11 @@ enum class D {
 };
 
 template <class T, class Tuple, class = void>
-inline constexpr bool has_make_from_tuple = false;
+constexpr bool has_make_from_tuple = false;
 
 template <class T, class Tuple>
-inline constexpr bool
-    has_make_from_tuple<T, Tuple, std::void_t<decltype(std::make_from_tuple<T>(std::declval<Tuple>()))>> = true;
+constexpr bool has_make_from_tuple<T, Tuple, std::void_t<decltype(std::make_from_tuple<T>(std::declval<Tuple>()))>> =
+    true;
 
 // Test std::make_from_tuple.
 

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -7102,7 +7102,7 @@ namespace msvc {
         };
 
         template <class... Ts>
-        inline constexpr bool check_size = sizeof(std::variant<Ts...>) == sizeof(fake_variant<Ts...>);
+        constexpr bool check_size = sizeof(std::variant<Ts...>) == sizeof(fake_variant<Ts...>);
 
         template <int>
         struct empty {};
@@ -7757,9 +7757,9 @@ namespace msvc {
     } // namespace visit_pointer_to_member
 
     template <class, class = void>
-    inline constexpr bool has_type = false;
+    constexpr bool has_type = false;
     template <class T>
-    inline constexpr bool has_type<T, std::void_t<typename T::type>> = true;
+    constexpr bool has_type<T, std::void_t<typename T::type>> = true;
 
     // Verify that `_Meta_at_<_Meta_list<>, size_t(-1)>` has no member named `type`, and that instantiating it doesn't
     // consume the entire compiler heap.

--- a/tests/std/tests/P0122R7_span/test.cpp
+++ b/tests/std/tests/P0122R7_span/test.cpp
@@ -142,7 +142,7 @@ struct BasicRange {
 
 namespace std::ranges {
     template <typename T, bool Borrowed>
-    inline constexpr bool enable_borrowed_range<BasicRange<T, Borrowed>> = Borrowed;
+    constexpr bool enable_borrowed_range<BasicRange<T, Borrowed>> = Borrowed;
 }
 
 using ContiguousSizedRange = BasicRange<int>;
@@ -154,10 +154,10 @@ template <typename T, size_t Extent = dynamic_extent>
 constexpr void FunctionTakingSpan(type_identity_t<span<T, Extent>>) {}
 
 template <typename U, typename = void>
-inline constexpr bool AsWritableBytesCompilesFor = false;
+constexpr bool AsWritableBytesCompilesFor = false;
 
 template <typename U>
-inline constexpr bool AsWritableBytesCompilesFor<U, void_t<decltype(as_writable_bytes(declval<U>()))>> = true;
+constexpr bool AsWritableBytesCompilesFor<U, void_t<decltype(as_writable_bytes(declval<U>()))>> = true;
 
 constexpr bool test() {
     {

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -8114,7 +8114,7 @@ namespace msvc {
         struct __declspec(empty_bases) many_bases : empty<0>, empty<1>, empty<2>, empty<3> {};
 
         template <class T>
-        inline constexpr bool check_size = sizeof(std::optional<T>) == sizeof(T) + alignof(T);
+        constexpr bool check_size = sizeof(std::optional<T>) == sizeof(T) + alignof(T);
 
         STATIC_ASSERT(check_size<bool>);
         STATIC_ASSERT(check_size<char>);

--- a/tests/std/tests/P0448R4_spanstream/test.cpp
+++ b/tests/std/tests/P0448R4_spanstream/test.cpp
@@ -15,17 +15,17 @@
 using namespace std;
 
 template <class CharT>
-inline constexpr auto input_ptr = "1 2 3 4 5";
+constexpr auto input_ptr = "1 2 3 4 5";
 template <>
 inline constexpr auto input_ptr<wchar_t> = L"1 2 3 4 5";
 
 template <class CharT>
-inline constexpr auto input_view = "1 2 3 4 5"sv;
+constexpr auto input_view = "1 2 3 4 5"sv;
 template <>
 inline constexpr auto input_view<wchar_t> = L"1 2 3 4 5"sv;
 
 template <class CharT>
-inline constexpr array input_std_array{'1', ' ', '2', ' ', '3', ' ', '4', ' ', '5'};
+constexpr array input_std_array{'1', ' ', '2', ' ', '3', ' ', '4', ' ', '5'};
 template <>
 inline constexpr array input_std_array<wchar_t>{L'1', L' ', L'2', L' ', L'3', L' ', L'4', L' ', L'5'};
 

--- a/tests/std/tests/P0768R1_spaceship_cpos/test.cpp
+++ b/tests/std/tests/P0768R1_spaceship_cpos/test.cpp
@@ -34,7 +34,7 @@ template <const auto& CPO, typename E, typename F = E>
 using CpoResult = CpoResultImpl<CPO, E, F>::type;
 
 template <const auto& CPO, typename E, typename F = E>
-inline constexpr bool NoexceptCpo = noexcept(CPO(declval<E>(), declval<F>()));
+constexpr bool NoexceptCpo = noexcept(CPO(declval<E>(), declval<F>()));
 
 // Test when the decayed types differ.
 static_assert(is_same_v<CpoResult<std::strong_order, int, long>, IllFormed>); // [cmp.alg]/1.1

--- a/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
+++ b/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
@@ -27,7 +27,7 @@ template <class Ty>
 concept can_ranges_destroy_at = requires(Ty* ptr) { ranges::destroy_at(ptr); };
 
 template <class Ty, class... Types>
-inline constexpr bool can_construct_at = [] {
+constexpr bool can_construct_at = [] {
     constexpr bool result = can_std_construct_at<Ty, Types...>;
     static_assert(can_ranges_construct_at<Ty, Types...> == result);
     return result;

--- a/tests/std/tests/P0896R4_counted_iterator/test.cpp
+++ b/tests/std/tests/P0896R4_counted_iterator/test.cpp
@@ -12,11 +12,11 @@
 using namespace std;
 
 template <class>
-inline constexpr void* must_be_countable = nullptr;
+constexpr void* must_be_countable = nullptr;
 
 template <input_or_output_iterator I>
     requires requires { typename counted_iterator<I>; }
-inline constexpr bool must_be_countable<I> = true;
+constexpr bool must_be_countable<I> = true;
 
 template <class... Is>
 concept Counted = (must_be_countable<Is> && ...);

--- a/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.compile.pass.cpp
+++ b/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.compile.pass.cpp
@@ -1015,7 +1015,7 @@ namespace special_memory_concepts {
     STATIC_ASSERT(forward_iterator<iterator_archetype<iterator_status::forward>>);
 
     template <class I>
-    inline constexpr bool has_lvalue_reference = std::is_lvalue_reference_v<std::iter_reference_t<I>>;
+    constexpr bool has_lvalue_reference = std::is_lvalue_reference_v<std::iter_reference_t<I>>;
     STATIC_ASSERT(has_lvalue_reference<iterator_archetype<iterator_status::not_input>>);
     STATIC_ASSERT(!has_lvalue_reference<iterator_archetype<iterator_status::not_lvalue_reference>>);
     STATIC_ASSERT(has_lvalue_reference<iterator_archetype<iterator_status::different_reference_and_value>>);
@@ -1023,7 +1023,7 @@ namespace special_memory_concepts {
     STATIC_ASSERT(has_lvalue_reference<iterator_archetype<iterator_status::forward>>);
 
     template <class I>
-    inline constexpr bool same_reference_value =
+    constexpr bool same_reference_value =
         std::same_as<std::remove_cvref_t<std::iter_reference_t<I>>, std::iter_value_t<I>>;
     STATIC_ASSERT(same_reference_value<iterator_archetype<iterator_status::not_input>>);
     STATIC_ASSERT(same_reference_value<iterator_archetype<iterator_status::not_lvalue_reference>>);

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -453,7 +453,7 @@ std::iter_difference_t<iterator_archetype<J>> operator-(
     iterator_archetype<J> const&, sized_sentinel_archetype<I> const&);
 
 template <class I>
-inline constexpr bool std::disable_sized_sentinel_for<sized_sentinel_archetype<11>, I> = true;
+constexpr bool std::disable_sized_sentinel_for<sized_sentinel_archetype<11>, I> = true;
 
 inline constexpr std::size_t sized_sentinel_archetype_max = 12;
 

--- a/tests/std/tests/P0896R4_ranges_subrange/test.compile.pass.cpp
+++ b/tests/std/tests/P0896R4_ranges_subrange/test.compile.pass.cpp
@@ -989,9 +989,9 @@ namespace test_subrange {
 
     // Validate many properties of a specialization of subrange
     template <class>
-    inline constexpr bool is_subrange = false;
+    constexpr bool is_subrange = false;
     template <class I, class S, subrange_kind K>
-    inline constexpr bool is_subrange<subrange<I, S, K>> = true;
+    constexpr bool is_subrange<subrange<I, S, K>> = true;
 
     template <class T>
     struct illformed {
@@ -999,9 +999,9 @@ namespace test_subrange {
     };
 
     template <class T>
-    inline constexpr auto kind_of = illformed<T>{};
+    constexpr auto kind_of = illformed<T>{};
     template <class I, class S, subrange_kind K>
-    inline constexpr auto kind_of<subrange<I, S, K>> = K;
+    constexpr auto kind_of<subrange<I, S, K>> = K;
 
     template <class Subrange, class Rng>
     constexpr bool test_subrange() {

--- a/tests/std/tests/P0896R4_ranges_to_address/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_to_address/test.cpp
@@ -10,9 +10,9 @@
 #include <test_death.hpp>
 
 template <class, template <class...> class>
-inline constexpr bool is_specialization = false;
+constexpr bool is_specialization = false;
 template <class... Args, template <class...> class T>
-inline constexpr bool is_specialization<T<Args...>, T> = true;
+constexpr bool is_specialization<T<Args...>, T> = true;
 
 template <bool IsConst, class C>
 using maybe_const_iter = std::conditional_t<IsConst, typename C::const_iterator, typename C::iterator>;

--- a/tests/std/tests/P0896R4_views_drop/test.cpp
+++ b/tests/std/tests/P0896R4_views_drop/test.cpp
@@ -38,9 +38,9 @@ struct evil_convertible_to_difference {
 constexpr auto pipeline = views::drop(1) | views::drop(1) | views::drop(1) | views::drop(1);
 
 template <class>
-inline constexpr bool is_subrange = false;
+constexpr bool is_subrange = false;
 template <class I, class S, ranges::subrange_kind K>
-inline constexpr bool is_subrange<ranges::subrange<I, S, K>> = true;
+constexpr bool is_subrange<ranges::subrange<I, S, K>> = true;
 
 template <class>
 struct mapped {

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -41,9 +41,9 @@ struct evil_convertible_to_difference {
 constexpr auto pipeline = views::take(7) | views::take(6) | views::take(5) | views::take(4);
 
 template <class>
-inline constexpr bool is_subrange = false;
+constexpr bool is_subrange = false;
 template <class I, class S, ranges::subrange_kind K>
-inline constexpr bool is_subrange<ranges::subrange<I, S, K>> = true;
+constexpr bool is_subrange<ranges::subrange<I, S, K>> = true;
 
 template <class>
 struct mapped {

--- a/tests/std/tests/P1614R2_spaceship/test.cpp
+++ b/tests/std/tests/P1614R2_spaceship/test.cpp
@@ -172,9 +172,9 @@ constexpr bool spaceship_test(const SmallType& smaller, const EqualType& smaller
 }
 
 template <class T>
-inline constexpr bool has_synth_ordered = false;
+constexpr bool has_synth_ordered = false;
 template <class V>
-inline constexpr bool has_synth_ordered<std::pair<const SynthOrdered, V>> = true;
+constexpr bool has_synth_ordered<std::pair<const SynthOrdered, V>> = true;
 template <>
 inline constexpr bool has_synth_ordered<SynthOrdered> = true;
 

--- a/tests/std/tests/P2165R4_tuple_like_common_type/test.compile.pass.cpp
+++ b/tests/std/tests/P2165R4_tuple_like_common_type/test.compile.pass.cpp
@@ -15,8 +15,7 @@ concept CanCommonType = requires { typename common_type<T, U>::type; };
 
 template <class T, class U, class Expected>
     requires CanCommonType<T, U>
-inline constexpr bool test_common_type =
-    same_as<common_type_t<T, U>, Expected> && same_as<common_type_t<U, T>, Expected>;
+constexpr bool test_common_type = same_as<common_type_t<T, U>, Expected> && same_as<common_type_t<U, T>, Expected>;
 
 struct Sentinel {
     bool operator==(const auto&) const; // not defined


### PR DESCRIPTION
Fixes #4533.