### PR TITLE
Use `_STL_INTERNAL_STATIC_ASSERT(false)` when appropriate

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -97,7 +97,7 @@ __declspec(noalias) void _Reverse_copy_vectorized(const void* _First, const void
     } else if constexpr (_Nx == 8) {
         ::__std_reverse_copy_trivially_copyable_8(_First, _Last, _Dest);
     } else {
-        static_assert(false, "Unexpected size");
+        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
     }
 }
 
@@ -120,7 +120,7 @@ pair<_Ty*, _Ty*> _Minmax_element_vectorized(_Ty* const _First, _Ty* const _Last)
     } else if constexpr (sizeof(_Ty) == 8) {
         _Res = ::__std_minmax_element_8(_First, _Last, _Signed);
     } else {
-        static_assert(false, "Unexpected size");
+        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
     }
 
     return {const_cast<_Ty*>(static_cast<const _Ty*>(_Res._Min)), const_cast<_Ty*>(static_cast<const _Ty*>(_Res._Max))};
@@ -166,7 +166,7 @@ auto _Minmax_vectorized(_Ty* const _First, _Ty* const _Last) noexcept {
             return ::__std_minmax_8u(_First, _Last);
         }
     } else {
-        static_assert(false, "Unexpected size");
+        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
     }
 }
 
@@ -193,7 +193,7 @@ _Ty* _Find_last_vectorized(_Ty* const _First, _Ty* const _Last, const _TVal _Val
         return const_cast<_Ty*>(
             static_cast<const _Ty*>(::__std_find_last_trivial_8(_First, _Last, static_cast<uint64_t>(_Val))));
     } else {
-        static_assert(false, "Unexpected size");
+        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
     }
 }
 
@@ -213,7 +213,7 @@ _Ty1* _Find_first_of_vectorized(
         return const_cast<_Ty1*>(
             static_cast<const _Ty1*>(::__std_find_first_of_trivial_8(_First1, _Last1, _First2, _Last2)));
     } else {
-        static_assert(false, "Unexpected size");
+        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
     }
 }
 
@@ -231,7 +231,7 @@ __declspec(noalias) void _Replace_vectorized(
     } else if constexpr (sizeof(_Ty) == 8) {
         ::__std_replace_8(_First, _Last, static_cast<uint64_t>(_Old_val), static_cast<uint64_t>(_New_val));
     } else {
-        static_assert(false, "Unexpected size");
+        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
     }
 }
 

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -72,7 +72,7 @@ _NODISCARD constexpr _Ty byteswap(const _Ty _Val) noexcept {
     } else if constexpr (sizeof(_Ty) == 8) {
         return static_cast<_Ty>(_Byteswap_uint64(static_cast<unsigned long long>(_Val)));
     } else {
-        static_assert(false, "Unexpected integer size");
+        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
     }
 }
 #endif // _HAS_CXX23

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5387,7 +5387,7 @@ namespace chrono {
             } else if constexpr (_Is_specialization_v<_Ty, _Local_time_format_t>) {
                 return _Type == 'z' || _Type == 'Z' || _Is_valid_type<decltype(_Ty::_Time)>(_Type);
             } else {
-                static_assert(false, "should be unreachable");
+                _STL_INTERNAL_STATIC_ASSERT(false); // unexpected type
             }
         }
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -3037,7 +3037,7 @@ namespace chrono {
             static_assert(false, "A three-step clock time conversion is required to be unique, "
                                  "either utc-to-system or system-to-utc, but not both (N4950 [time.clock.cast.fn]/2).");
         } else {
-            static_assert(false, "should be unreachable");
+            _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
         }
     }
 

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -453,7 +453,7 @@ namespace _Strong_order {
             } else if constexpr (_Strat == _St::_Three) {
                 return static_cast<strong_ordering>(compare_three_way{}(_Left, _Right));
             } else {
-                static_assert(false, "should be unreachable");
+                _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
             }
         }
     };
