### PR TITLE
Prefer xor to sub for counting bits

### DIFF
--- a/stl/inc/__msvc_bit_utils.hpp
+++ b/stl/inc/__msvc_bit_utils.hpp
@@ -107,7 +107,7 @@ _NODISCARD int _Countl_zero_bsr(const _Ty _Val) noexcept {
 #ifdef _M_IX86
         const unsigned int _High = _Val >> 32;
         if (_BitScanReverse(&_Result, _High)) {
-            return static_cast<int>(31 - _Result);
+            return static_cast<int>(31 ^ _Result);
         }
 
         const auto _Low = static_cast<unsigned int>(_Val);

--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -746,7 +746,7 @@ _NODISCARD inline bool _Multiply_by_power_of_ten(_Big_integer_flt& _Xval, const 
 // Computes the number of zeroes higher than the most significant set bit in _Ux
 _NODISCARD inline uint32_t _Count_sequential_high_zeroes(const uint32_t _Ux) noexcept {
     unsigned long _Index; // Intentionally uninitialized for better codegen
-    return _BitScanReverse(&_Index, _Ux) ? 31 - _Index : 32;
+    return _BitScanReverse(&_Index, _Ux) ? 31 ^ _Index : 32;
 }
 
 // This high-precision integer division implementation was translated from the implementation of


### PR DESCRIPTION
For subtracting from 63 or 31 alone, exclusive or is faster than sub because exclusive or doesn't set any flags, unlike sub.