### PR TITLE
Refactor `<limits>` usage

### DIFF
--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -1416,6 +1416,19 @@ struct common_type<_Unsigned128, _Signed128> {
 };
 
 template <class _Ty>
+_NODISCARD constexpr _Ty _Min_limit() noexcept;
+
+template <>
+_NODISCARD constexpr _Unsigned128 _Min_limit<_Unsigned128>() noexcept {
+    return 0;
+}
+
+template <>
+_NODISCARD constexpr _Signed128 _Min_limit<_Signed128>() noexcept {
+    return _Signed128{0ull, 1ull << 63};
+}
+
+template <class _Ty>
 _NODISCARD constexpr _Ty _Max_limit() noexcept;
 
 template <>

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -1415,6 +1415,19 @@ struct common_type<_Unsigned128, _Signed128> {
     using type = _Unsigned128;
 };
 
+template <class _Ty>
+_NODISCARD constexpr _Ty _Max_limit() noexcept;
+
+template <>
+_NODISCARD constexpr _Unsigned128 _Max_limit<_Unsigned128>() noexcept {
+    return _Unsigned128{~0ull, ~0ull};
+}
+
+template <>
+_NODISCARD constexpr _Signed128 _Max_limit<_Signed128>() noexcept {
+    return _Signed128{~0ull, ~0ull >> 1};
+}
+
 #undef _STL_128_INTRINSICS
 #undef _STL_128_DIV_INTRINSICS
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -2219,7 +2219,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt search_n(
         return _First;
     }
 
-    if (static_cast<uintmax_t>(_Count) > static_cast<uintmax_t>((numeric_limits<_Iter_diff_t<_FwdIt>>::max)())) {
+    if (static_cast<uintmax_t>(_Count) > static_cast<uintmax_t>(_STD _Max_limit<_Iter_diff_t<_FwdIt>>())) {
         // if the number of _Vals searched for is larger than the longest possible sequence, we can't find it
         return _Last;
     }

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -8,6 +8,7 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 #include <__msvc_minmax.hpp>
+#include <limits>
 #include <xmemory>
 
 #if _HAS_CXX23

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -8,7 +8,6 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 #include <__msvc_minmax.hpp>
-#include <limits>
 #include <xmemory>
 
 #if _HAS_CXX23

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -325,7 +325,7 @@ public:
                 }
             }
 
