### PR TITLE
`vector_algorithms.cpp`: `minmax` for 64-bit elements: replace ugly x86 workaround with a nice one

### DIFF
--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -1110,7 +1110,7 @@ namespace {
         }
 
         static uint64_t _Get_any_u(const __m128i _Cur) noexcept {
-            return _Minmax_traits_8::_Get_any(_Cur);
+            return _Minmax_traits_8::_Get_v_pos(_Cur, 0);
         }
 
         static uint64_t _Get_v_pos(const __m128i _Idx, const unsigned long _H_pos) noexcept {

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -1114,9 +1114,7 @@ namespace {
         }
 
         static uint64_t _Get_v_pos(const __m128i _Idx, const unsigned long _H_pos) noexcept {
-            uint64_t _Array[2];
-            _mm_storeu_si128(reinterpret_cast<__m128i*>(&_Array), _Idx);
-            return _Array[_H_pos >> 3];
+            return _Minmax_traits_8::_Get_v_pos(_Idx, _H_pos);
         }
 
         static __m128d _Cmp_eq(const __m128d _First, const __m128d _Second) noexcept {

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -901,13 +901,11 @@ namespace {
         }
 
         static _Signed_t _Get_any(const __m128i _Cur) noexcept {
-#ifdef _M_IX86
-            return static_cast<_Signed_t>(
-                (static_cast<_Unsigned_t>(static_cast<uint32_t>(_mm_extract_epi32(_Cur, 1))) << 32)
-                | static_cast<_Unsigned_t>(static_cast<uint32_t>(_mm_cvtsi128_si32(_Cur))));
-#else // ^^^ x86 / x64 vvv
-            return static_cast<_Signed_t>(_mm_cvtsi128_si64(_Cur));
-#endif // ^^^ x64 ^^^
+            // With optimizations enabled, compiles into registers movement, rather than actual stack spill.
+            // Works around _mm_cvtsi128_si64 absence on 32-bit
+            uint64_t _Tmp[4];
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(_Tmp), _Cur);
+            return _Tmp[0];
         }
 
         static _Unsigned_t _Get_v_pos(const __m128i _Idx, const unsigned long _H_pos) noexcept {

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -901,8 +901,8 @@ namespace {
         }
 
         static _Signed_t _Get_any(const __m128i _Cur) noexcept {
-            // With optimizations enabled, compiles into registers movement, rather than actual stack spill.
-            // Works around _mm_cvtsi128_si64 absence on 32-bit
+            // With optimizations enabled, compiles into register movement, rather than an actual stack spill.
+            // Works around the absence of _mm_cvtsi128_si64 on 32-bit.
             uint64_t _Tmp[2];
             _mm_storeu_si128(reinterpret_cast<__m128i*>(_Tmp), _Cur);
             return _Tmp[0];

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -903,9 +903,7 @@ namespace {
         static _Signed_t _Get_any(const __m128i _Cur) noexcept {
             // With optimizations enabled, compiles into register movement, rather than an actual stack spill.
             // Works around the absence of _mm_cvtsi128_si64 on 32-bit.
-            uint64_t _Tmp[2];
-            _mm_storeu_si128(reinterpret_cast<__m128i*>(_Tmp), _Cur);
-            return _Tmp[0];
+            return static_cast<_Signed_t>(_Get_v_pos(_Cur, 0));
         }
 
         static _Unsigned_t _Get_v_pos(const __m128i _Idx, const unsigned long _H_pos) noexcept {

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -1112,12 +1112,7 @@ namespace {
         }
 
         static uint64_t _Get_any_u(const __m128i _Cur) noexcept {
-#ifdef _M_IX86
-            return (static_cast<uint64_t>(static_cast<uint32_t>(_mm_extract_epi32(_Cur, 1))) << 32)
-                 | static_cast<uint64_t>(static_cast<uint32_t>(_mm_cvtsi128_si32(_Cur)));
-#else // ^^^ x86 / x64 vvv
-            return static_cast<uint64_t>(_mm_cvtsi128_si64(_Cur));
-#endif // ^^^ x64 ^^^
+            return _Minmax_traits_8::_Get_any(_Cur);
         }
 
         static uint64_t _Get_v_pos(const __m128i _Idx, const unsigned long _H_pos) noexcept {

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -903,7 +903,7 @@ namespace {
         static _Signed_t _Get_any(const __m128i _Cur) noexcept {
             // With optimizations enabled, compiles into registers movement, rather than actual stack spill.
             // Works around _mm_cvtsi128_si64 absence on 32-bit
-            uint64_t _Tmp[4];
+            uint64_t _Tmp[2];
             _mm_storeu_si128(reinterpret_cast<__m128i*>(_Tmp), _Cur);
             return _Tmp[0];
         }


### PR DESCRIPTION
This: piece
https://github.com/microsoft/STL/blob/8dc4faadafb52e3e0a627e046b41258032d9bc6a/stl/src/vector_algorithms.cpp#L1116-L1123
works around the oddity of not having `_mm_cvtsi128_si64` on 32-bit x86

It has been problematic:
 * An internal bug was reported; fixed by #2821 
 * A compiler bug was caught, it blocked #3922

I have discovered a nicer workaround!

If we spill the reg into the stack, the spill will optimize away. 
On 32-bit with at least `/arch:SSE2` it even produces better code than the existing workaround.
Demo: https://godbolt.org/z/ErGWz8GYT

It still does the actual spill on `/arch:IA32`. But given that this path is executed only once per function call (there are no intermediate reductions for 64-bit elements), and there's a plan to lift to `/arch:SSE2`, I think that's fine.