@@ -579,7 +579,7 @@ namespace _Weak_order {
                 return static_cast<weak_ordering>(
                     static_cast<strong_ordering>(strong_order(_Left, _Right))); // intentional ADL
             } else {
-                static_assert(false, "should be unreachable");
+                _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
             }
         }
     };
@@ -664,7 +664,7 @@ namespace _Partial_order {
                 return static_cast<partial_ordering>(
                     static_cast<strong_ordering>(strong_order(_Left, _Right))); // intentional ADL
             } else {
-                static_assert(false, "should be unreachable");
+                _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
             }
         }
     };
@@ -720,7 +720,7 @@ namespace _Compare_strong_order_fallback {
                      : _Left < _Right  ? strong_ordering::less
                                        : strong_ordering::greater;
             } else {
-                static_assert(false, "should be unreachable");
+                _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
             }
         }
     };
@@ -770,7 +770,7 @@ namespace _Compare_weak_order_fallback {
                      : _Left < _Right  ? weak_ordering::less
                                        : weak_ordering::greater;
             } else {
-                static_assert(false, "should be unreachable");
+                _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
             }
         }
     };
@@ -829,7 +829,7 @@ namespace _Compare_partial_order_fallback {
                      : _Right < _Left  ? partial_ordering::greater
                                        : partial_ordering::unordered;
             } else {
-                static_assert(false, "should be unreachable");
+                _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
             }
         }
     };

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -2605,7 +2605,7 @@ public:
             } else if constexpr (_Del == _Deletion_kind::_Normal_array) {
                 delete[] _Ptr;
             } else {
-                static_assert(false, "Unknown _Deletion_kind.");
+                _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
             }
         }
     }

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2030,7 +2030,7 @@ namespace ranges {
                 } else if constexpr (_Strat == _St::_Own) {
                     return owning_view{_STD forward<_Rng>(_Range)};
                 } else {
-                    static_assert(false, "Should be unreachable");
+                    _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
                 }
             }
         };
@@ -2164,7 +2164,7 @@ namespace ranges {
                 } else if constexpr (_Strat == _St::_As_rvalue) {
                     return as_rvalue_view{_STD forward<_Rng>(_Range)};
                 } else {
-                    static_assert(false, "Should be unreachable");
+                    _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
                 }
             }
         };
@@ -3142,7 +3142,7 @@ namespace ranges {
                     } else if constexpr (_Strat == _St::_Reconstruct_subrange) {
                         return subrange(_First, _First + _Count);
                     } else {
-                        static_assert(false, "Should be unreachable");
+                        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
                     }
                 }
             }
@@ -3548,7 +3548,7 @@ namespace ranges {
                     } else if constexpr (_Strat == _St::_Reconstruct_other) {
                         return remove_cvref_t<_Rng>(_RANGES begin(_Range) + _Count, _RANGES end(_Range));
                     } else {
-                        static_assert(false, "Should be unreachable");
+                        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
                     }
                 }
             }
@@ -5389,7 +5389,7 @@ namespace ranges {
                 } else if constexpr (_Strat == _St::_Common) {
                     return common_view{_STD forward<_Rng>(_Range)};
                 } else {
-                    static_assert(false, "Should be unreachable");
+                    _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
                 }
             }
         };
@@ -5548,7 +5548,7 @@ namespace ranges {
                 } else if constexpr (_Strat == _St::_Reverse) {
                     return reverse_view{_STD forward<_Rng>(_Range)};
                 } else {
-                    static_assert(false, "Should be unreachable");
+                    _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
                 }
             }
         };
@@ -5692,7 +5692,7 @@ namespace ranges {
                 } else if constexpr (_Strat == _St::_As_const) {
                     return as_const_view{_STD forward<_Rng>(_Range)};
                 } else {
-                    static_assert(false, "Should be unreachable");
+                    _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
                 }
             }
         };

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -954,8 +954,8 @@ _NODISCARD constexpr _Ty& get(tuple<_Types...>& _Tuple) noexcept {
         using _Ttype = typename tuple_element<_Idx, tuple<_Types...>>::_Ttype;
         return static_cast<_Ttype&>(_Tuple)._Myfirst._Val;
     } else {
-        static_assert(
-            false, "get<T>(tuple<Types...>&) requires T to occur exactly once in Types. (N4971 [tuple.elem]/5)");
+        static_assert(false, "get<T>(tuple<Types...>&) "
+                             "requires T to occur exactly once in Types. (N4971 [tuple.elem]/5)");
     }
 }
 
