### PR TITLE
Improve `count` vectorization: replace `popcnt` implementation with vector counting

### DIFF
--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2100,7 +2100,7 @@ namespace {
                 if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
                     _Advance_bytes(_Stop_at, _Avx_size);
                 } else {
-                    constexpr size_t _Max_portion_size = (_Traits::_Max_count - 1) * (32 / sizeof(_Ty));
+                    constexpr size_t _Max_portion_size = (_Traits::_Max_count - 1) * 32;
                     const size_t _Portion_size         = _Avx_size < _Max_portion_size ? _Avx_size : _Max_portion_size;
                     _Advance_bytes(_Stop_at, _Portion_size);
                     _Avx_size -= _Portion_size;
@@ -2149,7 +2149,7 @@ namespace {
                 if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
                     _Advance_bytes(_Stop_at, _Sse_size);
                 } else {
-                    constexpr size_t _Max_portion_size = _Traits::_Max_count * (16 / sizeof(_Ty));
+                    constexpr size_t _Max_portion_size = _Traits::_Max_count * 16;
                     const size_t _Portion_size         = _Sse_size < _Max_portion_size ? _Sse_size : _Max_portion_size;
                     _Advance_bytes(_Stop_at, _Portion_size);
                     _Sse_size -= _Portion_size;

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2017,14 +2017,14 @@ namespace {
             constexpr auto _Shuf = _MM_SHUFFLE(3, 1, 2, 0); // Cross lane, to reduce further on low lane
             const __m256i _Rx4   = _mm256_hadd_epi32(_Val, _mm256_setzero_si256()); // (0+1),(2+3),0,0 per lane
             const __m256i _Rx5   = _mm256_permute4x64_epi64(_Rx4, _Shuf); // low lane  (0+1),(2+3),(4+5),(6+7)
-            const __m256i _Rx6   = _mm256_hadd_epi32(_Rx5, _mm256_setzero_si256()); // (0+3),(4+7),0,0
-            const __m256i _Rx7   = _mm256_hadd_epi32(_Rx6, _mm256_setzero_si256()); // (0+7),0,0,0
+            const __m256i _Rx6   = _mm256_hadd_epi32(_Rx5, _mm256_setzero_si256()); // (0+..+3),(4+...+7),0,0
+            const __m256i _Rx7   = _mm256_hadd_epi32(_Rx6, _mm256_setzero_si256()); // (0+...+7),0,0,0
             return _mm_cvtsi128_si32(_mm256_castsi256_si128(_Rx7));
         }
 
         static size_t _Reduce_sse(const __m128i _Val) noexcept {
             const __m128i _Rx4 = _mm_hadd_epi32(_Val, _mm_setzero_si128()); // (0+1),(2+3),0,0
-            const __m128i _Rx5 = _mm_hadd_epi32(_Rx4, _mm_setzero_si128()); // (0+3),0,0,0
+            const __m128i _Rx5 = _mm_hadd_epi32(_Rx4, _mm_setzero_si128()); // (0+...+3),0,0,0
             return _mm_cvtsi128_si32(_Rx5);
         }
 #endif // !_M_ARM64EC
@@ -2043,14 +2043,14 @@ namespace {
         }
 
         static size_t _Reduce_avx(const __m256i _Val) noexcept {
-            const __m256i _Rx2 = _mm256_hadd_epi16(_Val, _mm256_setzero_si256()); // (0+1),..,(6+7),0,0,0,0 per lane
-            const __m256i _Rx3 = _mm256_unpacklo_epi16(_Rx2, _mm256_setzero_si256()); // zero extend
+            const __m256i _Rx2 = _mm256_hadd_epi16(_Val, _mm256_setzero_si256());
+            const __m256i _Rx3 = _mm256_unpacklo_epi16(_Rx2, _mm256_setzero_si256());
             return _Count_traits_4::_Reduce_avx(_Rx3);
         }
 
         static size_t _Reduce_sse(const __m128i _Val) noexcept {
-            const __m128i _Rx2 = _mm_hadd_epi16(_Val, _mm_setzero_si128()); // (0+1),..,(6+7),0,0,0,0
-            const __m128i _Rx3 = _mm_unpacklo_epi16(_Rx2, _mm_setzero_si128()); // zero extend
+            const __m128i _Rx2 = _mm_hadd_epi16(_Val, _mm_setzero_si128());
+            const __m128i _Rx3 = _mm_unpacklo_epi16(_Rx2, _mm_setzero_si128());
             return _Count_traits_4::_Reduce_sse(_Rx3);
         }
 #endif // !_M_ARM64EC
@@ -2071,14 +2071,14 @@ namespace {
         static size_t _Reduce_avx(const __m256i _Val) noexcept {
             const __m256i _Hi8 = _mm256_unpackhi_epi8(_Val, _mm256_setzero_si256());
             const __m256i _Lo8 = _mm256_unpacklo_epi8(_Val, _mm256_setzero_si256());
-            const __m256i _Rx1 = _mm256_hadd_epi16(_Lo8, _Hi8); // (0+1),..,(15+16) per lane
+            const __m256i _Rx1 = _mm256_hadd_epi16(_Lo8, _Hi8);
             return _Count_traits_2::_Reduce_avx(_Rx1);
         }
 
         static size_t _Reduce_sse(const __m128i _Val) noexcept {
             const __m128i _Hi8 = _mm_unpackhi_epi8(_Val, _mm_setzero_si128());
             const __m128i _Lo8 = _mm_unpacklo_epi8(_Val, _mm_setzero_si128());
-            const __m128i _Rx1 = _mm_hadd_epi16(_Lo8, _Hi8); // (0+1),..,(15+16)
+            const __m128i _Rx1 = _mm_hadd_epi16(_Lo8, _Hi8);
             return _Count_traits_2::_Reduce_sse(_Rx1);
         }
 #endif // !_M_ARM64EC

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -1970,9 +1970,9 @@ namespace {
         }
     }
 
-        struct _Count_traits_8 : _Find_traits_8 {
+    struct _Count_traits_8 : _Find_traits_8 {
 #ifndef _M_ARM64EC
-         static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
+        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
             return _mm256_sub_epi64(_Lhs, _Rhs);
         }
 

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -1984,11 +1984,7 @@ namespace {
             const __m128i _Lo64 = _mm256_extracti128_si256(_Val, 0);
             const __m128i _Hi64 = _mm256_extracti128_si256(_Val, 1);
             const __m128i _Rx8  = _mm_add_epi64(_Lo64, _Hi64);
-#ifdef _M_IX86
-            return _mm_cvtsi128_si32(_Rx8) + _mm_extract_epi32(_Rx8, 2);
-#else // ^^^ defined(_M_IX86) / defined(_M_X64) vvv
-            return _mm_cvtsi128_si64(_Rx8) + _mm_extract_epi64(_Rx8, 1);
-#endif // ^^^ defined(_M_X64) ^^^
+            return _Reduce_sse(_Rx8);
         }
 
         static size_t _Reduce_sse(const __m128i _Val) noexcept {

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -1989,7 +1989,7 @@ namespace {
 
         static size_t _Reduce_sse(const __m128i _Val) noexcept {
 #ifdef _M_IX86
-            return _mm_cvtsi128_si32(_Val) + _mm_extract_epi32(_Val, 2);
+            return static_cast<uint32_t>(_mm_cvtsi128_si32(_Val)) + static_cast<uint32_t>(_mm_extract_epi32(_Val, 2));
 #else // ^^^ defined(_M_IX86) / defined(_M_X64) vvv
             return _mm_cvtsi128_si64(_Val) + _mm_extract_epi64(_Val, 1);
 #endif // ^^^ defined(_M_X64) ^^^
@@ -1999,17 +1999,14 @@ namespace {
 
     struct _Count_traits_4 : _Find_traits_4 {
 #ifndef _M_ARM64EC
-        // For both AVX2 and SSE4.2, the reduced result is extracted by _mm_cvtsi128_si32
-        // as a signed 32-bit integer, so we can count at most 2^31 - 1 elements (0x7FFF'FFFF).
+        // For AVX2, we reduce using hadd_epi32 3 times, therefore to avoid oveflow _Max_count is 0x1FFF'FFFF,
+        // which is multiplied by two 3 times 0xFFFF'FFF8, a greater limit would overflow
 
-        // For AVX2, _Max_portion_size below is _Max_count * 32 bytes, i.e. _Max_count * 8 elements.
-        // Therefore, _Max_count is 0x7FFF'FFFF / 8 which truncates to 0xFFF'FFFF.
-
-        // For SSE4.2, _Max_portion_size below is _Max_count * 16 bytes, i.e. _Max_count * 4 elements.
-        // Therefore, _Max_count could be 0x7FFF'FFFF / 4 which truncates to 0x1FFF'FFFF,
+        // For AVX2, we reduce using hadd_epi32 2 times, therefore to avoid oveflow _Max_count is 0x3FFF'FFFF,
+        // which is multiplied by two 2 times 0xFFFF'FFFC, a greater limit would overflow
         // but it's simpler to use the smaller bound for both codepaths.
 
-        static constexpr size_t _Max_count = 0xFFF'FFFF;
+        static constexpr size_t _Max_count = 0x1FFF'FFFF;
 
         static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
             return _mm256_sub_epi32(_Lhs, _Rhs);
@@ -2025,26 +2022,22 @@ namespace {
             const __m256i _Rx5   = _mm256_permute4x64_epi64(_Rx4, _Shuf); // low lane  (0+1),(2+3),(4+5),(6+7)
             const __m256i _Rx6   = _mm256_hadd_epi32(_Rx5, _mm256_setzero_si256()); // (0+..+3),(4+...+7),0,0
             const __m256i _Rx7   = _mm256_hadd_epi32(_Rx6, _mm256_setzero_si256()); // (0+...+7),0,0,0
-            return _mm_cvtsi128_si32(_mm256_castsi256_si128(_Rx7));
+            return static_cast<uint32_t>(_mm_cvtsi128_si32(_mm256_castsi256_si128(_Rx7)));
         }
 
         static size_t _Reduce_sse(const __m128i _Val) noexcept {
             const __m128i _Rx4 = _mm_hadd_epi32(_Val, _mm_setzero_si128()); // (0+1),(2+3),0,0
             const __m128i _Rx5 = _mm_hadd_epi32(_Rx4, _mm_setzero_si128()); // (0+...+3),0,0,0
-            return _mm_cvtsi128_si32(_Rx5);
+            return static_cast<uint32_t>(_mm_cvtsi128_si32(_Rx5));
         }
 #endif // !_M_ARM64EC
     };
 
     struct _Count_traits_2 : _Find_traits_2 {
 #ifndef _M_ARM64EC
-        // For AVX2, _Max_portion_size below is _Max_count * 32 bytes, i.e. _Max_count * 16 elements.
-        // _mm256_hadd_epi16 processes signed 16-bit integers, and 16 of those fit in 256 bits.
-
-        // For SSE4.2, _Max_portion_size below is _Max_count * 16 bytes, i.e. _Max_count * 8 elements.
-        // _mm_hadd_epi16 processes signed 16-bit integers, and 8 of those fit in 128 bits.
-
-        // For both codepaths, this is why _Max_count is the maximum signed 16-bit integer.
+        // For both AVX2 and SSE2 we need to fit elements after hadd_epi16 to 16 bits,
+        // therefore _Max_count is 0x7FFF, which is when added to itself is 0xFFFE,
+        // a greater limit would overflow.
 
         static constexpr size_t _Max_count = 0x7FFF;
 

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2145,13 +2145,12 @@ namespace {
             }
 
             if (const size_t _Avx_tail_size = _Size_bytes & 0x1C; _Avx_tail_size != 0) {
-                __m256i _Count_vector    = _mm256_setzero_si256();
                 const __m256i _Tail_mask = _Avx2_tail_mask_32(_Avx_tail_size >> 2);
                 const __m256i _Data      = _mm256_maskload_epi32(static_cast<const int*>(_First), _Tail_mask);
-                const __m256i _Mask      = _Traits::_Cmp_avx(_Data, _Comparand);
-                _Count_vector            = _Traits::_Sub_avx(_Count_vector, _mm256_and_si256(_Mask, _Tail_mask));
+                const __m256i _Mask      = _mm256_and_si256(_Traits::_Cmp_avx(_Data, _Comparand), _Tail_mask);
+                const size_t _Tail_count = __popcnt(_mm256_movemask_epi8(_Mask)) / sizeof(_Ty);
                 _Advance_bytes(_First, _Avx_tail_size);
-                _Result += _Traits::_Reduce_avx(_Count_vector);
+                _Result += _Tail_count;
             }
 
             _mm256_zeroupper(); // TRANSITION, DevCom-10331414

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2154,6 +2154,8 @@ namespace {
                     _Advance_bytes(_First, 16);
                 } while (_First != _Stop_at);
 
+                _Result += _Traits::_Reduce_sse(_Count_vector);
+
                 if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
                     break;
                 } else {
@@ -2161,12 +2163,9 @@ namespace {
                         break;
                     }
 
-                    _Result += _Traits::_Reduce_sse(_Count_vector);
                     _Count_vector = _mm_setzero_si128();
                 }
             }
-
-            _Result += _Traits::_Reduce_sse(_Count_vector);
         }
 #endif // !_M_ARM64EC
 

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -1750,37 +1750,6 @@ namespace {
         static __m128i _Cmp_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
             return _mm_cmpeq_epi8(_Lhs, _Rhs);
         }
-
-        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
-            return _mm256_sub_epi8(_Lhs, _Rhs);
-        }
-
-        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
-            return _mm_sub_epi8(_Lhs, _Rhs);
-        }
-
-        static size_t _Reduce_avx(const __m256i _Val) noexcept {
-            const __m256i _Hi8 = _mm256_unpackhi_epi8(_Val, _mm256_setzero_si256());
-            const __m256i _Lo8 = _mm256_unpacklo_epi8(_Val, _mm256_setzero_si256());
-            const __m256i _Rx1 = _mm256_hadd_epi16(_Lo8, _Hi8); //                   (0+1),..,(15+16) per lane
-            const __m256i _Rx2 = _mm256_hadd_epi16(_Rx1, _mm256_setzero_si256()); // (0+1+2+3),..,(13+14+15+16),0,0,0,0
-            const __m256i _Rx3 = _mm256_unpacklo_epi16(_Rx2, _mm256_setzero_si256()); // zero extend
-            const __m256i _Rx4 = _mm256_hadd_epi32(_Rx3, _mm256_setzero_si256()); // (0+...+7),(8+...+15),0,0
-            const __m256i _Rx5 = _mm256_hadd_epi32(_Rx4, _mm256_setzero_si256()); // (0+...+15),0,0,0
-            return _mm_cvtsi128_si32(_mm256_extracti128_si256(_Rx5, 0))
-                 + _mm_cvtsi128_si32(_mm256_extracti128_si256(_Rx5, 1));
-        }
-
-        static size_t _Reduce_sse(const __m128i _Val) noexcept {
-            const __m128i _Hi8 = _mm_unpackhi_epi8(_Val, _mm_setzero_si128());
-            const __m128i _Lo8 = _mm_unpacklo_epi8(_Val, _mm_setzero_si128());
-            const __m128i _Rx1 = _mm_hadd_epi16(_Lo8, _Hi8); //                (0+1),..,(15+16)
-            const __m128i _Rx2 = _mm_hadd_epi16(_Rx1, _mm_setzero_si128()); // (0+1+2+3),..,(13+14+15+16),0,0,0,0
-            const __m128i _Rx3 = _mm_unpacklo_epi16(_Rx2, _mm_setzero_si128()); // zero extend
-            const __m128i _Rx4 = _mm_hadd_epi32(_Rx3, _mm_setzero_si128()); // (0+...+7),(8+...+15),0,0
-            const __m128i _Rx5 = _mm_hadd_epi32(_Rx4, _mm_setzero_si128()); // (0+...+15),0,0,0
-            return _mm_cvtsi128_si32(_Rx5);
-        }
 #endif // !_M_ARM64EC
     };
 
@@ -1800,31 +1769,6 @@ namespace {
 
         static __m128i _Cmp_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
             return _mm_cmpeq_epi16(_Lhs, _Rhs);
-        }
-
-        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
-            return _mm256_sub_epi16(_Lhs, _Rhs);
-        }
-
-        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
-            return _mm_sub_epi16(_Lhs, _Rhs);
-        }
-
-        static size_t _Reduce_avx(const __m256i _Val) noexcept {
-            const __m256i _Rx2 = _mm256_hadd_epi16(_Val, _mm256_setzero_si256()); // (0+1),..,(6+7),0,0,0,0 per lane
-            const __m256i _Rx3 = _mm256_unpacklo_epi16(_Rx2, _mm256_setzero_si256()); // zero extend
-            const __m256i _Rx4 = _mm256_hadd_epi32(_Rx3, _mm256_setzero_si256()); // (0+...+3),(4+...+7),0,0
-            const __m256i _Rx5 = _mm256_hadd_epi32(_Rx4, _mm256_setzero_si256()); // (0+...+7),0,0,0
-            return _mm_cvtsi128_si32(_mm256_extracti128_si256(_Rx5, 0))
-                 + _mm_cvtsi128_si32(_mm256_extracti128_si256(_Rx5, 1));
-        }
-
-        static size_t _Reduce_sse(const __m128i _Val) noexcept {
-            const __m128i _Rx2 = _mm_hadd_epi16(_Val, _mm_setzero_si128()); // (0+1),..,(6+7),0,0,0,0
-            const __m128i _Rx3 = _mm_unpacklo_epi16(_Rx2, _mm_setzero_si128()); // zero extend
-            const __m128i _Rx4 = _mm_hadd_epi32(_Rx3, _mm_setzero_si128()); // (0+...+3),(4+...+7),0,0
-            const __m128i _Rx5 = _mm_hadd_epi32(_Rx4, _mm_setzero_si128()); // (0+...+7),0,0,0
-            return _mm_cvtsi128_si32(_Rx5);
         }
 #endif // !_M_ARM64EC
     };
