### PR TITLE
llvm-project Meso-Update

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -22,10 +22,6 @@ std/time/time.syn/formatter.year_month_day_last.pass.cpp:1 FAIL
 std/time/time.syn/formatter.year_month_weekday.pass.cpp:0 FAIL
 std/time/time.syn/formatter.year_month_weekday.pass.cpp:1 FAIL
 
-# LLVM-74221: [libc++][test] nasty_char_traits::move is incompatible with constexpr
-std/strings/basic.string/string.modifiers/string_append/initializer_list.pass.cpp:2 FAIL
-std/strings/basic.string/string.modifiers/string_assign/string.pass.cpp:2 FAIL
-
 # LLVM-74756: [libc++][test] overload_compare_iterator doesn't support its claimed iterator_category
 std/utilities/memory/specialized.algorithms/uninitialized.copy/uninitialized_copy.pass.cpp FAIL
 std/utilities/memory/specialized.algorithms/uninitialized.move/uninitialized_move.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -328,7 +328,6 @@ std/concepts/concepts.compare/concept.equalitycomparable/equality_comparable_wit
 std/concepts/concepts.compare/concept.equalitycomparable/equality_comparable_with.compile.pass.cpp:1 FAIL
 
 # DevCom-10439137 VSO-1869865: Discarded id-expression causes unnecessary reading
-# Also: LLVM-79793 [libc++][test] Fix MSVC warning C4127 in array.cons/initialization.pass.cpp
 std/containers/sequences/array/array.cons/initialization.pass.cpp:0 FAIL
 std/containers/sequences/array/array.cons/initialization.pass.cpp:1 FAIL
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -98,9 +98,6 @@ std/utilities/function.objects/range.cmp/not_equal_to.pass.cpp FAIL
 # libc++ doesn't implement P2588R3 barrier's Phase Completion Guarantees
 std/language.support/support.limits/support.limits.general/barrier.version.compile.pass.cpp FAIL
 
-# libc++ doesn't implement P2602R2 "Poison Pills Are Too Toxic"
-std/ranges/range.access/size.pass.cpp FAIL
-
 # libc++ has not implemented P2937R0: "Freestanding Library: Remove strtok"
 std/language.support/support.limits/support.limits.general/cstring.version.compile.pass.cpp FAIL
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -202,30 +202,6 @@ std/strings/c.strings/cuchar.compile.pass.cpp FAIL
 std/language.support/support.limits/support.limits.general/cmath.version.compile.pass.cpp FAIL
 std/language.support/support.limits/support.limits.general/cstdlib.version.compile.pass.cpp FAIL
 
-# P0543R3 Saturation Arithmetic
-std/language.support/support.limits/support.limits.general/numeric.version.compile.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/add_sat.compile.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/add_sat.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/div_sat.compile.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/div_sat.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/mul_sat.compile.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/mul_sat.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/saturate_cast.compile.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/saturate_cast.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/sub_sat.compile.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/sub_sat.pass.cpp FAIL
-
-# P1759R6 Native Handles And File Streams
-std/input.output/file.streams/fstreams/filebuf.members/native_handle.pass.cpp FAIL
-std/input.output/file.streams/fstreams/filebuf/types.pass.cpp FAIL
-std/input.output/file.streams/fstreams/fstream.members/native_handle.pass.cpp FAIL
-std/input.output/file.streams/fstreams/fstream/types.pass.cpp FAIL
-std/input.output/file.streams/fstreams/ifstream.members/native_handle.pass.cpp FAIL
-std/input.output/file.streams/fstreams/ifstream/types.pass.cpp FAIL
-std/input.output/file.streams/fstreams/ofstream.members/native_handle.pass.cpp FAIL
-std/input.output/file.streams/fstreams/ofstream/types.pass.cpp FAIL
-std/language.support/support.limits/support.limits.general/fstream.version.compile.pass.cpp FAIL
-
 # P2255R2 "Type Traits To Detect References Binding To Temporaries"
 std/language.support/support.limits/support.limits.general/type_traits.version.compile.pass.cpp FAIL
 
@@ -260,61 +236,6 @@ std/utilities/format/format.range/format.range.formatter/format.functions.format
 std/utilities/format/format.range/format.range.formatter/format.functions.vformat.pass.cpp FAIL
 std/utilities/format/format.range/format.range.formatter/format.pass.cpp FAIL
 std/utilities/format/format.range/format.range.formatter/parse.pass.cpp FAIL
-
-# P2363R5 Extending Associative Containers With The Remaining Heterogeneous Overloads
-std/language.support/support.limits/support.limits.general/map.version.compile.pass.cpp FAIL
-std/language.support/support.limits/support.limits.general/set.version.compile.pass.cpp FAIL
-std/language.support/support.limits/support.limits.general/unordered_map.version.compile.pass.cpp FAIL
-std/language.support/support.limits/support.limits.general/unordered_set.version.compile.pass.cpp FAIL
-
-# P2407R5 Freestanding Library: Partial Classes
-std/language.support/support.limits/support.limits.general/array.version.compile.pass.cpp FAIL
-std/language.support/support.limits/support.limits.general/optional.version.compile.pass.cpp FAIL
-std/language.support/support.limits/support.limits.general/string_view.version.compile.pass.cpp FAIL
-
-# P2447R6 Constructing span<const T> From initializer_list<T>
-std/containers/views/views.span/span.cons/initializer_list.pass.cpp FAIL
-std/language.support/support.limits/support.limits.general/span.version.compile.pass.cpp FAIL
-
-# P2495R3 Interfacing stringstreams With string_view
-std/language.support/support.limits/support.limits.general/sstream.version.compile.pass.cpp FAIL
-
-# P2497R0 Testing For Success Or Failure Of <charconv> Functions
-std/language.support/support.limits/support.limits.general/charconv.version.compile.pass.cpp FAIL
-std/utilities/charconv/charconv.syn/from_chars_result.operator_bool.pass.cpp FAIL
-std/utilities/charconv/charconv.syn/to_chars_result.operator_bool.pass.cpp FAIL
-
-# P2587R3 Redefining to_string To Use to_chars
-std/language.support/support.limits/support.limits.general/string.version.compile.pass.cpp FAIL
-
-# P2637R3 Member visit
-std/utilities/variant/variant.visit.member/robust_against_adl.pass.cpp FAIL
-std/utilities/variant/variant.visit.member/visit_return_type.pass.cpp FAIL
-std/utilities/variant/variant.visit.member/visit.pass.cpp FAIL
-
-# P2697R1 Interfacing bitset With string_view
-std/language.support/support.limits/support.limits.general/bitset.version.compile.pass.cpp FAIL
-std/utilities/template.bitset/bitset.cons/string_view_ctor.pass.cpp FAIL
-
-# P2734R0 Adding The New SI Prefixes
-std/language.support/support.limits/support.limits.general/ratio.version.compile.pass.cpp FAIL
-
-# P2819R2 Add The Tuple Protocol To complex
-std/language.support/support.limits/support.limits.general/tuple.version.compile.pass.cpp FAIL
-std/language.support/support.limits/support.limits.general/utility.version.compile.pass.cpp FAIL
-
-# P2821R5 span::at()
-std/containers/views/views.span/span.elem/at.pass.cpp FAIL
-
-# P2833R2 Freestanding Library: inout expected span
-std/language.support/support.limits/support.limits.general/expected.version.compile.pass.cpp FAIL
-std/language.support/support.limits/support.limits.general/mdspan.version.compile.pass.cpp FAIL
-
-# P2918R2 Runtime Format Strings II
-std/utilities/format/format.fmt.string/ctor.runtime-format-string.pass.cpp FAIL
-std/utilities/format/format.functions/format.locale.runtime_format.pass.cpp FAIL
-std/utilities/format/format.functions/format.runtime_format.pass.cpp FAIL
-std/utilities/format/format.syn/runtime_format_string.pass.cpp FAIL
 
 
 # *** MISSING COMPILER FEATURES ***

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -109,9 +109,6 @@ std/language.support/support.limits/support.limits.general/barrier.version.compi
 # libc++ doesn't implement P2602R2 "Poison Pills Are Too Toxic"
 std/ranges/range.access/size.pass.cpp FAIL
 