@@ -966,8 +966,8 @@ _NODISCARD constexpr const _Ty& get(const tuple<_Types...>& _Tuple) noexcept {
         using _Ttype = typename tuple_element<_Idx, tuple<_Types...>>::_Ttype;
         return static_cast<const _Ttype&>(_Tuple)._Myfirst._Val;
     } else {
-        static_assert(
-            false, "get<T>(const tuple<Types...>&) requires T to occur exactly once in Types. (N4971 [tuple.elem]/5)");
+        static_assert(false, "get<T>(const tuple<Types...>&) "
+                             "requires T to occur exactly once in Types. (N4971 [tuple.elem]/5)");
     }
 }
 
@@ -978,8 +978,8 @@ _NODISCARD constexpr _Ty&& get(tuple<_Types...>&& _Tuple) noexcept {
         using _Ttype = typename tuple_element<_Idx, tuple<_Types...>>::_Ttype;
         return static_cast<_Ty&&>(static_cast<_Ttype&>(_Tuple)._Myfirst._Val);
     } else {
-        static_assert(
-            false, "get<T>(tuple<Types...>&&) requires T to occur exactly once in Types. (N4971 [tuple.elem]/5)");
+        static_assert(false, "get<T>(tuple<Types...>&&) "
+                             "requires T to occur exactly once in Types. (N4971 [tuple.elem]/5)");
     }
 }
 
@@ -990,8 +990,8 @@ _NODISCARD constexpr const _Ty&& get(const tuple<_Types...>&& _Tuple) noexcept {
         using _Ttype = typename tuple_element<_Idx, tuple<_Types...>>::_Ttype;
         return static_cast<const _Ty&&>(static_cast<const _Ttype&>(_Tuple)._Myfirst._Val);
     } else {
-        static_assert(
-            false, "get<T>(const tuple<Types...>&&) requires T to occur exactly once in Types. (N4971 [tuple.elem]/5)");
+        static_assert(false, "get<T>(const tuple<Types...>&&) "
+                             "requires T to occur exactly once in Types. (N4971 [tuple.elem]/5)");
     }
 }
 

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -1196,8 +1196,8 @@ _NODISCARD constexpr decltype(auto) get(variant<_Types...>& _Var) {
     if constexpr (_Idx < sizeof...(_Types)) {
         return _STD get<_Idx>(_Var);
     } else {
-        static_assert(
-            false, "get<T>(variant<Types...>&) requires T to occur exactly once in Types. (N4971 [variant.get]/8)");
+        static_assert(false, "get<T>(variant<Types...>&) "
+                             "requires T to occur exactly once in Types. (N4971 [variant.get]/8)");
     }
 }
 _EXPORT_STD template <class _Ty, class... _Types>
@@ -1207,8 +1207,8 @@ _NODISCARD constexpr decltype(auto) get(variant<_Types...>&& _Var) {
     if constexpr (_Idx < sizeof...(_Types)) {
         return _STD get<_Idx>(_STD move(_Var));
     } else {
-        static_assert(
-            false, "get<T>(variant<Types...>&&) requires T to occur exactly once in Types. (N4971 [variant.get]/8)");
+        static_assert(false, "get<T>(variant<Types...>&&) "
+                             "requires T to occur exactly once in Types. (N4971 [variant.get]/8)");
     }
 }
 _EXPORT_STD template <class _Ty, class... _Types>
@@ -1218,8 +1218,8 @@ _NODISCARD constexpr decltype(auto) get(const variant<_Types...>& _Var) {
     if constexpr (_Idx < sizeof...(_Types)) {
         return _STD get<_Idx>(_Var);
     } else {
-        static_assert(false,
-            "get<T>(const variant<Types...>&) requires T to occur exactly once in Types. (N4971 [variant.get]/8)");
+        static_assert(false, "get<T>(const variant<Types...>&) "
+                             "requires T to occur exactly once in Types. (N4971 [variant.get]/8)");
     }
 }
 _EXPORT_STD template <class _Ty, class... _Types>