@@ -1846,27 +1790,6 @@ namespace {
         static __m128i _Cmp_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
             return _mm_cmpeq_epi32(_Lhs, _Rhs);
         }
-
-        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
-            return _mm256_sub_epi32(_Lhs, _Rhs);
-        }
-
-        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
-            return _mm_sub_epi32(_Lhs, _Rhs);
-        }
-
-        static size_t _Reduce_avx(const __m256i _Val) noexcept {
-            const __m256i _Rx4 = _mm256_hadd_epi32(_Val, _mm256_setzero_si256()); // (0+1),(2+3),0,0 per lane
-            const __m256i _Rx5 = _mm256_hadd_epi32(_Rx4, _mm256_setzero_si256()); // (0+3),0,0,0
-            return _mm_cvtsi128_si32(_mm256_extracti128_si256(_Rx5, 0))
-                 + _mm_cvtsi128_si32(_mm256_extracti128_si256(_Rx5, 1));
-        }
-
-        static size_t _Reduce_sse(const __m128i _Val) noexcept {
-            const __m128i _Rx4 = _mm_hadd_epi32(_Val, _mm_setzero_si128()); // (0+1),(2+3),0,0
-            const __m128i _Rx5 = _mm_hadd_epi32(_Rx4, _mm_setzero_si128()); // (0+3),0,0,0
-            return _mm_cvtsi128_si32(_Rx5);
-        }
 #endif // !_M_ARM64EC
     };
 
