### PR TITLE
Skip Component Governance autodetection

### DIFF
--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -22,3 +22,6 @@ variables:
 - name: Codeql.SkipTaskAutoInjection
   value: true
   readonly: true
+- name: skipComponentGovernanceDetection
+  value: true
+  readonly: true


### PR DESCRIPTION
An unnecessary new script (we don't ship from this repository, so the checks in the Microsoft-internal repo suffice) auto-injected into our pipeline causing problems.