### PR TITLE
WIP: Allow detailed selection with CTest

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,36 @@ list(APPEND STLASAN_LIT_COMMAND "${STL_LIT_OUTPUT}"
                                 "-D" "tags=ASAN"
                                 "${STL_LIT_TEST_DIRS}")
 
-add_test(NAME stl COMMAND ${Python_EXECUTABLE} ${STL_LIT_COMMAND} COMMAND_EXPAND_LISTS)
-add_test(NAME stlasan COMMAND ${Python_EXECUTABLE} ${STLASAN_LIT_COMMAND} COMMAND_EXPAND_LISTS)
-set_tests_properties(stl stlasan PROPERTIES RUN_SERIAL ON)
+# libcxx will be handled differently, because they use their own runner
+foreach(DIR std tr1)
+    file(GLOB globbed_dirs
+         LIST_DIRECTORIES ON
+         "${DIR}/tests/*")
+    foreach(test_dir ${globbed_dirs})
+        # There are some .lst files alongside the directories
+        if (NOT IS_DIRECTORY ${test_dir})
+            continue()
+        endif()
+        get_filename_component(just_folder ${test_dir} NAME)
+        add_test(NAME "${DIR}::${just_folder}"
+          COMMAND ${Python_EXECUTABLE} ${STL_LIT_OUTPUT} ${LIT_FLAGS} "-o" "${CMAKE_CURRENT_BINARY_DIR}/test_results_${DIR}_${just_folder}.json" "-D" "notags=ASAN" ${test_dir})
+        set_tests_properties("${DIR}::${just_folder}"
+          PROPERTIES
+            RUN_SERIAL ON
+            LABELS "${DIR}"
+        )
+        add_test(NAME "${DIR}::${just_folder}::ASAN"
+          COMMAND ${Python_EXECUTABLE} ${STL_LIT_OUTPUT} ${LIT_FLAGS} "-o" "${CMAKE_CURRENT_BINARY_DIR}/test_results_${DIR}_${just_folder}_asan.json" "-D" "tags=ASAN" ${test_dir})
+        set_tests_properties("${DIR}::${just_folder}::ASAN"
+          PROPERTIES
+            RUN_SERIAL ON
+            LABELS "${DIR};asan"
+        )
+    endforeach()
+endforeach()
+
+
+# TODO: explicitly add libcxx the way it was done before
+#add_test(NAME stl COMMAND ${Python_EXECUTABLE} ${STL_LIT_COMMAND} COMMAND_EXPAND_LISTS)
+#add_test(NAME stlasan COMMAND ${Python_EXECUTABLE} ${STLASAN_LIT_COMMAND} COMMAND_EXPAND_LISTS)
+#set_tests_properties(stl stlasan PROPERTIES RUN_SERIAL ON)


### PR DESCRIPTION
This is a preview of potential CTest integration extension, which would allow running tests with better granularity than just "asan" vs "no-asan" like now. This is unfinished, because before cleaning it up I want to know whether there is an interest in having this.

### Examples (I am using `-N` so instead of running the tests, CTest just lists them):

**tests for P0009R18**
```
STL\out\x64>ctest -R P0009 -N
Test project C:/ubuntu/STL/out/x64
  Test #509: std::P0009R18_mdspan_default_accessor
  Test #510: std::P0009R18_mdspan_default_accessor::ASAN
  Test #511: std::P0009R18_mdspan_extents
  Test #512: std::P0009R18_mdspan_extents::ASAN
  Test #513: std::P0009R18_mdspan_extents_death
  Test #514: std::P0009R18_mdspan_extents_death::ASAN
  Test #515: std::P0009R18_mdspan_layout_left
  Test #516: std::P0009R18_mdspan_layout_left::ASAN
  Test #517: std::P0009R18_mdspan_layout_left_death
  Test #518: std::P0009R18_mdspan_layout_left_death::ASAN
  Test #519: std::P0009R18_mdspan_layout_right
  Test #520: std::P0009R18_mdspan_layout_right::ASAN
  Test #521: std::P0009R18_mdspan_layout_right_death
  Test #522: std::P0009R18_mdspan_layout_right_death::ASAN
  Test #523: std::P0009R18_mdspan_layout_stride
  Test #524: std::P0009R18_mdspan_layout_stride::ASAN
  Test #525: std::P0009R18_mdspan_layout_stride_death
  Test #526: std::P0009R18_mdspan_layout_stride_death::ASAN
  Test #527: std::P0009R18_mdspan_mdspan
  Test #528: std::P0009R18_mdspan_mdspan::ASAN
  Test #529: std::P0009R18_mdspan_mdspan_death
  Test #530: std::P0009R18_mdspan_mdspan_death::ASAN

Total Tests: 22
```