@@ -1886,34 +1809,6 @@ namespace {
 
         static __m128i _Cmp_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
             return _mm_cmpeq_epi64(_Lhs, _Rhs);
-        }
-
-        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
-            return _mm256_sub_epi64(_Lhs, _Rhs);
-        }
-
-        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
-            return _mm_sub_epi64(_Lhs, _Rhs);
-        }
-
-        static size_t _Reduce_avx(const __m256i _Val) noexcept {
-            const __m128i _Rx6 = _mm256_extracti128_si256(_Val, 0);
-            const __m128i _Rx7 = _mm256_extracti128_si256(_Val, 1);
-#ifdef _M_IX86
-            return _mm_cvtsi128_si32(_Rx6) + _mm_extract_epi32(_Rx6, 2) //
-                 + _mm_cvtsi128_si32(_Rx7) + _mm_extract_epi32(_Rx7, 2);
-#else // ^^^ defined(_M_IX86) / defined(_M_X64) vvv
-            return _mm_cvtsi128_si64(_Rx6) + _mm_extract_epi64(_Rx6, 1) //
-                 + _mm_cvtsi128_si64(_Rx7) + _mm_extract_epi64(_Rx7, 1);
-#endif // ^^^ defined(_M_X64) ^^^
-        }
-
-        static size_t _Reduce_sse(const __m128i _Val) noexcept {
-#ifdef _M_IX86
-            return _mm_cvtsi128_si32(_Val) + _mm_extract_epi32(_Val, 2);
-#else // ^^^ defined(_M_IX86) / defined(_M_X64) vvv
-            return _mm_cvtsi128_si64(_Val) + _mm_extract_epi64(_Val, 1);
-#endif // ^^^ defined(_M_X64) ^^^
         }
 #endif // !_M_ARM64EC
     };