-# libc++ doesn't implement P2652R2 "Disallowing User Specialization Of allocator_traits"
-std/utilities/memory/allocator.traits/allocate_at_least.pass.cpp FAIL
-
 # libc++ has not implemented P2937R0: "Freestanding Library: Remove strtok"
 std/language.support/support.limits/support.limits.general/cstring.version.compile.pass.cpp FAIL
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1337,18 +1337,4 @@ std/iterators/iterator.container/ssize.LWG3207.compile.pass.cpp:9 SKIPPED
 
 # These tests are marked as "UNSUPPORTED: !has-unix-headers" with comments saying:
 # "`check_assertion.h` requires Unix headers".
-std/algorithms/alg.modifying.operations/alg.fill/pstl.exception_handling.pass.cpp:9 SKIPPED
-std/algorithms/alg.modifying.operations/alg.move/pstl.exception_handling.pass.cpp:9 SKIPPED
-std/algorithms/alg.modifying.operations/alg.replace/pstl.exception_handling.pass.cpp:9 SKIPPED
-std/algorithms/alg.modifying.operations/alg.rotate/pstl.exception_handling.pass.cpp:9 SKIPPED
-std/algorithms/alg.modifying.operations/alg.transform/pstl.exception_handling.pass.cpp:9 SKIPPED
-std/algorithms/alg.nonmodifying/alg.all_of/pstl.exception_handling.pass.cpp:9 SKIPPED
-std/algorithms/alg.nonmodifying/alg.any_of/pstl.exception_handling.pass.cpp:9 SKIPPED
-std/algorithms/alg.nonmodifying/alg.equal/pstl.exception_handling.pass.cpp:9 SKIPPED
-std/algorithms/alg.nonmodifying/alg.find/pstl.exception_handling.pass.cpp:9 SKIPPED
-std/algorithms/alg.nonmodifying/alg.foreach/pstl.exception_handling.pass.cpp:9 SKIPPED
-std/algorithms/alg.nonmodifying/alg.none_of/pstl.exception_handling.pass.cpp:9 SKIPPED
-std/algorithms/alg.sorting/alg.merge/pstl.exception_handling.pass.cpp:9 SKIPPED
-std/algorithms/alg.sorting/alg.sort/stable.sort/pstl.exception_handling.pass.cpp:9 SKIPPED
-std/algorithms/numeric.ops/reduce/pstl.exception_handling.pass.cpp:9 SKIPPED
-std/algorithms/numeric.ops/transform.reduce/pstl.exception_handling.pass.cpp:9 SKIPPED
+std/algorithms/pstl.exception_handling.pass.cpp:9 SKIPPED

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -30,9 +30,6 @@ std/strings/basic.string/string.modifiers/string_assign/string.pass.cpp:2 FAIL
 std/utilities/memory/specialized.algorithms/uninitialized.copy/uninitialized_copy.pass.cpp FAIL
 std/utilities/memory/specialized.algorithms/uninitialized.move/uninitialized_move.pass.cpp FAIL
 
-# LLVM-79783: [libc++][test] array/size_and_alignment.compile.pass.cpp includes non-Standard <__type_traits/datasizeof.h>
-std/containers/sequences/array/size_and_alignment.compile.pass.cpp FAIL
-
 # LLVM-83734: [libc++][test] Don't include test_format_context.h in parse.pass.cpp
 std/containers/sequences/vector.bool/vector.bool.fmt/parse.pass.cpp FAIL
 std/thread/thread.threads/thread.thread.class/thread.thread.id/parse.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -234,7 +234,6 @@ std/utilities/format/format.range/format.range.fmtstr/format.pass.cpp FAIL
 std/utilities/format/format.range/format.range.fmtstr/parse.pass.cpp FAIL
 std/utilities/format/format.range/format.range.formatter/format.functions.format.pass.cpp FAIL
 std/utilities/format/format.range/format.range.formatter/format.functions.vformat.pass.cpp FAIL
-std/utilities/format/format.range/format.range.formatter/format.pass.cpp FAIL
 
 
 # *** MISSING COMPILER FEATURES ***
@@ -981,6 +980,7 @@ std/utilities/format/format.formatter/format.formatter.spec/formatter.pointer.pa
 std/utilities/format/format.formatter/format.formatter.spec/formatter.signed_integral.pass.cpp FAIL
 std/utilities/format/format.formatter/format.formatter.spec/formatter.string.pass.cpp FAIL
 std/utilities/format/format.formatter/format.formatter.spec/formatter.unsigned_integral.pass.cpp FAIL
+std/utilities/format/format.range/format.range.formatter/format.pass.cpp FAIL
 std/utilities/format/format.range/format.range.formatter/set_brackets.pass.cpp FAIL
 std/utilities/format/format.range/format.range.formatter/set_separator.pass.cpp FAIL
 std/utilities/format/format.tuple/format.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1076,6 +1076,8 @@ std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.it
 std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.iterator.pass.cpp:1 SKIPPED
 std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.range.pass.cpp:0 SKIPPED
 std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.range.pass.cpp:1 SKIPPED
+std/algorithms/alg.nonmodifying/alg.ends_with/ranges.ends_with.pass.cpp:0 SKIPPED
+std/algorithms/alg.nonmodifying/alg.ends_with/ranges.ends_with.pass.cpp:1 SKIPPED
 std/algorithms/alg.sorting/alg.merge/ranges_merge.pass.cpp:0 SKIPPED
 std/algorithms/alg.sorting/alg.merge/ranges_merge.pass.cpp:1 SKIPPED
 std/algorithms/alg.sorting/alg.set.operations/includes/ranges_includes.pass.cpp:0 SKIPPED

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1189,6 +1189,57 @@ std/input.output/iostream.format/output.streams/ostream.formatted/ostream.format
 std/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/vprint_nonunicode.pass.cpp FAIL
 std/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/vprint_unicode.pass.cpp FAIL
 