**tests for P0009R18, but without ASAN**
```
STL\out\x64>ctest -R P0009 -LE asan -N
Test project C:/ubuntu/STL/out/x64
  Test #509: std::P0009R18_mdspan_default_accessor
  Test #511: std::P0009R18_mdspan_extents
  Test #513: std::P0009R18_mdspan_extents_death
  Test #515: std::P0009R18_mdspan_layout_left
  Test #517: std::P0009R18_mdspan_layout_left_death
  Test #519: std::P0009R18_mdspan_layout_right
  Test #521: std::P0009R18_mdspan_layout_right_death
  Test #523: std::P0009R18_mdspan_layout_stride
  Test #525: std::P0009R18_mdspan_layout_stride_death
  Test #527: std::P0009R18_mdspan_mdspan
  Test #529: std::P0009R18_mdspan_mdspan_death

Total Tests: 11
```

**ASAN tests under tr1**
```
STL\out\x64>ctest -L tr1 -N -L asan
Test project C:/ubuntu/STL/out/x64
  Test #1492: tr1::algorithm::ASAN
  Test #1494: tr1::array::ASAN
  Test #1496: tr1::atomic::ASAN
  Test #1498: tr1::bitset::ASAN
  Test #1500: tr1::cctype::ASAN
  Test #1502: tr1::cerrno::ASAN
  Test #1504: tr1::cfloat::ASAN
  Test #1506: tr1::chrono::ASAN
  Test #1508: tr1::ciso646::ASAN
  Test #1510: tr1::climits::ASAN
  Test #1512: tr1::clocale::ASAN
   < snip >
```

**Output from actually running tests**
```
STL\out\x64>ctest -R P0009 -LE asan
Test project C:/ubuntu/STL/out/x64
      Start 509: std::P0009R18_mdspan_default_accessor
 1/11 Test #509: std::P0009R18_mdspan_default_accessor ......   Passed    4.10 sec
      Start 511: std::P0009R18_mdspan_extents
 2/11 Test #511: std::P0009R18_mdspan_extents ...............   Passed   71.48 sec
      Start 513: std::P0009R18_mdspan_extents_death
 3/11 Test #513: std::P0009R18_mdspan_extents_death .........   Passed    6.21 sec
      Start 515: std::P0009R18_mdspan_layout_left
 4/11 Test #515: std::P0009R18_mdspan_layout_left ...........   Passed   68.20 sec
      Start 517: std::P0009R18_mdspan_layout_left_death
 5/11 Test #517: std::P0009R18_mdspan_layout_left_death .....   Passed    5.21 sec
      Start 519: std::P0009R18_mdspan_layout_right
 6/11 Test #519: std::P0009R18_mdspan_layout_right ..........   Passed   71.26 sec
      Start 521: std::P0009R18_mdspan_layout_right_death
 7/11 Test #521: std::P0009R18_mdspan_layout_right_death ....   Passed    5.63 sec
      Start 523: std::P0009R18_mdspan_layout_stride
 8/11 Test #523: std::P0009R18_mdspan_layout_stride .........   Passed   34.91 sec
      Start 525: std::P0009R18_mdspan_layout_stride_death
 9/11 Test #525: std::P0009R18_mdspan_layout_stride_death ...   Passed    6.36 sec
      Start 527: std::P0009R18_mdspan_mdspan
10/11 Test #527: std::P0009R18_mdspan_mdspan ................   Passed    9.71 sec
      Start 529: std::P0009R18_mdspan_mdspan_death
11/11 Test #529: std::P0009R18_mdspan_mdspan_death ..........   Passed    5.30 sec

100% tests passed, 0 tests failed out of 11

Label Time Summary:
std    = 288.37 sec*proc (11 tests)

Total Test time (real) = 288.50 sec
```


--------

Downside to this is that if you run all tests, it will finish slower, than the old implementation. The reason is that CTest is told to run each test on its own (because `lit` is internally parallelized), and so there will be tails where `lit` is not using all cores, but CTest cannot start the next test yet.