@@ -1229,8 +1229,8 @@ _NODISCARD constexpr decltype(auto) get(const variant<_Types...>&& _Var) {
     if constexpr (_Idx < sizeof...(_Types)) {
         return _STD get<_Idx>(_STD move(_Var));
     } else {
-        static_assert(false,
-            "get<T>(const variant<Types...>&&) requires T to occur exactly once in Types. (N4971 [variant.get]/8)");
+        static_assert(false, "get<T>(const variant<Types...>&&) "
+                             "requires T to occur exactly once in Types. (N4971 [variant.get]/8)");
     }
 }
 

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -2077,7 +2077,7 @@ private:
             } else if constexpr (sizeof...(_Val) == 2) {
                 _My_data._Mylast = _STD _Uninitialized_copy(_STD forward<_Valty>(_Val)..., _My_data._Myfirst, _Al);
             } else {
-                static_assert(false, "Should be unreachable");
+                _STL_INTERNAL_STATIC_ASSERT(false); // unexpected number of arguments
             }
             _ASAN_VECTOR_CREATE;
             _Guard._Target = nullptr;

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -1190,7 +1190,7 @@ int _Float_put_desired_precision(const streamsize _Precision, const ios_base::fm
         } else if constexpr (is_same_v<_Ty, long double>) {
             return ((LDBL_MANT_DIG - 1) + 3) / 4;
         } else {
-            static_assert(false, "Expected only double or long double here (not float).");
+            _STL_INTERNAL_STATIC_ASSERT(false); // unexpected type; shouldn't be float
         }
     }
 

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2297,7 +2297,8 @@ _EXPORT_STD template <class _Ty, class _Alloc, class... _Types, enable_if_t<!_Is
 _NODISCARD constexpr auto uses_allocator_construction_args(const _Alloc& _Al, _Types&&... _Args) noexcept {
     if constexpr (!uses_allocator_v<remove_cv_t<_Ty>, _Alloc>) {
         static_assert(is_constructible_v<_Ty, _Types...>,
-            "If uses_allocator_v<remove_cv_t<T>, Alloc> does not hold, T must be constructible from Types...");
+            "If uses_allocator_v<remove_cv_t<T>, Alloc> is false, "
+            "T must be constructible from (Types...). (N4981 [allocator.uses.construction]/5)");
         (void) _Al;
         return _STD forward_as_tuple(_STD forward<_Types>(_Args)...);
     } else if constexpr (is_constructible_v<_Ty, allocator_arg_t, const _Alloc&, _Types...>) {
@@ -2306,8 +2307,9 @@ _NODISCARD constexpr auto uses_allocator_construction_args(const _Alloc& _Al, _T
     } else if constexpr (is_constructible_v<_Ty, _Types..., const _Alloc&>) {
         return _STD forward_as_tuple(_STD forward<_Types>(_Args)..., _Al);
     } else {
-        static_assert(false, "T must be constructible from either (allocator_arg_t, const Alloc&, Types...) "
-                             "or (Types..., const Alloc&) if uses_allocator_v<remove_cv_t<T>, Alloc> is true");
+        static_assert(false, "If uses_allocator_v<remove_cv_t<T>, Alloc> is true, "
+                             "T must be constructible from either (allocator_arg_t, const Alloc&, Types...) "
+                             "or (Types..., const Alloc&). (N4981 [allocator.uses.construction]/5)");
     }
 }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -802,7 +802,7 @@ namespace ranges {
                         return *static_cast<_Ty&&>(_Val);
                     }
                 } else {
-                    static_assert(false, "should be unreachable");
+                    _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
                 }
             }
         };
@@ -1142,7 +1142,7 @@ namespace ranges {
                     *static_cast<_Ty1&&>(_Val1) =
                         _Iter_swap::_Iter_exchange_move(static_cast<_Ty2&&>(_Val2), static_cast<_Ty1&&>(_Val1));
                 } else {
-                    static_assert(false, "should be unreachable");
+                    _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
                 }
             }
         };
