### PR TITLE
auto vectorize `std::count`

### DIFF
--- a/benchmarks/src/find_and_count.cpp
+++ b/benchmarks/src/find_and_count.cpp
@@ -33,12 +33,14 @@ void bm(benchmark::State& state) {
     }
 
     for (auto _ : state) {
+        benchmark::DoNotOptimize(a);
+
         if constexpr (Operation == Op::FindSized) {
             benchmark::DoNotOptimize(ranges::find(a.begin(), a.end(), T{'1'}));
         } else if constexpr (Operation == Op::FindUnsized) {
             benchmark::DoNotOptimize(ranges::find(a.begin(), unreachable_sentinel, T{'1'}));
         } else if constexpr (Operation == Op::Count) {
-            benchmark::DoNotOptimize(ranges::count(a.begin(), a.end(), T{'1'}));
+            benchmark::DoNotOptimize(count(a.begin(), a.end(), T{'1'}));
         }
     }
 }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6203,7 +6203,7 @@ _NODISCARD _CONSTEXPR20 _Iter_diff_t<_InIt> count(const _InIt _First, const _InI
                 return static_cast<_Result_type>(_Count);
             } else {
                 _Result_type _Outer_count                 = 0;
-                constexpr _Counter_type _Max_portion_size = _Max_limit<_Counter_type>();
+                constexpr _Counter_type _Max_portion_size = _Counter_type{1} << (sizeof(_Counter_type) * 8 - 1);
 
                 while (_UFirst != _ULast) {
                     _Counter_type _Inner_count = 0;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5975,6 +5975,22 @@ _NODISCARD constexpr bool _Could_compare_equal_to_value_type(const _Ty& _Val) {
     }
 }
 
+template <class _Ty>
+using _Auto_vectorize_counter = //
+    conditional_t<sizeof(_Ty) == 8, unsigned long long, //
+        conditional_t<sizeof(_Ty) == 4, unsigned int, //
+            conditional_t<sizeof(_Ty) == 2, unsigned short, //
+                conditional_t<sizeof(_Ty) == 1, unsigned char, void>>>>;
+
+
+// Can we attempt auto vectorization for count?
+template <class _Iter>
+constexpr bool _Can_try_auto_vectorize_count =
+    _Iterator_is_contiguous<_Iter> // The iterator must be contiguous
+    && !_Iterator_is_volatile<_Iter> // volatile iterators do ono auto vectorize
+    && is_fundamental_v<_Iter_value_t<_Iter>> // MSVC only auto vectorizes counting of fundametal types
+    && !is_same_v<_Auto_vectorize_counter<_Iter_value_t<_Iter>>, void>; // Vector element size matches
+
 template <class _InIt, class _Ty>
 _NODISCARD _CONSTEXPR20 _InIt _Find_unchecked(_InIt _First, const _InIt _Last, const _Ty& _Val) {
     // find first matching _Val; choose optimization
@@ -6170,16 +6186,56 @@ _NODISCARD _CONSTEXPR20 _Iter_diff_t<_InIt> count(const _InIt _First, const _InI
             }
         }
 #endif // _USE_STD_VECTOR_ALGORITHMS
+        using _Result_type = _Iter_diff_t<_InIt>;
 
-        _Iter_diff_t<_InIt> _Count = 0;
+        if constexpr (_Can_try_auto_vectorize_count<decltype(_UFirst)>) {
+            using _Counter_type = _Auto_vectorize_counter<_Iter_value_t<decltype(_UFirst)>>;
 
-        for (; _UFirst != _ULast; ++_UFirst) {
-            if (*_UFirst == _Val) {
-                ++_Count;
+            if constexpr (sizeof(_Counter_type) >= sizeof(_Result_type)) {
+                _Counter_type _Count = 0;
+
+                for (; _UFirst != _ULast; ++_UFirst) {
+                    if (*_UFirst == _Val) {
+                        ++_Count;
+                    }
+                }
+
+                return static_cast<_Result_type>(_Count);
+            } else {
+                _Result_type _Outer_count                 = 0;
+                constexpr _Counter_type _Max_portion_size = _Max_limit<_Counter_type>();
+
+                while (_UFirst != _ULast) {
+                    _Counter_type _Inner_count = 0;
+                    _Result_type _Portion_size = static_cast<_Result_type>(_ULast - _UFirst);
+                    if (_Portion_size > _Max_portion_size) {
+                        _Portion_size = _Max_portion_size;
+                    }
+
+                    const auto _UStop = _UFirst + _Portion_size;
+
+                    for (; _UFirst != _UStop; ++_UFirst) {
+                        if (*_UFirst == _Val) {
+                            ++_Inner_count;
+                        }
+                    }
+
+                    _Outer_count += _Inner_count;
+                }
+
+                return _Outer_count;
             }
-        }
+        } else {
+            _Result_type _Count = 0;
 
-        return _Count;
+            for (; _UFirst != _ULast; ++_UFirst) {
+                if (*_UFirst == _Val) {
+                    ++_Count;
+                }
+            }
+
+            return _Count;
+        }
     }
 }
 


