### PR TITLE
Restore `<exception>`'s inclusion of `<malloc.h>`

### DIFF
--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -30,6 +30,7 @@ _STD_END
 
 #if _HAS_EXCEPTIONS
 
+#include <malloc.h> // TRANSITION, VSO-2048380: This is unnecessary, but many projects assume it as of 2024-04-29
 #include <vcruntime_exception.h>
 
 _STD_BEGIN


### PR DESCRIPTION
In #4626, I was a greedy kitty and added a one-line throughput improvement to make `<exception>` stop dragging in `<malloc.h>`, which it totally doesn't need.

Unfortunately, as `<exception>` is an ancient header, many projects have grown to assume this inclusion (over 15 found in our Real World Code test suite alone as reported by VSO-2048380; other codebases like Windows and Office are presumably similarly affected). That's too many for me to submit upstream fixes for, at least right now, and I didn't have a pressing need to make this change (unlike, say, increased deprecations where we're working towards removal). I did create chriskohlhoff/asio#1472 to fix Boost.Asio, though.

I want to revert this drive-by cleanup before 17.11 Preview 2 branches for release, so that no customers will experience this theoretically righteous, logistically annoying change.

I've included a comment explaining why this unnecessary include has been retained, tagged with today's date as a subtle reminder that future maintainers/contributors could revisit the issue and attempt to do the tedious work of cleaning up the ecosystem. If anyone's eager enough to start working on that, here's the list of libraries that our RWC suite found were affected (I don't have exact files/line numbers for them, but searching for `_alloca` and related `<malloc.h>` identifiers will turn up usage fairly easily):

* AirSim
* Annoy
* Autowiring
* Blender
* Boost
  + I'm unsure if other Boost libraries beyond Asio were affected.
* Cinder
* CoreCLR
* Mame
* Openvr
* OSQuery
* PrusaSlicer
* react_native_windows
* synergy_core
* TarsCpp
* xbmc
* Xmr_stak
