### PR TITLE
Avoid triggering ASan bug in `Dev09_056375_locale_cleanup`

### DIFF
--- a/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
+++ b/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
@@ -65,7 +65,9 @@ void test_dll() {
     TheFuncProc pFunc = reinterpret_cast<TheFuncProc>(GetProcAddress(hLibrary, "DllTest"));
     assert(pFunc != nullptr);
     pFunc();
+#if defined(_DLL) || !defined(__SANITIZE_ADDRESS__) // TRANSITION, VSO-2046190
     FreeLibrary(hLibrary);
+#endif // defined(_DLL) || !defined(__SANITIZE_ADDRESS__)
 #endif // ^^^ !defined(_M_CEE) ^^^
 }
 


### PR DESCRIPTION
Avoid triggering VSO-2046190 in `Dev09_056375_locale_cleanup` by leaving the DLL loaded in ASan instrumented statically-linked configs.

This test is failing with 17.10p5 and current dev compilers, I suspect due to a change in the ASan runtime's interception of `memcpy`. Recall that `memcpy` is part of VCRuntime, so statically-linked configs of this test have a copy of `memcpy` linked to the program and another copy of `memcpy` linked into the DLL. When the program unloads the DLL, I believe the ASan runtime's "pointer to actual memcpy" is left pointing into unallocated space where the DLL's copy used to be.

I'm going to disable unloading the DLL for this case to avoid the problem until we can implement and ship a fix.
