### PR TITLE
Vectorize `find_first_of` for 4 and 8 byte elements

### DIFF
--- a/benchmarks/src/find_first_of.cpp
+++ b/benchmarks/src/find_first_of.cpp
@@ -33,18 +33,14 @@ void bm(benchmark::State& state) {
     }
 }
 
-#define ARGS               \
-    Args({2, 3})           \
-        ->Args({7, 4})     \
-        ->Args({9, 3})     \
-        ->Args({22, 5})    \
-        ->Args({58, 2})    \
-        ->Args({102, 4})   \
-        ->Args({325, 1})   \
-        ->Args({1011, 11}) \
-        ->Args({3056, 7});
+void common_args(auto bm) {
+    bm->Args({2, 3})->Args({7, 4})->Args({9, 3})->Args({22, 5})->Args({58, 2});
+    bm->Args({102, 4})->Args({325, 1})->Args({1011, 11})->Args({3056, 7});
+}
 
-BENCHMARK(bm<uint8_t>)->ARGS;
-BENCHMARK(bm<uint16_t>)->ARGS;
+BENCHMARK(bm<uint8_t>)->Apply(common_args);
+BENCHMARK(bm<uint16_t>)->Apply(common_args);
+BENCHMARK(bm<uint32_t>)->Apply(common_args);
+BENCHMARK(bm<uint64_t>)->Apply(common_args);
 
 BENCHMARK_MAIN();

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -62,6 +62,11 @@ const void* __stdcall __std_find_first_of_trivial_1(
     const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept;
 const void* __stdcall __std_find_first_of_trivial_2(
     const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept;
+const void* __stdcall __std_find_first_of_trivial_4(
+    const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept;
+const void* __stdcall __std_find_first_of_trivial_8(
+    const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept;
+
 
 __declspec(noalias) _Min_max_1i __stdcall __std_minmax_1i(const void* _First, const void* _Last) noexcept;
 __declspec(noalias) _Min_max_1u __stdcall __std_minmax_1u(const void* _First, const void* _Last) noexcept;
@@ -202,6 +207,12 @@ _Ty1* _Find_first_of_vectorized(
     } else if constexpr (sizeof(_Ty1) == 2) {
         return const_cast<_Ty1*>(
             static_cast<const _Ty1*>(::__std_find_first_of_trivial_2(_First1, _Last1, _First2, _Last2)));
+    } else if constexpr (sizeof(_Ty1) == 4) {
+        return const_cast<_Ty1*>(
+            static_cast<const _Ty1*>(::__std_find_first_of_trivial_4(_First1, _Last1, _First2, _Last2)));
+    } else if constexpr (sizeof(_Ty1) == 8) {
+        return const_cast<_Ty1*>(
+            static_cast<const _Ty1*>(::__std_find_first_of_trivial_8(_First1, _Last1, _First2, _Last2)));
     } else {
         static_assert(_Always_false<_Ty1>, "Unexpected size");
     }
@@ -230,9 +241,7 @@ _INLINE_VAR constexpr ptrdiff_t _Threshold_find_first_of = 16;
 
 // Can we activate the vector algorithms for find_first_of?
 template <class _It1, class _It2, class _Pr>
-constexpr bool _Vector_alg_in_find_first_of_is_safe =
-    _Equal_memcmp_is_safe<_It1, _It2, _Pr> // can replace value comparison with bitwise comparison
-    && sizeof(_Iter_value_t<_It1>) <= 2; // pcmpestri compatible size
+constexpr bool _Vector_alg_in_find_first_of_is_safe = _Equal_memcmp_is_safe<_It1, _It2, _Pr>;
 
 // Can we activate the vector algorithms for replace?
 template <class _Iter, class _Ty1>

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -67,7 +67,6 @@ const void* __stdcall __std_find_first_of_trivial_4(
 const void* __stdcall __std_find_first_of_trivial_8(
     const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept;
 
-
 __declspec(noalias) _Min_max_1i __stdcall __std_minmax_1i(const void* _First, const void* _Last) noexcept;
 __declspec(noalias) _Min_max_1u __stdcall __std_minmax_1u(const void* _First, const void* _Last) noexcept;
 __declspec(noalias) _Min_max_2i __stdcall __std_minmax_2i(const void* _First, const void* _Last) noexcept;

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2060,8 +2060,8 @@ namespace {
         }
 
         template <class _Ty>
-        const void* __stdcall __pcmpestri_impl(const void* _First1, const void* const _Last1,
-            const void* const _First2, const void* const _Last2) noexcept {
+        const void* __stdcall __pcmpestri_impl(const void* _First1, const void* const _Last1, const void* const _First2,
+            const void* const _Last2) noexcept {
 #ifndef _M_ARM64EC
             if (_Use_sse42()) {
                 constexpr int _Op = (sizeof(_Ty) == 1 ? _SIDD_UBYTE_OPS : _SIDD_UWORD_OPS) | _SIDD_CMP_EQUAL_ANY
@@ -2344,8 +2344,8 @@ namespace {
         }
 
         template <class _Traits>
-        const void* __stdcall __48_impl(const void* const _First1, const void* const _Last1,
-            const void* const _First2, const void* const _Last2) noexcept {
+        const void* __stdcall __48_impl(const void* const _First1, const void* const _Last1, const void* const _First2,
+            const void* const _Last2) noexcept {
             using _Ty = typename _Traits::_Ty;
 #ifndef _M_ARM64EC
             if (_Use_avx2()) {

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2387,7 +2387,7 @@ namespace {
                     for (auto _Ptr2 = _First2; _Ptr2 != _Stop2; _Advance_bytes(_Ptr2, 32)) {
                         const __m256i _Data2 = _mm256_loadu_si256(static_cast<const __m256i*>(_Ptr2));
                         const __m256i _Eq    = _Traits::_Cmp_avx(_Data1, _Data2);
-                        if (_mm256_testz_si256(_Eq, _Eq) == 0) {
+                        if (!_mm256_testz_si256(_Eq, _Eq)) {
                             return _Ptr1;
                         }
                     }
@@ -2395,7 +2395,7 @@ namespace {
                     if (_Needle_length_tail != 0) {
                         const __m256i _Data2 = _mm256_maskload_epi32(static_cast<const int*>(_Stop2), _Tail_mask);
                         const __m256i _Eq    = _Traits::_Cmp_avx(_Data1, _Data2);
-                        if (_mm256_testz_si256(_Eq, _Tail_mask) == 0) {
+                        if (!_mm256_testz_si256(_Eq, _Tail_mask)) {
                             return _Ptr1;
                         }
                     }

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2278,7 +2278,7 @@ namespace {
 
 #ifndef _M_ARM64EC
         template <class _Traits, size_t _Needle_length_el_magnitude>
-        const __m256i _Shuffle_step(const __m256i _Data1, const __m256i _Data2s0) noexcept {
+        __m256i _Shuffle_step(const __m256i _Data1, const __m256i _Data2s0) noexcept {
             __m256i _Eq = _Traits::_Cmp_avx(_Data1, _Data2s0);
             if constexpr (_Needle_length_el_magnitude >= 2) {
                 const __m256i _Data2s1 = _Traits::_Shuffle_avx<1>(_Data2s0);

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2303,7 +2303,7 @@ namespace {
         template <class _Traits, size_t _Needle_length_el_magnitude>
         const void* __shuffle_impl(
             const void* _First1, const void* const _Last1, const void* const _First2, const size_t _Needle_length_el) {
-            using _Ty            = typename _Traits::_Ty;
+            using _Ty            = _Traits::_Ty;
             const __m256i _Data2 = _mm256_maskload_epi32(
                 reinterpret_cast<const int*>(_First2), _Avx2_tail_mask_32(_Needle_length_el * (sizeof(_Ty) / 4)));
             const __m256i _Data2s0 = _Traits::_Spread_avx<_Needle_length_el_magnitude>(_Data2, _Needle_length_el);
@@ -2346,7 +2346,7 @@ namespace {
         template <class _Traits>
         const void* __stdcall __48_impl(const void* const _First1, const void* const _Last1, const void* const _First2,
             const void* const _Last2) noexcept {
-            using _Ty = typename _Traits::_Ty;
+            using _Ty = _Traits::_Ty;
 #ifndef _M_ARM64EC
             if (_Use_avx2()) {
                 _Zeroupper_on_exit _Guard; // TRANSITION, DevCom-10331414

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2115,9 +2115,9 @@ namespace {
 
                     const int _Last_needle_length = static_cast<int>(_Needle_length & 0xF);
 
-                    alignas(16) uint8_t _Tmp1[16];
-                    memcpy(_Tmp1, _Last_needle, _Last_needle_length);
-                    const __m128i _Last_needle_val   = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp1));
+                    alignas(16) uint8_t _Tmp2[16];
+                    memcpy(_Tmp2, _Last_needle, _Last_needle_length);
+                    const __m128i _Last_needle_val   = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp2));
                     const int _Last_needle_length_el = _Last_needle_length / sizeof(_Ty);
 
                     constexpr int _Not_found = 16; // arbitrary value greater than any found value
@@ -2163,9 +2163,9 @@ namespace {
                     const size_t _Last_part_size = _Haystack_length & 0xF;
                     const int _Last_part_size_el = static_cast<int>(_Last_part_size / sizeof(_Ty));
 
-                    alignas(16) uint8_t _Tmp2[16];
-                    memcpy(_Tmp2, _First1, _Last_part_size);
-                    const __m128i _Data1 = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp2));
+                    alignas(16) uint8_t _Tmp1[16];
+                    memcpy(_Tmp1, _First1, _Last_part_size);
+                    const __m128i _Data1 = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp1));
 
                     _Found_pos = _Last_part_size_el;
 

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -8,7 +8,6 @@
 #if defined(_M_IX86) || defined(_M_X64) // NB: includes _M_ARM64EC
 #include <__msvc_minmax.hpp>
 #include <cstdint>
-#include <cstdlib>
 #include <cstring>
 #include <xtr1common>
 
@@ -2360,8 +2359,7 @@ namespace {
                 if (_Needle_length_el == 0) {
                     return _Last1;
                 } else if (_Needle_length_el == 1) {
-                    // This is expected to be forwarded to 'find' on an upper level
-                    _CSTD abort();
+                    _STL_UNREACHABLE; // This is expected to be forwarded to 'find' on an upper level
                 } else if (_Needle_length_el == 2) {
                     return __shuffle_impl<_Traits, 2>(_First1, _Last1, _First2, _Needle_length_el);
                 } else if (_Needle_length_el <= 4) {

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2223,7 +2223,7 @@ namespace {
 
                 return _Val;
             } else {
-                static_assert(_Amount != _Amount, "Unexpected amount");
+                static_assert(false, "Unexpected amount");
             }
         }
 
@@ -2236,7 +2236,7 @@ namespace {
             } else if constexpr (_Amount == 4) {
                 return _mm256_permute4x64_epi64(_Val, _MM_SHUFFLE(1, 0, 3, 2));
             } else {
-                static_assert(_Amount != _Amount, "Unexpected amount");
+                static_assert(false, "Unexpected amount");
             }
         }
     };
@@ -2257,7 +2257,7 @@ namespace {
 
                 return _Val;
             } else {
-                static_assert(_Amount != _Amount, "Unexpected amount");
+                static_assert(false, "Unexpected amount");
             }
         }
 
@@ -2268,7 +2268,7 @@ namespace {
             } else if constexpr (_Amount == 2) {
                 return _mm256_permute4x64_epi64(_Val, _MM_SHUFFLE(1, 0, 3, 2));
             } else {
-                static_assert(_Amount != _Amount, "Unexpected amount");
+                static_assert(false, "Unexpected amount");
             }
         }
     };

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2247,7 +2247,7 @@ namespace {
             using _Ty = uint64_t;
 #ifndef _M_ARM64EC
             template <size_t _Amount>
-            static __m256i _Spread_avx(__m256i _Val, const size_t _Needle_length_el) noexcept {
+            static __m256i _Spread_avx(const __m256i _Val, const size_t _Needle_length_el) noexcept {
                 if constexpr (_Amount == 1) {
                     return _mm256_broadcastq_epi64(_mm256_castsi256_si128(_Val));
                 } else if constexpr (_Amount == 2) {

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2038,102 +2038,143 @@ namespace {
         return _Result;
     }
 
-    template <class _Ty>
-    const void* __stdcall __std_find_first_of_trivial_fallback(
-        const void* _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) {
-        auto _Ptr_haystack           = static_cast<const _Ty*>(_First1);
-        const auto _Ptr_haystack_end = static_cast<const _Ty*>(_Last1);
-        const auto _Ptr_needle       = static_cast<const _Ty*>(_First2);
-        const auto _Ptr_needle_end   = static_cast<const _Ty*>(_Last2);
+    namespace __std_find_first_of {
 
-        for (; _Ptr_haystack != _Ptr_haystack_end; ++_Ptr_haystack) {
-            for (auto _Ptr = _Ptr_needle; _Ptr != _Ptr_needle_end; ++_Ptr) {
-                if (*_Ptr_haystack == *_Ptr) {
-                    return _Ptr_haystack;
+        template <class _Ty>
+        const void* __stdcall __fallback(
+            const void* _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) {
+            auto _Ptr_haystack           = static_cast<const _Ty*>(_First1);
+            const auto _Ptr_haystack_end = static_cast<const _Ty*>(_Last1);
+            const auto _Ptr_needle       = static_cast<const _Ty*>(_First2);
+            const auto _Ptr_needle_end   = static_cast<const _Ty*>(_Last2);
+
+            for (; _Ptr_haystack != _Ptr_haystack_end; ++_Ptr_haystack) {
+                for (auto _Ptr = _Ptr_needle; _Ptr != _Ptr_needle_end; ++_Ptr) {
+                    if (*_Ptr_haystack == *_Ptr) {
+                        return _Ptr_haystack;
+                    }
                 }
             }
+
+            return _Ptr_haystack;
         }
 
-        return _Ptr_haystack;
-    }
-
-    template <class _Ty>
-    const void* __stdcall __std_find_first_of_trivial_pcmpestri_impl(
-        const void* _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
+        template <class _Ty>
+        const void* __stdcall __pcmpestri_impl(const void* _First1, const void* const _Last1,
+            const void* const _First2, const void* const _Last2) noexcept {
 #ifndef _M_ARM64EC
-        if (_Use_sse42()) {
-            constexpr int _Op =
-                (sizeof(_Ty) == 1 ? _SIDD_UBYTE_OPS : _SIDD_UWORD_OPS) | _SIDD_CMP_EQUAL_ANY | _SIDD_LEAST_SIGNIFICANT;
-            constexpr int _Part_size_el = sizeof(_Ty) == 1 ? 16 : 8;
-            const size_t _Needle_length = _Byte_length(_First2, _Last2);
+            if (_Use_sse42()) {
+                constexpr int _Op = (sizeof(_Ty) == 1 ? _SIDD_UBYTE_OPS : _SIDD_UWORD_OPS) | _SIDD_CMP_EQUAL_ANY
+                                  | _SIDD_LEAST_SIGNIFICANT;
+                constexpr int _Part_size_el = sizeof(_Ty) == 1 ? 16 : 8;
+                const size_t _Needle_length = _Byte_length(_First2, _Last2);
 
-            if (_Needle_length <= 16) {
-                // Special handling of small needle
-                // The generic branch could also handle it but with slightly worse performance
+                if (_Needle_length <= 16) {
+                    // Special handling of small needle
+                    // The generic branch could also handle it but with slightly worse performance
 
-                const int _Needle_length_el = static_cast<int>(_Needle_length / sizeof(_Ty));
+                    const int _Needle_length_el = static_cast<int>(_Needle_length / sizeof(_Ty));
 
-                alignas(16) uint8_t _Tmp1[16];
-                memcpy(_Tmp1, _First2, _Needle_length);
-                const __m128i _Needle = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp1));
+                    alignas(16) uint8_t _Tmp1[16];
+                    memcpy(_Tmp1, _First2, _Needle_length);
+                    const __m128i _Data2 = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp1));
 
-                const size_t _Haystack_length = _Byte_length(_First1, _Last1);
-                const void* _Stop_at          = _First1;
-                _Advance_bytes(_Stop_at, _Haystack_length & ~size_t{0xF});
+                    const size_t _Haystack_length = _Byte_length(_First1, _Last1);
+                    const void* _Stop_at          = _First1;
+                    _Advance_bytes(_Stop_at, _Haystack_length & ~size_t{0xF});
 
-                while (_First1 != _Stop_at) {
-                    const __m128i _Haystack_part = _mm_loadu_si128(static_cast<const __m128i*>(_First1));
-                    if (_mm_cmpestrc(_Needle, _Needle_length_el, _Haystack_part, _Part_size_el, _Op)) {
-                        const int _Pos = _mm_cmpestri(_Needle, _Needle_length_el, _Haystack_part, _Part_size_el, _Op);
+                    while (_First1 != _Stop_at) {
+                        const __m128i _Data1 = _mm_loadu_si128(static_cast<const __m128i*>(_First1));
+                        if (_mm_cmpestrc(_Data2, _Needle_length_el, _Data1, _Part_size_el, _Op)) {
+                            const int _Pos = _mm_cmpestri(_Data2, _Needle_length_el, _Data1, _Part_size_el, _Op);
+                            _Advance_bytes(_First1, _Pos * sizeof(_Ty));
+                            return _First1;
+                        }
+
+                        _Advance_bytes(_First1, 16);
+                    }
+
+                    const size_t _Last_part_size = _Haystack_length & 0xF;
+                    const int _Last_part_size_el = static_cast<int>(_Last_part_size / sizeof(_Ty));
+
+                    alignas(16) uint8_t _Tmp2[16];
+                    memcpy(_Tmp2, _First1, _Last_part_size);
+                    const __m128i _Data1 = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp2));
+
+                    if (_mm_cmpestrc(_Data2, _Needle_length_el, _Data1, _Last_part_size_el, _Op)) {
+                        const int _Pos = _mm_cmpestri(_Data2, _Needle_length_el, _Data1, _Last_part_size_el, _Op);
                         _Advance_bytes(_First1, _Pos * sizeof(_Ty));
                         return _First1;
                     }
 
-                    _Advance_bytes(_First1, 16);
-                }
-
-                const size_t _Last_part_size = _Haystack_length & 0xF;
-                const int _Last_part_size_el = static_cast<int>(_Last_part_size / sizeof(_Ty));
-
-                alignas(16) uint8_t _Tmp2[16];
-                memcpy(_Tmp2, _First1, _Last_part_size);
-                const __m128i _Haystack_part = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp2));
-
-                if (_mm_cmpestrc(_Needle, _Needle_length_el, _Haystack_part, _Last_part_size_el, _Op)) {
-                    const int _Pos = _mm_cmpestri(_Needle, _Needle_length_el, _Haystack_part, _Last_part_size_el, _Op);
-                    _Advance_bytes(_First1, _Pos * sizeof(_Ty));
+                    _Advance_bytes(_First1, _Last_part_size);
                     return _First1;
-                }
+                } else {
+                    const void* _Last_needle = _First2;
+                    _Advance_bytes(_Last_needle, _Needle_length & ~size_t{0xF});
 
-                _Advance_bytes(_First1, _Last_part_size);
-                return _First1;
-            } else {
-                const void* _Last_needle = _First2;
-                _Advance_bytes(_Last_needle, _Needle_length & ~size_t{0xF});
+                    const int _Last_needle_length = static_cast<int>(_Needle_length & 0xF);
 
-                const int _Last_needle_length = static_cast<int>(_Needle_length & 0xF);
+                    alignas(16) uint8_t _Tmp1[16];
+                    memcpy(_Tmp1, _Last_needle, _Last_needle_length);
+                    const __m128i _Last_needle_val   = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp1));
+                    const int _Last_needle_length_el = _Last_needle_length / sizeof(_Ty);
 
-                alignas(16) uint8_t _Tmp1[16];
-                memcpy(_Tmp1, _Last_needle, _Last_needle_length);
-                const __m128i _Last_needle_val   = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp1));
-                const int _Last_needle_length_el = _Last_needle_length / sizeof(_Ty);
+                    constexpr int _Not_found = 16; // arbitrary value greater than any found value
 
-                constexpr int _Not_found = 16; // arbitrary value greater than any found value
+                    int _Found_pos = _Not_found;
 
-                int _Found_pos = _Not_found;
+                    const size_t _Haystack_length = _Byte_length(_First1, _Last1);
+                    const void* _Stop_at          = _First1;
+                    _Advance_bytes(_Stop_at, _Haystack_length & ~size_t{0xF});
 
-                const size_t _Haystack_length = _Byte_length(_First1, _Last1);
-                const void* _Stop_at          = _First1;
-                _Advance_bytes(_Stop_at, _Haystack_length & ~size_t{0xF});
+                    while (_First1 != _Stop_at) {
+                        const __m128i _Data1 = _mm_loadu_si128(static_cast<const __m128i*>(_First1));
 
-                while (_First1 != _Stop_at) {
-                    const __m128i _Haystack_part = _mm_loadu_si128(static_cast<const __m128i*>(_First1));
+                        for (const void* _Cur_needle = _First2; _Cur_needle != _Last_needle;
+                             _Advance_bytes(_Cur_needle, 16)) {
+                            const __m128i _Data2 = _mm_loadu_si128(static_cast<const __m128i*>(_Cur_needle));
+                            if (_mm_cmpestrc(_Data2, _Part_size_el, _Data1, _Part_size_el, _Op)) {
+                                const int _Pos = _mm_cmpestri(_Data2, _Part_size_el, _Data1, _Part_size_el, _Op);
+                                if (_Pos < _Found_pos) {
+                                    _Found_pos = _Pos;
+                                }
+                            }
+                        }
+
+                        if (const int _Needle_length_el = _Last_needle_length_el; _Needle_length_el != 0) {
+                            const __m128i _Data2 = _Last_needle_val;
+                            if (_mm_cmpestrc(_Data2, _Needle_length_el, _Data1, _Part_size_el, _Op)) {
+                                const int _Pos = _mm_cmpestri(_Data2, _Needle_length_el, _Data1, _Part_size_el, _Op);
+                                if (_Pos < _Found_pos) {
+                                    _Found_pos = _Pos;
+                                }
+                            }
+                        }
+
+                        if (_Found_pos != _Not_found) {
+                            _Advance_bytes(_First1, _Found_pos * sizeof(_Ty));
+                            return _First1;
+                        }
+
+                        _Advance_bytes(_First1, 16);
+                    }
+
+                    const size_t _Last_part_size = _Haystack_length & 0xF;
+                    const int _Last_part_size_el = static_cast<int>(_Last_part_size / sizeof(_Ty));
+
+                    alignas(16) uint8_t _Tmp2[16];
+                    memcpy(_Tmp2, _First1, _Last_part_size);
+                    const __m128i _Data1 = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp2));
+
+                    _Found_pos = _Last_part_size_el;
 
                     for (const void* _Cur_needle = _First2; _Cur_needle != _Last_needle;
                          _Advance_bytes(_Cur_needle, 16)) {
-                        const __m128i _Needle = _mm_loadu_si128(static_cast<const __m128i*>(_Cur_needle));
-                        if (_mm_cmpestrc(_Needle, _Part_size_el, _Haystack_part, _Part_size_el, _Op)) {
-                            const int _Pos = _mm_cmpestri(_Needle, _Part_size_el, _Haystack_part, _Part_size_el, _Op);
+                        const __m128i _Data2 = _mm_loadu_si128(static_cast<const __m128i*>(_Cur_needle));
+
+                        if (_mm_cmpestrc(_Data2, _Part_size_el, _Data1, _Last_part_size_el, _Op)) {
+                            const int _Pos = _mm_cmpestri(_Data2, _Part_size_el, _Data1, _Last_part_size_el, _Op);
                             if (_Pos < _Found_pos) {
                                 _Found_pos = _Pos;
                             }
@@ -2141,273 +2182,227 @@ namespace {
                     }
 
                     if (const int _Needle_length_el = _Last_needle_length_el; _Needle_length_el != 0) {
-                        const __m128i _Needle = _Last_needle_val;
-                        if (_mm_cmpestrc(_Needle, _Needle_length_el, _Haystack_part, _Part_size_el, _Op)) {
-                            const int _Pos =
-                                _mm_cmpestri(_Needle, _Needle_length_el, _Haystack_part, _Part_size_el, _Op);
+                        const __m128i _Data2 = _Last_needle_val;
+                        if (_mm_cmpestrc(_Data2, _Needle_length_el, _Data1, _Last_part_size_el, _Op)) {
+                            const int _Pos = _mm_cmpestri(_Data2, _Needle_length_el, _Data1, _Last_part_size_el, _Op);
                             if (_Pos < _Found_pos) {
                                 _Found_pos = _Pos;
                             }
                         }
                     }
 
-                    if (_Found_pos != _Not_found) {
-                        _Advance_bytes(_First1, _Found_pos * sizeof(_Ty));
-                        return _First1;
-                    }
-
-                    _Advance_bytes(_First1, 16);
+                    _Advance_bytes(_First1, _Found_pos * sizeof(_Ty));
+                    return _First1;
                 }
-
-                const size_t _Last_part_size = _Haystack_length & 0xF;
-                const int _Last_part_size_el = static_cast<int>(_Last_part_size / sizeof(_Ty));
-
-                alignas(16) uint8_t _Tmp2[16];
-                memcpy(_Tmp2, _First1, _Last_part_size);
-                const __m128i _Haystack_part = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp2));
-
-                _Found_pos = _Last_part_size_el;
-
-                for (const void* _Cur_needle = _First2; _Cur_needle != _Last_needle; _Advance_bytes(_Cur_needle, 16)) {
-                    const __m128i _Needle = _mm_loadu_si128(static_cast<const __m128i*>(_Cur_needle));
-
-                    if (_mm_cmpestrc(_Needle, _Part_size_el, _Haystack_part, _Last_part_size_el, _Op)) {
-                        const int _Pos = _mm_cmpestri(_Needle, _Part_size_el, _Haystack_part, _Last_part_size_el, _Op);
-                        if (_Pos < _Found_pos) {
-                            _Found_pos = _Pos;
-                        }
-                    }
-                }
-
-                if (const int _Needle_length_el = _Last_needle_length_el; _Needle_length_el != 0) {
-                    const __m128i _Needle = _Last_needle_val;
-                    if (_mm_cmpestrc(_Needle, _Needle_length_el, _Haystack_part, _Last_part_size_el, _Op)) {
-                        const int _Pos =
-                            _mm_cmpestri(_Needle, _Needle_length_el, _Haystack_part, _Last_part_size_el, _Op);
-                        if (_Pos < _Found_pos) {
-                            _Found_pos = _Pos;
-                        }
-                    }
-                }
-
-                _Advance_bytes(_First1, _Found_pos * sizeof(_Ty));
-                return _First1;
             }
-        }
 #endif // !_M_ARM64EC
-        return __std_find_first_of_trivial_fallback<_Ty>(_First1, _Last1, _First2, _Last2);
-    }
-
-    struct _Find_first_of_traits_4 : _Find_traits_4 {
-        using _Ty = uint32_t;
-
-        template <size_t _Amount>
-        static __m256i _Spread_avx(__m256i _Val, const size_t _Needle_length_el) noexcept {
-            if constexpr (_Amount == 1) {
-                return _mm256_broadcastd_epi32(_mm256_castsi256_si128(_Val));
-            } else if constexpr (_Amount == 2) {
-                return _mm256_broadcastq_epi64(_mm256_castsi256_si128(_Val));
-            } else if constexpr (_Amount == 4) {
-                if (_Needle_length_el < 4) {
-                    _Val = _mm256_shuffle_epi32(_Val, _MM_SHUFFLE(0, 2, 1, 0));
-                }
-
-                return _mm256_permute4x64_epi64(_Val, _MM_SHUFFLE(1, 0, 1, 0));
-            } else if constexpr (_Amount == 8) {
-                if (_Needle_length_el < _Amount) {
-                    const __m256i _Mask = _Avx2_tail_mask_32(_Needle_length_el);
-                    // zero unused elements in sequenctial permutation mask, so will be filled by 1st
-                    const __m256i _Perm = _mm256_and_si256(_mm256_set_epi32(7, 6, 5, 4, 3, 2, 1, 0), _Mask);
-                    _Val                = _mm256_permutevar8x32_epi32(_Val, _Perm);
-                }
-
-                return _Val;
-            } else {
-                static_assert(false, "Unexpected amount");
-            }
+            return __fallback<_Ty>(_First1, _Last1, _First2, _Last2);
         }
 
-        template <size_t _Amount>
-        static __m256i _Shuffle_avx(const __m256i _Val) noexcept {
-            if constexpr (_Amount == 1) {
-                return _mm256_shuffle_epi32(_Val, _MM_SHUFFLE(2, 3, 0, 1));
-            } else if constexpr (_Amount == 2) {
-                return _mm256_shuffle_epi32(_Val, _MM_SHUFFLE(1, 0, 3, 2));
-            } else if constexpr (_Amount == 4) {
-                return _mm256_permute4x64_epi64(_Val, _MM_SHUFFLE(1, 0, 3, 2));
-            } else {
-                static_assert(false, "Unexpected amount");
-            }
-        }
-    };
+        struct _Traits_4 : _Find_traits_4 {
+            using _Ty = uint32_t;
 
-    struct _Find_first_of_traits_8 : _Find_traits_8 {
-        using _Ty = uint64_t;
+            template <size_t _Amount>
+            static __m256i _Spread_avx(__m256i _Val, const size_t _Needle_length_el) noexcept {
+                if constexpr (_Amount == 1) {
+                    return _mm256_broadcastd_epi32(_mm256_castsi256_si128(_Val));
+                } else if constexpr (_Amount == 2) {
+                    return _mm256_broadcastq_epi64(_mm256_castsi256_si128(_Val));
+                } else if constexpr (_Amount == 4) {
+                    if (_Needle_length_el < 4) {
+                        _Val = _mm256_shuffle_epi32(_Val, _MM_SHUFFLE(0, 2, 1, 0));
+                    }
 
-        template <size_t _Amount>
-        static __m256i _Spread_avx(__m256i _Val, const size_t _Needle_length_el) noexcept {
-            if constexpr (_Amount == 1) {
-                return _mm256_broadcastq_epi64(_mm256_castsi256_si128(_Val));
-            } else if constexpr (_Amount == 2) {
-                return _mm256_permute4x64_epi64(_Val, _MM_SHUFFLE(1, 0, 1, 0));
-            } else if constexpr (_Amount == 4) {
-                if (_Needle_length_el < 4) {
-                    return _mm256_permute4x64_epi64(_Val, _MM_SHUFFLE(0, 2, 1, 0));
-                }
+                    return _mm256_permute4x64_epi64(_Val, _MM_SHUFFLE(1, 0, 1, 0));
+                } else if constexpr (_Amount == 8) {
+                    if (_Needle_length_el < _Amount) {
+                        const __m256i _Mask = _Avx2_tail_mask_32(_Needle_length_el);
+                        // zero unused elements in sequenctial permutation mask, so will be filled by 1st
+                        const __m256i _Perm = _mm256_and_si256(_mm256_set_epi32(7, 6, 5, 4, 3, 2, 1, 0), _Mask);
+                        _Val                = _mm256_permutevar8x32_epi32(_Val, _Perm);
+                    }
 
-                return _Val;
-            } else {
-                static_assert(false, "Unexpected amount");
-            }
-        }
-
-        template <size_t _Amount>
-        static __m256i _Shuffle_avx(const __m256i _Val) noexcept {
-            if constexpr (_Amount == 1) {
-                return _mm256_shuffle_epi32(_Val, _MM_SHUFFLE(1, 0, 3, 2));
-            } else if constexpr (_Amount == 2) {
-                return _mm256_permute4x64_epi64(_Val, _MM_SHUFFLE(1, 0, 3, 2));
-            } else {
-                static_assert(false, "Unexpected amount");
-            }
-        }
-    };
-
-    template <class _Traits, size_t _Needle_length_el_magnitude>
-    const __m256i __std_find_first_of_trivial_shuffle_step(const __m256i _Data1, const __m256i _Data2s0) {
-        __m256i _Eq = _Traits::_Cmp_avx(_Data1, _Data2s0);
-        if constexpr (_Needle_length_el_magnitude >= 2) {
-            const __m256i _Data2s1 = _Traits::_Shuffle_avx<1>(_Data2s0);
-            _Eq                    = _mm256_or_si256(_Eq, _Traits::_Cmp_avx(_Data1, _Data2s1));
-            if constexpr (_Needle_length_el_magnitude >= 4) {
-                const __m256i _Data2s2 = _Traits::_Shuffle_avx<2>(_Data2s0);
-                _Eq                    = _mm256_or_si256(_Eq, _Traits::_Cmp_avx(_Data1, _Data2s2));
-                const __m256i _Data2s3 = _Traits::_Shuffle_avx<1>(_Data2s2);
-                _Eq                    = _mm256_or_si256(_Eq, _Traits::_Cmp_avx(_Data1, _Data2s3));
-                if constexpr (_Needle_length_el_magnitude >= 8) {
-                    const __m256i _Data2s4 = _Traits::_Shuffle_avx<4>(_Data2s0);
-                    _Eq                    = _mm256_or_si256(_Eq, _Traits::_Cmp_avx(_Data1, _Data2s4));
-                    const __m256i _Data2s5 = _Traits::_Shuffle_avx<1>(_Data2s4);
-                    _Eq                    = _mm256_or_si256(_Eq, _Traits::_Cmp_avx(_Data1, _Data2s5));
-                    const __m256i _Data2s6 = _Traits::_Shuffle_avx<2>(_Data2s4);
-                    _Eq                    = _mm256_or_si256(_Eq, _Traits::_Cmp_avx(_Data1, _Data2s6));
-                    const __m256i _Data2s7 = _Traits::_Shuffle_avx<1>(_Data2s6);
-                    _Eq                    = _mm256_or_si256(_Eq, _Traits::_Cmp_avx(_Data1, _Data2s7));
+                    return _Val;
+                } else {
+                    static_assert(false, "Unexpected amount");
                 }
             }
-        }
-        return _Eq;
-    }
 
-    template <class _Traits, size_t _Needle_length_el_magnitude>
-    const void* __std_find_first_of_trivial_shuffle_impl(
-        const void* _First1, const void* const _Last1, const void* const _First2, const size_t _Needle_length_el) {
-        using _Ty            = typename _Traits::_Ty;
-        const __m256i _Data2 = _mm256_maskload_epi32(
-            reinterpret_cast<const int*>(_First2), _Avx2_tail_mask_32(_Needle_length_el * (sizeof(_Ty) / 4)));
-        const __m256i _Data2s0 = _Traits::_Spread_avx<_Needle_length_el_magnitude>(_Data2, _Needle_length_el);
-
-        const size_t _Haystack_length = _Byte_length(_First1, _Last1);
-
-        const void* _Stop1 = _First1;
-        _Advance_bytes(_Stop1, _Haystack_length & ~size_t{0x1F});
-
-        for (; _First1 != _Stop1; _Advance_bytes(_First1, 32)) {
-            const __m256i _Data1 = _mm256_loadu_si256(static_cast<const __m256i*>(_First1));
-            const __m256i _Eq =
-                __std_find_first_of_trivial_shuffle_step<_Traits, _Needle_length_el_magnitude>(_Data1, _Data2s0);
-            const int _Bingo = _mm256_movemask_epi8(_Eq);
-
-            if (_Bingo != 0) {
-                const unsigned long _Offset = _tzcnt_u32(_Bingo);
-                _Advance_bytes(_First1, _Offset);
-                return _First1;
+            template <size_t _Amount>
+            static __m256i _Shuffle_avx(const __m256i _Val) noexcept {
+                if constexpr (_Amount == 1) {
+                    return _mm256_shuffle_epi32(_Val, _MM_SHUFFLE(2, 3, 0, 1));
+                } else if constexpr (_Amount == 2) {
+                    return _mm256_shuffle_epi32(_Val, _MM_SHUFFLE(1, 0, 3, 2));
+                } else if constexpr (_Amount == 4) {
+                    return _mm256_permute4x64_epi64(_Val, _MM_SHUFFLE(1, 0, 3, 2));
+                } else {
+                    static_assert(false, "Unexpected amount");
+                }
             }
-        }
+        };
 
-        if (const size_t _Haystack_tail_length = _Haystack_length & 0x1C; _Haystack_tail_length != 0) {
-            const __m256i _Tail_mask = _Avx2_tail_mask_32(_Haystack_tail_length >> 2);
-            const __m256i _Data1     = _mm256_maskload_epi32(static_cast<const int*>(_First1), _Tail_mask);
-            const __m256i _Eq =
-                __std_find_first_of_trivial_shuffle_step<_Traits, _Needle_length_el_magnitude>(_Data1, _Data2s0);
-            const int _Bingo = _mm256_movemask_epi8(_mm256_and_si256(_Eq, _Tail_mask));
+        struct _Traits_8 : _Find_traits_8 {
+            using _Ty = uint64_t;
 
-            if (_Bingo != 0) {
-                const unsigned long _Offset = _tzcnt_u32(_Bingo);
-                _Advance_bytes(_First1, _Offset);
-                return _First1;
+            template <size_t _Amount>
+            static __m256i _Spread_avx(__m256i _Val, const size_t _Needle_length_el) noexcept {
+                if constexpr (_Amount == 1) {
+                    return _mm256_broadcastq_epi64(_mm256_castsi256_si128(_Val));
+                } else if constexpr (_Amount == 2) {
+                    return _mm256_permute4x64_epi64(_Val, _MM_SHUFFLE(1, 0, 1, 0));
+                } else if constexpr (_Amount == 4) {
+                    if (_Needle_length_el < 4) {
+                        return _mm256_permute4x64_epi64(_Val, _MM_SHUFFLE(0, 2, 1, 0));
+                    }
+
+                    return _Val;
+                } else {
+                    static_assert(false, "Unexpected amount");
+                }
             }
 
-            _Advance_bytes(_First1, _Haystack_tail_length);
+            template <size_t _Amount>
+            static __m256i _Shuffle_avx(const __m256i _Val) noexcept {
+                if constexpr (_Amount == 1) {
+                    return _mm256_shuffle_epi32(_Val, _MM_SHUFFLE(1, 0, 3, 2));
+                } else if constexpr (_Amount == 2) {
+                    return _mm256_permute4x64_epi64(_Val, _MM_SHUFFLE(1, 0, 3, 2));
+                } else {
+                    static_assert(false, "Unexpected amount");
+                }
+            }
+        };
+
+        template <class _Traits, size_t _Needle_length_el_magnitude>
+        const __m256i __shuffle_step(const __m256i _Data1, const __m256i _Data2s0) {
+            __m256i _Eq = _Traits::_Cmp_avx(_Data1, _Data2s0);
+            if constexpr (_Needle_length_el_magnitude >= 2) {
+                const __m256i _Data2s1 = _Traits::_Shuffle_avx<1>(_Data2s0);
+                _Eq                    = _mm256_or_si256(_Eq, _Traits::_Cmp_avx(_Data1, _Data2s1));
+                if constexpr (_Needle_length_el_magnitude >= 4) {
+                    const __m256i _Data2s2 = _Traits::_Shuffle_avx<2>(_Data2s0);
+                    _Eq                    = _mm256_or_si256(_Eq, _Traits::_Cmp_avx(_Data1, _Data2s2));
+                    const __m256i _Data2s3 = _Traits::_Shuffle_avx<1>(_Data2s2);
+                    _Eq                    = _mm256_or_si256(_Eq, _Traits::_Cmp_avx(_Data1, _Data2s3));
+                    if constexpr (_Needle_length_el_magnitude >= 8) {
+                        const __m256i _Data2s4 = _Traits::_Shuffle_avx<4>(_Data2s0);
+                        _Eq                    = _mm256_or_si256(_Eq, _Traits::_Cmp_avx(_Data1, _Data2s4));
+                        const __m256i _Data2s5 = _Traits::_Shuffle_avx<1>(_Data2s4);
+                        _Eq                    = _mm256_or_si256(_Eq, _Traits::_Cmp_avx(_Data1, _Data2s5));
+                        const __m256i _Data2s6 = _Traits::_Shuffle_avx<2>(_Data2s4);
+                        _Eq                    = _mm256_or_si256(_Eq, _Traits::_Cmp_avx(_Data1, _Data2s6));
+                        const __m256i _Data2s7 = _Traits::_Shuffle_avx<1>(_Data2s6);
+                        _Eq                    = _mm256_or_si256(_Eq, _Traits::_Cmp_avx(_Data1, _Data2s7));
+                    }
+                }
+            }
+            return _Eq;
         }
 
-        return _First1;
-    }
+        template <class _Traits, size_t _Needle_length_el_magnitude>
+        const void* __shuffle_impl(
+            const void* _First1, const void* const _Last1, const void* const _First2, const size_t _Needle_length_el) {
+            using _Ty            = typename _Traits::_Ty;
+            const __m256i _Data2 = _mm256_maskload_epi32(
+                reinterpret_cast<const int*>(_First2), _Avx2_tail_mask_32(_Needle_length_el * (sizeof(_Ty) / 4)));
+            const __m256i _Data2s0 = _Traits::_Spread_avx<_Needle_length_el_magnitude>(_Data2, _Needle_length_el);
 
-    template <class _Traits>
-    const void* __stdcall __std_find_first_of_trivial_48_impl(const void* const _First1, const void* const _Last1,
-        const void* const _First2, const void* const _Last2) noexcept {
-        using _Ty = typename _Traits::_Ty;
+            const size_t _Haystack_length = _Byte_length(_First1, _Last1);
+
+            const void* _Stop1 = _First1;
+            _Advance_bytes(_Stop1, _Haystack_length & ~size_t{0x1F});
+
+            for (; _First1 != _Stop1; _Advance_bytes(_First1, 32)) {
+                const __m256i _Data1 = _mm256_loadu_si256(static_cast<const __m256i*>(_First1));
+                const __m256i _Eq    = __shuffle_step<_Traits, _Needle_length_el_magnitude>(_Data1, _Data2s0);
+                const int _Bingo     = _mm256_movemask_epi8(_Eq);
+
+                if (_Bingo != 0) {
+                    const unsigned long _Offset = _tzcnt_u32(_Bingo);
+                    _Advance_bytes(_First1, _Offset);
+                    return _First1;
+                }
+            }
+
+            if (const size_t _Haystack_tail_length = _Haystack_length & 0x1C; _Haystack_tail_length != 0) {
+                const __m256i _Tail_mask = _Avx2_tail_mask_32(_Haystack_tail_length >> 2);
+                const __m256i _Data1     = _mm256_maskload_epi32(static_cast<const int*>(_First1), _Tail_mask);
+                const __m256i _Eq        = __shuffle_step<_Traits, _Needle_length_el_magnitude>(_Data1, _Data2s0);
+                const int _Bingo         = _mm256_movemask_epi8(_mm256_and_si256(_Eq, _Tail_mask));
+
+                if (_Bingo != 0) {
+                    const unsigned long _Offset = _tzcnt_u32(_Bingo);
+                    _Advance_bytes(_First1, _Offset);
+                    return _First1;
+                }
+
+                _Advance_bytes(_First1, _Haystack_tail_length);
+            }
+
+            return _First1;
+        }
+
+        template <class _Traits>
+        const void* __stdcall __48_impl(const void* const _First1, const void* const _Last1,
+            const void* const _First2, const void* const _Last2) noexcept {
+            using _Ty = typename _Traits::_Ty;
 #ifndef _M_ARM64EC
-        if (_Use_avx2()) {
-            _Zeroupper_on_exit _Guard; // TRANSITION, DevCom-10331414
+            if (_Use_avx2()) {
+                _Zeroupper_on_exit _Guard; // TRANSITION, DevCom-10331414
 
-            const size_t _Needle_length = _Byte_length(_First2, _Last2);
-            const int _Needle_length_el = static_cast<int>(_Needle_length / sizeof(_Ty));
+                const size_t _Needle_length = _Byte_length(_First2, _Last2);
+                const int _Needle_length_el = static_cast<int>(_Needle_length / sizeof(_Ty));
 
-            // Special handling of small needle
-            // The generic approach could also handle it but with worse performance
-            if (_Needle_length_el == 0) {
+                // Special handling of small needle
+                // The generic approach could also handle it but with worse performance
+                if (_Needle_length_el == 0) {
+                    return _Last1;
+                } else if (_Needle_length_el == 1) {
+                    // This is expected to be done on an upper level with better efficeiency
+                    return __shuffle_impl<_Traits, 1>(_First1, _Last1, _First2, _Needle_length_el);
+                } else if (_Needle_length_el == 2) {
+                    return __shuffle_impl<_Traits, 2>(_First1, _Last1, _First2, _Needle_length_el);
+                } else if (_Needle_length_el <= 4) {
+                    return __shuffle_impl<_Traits, 4>(_First1, _Last1, _First2, _Needle_length_el);
+                } else if (_Needle_length_el <= 8) {
+                    if constexpr (sizeof(_Ty) == 4) {
+                        return __shuffle_impl<_Traits, 8>(_First1, _Last1, _First2, _Needle_length_el);
+                    }
+                }
+
+                // Generic approach
+                const size_t _Needle_length_tail = _Needle_length & 0x1C;
+                const __m256i _Tail_mask         = _Avx2_tail_mask_32(_Needle_length_tail >> 2);
+
+                const void* _Stop2 = _First2;
+                _Advance_bytes(_Stop2, _Needle_length & ~size_t{0x1F});
+
+                for (auto _Ptr1 = static_cast<const _Ty*>(_First1); _Ptr1 != _Last1; ++_Ptr1) {
+                    const auto _Data1 = _Traits::_Set_avx(*_Ptr1);
+                    for (auto _Ptr2 = _First2; _Ptr2 != _Stop2; _Advance_bytes(_Ptr2, 32)) {
+                        const __m256i _Data2 = _mm256_loadu_si256(static_cast<const __m256i*>(_Ptr2));
+                        const __m256i _Eq    = _Traits::_Cmp_avx(_Data1, _Data2);
+                        if (!_mm256_testz_si256(_Eq, _Eq)) {
+                            return _Ptr1;
+                        }
+                    }
+
+                    if (_Needle_length_tail != 0) {
+                        const __m256i _Data2 = _mm256_maskload_epi32(static_cast<const int*>(_Stop2), _Tail_mask);
+                        const __m256i _Eq    = _Traits::_Cmp_avx(_Data1, _Data2);
+                        if (!_mm256_testz_si256(_Eq, _Tail_mask)) {
+                            return _Ptr1;
+                        }
+                    }
+                }
+
                 return _Last1;
-            } else if (_Needle_length_el == 1) {
-                // This is expected to be done on an upper level with better efficeiency
-                return __std_find_first_of_trivial_shuffle_impl<_Traits, 1>(
-                    _First1, _Last1, _First2, _Needle_length_el);
-            } else if (_Needle_length_el == 2) {
-                return __std_find_first_of_trivial_shuffle_impl<_Traits, 2>(
-                    _First1, _Last1, _First2, _Needle_length_el);
-            } else if (_Needle_length_el <= 4) {
-                return __std_find_first_of_trivial_shuffle_impl<_Traits, 4>(
-                    _First1, _Last1, _First2, _Needle_length_el);
-            } else if (_Needle_length_el <= 8) {
-                if constexpr (sizeof(_Ty) == 4) {
-                    return __std_find_first_of_trivial_shuffle_impl<_Traits, 8>(
-                        _First1, _Last1, _First2, _Needle_length_el);
-                }
             }
-
-            // Generic approach
-            const size_t _Needle_length_tail = _Needle_length & 0x1C;
-            const __m256i _Tail_mask         = _Avx2_tail_mask_32(_Needle_length_tail >> 2);
-
-            const void* _Stop2 = _First2;
-            _Advance_bytes(_Stop2, _Needle_length & ~size_t{0x1F});
-
-            for (auto _Ptr1 = static_cast<const _Ty*>(_First1); _Ptr1 != _Last1; ++_Ptr1) {
-                const auto _Data1 = _Traits::_Set_avx(*_Ptr1);
-                for (auto _Ptr2 = _First2; _Ptr2 != _Stop2; _Advance_bytes(_Ptr2, 32)) {
-                    const __m256i _Data2 = _mm256_loadu_si256(static_cast<const __m256i*>(_Ptr2));
-                    const __m256i _Eq    = _Traits::_Cmp_avx(_Data1, _Data2);
-                    if (!_mm256_testz_si256(_Eq, _Eq)) {
-                        return _Ptr1;
-                    }
-                }
-
-                if (_Needle_length_tail != 0) {
-                    const __m256i _Data2 = _mm256_maskload_epi32(static_cast<const int*>(_Stop2), _Tail_mask);
-                    const __m256i _Eq    = _Traits::_Cmp_avx(_Data1, _Data2);
-                    if (!_mm256_testz_si256(_Eq, _Tail_mask)) {
-                        return _Ptr1;
-                    }
-                }
-            }
-
-            return _Last1;
-        }
 #endif // !_M_ARM64EC
-        return __std_find_first_of_trivial_fallback<_Ty>(_First1, _Last1, _First2, _Last2);
-    }
-
+            return __fallback<_Ty>(_First1, _Last1, _First2, _Last2);
+        }
+    } // namespace __std_find_first_of
 
     template <class _Traits, class _Ty>
     __declspec(noalias) size_t __stdcall __std_mismatch_impl(
@@ -2568,22 +2563,22 @@ __declspec(noalias) size_t
 
 const void* __stdcall __std_find_first_of_trivial_1(
     const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept {
-    return __std_find_first_of_trivial_pcmpestri_impl<uint8_t>(_First1, _Last1, _First2, _Last2);
+    return __std_find_first_of::__pcmpestri_impl<uint8_t>(_First1, _Last1, _First2, _Last2);
 }
 
 const void* __stdcall __std_find_first_of_trivial_2(
     const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept {
-    return __std_find_first_of_trivial_pcmpestri_impl<uint16_t>(_First1, _Last1, _First2, _Last2);
+    return __std_find_first_of::__pcmpestri_impl<uint16_t>(_First1, _Last1, _First2, _Last2);
 }
 
 const void* __stdcall __std_find_first_of_trivial_4(
     const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept {
-    return __std_find_first_of_trivial_48_impl<_Find_first_of_traits_4>(_First1, _Last1, _First2, _Last2);
+    return __std_find_first_of::__48_impl<__std_find_first_of::_Traits_4>(_First1, _Last1, _First2, _Last2);
 }
 
 const void* __stdcall __std_find_first_of_trivial_8(
     const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept {
-    return __std_find_first_of_trivial_48_impl<_Find_first_of_traits_8>(_First1, _Last1, _First2, _Last2);
+    return __std_find_first_of::__48_impl<__std_find_first_of::_Traits_8>(_First1, _Last1, _First2, _Last2);
 }
 
 __declspec(noalias) size_t

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -8,6 +8,7 @@
 #if defined(_M_IX86) || defined(_M_X64) // NB: includes _M_ARM64EC
 #include <__msvc_minmax.hpp>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <xtr1common>
 

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2359,8 +2359,8 @@ namespace {
                 if (_Needle_length_el == 0) {
                     return _Last1;
                 } else if (_Needle_length_el == 1) {
-                    // This is expected to be done on an upper level with better efficeiency
-                    return __shuffle_impl<_Traits, 1>(_First1, _Last1, _First2, _Needle_length_el);
+                    // This is expected to be forwarded to 'find' on an upper level
+                    _CSTD abort();
                 } else if (_Needle_length_el == 2) {
                     return __shuffle_impl<_Traits, 2>(_First1, _Last1, _First2, _Needle_length_el);
                 } else if (_Needle_length_el <= 4) {

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2387,7 +2387,7 @@ namespace {
                     for (auto _Ptr2 = _First2; _Ptr2 != _Stop2; _Advance_bytes(_Ptr2, 32)) {
                         const __m256i _Data2 = _mm256_loadu_si256(static_cast<const __m256i*>(_Ptr2));
                         const __m256i _Eq    = _Traits::_Cmp_avx(_Data1, _Data2);
-                        if (!_mm256_testz_si256(_Eq, _Eq)) {
+                        if (_mm256_testz_si256(_Eq, _Eq) == 0) {
                             return _Ptr1;
                         }
                     }
@@ -2395,7 +2395,7 @@ namespace {
                     if (_Needle_length_tail != 0) {
                         const __m256i _Data2 = _mm256_maskload_epi32(static_cast<const int*>(_Stop2), _Tail_mask);
                         const __m256i _Eq    = _Traits::_Cmp_avx(_Data1, _Data2);
-                        if (!_mm256_testz_si256(_Eq, _Tail_mask)) {
+                        if (_mm256_testz_si256(_Eq, _Tail_mask) == 0) {
                             return _Ptr1;
                         }
                     }

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2344,7 +2344,7 @@ namespace {
         }
 
         template <class _Traits>
-        const void* __stdcall __48_impl(const void* const _First1, const void* const _Last1, const void* const _First2,
+        const void* __stdcall __4_8_impl(const void* const _First1, const void* const _Last1, const void* const _First2,
             const void* const _Last2) noexcept {
             using _Ty = _Traits::_Ty;
 #ifndef _M_ARM64EC
@@ -2572,12 +2572,12 @@ const void* __stdcall __std_find_first_of_trivial_2(
 
 const void* __stdcall __std_find_first_of_trivial_4(
     const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept {
-    return __std_find_first_of::__48_impl<__std_find_first_of::_Traits_4>(_First1, _Last1, _First2, _Last2);
+    return __std_find_first_of::__4_8_impl<__std_find_first_of::_Traits_4>(_First1, _Last1, _First2, _Last2);
 }
 
 const void* __stdcall __std_find_first_of_trivial_8(
     const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept {
-    return __std_find_first_of::__48_impl<__std_find_first_of::_Traits_8>(_First1, _Last1, _First2, _Last2);
+    return __std_find_first_of::__4_8_impl<__std_find_first_of::_Traits_8>(_First1, _Last1, _First2, _Last2);
 }
 
 __declspec(noalias) size_t

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2215,7 +2215,7 @@ namespace {
 
                     return _mm256_permute4x64_epi64(_Val, _MM_SHUFFLE(1, 0, 1, 0));
                 } else if constexpr (_Amount == 8) {
-                    if (_Needle_length_el < _Amount) {
+                    if (_Needle_length_el < 8) {
                         const __m256i _Mask = _Avx2_tail_mask_32(_Needle_length_el);
                         // zero unused elements in sequential permutation mask, so will be filled by 1st
                         const __m256i _Perm = _mm256_and_si256(_mm256_set_epi32(7, 6, 5, 4, 3, 2, 1, 0), _Mask);

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2201,7 +2201,7 @@ namespace {
 
         struct _Traits_4 : _Find_traits_4 {
             using _Ty = uint32_t;
-
+#ifndef _M_ARM64EC
             template <size_t _Amount>
             static __m256i _Spread_avx(__m256i _Val, const size_t _Needle_length_el) noexcept {
                 if constexpr (_Amount == 1) {
@@ -2240,11 +2240,12 @@ namespace {
                     static_assert(false, "Unexpected amount");
                 }
             }
+#endif // !_M_ARM64EC
         };
 
         struct _Traits_8 : _Find_traits_8 {
             using _Ty = uint64_t;
-
+#ifndef _M_ARM64EC
             template <size_t _Amount>
             static __m256i _Spread_avx(__m256i _Val, const size_t _Needle_length_el) noexcept {
                 if constexpr (_Amount == 1) {
@@ -2272,8 +2273,10 @@ namespace {
                     static_assert(false, "Unexpected amount");
                 }
             }
+#endif // !_M_ARM64EC
         };
 
+#ifndef _M_ARM64EC
         template <class _Traits, size_t _Needle_length_el_magnitude>
         const __m256i __shuffle_step(const __m256i _Data1, const __m256i _Data2s0) noexcept {
             __m256i _Eq = _Traits::_Cmp_avx(_Data1, _Data2s0);
@@ -2342,6 +2345,8 @@ namespace {
 
             return _First1;
         }
+
+#endif // !_M_ARM64EC
 
         template <class _Traits>
         const void* __stdcall __4_8_impl(const void* const _First1, const void* const _Last1, const void* const _First2,

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2041,7 +2041,7 @@ namespace {
     namespace __std_find_first_of {
 
         template <class _Ty>
-        const void* __stdcall __fallback(const void* _First1, const void* const _Last1, const void* const _First2,
+        const void* __stdcall _Fallback(const void* _First1, const void* const _Last1, const void* const _First2,
             const void* const _Last2) noexcept {
             auto _Ptr_haystack           = static_cast<const _Ty*>(_First1);
             const auto _Ptr_haystack_end = static_cast<const _Ty*>(_Last1);
@@ -2060,7 +2060,7 @@ namespace {
         }
 
         template <class _Ty>
-        const void* __stdcall __pcmpestri_impl(const void* _First1, const void* const _Last1, const void* const _First2,
+        const void* __stdcall _Impl_pcmpestri(const void* _First1, const void* const _Last1, const void* const _First2,
             const void* const _Last2) noexcept {
 #ifndef _M_ARM64EC
             if (_Use_sse42()) {
@@ -2196,7 +2196,7 @@ namespace {
                 }
             }
 #endif // !_M_ARM64EC
-            return __fallback<_Ty>(_First1, _Last1, _First2, _Last2);
+            return _Fallback<_Ty>(_First1, _Last1, _First2, _Last2);
         }
 
         struct _Traits_4 : _Find_traits_4 {
@@ -2278,7 +2278,7 @@ namespace {
 
 #ifndef _M_ARM64EC
         template <class _Traits, size_t _Needle_length_el_magnitude>
-        const __m256i __shuffle_step(const __m256i _Data1, const __m256i _Data2s0) noexcept {
+        const __m256i _Shuffle_step(const __m256i _Data1, const __m256i _Data2s0) noexcept {
             __m256i _Eq = _Traits::_Cmp_avx(_Data1, _Data2s0);
             if constexpr (_Needle_length_el_magnitude >= 2) {
                 const __m256i _Data2s1 = _Traits::_Shuffle_avx<1>(_Data2s0);
@@ -2304,7 +2304,7 @@ namespace {
         }
 
         template <class _Traits, size_t _Needle_length_el_magnitude>
-        const void* __shuffle_impl(const void* _First1, const void* const _Last1, const void* const _First2,
+        const void* _Shuffle_impl(const void* _First1, const void* const _Last1, const void* const _First2,
             const size_t _Needle_length_el) noexcept {
             using _Ty            = _Traits::_Ty;
             const __m256i _Data2 = _mm256_maskload_epi32(
@@ -2318,7 +2318,7 @@ namespace {
 
             for (; _First1 != _Stop1; _Advance_bytes(_First1, 32)) {
                 const __m256i _Data1 = _mm256_loadu_si256(static_cast<const __m256i*>(_First1));
-                const __m256i _Eq    = __shuffle_step<_Traits, _Needle_length_el_magnitude>(_Data1, _Data2s0);
+                const __m256i _Eq    = _Shuffle_step<_Traits, _Needle_length_el_magnitude>(_Data1, _Data2s0);
                 const int _Bingo     = _mm256_movemask_epi8(_Eq);
 
                 if (_Bingo != 0) {
@@ -2331,7 +2331,7 @@ namespace {
             if (const size_t _Haystack_tail_length = _Haystack_length & 0x1C; _Haystack_tail_length != 0) {
                 const __m256i _Tail_mask = _Avx2_tail_mask_32(_Haystack_tail_length >> 2);
                 const __m256i _Data1     = _mm256_maskload_epi32(static_cast<const int*>(_First1), _Tail_mask);
-                const __m256i _Eq        = __shuffle_step<_Traits, _Needle_length_el_magnitude>(_Data1, _Data2s0);
+                const __m256i _Eq        = _Shuffle_step<_Traits, _Needle_length_el_magnitude>(_Data1, _Data2s0);
                 const int _Bingo         = _mm256_movemask_epi8(_mm256_and_si256(_Eq, _Tail_mask));
 
                 if (_Bingo != 0) {
@@ -2349,7 +2349,7 @@ namespace {
 #endif // !_M_ARM64EC
 
         template <class _Traits>
-        const void* __stdcall __4_8_impl(const void* const _First1, const void* const _Last1, const void* const _First2,
+        const void* __stdcall _Impl_4_8(const void* const _First1, const void* const _Last1, const void* const _First2,
             const void* const _Last2) noexcept {
             using _Ty = _Traits::_Ty;
 #ifndef _M_ARM64EC
@@ -2366,12 +2366,12 @@ namespace {
                 } else if (_Needle_length_el == 1) {
                     _STL_UNREACHABLE; // This is expected to be forwarded to 'find' on an upper level
                 } else if (_Needle_length_el == 2) {
-                    return __shuffle_impl<_Traits, 2>(_First1, _Last1, _First2, _Needle_length_el);
+                    return _Shuffle_impl<_Traits, 2>(_First1, _Last1, _First2, _Needle_length_el);
                 } else if (_Needle_length_el <= 4) {
-                    return __shuffle_impl<_Traits, 4>(_First1, _Last1, _First2, _Needle_length_el);
+                    return _Shuffle_impl<_Traits, 4>(_First1, _Last1, _First2, _Needle_length_el);
                 } else if (_Needle_length_el <= 8) {
                     if constexpr (sizeof(_Ty) == 4) {
-                        return __shuffle_impl<_Traits, 8>(_First1, _Last1, _First2, _Needle_length_el);
+                        return _Shuffle_impl<_Traits, 8>(_First1, _Last1, _First2, _Needle_length_el);
                     }
                 }
 
@@ -2404,7 +2404,7 @@ namespace {
                 return _Last1;
             }
 #endif // !_M_ARM64EC
-            return __fallback<_Ty>(_First1, _Last1, _First2, _Last2);
+            return _Fallback<_Ty>(_First1, _Last1, _First2, _Last2);
         }
     } // namespace __std_find_first_of
 
@@ -2567,22 +2567,22 @@ __declspec(noalias) size_t
 
 const void* __stdcall __std_find_first_of_trivial_1(
     const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept {
-    return __std_find_first_of::__pcmpestri_impl<uint8_t>(_First1, _Last1, _First2, _Last2);
+    return __std_find_first_of::_Impl_pcmpestri<uint8_t>(_First1, _Last1, _First2, _Last2);
 }
 
 const void* __stdcall __std_find_first_of_trivial_2(
     const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept {
-    return __std_find_first_of::__pcmpestri_impl<uint16_t>(_First1, _Last1, _First2, _Last2);
+    return __std_find_first_of::_Impl_pcmpestri<uint16_t>(_First1, _Last1, _First2, _Last2);
 }
 
 const void* __stdcall __std_find_first_of_trivial_4(
     const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept {
-    return __std_find_first_of::__4_8_impl<__std_find_first_of::_Traits_4>(_First1, _Last1, _First2, _Last2);
+    return __std_find_first_of::_Impl_4_8<__std_find_first_of::_Traits_4>(_First1, _Last1, _First2, _Last2);
 }
 
 const void* __stdcall __std_find_first_of_trivial_8(
     const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept {
-    return __std_find_first_of::__4_8_impl<__std_find_first_of::_Traits_8>(_First1, _Last1, _First2, _Last2);
+    return __std_find_first_of::_Impl_4_8<__std_find_first_of::_Traits_8>(_First1, _Last1, _First2, _Last2);
 }
 
 __declspec(noalias) size_t

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2041,8 +2041,8 @@ namespace {
     namespace __std_find_first_of {
 
         template <class _Ty>
-        const void* __stdcall __fallback(
-            const void* _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) {
+        const void* __stdcall __fallback(const void* _First1, const void* const _Last1, const void* const _First2,
+            const void* const _Last2) noexcept {
             auto _Ptr_haystack           = static_cast<const _Ty*>(_First1);
             const auto _Ptr_haystack_end = static_cast<const _Ty*>(_Last1);
             const auto _Ptr_needle       = static_cast<const _Ty*>(_First2);
@@ -2275,7 +2275,7 @@ namespace {
         };
 
         template <class _Traits, size_t _Needle_length_el_magnitude>
-        const __m256i __shuffle_step(const __m256i _Data1, const __m256i _Data2s0) {
+        const __m256i __shuffle_step(const __m256i _Data1, const __m256i _Data2s0) noexcept {
             __m256i _Eq = _Traits::_Cmp_avx(_Data1, _Data2s0);
             if constexpr (_Needle_length_el_magnitude >= 2) {
                 const __m256i _Data2s1 = _Traits::_Shuffle_avx<1>(_Data2s0);
@@ -2301,8 +2301,8 @@ namespace {
         }
 
         template <class _Traits, size_t _Needle_length_el_magnitude>
-        const void* __shuffle_impl(
-            const void* _First1, const void* const _Last1, const void* const _First2, const size_t _Needle_length_el) {
+        const void* __shuffle_impl(const void* _First1, const void* const _Last1, const void* const _First2,
+            const size_t _Needle_length_el) noexcept {
             using _Ty            = _Traits::_Ty;
             const __m256i _Data2 = _mm256_maskload_epi32(
                 reinterpret_cast<const int*>(_First2), _Avx2_tail_mask_32(_Needle_length_el * (sizeof(_Ty) / 4)));

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2209,7 +2209,7 @@ namespace {
                 return _mm256_broadcastq_epi64(_mm256_castsi256_si128(_Val));
             } else if constexpr (_Amount == 4) {
                 if (_Needle_length_el < 4) {
-                    _Val = _mm256_insert_epi32(_Val, _mm256_cvtsi256_si32(_Val), 3);
+                    _Val = _mm256_shuffle_epi32(_Val, _MM_SHUFFLE(0, 2, 1, 0));
                 }
 
                 return _mm256_permute4x64_epi64(_Val, _MM_SHUFFLE(1, 0, 1, 0));
@@ -2252,7 +2252,7 @@ namespace {
                 return _mm256_permute4x64_epi64(_Val, _MM_SHUFFLE(1, 0, 1, 0));
             } else if constexpr (_Amount == 4) {
                 if (_Needle_length_el < 4) {
-                    _Val = _mm256_insert_epi64(_Val, _mm256_cvtsi256_si64(_Val), 3);
+                    return _mm256_permute4x64_epi64(_Val, _MM_SHUFFLE(0, 2, 1, 0));
                 }
 
                 return _Val;

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2075,9 +2075,9 @@ namespace {
 
                     const int _Needle_length_el = static_cast<int>(_Needle_length / sizeof(_Ty));
 
-                    alignas(16) uint8_t _Tmp1[16];
-                    memcpy(_Tmp1, _First2, _Needle_length);
-                    const __m128i _Data2 = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp1));
+                    alignas(16) uint8_t _Tmp2[16];
+                    memcpy(_Tmp2, _First2, _Needle_length);
+                    const __m128i _Data2 = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp2));
 
                     const size_t _Haystack_length = _Byte_length(_First1, _Last1);
                     const void* _Stop_at          = _First1;
@@ -2097,9 +2097,9 @@ namespace {
                     const size_t _Last_part_size = _Haystack_length & 0xF;
                     const int _Last_part_size_el = static_cast<int>(_Last_part_size / sizeof(_Ty));
 
-                    alignas(16) uint8_t _Tmp2[16];
-                    memcpy(_Tmp2, _First1, _Last_part_size);
-                    const __m128i _Data1 = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp2));
+                    alignas(16) uint8_t _Tmp1[16];
+                    memcpy(_Tmp1, _First1, _Last_part_size);
+                    const __m128i _Data1 = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp1));
 
                     if (_mm_cmpestrc(_Data2, _Needle_length_el, _Data1, _Last_part_size_el, _Op)) {
                         const int _Pos = _mm_cmpestri(_Data2, _Needle_length_el, _Data1, _Last_part_size_el, _Op);

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2227,7 +2227,7 @@ namespace {
             }
         }
 
-        template<size_t _Amount>
+        template <size_t _Amount>
         static __m256i _Shuffle_avx(const __m256i _Val) noexcept {
             if constexpr (_Amount == 1) {
                 return _mm256_shuffle_epi32(_Val, _MM_SHUFFLE(2, 3, 0, 1));
@@ -2248,7 +2248,7 @@ namespace {
         static __m256i _Spread_avx(__m256i _Val, const size_t _Needle_length_el) noexcept {
             if constexpr (_Amount == 1) {
                 return _mm256_broadcastq_epi64(_mm256_castsi256_si128(_Val));
-            } else if constexpr(_Amount == 2) {
+            } else if constexpr (_Amount == 2) {
                 return _mm256_permute4x64_epi64(_Val, _MM_SHUFFLE(1, 0, 1, 0));
             } else if constexpr (_Amount == 4) {
                 if (_Needle_length_el < 4) {
@@ -2300,10 +2300,11 @@ namespace {
     }
 
     template <class _Traits, size_t _Needle_length_el_magnitude>
-    const void* __std_find_first_of_trivial_shuffle_impl(const void* _First1, const void* const _Last1,
-        const void* const _First2, const size_t _Needle_length_el) {
+    const void* __std_find_first_of_trivial_shuffle_impl(
+        const void* _First1, const void* const _Last1, const void* const _First2, const size_t _Needle_length_el) {
         using _Ty            = typename _Traits::_Ty;
-        const __m256i _Data2 = _mm256_maskload_epi32(reinterpret_cast<const int*>(_First2), _Avx2_tail_mask_32(_Needle_length_el * (sizeof(_Ty) / 4)));
+        const __m256i _Data2 = _mm256_maskload_epi32(
+            reinterpret_cast<const int*>(_First2), _Avx2_tail_mask_32(_Needle_length_el * (sizeof(_Ty) / 4)));
         const __m256i _Data2s0 = _Traits::_Spread_avx<_Needle_length_el_magnitude>(_Data2, _Needle_length_el);
 
         const size_t _Haystack_length = _Byte_length(_First1, _Last1);
@@ -2344,8 +2345,8 @@ namespace {
     }
 
     template <class _Traits>
-    const void* __stdcall __std_find_first_of_trivial_48_impl(
-        const void* const _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
+    const void* __stdcall __std_find_first_of_trivial_48_impl(const void* const _First1, const void* const _Last1,
+        const void* const _First2, const void* const _Last2) noexcept {
         using _Ty = typename _Traits::_Ty;
 #ifndef _M_ARM64EC
         if (_Use_avx2()) {

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2217,7 +2217,7 @@ namespace {
                 } else if constexpr (_Amount == 8) {
                     if (_Needle_length_el < _Amount) {
                         const __m256i _Mask = _Avx2_tail_mask_32(_Needle_length_el);
-                        // zero unused elements in sequenctial permutation mask, so will be filled by 1st
+                        // zero unused elements in sequential permutation mask, so will be filled by 1st
                         const __m256i _Perm = _mm256_and_si256(_mm256_set_epi32(7, 6, 5, 4, 3, 2, 1, 0), _Mask);
                         _Val                = _mm256_permutevar8x32_epi32(_Val, _Perm);
                     }


### PR DESCRIPTION
The specialized approach shuffles the needle so that every element is on every place and compares it with the haystack part. Then `or`s all comparison results to find the lowest index match, then if there's a match returns it.

The generic approach finds a haystack element in the needle, it is like `find` with reversed haystack/needle, but instead of `vpmovmskb` and checking that index and computing offset, we have `vptest`, as we don't need the index.

Looks like we will have way better results if specialized approach is generalized,, instead of having different and simpler generic approach. But the complexity would grow.

If only the generic approach is used, the complexity would be reduced, but the performance for small needles would be worse, the generic approach for small needles and 64-bit elements even loses to the scalar implementation.

## Benchmark results

Before:
```
---------------------------------------------------------------
Benchmark                     Time             CPU   Iterations
---------------------------------------------------------------
bm<uint32_t>/2/3           2.84 ns         2.19 ns    527058824
bm<uint32_t>/7/4           13.5 ns         11.4 ns    112000000
bm<uint32_t>/9/3           13.3 ns         8.06 ns    128000000
bm<uint32_t>/22/5          48.9 ns         39.1 ns     33185185
bm<uint32_t>/58/2          58.8 ns         41.4 ns     24888889
bm<uint32_t>/102/4          135 ns          105 ns     10000000
bm<uint32_t>/325/1         15.4 ns         12.7 ns    112000000
bm<uint32_t>/1011/11       3720 ns         3125 ns       640000
bm<uint32_t>/3056/7        6076 ns         4688 ns       280000
bm<uint64_t>/2/3           2.78 ns         2.15 ns    560000000
bm<uint64_t>/7/4           13.5 ns         10.8 ns    100000000
bm<uint64_t>/9/3           13.6 ns         10.3 ns    100000000
bm<uint64_t>/22/5          49.4 ns         31.2 ns     32000000
bm<uint64_t>/58/2          59.7 ns         45.8 ns     35840000
bm<uint64_t>/102/4          132 ns         89.1 ns     12800000
bm<uint64_t>/325/1         42.5 ns         32.2 ns     40727273
bm<uint64_t>/1011/11       3611 ns         2846 ns       560000
bm<uint64_t>/3056/7        6175 ns         2084 ns       757262
```

After:
```
---------------------------------------------------------------
Benchmark                     Time             CPU   Iterations
---------------------------------------------------------------
bm<uint32_t>/2/3           2.99 ns         1.90 ns    560000000
bm<uint32_t>/7/4           14.1 ns         6.58 ns    182857143
bm<uint32_t>/9/3           4.34 ns         1.67 ns   1000000000
bm<uint32_t>/22/5          7.78 ns         3.92 ns    358400000
bm<uint32_t>/58/2          4.80 ns         2.49 ns    670690059
bm<uint32_t>/102/4         12.0 ns         5.01 ns    321126400
bm<uint32_t>/325/1         15.7 ns         7.08 ns    218536585
bm<uint32_t>/1011/11       1002 ns          507 ns      2560000
bm<uint32_t>/3056/7         522 ns          455 ns      2986667
bm<uint64_t>/2/3           2.84 ns         1.48 ns   1000000000
bm<uint64_t>/7/4           13.8 ns         6.44 ns    344615385
bm<uint64_t>/9/3           4.93 ns         2.86 ns    995555556
bm<uint64_t>/22/5          26.5 ns         13.7 ns    136533334
bm<uint64_t>/58/2          10.1 ns         4.94 ns    344615385
bm<uint64_t>/102/4         20.8 ns         10.8 ns    100000000
bm<uint64_t>/325/1         38.0 ns         17.4 ns     74666667
bm<uint64_t>/1011/11       1313 ns         1094 ns      1000000
bm<uint64_t>/3056/7        3186 ns         1496 ns       814545
```