### PR TITLE
`<xstring>`: Make `char_traits::assign` not start lifetime of elements

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -161,31 +161,15 @@ struct _Char_traits { // properties of a string or stream element
     static _CONSTEXPR20 _Elem* assign(
         _Out_writes_all_(_Count) _Elem* const _First, size_t _Count, const _Elem _Ch) noexcept /* strengthened */ {
         // assign _Count * _Ch to [_First, ...)
-#if _HAS_CXX20
-        if (_STD is_constant_evaluated()) {
-            for (_Elem* _Next = _First; _Count > 0; --_Count, ++_Next) {
-                _STD construct_at(_Next, _Ch);
-            }
-        } else
-#endif // _HAS_CXX20
-        {
-            for (_Elem* _Next = _First; _Count > 0; --_Count, ++_Next) {
-                *_Next = _Ch;
-            }
+        for (_Elem* _Next = _First; _Count > 0; --_Count, ++_Next) {
+            *_Next = _Ch;
         }
 
         return _First;
     }
 
     static _CONSTEXPR17 void assign(_Elem& _Left, const _Elem& _Right) noexcept {
-#if _HAS_CXX20
-        if (_STD is_constant_evaluated()) {
-            _STD construct_at(_STD addressof(_Left), _Right);
-        } else
-#endif // _HAS_CXX20
-        {
-            _Left = _Right;
-        }
+        _Left = _Right;
     }
 
     _NODISCARD static constexpr bool eq(const _Elem _Left, const _Elem _Right) noexcept {


### PR DESCRIPTION
As specified in [[char.traits.specializations]](https://eel.is/c++draft/char.traits.specializations), `char_traits::assign` should just perform assignments. #1502 made these functions also start lifetime of elements since C++20, but this is possibly wrong as the difference is theoretically observable due to lack of constant evaluation failure. This PR reverts changes of `char_traits::assign`.

Notes:
- #3334 (and following-up PR #4047) correctly made `basic_string` start lifetime of elements when required.
- After the changes, Clang behaves correctly but MSVC doesn't. DevCom-10642767 is reported for this.