-            if (_Array[0] > ULONG_MAX) {
+            if (!_STD _In_range<unsigned long>(_Array[0])) {
                 _Xoflo();
             }
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -4790,7 +4790,7 @@ private:
     _ParseContext& _Parse_ctx;
 
     _NODISCARD static constexpr int _Verify_dynamic_arg_index_in_range(const size_t _Idx) {
-        if (!_STD _In_range<int>(_Idx)) {
+        if (!_STD in_range<int>(_Idx)) {
             _Throw_format_error("Dynamic width or precision index too large.");
         }
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -58,7 +58,7 @@ _NODISCARD basic_string<typename _Traits::char_type, _Traits, _Alloc> _Convert_w
     basic_string<typename _Traits::char_type, _Traits, _Alloc> _Output(_Al);
 
     if (!_Input.empty()) {
-        if (_Input.size() > static_cast<size_t>(INT_MAX)) {
+        if (!_STD _In_range<int>(_Input.size())) {
             _Throw_system_error(errc::invalid_argument);
         }
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -4790,7 +4790,7 @@ private:
     _ParseContext& _Parse_ctx;
 
     _NODISCARD static constexpr int _Verify_dynamic_arg_index_in_range(const size_t _Idx) {
-        if (_Idx > static_cast<size_t>((numeric_limits<int>::max)())) {
+        if (!_STD _In_range<int>(_Idx)) {
             _Throw_format_error("Dynamic width or precision index too large.");
         }
 

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -962,8 +962,7 @@ public:
     }
 
     _NODISCARD size_type max_size() const noexcept {
-        return (_STD min)(
-            static_cast<size_type>((numeric_limits<difference_type>::max)()), _Alty_traits::max_size(_Getal()));
+        return (_STD min)(static_cast<size_type>(_STD _Max_limit<difference_type>()), _Alty_traits::max_size(_Getal()));
     }
 
     void resize(_CRT_GUARDOVERFLOW size_type _Newsize) {

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -2279,7 +2279,7 @@ _NODISCARD _FwdIt search_n(_ExPo&&, const _FwdIt _First, _FwdIt _Last, const _Di
         return _Last;
     }
 
-    if (static_cast<uintmax_t>(_Count) > static_cast<uintmax_t>((numeric_limits<_Iter_diff_t<_FwdIt>>::max)())) {
+    if (static_cast<uintmax_t>(_Count) > static_cast<uintmax_t>(_STD _Max_limit<_Iter_diff_t<_FwdIt>>())) {
         // if the number of _Vals searched for is larger than the longest possible sequence, we can't find it
         return _Last;
     }

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -40,7 +40,7 @@ namespace filesystem {
         wstring _Output;
 
         if (!_Input.empty()) {
-            if (_Input.size() > static_cast<size_t>(INT_MAX)) {
+            if (!_STD _In_range<int>(_Input.size())) {
                 _Throw_system_error(errc::invalid_argument);
             }
 
@@ -64,7 +64,7 @@ namespace filesystem {
         basic_string<typename _Traits::char_type, _Traits, _Alloc> _Output(_Al);
 
         if (!_Input.empty()) {
-            if (_Input.size() > static_cast<size_t>(INT_MAX)) {
+            if (!_STD _In_range<int>(_Input.size())) {
                 _Throw_system_error(errc::invalid_argument);
             }
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1659,7 +1659,7 @@ template <class _Handler, class _FormatArg>
 _NODISCARD constexpr int _Get_dynamic_specs(const _FormatArg _Arg) {
     _STL_INTERNAL_STATIC_ASSERT(_Is_any_of_v<_Handler, _Width_checker, _Precision_checker>);
     const unsigned long long _Val = _STD visit_format_arg(_Handler{}, _Arg);
-    if (!_STD _In_range<int>(_Val)) {
+    if (!_STD in_range<int>(_Val)) {
         _Throw_format_error("Number is too big.");
     }
 
@@ -1739,7 +1739,7 @@ private:
     _ParseContext& _Parse_ctx;
 
     _NODISCARD static constexpr int _Verify_dynamic_arg_index_in_range(const size_t _Idx) {
-        if (!_STD _In_range<int>(_Idx)) {
+        if (!_STD in_range<int>(_Idx)) {
             _Throw_format_error("Dynamic width or precision index too large.");
         }
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -50,7 +50,6 @@ _EMIT_STL_WARNING(STL4038, "The contents of <format> are available only with C++
 #include <concepts>
 #include <cstdint>
 #include <iterator>
-#include <limits>
 #include <locale>
 #include <stdexcept>
 #include <xcall_once.h>
@@ -936,7 +935,7 @@ _NODISCARD constexpr const _CharT* _Parse_nonnegative_integer(
     const _CharT* _First, const _CharT* _Last, unsigned int& _Value) {
     _STL_INTERNAL_CHECK(_First != _Last && '0' <= *_First && *_First <= '9');
 
-    constexpr auto _Max_int = static_cast<unsigned int>((numeric_limits<int>::max)());
+    constexpr auto _Max_int = static_cast<unsigned int>(_STD _Max_limit<int>());
     constexpr auto _Big_int = _Max_int / 10u;
 
     _Value = 0;
@@ -1660,7 +1659,7 @@ template <class _Handler, class _FormatArg>
 _NODISCARD constexpr int _Get_dynamic_specs(const _FormatArg _Arg) {
     _STL_INTERNAL_STATIC_ASSERT(_Is_any_of_v<_Handler, _Width_checker, _Precision_checker>);
     const unsigned long long _Val = _STD visit_format_arg(_Handler{}, _Arg);
-    if (_Val > static_cast<unsigned long long>((numeric_limits<int>::max)())) {
+    if (!_STD _In_range<int>(_Val)) {
         _Throw_format_error("Number is too big.");
     }
 
@@ -1740,7 +1739,7 @@ private:
     _ParseContext& _Parse_ctx;
 
     _NODISCARD static constexpr int _Verify_dynamic_arg_index_in_range(const size_t _Idx) {
-        if (_Idx > static_cast<size_t>((numeric_limits<int>::max)())) {
+        if (!_STD _In_range<int>(_Idx)) {
             _Throw_format_error("Dynamic width or precision index too large.");
         }
 
@@ -1823,7 +1822,7 @@ public:
 
     template <class _CharT>
     constexpr void _On_type(_CharT _Type) {
-        if (_Type < 0 || _Type > (numeric_limits<signed char>::max)()) {
+        if (_Type < 0 || _Type > _STD _Max_limit<signed char>()) {
             _Throw_format_error("Invalid type specification.");
         }
         const char _Narrow_type = static_cast<char>(_Type);
@@ -3350,7 +3349,7 @@ _NODISCARD const _CharT* _Measure_string_prefix(const basic_string_view<_CharT> 
     _Measure_string_prefix_iterator<_CharT> _Pfx_iter(_First, _Last);
     int _Estimated_width = 0; // the estimated width of [_First, _Pfx_iter)
 
-    constexpr auto _Max_int = (numeric_limits<int>::max)();
+    constexpr auto _Max_int = _STD _Max_limit<int>();
 
     while (_Pfx_iter != default_sentinel) {
         if (_Estimated_width == _Max_width && _Max_width >= 0) {

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -888,7 +888,7 @@ public:
 
     _NODISCARD size_type max_size() const noexcept {
         return (_STD min)(
-            static_cast<size_type>((numeric_limits<difference_type>::max)()), _Alnode_traits::max_size(_Getal()));
+            static_cast<size_type>(_STD _Max_limit<difference_type>()), _Alnode_traits::max_size(_Getal()));
     }
 
     _NODISCARD_EMPTY_MEMBER bool empty() const noexcept {

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -2638,7 +2638,7 @@ void _Build_boyer_moore_delta_2_table(_Iter_diff_t<_RanItPat>* const _Shifts, co
         return;
     }
 
-    if ((numeric_limits<_Diff>::max)() - _Pat_size < _Pat_size) {
+    if (_STD _Max_limit<_Diff>() - _Pat_size < _Pat_size) {
         _Xlength_error("Boyer-Moore pattern is too long");
     }
 

--- a/stl/inc/istream
+++ b/stl/inc/istream
@@ -210,7 +210,7 @@ private:
 
     template <class = void>
     void _Increment_gcount() noexcept {
-        if (_Chcount != (numeric_limits<streamsize>::max)()) {
+        if (_Chcount != _STD _Max_limit<streamsize>()) {
             ++_Chcount;
         }
     }
@@ -492,7 +492,7 @@ public:
             _TRY_IO_BEGIN
             for (;;) { // get a metacharacter if more room in buffer
                 int_type _Meta;
-                if (_Count != (numeric_limits<streamsize>::max)() && --_Count < 0) {
+                if (_Count != _STD _Max_limit<streamsize>() && --_Count < 0) {
                     break; // buffer full, quit
                 } else if (_Traits::eq_int_type(_Traits::eof(),
                                _Meta = _Myios::rdbuf()->sbumpc())) { // end of file, quit

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -9,7 +9,7 @@
 #if _STL_COMPILER_PREPROCESSOR
 #include <cfloat>
 #include <climits>
-#include <cwchar>
+#include <cwchar> // TRANSITION, see GH-3631: Lots of user code assumes that <limits> drags in <cwchar>
 #include <xtr1common>
 
 #include _STL_INTRIN_HEADER
@@ -452,11 +452,11 @@ template <>
 class numeric_limits<wchar_t> : public _Num_int_base {
 public:
     _NODISCARD static constexpr wchar_t(min)() noexcept {
-        return WCHAR_MIN;
+        return 0;
     }
 
     _NODISCARD static constexpr wchar_t(max)() noexcept {
-        return WCHAR_MAX;
+        return 0xffff;
     }
 
     _NODISCARD static constexpr wchar_t lowest() noexcept {

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -1193,7 +1193,7 @@ public:
 
     _NODISCARD size_type max_size() const noexcept {
         return (_STD min)(
-            static_cast<size_type>((numeric_limits<difference_type>::max)()), _Alnode_traits::max_size(_Getal()));
+            static_cast<size_type>(_STD _Max_limit<difference_type>()), _Alnode_traits::max_size(_Getal()));
     }
 
     _NODISCARD_EMPTY_MEMBER bool empty() const noexcept {

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -11,7 +11,6 @@
 _EMIT_STL_WARNING(STL4038, "The contents of <mdspan> are available only with C++23 or later.");
 #else // ^^^ !_HAS_CXX23 / _HAS_CXX23 vvv
 #include <array>
-#include <limits>
 #include <span>
 #include <tuple>
 #include <type_traits>
@@ -213,7 +212,7 @@ public:
         requires (sizeof...(_OtherExtents) == rank())
               && ((_OtherExtents == dynamic_extent || _Extents == dynamic_extent || _OtherExtents == _Extents) && ...)
     constexpr explicit(((_Extents != dynamic_extent && _OtherExtents == dynamic_extent) || ...)
-                       || (numeric_limits<index_type>::max)() < (numeric_limits<_OtherIndexType>::max)())
+                       || _Max_limit<index_type>() < _Max_limit<_OtherIndexType>())
         extents(const extents<_OtherIndexType, _OtherExtents...>& _Other) noexcept
         : extents(_Other, make_index_sequence<rank_dynamic()>{}) {}
 

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -212,7 +212,7 @@ public:
         requires (sizeof...(_OtherExtents) == rank())
               && ((_OtherExtents == dynamic_extent || _Extents == dynamic_extent || _OtherExtents == _Extents) && ...)
     constexpr explicit(((_Extents != dynamic_extent && _OtherExtents == dynamic_extent) || ...)
-                       || _Max_limit<index_type>() < _Max_limit<_OtherIndexType>())
+                       || _STD _Max_limit<index_type>() < _STD _Max_limit<_OtherIndexType>())
         extents(const extents<_OtherIndexType, _OtherExtents...>& _Other) noexcept
         : extents(_Other, make_index_sequence<rank_dynamic()>{}) {}
 

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -567,7 +567,7 @@ int _Iter_compare(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Las
 
 inline bool _Is_word(unsigned char _UCh) {
     // special casing char to avoid branches for std::regex in this path
-    static constexpr bool _Is_word_table[(numeric_limits<unsigned char>::max)() + 1] = {
+    static constexpr bool _Is_word_table[_STD _Max_limit<unsigned char>() + 1] = {
         //        X0 X1 X2 X3 X4 X5 X6 X7 X8 X9 XA XB XC XD XE XF
         /* 0X */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         /* 1X */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2958,7 +2958,7 @@ void _Builder<_FwdIt, _Elem, _RxTraits>::_Add_named_class(typename _Regex_traits
     bool _Negate) { // add contents of named class to bracket expression
     _Node_class<_Elem, _RxTraits>* _Node = static_cast<_Node_class<_Elem, _RxTraits>*>(_Current);
     _Add_elts(_Node, _Cl, _Negate);
-    if (_Bmp_max < static_cast<unsigned int>((numeric_limits<_Elem>::max)())) {
+    if (_Bmp_max < static_cast<unsigned int>(_STD _Max_limit<_Elem>())) {
         _Node->_Classes = static_cast<_Regex_traits_base::char_class_type>(_Node->_Classes | _Cl);
     }
 }
@@ -3005,7 +3005,7 @@ void _Builder<_FwdIt, _Elem, _RxTraits>::_Add_equiv(_FwdIt _First, _FwdIt _Last,
             _Node->_Small->_Mark(_Ch);
         }
     }
-    if (_Bmp_max < static_cast<unsigned int>((numeric_limits<_Elem>::max)())) { // map range
+    if (_Bmp_max < static_cast<unsigned int>(_STD _Max_limit<_Elem>())) { // map range
         _Sequence<_Elem>** _Cur = _STD addressof(_Node->_Equiv);
         _Char_to_elts(_First, _Last, _Diff, _Cur);
     }
@@ -4330,7 +4330,7 @@ bool _Parser<_FwdIt, _Elem, _RxTraits>::_CharacterEscape() { // check for valid 
         return _IdentityEscape();
     }
 
-    if ((numeric_limits<typename _RxTraits::_Uelem>::max)() < static_cast<unsigned int>(_Val)) {
+    if (_STD _Max_limit<typename _RxTraits::_Uelem>() < static_cast<unsigned int>(_Val)) {
         _Error(regex_constants::error_escape);
     }
 

--- a/stl/inc/semaphore
+++ b/stl/inc/semaphore
@@ -43,8 +43,8 @@ _NODISCARD unsigned long _Semaphore_remaining_timeout(const chrono::time_point<_
     }
 
     const auto _Rel_time = chrono::ceil<chrono::milliseconds>(_Abs_time - _Now);
-    static constexpr chrono::milliseconds _Ten_days{chrono::hours{24 * 10}};
-    static_assert(_Ten_days.count() < ULONG_MAX, "Bad sizing assumption");
+    constexpr chrono::milliseconds _Ten_days{chrono::hours{24 * 10}};
+    _STL_INTERNAL_STATIC_ASSERT(_STD in_range<unsigned long>(_Ten_days.count()));
     if (_Rel_time >= _Ten_days) {
         return static_cast<unsigned long>(_Ten_days.count());
     }

--- a/stl/inc/spanstream
+++ b/stl/inc/spanstream
@@ -123,7 +123,7 @@ protected:
                 const auto _Baseoff = (_Mode & ios_base::out) && !(_Mode & ios_base::in)
                                         ? static_cast<off_type>(_Mysb::pptr() - _Mysb::pbase())
                                         : static_cast<off_type>(_Buf.size());
-                if (_Off > (numeric_limits<off_type>::max)() - _Baseoff) { // overflow, _Baseoff is always non-negative
+                if (_Off > _STD _Max_limit<off_type>() - _Baseoff) { // overflow, _Baseoff is always non-negative
                     return pos_type{off_type{-1}}; // report failure
                 }
 

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -849,17 +849,6 @@ _NODISCARD constexpr _Ty _Min_limit() noexcept { // same as (numeric_limits<_Ty>
     }
 }
 
-template <class _Ty>
-_NODISCARD constexpr _Ty _Max_limit() noexcept { // same as (numeric_limits<_Ty>::max)(), less throughput cost
-    _STL_INTERNAL_STATIC_ASSERT(is_integral_v<_Ty>); // doesn't attempt to handle all types
-    if constexpr (is_signed_v<_Ty>) {
-        constexpr auto _Unsigned_max = static_cast<make_unsigned_t<_Ty>>(-1);
-        return static_cast<_Ty>(_Unsigned_max >> 1);
-    } else {
-        return static_cast<_Ty>(-1);
-    }
-}
-
 template <class _Rx, class _Ty>
 _NODISCARD constexpr bool _In_range(const _Ty _Value) noexcept {
     static_assert(_Is_standard_integer<_Rx> && _Is_standard_integer<_Ty>,

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -840,7 +840,7 @@ _NODISCARD constexpr bool _Cmp_greater_equal(const _Ty1 _Left, const _Ty2 _Right
 
 template <class _Ty>
 _NODISCARD constexpr _Ty _Min_limit() noexcept { // same as (numeric_limits<_Ty>::min)(), less throughput cost
-    _STL_INTERNAL_STATIC_ASSERT(_Is_standard_integer<_Ty>); // doesn't attempt to handle all types
+    _STL_INTERNAL_STATIC_ASSERT(is_integral_v<_Ty>); // doesn't attempt to handle all types
     if constexpr (is_signed_v<_Ty>) {
         constexpr auto _Unsigned_max = static_cast<make_unsigned_t<_Ty>>(-1);
         return static_cast<_Ty>((_Unsigned_max >> 1) + 1); // well-defined, N4950 [conv.integral]/3
@@ -851,7 +851,7 @@ _NODISCARD constexpr _Ty _Min_limit() noexcept { // same as (numeric_limits<_Ty>
 
 template <class _Ty>
 _NODISCARD constexpr _Ty _Max_limit() noexcept { // same as (numeric_limits<_Ty>::max)(), less throughput cost
-    _STL_INTERNAL_STATIC_ASSERT(_Is_standard_integer<_Ty>); // doesn't attempt to handle all types
+    _STL_INTERNAL_STATIC_ASSERT(is_integral_v<_Ty>); // doesn't attempt to handle all types
     if constexpr (is_signed_v<_Ty>) {
         constexpr auto _Unsigned_max = static_cast<make_unsigned_t<_Ty>>(-1);
         return static_cast<_Ty>(_Unsigned_max >> 1);

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -849,6 +849,17 @@ _NODISCARD constexpr _Ty _Min_limit() noexcept { // same as (numeric_limits<_Ty>
     }
 }
 
+template <class _Ty>
+_NODISCARD constexpr _Ty _Max_limit() noexcept { // same as (numeric_limits<_Ty>::max)(), less throughput cost
+    _STL_INTERNAL_STATIC_ASSERT(is_integral_v<_Ty>); // doesn't attempt to handle all types
+    if constexpr (is_signed_v<_Ty>) {
+        constexpr auto _Unsigned_max = static_cast<make_unsigned_t<_Ty>>(-1);
+        return static_cast<_Ty>(_Unsigned_max >> 1);
+    } else {
+        return static_cast<_Ty>(-1);
+    }
+}
+
 template <class _Rx, class _Ty>
 _NODISCARD constexpr bool _In_range(const _Ty _Value) noexcept {
     static_assert(_Is_standard_integer<_Rx> && _Is_standard_integer<_Ty>,

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -9,7 +9,6 @@
 #if _STL_COMPILER_PREPROCESSOR
 #include <__msvc_bit_utils.hpp>
 #include <__msvc_sanitizer_annotate_container.hpp>
-#include <limits>
 #include <xmemory>
 
 #if _HAS_CXX17

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -1874,8 +1874,7 @@ public:
     }
 
     _NODISCARD _CONSTEXPR20 size_type max_size() const noexcept {
-        return (_STD min)(
-            static_cast<size_type>((numeric_limits<difference_type>::max)()), _Alty_traits::max_size(_Getal()));
+        return (_STD min)(static_cast<size_type>(_STD _Max_limit<difference_type>()), _Alty_traits::max_size(_Getal()));
     }
 
     _NODISCARD _CONSTEXPR20 size_type capacity() const noexcept {
@@ -3149,7 +3148,7 @@ public:
     }
 
     _NODISCARD _CONSTEXPR20 size_type max_size() const noexcept {
-        constexpr auto _Diff_max  = static_cast<size_type>((numeric_limits<difference_type>::max)());
+        constexpr auto _Diff_max  = static_cast<size_type>(_STD _Max_limit<difference_type>());
         const size_type _Ints_max = this->_Myvec.max_size();
         if (_Ints_max > _Diff_max / _VBITS) { // max_size bound by difference_type limits
             return _Diff_max;

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -9,6 +9,7 @@
 #if _STL_COMPILER_PREPROCESSOR
 #include <__msvc_bit_utils.hpp>
 #include <__msvc_sanitizer_annotate_container.hpp>
+#include <limits>
 #include <xmemory>
 
 #if _HAS_CXX17

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -271,8 +271,8 @@ struct _Hash_vec {
     }
 
     _NODISCARD size_type max_size() const noexcept {
-        return (_STD min)(static_cast<size_type>((numeric_limits<difference_type>::max)()),
-            _Aliter_traits::max_size(_Mypair._Get_first()));
+        return (_STD min)(
+            static_cast<size_type>(_STD _Max_limit<difference_type>()), _Aliter_traits::max_size(_Mypair._Get_first()));
     }
 
     _NODISCARD size_type capacity() const noexcept {

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -8,6 +8,7 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 #include <cfloat>
+#include <climits>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -7,10 +7,10 @@
 #define _XLOCNUM_
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
-#include <climits>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <float.h>
 #include <iterator>
 #include <streambuf>
 

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -9,6 +9,7 @@
 #if _STL_COMPILER_PREPROCESSOR
 #include <cstdint>
 #include <cstdlib>
+#include <limits> // TRANSITION, see GH-4634: Lots of user code assumes that <xmemory> drags in <limits>
 #include <new>
 #include <xatomic.h>
 #include <xutility>
@@ -16,10 +17,6 @@
 #if _HAS_CXX20
 #include <tuple>
 #endif // _HAS_CXX20
-
-#ifdef _LEGACY_CODE_ASSUMES_XMEMORY_INCLUDES_LIMITS
-#include <limits>
-#endif
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1086,8 +1086,10 @@ _NODISCARD constexpr _Size_type _Convert_size(const _Unsigned_type _Len) noexcep
     _STL_INTERNAL_STATIC_ASSERT(_Unsigned_type(-1) > 0);
     _STL_INTERNAL_STATIC_ASSERT(_Size_type(-1) > 0);
 
-    if (!_STD _In_range<_Size_type>(_Len)) {
-        _Xlength_error("size is too long for _Size_type");
+    if constexpr (sizeof(_Unsigned_type) > sizeof(_Size_type)) {
+        if (_Len > _STD _Max_limit<_Size_type>()) {
+            _Xlength_error("size is too long for _Size_type");
+        }
     }
 
     return static_cast<_Size_type>(_Len);

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -9,8 +9,8 @@
 #if _STL_COMPILER_PREPROCESSOR
 #include <cstdint>
 #include <cstdlib>
-#include <limits>
 #include <new>
+#include <utility>
 #include <xatomic.h>
 #include <xutility>
 
@@ -606,7 +606,7 @@ struct _Normal_allocator_traits { // defines traits for allocators
         if constexpr (_Has_max_size<_Alloc>::value) {
             return _Al.max_size();
         } else {
-            return (numeric_limits<size_type>::max)() / sizeof(value_type);
+            return _STD _Max_limit<size_type>() / sizeof(value_type);
         }
     }
 
@@ -1086,10 +1086,8 @@ _NODISCARD constexpr _Size_type _Convert_size(const _Unsigned_type _Len) noexcep
     _STL_INTERNAL_STATIC_ASSERT(_Unsigned_type(-1) > 0);
     _STL_INTERNAL_STATIC_ASSERT(_Size_type(-1) > 0);
 
-    if constexpr (sizeof(_Unsigned_type) > sizeof(_Size_type)) {
-        if (_Len > (numeric_limits<_Size_type>::max)()) {
-            _Xlength_error("size is too long for _Size_type");
-        }
+    if (!_STD _In_range<_Size_type>(_Len)) {
+        _Xlength_error("size is too long for _Size_type");
     }
 
     return static_cast<_Size_type>(_Len);

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -17,6 +17,10 @@
 #include <tuple>
 #endif // _HAS_CXX20
 
+#ifdef _LEGACY_CODE_ASSUMES_XMEMORY_INCLUDES_LIMITS
+#include <limits>
+#endif
+
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
 #pragma warning(disable : _STL_DISABLED_WARNINGS)

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -10,8 +10,8 @@
 #include <cstdint>
 #include <cstdlib>
 #include <new>
+#include <utility>
 #include <xatomic.h>
-#include <xtr1common>
 #include <xutility>
 
 #if _HAS_CXX20

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -10,8 +10,8 @@
 #include <cstdint>
 #include <cstdlib>
 #include <new>
-#include <utility>
 #include <xatomic.h>
+#include <xtr1common>
 #include <xutility>
 
 #if _HAS_CXX20

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -10,7 +10,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <new>
-#include <utility>
 #include <xatomic.h>
 #include <xutility>
 

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -4151,7 +4151,7 @@ public:
         const size_type _Alloc_max   = _Alty_traits::max_size(_Getal());
         const size_type _Storage_max = // can always store small string
             (_STD max)(_Alloc_max, static_cast<size_type>(_BUF_SIZE));
-        return (_STD min)(static_cast<size_type>((numeric_limits<difference_type>::max)()),
+        return (_STD min)(static_cast<size_type>(_STD _Max_limit<difference_type>()),
             _Storage_max - 1 // -1 is for null terminator and/or npos
         );
     }

--- a/stl/inc/xtr1common
+++ b/stl/inc/xtr1common
@@ -244,6 +244,16 @@ struct remove_cvref {
 };
 #endif // _HAS_CXX20
 
+template <class _Ty>
+_NODISCARD constexpr _Ty _Max_limit() noexcept { // same as (numeric_limits<_Ty>::max)(), less throughput cost
+    _STL_INTERNAL_STATIC_ASSERT(is_integral_v<_Ty>); // doesn't attempt to handle all types
+    if constexpr (static_cast<_Ty>(-1) < _Ty{0}) {
+        return ~_Ty{-128 * (_Ty{1} << ((sizeof(_Ty) - 1) * 8))}; // Signed type, form 0x80..0 then bitwise negate
+    } else {
+        return static_cast<_Ty>(-1); // Unsigned tpye
+    }
+}
+
 _STD_END
 
 // TRANSITION, non-_Ugly attribute tokens

--- a/stl/inc/xtr1common
+++ b/stl/inc/xtr1common
@@ -244,16 +244,6 @@ struct remove_cvref {
 };
 #endif // _HAS_CXX20
 
-template <class _Ty>
-_NODISCARD constexpr _Ty _Max_limit() noexcept { // same as (numeric_limits<_Ty>::max)(), less throughput cost
-    _STL_INTERNAL_STATIC_ASSERT(is_integral_v<_Ty>); // doesn't attempt to handle all types
-    if constexpr (static_cast<_Ty>(-1) < _Ty{0}) {
-        return ~_Ty{-128 * (_Ty{1} << ((sizeof(_Ty) - 1) * 8))}; // Signed type, form 0x80..0 then bitwise negate
-    } else {
-        return static_cast<_Ty>(-1); // Unsigned tpye
-    }
-}
-
 _STD_END
 
 // TRANSITION, non-_Ugly attribute tokens

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -1187,7 +1187,7 @@ public:
 
     _NODISCARD size_type max_size() const noexcept {
         return (_STD min)(
-            static_cast<size_type>((numeric_limits<difference_type>::max)()), _Alnode_traits::max_size(_Getal()));
+            static_cast<size_type>(_STD _Max_limit<difference_type>()), _Alnode_traits::max_size(_Getal()));
     }
 
     _NODISCARD_EMPTY_MEMBER bool empty() const noexcept {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5938,9 +5938,8 @@ _NODISCARD constexpr bool _Could_compare_equal_to_value_type(const _Ty& _Val) {
         if constexpr (is_same_v<_Elem, bool>) {
             return _Val == true || _Val == false;
         } else if constexpr (is_signed_v<_Elem>) {
-            // use instead of numeric_limits::min/max; avoid <limits> dependency
-            constexpr _Elem _Min = static_cast<_Elem>(_Elem{1} << (sizeof(_Elem) * CHAR_BIT - 1));
-            constexpr _Elem _Max = static_cast<_Elem>(~_Min);
+            constexpr _Elem _Min = _STD _Min_limit<_Elem>();
+            constexpr _Elem _Max = _STD _Max_limit<_Elem>();
 
             if constexpr (is_signed_v<_Ty>) {
                 // signed _Elem, signed _Ty

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5955,7 +5955,7 @@ _NODISCARD constexpr bool _Could_compare_equal_to_value_type(const _Ty& _Val) {
                 }
             }
         } else {
-            constexpr _Elem _Max = static_cast<_Elem>(~_Elem{0});
+            constexpr _Elem _Max = _STD _Max_limit<_Elem>();
 
             if constexpr (is_unsigned_v<_Ty>) {
                 // unsigned _Elem, unsigned _Ty

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -7386,8 +7386,7 @@ _NODISCARD constexpr bool _Mul_overflow(const _Int _Left, const _Int _Right, _In
 #endif // defined(__clang__)
     {
         if constexpr (!_Signed_integer_like<_Int>) {
-            // use instead of numeric_limits::max; avoid <limits> dependency
-            constexpr auto _UInt_max = static_cast<_Int>(-1);
+            constexpr auto _UInt_max = _STD _Max_limit<_Int>();
             const bool _Overflow     = _Left != 0 && _Right > _UInt_max / _Left;
             if (!_Overflow) {
                 _Out = static_cast<_Int>(_Left * _Right);
@@ -7416,8 +7415,7 @@ _NODISCARD constexpr bool _Mul_overflow(const _Int _Left, const _Int _Right, _In
                 return false;
             }
 
-            // use instead of numeric_limits::max; avoid <limits> dependency
-            constexpr auto _Int_max = static_cast<_UInt>(static_cast<_UInt>(-1) / 2);
+            constexpr auto _Int_max = static_cast<_UInt>(_STD _Max_limit<_Int>());
             if (_Negative) {
                 return _ULeft > (_Int_max + _UInt{1}) / _URight;
             } else {

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -593,6 +593,7 @@ std/depr/depr.c.headers/stddef_h.compile.pass.cpp:1 FAIL
 # libcxx assumes numeric_limits is dragged in without an explicit include
 std/utilities/format/format.arguments/format.arg/visit_format_arg.pass.cpp FAIL
 std/utilities/format/format.arguments/format.args/get.pass.cpp FAIL
+std/numerics/numeric.ops/numeric.ops.midpoint/midpoint.float.pass.cpp FAIL
 
 # Test bug after LWG-2899 "is_(nothrow_)move_constructible and tuple, optional and unique_ptr" was accepted.
 std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -38,6 +38,10 @@ std/containers/sequences/vector.bool/vector.bool.fmt/parse.pass.cpp FAIL
 std/thread/thread.threads/thread.thread.class/thread.thread.id/parse.pass.cpp FAIL
 std/utilities/format/format.tuple/parse.pass.cpp FAIL
 
+# LLVM-90345: libcxx assumes numeric_limits is dragged in without an explicit include
+std/strings/string.conversions/stoi.pass.cpp FAIL
+std/utilities/format/format.arguments/format.args/get.pass.cpp FAIL
+
 # Non-Standard regex behavior.
 # "It seems likely that the test is still non-conforming due to how libc++ handles the 'w' character class."
 std/re/re.traits/lookup_classname.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -39,7 +39,9 @@ std/thread/thread.threads/thread.thread.class/thread.thread.id/parse.pass.cpp FA
 std/utilities/format/format.tuple/parse.pass.cpp FAIL
 
 # LLVM-90345: libcxx assumes numeric_limits is dragged in without an explicit include
+std/numerics/numeric.ops/numeric.ops.midpoint/midpoint.float.pass.cpp FAIL
 std/strings/string.conversions/stoi.pass.cpp FAIL
+std/utilities/format/format.arguments/format.arg/visit_format_arg.pass.cpp FAIL
 std/utilities/format/format.arguments/format.args/get.pass.cpp FAIL
 
 # Non-Standard regex behavior.

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -590,6 +590,10 @@ std/depr/depr.c.headers/stddef_h.compile.pass.cpp:1 FAIL
 
 # *** LIKELY BOGUS TESTS ***
 
+# libcxx assumes numeric_limits is dragged in without an explicit include
+std/utilities/format/format.arguments/format.arg/visit_format_arg.pass.cpp FAIL
+std/utilities/format/format.arguments/format.args/get.pass.cpp FAIL
+
 # Test bug after LWG-2899 "is_(nothrow_)move_constructible and tuple, optional and unique_ptr" was accepted.
 std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.pass.cpp FAIL
 std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.runtime.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -38,6 +38,12 @@ std/containers/sequences/vector.bool/vector.bool.fmt/parse.pass.cpp FAIL
 std/thread/thread.threads/thread.thread.class/thread.thread.id/parse.pass.cpp FAIL
 std/utilities/format/format.tuple/parse.pass.cpp FAIL
 
+# LLVM-90345: libcxx assumes numeric_limits is dragged in without an explicit include
+std/utilities/format/format.arguments/format.arg/visit_format_arg.pass.cpp FAIL
+std/utilities/format/format.arguments/format.args/get.pass.cpp FAIL
+std/numerics/numeric.ops/numeric.ops.midpoint/midpoint.float.pass.cpp FAIL
+std/strings/string.conversions/stoi.pass.cpp FAIL
+
 # Non-Standard regex behavior.
 # "It seems likely that the test is still non-conforming due to how libc++ handles the 'w' character class."
 std/re/re.traits/lookup_classname.pass.cpp FAIL
@@ -589,12 +595,6 @@ std/depr/depr.c.headers/stddef_h.compile.pass.cpp:1 FAIL
 
 
 # *** LIKELY BOGUS TESTS ***
-
-# libcxx assumes numeric_limits is dragged in without an explicit include
-std/utilities/format/format.arguments/format.arg/visit_format_arg.pass.cpp FAIL
-std/utilities/format/format.arguments/format.args/get.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.midpoint/midpoint.float.pass.cpp FAIL
-std/strings/string.conversions/stoi.pass.cpp FAIL
 
 # Test bug after LWG-2899 "is_(nothrow_)move_constructible and tuple, optional and unique_ptr" was accepted.
 std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -38,12 +38,6 @@ std/containers/sequences/vector.bool/vector.bool.fmt/parse.pass.cpp FAIL
 std/thread/thread.threads/thread.thread.class/thread.thread.id/parse.pass.cpp FAIL
 std/utilities/format/format.tuple/parse.pass.cpp FAIL
 
-# LLVM-90345: libcxx assumes numeric_limits is dragged in without an explicit include
-std/numerics/numeric.ops/numeric.ops.midpoint/midpoint.float.pass.cpp FAIL
-std/strings/string.conversions/stoi.pass.cpp FAIL
-std/utilities/format/format.arguments/format.arg/visit_format_arg.pass.cpp FAIL
-std/utilities/format/format.arguments/format.args/get.pass.cpp FAIL
-
 # Non-Standard regex behavior.
 # "It seems likely that the test is still non-conforming due to how libc++ handles the 'w' character class."
 std/re/re.traits/lookup_classname.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -594,6 +594,7 @@ std/depr/depr.c.headers/stddef_h.compile.pass.cpp:1 FAIL
 std/utilities/format/format.arguments/format.arg/visit_format_arg.pass.cpp FAIL
 std/utilities/format/format.arguments/format.args/get.pass.cpp FAIL
 std/numerics/numeric.ops/numeric.ops.midpoint/midpoint.float.pass.cpp FAIL
+std/strings/string.conversions/stoi.pass.cpp FAIL
 
 # Test bug after LWG-2899 "is_(nothrow_)move_constructible and tuple, optional and unique_ptr" was accepted.
 std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.pass.cpp FAIL


### PR DESCRIPTION
Based on #4627 fixup that extracts `_In_range`.
This also makes some place directly using `_In_range`, but mostly `_Max_limit` is used.