+# Not analyzed. test_chrono_leap_second.h wants us to provide a vendor-specific version of
+# test_leap_second_create(), but it's unclear how to adapt their parameters to our implementation.
+std/time/time.zone/time.zone.leap/assign.copy.pass.cpp FAIL
+std/time/time.zone/time.zone.leap/cons.copy.pass.cpp FAIL
+std/time/time.zone/time.zone.leap/members/date.pass.cpp FAIL
+std/time/time.zone/time.zone.leap/members/value.pass.cpp FAIL
+std/time/time.zone/time.zone.leap/nonmembers/comparison.pass.cpp FAIL
+
+# Not analyzed. Assertion failed: tzdb.leap_seconds.size() >= leap_seconds.size()
+std/time/time.zone/time.zone.db/leap_seconds.pass.cpp FAIL
+
+# Not analyzed. Assertion failed: tz->name() == zone
+std/time/time.zone/time.zone.db/time.zone.db.access/current_zone.pass.cpp FAIL
+std/time/time.zone/time.zone.db/time.zone.db.tzdb/current_zone.pass.cpp FAIL
+
+# Not analyzed. Assertion failed: buffer.pubsetbuf(b, 10) == &buffer
+std/input.output/file.streams/fstreams/filebuf.virtuals/setbuf.pass.cpp FAIL
+
+# Not analyzed. constexpr evaluation fails in assert(it.stride_count() == expected_counts.stride_count).
+std/iterators/iterator.primitives/range.iter.ops/range.iter.ops.advance/iterator_count_sentinel.pass.cpp FAIL
+
+# Not analyzed. Says "no exception is thrown while an exception of type std::format_error was expected".
+std/time/time.syn/formatter.local_info.pass.cpp FAIL
+
+# Not analyzed. <atomic> Assertion failed: atomic_ref underlying object is not aligned as required_alignment
+# SKIPPED because failures are sporadic and/or architecture-dependent.
+std/atomics/atomics.ref/assign.pass.cpp SKIPPED
+std/atomics/atomics.ref/bitwise_and_assign.pass.cpp SKIPPED
+std/atomics/atomics.ref/bitwise_or_assign.pass.cpp SKIPPED
+std/atomics/atomics.ref/bitwise_xor_assign.pass.cpp SKIPPED
+std/atomics/atomics.ref/compare_exchange_strong.pass.cpp SKIPPED
+std/atomics/atomics.ref/compare_exchange_weak.pass.cpp SKIPPED
+std/atomics/atomics.ref/convert.pass.cpp SKIPPED
+std/atomics/atomics.ref/ctor.pass.cpp SKIPPED
+std/atomics/atomics.ref/deduction.pass.cpp SKIPPED
+std/atomics/atomics.ref/exchange.pass.cpp SKIPPED
+std/atomics/atomics.ref/fetch_add.pass.cpp SKIPPED
+std/atomics/atomics.ref/fetch_and.pass.cpp SKIPPED
+std/atomics/atomics.ref/fetch_or.pass.cpp SKIPPED
+std/atomics/atomics.ref/fetch_sub.pass.cpp SKIPPED
+std/atomics/atomics.ref/fetch_xor.pass.cpp SKIPPED
+std/atomics/atomics.ref/increment_decrement.pass.cpp SKIPPED
+std/atomics/atomics.ref/is_always_lock_free.pass.cpp SKIPPED
+std/atomics/atomics.ref/load.pass.cpp SKIPPED
+std/atomics/atomics.ref/notify_all.pass.cpp SKIPPED
+std/atomics/atomics.ref/notify_one.pass.cpp SKIPPED
+std/atomics/atomics.ref/operator_minus_equals.pass.cpp SKIPPED
+std/atomics/atomics.ref/operator_plus_equals.pass.cpp SKIPPED
+std/atomics/atomics.ref/store.pass.cpp SKIPPED
+std/atomics/atomics.ref/wait.pass.cpp SKIPPED
+
 
 # *** XFAILs WHICH PASS ***
 # These tests contain `// XFAIL: msvc` comments, which accurately describe runtime failures for x86 and x64.

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -30,11 +30,6 @@ std/strings/basic.string/string.modifiers/string_assign/string.pass.cpp:2 FAIL
 std/utilities/memory/specialized.algorithms/uninitialized.copy/uninitialized_copy.pass.cpp FAIL
 std/utilities/memory/specialized.algorithms/uninitialized.move/uninitialized_move.pass.cpp FAIL
 
-# LLVM-83734: [libc++][test] Don't include test_format_context.h in parse.pass.cpp
-std/containers/sequences/vector.bool/vector.bool.fmt/parse.pass.cpp FAIL
-std/thread/thread.threads/thread.thread.class/thread.thread.id/parse.pass.cpp FAIL
-std/utilities/format/format.tuple/parse.pass.cpp FAIL
-
 # Non-Standard regex behavior.
 # "It seems likely that the test is still non-conforming due to how libc++ handles the 'w' character class."
 std/re/re.traits/lookup_classname.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -140,10 +140,6 @@ std/language.support/support.limits/support.limits.general/ranges.version.compil
 # libc++ is missing various <format> DRs
 std/language.support/support.limits/support.limits.general/format.version.compile.pass.cpp FAIL
 
-# libc++ doesn't implement LWG-2381
-std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_double.pass.cpp FAIL
-std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_float.pass.cpp FAIL
-
 # libc++ doesn't implement LWG-3670
 std/ranges/range.factories/range.iota.view/iterator/member_typedefs.compile.pass.cpp FAIL
 
@@ -708,9 +704,6 @@ std/time/time.clock/time.clock.file/to_from_sys.pass.cpp FAIL
 
 # libc++'s filesystem::path::iterator models bidirectional_iterator, which is not guaranteed by the Standard
 std/input.output/filesystems/class.path/range_concept_conformance.compile.pass.cpp FAIL
-
-# libc++ assumes long double is at least 80-bit; also affected by LWG-2381
-std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_long_double.pass.cpp FAIL
 
 # libc++ speculatively implemented an old proposed resolution for LWG-3645.
 # This test is bogus according to the wording that was ultimately accepted for C++23.

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1018,7 +1018,7 @@ std/time/time.duration/time.duration.nonmember/ostream.pass.cpp FAIL
 # Not analyzed. Assertion failed: loc.name() == "*"
 std/localization/locales/locale/locale.cons/name_construction.pass.cpp FAIL
 
-# Not analyzed. After LLVM-74630 fixes LLVM-74214, will be blocked by our ctype_base deriving from locale::facet.
+# Not analyzed. Blocked by our ctype_base deriving from locale::facet.
 std/localization/locale.categories/category.numeric/locale.num.get/user_defined_char_type.pass.cpp FAIL
 
 # Not analyzed. Assertion failed: res == cvt.ok

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -240,6 +240,8 @@ std/utilities/format/format.range/format.range.formatter/parse.pass.cpp FAIL
 
 # *** MISSING COMPILER FEATURES ***
 # P1169R4 static operator()
+std/ranges/range.adaptors/range.adaptor.object/range_adaptor_closure.pass.cpp:0 FAIL
+std/ranges/range.adaptors/range.adaptor.object/range_adaptor_closure.pass.cpp:1 FAIL
 std/thread/futures/futures.task/futures.task.members/ctad.static.compile.pass.cpp:0 FAIL
 std/thread/futures/futures.task/futures.task.members/ctad.static.compile.pass.cpp:1 FAIL
 std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/ctad.static.compile.pass.cpp:0 FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -654,15 +654,6 @@ std/numerics/complex.number/cmplx.over/proj.pass.cpp:1 FAIL
 # libc++ handles those input values differently
 std/numerics/complex.number/complex.value.ops/polar.pass.cpp FAIL
 
-# Assertion failed: std::abs(skew - x_skew) < 0.01
-# Random number generation test with too strict pass criteria (test8 failure probability ~= 0.04)
-std/numerics/rand/rand.dist/rand.dist.samp/rand.dist.samp.pconst/eval.pass.cpp FAIL
-
-# Assertion failed: std::abs(f(u[i], a, m, bk, c) - double(i)/N) < .001
-# Random number generation test with too strict pass criteria (test6 failure probability > 0.2)
-std/numerics/rand/rand.dist/rand.dist.samp/rand.dist.samp.plinear/eval_param.pass.cpp FAIL
-std/numerics/rand/rand.dist/rand.dist.samp/rand.dist.samp.plinear/eval.pass.cpp FAIL
-
 # Assertion failed: invalid min and max arguments for uniform_real
 # `param_type p(5);` is a precondition violation.
 std/numerics/rand/rand.dist/rand.dist.uni/rand.dist.uni.real/param_ctor.pass.cpp FAIL
@@ -878,25 +869,6 @@ std/iterators/iterator.primitives/iterator.operations/advance.pass.cpp SKIPPED
 
 # Not analyzed. Maybe Clang over-eagerly instantiating noexcept-specifier?
 std/utilities/memory/unique.ptr/iterator_concept_conformance.compile.pass.cpp:2 SKIPPED
