### PR TITLE
Check `is_clock_v` for thread utilities before C++20

### DIFF
--- a/stl/inc/__msvc_chrono.hpp
+++ b/stl/inc/__msvc_chrono.hpp
@@ -52,6 +52,21 @@ namespace chrono {
     };
 
 #if _HAS_CXX20
+    _EXPORT_STD template <class _Clock>
+    constexpr bool is_clock_v = requires {
+        typename _Clock::rep;
+        typename _Clock::period;
+        typename _Clock::duration;
+        typename _Clock::time_point;
+        _Clock::is_steady;
+        _Clock::now();
+    };
+    _EXPORT_STD template <class _Clock>
+    struct is_clock : bool_constant<is_clock_v<_Clock>> {};
+
+    template <class _Clock>
+    constexpr bool _Is_clock_v = is_clock_v<_Clock>;
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
     template <class _Clock, class = void>
     constexpr bool _Is_clock_v = false;
 
@@ -59,13 +74,8 @@ namespace chrono {
     constexpr bool
         _Is_clock_v<_Clock, void_t<typename _Clock::rep, typename _Clock::period, typename _Clock::duration,
                                 typename _Clock::time_point, decltype(_Clock::is_steady), decltype(_Clock::now())>> =
-            true; // TRANSITION, GH-602
-
-    _EXPORT_STD template <class _Clock>
-    struct is_clock : bool_constant<_Is_clock_v<_Clock>> {};
-    _EXPORT_STD template <class _Clock>
-    constexpr bool is_clock_v = _Is_clock_v<_Clock>;
-#endif // _HAS_CXX20
+            true;
+#endif // ^^^ !_HAS_CXX20 ^^^
 
     _EXPORT_STD template <class _Rep, class _Period = ratio<1>>
     class duration;

--- a/stl/inc/condition_variable
+++ b/stl/inc/condition_variable
@@ -92,9 +92,7 @@ public:
     template <class _Lock, class _Clock, class _Duration>
     cv_status wait_until(_Lock& _Lck, const chrono::time_point<_Clock, _Duration>& _Abs_time) {
         // wait until time point
-#if _HAS_CXX20
-        static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
-#endif // _HAS_CXX20
+        static_assert(chrono::_Is_clock_v<_Clock>, "Clock type required");
         const auto _Now                  = _Clock::now();
         using _Common_duration           = decltype(_Abs_time - _Now);
         const _Common_duration _Rel_time = (_Abs_time <= _Now) ? _Common_duration::zero() : _Abs_time - _Now;

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -761,9 +761,7 @@ public:
 
     template <class _Clock, class _Dur>
     future_status wait_until(const chrono::time_point<_Clock, _Dur>& _Abs_time) const { // wait until time point
-#if _HAS_CXX20
-        static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
-#endif // _HAS_CXX20
+        static_assert(chrono::_Is_clock_v<_Clock>, "Clock type required");
         if (!valid()) {
             _Throw_future_error2(future_errc::no_state);
         }

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -162,9 +162,7 @@ public:
     _NODISCARD_CTOR_LOCK unique_lock(_Mutex& _Mtx, const chrono::time_point<_Clock, _Duration>& _Abs_time)
         : _Pmtx(_STD addressof(_Mtx)), _Owns(_Pmtx->try_lock_until(_Abs_time)) {
         // construct and lock with timeout
-#if _HAS_CXX20
-        static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
-#endif // _HAS_CXX20
+        static_assert(chrono::_Is_clock_v<_Clock>, "Clock type required");
     }
 
     _NODISCARD_CTOR_LOCK unique_lock(unique_lock&& _Other) noexcept : _Pmtx(_Other._Pmtx), _Owns(_Other._Owns) {
@@ -216,9 +214,7 @@ public:
 
     template <class _Clock, class _Duration>
     _NODISCARD_TRY_CHANGE_STATE bool try_lock_until(const chrono::time_point<_Clock, _Duration>& _Abs_time) {
-#if _HAS_CXX20
-        static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
-#endif // _HAS_CXX20
+        static_assert(chrono::_Is_clock_v<_Clock>, "Clock type required");
         _Validate();
         _Owns = _Pmtx->try_lock_until(_Abs_time);
         return _Owns;
@@ -585,9 +581,7 @@ public:
     template <class _Clock, class _Duration>
     cv_status wait_until(unique_lock<mutex>& _Lck, const chrono::time_point<_Clock, _Duration>& _Abs_time) {
         // wait until time point
-#if _HAS_CXX20
-        static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
-#endif // _HAS_CXX20
+        static_assert(chrono::_Is_clock_v<_Clock>, "Clock type required");
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(
             _Lck.owns_lock(), "wait_until's caller must own the lock argument (N4958 [thread.condition.condvar]/17)");
@@ -614,9 +608,7 @@ public:
     bool wait_until(
         unique_lock<mutex>& _Lck, const chrono::time_point<_Clock, _Duration>& _Abs_time, _Predicate _Pred) {
         // wait for signal with timeout and check predicate
-#if _HAS_CXX20
-        static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
-#endif // _HAS_CXX20
+        static_assert(chrono::_Is_clock_v<_Clock>, "Clock type required");
         while (!_Pred()) {
             if (wait_until(_Lck, _Abs_time) == cv_status::timeout) {
                 return _Pred();
@@ -696,9 +688,7 @@ public:
     template <class _Clock, class _Duration>
     _NODISCARD_TRY_CHANGE_STATE bool try_lock_until(const chrono::time_point<_Clock, _Duration>& _Abs_time) {
         // try to lock the mutex with timeout
-#if _HAS_CXX20
-        static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
-#endif // _HAS_CXX20
+        static_assert(chrono::_Is_clock_v<_Clock>, "Clock type required");
         unique_lock<mutex> _Lock(_My_mutex);
         if (!_My_cond.wait_until(_Lock, _Abs_time, _UInt_is_zero{_My_locked})) {
             return false;
@@ -792,9 +782,7 @@ public:
     template <class _Clock, class _Duration>
     _NODISCARD_TRY_CHANGE_STATE bool try_lock_until(const chrono::time_point<_Clock, _Duration>& _Abs_time) {
         // try to lock the mutex with timeout
-#if _HAS_CXX20
-        static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
-#endif // _HAS_CXX20
+        static_assert(chrono::_Is_clock_v<_Clock>, "Clock type required");
         const thread::id _Tid = this_thread::get_id();
 
         unique_lock<mutex> _Lock(_My_mutex);

--- a/stl/inc/shared_mutex
+++ b/stl/inc/shared_mutex
@@ -107,9 +107,7 @@ public:
     template <class _Clock, class _Duration>
     _NODISCARD_TRY_CHANGE_STATE bool try_lock_until(const chrono::time_point<_Clock, _Duration>& _Abs_time) {
         // try to lock until time point
-#if _HAS_CXX20
-        static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
-#endif // _HAS_CXX20
+        static_assert(chrono::_Is_clock_v<_Clock>, "Clock type required");
         auto _Not_writing  = [this] { return !_Writing; };
         auto _Zero_readers = [this] { return _Readers == 0; };
         unique_lock<mutex> _Lock(_Mymtx);
@@ -168,9 +166,7 @@ public:
     template <class _Clock, class _Duration>
     _NODISCARD_TRY_CHANGE_STATE bool try_lock_shared_until(const chrono::time_point<_Clock, _Duration>& _Abs_time) {
         // try to lock non-exclusive until absolute time
-#if _HAS_CXX20
-        static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
-#endif // _HAS_CXX20
+        static_assert(chrono::_Is_clock_v<_Clock>, "Clock type required");
         const auto _Can_acquire = [this] { return !_Writing && _Readers < _Max_readers; };
 
         unique_lock<mutex> _Lock(_Mymtx);
@@ -240,9 +236,7 @@ public:
     _NODISCARD_CTOR_LOCK shared_lock(mutex_type& _Mtx, const chrono::time_point<_Clock, _Duration>& _Abs_time)
         : _Pmtx(_STD addressof(_Mtx)), _Owns(_Mtx.try_lock_shared_until(_Abs_time)) {
         // construct with mutex and try to lock until absolute time
-#if _HAS_CXX20
-        static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
-#endif // _HAS_CXX20
+        static_assert(chrono::_Is_clock_v<_Clock>, "Clock type required");
     }
 
     ~shared_lock() noexcept {
@@ -294,9 +288,7 @@ public:
     template <class _Clock, class _Duration>
     _NODISCARD_TRY_CHANGE_STATE bool try_lock_until(const chrono::time_point<_Clock, _Duration>& _Abs_time) {
         // try to lock the mutex until _Abs_time
-#if _HAS_CXX20
-        static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
-#endif // _HAS_CXX20
+        static_assert(chrono::_Is_clock_v<_Clock>, "Clock type required");
         _Validate();
         _Owns = _Pmtx->try_lock_shared_until(_Abs_time);
         return _Owns;

--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -206,9 +206,7 @@ namespace this_thread {
 
     _EXPORT_STD template <class _Clock, class _Duration>
     void sleep_until(const chrono::time_point<_Clock, _Duration>& _Abs_time) {
-#if _HAS_CXX20
-        static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
-#endif // _HAS_CXX20
+        static_assert(chrono::_Is_clock_v<_Clock>, "Clock type required");
         for (;;) {
             const auto _Now = _Clock::now();
             if (_Abs_time <= _Now) {


### PR DESCRIPTION
This PR generalizes #1687 to C++14/17 modes and reimplements `is_clock_v` with a `requires`-expression. Towards #602.

In [N4659 [time.point]/1](https://timsong-cpp.github.io/cppwp/n4659/time.point#1), the `Clock` template parameter was required to meet the Clock (_Cpp17Clock_ now) requirements. The requirement was changed by WG21-P0355R7 in C++20 and removed by WG21-P2212R2 in C++23.

All involved thread functions take a `time_point` parameter, so it was already invalid (probably UB) in C++11 to use these functions with an invalid `time_point` type. Static checking seems OK to me as we've been statically asserting `is_standard_layout_v` and `is_trivial_v` for `basic_string`.