### PR TITLE
`<tuple>`, `<variant>`: Make error messages from get-by-type functions clearer

### DIFF
--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -955,7 +955,7 @@ _NODISCARD constexpr _Ty& get(tuple<_Types...>& _Tuple) noexcept {
         return static_cast<_Ttype&>(_Tuple)._Myfirst._Val;
     } else {
         static_assert(_Always_false<_Ty>,
-            "get<T>(tuple<Types...>&) requires T to occur exactly once in Types. (N4971 [tuple.elem]/3)");
+            "get<T>(tuple<Types...>&) requires T to occur exactly once in Types. (N4971 [tuple.elem]/5)");
     }
 }
 
@@ -967,7 +967,7 @@ _NODISCARD constexpr const _Ty& get(const tuple<_Types...>& _Tuple) noexcept {
         return static_cast<const _Ttype&>(_Tuple)._Myfirst._Val;
     } else {
         static_assert(_Always_false<_Ty>,
-            "get<T>(const tuple<Types...>&) requires T to occur exactly once in Types. (N4971 [tuple.elem]/3)");
+            "get<T>(const tuple<Types...>&) requires T to occur exactly once in Types. (N4971 [tuple.elem]/5)");
     }
 }
 
@@ -979,7 +979,7 @@ _NODISCARD constexpr _Ty&& get(tuple<_Types...>&& _Tuple) noexcept {
         return static_cast<_Ty&&>(static_cast<_Ttype&>(_Tuple)._Myfirst._Val);
     } else {
         static_assert(_Always_false<_Ty>,
-            "get<T>(tuple<Types...>&&) requires T to occur exactly once in Types. (N4971 [tuple.elem]/3)");
+            "get<T>(tuple<Types...>&&) requires T to occur exactly once in Types. (N4971 [tuple.elem]/5)");
     }
 }
 
@@ -991,7 +991,7 @@ _NODISCARD constexpr const _Ty&& get(const tuple<_Types...>&& _Tuple) noexcept {
         return static_cast<const _Ty&&>(static_cast<const _Ttype&>(_Tuple)._Myfirst._Val);
     } else {
         static_assert(_Always_false<_Ty>,
-            "get<T>(const tuple<Types...>&&) requires T to occur exactly once in Types. (N4971 [tuple.elem]/3)");
+            "get<T>(const tuple<Types...>&&) requires T to occur exactly once in Types. (N4971 [tuple.elem]/5)");
     }
 }
 

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -913,19 +913,6 @@ constexpr void swap(const tuple<_Types...>& _Left, const tuple<_Types...>& _Righ
 }
 #endif // _HAS_CXX23
 