-
-# Not analyzed. Assertion failed: std::abs((kurtosis - x_kurtosis) / x_kurtosis) < VARIOUS_VALUES
-std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.bin/eval.PR44847.pass.cpp FAIL
-std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.geo/eval_param.pass.cpp FAIL
-std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.geo/eval.pass.cpp FAIL
-std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.negbin/eval_param.pass.cpp FAIL
-std/numerics/rand/rand.dist/rand.dist.norm/rand.dist.norm.lognormal/eval_param.pass.cpp FAIL
-std/numerics/rand/rand.dist/rand.dist.norm/rand.dist.norm.lognormal/eval.pass.cpp FAIL
-std/numerics/rand/rand.dist/rand.dist.norm/rand.dist.norm.t/eval_param.pass.cpp FAIL
-std/numerics/rand/rand.dist/rand.dist.norm/rand.dist.norm.t/eval.pass.cpp FAIL
-std/numerics/rand/rand.dist/rand.dist.pois/rand.dist.pois.extreme/eval_param.pass.cpp FAIL
-std/numerics/rand/rand.dist/rand.dist.pois/rand.dist.pois.extreme/eval.pass.cpp FAIL
-std/numerics/rand/rand.dist/rand.dist.pois/rand.dist.pois.gamma/eval_param.pass.cpp FAIL
-std/numerics/rand/rand.dist/rand.dist.pois/rand.dist.pois.gamma/eval.pass.cpp FAIL
-std/numerics/rand/rand.dist/rand.dist.pois/rand.dist.pois.poisson/eval_param.pass.cpp FAIL
-
-# Not analyzed. Assertion failed: std::abs((skew - x_skew) / x_skew) < 0.01
-std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.bin/eval_param.pass.cpp FAIL
-std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.bin/eval.pass.cpp FAIL
 
 # Not analyzed. Runs forever
 std/numerics/rand/rand.dist/rand.dist.pois/rand.dist.pois.poisson/eval.pass.cpp SKIPPED

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -780,6 +780,7 @@ std/re/re.alg/re.alg.search/awk.locale.pass.cpp FAIL
 std/re/re.alg/re.alg.search/basic.locale.pass.cpp FAIL
 std/re/re.alg/re.alg.search/ecma.locale.pass.cpp FAIL
 std/re/re.alg/re.alg.search/extended.locale.pass.cpp FAIL
+
 # Not analyzed. Error mentions allocator<const T>.
 std/utilities/memory/specialized.algorithms/specialized.construct/construct_at.pass.cpp FAIL
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -946,6 +946,7 @@ std/algorithms/alg.nonmodifying/alg.count/ranges.count.pass.cpp FAIL
 std/containers/sequences/vector.bool/append_range.pass.cpp FAIL
 std/containers/sequences/vector.bool/assign_range.pass.cpp FAIL
 std/containers/sequences/vector.bool/insert_range.pass.cpp FAIL
+std/containers/sequences/vector/vector.modifiers/destroy_elements.pass.cpp FAIL
 std/containers/sequences/vector/vector.modifiers/insert_range.pass.cpp FAIL
 std/strings/basic.string/string.modifiers/string_replace/replace_with_range.pass.cpp FAIL
 std/utilities/charconv/charconv.to.chars/integral.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -235,7 +235,6 @@ std/utilities/format/format.range/format.range.fmtstr/parse.pass.cpp FAIL
 std/utilities/format/format.range/format.range.formatter/format.functions.format.pass.cpp FAIL
 std/utilities/format/format.range/format.range.formatter/format.functions.vformat.pass.cpp FAIL
 std/utilities/format/format.range/format.range.formatter/format.pass.cpp FAIL
-std/utilities/format/format.range/format.range.formatter/parse.pass.cpp FAIL
 
 
 # *** MISSING COMPILER FEATURES ***

--- a/tests/libcxx/magic_comments.txt
+++ b/tests/libcxx/magic_comments.txt
@@ -5,9 +5,11 @@
 // REQUIRES: c++11
 // REQUIRES: c++11 || c++14
 // REQUIRES: c++11 || c++14 || c++17 || c++20
+// REQUIRES: c++17
 // REQUIRES: has-unix-headers
 // REQUIRES: stdlib=libc++
-// UNSUPPORTED: c++14, c++17, c++2a
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23, c++26
 // UNSUPPORTED: msvc
-// UNSUPPORTED: msvc, target={{.+}}-windows-gnu
+// UNSUPPORTED: no-filesystem, no-localization, no-tzdb, has-no-zdump
 // UNSUPPORTED: windows

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -1394,12 +1394,12 @@ int run_test()
   static_assert(!std::is_assignable<std::variant<int, int>, int>::value, "");
   static_assert(!std::is_assignable<std::variant<long, long long>, int>::value, "");
 #if _HAS_CXX20
-  static_assert(std::is_assignable<std::variant<char>, int>::value == VariantAllowsNarrowingConversions, "");
+  static_assert(std::is_assignable<std::variant<char>, int>::value == false, "");
 
   static_assert(std::is_assignable<std::variant<std::string, float>, int>::value
-    == VariantAllowsNarrowingConversions, "");
+    == false, "");
   static_assert(std::is_assignable<std::variant<std::string, double>, int>::value
-    == VariantAllowsNarrowingConversions, "");
+    == false, "");
   static_assert(!std::is_assignable<std::variant<std::string, bool>, int>::value, "");
 
   static_assert(!std::is_assignable<std::variant<int, bool>, decltype("meow")>::value, "");