@@ -2532,7 +2532,7 @@ namespace ranges {
                 } else if constexpr (_Strat == _St::_Non_member) {
                     return begin(_Val); // intentional ADL
                 } else {
-                    static_assert(false, "Should be unreachable");
+                    _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
                 }
             }
         };
@@ -2609,7 +2609,7 @@ namespace ranges {
                 } else if constexpr (_Strat == _St::_Non_member) {
                     return end(_Val); // intentional ADL
                 } else {
-                    static_assert(false, "should be unreachable");
+                    _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
                 }
             }
         };
@@ -2745,7 +2745,7 @@ namespace ranges {
                 } else if constexpr (_Strat == _St::_Unwrap) {
                     return _RANGES _Unwrap_range_iter<_Ty>(_RANGES begin(_Val));
                 } else {
-                    static_assert(false, "Should be unreachable");
+                    _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
                 }
             }
         };
@@ -2796,7 +2796,7 @@ namespace ranges {
                 } else if constexpr (_Strat == _St::_Unwrap) {
                     return _RANGES _Unwrap_range_sent<_Ty>(_RANGES end(_Val));
                 } else {
-                    static_assert(false, "Should be unreachable");
+                    _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
                 }
             }
         };
@@ -2962,7 +2962,7 @@ namespace ranges {
                 } else if constexpr (_Strat == _St::_Make_reverse) {
                     return _STD make_reverse_iterator(_RANGES end(_Val));
                 } else {
-                    static_assert(false, "should be unreachable");
+                    _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
                 }
             }
         };
@@ -3033,7 +3033,7 @@ namespace ranges {
                 } else if constexpr (_Strat == _St::_Make_reverse) {
                     return _STD make_reverse_iterator(_RANGES begin(_Val));
                 } else {
-                    static_assert(false, "should be unreachable");
+                    _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
                 }
             }
         };
@@ -3178,7 +3178,7 @@ namespace ranges {
                     const auto _Delta = _RANGES end(_Val) - _RANGES begin(_Val);
                     return static_cast<_Make_unsigned_like_t<remove_cv_t<decltype(_Delta)>>>(_Delta);
                 } else {
-                    static_assert(false, "should be unreachable");
+                    _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
                 }
             }
         };
@@ -3240,7 +3240,7 @@ namespace ranges {
                 } else if constexpr (_Strat == _St::_Compare) {
                     return static_cast<bool>(_RANGES begin(_Val) == _RANGES end(_Val));
                 } else {
-                    static_assert(false, "should be unreachable");
+                    _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
                 }
             }
         };
@@ -3295,7 +3295,7 @@ namespace ranges {
                 } else if constexpr (_Strat == _St::_Address) {
                     return _STD to_address(_RANGES begin(_Val));
                 } else {
-                    static_assert(false, "should be unreachable");
+                    _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
                 }
             }
         };

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -143,7 +143,7 @@ __declspec(noalias) void _Reverse_vectorized(void* _First, void* _Last) noexcept
     } else if constexpr (_Nx == 8) {
         ::__std_reverse_trivially_swappable_8(_First, _Last);
     } else {
-        static_assert(false, "Unexpected size");
+        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
     }
 }
 
@@ -164,7 +164,7 @@ __declspec(noalias) size_t _Count_vectorized(_Ty* const _First, _Ty* const _Last
     } else if constexpr (sizeof(_Ty) == 8) {
         return ::__std_count_trivial_8(_First, _Last, static_cast<uint64_t>(_Val));
     } else {
-        static_assert(false, "Unexpected size");
+        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
     }
 }
 
@@ -191,7 +191,7 @@ _Ty* _Find_vectorized(_Ty* const _First, _Ty* const _Last, const _TVal _Val) noe
         return const_cast<_Ty*>(
             static_cast<const _Ty*>(::__std_find_trivial_8(_First, _Last, static_cast<uint64_t>(_Val))));
     } else {
-        static_assert(false, "Unexpected size");
+        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
     }
 }
 
