### PR TITLE
Optimize `find_first_of` for one element needle

### DIFF
--- a/benchmarks/src/find_first_of.cpp
+++ b/benchmarks/src/find_first_of.cpp
@@ -5,6 +5,7 @@
 #include <benchmark/benchmark.h>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <numeric>
 #include <vector>
 

--- a/benchmarks/src/find_first_of.cpp
+++ b/benchmarks/src/find_first_of.cpp
@@ -10,14 +10,21 @@
 
 using namespace std;
 
-template <class T, size_t Pos, size_t NSize, size_t HSize = Pos * 2, size_t Which = 0>
+template <class T>
 void bm(benchmark::State& state) {
+    const size_t Pos   = static_cast<size_t>(state.range(0));
+    const size_t NSize = static_cast<size_t>(state.range(1));
+    const size_t HSize = Pos * 2;
+    const size_t Which = 0;
+
     vector<T> h(HSize, T{'.'});
     vector<T> n(NSize);
     iota(n.begin(), n.end(), T{'a'});
 
-    static_assert(Pos < HSize);
-    static_assert(Which < NSize);
+    if (Pos >= HSize || Which >= NSize) {
+        abort();
+    }
+
     h[Pos] = n[Which];
 
     for (auto _ : state) {
@@ -25,25 +32,18 @@ void bm(benchmark::State& state) {
     }
 }
 
-BENCHMARK(bm<uint8_t, 2, 3>);
-BENCHMARK(bm<uint16_t, 2, 3>);
+#define ARGS               \
+    Args({2, 3})           \
+        ->Args({7, 4})     \
+        ->Args({9, 3})     \
+        ->Args({22, 5})    \
+        ->Args({58, 2})    \
+        ->Args({102, 4})   \
+        ->Args({325, 1})   \
+        ->Args({1011, 11}) \
+        ->Args({3056, 7});
 
-BENCHMARK(bm<uint8_t, 7, 4>);
-BENCHMARK(bm<uint16_t, 7, 4>);
-
-BENCHMARK(bm<uint8_t, 9, 3>);
-BENCHMARK(bm<uint16_t, 9, 3>);
-
-BENCHMARK(bm<uint8_t, 22, 5>);
-BENCHMARK(bm<uint16_t, 22, 5>);
-
-BENCHMARK(bm<uint8_t, 325, 1>);
-BENCHMARK(bm<uint16_t, 325, 1>);
-
-BENCHMARK(bm<uint8_t, 3056, 7>);
-BENCHMARK(bm<uint16_t, 3056, 7>);
-
-BENCHMARK(bm<uint8_t, 1011, 11>);
-BENCHMARK(bm<uint16_t, 1011, 11>);
+BENCHMARK(bm<uint8_t>)->ARGS;
+BENCHMARK(bm<uint16_t>)->ARGS;
 
 BENCHMARK_MAIN();

--- a/benchmarks/src/find_first_of.cpp
+++ b/benchmarks/src/find_first_of.cpp
@@ -37,6 +37,9 @@ BENCHMARK(bm<uint16_t, 9, 3>);
 BENCHMARK(bm<uint8_t, 22, 5>);
 BENCHMARK(bm<uint16_t, 22, 5>);
 
+BENCHMARK(bm<uint8_t, 325, 1>);
+BENCHMARK(bm<uint16_t, 325, 1>);
+
 BENCHMARK(bm<uint8_t, 3056, 7>);
 BENCHMARK(bm<uint16_t, 3056, 7>);
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -3390,7 +3390,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt1 find_first_of(
 #endif // _HAS_CXX20
         _STD equal_to<>>;
 
-    if constexpr (_Is_ranges_random_iter_v<_FwdIt2> && _Is_predicate_equal) {
+    if constexpr (_Is_ranges_random_iter_v<decltype(_UFirst2)> && _Is_predicate_equal) {
         const auto _Count2 = _Last2 - _First2;
         if (_Count2 == 1) {
             _UFirst1 = _STD _Find_unchecked(_STD move(_UFirst1), _STD move(_ULast1), *_UFirst2);
@@ -3398,7 +3398,6 @@ _NODISCARD _CONSTEXPR20 _FwdIt1 find_first_of(
             return _First1;
         }
     }
-
 
 #if _USE_STD_VECTOR_ALGORITHMS
     if constexpr (_Vector_alg_in_find_first_of_is_safe<decltype(_UFirst1), decltype(_UFirst2), _Pr>) {

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -3390,7 +3390,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt1 find_first_of(
 #endif // _HAS_CXX20
         _STD equal_to<>>;
 
-    if constexpr (_Is_ranges_random_iter_v<decltype(_UFirst2)> && _Is_predicate_equal) {
+    if constexpr (_Is_ranges_random_iter_v<remove_const_t<decltype(_UFirst2)>> && _Is_predicate_equal) {
         const auto _Count2 = _Last2 - _First2;
         if (_Count2 == 1) {
             _UFirst1 = _STD _Find_unchecked(_STD move(_UFirst1), _STD move(_ULast1), *_UFirst2);

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -3384,7 +3384,13 @@ _NODISCARD _CONSTEXPR20 _FwdIt1 find_first_of(
     const auto _UFirst2 = _STD _Get_unwrapped(_First2);
     const auto _ULast2  = _STD _Get_unwrapped(_Last2);
 
-    if constexpr (_Is_ranges_random_iter_v<_FwdIt2> && _Is_any_of_v<_Pr, _STD equal_to<>, _RANGES equal_to>) {
+    constexpr bool _Is_predicate_equal = _Is_any_of_v<_Pr,
+#if _HAS_CXX20
+        _RANGES equal_to,
+#endif // _HAS_CXX20
+        _STD equal_to<>>;
+
+    if constexpr (_Is_ranges_random_iter_v<_FwdIt2> && _Is_predicate_equal) {
         const auto _Count2 = _Last2 - _First2;
         if (_Count2 == 1) {
             _UFirst1 = _STD _Find_unchecked(_STD move(_UFirst1), _STD move(_ULast1), *_UFirst2);

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -3384,7 +3384,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt1 find_first_of(
     const auto _UFirst2 = _STD _Get_unwrapped(_First2);
     const auto _ULast2  = _STD _Get_unwrapped(_Last2);
 
-    if constexpr (_Is_ranges_random_iter_v<_FwdIt2>) {
+    if constexpr (_Is_ranges_random_iter_v<_FwdIt2> && _Is_any_of_v<_Pr, _STD equal_to<>, _RANGES equal_to>) {
         const auto _Count2 = _Last2 - _First2;
         if (_Count2 == 1) {
             _UFirst1 = _STD _Find_unchecked(_STD move(_UFirst1), _STD move(_ULast1), *_UFirst2);

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -3383,6 +3383,17 @@ _NODISCARD _CONSTEXPR20 _FwdIt1 find_first_of(
     const auto _ULast1  = _STD _Get_unwrapped(_Last1);
     const auto _UFirst2 = _STD _Get_unwrapped(_First2);
     const auto _ULast2  = _STD _Get_unwrapped(_Last2);
+
+    if constexpr (_Is_ranges_random_iter_v<_FwdIt2>) {
+        const auto _Count2 = _Last2 - _First2;
+        if (_Count2 == 1) {
+            _UFirst1 = _STD _Find_unchecked(_STD move(_UFirst1), _STD move(_ULast1), *_UFirst2);
+            _STD _Seek_wrapped(_First1, _UFirst1);
+            return _First1;
+        }
+    }
+
+
 #if _USE_STD_VECTOR_ALGORITHMS
     if constexpr (_Vector_alg_in_find_first_of_is_safe<decltype(_UFirst1), decltype(_UFirst2), _Pr>) {
         if (!_STD _Is_constant_evaluated() && _ULast1 - _UFirst1 >= _Threshold_find_first_of) {
@@ -3477,6 +3488,14 @@ namespace ranges {
             _STL_INTERNAL_STATIC_ASSERT(forward_iterator<_It2>);
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se2, _It2>);
             _STL_INTERNAL_STATIC_ASSERT(indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>);
+
+            if constexpr (_Is_ranges_random_iter_v<_It2> && sized_sentinel_for<_Se2, _It2>) {
+                const auto _Count2 = _Last2 - _First2;
+                if (_Count2 == 1) {
+                    return _RANGES _Find_unchecked(
+                        _STD move(_First1), _STD move(_Last1), _STD invoke(_Proj2, *_First2), _Proj1);
+                }
+            }
 
 #if _USE_STD_VECTOR_ALGORITHMS
             if constexpr (_Vector_alg_in_find_first_of_is_safe<_It1, _It2, _Pr> && sized_sentinel_for<_Se1, _It1>

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -3500,7 +3500,7 @@ namespace ranges {
                 const auto _Count2 = _Last2 - _First2;
                 if (_Count2 == 1) {
                     return _RANGES _Find_unchecked(
-                        _STD move(_First1), _STD move(_Last1), _STD invoke(_Proj2, *_First2), _STD _Pass_fn(_Proj1));
+                        _STD move(_First1), _STD move(_Last1), _STD invoke(_Proj2, *_First2), _Proj1);
                 }
             }
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -3391,7 +3391,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt1 find_first_of(
         _STD equal_to<>>;
 
     if constexpr (_Is_ranges_random_iter_v<remove_const_t<decltype(_UFirst2)>> && _Is_predicate_equal) {
-        const auto _Count2 = _Last2 - _First2;
+        const auto _Count2 = _ULast2 - _UFirst2;
         if (_Count2 == 1) {
             _UFirst1 = _STD _Find_unchecked(_STD move(_UFirst1), _STD move(_ULast1), *_UFirst2);
             _STD _Seek_wrapped(_First1, _UFirst1);

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -3489,11 +3489,13 @@ namespace ranges {
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se2, _It2>);
             _STL_INTERNAL_STATIC_ASSERT(indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>);
 
-            if constexpr (_Is_ranges_random_iter_v<_It2> && sized_sentinel_for<_Se2, _It2>) {
+
+            if constexpr (_Is_ranges_random_iter_v<_It2> && sized_sentinel_for<_Se2, _It2>
+                          && _Is_any_of_v<_Pr, _STD equal_to<>, _RANGES equal_to>) {
                 const auto _Count2 = _Last2 - _First2;
                 if (_Count2 == 1) {
                     return _RANGES _Find_unchecked(
-                        _STD move(_First1), _STD move(_Last1), _STD invoke(_Proj2, *_First2), _Proj1);
+                        _STD move(_First1), _STD move(_Last1), _STD invoke(_Proj2, *_First2), _STD _Pass_fn(_Proj1));
                 }
             }
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -3379,10 +3379,10 @@ _NODISCARD _CONSTEXPR20 _FwdIt1 find_first_of(
     // look for one of [_First2, _Last2) satisfying _Pred with element
     _STD _Adl_verify_range(_First1, _Last1);
     _STD _Adl_verify_range(_First2, _Last2);
-    auto _UFirst1       = _STD _Get_unwrapped(_First1);
-    const auto _ULast1  = _STD _Get_unwrapped(_Last1);
-    const auto _UFirst2 = _STD _Get_unwrapped(_First2);
-    const auto _ULast2  = _STD _Get_unwrapped(_Last2);
+    auto _UFirst1      = _STD _Get_unwrapped(_First1);
+    auto _ULast1       = _STD _Get_unwrapped(_Last1);
+    auto _UFirst2      = _STD _Get_unwrapped(_First2);
+    const auto _ULast2 = _STD _Get_unwrapped(_Last2);
 
     constexpr bool _Is_predicate_equal = _Is_any_of_v<_Pr,
 #if _HAS_CXX20
@@ -3390,7 +3390,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt1 find_first_of(
 #endif // _HAS_CXX20
         _STD equal_to<>>;
 
-    if constexpr (_Is_ranges_random_iter_v<remove_const_t<decltype(_UFirst2)>> && _Is_predicate_equal) {
+    if constexpr (_Is_ranges_random_iter_v<decltype(_UFirst2)> && _Is_predicate_equal) {
         const auto _Count2 = _ULast2 - _UFirst2;
         if (_Count2 == 1) {
             _UFirst1 = _STD _Find_unchecked(_STD move(_UFirst1), _STD move(_ULast1), *_UFirst2);
@@ -3486,14 +3486,13 @@ namespace ranges {
 
     private:
         template <class _It1, class _Se1, class _It2, class _Se2, class _Pr, class _Pj1, class _Pj2>
-        _NODISCARD static constexpr _It1 _Find_first_of_unchecked(_It1 _First1, const _Se1 _Last1, const _It2 _First2,
-            const _Se2 _Last2, _Pr _Pred, _Pj1 _Proj1, _Pj2 _Proj2) {
+        _NODISCARD static constexpr _It1 _Find_first_of_unchecked(
+            _It1 _First1, _Se1 _Last1, const _It2 _First2, const _Se2 _Last2, _Pr _Pred, _Pj1 _Proj1, _Pj2 _Proj2) {
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It1>);
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se1, _It1>);
             _STL_INTERNAL_STATIC_ASSERT(forward_iterator<_It2>);
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se2, _It2>);
             _STL_INTERNAL_STATIC_ASSERT(indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>);
-
 
             if constexpr (_Is_ranges_random_iter_v<_It2> && sized_sentinel_for<_Se2, _It2>
                           && _Is_any_of_v<_Pr, _STD equal_to<>, _RANGES equal_to>) {


### PR DESCRIPTION
Look for `/325/1` lines in the result:

Before:
```
---------------------------------------------------------------
Benchmark                     Time             CPU   Iterations
---------------------------------------------------------------
bm<uint8_t>/2/3            3.58 ns         2.47 ns    640000000
bm<uint8_t>/7/4            13.8 ns         11.8 ns     99555556
bm<uint8_t>/9/3            9.76 ns         7.25 ns    213333333
bm<uint8_t>/22/5           10.1 ns         8.79 ns    186666667
bm<uint8_t>/58/2           11.4 ns         10.2 ns    100000000
bm<uint8_t>/102/4          13.4 ns         11.9 ns    100000000
bm<uint8_t>/325/1          33.0 ns         27.6 ns     49777778
bm<uint8_t>/1011/11        94.6 ns         79.4 ns     19478261
bm<uint8_t>/3056/7          276 ns          222 ns      5973333
bm<uint16_t>/2/3           2.72 ns         2.25 ns    896000000
bm<uint16_t>/7/4           16.5 ns         13.3 ns     89600000
bm<uint16_t>/9/3           10.5 ns         8.80 ns    154482759
bm<uint16_t>/22/5          11.1 ns         10.8 ns    100000000
bm<uint16_t>/58/2          15.1 ns         12.6 ns    128000000
bm<uint16_t>/102/4         22.3 ns         20.1 ns     89600000
bm<uint16_t>/325/1         59.8 ns         52.7 ns     24888889
bm<uint16_t>/1011/11       3534 ns         3214 ns       471579
bm<uint16_t>/3056/7         541 ns          455 ns      2986667
```
After:
```
---------------------------------------------------------------
Benchmark                     Time             CPU   Iterations
---------------------------------------------------------------
bm<uint8_t>/2/3            2.88 ns         2.30 ns    597333333
bm<uint8_t>/7/4            13.9 ns         11.7 ns    112000000
bm<uint8_t>/9/3            9.94 ns         7.85 ns    179200000
bm<uint8_t>/22/5           10.4 ns         6.98 ns    179200000
bm<uint8_t>/58/2           11.5 ns         8.32 ns    169056604
bm<uint8_t>/102/4          13.4 ns         11.2 ns    154482759
bm<uint8_t>/325/1          5.72 ns         3.74 ns    308965517
bm<uint8_t>/1011/11        93.7 ns         85.0 ns     16000000
bm<uint8_t>/3056/7          275 ns          243 ns      5973333
bm<uint16_t>/2/3           3.51 ns         3.11 ns    471578947
bm<uint16_t>/7/4           13.9 ns         11.7 ns    100000000
bm<uint16_t>/9/3           10.8 ns         8.91 ns    128000000
bm<uint16_t>/22/5          11.3 ns         10.5 ns    100000000
bm<uint16_t>/58/2          15.3 ns         13.4 ns    112000000
bm<uint16_t>/102/4         22.2 ns         20.0 ns     64000000
bm<uint16_t>/325/1         8.40 ns         7.54 ns    194782609
bm<uint16_t>/1011/11       3369 ns         3024 ns       527059
bm<uint16_t>/3056/7         516 ns          466 ns      2986667
```