### PR TITLE
`<ranges>`: Check and test preconditions for `take_view` and `drop_view`'s constructors

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2950,7 +2950,7 @@ namespace ranges {
             is_nothrow_move_constructible_v<_Vw>) // strengthened
             : _Range(_STD move(_Range_)), _Count{_Count_} {
 #if _CONTAINER_DEBUG_LEVEL > 0
-            _STL_VERIFY(_Count_ >= 0, "Number of elements to take must be non-negative (N4971 [range.take.view]/1");
+            _STL_VERIFY(_Count_ >= 0, "Number of elements to take must be non-negative (N4971 [range.take.view]/1)");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
         }
 
@@ -3370,7 +3370,7 @@ namespace ranges {
             is_nothrow_move_constructible_v<_Vw>) // strengthened
             : _Range(_STD move(_Range_)), _Count{_Count_} {
 #if _CONTAINER_DEBUG_LEVEL > 0
-            _STL_VERIFY(_Count_ >= 0, "Number of elements to drop must be non-negative (N4950 [range.drop.view]/1");
+            _STL_VERIFY(_Count_ >= 0, "Number of elements to drop must be non-negative (N4971 [range.drop.view]/1)");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
         }
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2948,7 +2948,11 @@ namespace ranges {
 
         constexpr explicit take_view(_Vw _Range_, const range_difference_t<_Vw> _Count_) noexcept(
             is_nothrow_move_constructible_v<_Vw>) // strengthened
-            : _Range(_STD move(_Range_)), _Count{_Count_} {}
+            : _Range(_STD move(_Range_)), _Count{_Count_} {
+#if _CONTAINER_DEBUG_LEVEL > 0
+            _STL_VERIFY(_Count_ >= 0, "Number of elements to take must be non-negative (N4971 [range.take.view]/1");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
+        }
 
         _NODISCARD constexpr _Vw base() const& noexcept(is_nothrow_copy_constructible_v<_Vw>) /* strengthened */
             requires copy_constructible<_Vw>

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -479,6 +479,7 @@ tests\P0896R4_views_common
 tests\P0896R4_views_counted
 tests\P0896R4_views_counted_death
 tests\P0896R4_views_drop
+tests\P0896R4_views_drop_death
 tests\P0896R4_views_drop_while
 tests\P0896R4_views_drop_while_death
 tests\P0896R4_views_elements
@@ -494,6 +495,7 @@ tests\P0896R4_views_reverse
 tests\P0896R4_views_single
 tests\P0896R4_views_split
 tests\P0896R4_views_take
+tests\P0896R4_views_take_death
 tests\P0896R4_views_take_while
 tests\P0896R4_views_take_while_death
 tests\P0896R4_views_transform

--- a/tests/std/tests/P0896R4_views_drop_death/env.lst
+++ b/tests/std/tests/P0896R4_views_drop_death/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_drop_death/test.cpp
+++ b/tests/std/tests/P0896R4_views_drop_death/test.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#define _CONTAINER_DEBUG_LEVEL 1
+
+#include <ranges>
+
+#include <test_death.hpp>
+using namespace std;
+
+constexpr int some_ints[] = {0, 1, 2, 3};
+
+void test_constructor_negative_size() {
+    (void) views::drop(some_ints, -3); // Number of elements to drop must be non-negative
+}
+
+int main(int argc, char* argv[]) {
+    std_testing::death_test_executive exec;
+
+#ifdef _DEBUG
+    exec.add_death_tests({
+        test_constructor_negative_size,
+    });
+#endif // _DEBUG
+
+    return exec.run(argc, argv);
+}

--- a/tests/std/tests/P0896R4_views_take_death/env.lst
+++ b/tests/std/tests/P0896R4_views_take_death/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_take_death/test.cpp
+++ b/tests/std/tests/P0896R4_views_take_death/test.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#define _CONTAINER_DEBUG_LEVEL 1
+
+#include <ranges>
+
+#include <test_death.hpp>
+using namespace std;
+
+constexpr int some_ints[] = {0, 1, 2, 3};
+
+void test_constructor_negative_size() {
+    (void) views::drop(some_ints, -3); // Number of elements to take must be non-negative
+}
+
+int main(int argc, char* argv[]) {
+    std_testing::death_test_executive exec;
+
+#ifdef _DEBUG
+    exec.add_death_tests({
+        test_constructor_negative_size,
+    });
+#endif // _DEBUG
+
+    return exec.run(argc, argv);
+}

--- a/tests/std/tests/P0896R4_views_take_death/test.cpp
+++ b/tests/std/tests/P0896R4_views_take_death/test.cpp
@@ -11,7 +11,7 @@ using namespace std;
 constexpr int some_ints[] = {0, 1, 2, 3};
 
 void test_constructor_negative_size() {
-    (void) views::drop(some_ints, -3); // Number of elements to take must be non-negative
+    (void) views::take(some_ints, -3); // Number of elements to take must be non-negative
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
Closes #4549.