### PR TITLE
Tests: un-skip a few libc++ tests that were believed to have timing assumptions

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -54,11 +54,6 @@ std/utilities/memory/default.allocator/allocator.ctor.pass.cpp FAIL
 # LWG-3197 "std::prev should not require BidirectionalIterator" (New)
 std/iterators/iterator.primitives/iterator.operations/prev.pass.cpp FAIL
 
-# Itanium ABI assumptions that current_exception and rethrow_exception don't copy the exception object.
-# The SKIPPED tests contain `XFAIL: msvc`, which is not well understood by the test harness.
-std/language.support/support.exception/except.nested/rethrow_if_nested.pass.cpp SKIPPED
-std/language.support/support.exception/propagation/current_exception.pass.cpp SKIPPED
-
 # Testing nonstandard behavior
 std/utilities/template.bitset/bitset.cons/string_ctor.pass.cpp FAIL
 
@@ -597,7 +592,6 @@ std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.
 std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move.pass.cpp FAIL
 
 # Not analyzed, likely bogus tests. Appears to be timing assumptions.
-std/atomics/atomics.types.operations/atomics.types.operations.wait/atomic_notify_all.pass.cpp SKIPPED
 std/thread/futures/futures.async/async.pass.cpp SKIPPED
 std/thread/futures/futures.shared_future/get.pass.cpp SKIPPED
 std/thread/futures/futures.shared_future/wait.pass.cpp SKIPPED
@@ -618,8 +612,6 @@ std/thread/thread.condition/thread.condition.condvarany/wait_for_pred.pass.cpp S
 std/thread/thread.condition/thread.condition.condvarany/wait_for.pass.cpp SKIPPED
 std/thread/thread.condition/thread.condition.condvarany/wait_until_pred.pass.cpp SKIPPED
 std/thread/thread.condition/thread.condition.condvarany/wait_until.pass.cpp SKIPPED
-std/thread/thread.mutex/thread.lock/thread.lock.guard/adopt_lock.pass.cpp SKIPPED
-std/thread/thread.mutex/thread.lock/thread.lock.guard/mutex.pass.cpp SKIPPED
 std/thread/thread.mutex/thread.lock/thread.lock.shared/thread.lock.shared.cons/mutex_duration.pass.cpp SKIPPED
 std/thread/thread.mutex/thread.lock/thread.lock.shared/thread.lock.shared.cons/mutex_time_point.pass.cpp SKIPPED
 std/thread/thread.mutex/thread.lock/thread.lock.shared/thread.lock.shared.cons/mutex_try_to_lock.pass.cpp SKIPPED
@@ -654,8 +646,6 @@ std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements
 std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/try_lock_for.pass.cpp SKIPPED
 std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/try_lock_until.pass.cpp SKIPPED
 std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/try_lock.pass.cpp SKIPPED
-std/thread/thread.threads/thread.thread.class/thread.thread.destr/dtor.pass.cpp SKIPPED
-std/thread/thread.threads/thread.thread.class/thread.thread.member/detach.pass.cpp SKIPPED
 std/thread/thread.threads/thread.thread.this/sleep_until.pass.cpp SKIPPED
 
 # Not analyzed, likely bogus tests. Various assertions, probably POSIX assumptions.
@@ -1357,6 +1347,10 @@ std/time/time.syn/formatter.weekday_last.pass.cpp:2 SKIPPED
 std/time/time.syn/formatter.weekday.pass.cpp:0 SKIPPED
 std/time/time.syn/formatter.weekday.pass.cpp:2 SKIPPED
 std/time/time.syn/formatter.year_month_day.pass.cpp:2 SKIPPED
+std/language.support/support.exception/except.nested/rethrow_if_nested.pass.cpp:0 SKIPPED
+std/language.support/support.exception/except.nested/rethrow_if_nested.pass.cpp:2 SKIPPED
+std/language.support/support.exception/propagation/current_exception.pass.cpp:0 SKIPPED
+std/language.support/support.exception/propagation/current_exception.pass.cpp:2 SKIPPED
 
 
 # *** MSVC-INTERNAL TEST HARNESS ISSUES (note: configuration :9 restricts these skips to be MSVC-internal) ***


### PR DESCRIPTION
- `std/atomics/atomics.types.operations/atomics.types.operations.wait/atomic_notify_all.pass.cpp`
  - The timing assumption has been removed by https://github.com/llvm/llvm-project/commit/b3b611fe1a2f41e3e3ccf294c3fd9b1316e70c4d and https://github.com/llvm/llvm-project/commit/e98195f318375978e3e0b153cade8bb3a05029bb.
- `std/thread/thread.mutex/thread.lock/thread.lock.guard/adopt_lock.pass.cpp`
  - The timing assumption has been removed by https://github.com/llvm/llvm-project/commit/a675c1dee483129611794f37e0867f565181827b.
- `std/thread/thread.mutex/thread.lock/thread.lock.guard/mutex.pass.cpp`
  - The timing assumption has been removed by https://github.com/llvm/llvm-project/commit/a675c1dee483129611794f37e0867f565181827b.
- `std/thread/thread.threads/thread.thread.class/thread.thread.destr/dtor.pass.cpp`
  - It doesn't seem to have timing assumptions. (There's a `sleep_for` call, which seems redundant.)
- `std/thread/thread.threads/thread.thread.class/thread.thread.member/detach.pass.cpp`
  - It doesn't seem to have timing assumptions.

Drive-by: move two `XFAIL: msvc` tests down to "XFAILs WHICH PASS" section.