### PR TITLE
Remove `lower_bound()`/`upper_bound()` from `hash_meow`/`unordered_meow`

### DIFF
--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -1247,36 +1247,6 @@ public:
         }
     }
 
-    _DEPRECATE_STDEXT_HASH_LOWER_BOUND _NODISCARD iterator lower_bound(const key_type& _Keyval) {
-        return _List._Make_iter(_Find(_Keyval, _Traitsobj(_Keyval)));
-    }
-
-    _DEPRECATE_STDEXT_HASH_LOWER_BOUND _NODISCARD const_iterator lower_bound(const key_type& _Keyval) const {
-        return _List._Make_const_iter(_Find(_Keyval, _Traitsobj(_Keyval)));
-    }
-
-    _DEPRECATE_STDEXT_HASH_UPPER_BOUND _NODISCARD iterator upper_bound(const key_type& _Keyval) {
-        auto _Target = _Find_last(_Keyval, _Traitsobj(_Keyval))._Duplicate;
-        if (_Target) {
-            _Target = _Target->_Next;
-        } else {
-            _Target = _List._Mypair._Myval2._Myhead;
-        }
-
-        return _List._Make_iter(_Target);
-    }
-
-    _DEPRECATE_STDEXT_HASH_UPPER_BOUND _NODISCARD const_iterator upper_bound(const key_type& _Keyval) const {
-        auto _Target = _Find_last(_Keyval, _Traitsobj(_Keyval))._Duplicate;
-        if (_Target) {
-            _Target = _Target->_Next;
-        } else {
-            _Target = _List._Mypair._Myval2._Myhead;
-        }
-
-        return _List._Make_const_iter(_Target);
-    }
-
 private:
     struct _Equal_range_result {
         _Unchecked_const_iterator _First;

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1266,30 +1266,8 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define _CXX20_DEPRECATE_U8PATH
 #endif // ^^^ warning disabled ^^^
 
-#if !defined(_SILENCE_STDEXT_HASH_LOWER_BOUND_DEPRECATION_WARNING)
-#define _DEPRECATE_STDEXT_HASH_LOWER_BOUND                                                                           \
-    [[deprecated(                                                                                                    \
-        "warning STL4022: "                                                                                          \
-        "The hash_meow and unordered_meow containers' non-Standard lower_bound() member was provided for interface " \
-        "compatibility with the ordered associative containers, and doesn't match the semantics of the "             \
-        "hash_meow or unordered_meow containers. Please use the find() member instead. You can define "              \
-        "_SILENCE_STDEXT_HASH_LOWER_BOUND_DEPRECATION_WARNING to suppress this warning.")]]
-#else // ^^^ warning enabled / warning disabled vvv
-#define _DEPRECATE_STDEXT_HASH_LOWER_BOUND
-#endif // ^^^ warning disabled ^^^
-
-#if !defined(_SILENCE_STDEXT_HASH_UPPER_BOUND_DEPRECATION_WARNING)
-#define _DEPRECATE_STDEXT_HASH_UPPER_BOUND                                                                           \
-    [[deprecated(                                                                                                    \
-        "warning STL4023: "                                                                                          \
-        "The hash_meow and unordered_meow containers' non-Standard upper_bound() member was provided for interface " \
-        "compatibility with the ordered associative containers, and doesn't match the semantics of the "             \
-        "hash_meow or unordered_meow containers. Please use the second iterator returned by the "                    \
-        "equal_range() member instead. You can define "                                                              \
-        "_SILENCE_STDEXT_HASH_UPPER_BOUND_DEPRECATION_WARNING to suppress this warning.")]]
-#else // ^^^ warning enabled / warning disabled vvv
-#define _DEPRECATE_STDEXT_HASH_UPPER_BOUND
-#endif // ^^^ warning disabled ^^^
+// STL4022 warned about "The hash_meow and unordered_meow containers' non-Standard lower_bound() member"
+// STL4023 warned about "The hash_meow and unordered_meow containers' non-Standard upper_bound() member"
 
 // P0966R1 [depr.string.capacity]
 #if _HAS_CXX20 && !defined(_SILENCE_CXX20_STRING_RESERVE_WITHOUT_ARGUMENT_DEPRECATION_WARNING) \

--- a/tests/tr1/tests/hash_map/test.cpp
+++ b/tests/tr1/tests/hash_map/test.cpp
@@ -5,8 +5,6 @@
 #define TEST_NAME "<hash_map>"
 
 #define _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS
-#define _SILENCE_STDEXT_HASH_LOWER_BOUND_DEPRECATION_WARNING
-#define _SILENCE_STDEXT_HASH_UPPER_BOUND_DEPRECATION_WARNING
 
 #include "tdefs.h"
 #include <functional>
@@ -181,8 +179,6 @@ void test_hash_map() { // test hash_map
     CHECK_INT((*v4.find('a')).first, 'a');
     CHECK_INT(v4.count('x'), 0);
     CHECK_INT(v4.count('a'), 1);
-    CHECK_INT((*v4.lower_bound('a')).first, 'a');
-    CHECK_INT((*--v4.upper_bound('a')).first, 'a'); // differs from map
 
     STD pair<Mycont::const_iterator, Mycont::const_iterator> pcc = v4.equal_range('a');
     CHECK_INT((*pcc.first).first, 'a');
@@ -475,8 +471,6 @@ void test_hash_multimap() { // test hash_multimap
     CHECK_INT((*v4.find('a')).first, 'a');
     CHECK_INT(v4.count('x'), 0);
     CHECK_INT(v4.count('a'), 1);
-    CHECK_INT((*v4.lower_bound('a')).first, 'a');
-    CHECK_INT((*--v4.upper_bound('a')).first, 'a'); // differs from multimap
 
     STD pair<Mycont::const_iterator, Mycont::const_iterator> pcc = v4.equal_range('a');
     CHECK_INT((*pcc.first).first, 'a');

--- a/tests/tr1/tests/hash_set/test.cpp
+++ b/tests/tr1/tests/hash_set/test.cpp
@@ -5,8 +5,6 @@
 #define TEST_NAME "<hash_set>"
 
 #define _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS
-#define _SILENCE_STDEXT_HASH_LOWER_BOUND_DEPRECATION_WARNING
-#define _SILENCE_STDEXT_HASH_UPPER_BOUND_DEPRECATION_WARNING
 
 #include "tdefs.h"
 #include <functional>
@@ -164,8 +162,6 @@ void test_hash_set() { // test hash_set
     CHECK_INT(*v4.find('a'), 'a');
     CHECK_INT(v4.count('x'), 0);
     CHECK_INT(v4.count('a'), 1);
-    CHECK_INT(*v4.lower_bound('a'), 'a');
-    CHECK_INT(*--v4.upper_bound('a'), 'a'); // differs from set
     STD pair<Mycont::const_iterator, Mycont::const_iterator> pcc = v4.equal_range('a');
     CHECK_INT(*pcc.first, 'a');
     CHECK_INT(*--pcc.second, 'a'); // differs from set
@@ -462,8 +458,6 @@ void test_hash_multiset() { // test hash_multiset
     CHECK_INT(*v4.find('a'), 'a');
     CHECK_INT(v4.count('x'), 0);
     CHECK_INT(v4.count('a'), 1);
-    CHECK_INT(*v4.lower_bound('a'), 'a');
-    CHECK_INT(*--v4.upper_bound('a'), 'a'); // differs from multiset
     STD pair<Mycont::const_iterator, Mycont::const_iterator> pcc = v4.equal_range('a');
     CHECK_INT(*pcc.first, 'a');
     CHECK_INT(*--pcc.second, 'a'); // differs from multiset


### PR DESCRIPTION
These member functions were unconditionally deprecated by MSVC-PR-181971 on 2019-05-23.

It's been *almost 5 years*, so it's time to remove this machinery now. Note that there is no loss of functionality - as the deprecation warnings advised, any calls can be exactly converted into `find()` or `equal_range()`.

We can remove the tr1 test coverage because we already have exactly equivalent coverage of `find()` and `equal_range()`.