@@ -212,7 +212,7 @@ _Ty* _Min_element_vectorized(_Ty* const _First, _Ty* const _Last) noexcept {
     } else if constexpr (sizeof(_Ty) == 8) {
         return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_min_element_8(_First, _Last, _Signed)));
     } else {
-        static_assert(false, "Unexpected size");
+        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
     }
 }
 
@@ -233,7 +233,7 @@ _Ty* _Max_element_vectorized(_Ty* const _First, _Ty* const _Last) noexcept {
     } else if constexpr (sizeof(_Ty) == 8) {
         return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_max_element_8(_First, _Last, _Signed)));
     } else {
-        static_assert(false, "Unexpected size");
+        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
     }
 }
 
@@ -276,7 +276,7 @@ auto _Min_vectorized(_Ty* const _First, _Ty* const _Last) noexcept {
             return ::__std_min_8u(_First, _Last);
         }
     } else {
-        static_assert(false, "Unexpected size");
+        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
     }
 }
 
@@ -319,7 +319,7 @@ auto _Max_vectorized(_Ty* const _First, _Ty* const _Last) noexcept {
             return ::__std_max_8u(_First, _Last);
         }
     } else {
-        static_assert(false, "Unexpected size");
+        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
     }
 }
 
@@ -335,7 +335,7 @@ inline size_t // TRANSITION, GH-4496
     } else if constexpr (_Element_size == 8) {
         return __std_mismatch_8(_First1, _First2, _Count);
     } else {
-        static_assert(false, "Unexpected size");
+        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
     }
 }
 _STD_END


### PR DESCRIPTION
Followup to #4591.

This was prompted by VSO-2045281 "\[RWC\]\[prod/fe\]\[Regression\] Taichi and Root failed with error G030630B7: static assertion failed: Unexpected size", although it doesn't attempt to completely fix those failures in our Real World Code test suite. (It appears that these projects are using unsupported compilers - i.e. non-MSVC/Clang/CUDA/IntelliSense - to parse our STL headers, and these compilers haven't implemented CWG-2518.)

Some occurrences of `static_assert(false, "message")` are enforcing requirements for users, providing nice messages (ideally with Standard citations). However, many occurrences were checking for "can't happen" scenarios, i.e. damaged logic in the STL itself. We should use `_STL_INTERNAL_STATIC_ASSERT` for such checks, as this clearly distinguishes "user was a bad kitty" from "STL was a bad kitty". (Also, `_STL_INTERNAL_STATIC_ASSERT` is active only within our test suites, so it results in a microscopic throughput improvement for users.)

I reviewed all of the following occurrences (i.e. not an unthinking search-and-replace):

Location | Change
--: | :--
Vectorized dispatchers | `_STL_INTERNAL_STATIC_ASSERT(false); // unexpected size`
CPOs and views | `_STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy`
`byteswap()` | `_STL_INTERNAL_STATIC_ASSERT(false); // unexpected size`
`~_Mini_ptr()` | `_STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy`
`vector::_Construct_n()` | `_STL_INTERNAL_STATIC_ASSERT(false); // unexpected number of arguments`
`_Float_put_desired_precision()` | `_STL_INTERNAL_STATIC_ASSERT(false); // unexpected type; shouldn't be float`
`_Chrono_formatter::_Is_valid_type()` | `_STL_INTERNAL_STATIC_ASSERT(false); // unexpected type`
`chrono::clock_cast()` | `_STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy`

I performed a couple of targeted cleanups along the way (we try to avoid mixing major changes with cleanups, but these aren't entangled, and they are in the same area):

* Cleanup `static_assert` messages and add citations in `uses_allocator_construction_args()`.
  + I chose to keep the current structure, although having `static_assert(condition)` in one branch and `static_assert(false)` in the other isn't super consistent.
* Style: Wrap `tuple`/`variant` "occur exactly once" messages consistently, to avoid wrapping `static_assert(false`.
  + I chose to keep `static_assert(false)` since it improves the error messages, even though other functions use `static_assert(condition)`.