### PR TITLE
`swap_ranges` benchmark

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -119,6 +119,7 @@ add_benchmark(priority_queue_push_range src/priority_queue_push_range.cpp)
 add_benchmark(random_integer_generation src/random_integer_generation.cpp)
 add_benchmark(replace src/replace.cpp)
 add_benchmark(std_copy src/std_copy.cpp)
+add_benchmark(swap_ranges src/swap_ranges.cpp)
 
 add_benchmark(vector_bool_copy src/std/containers/sequences/vector.bool/copy/test.cpp)
 add_benchmark(vector_bool_copy_n src/std/containers/sequences/vector.bool/copy_n/test.cpp)

--- a/benchmarks/src/swap_ranges.cpp
+++ b/benchmarks/src/swap_ranges.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <algorithm>
+#include <benchmark/benchmark.h>
+#include <vector>
+
+using namespace std;
+
+template <class T>
+void bm(benchmark::State& state) {
+    vector<T> a(static_cast<size_t>(state.range(0)), T{'a'});
+    vector<T> b(static_cast<size_t>(state.range(0)), T{'b'});
+
+    for (auto _ : state) {
+        swap_ranges(a.begin(), a.end(), b.begin());
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
+    }
+}
+
+BENCHMARK(bm<uint8_t>)->Arg(1)->Arg(5)->Arg(15)->Arg(26)->Arg(38)->Arg(60)->Arg(125)->Arg(800)->Arg(3000)->Arg(9000);
+
+BENCHMARK_MAIN();

--- a/benchmarks/src/swap_ranges.cpp
+++ b/benchmarks/src/swap_ranges.cpp
@@ -3,6 +3,8 @@
 
 #include <algorithm>
 #include <benchmark/benchmark.h>
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 using namespace std;


### PR DESCRIPTION
```
-----------------------------------------------------------
Benchmark                 Time             CPU   Iterations
-----------------------------------------------------------
bm<uint8_t>/1          1.95 ns        0.854 ns    640000000
bm<uint8_t>/5          2.96 ns         1.44 ns    640000000
bm<uint8_t>/15         4.40 ns         2.00 ns    320000000
bm<uint8_t>/26         2.93 ns         1.26 ns    448000000
bm<uint8_t>/38         3.90 ns         1.59 ns    373333333
bm<uint8_t>/60         4.21 ns         1.96 ns    446008889
bm<uint8_t>/125        5.31 ns         2.51 ns    373333333
bm<uint8_t>/800        15.5 ns         6.70 ns     95573333
bm<uint8_t>/3000       75.1 ns         36.8 ns     18666667
bm<uint8_t>/9000        140 ns         69.8 ns     11200000
```

I actually tried to improve by using masks, but it didn't become better with masks this time.