### PR TITLE
P3142R0: Printing Blank Lines with `println`

### DIFF
--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -1272,6 +1272,10 @@ void println(ostream& _Ostr, const format_string<_Types...> _Fmt, _Types&&... _A
     _STD _Print_impl(_Add_newline::_Yes, _Ostr, _Fmt, _STD forward<_Types>(_Args)...);
 }
 
+_EXPORT_STD inline void println(ostream& _Ostr) {
+    _STD print(_Ostr, "\n");
+}
+
 _EXPORT_STD template <int = 0> // improves throughput, see GH-2329
 void vprint_unicode(ostream& _Ostr, const string_view _Fmt_str, const format_args _Fmt_args) {
     _STD _Vprint_unicode_impl(_Add_newline::_Nope, _Ostr, _Fmt_str, _Fmt_args);

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -1272,7 +1272,8 @@ void println(ostream& _Ostr, const format_string<_Types...> _Fmt, _Types&&... _A
     _STD _Print_impl(_Add_newline::_Yes, _Ostr, _Fmt, _STD forward<_Types>(_Args)...);
 }
 
-_EXPORT_STD inline void println(ostream& _Ostr) {
+_EXPORT_STD template <int = 0> // improves throughput, see GH-2329
+void println(ostream& _Ostr) {
     _STD print(_Ostr, "\n");
 }
 

--- a/stl/inc/print
+++ b/stl/inc/print
@@ -131,6 +131,14 @@ void println(FILE* const _Stream, const format_string<_Types...> _Fmt, _Types&&.
     _STD _Print_impl(_Add_newline::_Yes, _Stream, _Fmt, _STD forward<_Types>(_Args)...);
 }
 
+_EXPORT_STD inline void println(FILE* _Stream) {
+    _STD print(_Stream, "\n");
+}
+
+_EXPORT_STD inline void println() {
+    println(stdout);
+}
+
 _EXPORT_STD template <class... _Types>
 void println(const format_string<_Types...> _Fmt, _Types&&... _Args) {
     _STD println(stdout, _Fmt, _STD forward<_Types>(_Args)...);

--- a/stl/inc/print
+++ b/stl/inc/print
@@ -138,7 +138,7 @@ void println(FILE* _Stream) {
 
 _EXPORT_STD template <int = 0> // improves throughput, see GH-2329
 void println() {
-    println(stdout);
+    _STD println(stdout);
 }
 
 _EXPORT_STD template <class... _Types>

--- a/stl/inc/print
+++ b/stl/inc/print
@@ -131,11 +131,13 @@ void println(FILE* const _Stream, const format_string<_Types...> _Fmt, _Types&&.
     _STD _Print_impl(_Add_newline::_Yes, _Stream, _Fmt, _STD forward<_Types>(_Args)...);
 }
 
-_EXPORT_STD inline void println(FILE* _Stream) {
+_EXPORT_STD template <int = 0> // improves throughput, see GH-2329
+void println(FILE* _Stream) {
     _STD print(_Stream, "\n");
 }
 
-_EXPORT_STD inline void println() {
+_EXPORT_STD template <int = 0> // improves throughput, see GH-2329
+void println() {
     println(stdout);
 }
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -384,6 +384,7 @@
 // P2713R1 Escaping Improvements In std::format
 // P2763R1 Fixing layout_stride's Default Constructor For Fully Static Extents
 // P2836R1 basic_const_iterator Should Follow Its Underlying Type's Convertibility
+// P3142R0 Printing Blank Lines With println()
 
 // _HAS_CXX23 and _SILENCE_ALL_CXX23_DEPRECATION_WARNINGS control:
 // P1413R3 Deprecate aligned_storage And aligned_union

--- a/tests/std/include/test_header_units_and_modules.hpp
+++ b/tests/std/include/test_header_units_and_modules.hpp
@@ -545,9 +545,11 @@ void test_print() {
     using namespace std;
     puts("Testing <print>.");
     println("Hello, world!");
+    println();
 
 #ifdef _CPPRTTI
     println(cout, "The answer to life, the universe, and everything: {}", 42);
+    println(cout);
 #endif // _CPPRTTI
 }
 #endif // TEST_STANDARD >= 23

--- a/tests/std/tests/P2093R14_formatted_output/test.cpp
+++ b/tests/std/tests/P2093R14_formatted_output/test.cpp
@@ -491,13 +491,25 @@ void test_stream_flush_console() {
         }
     }
 
+    println(console_file_stream);
+
+    {
+        const wstring extractedStr{temp_console.get_console_line(0)};
+
+        if constexpr (_Is_ordinary_literal_encoding_utf8()) {
+            assert(extractedStr == L"Hello,\n");
+        } else {
+            assert(extractedStr.empty());
+        }
+    }
+
     println(console_file_stream, " world!");
 
     {
         const wstring extractedStr{temp_console.get_console_line(0)};
 
         if constexpr (_Is_ordinary_literal_encoding_utf8()) {
-            assert(extractedStr == L"Hello, world!");
+            assert(extractedStr == L"Hello,\n world!");
         } else {
             assert(extractedStr.empty());
         }
@@ -507,7 +519,7 @@ void test_stream_flush_console() {
 
     {
         const wstring extractedStr{temp_console.get_console_line(0)};
-        assert(extractedStr == L"Hello, world!");
+        assert(extractedStr == L"Hello,\n world!");
     }
 }
 
@@ -519,7 +531,7 @@ void test_stream_flush_file() {
     {
         ofstream output_file_stream{temp_file_name_str};
 
-        print(output_file_stream, "Hello, ");
+        print(output_file_stream, "Hello,");
 
         {
             ifstream input_file_stream{temp_file_name_str};
@@ -530,7 +542,18 @@ void test_stream_flush_file() {
             assert(extracted_line_str.empty());
         }
 
-        println(output_file_stream, "world!");
+        println(output_file_stream);
+
+        {
+            ifstream input_file_stream{temp_file_name_str};
+
+            string extracted_line_str;
+            getline(input_file_stream, extracted_line_str);
+
+            assert(extracted_line_str.empty());
+        }
+
+        println(output_file_stream, " world!");
 
         {
             ifstream input_file_stream{temp_file_name_str};
@@ -549,7 +572,7 @@ void test_stream_flush_file() {
             string extracted_line_str;
             getline(input_file_stream, extracted_line_str);
 
-            assert(extracted_line_str == "Hello, world!");
+            assert(extracted_line_str == "Hello,\n world!");
         }
     }
 
@@ -567,6 +590,7 @@ void test_empty_strings_and_newlines() {
         print(output_file_stream, "-D\n");
         print(output_file_stream, "{{}} for {}!\n", "impact");
 
+        println(output_file_stream);
         println(output_file_stream, "I have {} cute {} kittens.", 1729, "fluffy");
         println(output_file_stream, "");
         println(output_file_stream, "What are an orthodontist's favorite characters? '{{' and '}}', of course!");
@@ -585,6 +609,7 @@ void test_empty_strings_and_newlines() {
         const vector<string> expected_lines{
             "NCC-1701-D",
             "{} for impact!",
+            "",
             "I have 1729 cute fluffy kittens.",
             "",
             "What are an orthodontist's favorite characters? '{' and '}', of course!",

--- a/tests/std/tests/P2093R14_formatted_output/test.cpp
+++ b/tests/std/tests/P2093R14_formatted_output/test.cpp
@@ -736,10 +736,7 @@ void test_blank_line() {
                 lines.push_back(str);
             }
 
-            const vector<string> expected_lines{
-                "",
-                ""
-            };
+            const vector<string> expected_lines{"", ""};
 
             assert(lines == expected_lines);
         }

--- a/tests/std/tests/P2093R14_formatted_output/test.cpp
+++ b/tests/std/tests/P2093R14_formatted_output/test.cpp
@@ -491,25 +491,13 @@ void test_stream_flush_console() {
         }
     }
 
-    println(console_file_stream);
-
-    {
-        const wstring extractedStr{temp_console.get_console_line(0)};
-
-        if constexpr (_Is_ordinary_literal_encoding_utf8()) {
-            assert(extractedStr == L"Hello,\n");
-        } else {
-            assert(extractedStr.empty());
-        }
-    }
-
     println(console_file_stream, " world!");
 
     {
         const wstring extractedStr{temp_console.get_console_line(0)};
 
         if constexpr (_Is_ordinary_literal_encoding_utf8()) {
-            assert(extractedStr == L"Hello,\n world!");
+            assert(extractedStr == L"Hello, world!");
         } else {
             assert(extractedStr.empty());
         }
@@ -519,7 +507,7 @@ void test_stream_flush_console() {
 
     {
         const wstring extractedStr{temp_console.get_console_line(0)};
-        assert(extractedStr == L"Hello,\n world!");
+        assert(extractedStr == L"Hello, world!");
     }
 }
 
@@ -531,7 +519,7 @@ void test_stream_flush_file() {
     {
         ofstream output_file_stream{temp_file_name_str};
 
-        print(output_file_stream, "Hello,");
+        print(output_file_stream, "Hello, ");
 
         {
             ifstream input_file_stream{temp_file_name_str};
@@ -542,18 +530,7 @@ void test_stream_flush_file() {
             assert(extracted_line_str.empty());
         }
 
-        println(output_file_stream);
-
-        {
-            ifstream input_file_stream{temp_file_name_str};
-
-            string extracted_line_str;
-            getline(input_file_stream, extracted_line_str);
-
-            assert(extracted_line_str.empty());
-        }
-
-        println(output_file_stream, " world!");
+        println(output_file_stream, "world!");
 
         {
             ifstream input_file_stream{temp_file_name_str};
@@ -572,7 +549,7 @@ void test_stream_flush_file() {
             string extracted_line_str;
             getline(input_file_stream, extracted_line_str);
 
-            assert(extracted_line_str == "Hello,\n world!");
+            assert(extracted_line_str == "Hello, world!");
         }
     }
 
@@ -590,7 +567,6 @@ void test_empty_strings_and_newlines() {
         print(output_file_stream, "-D\n");
         print(output_file_stream, "{{}} for {}!\n", "impact");
 
-        println(output_file_stream);
         println(output_file_stream, "I have {} cute {} kittens.", 1729, "fluffy");
         println(output_file_stream, "");
         println(output_file_stream, "What are an orthodontist's favorite characters? '{{' and '}}', of course!");
@@ -609,7 +585,6 @@ void test_empty_strings_and_newlines() {
         const vector<string> expected_lines{
             "NCC-1701-D",
             "{} for impact!",
-            "",
             "I have 1729 cute fluffy kittens.",
             "",
             "What are an orthodontist's favorite characters? '{' and '}', of course!",

--- a/tests/std/tests/P2093R14_formatted_output/test.cpp
+++ b/tests/std/tests/P2093R14_formatted_output/test.cpp
@@ -654,97 +654,6 @@ void test_empty_strings_and_newlines() {
     filesystem::remove(temp_file_name_str);
 }
 
-void test_blank_line() {
-    // Flush console
-    {
-        // If the ordinary literal encoding is UTF-8, then the FILE stream associated with
-        // a console should always be flushed before writing output during a call to std::println()
-        // and std::println(). Otherwise, the stream should *NOT* be flushed.
-        test::win_console temp_console{};
-        FILE* const console_file_stream = temp_console.get_file_stream();
-
-        println(console_file_stream);
-
-        {
-            const wstring extractedStr{temp_console.get_console_line(0)};
-
-            if constexpr (_Is_ordinary_literal_encoding_utf8()) {
-                assert(extractedStr == L"");
-            } else {
-                assert(extractedStr.empty());
-            }
-        }
-
-        maybe_flush_console_file_stream(temp_console);
-
-        {
-            const wstring extractedStr{temp_console.get_console_line(0)};
-            assert(extractedStr == L"");
-        }
-    }
-
-    // Flush file
-    {
-        // Regardless of the ordinary literal encoding, std::println()should flush file streams
-        // which do not refer to consoles.
-        const string temp_file_name_str = temp_file_name();
-
-        {
-            ofstream output_file_stream{temp_file_name_str};
-
-            println(output_file_stream);
-
-            {
-                ifstream input_file_stream{temp_file_name_str};
-
-                string extracted_line_str;
-                getline(input_file_stream, extracted_line_str);
-
-                assert(extracted_line_str.empty());
-            }
-
-            output_file_stream.flush();
-
-            {
-                ifstream input_file_stream{temp_file_name_str};
-
-                string extracted_line_str;
-                getline(input_file_stream, extracted_line_str);
-
-                assert(extracted_line_str == "");
-            }
-        }
-
-        filesystem::remove(temp_file_name_str);
-    }
-
-    {
-        const string temp_file_name_str = temp_file_name();
-
-        {
-            ofstream output_file_stream{temp_file_name_str};
-
-            println(output_file_stream);
-            println(output_file_stream);
-        }
-
-        {
-            ifstream input_file_stream{temp_file_name_str};
-
-            vector<string> lines;
-            for (string str; getline(input_file_stream, str);) {
-                lines.push_back(str);
-            }
-
-            const vector<string> expected_lines{"", ""};
-
-            assert(lines == expected_lines);
-        }
-
-        filesystem::remove(temp_file_name_str);
-    }
-}
-
 void all_tests() {
     test_print_optimizations();
 
@@ -755,8 +664,6 @@ void all_tests() {
     test_stream_flush_file();
 
     test_empty_strings_and_newlines();
-
-    test_blank_line();
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
Implements:  https://wg21.link/P3142R0 (Fixes GH-4524)

Applied retroactively as DR:
https://github.com/orgs/microsoft/projects/1143?pane=issue&itemId=57457187