### PR TITLE
vectorize `find_first_of` for long needle 🪡

### DIFF
--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2034,7 +2034,7 @@ namespace {
 
             alignas(16) uint8_t _Tmp1[16];
             memcpy(_Tmp1, _First2, _Last_needle_length);
-            const __m128i _Last_needle_val = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp1));
+            const __m128i _Last_needle_val   = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp1));
             const int _Last_needle_length_el = _Last_needle_length / sizeof(_Ty);
 
             const size_t _Haystack_length = _Byte_length(_First1, _Last1);

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2017,7 +2017,7 @@ namespace {
         return _Result;
     }
 
-     template <class _Ty>
+    template <class _Ty>
     const void* __stdcall __std_find_first_of_trivial_impl(
         const void* _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
 #ifndef _M_ARM64EC

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2021,18 +2021,21 @@ namespace {
     const void* __stdcall __std_find_first_of_trivial_impl(
         const void* _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
 #ifndef _M_ARM64EC
-        const size_t _Needle_length = _Byte_length(_First2, _Last2);
-
-        if (_Use_sse42() && _Needle_length <= 16) {
+        if (_Use_sse42()) {
             constexpr int _Op =
                 (sizeof(_Ty) == 1 ? _SIDD_UBYTE_OPS : _SIDD_UWORD_OPS) | _SIDD_CMP_EQUAL_ANY | _SIDD_LEAST_SIGNIFICANT;
             constexpr int _Part_size_el = sizeof(_Ty) == 1 ? 16 : 8;
 
-            const int _Needle_length_el = static_cast<int>(_Needle_length / sizeof(_Ty));
+            const size_t _Needle_length = _Byte_length(_First2, _Last2);
+            const void* _Last_needle    = _First2;
+            _Advance_bytes(_Last_needle, _Needle_length & ~size_t{0xF});
+
+            const int _Last_needle_length = static_cast<int>(_Needle_length & 0xF);
 
             alignas(16) uint8_t _Tmp1[16];
-            memcpy(_Tmp1, _First2, _Needle_length);
-            const __m128i _Needle = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp1));
+            memcpy(_Tmp1, _First2, _Last_needle_length);
+            const __m128i _Last_needle_val = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp1));
+            const int _Last_needle_length_el = _Last_needle_length / sizeof(_Ty);
 
             const size_t _Haystack_length = _Byte_length(_First1, _Last1);
             const void* _Stop_at          = _First1;
@@ -2041,6 +2044,18 @@ namespace {
             while (_First1 != _Stop_at) {
                 const __m128i _Haystack_part = _mm_loadu_si128(static_cast<const __m128i*>(_First1));
 
+                for (const void* _Cur_needle = _First2; _Cur_needle != _Last_needle; _Advance_bytes(_Cur_needle, 16)) {
+                    const __m128i _Needle = _mm_loadu_si128(static_cast<const __m128i*>(_Cur_needle));
+
+                    if (_mm_cmpestrc(_Needle, _Part_size_el, _Haystack_part, _Part_size_el, _Op)) {
+                        const int _Pos = _mm_cmpestri(_Needle, _Part_size_el, _Haystack_part, _Part_size_el, _Op);
+                        _Advance_bytes(_First1, _Pos * sizeof(_Ty));
+                        return _First1;
+                    }
+                }
+
+                const int _Needle_length_el = _Last_needle_length_el;
+                const __m128i _Needle       = _Last_needle_val;
                 if (_mm_cmpestrc(_Needle, _Needle_length_el, _Haystack_part, _Part_size_el, _Op)) {
                     const int _Pos = _mm_cmpestri(_Needle, _Needle_length_el, _Haystack_part, _Part_size_el, _Op);
                     _Advance_bytes(_First1, _Pos * sizeof(_Ty));
@@ -2057,6 +2072,18 @@ namespace {
             memcpy(_Tmp2, _First1, _Last_part_size);
             const __m128i _Haystack_last_part = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp2));
 
+            for (const void* _Cur_needle = _First2; _Cur_needle != _Last_needle; _Advance_bytes(_Cur_needle, 16)) {
+                const __m128i _Needle = _mm_loadu_si128(static_cast<const __m128i*>(_Cur_needle));
+
+                if (_mm_cmpestrc(_Needle, _Part_size_el, _Haystack_last_part, _Last_part_size_el, _Op)) {
+                    const int _Pos = _mm_cmpestri(_Needle, _Part_size_el, _Haystack_last_part, _Last_part_size_el, _Op);
+                    _Advance_bytes(_First1, _Pos * sizeof(_Ty));
+                    return _First1;
+                }
+            }
+
+            const int _Needle_length_el = _Last_needle_length_el;
+            const __m128i _Needle       = _Last_needle_val;
             if (_mm_cmpestrc(_Needle, _Needle_length_el, _Haystack_last_part, _Last_part_size_el, _Op)) {
                 const int _Pos = _mm_cmpestri(_Needle, _Needle_length_el, _Haystack_last_part, _Last_part_size_el, _Op);
                 _Advance_bytes(_First1, _Pos * sizeof(_Ty));

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -238,7 +238,7 @@ void test_case_find_first_of(const vector<T>& input_haystack, const vector<T>& i
 
 template <class T>
 void test_find_first_of(mt19937_64& gen) {
-    constexpr size_t needleDataCount = 30;
+    constexpr size_t needleDataCount = 50;
     using TD                         = conditional_t<sizeof(T) == 1, int, T>;
     uniform_int_distribution<TD> dis('a', 'z');
     vector<T> input_haystack;


### PR DESCRIPTION
In benchmark results only the last line changed:

before
```
-----------------------------------------------------------------
Benchmark                       Time             CPU   Iterations
-----------------------------------------------------------------
bm<uint8_t, 2, 3>            2.70 ns         2.35 ns    597333333
bm<uint16_t, 2, 3>           2.71 ns         2.13 ns    689230769
bm<uint8_t, 7, 4>            14.1 ns         10.9 ns    112000000
bm<uint16_t, 7, 4>           12.4 ns         10.6 ns    100000000
bm<uint8_t, 9, 3>            9.77 ns         7.70 ns    190638298
bm<uint16_t, 9, 3>           10.4 ns         8.06 ns    162909091
bm<uint8_t, 22, 5>           10.1 ns         8.02 ns    208372093
bm<uint16_t, 22, 5>          11.0 ns         8.64 ns    151864407
bm<uint8_t, 3056, 7>          273 ns          233 ns      5973333
bm<uint16_t, 3056, 7>         561 ns          425 ns      3089655
bm<uint8_t, 1011, 11>        95.5 ns         79.2 ns     17568627
bm<uint16_t, 1011, 11>       2872 ns         2448 ns       497778
```
after
```
-----------------------------------------------------------------
Benchmark                       Time             CPU   Iterations
-----------------------------------------------------------------
bm<uint8_t, 2, 3>            2.71 ns         1.80 ns    746666667
bm<uint16_t, 2, 3>           2.71 ns         1.55 ns   1000000000
bm<uint8_t, 7, 4>            14.1 ns         7.47 ns    175686275
bm<uint16_t, 7, 4>           12.3 ns         5.82 ns    190638298
bm<uint8_t, 9, 3>            9.78 ns         6.75 ns    208372093
bm<uint16_t, 9, 3>           10.7 ns         7.54 ns    190638298
bm<uint8_t, 22, 5>           10.3 ns         7.21 ns    169056604
bm<uint16_t, 22, 5>          11.1 ns         8.63 ns    175686275
bm<uint8_t, 3056, 7>          276 ns          205 ns     11200000
bm<uint16_t, 3056, 7>         552 ns          432 ns      2890323
bm<uint8_t, 1011, 11>        94.4 ns         76.2 ns     19478261
bm<uint16_t, 1011, 11>        481 ns          365 ns      3895652
```