@@ -2074,6 +1969,113 @@ namespace {
             }
         }
     }
+
+        struct _Count_traits_8 : _Find_traits_8 {
+#ifndef _M_ARM64EC
+         static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
+            return _mm256_sub_epi64(_Lhs, _Rhs);
+        }
+
+        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
+            return _mm_sub_epi64(_Lhs, _Rhs);
+        }
+
+        static size_t _Reduce_avx(const __m256i _Val) noexcept {
+            const __m128i _Rx6 = _mm256_extracti128_si256(_Val, 0);
+            const __m128i _Rx7 = _mm256_extracti128_si256(_Val, 1);
+#ifdef _M_IX86
+            return _mm_cvtsi128_si32(_Rx6) + _mm_extract_epi32(_Rx6, 2) //
+                 + _mm_cvtsi128_si32(_Rx7) + _mm_extract_epi32(_Rx7, 2);
+#else // ^^^ defined(_M_IX86) / defined(_M_X64) vvv
+            return _mm_cvtsi128_si64(_Rx6) + _mm_extract_epi64(_Rx6, 1) //
+                 + _mm_cvtsi128_si64(_Rx7) + _mm_extract_epi64(_Rx7, 1);
+#endif // ^^^ defined(_M_X64) ^^^
+        }
+
+        static size_t _Reduce_sse(const __m128i _Val) noexcept {
+#ifdef _M_IX86
+            return _mm_cvtsi128_si32(_Val) + _mm_extract_epi32(_Val, 2);
+#else // ^^^ defined(_M_IX86) / defined(_M_X64) vvv
+            return _mm_cvtsi128_si64(_Val) + _mm_extract_epi64(_Val, 1);
+#endif // ^^^ defined(_M_X64) ^^^
+        }
+#endif // !_M_ARM64EC
+    };
+
+    struct _Count_traits_4 : _Find_traits_4 {
+#ifndef _M_ARM64EC
+        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
+            return _mm256_sub_epi32(_Lhs, _Rhs);
+        }
+
+        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
+            return _mm_sub_epi32(_Lhs, _Rhs);
+        }
+
+        static size_t _Reduce_avx(const __m256i _Val) noexcept {
+            const __m256i _Rx4 = _mm256_hadd_epi32(_Val, _mm256_setzero_si256()); // (0+1),(2+3),0,0 per lane
+            const __m256i _Rx5 = _mm256_hadd_epi32(_Rx4, _mm256_setzero_si256()); // (0+3),0,0,0
+            return _mm_cvtsi128_si32(_mm256_extracti128_si256(_Rx5, 0))
+                 + _mm_cvtsi128_si32(_mm256_extracti128_si256(_Rx5, 1));
+        }
+
+        static size_t _Reduce_sse(const __m128i _Val) noexcept {
+            const __m128i _Rx4 = _mm_hadd_epi32(_Val, _mm_setzero_si128()); // (0+1),(2+3),0,0
+            const __m128i _Rx5 = _mm_hadd_epi32(_Rx4, _mm_setzero_si128()); // (0+3),0,0,0
+            return _mm_cvtsi128_si32(_Rx5);
+        }
+#endif // !_M_ARM64EC
+    };
+
+    struct _Count_traits_2 : _Find_traits_2 {
+#ifndef _M_ARM64EC
+        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
+            return _mm256_sub_epi16(_Lhs, _Rhs);
+        }
+
+        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
+            return _mm_sub_epi16(_Lhs, _Rhs);
+        }
+
+        static size_t _Reduce_avx(const __m256i _Val) noexcept {
+            const __m256i _Rx2 = _mm256_hadd_epi16(_Val, _mm256_setzero_si256()); // (0+1),..,(6+7),0,0,0,0 per lane
+            const __m256i _Rx3 = _mm256_unpacklo_epi16(_Rx2, _mm256_setzero_si256()); // zero extend
+            return _Count_traits_4::_Reduce_avx(_Rx3);
+        }
+
+        static size_t _Reduce_sse(const __m128i _Val) noexcept {
+            const __m128i _Rx2 = _mm_hadd_epi16(_Val, _mm_setzero_si128()); // (0+1),..,(6+7),0,0,0,0
+            const __m128i _Rx3 = _mm_unpacklo_epi16(_Rx2, _mm_setzero_si128()); // zero extend
+            return _Count_traits_4::_Reduce_sse(_Rx3);
+        }
+#endif // !_M_ARM64EC
+    };
+
+    struct _Count_traits_1 : _Find_traits_1 {
+#ifndef _M_ARM64EC
+        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
+            return _mm256_sub_epi8(_Lhs, _Rhs);
+        }
+
+        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
+            return _mm_sub_epi8(_Lhs, _Rhs);
+        }
+
+        static size_t _Reduce_avx(const __m256i _Val) noexcept {
+            const __m256i _Hi8 = _mm256_unpackhi_epi8(_Val, _mm256_setzero_si256());
+            const __m256i _Lo8 = _mm256_unpacklo_epi8(_Val, _mm256_setzero_si256());
+            const __m256i _Rx1 = _mm256_hadd_epi16(_Lo8, _Hi8); //                   (0+1),..,(15+16) per lane
+            return _Count_traits_2::_Reduce_avx(_Rx1);
+        }
+
+        static size_t _Reduce_sse(const __m128i _Val) noexcept {
+            const __m128i _Hi8 = _mm_unpackhi_epi8(_Val, _mm_setzero_si128());
+            const __m128i _Lo8 = _mm_unpacklo_epi8(_Val, _mm_setzero_si128());
+            const __m128i _Rx1 = _mm_hadd_epi16(_Lo8, _Hi8); //                (0+1),..,(15+16)
+            return _Count_traits_2::_Reduce_sse(_Rx1);
+        }
+#endif // !_M_ARM64EC
+    };
 
     template <class _Traits, class _Ty>
     __declspec(noalias) size_t
