### PR TITLE
`<mdspan>`: Throughput improvements

### DIFF
--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -218,8 +218,8 @@ public:
         : extents(_Other, make_index_sequence<rank_dynamic()>{}) {}
 
     template <class... _OtherIndexTypes>
-        requires (is_convertible_v<_OtherIndexTypes, index_type> && ...)
-              && (is_nothrow_constructible_v<index_type, _OtherIndexTypes> && ...)
+        requires conjunction_v<is_convertible<_OtherIndexTypes, index_type>...>
+              && conjunction_v<is_nothrow_constructible<index_type, _OtherIndexTypes>...>
               && (sizeof...(_OtherIndexTypes) == rank_dynamic() || sizeof...(_OtherIndexTypes) == rank())
     constexpr explicit extents(_OtherIndexTypes... _Exts) noexcept
         : extents(_Extents_from_tuple{}, _STD tie(_Exts...), make_index_sequence<rank_dynamic()>{}) {
@@ -305,7 +305,7 @@ public:
     template <size_t... _Seq, class... _IndexTypes>
     _NODISCARD constexpr bool _Contains_multidimensional_index(
         index_sequence<_Seq...>, _IndexTypes... _Indices) const noexcept {
-        _STL_INTERNAL_STATIC_ASSERT((same_as<_IndexTypes, index_type> && ...));
+        _STL_INTERNAL_STATIC_ASSERT(conjunction_v<is_same<_IndexTypes, index_type>...>);
         if constexpr (unsigned_integral<index_type>) {
             return ((_Indices < extent(_Seq)) && ...);
         } else {
@@ -318,7 +318,7 @@ template <class>
 inline constexpr size_t _Repeat_dynamic_extent = dynamic_extent;
 
 template <class... _Integrals>
-    requires (is_convertible_v<_Integrals, size_t> && ...)
+    requires conjunction_v<is_convertible<_Integrals, size_t>...>
 explicit extents(_Integrals...) -> extents<size_t, _Repeat_dynamic_extent<_Integrals>...>;
 
 template <class _IndexType, class _Indices>
@@ -561,8 +561,9 @@ public:
     }
 
     template <class... _IndexTypes>
-        requires (sizeof...(_IndexTypes) == extents_type::rank()) && (is_convertible_v<_IndexTypes, index_type> && ...)
-              && (is_nothrow_constructible_v<index_type, _IndexTypes> && ...)
+        requires (sizeof...(_IndexTypes) == extents_type::rank())
+              && conjunction_v<is_convertible<_IndexTypes, index_type>...>
+              && conjunction_v<is_nothrow_constructible<index_type, _IndexTypes>...>
     _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
         return _Index_impl(make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...);
     }
@@ -611,7 +612,7 @@ private:
     template <class... _IndexTypes, size_t... _Seq>
     _NODISCARD constexpr index_type _Index_impl(
         [[maybe_unused]] index_sequence<_Seq...> _Index_seq, _IndexTypes... _Indices) const noexcept {
-        _STL_INTERNAL_STATIC_ASSERT((same_as<_IndexTypes, index_type> && ...));
+        _STL_INTERNAL_STATIC_ASSERT(conjunction_v<is_same<_IndexTypes, index_type>...>);
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(this->_Exts._Contains_multidimensional_index(_Index_seq, _Indices...),
             "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
@@ -713,8 +714,9 @@ public:
     }
 
     template <class... _IndexTypes>
-        requires (sizeof...(_IndexTypes) == extents_type::rank()) && (is_convertible_v<_IndexTypes, index_type> && ...)
-              && (is_nothrow_constructible_v<index_type, _IndexTypes> && ...)
+        requires (sizeof...(_IndexTypes) == extents_type::rank())
+              && conjunction_v<is_convertible<_IndexTypes, index_type>...>
+              && conjunction_v<is_nothrow_constructible<index_type, _IndexTypes>...>
     _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
         return _Index_impl(make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...);
     }
@@ -763,7 +765,7 @@ private:
     template <class... _IndexTypes, size_t... _Seq>
     _NODISCARD constexpr index_type _Index_impl(
         [[maybe_unused]] index_sequence<_Seq...> _Index_seq, _IndexTypes... _Indices) const noexcept {
-        _STL_INTERNAL_STATIC_ASSERT((same_as<_IndexTypes, index_type> && ...));
+        _STL_INTERNAL_STATIC_ASSERT(conjunction_v<is_same<_IndexTypes, index_type>...>);
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(this->_Exts._Contains_multidimensional_index(_Index_seq, _Indices...),
             "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
@@ -938,8 +940,9 @@ public:
     }
 
     template <class... _IndexTypes>
-        requires (sizeof...(_IndexTypes) == extents_type::rank()) && (is_convertible_v<_IndexTypes, index_type> && ...)
-              && (is_nothrow_constructible_v<index_type, _IndexTypes> && ...)
+        requires (sizeof...(_IndexTypes) == extents_type::rank())
+              && conjunction_v<is_convertible<_IndexTypes, index_type>...>
+              && conjunction_v<is_nothrow_constructible<index_type, _IndexTypes>...>
     _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
         return _Index_impl(make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...);
     }
@@ -1020,7 +1023,7 @@ private:
     template <class... _IndexTypes, size_t... _Seq>
     _NODISCARD constexpr index_type _Index_impl(
         [[maybe_unused]] index_sequence<_Seq...> _Index_seq, _IndexTypes... _Indices) const noexcept {
-        _STL_INTERNAL_STATIC_ASSERT((same_as<_IndexTypes, index_type> && ...));
+        _STL_INTERNAL_STATIC_ASSERT(conjunction_v<is_same<_IndexTypes, index_type>...>);
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(this->_Exts._Contains_multidimensional_index(_Index_seq, _Indices...),
             "Value of extents_type::index-cast(i) must be a multidimensional index in extents_ (N4950 "
@@ -1215,8 +1218,8 @@ public:
     constexpr mdspan(mdspan&&)      = default;
 
     template <class... _OtherIndexTypes>
-        requires (is_convertible_v<_OtherIndexTypes, index_type> && ...)
-                  && (is_nothrow_constructible_v<index_type, _OtherIndexTypes> && ...)
+        requires conjunction_v<is_convertible<_OtherIndexTypes, index_type>...>
+                  && conjunction_v<is_nothrow_constructible<index_type, _OtherIndexTypes>...>
                   && (sizeof...(_OtherIndexTypes) == rank() || sizeof...(_OtherIndexTypes) == rank_dynamic())
                   && is_constructible_v<mapping_type, extents_type> && is_default_constructible_v<accessor_type>
     constexpr explicit mdspan(data_handle_type _Ptr_, _OtherIndexTypes... _Exts) noexcept(
@@ -1295,8 +1298,8 @@ public:
 
 #ifdef __cpp_multidimensional_subscript // TRANSITION, P2128R6
     template <class... _OtherIndexTypes>
-        requires (is_convertible_v<_OtherIndexTypes, index_type> && ...)
-              && (is_nothrow_constructible_v<index_type, _OtherIndexTypes> && ...)
+        requires conjunction_v<is_convertible<_OtherIndexTypes, index_type>...>
+              && conjunction_v<is_nothrow_constructible<index_type, _OtherIndexTypes>...>
               && (sizeof...(_OtherIndexTypes) == rank())
     _NODISCARD constexpr reference operator[](_OtherIndexTypes... _Indices) const
         noexcept(noexcept(_Access_impl(static_cast<index_type>(_STD move(_Indices))...))) /* strengthened */ {
@@ -1427,7 +1430,7 @@ private:
     template <class... _OtherIndexTypes>
     _NODISCARD constexpr reference _Access_impl(_OtherIndexTypes... _Indices) const
         noexcept(noexcept(this->_Acc.access(_Ptr, static_cast<size_t>(this->_Map(_Indices...))))) {
-        _STL_INTERNAL_STATIC_ASSERT((same_as<_OtherIndexTypes, index_type> && ...));
+        _STL_INTERNAL_STATIC_ASSERT(conjunction_v<is_same<_OtherIndexTypes, index_type>...>);
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(this->_Map.extents()._Contains_multidimensional_index(make_index_sequence<rank()>{}, _Indices...),
             "I must be a multidimensional index in extents() (N4950 [mdspan.mdspan.members]/3).");
@@ -1448,7 +1451,7 @@ template <class _Pointer>
 mdspan(_Pointer&&) -> mdspan<remove_pointer_t<remove_reference_t<_Pointer>>, extents<size_t>>;
 
 template <class _ElementType, class... _Integrals>
-    requires ((is_convertible_v<_Integrals, size_t> && ...) && sizeof...(_Integrals) > 0)
+    requires conjunction_v<is_convertible<_Integrals, size_t>...> && (sizeof...(_Integrals) > 0)
 explicit mdspan(_ElementType*, _Integrals...) -> mdspan<_ElementType, dextents<size_t, sizeof...(_Integrals)>>;
 
 template <class _ElementType, class _OtherIndexType, size_t _Nx>

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -218,8 +218,8 @@ public:
         : extents(_Other, make_index_sequence<rank_dynamic()>{}) {}
 
     template <class... _OtherIndexTypes>
-        requires conjunction_v<is_convertible<_OtherIndexTypes, index_type>...>
-              && conjunction_v<is_nothrow_constructible<index_type, _OtherIndexTypes>...>
+        requires conjunction_v<is_convertible<_OtherIndexTypes, index_type>...,
+                     is_nothrow_constructible<index_type, _OtherIndexTypes>...>
               && (sizeof...(_OtherIndexTypes) == rank_dynamic() || sizeof...(_OtherIndexTypes) == rank())
     constexpr explicit extents(_OtherIndexTypes... _Exts) noexcept
         : extents(_Extents_from_tuple{}, _STD tie(_Exts...), make_index_sequence<rank_dynamic()>{}) {
@@ -562,8 +562,8 @@ public:
 
     template <class... _IndexTypes>
         requires (sizeof...(_IndexTypes) == extents_type::rank())
-              && conjunction_v<is_convertible<_IndexTypes, index_type>...>
-              && conjunction_v<is_nothrow_constructible<index_type, _IndexTypes>...>
+              && conjunction_v<is_convertible<_IndexTypes, index_type>...,
+                  is_nothrow_constructible<index_type, _IndexTypes>...>
     _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
         return _Index_impl(make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...);
     }
@@ -715,8 +715,8 @@ public:
 
     template <class... _IndexTypes>
         requires (sizeof...(_IndexTypes) == extents_type::rank())
-              && conjunction_v<is_convertible<_IndexTypes, index_type>...>
-              && conjunction_v<is_nothrow_constructible<index_type, _IndexTypes>...>
+              && conjunction_v<is_convertible<_IndexTypes, index_type>...,
+                  is_nothrow_constructible<index_type, _IndexTypes>...>
     _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
         return _Index_impl(make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...);
     }
@@ -941,8 +941,8 @@ public:
 
     template <class... _IndexTypes>
         requires (sizeof...(_IndexTypes) == extents_type::rank())
-              && conjunction_v<is_convertible<_IndexTypes, index_type>...>
-              && conjunction_v<is_nothrow_constructible<index_type, _IndexTypes>...>
+              && conjunction_v<is_convertible<_IndexTypes, index_type>...,
+                  is_nothrow_constructible<index_type, _IndexTypes>...>
     _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
         return _Index_impl(make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...);
     }
@@ -1218,8 +1218,8 @@ public:
     constexpr mdspan(mdspan&&)      = default;
 
     template <class... _OtherIndexTypes>
-        requires conjunction_v<is_convertible<_OtherIndexTypes, index_type>...>
-                  && conjunction_v<is_nothrow_constructible<index_type, _OtherIndexTypes>...>
+        requires conjunction_v<is_convertible<_OtherIndexTypes, index_type>...,
+                     is_nothrow_constructible<index_type, _OtherIndexTypes>...>
                   && (sizeof...(_OtherIndexTypes) == rank() || sizeof...(_OtherIndexTypes) == rank_dynamic())
                   && is_constructible_v<mapping_type, extents_type> && is_default_constructible_v<accessor_type>
     constexpr explicit mdspan(data_handle_type _Ptr_, _OtherIndexTypes... _Exts) noexcept(
@@ -1298,8 +1298,8 @@ public:
 
 #ifdef __cpp_multidimensional_subscript // TRANSITION, P2128R6
     template <class... _OtherIndexTypes>
-        requires conjunction_v<is_convertible<_OtherIndexTypes, index_type>...>
-              && conjunction_v<is_nothrow_constructible<index_type, _OtherIndexTypes>...>
+        requires conjunction_v<is_convertible<_OtherIndexTypes, index_type>...,
+                     is_nothrow_constructible<index_type, _OtherIndexTypes>...>
               && (sizeof...(_OtherIndexTypes) == rank())
     _NODISCARD constexpr reference operator[](_OtherIndexTypes... _Indices) const
         noexcept(noexcept(_Access_impl(static_cast<index_type>(_STD move(_Indices))...))) /* strengthened */ {

--- a/tests/std/include/test_mdspan_support.hpp
+++ b/tests/std/include/test_mdspan_support.hpp
@@ -256,7 +256,7 @@ MappingProperties<Mapping> get_mapping_properties(const Mapping& mapping) {
         return std::views::cartesian_product(std::views::iota(IndexType{0}, get_extent(Indices))...);
     }(rank_indices);
 
-    auto map_index      = [&](const auto& tpl) { return std::apply([&](auto... i) { return mapping(i...); }, tpl); };
+    auto map_index      = [&](const auto& tpl) { return std::apply(mapping, tpl); };
     auto mapped_indices = multidim_indices | std::views::transform(map_index) | std::ranges::to<std::vector>();
     std::ranges::sort(mapped_indices);
 


### PR DESCRIPTION
* Use `conjunction_v` instead of fold expressions
* Drive-by: remove unnecessary lambda in `test_mdspan_support.hpp`
