### PR TITLE
Fix #4507: LWG-4053 Unary call to std::views::repeat does not decay the argument

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1708,8 +1708,8 @@ namespace ranges {
         }
     };
 
-    template <class _Ty, class _Bo>
-    repeat_view(_Ty, _Bo) -> repeat_view<_Ty, _Bo>;
+    template <class _Ty, class _Bo = unreachable_sentinel_t>
+    repeat_view(_Ty, _Bo = _Bo()) -> repeat_view<_Ty, _Bo>;
 
     namespace views {
         struct _Repeat_fn {

--- a/tests/std/tests/P2474R2_views_repeat/test.cpp
+++ b/tests/std/tests/P2474R2_views_repeat/test.cpp
@@ -360,6 +360,16 @@ constexpr bool test() {
     test_iterator_arithmetic<wchar_t>();
     test_iterator_arithmetic<_Signed128>();
 
+    // GH-4507: LWG-4053 Unary call to std::views::repeat does not decay the argument
+    {
+        using RPV = std::ranges::repeat_view<const char*>;
+
+        static_assert(std::same_as<decltype(std::views::repeat("foo", std::unreachable_sentinel)), RPV>);
+        static_assert(std::same_as<decltype(std::views::repeat(+"foo", std::unreachable_sentinel)), RPV>);
+        static_assert(std::same_as<decltype(std::views::repeat("foo")), RPV>);
+        static_assert(std::same_as<decltype(std::views::repeat(+"foo")), RPV>);
+    }
+
     return true;
 }
 

--- a/tests/std/tests/P2474R2_views_repeat/test.cpp
+++ b/tests/std/tests/P2474R2_views_repeat/test.cpp
@@ -362,12 +362,12 @@ constexpr bool test() {
 
     // GH-4507: LWG-4053 Unary call to std::views::repeat does not decay the argument
     {
-        using RPV = std::ranges::repeat_view<const char*>;
+        using RPV = ranges::repeat_view<const char*>;
 
-        static_assert(std::same_as<decltype(std::views::repeat("foo", std::unreachable_sentinel)), RPV>);
-        static_assert(std::same_as<decltype(std::views::repeat(+"foo", std::unreachable_sentinel)), RPV>);
-        static_assert(std::same_as<decltype(std::views::repeat("foo")), RPV>);
-        static_assert(std::same_as<decltype(std::views::repeat(+"foo")), RPV>);
+        static_assert(same_as<decltype(views::repeat("foo", unreachable_sentinel)), RPV>);
+        static_assert(same_as<decltype(views::repeat(+"foo", unreachable_sentinel)), RPV>);
+        static_assert(same_as<decltype(views::repeat("foo")), RPV>);
+        static_assert(same_as<decltype(views::repeat(+"foo")), RPV>);
     }
 
     return true;


### PR DESCRIPTION
Fix #4507