@@ -2676,7 +2676,7 @@ void test_T_assignment_sfinae() {
 #if _HAS_CXX20
   {
     using V = std::variant<std::string, float>;
-    static_assert(std::is_assignable<V, int>::value == VariantAllowsNarrowingConversions,
+    static_assert(std::is_assignable<V, int>::value == false,
     "no matching operator=");
   }
   {
@@ -2867,12 +2867,12 @@ int run_test()
   static_assert(!std::is_constructible<std::variant<int, int>, int>::value, "");
   static_assert(!std::is_constructible<std::variant<long, long long>, int>::value, "");
 #if _HAS_CXX20
-  static_assert(std::is_constructible<std::variant<char>, int>::value == VariantAllowsNarrowingConversions, "");
+  static_assert(std::is_constructible<std::variant<char>, int>::value == false, "");
 
   static_assert(std::is_constructible<std::variant<std::string, float>, int>::value
-    == VariantAllowsNarrowingConversions, "");
+    == false, "");
   static_assert(std::is_constructible<std::variant<std::string, double>, int>::value
-    == VariantAllowsNarrowingConversions, "");
+    == false, "");
   static_assert(!std::is_constructible<std::variant<std::string, bool>, int>::value, "");
 
   static_assert(!std::is_constructible<std::variant<int, bool>, decltype("meow")>::value, "");
@@ -4159,7 +4159,7 @@ void test_T_ctor_sfinae() {
 #if _HAS_CXX20
   {
     using V = std::variant<std::string, float>;
-    static_assert(std::is_constructible<V, int>::value == VariantAllowsNarrowingConversions,
+    static_assert(std::is_constructible<V, int>::value == false,
                   "no matching constructor");
   }
   {

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -140,30 +140,6 @@ void test_const_get_if() {
     static_assert(*std::get_if<1>(&v) == 42, "");
     static_assert(std::get_if<0>(&v) == nullptr, "");
   }
-// TODO: Remove these once reference support is reinstated
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int &>;
-    int x = 42;
-    const V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get_if<0>(&v)), int *);
-    assert(std::get_if<0>(&v) == &x);
-  }
-  {
-    using V = std::variant<int &&>;
-    int x = 42;
-    const V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get_if<0>(&v)), int *);
-    assert(std::get_if<0>(&v) == &x);
-  }
-  {
-    using V = std::variant<const int &&>;
-    int x = 42;
-    const V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get_if<0>(&v)), const int *);
-    assert(std::get_if<0>(&v) == &x);
-  }
-#endif
 }
 
 void test_get_if() {
@@ -187,37 +163,6 @@ void test_get_if() {
     assert(*std::get_if<1>(&v) == 42);
     assert(std::get_if<0>(&v) == nullptr);
   }
-// TODO: Remove these once reference support is reinstated
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int &>;
-    int x = 42;
-    V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get_if<0>(&v)), int *);
-    assert(std::get_if<0>(&v) == &x);
-  }
-  {
-    using V = std::variant<const int &>;
-    int x = 42;
-    V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get_if<0>(&v)), const int *);
-    assert(std::get_if<0>(&v) == &x);
-  }
-  {
-    using V = std::variant<int &&>;
-    int x = 42;
-    V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get_if<0>(&v)), int *);
-    assert(std::get_if<0>(&v) == &x);
-  }
-  {
-    using V = std::variant<const int &&>;
-    int x = 42;
-    V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get_if<0>(&v)), const int *);
-    assert(std::get_if<0>(&v) == &x);
-  }
-#endif
 }
 
 int run_test() {
@@ -274,30 +219,6 @@ void test_const_get_if() {
     static_assert(*std::get_if<const long>(&v) == 42, "");
     static_assert(std::get_if<int>(&v) == nullptr, "");
   }
-// TODO: Remove these once reference support is reinstated
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int &>;
-    int x = 42;
-    const V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get_if<int &>(&v)), int *);
-    assert(std::get_if<int &>(&v) == &x);
-  }
-  {
-    using V = std::variant<int &&>;
-    int x = 42;
-    const V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get_if<int &&>(&v)), int *);
-    assert(std::get_if<int &&>(&v) == &x);
-  }
-  {
-    using V = std::variant<const int &&>;
-    int x = 42;
-    const V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get_if<const int &&>(&v)), const int *);
-    assert(std::get_if<const int &&>(&v) == &x);
-  }
-#endif
 }
 
 void test_get_if() {
@@ -321,37 +242,6 @@ void test_get_if() {
     assert(*std::get_if<const long>(&v) == 42);
     assert(std::get_if<int>(&v) == nullptr);
   }
-// TODO: Remove these once reference support is reinstated
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int &>;
-    int x = 42;
-    V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get_if<int &>(&v)), int *);
-    assert(std::get_if<int &>(&v) == &x);
-  }
-  {
-    using V = std::variant<const int &>;
-    int x = 42;
-    V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get_if<const int &>(&v)), const int *);
-    assert(std::get_if<const int &>(&v) == &x);
-  }
-  {
-    using V = std::variant<int &&>;
-    int x = 42;
-    V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get_if<int &&>(&v)), int *);
-    assert(std::get_if<int &&>(&v) == &x);
-  }
-  {
-    using V = std::variant<const int &&>;
-    int x = 42;
-    V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get_if<const int &&>(&v)), const int *);
-    assert(std::get_if<const int &&>(&v) == &x);
-  }
-#endif
 }
 
 int run_test() {
@@ -436,30 +326,6 @@ void test_const_lvalue_get() {
     ASSERT_SAME_TYPE(decltype(std::get<1>(v)), const long &);
     assert(std::get<1>(v) == 42);
   }
-// TODO: Remove these once reference support is reinstated
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int &>;
-    int x = 42;
-    const V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get<0>(v)), int &);
-    assert(&std::get<0>(v) == &x);
-  }
-  {
-    using V = std::variant<int &&>;
-    int x = 42;
-    const V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get<0>(v)), int &);
-    assert(&std::get<0>(v) == &x);
-  }
-  {
-    using V = std::variant<const int &&>;
-    int x = 42;
-    const V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get<0>(v)), const int &);
-    assert(&std::get<0>(v) == &x);
-  }
-#endif
 }
 
 void test_lvalue_get() {
@@ -476,37 +342,6 @@ void test_lvalue_get() {
     ASSERT_SAME_TYPE(decltype(std::get<1>(v)), const long &);
     assert(std::get<1>(v) == 42);
   }
-// TODO: Remove these once reference support is reinstated
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int &>;
-    int x = 42;
-    V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get<0>(v)), int &);
-    assert(&std::get<0>(v) == &x);
-  }
-  {
-    using V = std::variant<const int &>;
-    int x = 42;
-    V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get<0>(v)), const int &);
-    assert(&std::get<0>(v) == &x);
-  }
-  {
-    using V = std::variant<int &&>;
-    int x = 42;
-    V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get<0>(v)), int &);
-    assert(&std::get<0>(v) == &x);
-  }
-  {
-    using V = std::variant<const int &&>;
-    int x = 42;
-    V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get<0>(v)), const int &);
-    assert(&std::get<0>(v) == &x);
-  }
-#endif
 }
 
 void test_rvalue_get() {
@@ -523,39 +358,6 @@ void test_rvalue_get() {
     ASSERT_SAME_TYPE(decltype(std::get<1>(std::move(v))), const long &&);
     assert(std::get<1>(std::move(v)) == 42);
   }
-// TODO: Remove these once reference support is reinstated
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int &>;
-    int x = 42;
-    V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get<0>(std::move(v))), int &);
-    assert(&std::get<0>(std::move(v)) == &x);
-  }
-  {
-    using V = std::variant<const int &>;
-    int x = 42;
-    V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get<0>(std::move(v))), const int &);
-    assert(&std::get<0>(std::move(v)) == &x);
-  }
-  {
-    using V = std::variant<int &&>;
-    int x = 42;
-    V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get<0>(std::move(v))), int &&);
-    int &&xref = std::get<0>(std::move(v));
-    assert(&xref == &x);
-  }
-  {
-    using V = std::variant<const int &&>;
-    int x = 42;
-    V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get<0>(std::move(v))), const int &&);
-    const int &&xref = std::get<0>(std::move(v));
-    assert(&xref == &x);
-  }
-#endif
 }
 
 void test_const_rvalue_get() {
@@ -572,39 +374,6 @@ void test_const_rvalue_get() {
     ASSERT_SAME_TYPE(decltype(std::get<1>(std::move(v))), const long &&);
     assert(std::get<1>(std::move(v)) == 42);
   }
-// TODO: Remove these once reference support is reinstated
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int &>;
-    int x = 42;
-    const V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get<0>(std::move(v))), int &);
-    assert(&std::get<0>(std::move(v)) == &x);
-  }
-  {
-    using V = std::variant<const int &>;
-    int x = 42;
-    const V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get<0>(std::move(v))), const int &);
-    assert(&std::get<0>(std::move(v)) == &x);
-  }
-  {
-    using V = std::variant<int &&>;
-    int x = 42;
-    const V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get<0>(std::move(v))), int &&);
-    int &&xref = std::get<0>(std::move(v));
-    assert(&xref == &x);
-  }
-  {
-    using V = std::variant<const int &&>;
-    int x = 42;
-    const V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get<0>(std::move(v))), const int &&);
-    const int &&xref = std::get<0>(std::move(v));
-    assert(&xref == &x);
-  }
-#endif
 }
 
 template <std::size_t I> using Idx = std::integral_constant<size_t, I>;
@@ -728,30 +497,6 @@ void test_const_lvalue_get() {
     ASSERT_SAME_TYPE(decltype(std::get<const long>(v)), const long &);
     assert(std::get<const long>(v) == 42);
   }
