### PR TITLE
`<expected>`: Workaround for DevCom-10655311 "Class derived from `std::expected` can't be constructed with `bool` value type"

### DIFF
--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -306,11 +306,18 @@ public:
     template <class _Uty = _Ty>
         requires (!is_same_v<remove_cvref_t<_Uty>, in_place_t> && !is_same_v<remove_cvref_t<_Uty>, expected>
                      && !_Is_specialization_v<remove_cvref_t<_Uty>, unexpected>
-                     && (!is_same_v<remove_cv_t<_Ty>, bool> || !_Is_specialization_v<remove_cvref_t<_Uty>, expected>)
+                     && (!is_same_v<remove_cv_t<_Ty>, bool>
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10655311
+                         || !_Is_specialization_v<remove_cvref_t<_Uty>, expected>
+#else // ^^^ no workaround / workaround vvv
+                         || !_Is_specialization_v<remove_cvref_t<_Uty>, _STD expected>
+#endif // ^^^ workaround ^^^
+                         )
                      && is_constructible_v<_Ty, _Uty>)
     constexpr explicit(!is_convertible_v<_Uty, _Ty>)
         expected(_Uty&& _Other) noexcept(is_nothrow_constructible_v<_Ty, _Uty>) // strengthened
-        : _Value(_STD forward<_Uty>(_Other)), _Has_value(true) {}
+        : _Value(_STD forward<_Uty>(_Other)), _Has_value(true) {
+    }
 
     template <class _UErr>
         requires is_constructible_v<_Err, const _UErr&>

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -2317,6 +2317,30 @@ void test_lwg_3843() {
 static_assert(copyable<expected<any, int>>);
 static_assert(copyable<expected<void, any>>);
 
+// Test workaround for DevCom-10655311: Class derived from std::expected can't be constructed with bool value type
+template <class T, class E>
+class DerivedFromExpected : private expected<T, E> {
+public:
+    using expected<T, E>::expected;
+    using expected<T, E>::value;
+};
+
+static_assert(is_constructible_v<DerivedFromExpected<bool, int>, bool>);
+static_assert(is_constructible_v<DerivedFromExpected<bool, int>, const bool&>);
+
+constexpr bool test_inherited_constructors() {
+    DerivedFromExpected<bool, int> wrapped_false_val(false);
+    assert(!wrapped_false_val.value());
+
+    constexpr bool true_val = true;
+    DerivedFromExpected<bool, int> wrapped_true_val(true_val);
+    assert(wrapped_true_val.value());
+
+    return true;
+}
+
+static_assert(test_inherited_constructors());
+
 int main() {
     test_unexpected::test_all();
     static_assert(test_unexpected::test_all());
@@ -2333,4 +2357,5 @@ int main() {
 
     test_reinit_regression();
     test_lwg_3843();
+    test_inherited_constructors();
 }


### PR DESCRIPTION
Works around DevCom-10655311. The reason of the issue seems to be that MSVC cannot recognize the injected-class-name as a template name in associated constraints in inherited constructors.

The workaround seemingly works with `/permissive` so there wouldn't be stealing conflicts with #4658, AFAIK.