### PR TITLE
`<format>`: Fix handling of replacement field when format-spec is absent

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -3537,6 +3537,7 @@ struct _Default_arg_formatter {
     _OutputIt _Out;
     basic_format_args<_Context> _Args;
     _Lazy_locale _Loc;
+    basic_format_parse_context<_CharT>& _Parse_ctx;
 
     template <class _Ty>
     _OutputIt operator()(_Ty _Val) && {
@@ -3544,7 +3545,6 @@ struct _Default_arg_formatter {
     }
 
     _OutputIt operator()(basic_format_arg<_Context>::handle _Handle) && {
-        basic_format_parse_context<_CharT> _Parse_ctx({});
         auto _Format_ctx = _Context::_Make_from(_STD move(_Out), _Args, _Loc);
         _Handle.format(_Parse_ctx, _Format_ctx);
         return _Format_ctx.out();
@@ -3606,9 +3606,9 @@ struct _Format_checker {
         : _Parse_context(_Fmt, _Num_args, _Arg_type),
           _Parse_funcs{&_Compile_time_parse_format_specs<_Args, _ParseContext>...} {}
     constexpr void _On_text(const _CharT*, const _CharT*) const noexcept {}
-    constexpr void _On_replacement_field(const size_t _Id, const _CharT*) const {
-        _ParseContext _Parse_ctx({});
-        (void) _Parse_funcs[_Id](_Parse_ctx);
+    constexpr void _On_replacement_field(const size_t _Id, const _CharT*) {
+        _Parse_context.advance_to(_Parse_context.end());
+        (void) _Parse_funcs[_Id](_Parse_context);
     }
     constexpr const _CharT* _On_format_specs(const size_t _Id, const _CharT* _First, const _CharT*) {
         _Parse_context.advance_to(_Parse_context.begin() + (_First - _Parse_context.begin()._Unwrapped()));
@@ -3643,8 +3643,12 @@ struct _Format_handler {
 
     void _On_replacement_field(const size_t _Id, const _CharT*) {
         auto _Arg = _Get_arg(_Ctx, _Id);
-        _Ctx.advance_to(_STD visit_format_arg(
-            _Default_arg_formatter<_OutputIt, _CharT>{_Ctx.out(), _Ctx._Get_args(), _Ctx._Get_lazy_locale()}, _Arg));
+        if (_Arg._Active_state == _Basic_format_arg_type::_Custom_type) {
+            _Parse_context.advance_to(_Parse_context.end());
+        }
+        _Ctx.advance_to(_STD visit_format_arg(_Default_arg_formatter<_OutputIt, _CharT>{_Ctx.out(), _Ctx._Get_args(),
+                                                  _Ctx._Get_lazy_locale(), _Parse_context},
+            _Arg));
     }
 
     const _CharT* _On_format_specs(const size_t _Id, const _CharT* _First, const _CharT* _Last) {

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -3606,8 +3606,8 @@ struct _Format_checker {
         : _Parse_context(_Fmt, _Num_args, _Arg_type),
           _Parse_funcs{&_Compile_time_parse_format_specs<_Args, _ParseContext>...} {}
     constexpr void _On_text(const _CharT*, const _CharT*) const noexcept {}
-    constexpr void _On_replacement_field(const size_t _Id, const _CharT*) {
-        _Parse_context.advance_to(_Parse_context.end());
+    constexpr void _On_replacement_field(const size_t _Id, const _CharT* _Last) {
+        _Parse_context.advance_to(_Parse_context.begin() + (_Last - &*_Parse_context.begin()));
         (void) _Parse_funcs[_Id](_Parse_context);
     }
     constexpr const _CharT* _On_format_specs(const size_t _Id, const _CharT* _First, const _CharT*) {
@@ -3641,10 +3641,10 @@ struct _Format_handler {
         _Ctx.advance_to(_RANGES _Copy_unchecked(_First, _Last, _Ctx.out()).out);
     }
 
-    void _On_replacement_field(const size_t _Id, const _CharT*) {
+    void _On_replacement_field(const size_t _Id, const _CharT* _Last) {
         auto _Arg = _Get_arg(_Ctx, _Id);
         if (_Arg._Active_state == _Basic_format_arg_type::_Custom_type) {
-            _Parse_context.advance_to(_Parse_context.end());
+            _Parse_context.advance_to(_Parse_context.begin() + (_Last - &*_Parse_context.begin()));
         }
         _Ctx.advance_to(_STD visit_format_arg(_Default_arg_formatter<_OutputIt, _CharT>{_Ctx.out(), _Ctx._Get_args(),
                                                   _Ctx._Get_lazy_locale(), _Parse_context},

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -3607,7 +3607,7 @@ struct _Format_checker {
           _Parse_funcs{&_Compile_time_parse_format_specs<_Args, _ParseContext>...} {}
     constexpr void _On_text(const _CharT*, const _CharT*) const noexcept {}
     constexpr void _On_replacement_field(const size_t _Id, const _CharT* _Last) {
-        _Parse_context.advance_to(_Parse_context.begin() + (_Last - &*_Parse_context.begin()));
+        _Parse_context.advance_to(_Parse_context.begin() + (_Last - _Parse_context.begin()._Unwrapped()));
         (void) _Parse_funcs[_Id](_Parse_context);
     }
     constexpr const _CharT* _On_format_specs(const size_t _Id, const _CharT* _First, const _CharT*) {
@@ -3644,7 +3644,7 @@ struct _Format_handler {
     void _On_replacement_field(const size_t _Id, const _CharT* _Last) {
         auto _Arg = _Get_arg(_Ctx, _Id);
         if (_Arg._Active_state == _Basic_format_arg_type::_Custom_type) {
-            _Parse_context.advance_to(_Parse_context.begin() + (_Last - &*_Parse_context.begin()));
+            _Parse_context.advance_to(_Parse_context.begin() + (_Last - _Parse_context.begin()._Unwrapped()));
         }
         _Ctx.advance_to(_STD visit_format_arg(_Default_arg_formatter<_OutputIt, _CharT>{_Ctx.out(), _Ctx._Get_args(),
                                                   _Ctx._Get_lazy_locale(), _Parse_context},
@@ -3652,7 +3652,7 @@ struct _Format_handler {
     }
 
     const _CharT* _On_format_specs(const size_t _Id, const _CharT* _First, const _CharT* _Last) {
-        _Parse_context.advance_to(_Parse_context.begin() + (_First - &*_Parse_context.begin()));
+        _Parse_context.advance_to(_Parse_context.begin() + (_First - _Parse_context.begin()._Unwrapped()));
         auto _Arg = _Get_arg(_Ctx, _Id);
         if (_Arg._Active_state == _Basic_format_arg_type::_Custom_type) {
             _Arg._Custom_state.format(_Parse_context, _Ctx);

--- a/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <format>
 #include <iterator>
 #include <limits>
@@ -315,12 +316,13 @@ struct NeedMagicWord {};
 
 template <class CharT>
 struct std::formatter<NeedMagicWord, CharT> {
-    constexpr auto parse(basic_format_parse_context<CharT> const& ctx) {
+    constexpr auto parse(const basic_format_parse_context<CharT>& ctx) {
         constexpr basic_string_view<CharT> magic_word{TYPED_LITERAL(CharT, "narf")};
         auto [i, j] = ranges::mismatch(ctx, magic_word);
         if (j != magic_word.end()) {
             throw format_error{"you didn't say the magic word!"};
         }
+
         if (i != ctx.end() && *i != '}') {
             throw format_error{"the whole spec must be the magic word!"};
         }

--- a/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
@@ -319,7 +319,10 @@ struct std::formatter<NeedMagicWord, CharT> {
         constexpr basic_string_view<CharT> magic_word{TYPED_LITERAL(CharT, "narf")};
         auto [i, j] = ranges::mismatch(ctx, magic_word);
         if (j != magic_word.end()) {
-            throw runtime_error{"you didn't say the magic word!"};
+            throw format_error{"you didn't say the magic word!"};
+        }
+        if (i != ctx.end() && *i != '}') {
+            throw format_error{"the whole spec must be the magic word!"};
         }
         return i;
     }

--- a/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
@@ -58,10 +58,10 @@ struct not_const_formattable_type {
 template <>
 struct std::formatter<basic_custom_formattable_type, char> {
     constexpr basic_format_parse_context<char>::iterator parse(basic_format_parse_context<char>& parse_ctx) {
-        if (parse_ctx.begin() != parse_ctx.end()) {
+        if (parse_ctx.begin() != parse_ctx.end() && *parse_ctx.begin() != '}') {
             throw format_error{"only empty specs please"};
         }
-        return parse_ctx.end();
+        return parse_ctx.begin();
     }
     format_context::iterator format(const basic_custom_formattable_type& val, format_context& ctx) const {
         ctx.advance_to(copy(val.string_content.begin(), val.string_content.end(), ctx.out()));
@@ -72,10 +72,10 @@ struct std::formatter<basic_custom_formattable_type, char> {
 template <>
 struct std::formatter<not_const_formattable_type, char> {
     constexpr basic_format_parse_context<char>::iterator parse(basic_format_parse_context<char>& parse_ctx) {
-        if (parse_ctx.begin() != parse_ctx.end()) {
+        if (parse_ctx.begin() != parse_ctx.end() && *parse_ctx.begin() != '}') {
             throw format_error{"only empty specs please"};
         }
-        return parse_ctx.end();
+        return parse_ctx.begin();
     }
     format_context::iterator format(not_const_formattable_type& val, format_context& ctx) const {
         ctx.advance_to(copy(val.string_content.begin(), val.string_content.end(), ctx.out()));
@@ -287,7 +287,7 @@ public:
     constexpr auto parse(ParseContext& ctx) {
         auto it = ctx.begin();
         if (it != ctx.end() && *it != '}') {
-            throw std::format_error{"Expected empty spec"};
+            throw format_error{"Expected empty spec"};
         }
 
         arg_id = ctx.next_arg_id();
@@ -296,7 +296,7 @@ public:
 
     template <class FormatContext>
     auto format(FormatNextArg, FormatContext& ctx) const {
-        return std::format_to(ctx.out(), TYPED_LITERAL(CharT, "arg-id: {}"), arg_id);
+        return format_to(ctx.out(), TYPED_LITERAL(CharT, "arg-id: {}"), arg_id);
     }
 
 private:


### PR DESCRIPTION
Fixes #4636. Also fixes the runtime behavior - both output line in the reported example should be `arg-id: 1, arg-id: 3`.

I've verified that the example posted in #4078 still fails to compile (when using `/utf-8` or a `wchar_t` variant). But I don't know how to test such error in the test suits of MSVC STL.