-// TODO: Remove these once reference support is reinstated
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int &>;
-    int x = 42;
-    const V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get<int &>(v)), int &);
-    assert(&std::get<int &>(v) == &x);
-  }
-  {
-    using V = std::variant<int &&>;
-    int x = 42;
-    const V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get<int &&>(v)), int &);
-    assert(&std::get<int &&>(v) == &x);
-  }
-  {
-    using V = std::variant<const int &&>;
-    int x = 42;
-    const V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get<const int &&>(v)), const int &);
-    assert(&std::get<const int &&>(v) == &x);
-  }
-#endif
 }
 
 void test_lvalue_get() {
@@ -768,37 +513,6 @@ void test_lvalue_get() {
     ASSERT_SAME_TYPE(decltype(std::get<const long>(v)), const long &);
     assert(std::get<const long>(v) == 42);
   }
-// TODO: Remove these once reference support is reinstated
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int &>;
-    int x = 42;
-    V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get<int &>(v)), int &);
-    assert(&std::get<int &>(v) == &x);
-  }
-  {
-    using V = std::variant<const int &>;
-    int x = 42;
-    V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get<const int &>(v)), const int &);
-    assert(&std::get<const int &>(v) == &x);
-  }
-  {
-    using V = std::variant<int &&>;
-    int x = 42;
-    V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get<int &&>(v)), int &);
-    assert(&std::get<int &&>(v) == &x);
-  }
-  {
-    using V = std::variant<const int &&>;
-    int x = 42;
-    V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get<const int &&>(v)), const int &);
-    assert(&std::get<const int &&>(v) == &x);
-  }
-#endif
 }
 
 void test_rvalue_get() {
@@ -816,41 +530,6 @@ void test_rvalue_get() {
                      const long &&);
     assert(std::get<const long>(std::move(v)) == 42);
   }
-// TODO: Remove these once reference support is reinstated
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int &>;
-    int x = 42;
-    V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get<int &>(std::move(v))), int &);
-    assert(&std::get<int &>(std::move(v)) == &x);
-  }
-  {
-    using V = std::variant<const int &>;
-    int x = 42;
-    V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get<const int &>(std::move(v))),
-                     const int &);
-    assert(&std::get<const int &>(std::move(v)) == &x);
-  }
-  {
-    using V = std::variant<int &&>;
-    int x = 42;
-    V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get<int &&>(std::move(v))), int &&);
-    int &&xref = std::get<int &&>(std::move(v));
-    assert(&xref == &x);
-  }
-  {
-    using V = std::variant<const int &&>;
-    int x = 42;
-    V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get<const int &&>(std::move(v))),
-                     const int &&);
-    const int &&xref = std::get<const int &&>(std::move(v));
-    assert(&xref == &x);
-  }
-#endif
 }
 
 void test_const_rvalue_get() {
@@ -868,41 +547,6 @@ void test_const_rvalue_get() {
                      const long &&);
     assert(std::get<const long>(std::move(v)) == 42);
   }
-// TODO: Remove these once reference support is reinstated
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int &>;
-    int x = 42;
-    const V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get<int &>(std::move(v))), int &);
-    assert(&std::get<int &>(std::move(v)) == &x);
-  }
-  {
-    using V = std::variant<const int &>;
-    int x = 42;
-    const V v(x);
-    ASSERT_SAME_TYPE(decltype(std::get<const int &>(std::move(v))),
-                     const int &);
-    assert(&std::get<const int &>(std::move(v)) == &x);
-  }
-  {
-    using V = std::variant<int &&>;
-    int x = 42;
-    const V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get<int &&>(std::move(v))), int &&);
-    int &&xref = std::get<int &&>(std::move(v));
-    assert(&xref == &x);
-  }
-  {
-    using V = std::variant<const int &&>;
-    int x = 42;
-    const V v(std::move(x));
-    ASSERT_SAME_TYPE(decltype(std::get<const int &&>(std::move(v))),
-                     const int &&);
-    const int &&xref = std::get<const int &&>(std::move(v));
-    assert(&xref == &x);
-  }
-#endif
 }
 
 template <class Tp> struct identity { using type = Tp; };
@@ -1265,16 +909,6 @@ int run_test() {
     test<V, 2, const void *>();
     test<V, 3, long double>();
   }
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int, int &, const int &, int &&, long double>;
-    test<V, 0, int>();
-    test<V, 1, int &>();
-    test<V, 2, const int &>();
-    test<V, 3, int &&>();
-    test<V, 4, long double>();
-  }
-#endif
 
   return 0;
 }
@@ -3070,16 +2704,6 @@ void test_T_assignment_sfinae() {
     static_assert(std::is_assignable<V, Y>::value,
                   "regression on user-defined conversions in operator=");
   }
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int, int &&>;
-    static_assert(!std::is_assignable<V, int>::value, "ambiguous");
-  }
-  {
-    using V = std::variant<int, const int &>;
-    static_assert(!std::is_assignable<V, int>::value, "ambiguous");
-  }
-#endif // TEST_VARIANT_HAS_NO_REFERENCES
 }
 
 void test_T_assignment_basic() {
@@ -3135,25 +2759,6 @@ void test_T_assignment_basic() {
     assert(v.index() == 0);
     assert(std::get<0>(v));
   }
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int &, int &&, long>;
-    int x = 42;
-    V v(43l);
-    v = x;
-    assert(v.index() == 0);
-    assert(&std::get<0>(v) == &x);
-    v = std::move(x);
-    assert(v.index() == 1);
-    assert(&std::get<1>(v) == &x);
-    // 'long' is selected by FUN(const int &) since 'const int &' cannot bind
-    // to 'int&'.
-    const int &cx = x;
-    v = cx;
-    assert(v.index() == 2);
-    assert(std::get<2>(v) == 42);
-  }
-#endif // TEST_VARIANT_HAS_NO_REFERENCES
 }
 
 void test_T_assignment_performs_construction() {
@@ -3612,12 +3217,6 @@ void test_default_ctor_sfinae() {
     using V = std::variant<NonDefaultConstructible, int>;
     static_assert(!std::is_default_constructible<V>::value, "");
   }
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int &, int>;
-    static_assert(!std::is_default_constructible<V>::value, "");
-  }
-#endif
 }
 
 void test_default_ctor_noexcept() {
@@ -4599,16 +4198,6 @@ void test_T_ctor_sfinae() {
 
 
 
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int, int &&>;
-    static_assert(!std::is_constructible<V, int>::value, "ambiguous");
-  }
-  {
-    using V = std::variant<int, const int &>;
-    static_assert(!std::is_constructible<V, int>::value, "ambiguous");
-  }
-#endif
 }
 
 void test_T_ctor_basic() {
@@ -4656,24 +4245,6 @@ void test_T_ctor_basic() {
     std::variant<RValueConvertibleFrom<int>, AnyConstructible> v2 = x;
     assert(v2.index() == 1);
   }
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<const int &, int &&, long>;
-    static_assert(std::is_convertible<int &, V>::value, "must be implicit");
-    int x = 42;
-    V v(x);
-    assert(v.index() == 0);
-    assert(&std::get<0>(v) == &x);
-  }
-  {
-    using V = std::variant<const int &, int &&, long>;
-    static_assert(std::is_convertible<int, V>::value, "must be implicit");
-    int x = 42;
-    V v(std::move(x));
-    assert(v.index() == 1);
-    assert(&std::get<1>(v) == &x);
-  }
-#endif
 }
 
 #if !_HAS_CXX20 // Narrowing check occurs with P0608R3
