### PR TITLE
`<generator>`: Don't include `<ranges>`

### DIFF
--- a/stl/inc/generator
+++ b/stl/inc/generator
@@ -15,7 +15,7 @@ _EMIT_STL_WARNING(STL4038, "The contents of <generator> are available only with 
 
 #include <coroutine>
 #include <exception>
-#include <ranges>
+#include <xmemory>
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -84,24 +84,6 @@ namespace ranges {
     template <class _Ty, size_t _Extent>
         requires (_Extent != dynamic_extent)
     constexpr auto _Compile_time_max_size<const span<_Ty, _Extent>> = _Extent;
-
-#if defined(__cpp_lib_byte)
-    _EXPORT_STD template <range _Rng, class _Alloc = allocator<byte>>
-#else // ^^^ defined(__cpp_lib_byte) / !defined(__cpp_lib_byte) vvv
-    _EXPORT_STD template <range _Rng, class _Alloc>
-#endif // ^^^ !defined(__cpp_lib_byte) ^^^
-    struct elements_of {
-        /* [[no_unique_address]] */ _Rng range;
-        /* [[no_unique_address]] */ _Alloc allocator{};
-    };
-
-#if defined(__cpp_lib_byte)
-    template <class _Rng, class _Alloc = allocator<byte>>
-    elements_of(_Rng&&, _Alloc = {}) -> elements_of<_Rng&&, _Alloc>;
-#else // ^^^ defined(__cpp_lib_byte) / !defined(__cpp_lib_byte) vvv
-    template <class _Rng, class _Alloc>
-    elements_of(_Rng&&, _Alloc) -> elements_of<_Rng&&, _Alloc>;
-#endif // ^^^ !defined(__cpp_lib_byte) ^^^
 #endif // _HAS_CXX23
 
     // clang-format off

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2587,6 +2587,28 @@ template <class _Ty>
 concept _Transparent = _Is_transparent_v<_Ty>;
 #endif // _HAS_CXX20
 
+#if _HAS_CXX23
+namespace ranges {
+#if defined(__cpp_lib_byte)
+    _EXPORT_STD template <range _Rng, class _Alloc = allocator<byte>>
+#else // ^^^ defined(__cpp_lib_byte) / !defined(__cpp_lib_byte) vvv
+    _EXPORT_STD template <range _Rng, class _Alloc>
+#endif // ^^^ !defined(__cpp_lib_byte) ^^^
+    struct elements_of {
+        /* [[no_unique_address]] */ _Rng range;
+        /* [[no_unique_address]] */ _Alloc allocator{};
+    };
+
+#if defined(__cpp_lib_byte)
+    template <class _Rng, class _Alloc = allocator<byte>>
+    elements_of(_Rng&&, _Alloc = {}) -> elements_of<_Rng&&, _Alloc>;
+#else // ^^^ defined(__cpp_lib_byte) / !defined(__cpp_lib_byte) vvv
+    template <class _Rng, class _Alloc>
+    elements_of(_Rng&&, _Alloc) -> elements_of<_Rng&&, _Alloc>;
+#endif // ^^^ !defined(__cpp_lib_byte) ^^^
+} // namespace ranges
+#endif // _HAS_CXX23
+
 template <class _Elem, class _UTy>
 _NODISCARD _Elem* _UIntegral_to_buff(_Elem* _RNext, _UTy _UVal) { // used by both to_string and thread::id output
     // format _UVal into buffer *ending at* _RNext


### PR DESCRIPTION
This improves inclusion time of `<generator>`.

`generator.cpp`:
```c++
#include <generator>
```

Before:
```term
PS D:\stl-playground> cl /std:c++latest /Bt /nologo .\generator.cpp /Zs
generator.cpp
time(C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.40.33721\bin\HostX64\x64\c1xx.dll)=0.514s
```

After:
```term
PS D:\stl-playground> cl /std:c++latest /Bt /nologo .\generator.cpp /Zs
generator.cpp
time(C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.40.33721\bin\HostX64\x64\c1xx.dll)=0.257s
```