### PR TITLE
`<generator>`: Don't use `operator new[]` and `operator delete[]`

### DIFF
--- a/stl/inc/generator
+++ b/stl/inc/generator
@@ -128,7 +128,7 @@ private:
     }
 
     static void __stdcall _Dealloc_delete(void* const _Ptr, const size_t _Size) noexcept {
-        ::operator delete[](_Ptr, _Size + sizeof(_Dealloc_fn));
+        ::operator delete(_Ptr, _Size + sizeof(_Dealloc_fn));
     }
 
     template <class _ProtoAlloc>
@@ -164,7 +164,7 @@ private:
 
 public:
     static void* operator new(const size_t _Size) { // default: new/delete
-        void* const _Ptr           = ::operator new[](_Size + sizeof(_Dealloc_fn));
+        void* const _Ptr           = ::operator new(_Size + sizeof(_Dealloc_fn));
         const _Dealloc_fn _Dealloc = _Dealloc_delete;
         _CSTD memcpy(static_cast<char*>(_Ptr) + _Size, &_Dealloc, sizeof(_Dealloc_fn));
         return _Ptr;

--- a/tests/std/tests/P2502R2_generator_promise/test.cpp
+++ b/tests/std/tests/P2502R2_generator_promise/test.cpp
@@ -5,6 +5,7 @@
 #include <coroutine>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <forward_list>
 #include <generator>
 #include <list>
@@ -25,11 +26,11 @@ using namespace std;
 #pragma warning(disable : 28251) // Inconsistent annotation for 'new[]': this instance has no annotations.
 
 void* operator new[](size_t) {
-    unreachable();
+    abort();
 }
 
 void operator delete[](void*) noexcept {
-    unreachable();
+    abort();
 }
 
 template <class Promise, class... Args>

--- a/tests/std/tests/P2502R2_generator_promise/test.cpp
+++ b/tests/std/tests/P2502R2_generator_promise/test.cpp
@@ -22,6 +22,16 @@
 
 using namespace std;
 
+#pragma warning(disable : 28251) // Inconsistent annotation for 'new[]': this instance has no annotations.
+
+void* operator new[](size_t) {
+    unreachable();
+}
+
+void operator delete[](void*) noexcept {
+    unreachable();
+}
+
 template <class Promise, class... Args>
 concept HasOperatorNew = requires(Args&&... args) {
     { Promise::operator new(forward<Args>(args)...) } -> same_as<void*>;


### PR DESCRIPTION
`_Promise_allocator<void>`'s `operator new(size_t)` is specified to allocate memory with `allocator<_Aligned_block>` (see [[coro.generator.promise]/17](http://eel.is/c++draft/coro.generator#promise-17)), which internally uses `::operator new`, not `::operator new[]` (see [[allocator.members]/5](http://eel.is/c++draft/default.allocator#allocator.members-5)).