### PR TITLE
`<generator>`: Test `generator::iterator`

### DIFF
--- a/tests/std/include/test_generator_support.hpp
+++ b/tests/std/include/test_generator_support.hpp
@@ -58,6 +58,24 @@ struct Immovable {
 static_assert(!std::movable<Immovable>);
 
 template <class T>
-struct Proxy {
+class Proxy {
+public:
     Proxy(const T&) {}
+};
+
+template <std::equality_comparable T>
+class Proxy<T> {
+public:
+    Proxy(const T& _value_) : value(_value_) {}
+
+    bool operator==(const Proxy& other) const {
+        return value == other.value;
+    }
+
+    bool operator==(const T& x) const {
+        return value == x;
+    }
+
+private:
+    const T& value;
 };

--- a/tests/std/include/test_generator_support.hpp
+++ b/tests/std/include/test_generator_support.hpp
@@ -59,6 +59,5 @@ static_assert(!std::movable<Immovable>);
 
 template <class T>
 struct Proxy {
-    Proxy() {}
     Proxy(const T&) {}
 };

--- a/tests/std/include/test_generator_support.hpp
+++ b/tests/std/include/test_generator_support.hpp
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <concepts>
+#include <cstddef>
+#include <memory>
+#include <memory_resource>
+#include <new>
+#include <type_traits>
+
+template <class T, class AlwaysEqual = std::true_type, std::signed_integral DifferenceType = std::ptrdiff_t>
+class TestAllocator : public std::allocator<T> {
+public:
+    using value_type      = T;
+    using is_always_equal = AlwaysEqual;
+    using difference_type = DifferenceType;
+    using size_type       = std::make_unsigned_t<difference_type>;
+
+    TestAllocator() = default;
+
+    template <class U>
+    TestAllocator(const TestAllocator<U, AlwaysEqual, DifferenceType>&) {}
+
+    T* allocate(const size_type s) {
+        return static_cast<T*>(::operator new(static_cast<size_t>(s * sizeof(T)), std::align_val_t{alignof(T)}));
+    }
+
+    void deallocate(T* const p, size_type s) {
+        ::operator delete(p, s * sizeof(T), std::align_val_t{alignof(T)});
+    }
+
+    operator std::pmr::polymorphic_allocator<void>() const {
+        return {};
+    }
+
+    bool operator==(const TestAllocator&) const = default;
+};
+
+struct MoveOnly {
+    MoveOnly()                           = default;
+    MoveOnly(const MoveOnly&)            = delete;
+    MoveOnly& operator=(const MoveOnly&) = delete;
+    MoveOnly(MoveOnly&&)                 = default;
+    MoveOnly& operator=(MoveOnly&&)      = default;
+};
+
+static_assert(std::movable<MoveOnly>);
+static_assert(!std::copyable<MoveOnly>);
+
+struct Immovable {
+    Immovable()                       = default;
+    Immovable(Immovable&&)            = delete;
+    Immovable& operator=(Immovable&&) = delete;
+};
+
+static_assert(!std::movable<Immovable>);
+
+template <class T>
+struct Proxy {
+    Proxy() {}
+    Proxy(const T&) {}
+};

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -650,6 +650,7 @@ tests\P2474R2_views_repeat_death
 tests\P2494R2_move_only_range_adaptors
 tests\P2502R2_generator
 tests\P2502R2_generator_death
+tests\P2502R2_generator_iterator
 tests\P2502R2_generator_promise
 tests\P2505R5_monadic_functions_for_std_expected
 tests\P2510R3_text_formatting_pointers

--- a/tests/std/tests/P2502R2_generator/test.cpp
+++ b/tests/std/tests/P2502R2_generator/test.cpp
@@ -33,7 +33,6 @@ constexpr bool static_checks() {
     // Non-portable size checks
     static_assert(sizeof(G) == sizeof(void*));
     static_assert(sizeof(typename G::promise_type) == 3 * sizeof(void*));
-    static_assert(sizeof(ranges::iterator_t<G>) == sizeof(void*));
 
     return true;
 }

--- a/tests/std/tests/P2502R2_generator_iterator/env.lst
+++ b/tests/std/tests/P2502R2_generator_iterator/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P2502R2_generator_iterator/test.cpp
+++ b/tests/std/tests/P2502R2_generator_iterator/test.cpp
@@ -98,11 +98,11 @@ void test_one() {
         auto g = generate_one<Ref, V, Alloc>();
         auto i = g.begin();
 
-        [[maybe_unused]] same_as<gen_reference_t<Ref, V>> decltype(auto) r = *i;
+        same_as<gen_reference_t<Ref, V>> decltype(auto) r = *i;
 
-        using NoRef = remove_reference_t<Ref>;
-        if constexpr (default_initializable<NoRef> && equality_comparable<NoRef>) {
-            assert(r == NoRef{});
+        using ValueType = gen_value_t<Ref, V>;
+        if constexpr (default_initializable<ValueType> && equality_comparable<ValueType>) {
+            assert(r == ValueType{});
         }
     }
 

--- a/tests/std/tests/P2502R2_generator_iterator/test.cpp
+++ b/tests/std/tests/P2502R2_generator_iterator/test.cpp
@@ -48,6 +48,7 @@ void test_one() {
     using Gen  = generator<Ref, V, Alloc>;
     using Iter = ranges::iterator_t<Gen>;
     static_assert(input_iterator<Iter>);
+    static_assert(sizeof(Iter) == sizeof(void*)); // NB: implementation defined
 
     // Test member types
     static_assert(same_as<typename Iter::value_type, conditional_t<is_void_v<V>, remove_cvref_t<Ref>, V>>);
@@ -75,7 +76,6 @@ void test_one() {
         same_as<Iter&> decltype(auto) k = (i = move(j));
         assert(&k == &i);
         assert(k == default_sentinel);
-
         static_assert(is_nothrow_move_assignable_v<Iter>);
     }
 
@@ -127,9 +127,6 @@ void test_one() {
         same_as<bool> decltype(auto) b4 = default_sentinel != j;
         assert(!b4);
     }
-
-    // Test sizeof
-    static_assert(sizeof(Iter) == sizeof(void*)); // NB: implementation defined
 }
 
 template <class Ref, class V = void>

--- a/tests/std/tests/P2502R2_generator_iterator/test.cpp
+++ b/tests/std/tests/P2502R2_generator_iterator/test.cpp
@@ -13,9 +13,6 @@
 
 using namespace std;
 
-template <class>
-constexpr bool always_false = false;
-
 template <class Ref, class V, class Alloc>
 generator<Ref, V, Alloc> generate_zero() {
     co_return;

--- a/tests/std/tests/P2502R2_generator_iterator/test.cpp
+++ b/tests/std/tests/P2502R2_generator_iterator/test.cpp
@@ -36,12 +36,14 @@ generator<Ref, V, Alloc> generate_one() {
     }
 }
 
+#if !(defined(__clang__) && defined(_M_IX86)) // TRANSITION, LLVM-56507
 template <class Ref, class V, class Alloc>
 generator<Ref, V, Alloc> generate_one_recursively() {
     co_yield ranges::elements_of{generate_zero<Ref, V, Alloc>()};
     co_yield ranges::elements_of{generate_one<Ref, V, Alloc>()};
     co_yield ranges::elements_of{generate_zero<Ref, V, Alloc>()};
 }
+#endif // ^^^ no workaround ^^^
 
 template <class Ref, class V = void, class Alloc = void>
 void test_one() {
@@ -91,6 +93,7 @@ void test_one() {
         }
     }
 
+#if !(defined(__clang__) && defined(_M_IX86)) // TRANSITION, LLVM-56507
     { // Test pre-incrementation
         auto g = generate_one_recursively<Ref, V, Alloc>();
         auto i = g.begin();
@@ -108,6 +111,7 @@ void test_one() {
 
         static_assert(is_void_v<decltype(i++)>);
     }
+#endif // ^^^ no workaround ^^^
 
     { // Test equal operator
         auto g1 = generate_one<Ref, V, Alloc>();

--- a/tests/std/tests/P2502R2_generator_iterator/test.cpp
+++ b/tests/std/tests/P2502R2_generator_iterator/test.cpp
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cassert>
+#include <concepts>
+#include <generator>
+#include <memory>
+#include <memory_resource>
+#include <ranges>
+#include <type_traits>
+
+#include "test_generator_support.hpp"
+
+using namespace std;
+
+template <class>
+constexpr bool always_false = false;
+
+template <class Ref, class V, class Alloc>
+generator<Ref, V, Alloc> generate_zero() {
+    co_return;
+}
+
+template <class Ref, class V, class Alloc>
+    requires (is_reference_v<Ref> && default_initializable<_Gen_value_t<Ref, V>>) || default_initializable<Ref>
+generator<Ref, V, Alloc> generate_one() {
+    if constexpr (!is_reference_v<Ref>) {
+        co_yield Ref{};
+    } else if constexpr (is_lvalue_reference_v<Ref>) {
+        _Gen_value_t<Ref, V> val{};
+        remove_reference_t<Ref> ref{move(val)};
+        co_yield ref;
+    } else if constexpr (is_rvalue_reference_v<Ref>) {
+        _Gen_value_t<Ref, V> val{};
+        co_yield move(val);
+    }
+}
+
+template <class Ref, class V, class Alloc>
+generator<Ref, V, Alloc> generate_one_recursively() {
+    co_yield ranges::elements_of{generate_zero<Ref, V, Alloc>()};
+    co_yield ranges::elements_of{generate_one<Ref, V, Alloc>()};
+    co_yield ranges::elements_of{generate_zero<Ref, V, Alloc>()};
+}
+
+template <class Ref, class V = void, class Alloc = void>
+void test_one() {
+    using Gen  = generator<Ref, V, Alloc>;
+    using Iter = ranges::iterator_t<Gen>;
+    static_assert(input_iterator<Iter>);
+
+    // Test member types
+    static_assert(same_as<typename Iter::value_type, conditional_t<is_void_v<V>, remove_cvref_t<Ref>, V>>);
+    static_assert(same_as<typename Iter::difference_type, ptrdiff_t>);
+
+    // Test copying functions
+    static_assert(!is_copy_constructible_v<Iter>);
+    static_assert(!is_copy_assignable_v<Iter>);
+
+    { // Test move constructor
+        Gen g  = generate_zero<Ref, V, Alloc>();
+        Iter i = g.begin();
+        Iter j = move(i);
+        assert(j == default_sentinel);
+
+        static_assert(is_nothrow_move_constructible_v<Iter>);
+    }
+
+    { // Test move assignment operator
+        Gen g1 = generate_one<Ref, V, Alloc>();
+        Iter i = g1.begin();
+        Gen g2 = generate_zero<Ref, V, Alloc>();
+        Iter j = g2.begin();
+
+        same_as<Iter&> decltype(auto) k = (i = move(j));
+        assert(&k == &i);
+        assert(k == default_sentinel);
+
+        static_assert(is_nothrow_move_assignable_v<Iter>);
+    }
+
+    { // Test indirection
+        auto g = generate_one<Ref, V, Alloc>();
+        auto i = g.begin();
+
+        [[maybe_unused]] same_as<_Gen_reference_t<Ref, V>> decltype(auto) r = *i;
+
+        using NoRef = remove_reference_t<Ref>;
+        if constexpr (default_initializable<NoRef> && equality_comparable<NoRef>) {
+            assert(r == NoRef{});
+        }
+    }
+
+    { // Test pre-incrementation
+        auto g = generate_one_recursively<Ref, V, Alloc>();
+        auto i = g.begin();
+
+        same_as<Iter&> decltype(auto) i_ref = ++i;
+        assert(&i_ref == &i);
+        assert(i_ref == default_sentinel);
+    }
+
+    { // Test post-incrementation
+        auto g = generate_one_recursively<Ref, V, Alloc>();
+        auto i = g.begin();
+        i++;
+        assert(i == default_sentinel);
+
+        static_assert(is_void_v<decltype(i++)>);
+    }
+
+    { // Test equal operator
+        auto g1 = generate_one<Ref, V, Alloc>();
+        auto i  = g1.begin();
+        auto g2 = generate_zero<Ref, V, Alloc>();
+        auto j  = g2.begin();
+
+        same_as<bool> decltype(auto) b1 = i == default_sentinel;
+        assert(!b1);
+
+        same_as<bool> decltype(auto) b2 = default_sentinel == j;
+        assert(b2);
+
+        same_as<bool> decltype(auto) b3 = i != default_sentinel;
+        assert(b3);
+
+        same_as<bool> decltype(auto) b4 = default_sentinel != j;
+        assert(!b4);
+    }
+
+    // Test sizeof
+    static_assert(sizeof(Iter) == sizeof(void*)); // NB: implementation defined
+}
+
+template <class Ref, class V = void>
+void test_with_allocator() {
+    test_one<Ref, V>();
+    test_one<Ref, V, allocator<void>>();
+    test_one<Ref, V, pmr::polymorphic_allocator<void>>();
+    test_one<Ref, V, TestAllocator<void>>();
+}
+
+template <class T>
+void test_with_type() {
+    test_with_allocator<T>();
+    test_with_allocator<T&>();
+    test_with_allocator<const T&>();
+    test_with_allocator<T&&>();
+    test_with_allocator<const T&&>();
+
+    test_with_allocator<Proxy<T>, T>();
+    test_with_allocator<Proxy<T>&, T>();
+    test_with_allocator<const Proxy<T>&, T>();
+    test_with_allocator<Proxy<T>&&, T>();
+    test_with_allocator<const Proxy<T>&&, T>();
+}
+
+int main() {
+    test_with_type<int>();
+    test_with_type<float>();
+    test_with_type<string>();
+    test_with_type<MoveOnly>();
+}


### PR DESCRIPTION
* Add tests for `generator`'s iterator type in separate `P2502R2_generator_iterator/test.cpp` file
* Add `test_generator_support.hpp` header
* Move
  ```c++
  static_assert(sizeof(ranges::iterator_t<G>) == sizeof(void*));
  ```
  test from `P2502R2_generator/test.cpp` to the new file.