-template <class _Ty, class _Tuple>
-struct _Tuple_element {}; // backstop _Tuple_element definition
-
-template <class _This, class... _Rest>
-struct _Tuple_element<_This, tuple<_This, _Rest...>> { // select first element
-    using _Ttype = tuple<_This, _Rest...>;
-};
-
-template <class _Ty, class _This, class... _Rest>
-struct _Tuple_element<_Ty, tuple<_This, _Rest...>> { // recursive _Tuple_element definition
-    using _Ttype = typename _Tuple_element<_Ty, tuple<_Rest...>>::_Ttype;
-};
-
 _EXPORT_STD template <size_t _Index, class... _Types>
 _NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>& get(tuple<_Types...>& _Tuple) noexcept {
     using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;
@@ -964,7 +951,7 @@ _EXPORT_STD template <class _Ty, class... _Types>
 _NODISCARD constexpr _Ty& get(tuple<_Types...>& _Tuple) noexcept {
     constexpr size_t _Idx = _Meta_find_unique_index<tuple<_Types...>, _Ty>::value;
     if constexpr (_Idx < sizeof...(_Types)) {
-        using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
+        using _Ttype = typename tuple_element<_Idx, tuple<_Types...>>::_Ttype;
         return static_cast<_Ttype&>(_Tuple)._Myfirst._Val;
     } else {
         static_assert(_Always_false<_Ty>,
@@ -976,7 +963,7 @@ _EXPORT_STD template <class _Ty, class... _Types>
 _NODISCARD constexpr const _Ty& get(const tuple<_Types...>& _Tuple) noexcept {
     constexpr size_t _Idx = _Meta_find_unique_index<tuple<_Types...>, _Ty>::value;
     if constexpr (_Idx < sizeof...(_Types)) {
-        using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
+        using _Ttype = typename tuple_element<_Idx, tuple<_Types...>>::_Ttype;
         return static_cast<const _Ttype&>(_Tuple)._Myfirst._Val;
     } else {
         static_assert(_Always_false<_Ty>,
@@ -988,7 +975,7 @@ _EXPORT_STD template <class _Ty, class... _Types>
 _NODISCARD constexpr _Ty&& get(tuple<_Types...>&& _Tuple) noexcept {
     constexpr size_t _Idx = _Meta_find_unique_index<tuple<_Types...>, _Ty>::value;
     if constexpr (_Idx < sizeof...(_Types)) {
-        using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
+        using _Ttype = typename tuple_element<_Idx, tuple<_Types...>>::_Ttype;
         return static_cast<_Ty&&>(static_cast<_Ttype&>(_Tuple)._Myfirst._Val);
     } else {
         static_assert(_Always_false<_Ty>,
@@ -1000,7 +987,7 @@ _EXPORT_STD template <class _Ty, class... _Types>
 _NODISCARD constexpr const _Ty&& get(const tuple<_Types...>&& _Tuple) noexcept {
     constexpr size_t _Idx = _Meta_find_unique_index<tuple<_Types...>, _Ty>::value;
     if constexpr (_Idx < sizeof...(_Types)) {
-        using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
+        using _Ttype = typename tuple_element<_Idx, tuple<_Types...>>::_Ttype;
         return static_cast<const _Ty&&>(static_cast<const _Ttype&>(_Tuple)._Myfirst._Val);
     } else {
         static_assert(_Always_false<_Ty>,

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -918,7 +918,6 @@ struct _Tuple_element {}; // backstop _Tuple_element definition
 
 template <class _This, class... _Rest>
 struct _Tuple_element<_This, tuple<_This, _Rest...>> { // select first element
-    static_assert(!_Is_any_of_v<_This, _Rest...>, "duplicate type T in get<T>(tuple)");
     using _Ttype = tuple<_This, _Rest...>;
 };
 
@@ -963,26 +962,50 @@ _NODISCARD constexpr auto&& _Tuple_get(tuple<_Types...>&& _Tuple) noexcept {
 
 _EXPORT_STD template <class _Ty, class... _Types>
 _NODISCARD constexpr _Ty& get(tuple<_Types...>& _Tuple) noexcept {
-    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
-    return static_cast<_Ttype&>(_Tuple)._Myfirst._Val;
+    constexpr size_t _Idx = _Meta_find_unique_index<tuple<_Types...>, _Ty>::value;
+    if constexpr (_Idx < sizeof...(_Types)) {
+        using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
+        return static_cast<_Ttype&>(_Tuple)._Myfirst._Val;
+    } else {
+        static_assert(_Always_false<_Ty>,
+            "get<T>(tuple<Types...>&) requires T to occur exactly once in Types. (N4971 [tuple.elem]/3)");
+    }
 }
 
 _EXPORT_STD template <class _Ty, class... _Types>
 _NODISCARD constexpr const _Ty& get(const tuple<_Types...>& _Tuple) noexcept {
-    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
-    return static_cast<const _Ttype&>(_Tuple)._Myfirst._Val;
+    constexpr size_t _Idx = _Meta_find_unique_index<tuple<_Types...>, _Ty>::value;
+    if constexpr (_Idx < sizeof...(_Types)) {
+        using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
+        return static_cast<const _Ttype&>(_Tuple)._Myfirst._Val;
+    } else {
+        static_assert(_Always_false<_Ty>,
+            "get<T>(const tuple<Types...>&) requires T to occur exactly once in Types. (N4971 [tuple.elem]/3)");
+    }
 }
 
 _EXPORT_STD template <class _Ty, class... _Types>
 _NODISCARD constexpr _Ty&& get(tuple<_Types...>&& _Tuple) noexcept {
-    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
-    return static_cast<_Ty&&>(static_cast<_Ttype&>(_Tuple)._Myfirst._Val);
+    constexpr size_t _Idx = _Meta_find_unique_index<tuple<_Types...>, _Ty>::value;
+    if constexpr (_Idx < sizeof...(_Types)) {
+        using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
+        return static_cast<_Ty&&>(static_cast<_Ttype&>(_Tuple)._Myfirst._Val);
+    } else {
+        static_assert(_Always_false<_Ty>,
+            "get<T>(tuple<Types...>&&) requires T to occur exactly once in Types. (N4971 [tuple.elem]/3)");
+    }
 }
 
 _EXPORT_STD template <class _Ty, class... _Types>
 _NODISCARD constexpr const _Ty&& get(const tuple<_Types...>&& _Tuple) noexcept {
-    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
-    return static_cast<const _Ty&&>(static_cast<const _Ttype&>(_Tuple)._Myfirst._Val);
+    constexpr size_t _Idx = _Meta_find_unique_index<tuple<_Types...>, _Ty>::value;
+    if constexpr (_Idx < sizeof...(_Types)) {
+        using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
+        return static_cast<const _Ty&&>(static_cast<const _Ttype&>(_Tuple)._Myfirst._Val);
+    } else {
+        static_assert(_Always_false<_Ty>,
+            "get<T>(const tuple<Types...>&&) requires T to occur exactly once in Types. (N4971 [tuple.elem]/3)");
+    }
 }
 
 template <class _This, class... _Rest>

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -168,45 +168,6 @@ struct _Meta_at_<_List<_Types...>, _Idx, enable_if_t<(_Idx < sizeof...(_Types))>
 };
 #endif // ^^^ !defined(__clang__) ^^^
 
-inline constexpr auto _Meta_npos = ~size_t{0};
-
-constexpr size_t _Meta_find_index_i_(const bool* const _Ptr, const size_t _Count, size_t _Idx = 0) {
-    // return the index of the first true in the _Count bools at _Ptr, or _Meta_npos if all are false
-    for (; _Idx < _Count; ++_Idx) {
-        if (_Ptr[_Idx]) {
-            return _Idx;
-        }
-    }
-
-    return _Meta_npos;
-}
-
-template <class _List, class _Ty>
-struct _Meta_find_unique_index_ {
-    using type = integral_constant<size_t, _Meta_npos>;
-};
-template <class _List, class _Ty>
-using _Meta_find_unique_index =
-    // The index of _Ty in _List if it occurs exactly once, otherwise _Meta_npos
-    typename _Meta_find_unique_index_<_List, _Ty>::type;
-
-constexpr size_t _Meta_find_unique_index_i_2(const bool* const _Ptr, const size_t _Count, const size_t _First) {
-    // return _First if there is no _First < j < _Count such that _Ptr[j] is true, otherwise _Meta_npos
-    return _First != _Meta_npos && _STD _Meta_find_index_i_(_Ptr, _Count, _First + 1) == _Meta_npos ? _First
-                                                                                                    : _Meta_npos;
-}
-
-constexpr size_t _Meta_find_unique_index_i_(const bool* const _Ptr, const size_t _Count) {
-    // Pass the smallest i such that _Ptr[i] is true to _Meta_find_unique_index_i_2
-    return _STD _Meta_find_unique_index_i_2(_Ptr, _Count, _STD _Meta_find_index_i_(_Ptr, _Count));
-}
-
-template <template <class...> class _List, class _First, class... _Rest, class _Ty>
-struct _Meta_find_unique_index_<_List<_First, _Rest...>, _Ty> {
-    static constexpr bool _Bools[] = {is_same_v<_First, _Ty>, is_same_v<_Rest, _Ty>...};
-    using type = integral_constant<size_t, _STD _Meta_find_unique_index_i_(_Bools, 1 + sizeof...(_Rest))>;
-};
-
 template <class>
 struct _Meta_as_list_;
 template <class _Ty>
@@ -1179,9 +1140,12 @@ _EXPORT_STD template <class _Ty, class... _Types>
 _NODISCARD constexpr bool holds_alternative(const variant<_Types...>& _Var) noexcept {
     // true iff _Var holds alternative _Ty
     constexpr size_t _Idx = _Meta_find_unique_index<variant<_Types...>, _Ty>::value;
-    static_assert(_Idx != _Meta_npos, "holds_alternative<T>(const variant<Types...>&) requires T to occur exactly "
-                                      "once in Types. (N4950 [variant.get]/1)");
-    return _Var.index() == _Idx;
+    if constexpr (_Idx != _Meta_npos) {
+        return _Var.index() == _Idx;
+    } else {
+        static_assert(_Always_false<_Ty>, "holds_alternative<T>(const variant<Types...>&) requires T to occur exactly "
+                                          "once in Types. (N4971 [variant.get]/1)");
+    }
 }
 
 _EXPORT_STD template <size_t _Idx, class... _Types>
@@ -1229,33 +1193,45 @@ _EXPORT_STD template <class _Ty, class... _Types>
 _NODISCARD constexpr decltype(auto) get(variant<_Types...>& _Var) {
     // access the contained value of _Var if its alternative _Ty is active
     constexpr size_t _Idx = _Meta_find_unique_index<variant<_Types...>, _Ty>::value;
-    static_assert(_Idx < sizeof...(_Types),
-        "get<T>(variant<Types...>&) requires T to occur exactly once in Types. (N4950 [variant.get]/5)");
-    return _STD get<_Idx>(_Var);
+    if constexpr (_Idx < sizeof...(_Types)) {
+        return _STD get<_Idx>(_Var);
+    } else {
+        static_assert(_Always_false<_Ty>,
+            "get<T>(variant<Types...>&) requires T to occur exactly once in Types. (N4971 [variant.get]/8)");
+    }
 }
 _EXPORT_STD template <class _Ty, class... _Types>
 _NODISCARD constexpr decltype(auto) get(variant<_Types...>&& _Var) {
     // access the contained value of _Var if its alternative _Ty is active
     constexpr size_t _Idx = _Meta_find_unique_index<variant<_Types...>, _Ty>::value;
-    static_assert(_Idx < sizeof...(_Types),
-        "get<T>(variant<Types...>&&) requires T to occur exactly once in Types. (N4950 [variant.get]/5)");
-    return _STD get<_Idx>(_STD move(_Var));
+    if constexpr (_Idx < sizeof...(_Types)) {
+        return _STD get<_Idx>(_STD move(_Var));
+    } else {
+        static_assert(_Always_false<_Ty>,
+            "get<T>(variant<Types...>&&) requires T to occur exactly once in Types. (N4971 [variant.get]/8)");
+    }
 }
 _EXPORT_STD template <class _Ty, class... _Types>
 _NODISCARD constexpr decltype(auto) get(const variant<_Types...>& _Var) {
     // access the contained value of _Var if its alternative _Ty is active
     constexpr size_t _Idx = _Meta_find_unique_index<variant<_Types...>, _Ty>::value;
-    static_assert(_Idx < sizeof...(_Types),
-        "get<T>(const variant<Types...>&) requires T to occur exactly once in Types. (N4950 [variant.get]/5)");
-    return _STD get<_Idx>(_Var);
+    if constexpr (_Idx < sizeof...(_Types)) {
+        return _STD get<_Idx>(_Var);
+    } else {
+        static_assert(_Always_false<_Ty>,
+            "get<T>(const variant<Types...>&) requires T to occur exactly once in Types. (N4971 [variant.get]/8)");
+    }
 }
 _EXPORT_STD template <class _Ty, class... _Types>
 _NODISCARD constexpr decltype(auto) get(const variant<_Types...>&& _Var) {
     // access the contained value of _Var if its alternative _Ty is active
     constexpr size_t _Idx = _Meta_find_unique_index<variant<_Types...>, _Ty>::value;
-    static_assert(_Idx < sizeof...(_Types),
-        "get<T>(const variant<Types...>&&) requires T to occur exactly once in Types. (N4950 [variant.get]/5)");
-    return _STD get<_Idx>(_STD move(_Var));
+    if constexpr (_Idx < sizeof...(_Types)) {
+        return _STD get<_Idx>(_STD move(_Var));
+    } else {
+        static_assert(_Always_false<_Ty>,
+            "get<T>(const variant<Types...>&&) requires T to occur exactly once in Types. (N4971 [variant.get]/8)");
+    }
 }
 
 _EXPORT_STD template <size_t _Idx, class... _Types>
@@ -1275,17 +1251,23 @@ _EXPORT_STD template <class _Ty, class... _Types>
 _NODISCARD constexpr add_pointer_t<_Ty> get_if(variant<_Types...>* _Ptr) noexcept {
     // get the address of *_Ptr's contained value if it holds alternative _Ty
     constexpr size_t _Idx = _Meta_find_unique_index<variant<_Types...>, _Ty>::value;
-    static_assert(_Idx != _Meta_npos,
-        "get_if<T>(variant<Types...> *) requires T to occur exactly once in Types. (N4950 [variant.get]/9)");
-    return _STD get_if<_Idx>(_Ptr);
+    if constexpr (_Idx != _Meta_npos) {
+        return _STD get_if<_Idx>(_Ptr);
+    } else {
+        static_assert(_Always_false<_Ty>,
+            "get_if<T>(variant<Types...> *) requires T to occur exactly once in Types. (N4971 [variant.get]/12)");
+    }
 }
 _EXPORT_STD template <class _Ty, class... _Types>
 _NODISCARD constexpr add_pointer_t<const _Ty> get_if(const variant<_Types...>* _Ptr) noexcept {
     // get the address of *_Ptr's contained value if it holds alternative _Ty
     constexpr size_t _Idx = _Meta_find_unique_index<variant<_Types...>, _Ty>::value;
-    static_assert(_Idx != _Meta_npos,
-        "get_if<T>(const variant<Types...> *) requires T to occur exactly once in Types. (N4950 [variant.get]/9)");
-    return _STD get_if<_Idx>(_Ptr);
+    if constexpr (_Idx != _Meta_npos) {
+        return _STD get_if<_Idx>(_Ptr);
+    } else {
+        static_assert(_Always_false<_Ty>,
+            "get_if<T>(const variant<Types...> *) requires T to occur exactly once in Types. (N4971 [variant.get]/12)");
+    }
 }
 
 template <class _Op, class _Result, class... _Types>


### PR DESCRIPTION
Fixes #4575 by aborting recursive instantiation using `if constexpr`.
Also reuses `_Meta_find_unique_index` for overloads for `tuple`.