### PR TITLE
`<ranges>`: Replace one improper use of `_Iter_value_t` with `iter_value_t` in `_Stable_sort_fn`

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -8852,7 +8852,7 @@ namespace ranges {
                 return;
             }
 
-            _Optimistic_temporary_buffer<_Iter_value_t<_It>> _Temp_buf{_Count - _Count / 2};
+            _Optimistic_temporary_buffer<iter_value_t<_It>> _Temp_buf{_Count - _Count / 2};
             _Stable_sort_common_buffered(
                 _STD move(_First), _STD move(_Last), _Count, _Temp_buf._Data, _Temp_buf._Capacity, _Pred, _Proj);
         }


### PR DESCRIPTION
As the use of `_Iter_value_t` appeared within the implementation details of C++20 `ranges::stable_sort`, it should be replaced with `iter_value_t`.

See also https://github.com/microsoft/STL/issues/4436#issuecomment-1981978127 - this should be the only occurence of `_Iter_value_t` that "Should always be C++20 `iter_value_t`".