@@ -4853,29 +4424,6 @@ void test_emplace_sfinae() {
     static_assert(emplace_exists<V, 2, int *>(), "");
     static_assert(!emplace_exists<V, 3>(), "cannot construct");
   }
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int, int &, const int &, int &&, TestTypes::NoCtors>;
-    static_assert(emplace_exists<V, 0>(), "");
-    static_assert(emplace_exists<V, 0, int>(), "");
-    static_assert(emplace_exists<V, 0, long long>(), "");
-    static_assert(!emplace_exists<V, 0, int, int>(), "too many args");
-    static_assert(emplace_exists<V, 1, int &>(), "");
-    static_assert(!emplace_exists<V, 1>(), "cannot default construct ref");
-    static_assert(!emplace_exists<V, 1, const int &>(), "cannot bind ref");
-    static_assert(!emplace_exists<V, 1, int &&>(), "cannot bind ref");
-    static_assert(emplace_exists<V, 2, int &>(), "");
-    static_assert(emplace_exists<V, 2, const int &>(), "");
-    static_assert(emplace_exists<V, 2, int &&>(), "");
-    static_assert(!emplace_exists<V, 2, void *>(),
-                  "not constructible from void*");
-    static_assert(emplace_exists<V, 3, int>(), "");
-    static_assert(!emplace_exists<V, 3, int &>(), "cannot bind ref");
-    static_assert(!emplace_exists<V, 3, const int &>(), "cannot bind ref");
-    static_assert(!emplace_exists<V, 3, const int &&>(), "cannot bind ref");
-    static_assert(!emplace_exists<V, 4>(), "no ctors");
-  }
-#endif
 }
 
 void test_basic() {
@@ -4911,41 +4459,6 @@ void test_basic() {
     assert(std::get<4>(v) == "aaa");
     assert(&ref3 == &std::get<4>(v));
   }
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int, long, const int &, int &&, TestTypes::NoCtors,
-                           std::string>;
-    const int x = 100;
-    int y = 42;
-    int z = 43;
-    V v(std::in_place_index<0>, -1);
-    // default emplace a value
-    auto& ref1 = v.emplace<1>();
-    static_assert(std::is_same_v<long&, decltype(ref1)>, "");
-    assert(std::get<1>(v) == 0);
-    assert(&ref1 == &std::get<1>(v));
-    // emplace a reference
-    auto& ref2 = v.emplace<2>(x);
-    static_assert(std::is_same_v<&, decltype(ref)>, "");
-    assert(&std::get<2>(v) == &x);
-    assert(&ref2 == &std::get<2>(v));
-    // emplace an rvalue reference
-    auto& ref3 = v.emplace<3>(std::move(y));
-    static_assert(std::is_same_v<&, decltype(ref)>, "");
-    assert(&std::get<3>(v) == &y);
-    assert(&ref3 == &std::get<3>(v));
-    // re-emplace a new reference over the active member
-    auto& ref4 = v.emplace<3>(std::move(z));
-    static_assert(std::is_same_v<&, decltype(ref)>, "");
-    assert(&std::get<3>(v) == &z);
-    assert(&ref4 == &std::get<3>(v));
-    // emplace with multiple args
-    auto& ref5 = v.emplace<5>(3u, 'a');
-    static_assert(std::is_same_v<std::string&, decltype(ref5)>, "");
-    assert(std::get<5>(v) == "aaa");
-    assert(&ref5 == &std::get<5>(v));
-  }
-#endif
 }
 
 int run_test() {
@@ -5113,30 +4626,6 @@ void test_emplace_sfinae() {
     static_assert(emplace_exists<V, const void *, int *>(), "");
     static_assert(!emplace_exists<V, TestTypes::NoCtors>(), "cannot construct");
   }
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  using V = std::variant<int, int &, const int &, int &&, long, long,
-                         TestTypes::NoCtors>;
-  static_assert(emplace_exists<V, int>(), "");
-  static_assert(emplace_exists<V, int, int>(), "");
-  static_assert(emplace_exists<V, int, long long>(), "");
-  static_assert(!emplace_exists<V, int, int, int>(), "too many args");
-  static_assert(emplace_exists<V, int &, int &>(), "");
-  static_assert(!emplace_exists<V, int &>(), "cannot default construct ref");
-  static_assert(!emplace_exists<V, int &, const int &>(), "cannot bind ref");
-  static_assert(!emplace_exists<V, int &, int &&>(), "cannot bind ref");
-  static_assert(emplace_exists<V, const int &, int &>(), "");
-  static_assert(emplace_exists<V, const int &, const int &>(), "");
-  static_assert(emplace_exists<V, const int &, int &&>(), "");
-  static_assert(!emplace_exists<V, const int &, void *>(),
-                "not constructible from void*");
-  static_assert(emplace_exists<V, int &&, int>(), "");
-  static_assert(!emplace_exists<V, int &&, int &>(), "cannot bind ref");
-  static_assert(!emplace_exists<V, int &&, const int &>(), "cannot bind ref");
-  static_assert(!emplace_exists<V, int &&, const int &&>(), "cannot bind ref");
-  static_assert(!emplace_exists<V, long, long>(), "ambiguous");
-  static_assert(!emplace_exists<V, TestTypes::NoCtors>(),
-                "cannot construct void");
-#endif
 }
 
 void test_basic() {
@@ -5172,41 +4661,6 @@ void test_basic() {
     assert(std::get<4>(v) == "aaa");
     assert(&ref3 == &std::get<4>(v));
   }
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  {
-    using V = std::variant<int, long, const int &, int &&, TestTypes::NoCtors,
-                           std::string>;
-    const int x = 100;
-    int y = 42;
-    int z = 43;
-    V v(std::in_place_index<0>, -1);
-    // default emplace a value
-    auto& ref1 = v.emplace<long>();
-    static_assert(std::is_same_v<long&, decltype(ref1)>, "");
-    assert(std::get<long>(v) == 0);
-    assert(&ref1 == &std::get<long>(v));
-    // emplace a reference
-    auto& ref2 = v.emplace<const int &>(x);
-    static_assert(std::is_same_v<const int&, decltype(ref2)>, "");
-    assert(&std::get<const int &>(v) == &x);
-    assert(&ref2 == &std::get<const int &>(v));
-    // emplace an rvalue reference
-    auto& ref3 = v.emplace<int &&>(std::move(y));
-    static_assert(std::is_same_v<int &&, decltype(ref3)>, "");
-    assert(&std::get<int &&>(v) == &y);
-    assert(&ref3 == &std::get<int &&>(v));
-    // re-emplace a new reference over the active member
-    auto& ref4 = v.emplace<int &&>(std::move(z));
-    static_assert(std::is_same_v<int &, decltype(ref4)>, "");
-    assert(&std::get<int &&>(v) == &z);
-    assert(&ref4 == &std::get<int &&>(v));
-    // emplace with multiple args
-    auto& ref5 = v.emplace<std::string>(3u, 'a');
-    static_assert(std::is_same_v<std::string&, decltype(ref5)>, "");
-    assert(std::get<std::string>(v) == "aaa");
-    assert(&ref5 == &std::get<std::string>(v));
-  }
-#endif
 }
 
 int run_test() {
@@ -6208,36 +5662,6 @@ void test_argument_forwarding() {
     std::visit(obj, std::move(cv));
     assert(Fn::check_call<const int &&>(Val));
   }
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  { // single argument - lvalue reference
-    using V = std::variant<int &>;
-    int x = 42;
-    V v(x);
-    const V &cv = v;
-    std::visit(obj, v);
-    assert(Fn::check_call<int &>(Val));
-    std::visit(obj, cv);
-    assert(Fn::check_call<int &>(Val));
-    std::visit(obj, std::move(v));
-    assert(Fn::check_call<int &>(Val));
-    std::visit(obj, std::move(cv));
-    assert(Fn::check_call<int &>(Val));
-  }
-  { // single argument - rvalue reference
-    using V = std::variant<int &&>;
-    int x = 42;
-    V v(std::move(x));
-    const V &cv = v;
-    std::visit(obj, v);
-    assert(Fn::check_call<int &>(Val));
-    std::visit(obj, cv);
-    assert(Fn::check_call<int &>(Val));
-    std::visit(obj, std::move(v));
-    assert(Fn::check_call<int &&>(Val));
-    std::visit(obj, std::move(cv));
-    assert(Fn::check_call<int &&>(Val));
-  }
-#endif
   { // multi argument - multi variant
     using V = std::variant<int, std::string, long>;
     V v1(42), v2("hello"), v3(43l);
@@ -6659,36 +6083,6 @@ void test_argument_forwarding() {
     std::visit<ReturnType>(obj, std::move(cv));
     assert(Fn::check_call<const int &&>(Val));
   }
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-  { // single argument - lvalue reference
-    using V = std::variant<int &>;
-    int x = 42;
-    V v(x);
-    const V &cv = v;
-    std::visit<ReturnType>(obj, v);
-    assert(Fn::check_call<int &>(Val));
-    std::visit<ReturnType>(obj, cv);
-    assert(Fn::check_call<int &>(Val));
-    std::visit<ReturnType>(obj, std::move(v));
-    assert(Fn::check_call<int &>(Val));
-    std::visit<ReturnType>(obj, std::move(cv));
-    assert(Fn::check_call<int &>(Val));
-  }
-  { // single argument - rvalue reference
-    using V = std::variant<int &&>;
-    int x = 42;
-    V v(std::move(x));
-    const V &cv = v;
-    std::visit<ReturnType>(obj, v);
-    assert(Fn::check_call<int &>(Val));
-    std::visit<ReturnType>(obj, cv);
-    assert(Fn::check_call<int &>(Val));
-    std::visit<ReturnType>(obj, std::move(v));
-    assert(Fn::check_call<int &&>(Val));
-    std::visit<ReturnType>(obj, std::move(cv));
-    assert(Fn::check_call<int &&>(Val));
-  }
-#endif
   { // multi argument - multi variant
     using V = std::variant<int, std::string, long>;
     V v1(42), v2("hello"), v3(43l);
@@ -7446,52 +6840,6 @@ namespace msvc {
                 std::visit<R>(obj, std::move(cv));
                 assert(Fn::check_call<const int&&>(Val));
             }
-#if !defined(TEST_VARIANT_HAS_NO_REFERENCES)
-            { // single argument - lvalue reference
-                using V = std::variant<int&>;
-                int x   = 42;
-                V v(x);
-                const V& cv = v;
-                std::visit<R>(obj, v);
-                assert(Fn::check_call<int&>(Val));
-                std::visit<R>(obj, cv);
-                assert(Fn::check_call<int&>(Val));
-                std::visit<R>(obj, std::move(v));
-                assert(Fn::check_call<int&>(Val));
-                std::visit<R>(obj, std::move(cv));
-                assert(Fn::check_call<int&>(Val));
-            }
-            { // single argument - rvalue reference
-                using V = std::variant<int&&>;
-                int x   = 42;
-                V v(std::move(x));
-                const V& cv = v;
-                std::visit<R>(obj, v);
-                assert(Fn::check_call<int&>(Val));
-                std::visit<R>(obj, cv);
-                assert(Fn::check_call<int&>(Val));
-                std::visit<R>(obj, std::move(v));
-                assert(Fn::check_call<int&&>(Val));
-                std::visit<R>(obj, std::move(cv));
-                assert(Fn::check_call<int&&>(Val));
-            }
-            { // multi argument - multi variant
-                using S               = const std::string&;
-                using V               = std::variant<int, S, long&&>;
-                const std::string str = "hello";
-                long l                = 43;
-                V v1(42);
-                const V& cv1 = v1;
-                V v2(str);
-                const V& cv2 = v2;
-                V v3(std::move(l));
-                const V& cv3 = v3;
-                std::visit<R>(obj, v1, v2, v3);
-                assert((Fn::check_call<int&, S, long&>(Val)));
-                std::visit<R>(obj, cv1, cv2, std::move(v3));
-                assert((Fn::check_call<const int&, S, long&&>(Val)));
-            }
-#endif
         }
 
         struct ReturnFirst {

--- a/tests/utils/stl/test/features.py
+++ b/tests/utils/stl/test/features.py
@@ -24,6 +24,7 @@ def hasLocale(loc):
 def getDefaultFeatures(config, litConfig):
     DEFAULT_FEATURES = [
         Feature(name='has-64-bit-atomics'),
+        Feature(name='has-1024-bit-atomics'),
         Feature(name='msvc'),
         Feature(name='windows'),
     ]

--- a/tests/utils/stl/test/features.py
+++ b/tests/utils/stl/test/features.py
@@ -25,6 +25,7 @@ def getDefaultFeatures(config, litConfig):
     DEFAULT_FEATURES = [
         Feature(name='has-64-bit-atomics'),
         Feature(name='has-1024-bit-atomics'),
+        Feature(name='has-no-zdump'),
         Feature(name='msvc'),
         Feature(name='windows'),
     ]

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -267,7 +267,7 @@ class STLTest(Test):
             if flag[1:5] == 'std:':
                 foundStd = True
                 if flag[5:] == 'c++latest':
-                    self._addCustomFeature('c++2b')
+                    self._addCustomFeature('c++23')
                 elif flag[5:] == 'c++20':
                     self._addCustomFeature('c++20')
                 elif flag[5:] == 'c++17':

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -322,9 +322,6 @@ class STLTest(Test):
             self._addCustomFeature('MT')
             self._addCustomFeature('static_CRT')
 
-        self._addCustomFeature('non-lockfree-atomics') # we always support non-lockfree-atomics
-        self._addCustomFeature('is-lockfree-runtime-function') # Ditto
-
         # clang doesn't know how to link in the VS version of the asan runtime automatically
         if 'asan' in self.config.available_features and 'clang' in self.config.available_features:
             self.linkFlags.append("/INFERASANLIBS")


### PR DESCRIPTION
* This updates our llvm-project submodule for the first time in 4 months. Previously:
  + #4263
  + #4348
* To make this possible, I had to fix the following things upstream:
  + llvm/llvm-project#93255
  + llvm/llvm-project#93257
  + llvm/llvm-project#93259
* Tons of things have been fixed upstream, allowing us to remove many expected failures and update comments:
  + llvm/llvm-project#77948
  + llvm/llvm-project#79978
  + llvm/llvm-project#79856
  + llvm/llvm-project#83734
  + llvm/llvm-project#74534
  + llvm/llvm-project#88669
  + llvm/llvm-project#90981
  + llvm/llvm-project#88998
  + llvm/llvm-project#74630
  + llvm/llvm-project#79793
* libcxx replaced old Features with 'has-1024-bit-atomics' (and unconditional Features should be defined in features.py instead of tests.py):
  + llvm/llvm-project#75553
  + llvm/llvm-project#83841
* We 'has-no-zdump' (a unix program).
* libcxx now uses 'c++23' instead of 'c++2b'. I believe this was:
  + https://github.com/llvm/llvm-project/commit/71400505ca04
  + llvm/llvm-project#69035
* Remove C++26 features from 'MISSING STL FEATURES'.
  + Now that we're identifying ourselves as being a C++23 implementation.
* Update magic comments.
  + These are used by the internal test harness to skip tests.
  + The two removed lines no longer appear in libcxx.
* range_adaptor_closure.pass.cpp needs WG21-P1169R4 `static operator()`.
* Add missing newline.
* Mark vector.modifiers/destroy_elements.pass.cpp as failing due to constexpr step limits.
* Categorize failing tests.
* format.range.formatter/parse.pass.cpp is now passing after #4642.
* Recategorize format.range.formatter/format.pass.cpp.
* Skip ranges.ends_with.pass.cpp which sporadically fails with "fatal error C1060: compiler is out of heap space".
* Finally, we need to update `tests/std/tests/P0088R3_variant/test.cpp` because it uses LLVM machinery. Both `VariantAllowsNarrowingConversions` and `variant<T&>` coverage were removed:
  + llvm/llvm-project#83928
  + llvm/llvm-project#84222

I'm working on a full regeneration of `P0088R3_variant`, but that's going to be a *much* larger change and I don't want to mix that into this PR.