### PR TITLE
Measure display width in tuple formatter

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -3961,6 +3961,13 @@ _NODISCARD size_t formatted_size(const locale& _Loc, const wformat_string<_Types
 _FMT_P2286_END
 
 #if _HAS_CXX23
+template <class _CharT>
+_NODISCARD int _Measure_display_width(const basic_string_view<_CharT> _Value) {
+    int _Width = -1;
+    (void) _Measure_string_prefix(_Value, _Width);
+    return _Width;
+}
+
 enum class _Fmt_tuple_type : uint8_t { _None, _Key_value, _No_brackets };
 
 template <class _CharT>
@@ -4127,8 +4134,9 @@ protected:
         }(index_sequence_for<_ArgTypes...>{});
         _STD _Copy_unchecked(_Closing_bracket._Unchecked_begin(), _Closing_bracket._Unchecked_end(), _Tmp_ctx.out());
 
-        return _STD _Write_aligned(_Fmt_ctx.out(), static_cast<int>(_Tmp_buf.size()), _Format_specs, _Fmt_align::_Left,
-            [&](typename _FormatContext::iterator _Out) {
+        const int _Width = _Measure_display_width<_CharT>(_Tmp_buf);
+        return _STD _Write_aligned(
+            _Fmt_ctx.out(), _Width, _Format_specs, _Fmt_align::_Left, [&](typename _FormatContext::iterator _Out) {
                 return _STD _Fmt_write(_STD move(_Out), basic_string_view<_CharT>{_Tmp_buf});
             });
     }

--- a/tests/std/tests/P2286R8_text_formatting_escaping_legacy_text_encoding/test.cpp
+++ b/tests/std/tests/P2286R8_text_formatting_escaping_legacy_text_encoding/test.cpp
@@ -17,6 +17,15 @@ void test_escaped_string() {
     assert(format("{:?}", "\x81\x40\x40\x81") == "\"\\u{3000}\x40\\x{81}\"");
 }
 
+template <class TupleOrPair>
+void test_tuple_or_pair_escaping(TupleOrPair&& input) {
+    get<1>(input) = "hell\uff2f"; // U+FF2F FULLWIDTH LATIN CAPITAL LETTER O
+    assert(format("{}", input) == "('*', \"hell\uff2f\")");
+    assert(format("{:#^16}", input) == "('*', \"hell\uff2f\")#");
+}
+
 int main() {
     test_escaped_string();
+    test_tuple_or_pair_escaping(make_pair('*', ""));
+    test_tuple_or_pair_escaping(make_tuple('*', ""));
 }

--- a/tests/std/tests/P2286R8_text_formatting_escaping_utf8/test.cpp
+++ b/tests/std/tests/P2286R8_text_formatting_escaping_utf8/test.cpp
@@ -21,15 +21,32 @@ void test_escaped_string() {
     assert(format("{:?}", "a\u0300") == "\"a\u0300\"");
 }
 
-int main() {
+template <class TupleOrPair>
+void test_tuple_or_pair_escaping(TupleOrPair&& input) {
+    get<1>(input) = "hell\u00d6"; // U+00D6 LATIN CAPITAL LETTER O WITH DIAERESIS
+    assert(format("{}", input) == "('*', \"hell\u00d6\")");
+    assert(format("{:#^16}", input) == "#('*', \"hell\u00d6\")#");
+
+    get<1>(input) = "hell\uff2f"; // U+FF2F FULLWIDTH LATIN CAPITAL LETTER O
+    assert(format("{}", input) == "('*', \"hell\uff2f\")");
+    assert(format("{:#^16}", input) == "('*', \"hell\uff2f\")#");
+}
+
+void run_test() {
     test_escaped_string();
+    test_tuple_or_pair_escaping(make_pair('*', ""));
+    test_tuple_or_pair_escaping(make_tuple('*', ""));
+}
+
+int main() {
+    run_test();
 
     assert(setlocale(LC_ALL, ".1252") != nullptr);
-    test_escaped_string();
+    run_test();
 
     assert(setlocale(LC_ALL, ".932") != nullptr);
-    test_escaped_string();
+    run_test();
 
     assert(setlocale(LC_ALL, ".UTF-8") != nullptr);
-    test_escaped_string();
+    run_test();
 }

--- a/tests/std/tests/P2286R8_text_formatting_tuple/test.cpp
+++ b/tests/std/tests/P2286R8_text_formatting_tuple/test.cpp
@@ -157,9 +157,16 @@ void test_escaping(TestFunction check, TupleOrPair&& input) {
     check(SV(R"(('\u{0}', ""))"), SV("{}"), input);
 
     // String
-    get<0>(input) = CharT('*');
-    get<1>(input) = SV("hell\u00d6");
-    check(SV("('*', \"hell\u00d6\")"), SV("{}"), input);
+    if constexpr (is_same_v<CharT, wchar_t>) {
+        get<0>(input) = L'*';
+        get<1>(input) = L"hell\u00d6"; // U+00D6 LATIN CAPITAL LETTER O WITH DIAERESIS
+        check(L"('*', \"hell\u00d6\")"sv, L"{}"sv, input);
+        check(L"#('*', \"hell\u00d6\")#"sv, L"{:#^16}"sv, input);
+
+        get<1>(input) = L"hell\uff2f"; // U+FF2F FULLWIDTH LATIN CAPITAL LETTER O
+        check(L"('*', \"hell\uff2f\")"sv, L"{}"sv, input);
+        check(L"('*', \"hell\uff2f\")#"sv, L"{:#^16}"sv, input);
+    }
 }
 
 //


### PR DESCRIPTION
Currently, the tuple formatter uses `static_cast<int>(_Tmp_buf.size())` to compute the width of output (in order to determine the number of fill characters to insert). This gives the wrong width if

1. The output contains multibyte Unicode characters, or
1. `_Tmp_buf.size()` is larger than `INT_MAX` (see #4479).

Both problems can be avoided by using [`_Measure_string_prefix`](https://github.com/microsoft/STL/blob/0515a05b394596de92d08cb0f352614479a2a883/stl/inc/format#L3343-L3383), which computes the display width and clamps the result to `INT_MAX` (which means no fill character will be inserted).

Closes #4479

While working on this, I noticed that the tuple formatter test uses `\u00d6` which cannot be represented in some legacy text encodings. This PR adjusted the test to make it encoding-independent.

Closes #4635 

Future work: if no *width* is specified in the format string, there should be no need to use a temporary buffer. The use of `_Tmp_buf` should be skipped in this case.