### PR DESCRIPTION
Auto vectorize std count in addition to manual vectorization.

Auto vectorization is engaged with `_USE_STD_VECTOR_ALGORITHMS=0` on x86, x64, and possibly on Arm64

Towards #4653 

I tried to do also `count_if`, but for some reason auto-vectorization only worked for 8-bit elements. Might look into this later.

Is this worth doing? Drop manual vectorization or let them coexist?

----

Benchmark results of auto vectorization and no vectorization are produced by editing `benchmark\CMakeFile.txt` accordingly, i.e. by adding `/arch:AVX2` option and `_USE_STD_VECTOR_ALGORITHMS=0` define. default vectorization means SSE2 vectorization.

Note that the `uint64_t` was auto-vectorized even before the change, the results reflect that.

Benchmark                            |    None         |   Manual    | Auto, default | Auto, AVX2    |
-------------------------------------|----------------:|------------:|--------------:|------------:|
bm<uint8_t, Op::Count>/8021/3056     |     1971 ns     |   75.4 ns   |    196 ns     |    179 ns   |
bm<uint8_t, Op::Count>/63/62         |     26.4 ns     |   4.77 ns   |   13.7 ns     |   30.4 ns   |
bm<uint8_t, Op::Count>/31/30         |     10.3 ns     |   9.63 ns   |   15.2 ns     |   15.0 ns   |
bm<uint8_t, Op::Count>/15/14         |     5.94 ns     |   6.23 ns   |   7.51 ns     |   8.53 ns   |
bm<uint8_t, Op::Count>/7/6           |     3.10 ns     |   3.82 ns   |   4.02 ns     |   4.15 ns   |
bm<uint16_t, Op::Count>/8021/3056    |     1984 ns     |    132 ns   |    245 ns     |    126 ns   |
bm<uint16_t, Op::Count>/63/62        |     30.1 ns     |   4.93 ns   |   8.67 ns     |   16.8 ns   |
bm<uint16_t, Op::Count>/31/30        |     19.4 ns     |   4.75 ns   |   7.92 ns     |   14.3 ns   |
bm<uint16_t, Op::Count>/15/14        |     5.06 ns     |   5.03 ns   |   8.26 ns     |   8.49 ns   |
bm<uint16_t, Op::Count>/7/6          |     2.91 ns     |   3.74 ns   |   3.80 ns     |   4.06 ns   |
bm<uint32_t, Op::Count>/8021/3056    |     1926 ns     |    254 ns   |    411 ns     |    241 ns   |
bm<uint32_t, Op::Count>/63/62        |     26.6 ns     |   5.02 ns   |   9.73 ns     |   9.60 ns   |
bm<uint32_t, Op::Count>/31/30        |     9.97 ns     |   4.35 ns   |   5.09 ns     |   8.82 ns   |
bm<uint32_t, Op::Count>/15/14        |     5.82 ns     |   4.04 ns   |   4.46 ns     |   8.34 ns   |
bm<uint32_t, Op::Count>/7/6          |     3.00 ns     |   3.95 ns   |   3.69 ns     |   3.75 ns   |
bm<uint64_t, Op::Count>/8021/3056    |      776 ns     |    754 ns   |    785 ns     |    617 ns   |
bm<uint64_t, Op::Count>/63/62        |     11.7 ns     |   13.2 ns   |   10.2 ns     |   8.10 ns   |
bm<uint64_t, Op::Count>/31/30        |     5.05 ns     |   4.73 ns   |   5.07 ns     |   4.84 ns   |
bm<uint64_t, Op::Count>/15/14        |     3.74 ns     |   3.82 ns   |   3.63 ns     |   4.73 ns   |
bm<uint64_t, Op::Count>/7/6          |     2.89 ns     |   3.59 ns   |   3.33 ns     |   3.42 ns   |

----

Results interpretation:
 * `bm<uint8_t, Op::Count>/8021/3056` is way faster in manual vectorization than in auto AVX2, Auto vectorization has less efficient reduction, which is especially noticeable for 8-bit case, when it is needed often. It is less efficient because:
     * Not very efficient instructions choice for 8-bit case, in particular, no `sadbw` and no wider horizontal add, reported as DevCom-10657464
     * Not utilizing AVX2 width, using `xmm#` regs most of the time
     * Need to reduce often, each 0x80 count, not each 0xFF count. Note that if a count like 0xFE selected, there would be scalar tail on each portion. Without knowing the vector reg size and the loop unrolling factor, it is not possible to know maximum count that avoids scalar part, so we resort to power of two count.
 * Other `8021/3056` cases are a bit faster for auto AVX2 due to some loop unrolling
 * Small length tail benchmark results are terrible for auto vectorization, which does the tail in scalar way, rather than mask. Due to the loop unrolling, the tail is longer than a vector register.
 * Default SSE2 is somewhat slower than AVX2, almost twice for smaller elements.
 * No vectorization `uint64_t` is close to default vectorization, because both are equally vectorized.