### PR TITLE
Avoid `__vectorcall` on ARM64EC

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -395,7 +395,7 @@ constexpr bool is_compound_v = !is_fundamental_v<_Ty>;
 #define _EMIT_THISCALL(FUNC, OPT1, OPT2, OPT3)
 #endif // ^^^ __stdcall and __thiscall not supported ^^^
 
-#if ((defined(_M_IX86) && _M_IX86_FP >= 2) || defined(_M_X64)) && !defined(_M_CEE)
+#if ((defined(_M_IX86) && _M_IX86_FP >= 2) || (defined(_M_X64) && !defined(_M_ARM64EC))) && !defined(_M_CEE)
 #define _EMIT_VECTORCALL(FUNC, OPT1, OPT2, OPT3) FUNC(__vectorcall, OPT1, OPT2, OPT3)
 #else // ^^^ __vectorcall supported / __vectorcall not supported vvv
 #define _EMIT_VECTORCALL(FUNC, OPT1, OPT2, OPT3)

--- a/tests/std/tests/Dev09_158457_tr1_mem_fn_calling_conventions/test.cpp
+++ b/tests/std/tests/Dev09_158457_tr1_mem_fn_calling_conventions/test.cpp
@@ -64,7 +64,7 @@ struct Cat {
     }
 #endif
 
-#if (defined(_M_IX86) || defined(_M_X64)) && !defined(_M_CEE)
+#if (defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC))) && !defined(_M_CEE)
     int __vectorcall g() {
         return 2;
     }
@@ -115,7 +115,7 @@ int y(int i) {
 }
 #endif
 
-#if (defined(_M_IX86) || defined(_M_X64)) && !defined(_M_CEE)
+#if (defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC))) && !defined(_M_CEE)
 int __vectorcall z(int i) {
     return -4 * i;
 }

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -2879,12 +2879,12 @@ namespace test_invocable_concepts {
 #include "invocable_cc.hpp"
 
 #ifndef _M_CEE // avoid warning C4575: '__vectorcall' incompatible with the '/clr' option: converting to '__stdcall'
-#if !defined(_M_ARM) && !defined(_M_ARM64)
+#if !defined(_M_ARM) && !defined(_M_ARM64) && !defined(_M_ARM64EC)
 #define NAME      test_vector_vector
 #define CALLCONV  __vectorcall
 #define MCALLCONV __vectorcall
 #include "invocable_cc.hpp"
-#endif // ^^^ !ARM && !ARM64 ^^^
+#endif // ^^^ !ARM && !ARM64 && !ARM64EC ^^^
 #endif // _M_CEE
 
 } // namespace test_invocable_concepts


### PR DESCRIPTION
The documentation says "On ARM64EC, `__vectorcall` is unsupported and rejected by the compiler." I'm not sure why our usage isn't being rejected, but we have confirmation from the compiler team that ARM64 doesn't currently accept `__vectorcall` so we should avoid it.

Fixes #4596