@@ -2688,22 +2690,22 @@ const void* __stdcall __std_find_last_trivial_8(
 
 __declspec(noalias) size_t
     __stdcall __std_count_trivial_1(const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return __std_count_trivial_impl<_Find_traits_1>(_First, _Last, _Val);
+    return __std_count_trivial_impl<_Count_traits_1>(_First, _Last, _Val);
 }
 
 __declspec(noalias) size_t
     __stdcall __std_count_trivial_2(const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return __std_count_trivial_impl<_Find_traits_2>(_First, _Last, _Val);
+    return __std_count_trivial_impl<_Count_traits_2>(_First, _Last, _Val);
 }
 
 __declspec(noalias) size_t
     __stdcall __std_count_trivial_4(const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return __std_count_trivial_impl<_Find_traits_4>(_First, _Last, _Val);
+    return __std_count_trivial_impl<_Count_traits_4>(_First, _Last, _Val);
 }
 
 __declspec(noalias) size_t
     __stdcall __std_count_trivial_8(const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return __std_count_trivial_impl<_Find_traits_8>(_First, _Last, _Val);
+    return __std_count_trivial_impl<_Count_traits_8>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_first_of_trivial_1(

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -1999,7 +1999,7 @@ namespace {
 
     struct _Count_traits_4 : _Find_traits_4 {
 #ifndef _M_ARM64EC
-        static constexpr size_t _Max_count = 0x1FFF'FFFF;
+        static constexpr size_t _Max_count = 0xFFF'FFFF;
 
         static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
             return _mm256_sub_epi32(_Lhs, _Rhs);

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2141,9 +2141,10 @@ namespace {
                 const __m256i _Tail_mask = _Avx2_tail_mask_32(_Avx_tail_size >> 2);
                 const __m256i _Data      = _mm256_maskload_epi32(static_cast<const int*>(_First), _Tail_mask);
                 const __m256i _Mask      = _mm256_and_si256(_Traits::_Cmp_avx(_Data, _Comparand), _Tail_mask);
-                const size_t _Tail_count = __popcnt(_mm256_movemask_epi8(_Mask)) / sizeof(_Ty);
+                const int _Bingo         = _mm256_movemask_epi8(_Mask);
+                const size_t _Tail_count = __popcnt(_Bingo); // Assume available with SSE4.2
+                _Result += _Tail_count / sizeof(_Ty);
                 _Advance_bytes(_First, _Avx_tail_size);
-                _Result += _Tail_count;
             }
 
             _mm256_zeroupper(); // TRANSITION, DevCom-10331414

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2108,12 +2108,12 @@ namespace {
                 if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
                     break;
                 } else {
-                    _Result += _Traits::_Reduce_avx(_Count_vector);
-                    _Count_vector = _mm256_setzero_si256();
-
                     if (_Avx_size == 0) {
                         break;
                     }
+
+                    _Result += _Traits::_Reduce_avx(_Count_vector);
+                    _Count_vector = _mm256_setzero_si256();
                 }
             }
 
@@ -2157,12 +2157,12 @@ namespace {
                 if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
                     break;
                 } else {
-                    _Result += _Traits::_Reduce_sse(_Count_vector);
-                    _Count_vector = _mm_setzero_si128();
-
                     if (_Sse_size == 0) {
                         break;
                     }
+
+                    _Result += _Traits::_Reduce_sse(_Count_vector);
+                    _Count_vector = _mm_setzero_si128();
                 }
             }
 

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2162,7 +2162,6 @@ namespace {
         } else if (size_t _Sse_size = _Size_bytes & ~size_t{0xF}; _Sse_size != 0 && _Use_sse42()) {
             const __m128i _Comparand = _Traits::_Set_sse(_Val);
             const void* _Stop_at     = _First;
-            __m128i _Count_vector    = _mm_setzero_si128();
 
             for (;;) {
                 if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
@@ -2173,6 +2172,8 @@ namespace {
                     _Advance_bytes(_Stop_at, _Portion_size);
                     _Sse_size -= _Portion_size;
                 }
+
+                __m128i _Count_vector = _mm_setzero_si128();
 
                 do {
                     const __m128i _Data = _mm_loadu_si128(static_cast<const __m128i*>(_First));
@@ -2189,8 +2190,6 @@ namespace {
                     if (_Sse_size == 0) {
                         break;
                     }
-
-                    _Count_vector = _mm_setzero_si128();
                 }
             }
         }

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2002,7 +2002,7 @@ namespace {
         // For AVX2, we reduce using hadd_epi32 3 times, therefore to avoid oveflow _Max_count is 0x1FFF'FFFF,
         // which is multiplied by two 3 times 0xFFFF'FFF8, a greater limit would overflow
 
-        // For AVX2, we reduce using hadd_epi32 2 times, therefore to avoid oveflow _Max_count is 0x3FFF'FFFF,
+        // For SSE2, we reduce using hadd_epi32 2 times, therefore to avoid oveflow _Max_count is 0x3FFF'FFFF,
         // which is multiplied by two 2 times 0xFFFF'FFFC, a greater limit would overflow
         // but it's simpler to use the smaller bound for both codepaths.
 
@@ -2020,7 +2020,7 @@ namespace {
             constexpr auto _Shuf = _MM_SHUFFLE(3, 1, 2, 0); // Cross lane, to reduce further on low lane
             const __m256i _Rx4   = _mm256_hadd_epi32(_Val, _mm256_setzero_si256()); // (0+1),(2+3),0,0 per lane
             const __m256i _Rx5   = _mm256_permute4x64_epi64(_Rx4, _Shuf); // low lane  (0+1),(2+3),(4+5),(6+7)
-            const __m256i _Rx6   = _mm256_hadd_epi32(_Rx5, _mm256_setzero_si256()); // (0+..+3),(4+...+7),0,0
+            const __m256i _Rx6   = _mm256_hadd_epi32(_Rx5, _mm256_setzero_si256()); // (0+...+3),(4+...+7),0,0
             const __m256i _Rx7   = _mm256_hadd_epi32(_Rx6, _mm256_setzero_si256()); // (0+...+7),0,0,0
             return static_cast<uint32_t>(_mm_cvtsi128_si32(_mm256_castsi256_si128(_Rx7)));
         }

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2069,17 +2069,13 @@ namespace {
         }
 
         static size_t _Reduce_avx(const __m256i _Val) noexcept {
-            const __m256i _Hi8 = _mm256_unpackhi_epi8(_Val, _mm256_setzero_si256());
-            const __m256i _Lo8 = _mm256_unpacklo_epi8(_Val, _mm256_setzero_si256());
-            const __m256i _Rx1 = _mm256_hadd_epi16(_Lo8, _Hi8);
-            return _Count_traits_2::_Reduce_avx(_Rx1);
+            const __m256i _Rx1 = _mm256_sad_epu8(_Val, _mm256_setzero_si256());
+            return _Count_traits_8::_Reduce_avx(_Rx1);
         }
 
         static size_t _Reduce_sse(const __m128i _Val) noexcept {
-            const __m128i _Hi8 = _mm_unpackhi_epi8(_Val, _mm_setzero_si128());
-            const __m128i _Lo8 = _mm_unpacklo_epi8(_Val, _mm_setzero_si128());
-            const __m128i _Rx1 = _mm_hadd_epi16(_Lo8, _Hi8);
-            return _Count_traits_2::_Reduce_sse(_Rx1);
+            const __m128i _Rx1 = _mm_sad_epu8(_Val, _mm_setzero_si128());
+            return _Count_traits_8::_Reduce_sse(_Rx1);
         }
 #endif // !_M_ARM64EC
     };

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2092,7 +2092,7 @@ namespace {
                 if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
                     _Advance_bytes(_Stop_at, _Avx_size);
                 } else {
-                    constexpr size_t _Max_portion_size = (size_t{1} << ((sizeof(_Ty) * 8) - 1)) * 32 / sizeof(_Ty);
+                    constexpr size_t _Max_portion_size = ((size_t{1} << (sizeof(_Ty) * 8)) - 2) * 32 / sizeof(_Ty);
                     const size_t _Portion_size         = _Avx_size < _Max_portion_size ? _Avx_size : _Max_portion_size;
                     _Advance_bytes(_Stop_at, _Portion_size);
                     _Avx_size -= _Portion_size;
@@ -2141,7 +2141,7 @@ namespace {
                 if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
                     _Advance_bytes(_Stop_at, _Sse_size);
                 } else {
-                    constexpr size_t _Max_portion_size = (size_t{1} << ((sizeof(_Ty) * 8) - 1)) * 16 / sizeof(_Ty);
+                    constexpr size_t _Max_portion_size = ((size_t{1} << (sizeof(_Ty) * 8)) - 1) * 16 / sizeof(_Ty);
                     const size_t _Portion_size         = _Sse_size < _Max_portion_size ? _Sse_size : _Max_portion_size;
                     _Advance_bytes(_Stop_at, _Portion_size);
                     _Sse_size -= _Portion_size;

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2004,6 +2004,8 @@ namespace {
 
     struct _Count_traits_4 : _Find_traits_4 {
 #ifndef _M_ARM64EC
+        static constexpr size_t _Max_count = 0x1FFF'FFFF;
+
         static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
             return _mm256_sub_epi32(_Lhs, _Rhs);
         }
@@ -2029,6 +2031,8 @@ namespace {
 
     struct _Count_traits_2 : _Find_traits_2 {
 #ifndef _M_ARM64EC
+        static constexpr size_t _Max_count = 0x7FFF;
+
         static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
             return _mm256_sub_epi16(_Lhs, _Rhs);
         }
@@ -2053,6 +2057,8 @@ namespace {
 
     struct _Count_traits_1 : _Find_traits_1 {
 #ifndef _M_ARM64EC
+        static constexpr size_t _Max_count = 0xFF;
+
         static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
             return _mm256_sub_epi8(_Lhs, _Rhs);
         }
@@ -2064,14 +2070,14 @@ namespace {
         static size_t _Reduce_avx(const __m256i _Val) noexcept {
             const __m256i _Hi8 = _mm256_unpackhi_epi8(_Val, _mm256_setzero_si256());
             const __m256i _Lo8 = _mm256_unpacklo_epi8(_Val, _mm256_setzero_si256());
-            const __m256i _Rx1 = _mm256_hadd_epi16(_Lo8, _Hi8); //                   (0+1),..,(15+16) per lane
+            const __m256i _Rx1 = _mm256_hadd_epi16(_Lo8, _Hi8); // (0+1),..,(15+16) per lane
             return _Count_traits_2::_Reduce_avx(_Rx1);
         }
 
         static size_t _Reduce_sse(const __m128i _Val) noexcept {
             const __m128i _Hi8 = _mm_unpackhi_epi8(_Val, _mm_setzero_si128());
             const __m128i _Lo8 = _mm_unpacklo_epi8(_Val, _mm_setzero_si128());
-            const __m128i _Rx1 = _mm_hadd_epi16(_Lo8, _Hi8); //                (0+1),..,(15+16)
+            const __m128i _Rx1 = _mm_hadd_epi16(_Lo8, _Hi8); // (0+1),..,(15+16)
             return _Count_traits_2::_Reduce_sse(_Rx1);
         }
 #endif // !_M_ARM64EC
@@ -2094,7 +2100,7 @@ namespace {
                 if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
                     _Advance_bytes(_Stop_at, _Avx_size);
                 } else {
-                    constexpr size_t _Max_portion_size = ((size_t{1} << (sizeof(_Ty) * 8)) - 2) * 32 / sizeof(_Ty);
+                    constexpr size_t _Max_portion_size = (_Traits::_Max_count - 1) * (32 / sizeof(_Ty));
                     const size_t _Portion_size         = _Avx_size < _Max_portion_size ? _Avx_size : _Max_portion_size;
                     _Advance_bytes(_Stop_at, _Portion_size);
                     _Avx_size -= _Portion_size;
@@ -2143,7 +2149,7 @@ namespace {
                 if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
                     _Advance_bytes(_Stop_at, _Sse_size);
                 } else {
-                    constexpr size_t _Max_portion_size = ((size_t{1} << (sizeof(_Ty) * 8)) - 1) * 16 / sizeof(_Ty);
+                    constexpr size_t _Max_portion_size = _Traits::_Max_count * (16 / sizeof(_Ty));
                     const size_t _Portion_size         = _Sse_size < _Max_portion_size ? _Sse_size : _Max_portion_size;
                     _Advance_bytes(_Stop_at, _Portion_size);
                     _Sse_size -= _Portion_size;

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -102,6 +102,17 @@ void test_count(mt19937_64& gen) {
     }
 }
 
+template <class T>
+void test_count_zero() { // text that counters don't overflow
+    vector<T> input;
+    input.reserve(dataCount);
+    test_case_count(input, T{0});
+    for (size_t attempts = 0; attempts < dataCount; ++attempts) {
+        input.push_back(0);
+        test_case_count(input, T{0});
+    }
+}
+
 template <class FwdIt, class T>
 auto last_known_good_find(FwdIt first, FwdIt last, T v) {
     for (; first != last; ++first) {
@@ -741,6 +752,16 @@ void test_vector_algorithms(mt19937_64& gen) {
     test_count<unsigned int>(gen);
     test_count<long long>(gen);
     test_count<unsigned long long>(gen);
+
+    test_count_zero<char>();
+    test_count_zero<signed char>();
+    test_count_zero<unsigned char>();
+    test_count_zero<short>();
+    test_count_zero<unsigned short>();
+    test_count_zero<int>();
+    test_count_zero<unsigned int>();
+    test_count_zero<long long>();
+    test_count_zero<unsigned long long>();
 
     test_find<char>(gen);
     test_find<signed char>(gen);

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -104,13 +104,8 @@ void test_count(mt19937_64& gen) {
 
 template <class T>
 void test_count_zero() { // text that counters don't overflow
-    vector<T> input;
-    input.reserve(dataCount);
+    vector<T> input(1000000, T{0});
     test_case_count(input, T{0});
-    for (size_t attempts = 0; attempts < dataCount; ++attempts) {
-        input.push_back(0);
-        test_case_count(input, T{0});
-    }
 }
 
 template <class FwdIt, class T>

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -103,7 +103,7 @@ void test_count(mt19937_64& gen) {
 }
 
 template <class T>
-void test_count_zero() { // text that counters don't overflow
+void test_count_zero() { // test that counters don't overflow
     vector<T> input(1000000, T{0});
     test_case_count(input, T{0});
 }

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -83,6 +83,10 @@ void test_case_count(const vector<T>& input, T v) {
     auto expected = last_known_good_count(input.begin(), input.end(), v);
     auto actual   = count(input.begin(), input.end(), v);
     assert(expected == actual);
+#if _HAS_CXX20
+    auto actual_r = ranges::count(input, v);
+    assert(actual_r == actual);
+#endif // _HAS_CXX20
 }
 
 template <class T>

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -85,7 +85,7 @@ void test_case_count(const vector<T>& input, T v) {
     assert(expected == actual);
 #if _HAS_CXX20
     auto actual_r = ranges::count(input, v);
-    assert(actual_r == actual);
+    assert(actual_r == expected);
 #endif // _HAS_CXX20
 }
 


### PR DESCRIPTION
Somewhat better in a long run, some pessimization for a short one.
Before:
```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
bm<uint8_t, Op::Count>/8021/3056        97.4 ns         95.3 ns     10000000
bm<uint8_t, Op::Count>/63/62            3.86 ns         3.13 ns    194782609
bm<uint8_t, Op::Count>/31/30            9.98 ns         8.89 ns     89600000
bm<uint8_t, Op::Count>/15/14            5.00 ns         4.97 ns    144516129
bm<uint8_t, Op::Count>/7/6              3.08 ns         3.14 ns    248888889
bm<uint16_t, Op::Count>/8021/3056        198 ns          193 ns      3733333
bm<uint16_t, Op::Count>/63/62           3.92 ns         3.75 ns    179200000
bm<uint16_t, Op::Count>/31/30           3.51 ns         3.53 ns    203636364
bm<uint16_t, Op::Count>/15/14           4.06 ns         2.13 ns    248888889
bm<uint16_t, Op::Count>/7/6             3.31 ns         1.79 ns    280000000
bm<uint32_t, Op::Count>/8021/3056        364 ns          245 ns      3446154
bm<uint32_t, Op::Count>/63/62           4.62 ns         2.20 ns    248888889
bm<uint32_t, Op::Count>/31/30           3.45 ns         2.29 ns    464592593
bm<uint32_t, Op::Count>/15/14           2.83 ns         1.50 ns    407272727
bm<uint32_t, Op::Count>/7/6             3.05 ns         2.08 ns    263529412
bm<uint64_t, Op::Count>/8021/3056        737 ns          600 ns      1120000
bm<uint64_t, Op::Count>/63/62           8.65 ns         6.25 ns    100000000
bm<uint64_t, Op::Count>/31/30           4.75 ns         3.39 ns    248888889
bm<uint64_t, Op::Count>/15/14           3.54 ns         1.79 ns    280000000
bm<uint64_t, Op::Count>/7/6             3.08 ns         2.05 ns    640000000
```

After:
```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
bm<uint8_t, Op::Count>/8021/3056        77.5 ns         53.5 ns     27151515
bm<uint8_t, Op::Count>/63/62            4.34 ns         3.52 ns    497777778
bm<uint8_t, Op::Count>/31/30            10.1 ns         7.98 ns    172307692
bm<uint8_t, Op::Count>/15/14            5.30 ns         3.96 ns    320000000
bm<uint8_t, Op::Count>/7/6              3.50 ns         2.42 ns    471578947
bm<uint16_t, Op::Count>/8021/3056        136 ns          105 ns     10000000
bm<uint16_t, Op::Count>/63/62           4.85 ns         3.40 ns    358400000
bm<uint16_t, Op::Count>/31/30           4.33 ns         3.31 ns    471578947
bm<uint16_t, Op::Count>/15/14           5.08 ns         3.71 ns    358400000
bm<uint16_t, Op::Count>/7/6             3.64 ns         2.49 ns    426666667
bm<uint32_t, Op::Count>/8021/3056        254 ns          206 ns      6892308
bm<uint32_t, Op::Count>/63/62           4.60 ns         2.52 ns    670690059
bm<uint32_t, Op::Count>/31/30           4.23 ns         1.80 ns    995555556
bm<uint32_t, Op::Count>/15/14           3.72 ns         1.66 ns   1000000000
bm<uint32_t, Op::Count>/7/6             3.88 ns         1.48 ns    896000000
bm<uint64_t, Op::Count>/8021/3056        724 ns          392 ns      3584000
bm<uint64_t, Op::Count>/63/62           6.15 ns         2.42 ns    426666667
bm<uint64_t, Op::Count>/31/30           4.09 ns         2.07 ns    828499485
bm<uint64_t, Op::Count>/15/14           3.43 ns         1.42 ns   1000000000
bm<uint64_t, Op::Count>/7/6             3.15 ns         1.25 ns    814545455
```