### PR TITLE
Update _MSVC_STL_UPDATE to June 2024 in yvals_core.h

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -880,7 +880,7 @@
 
 #define _CPPLIB_VER       650
 #define _MSVC_STL_VERSION 143
-#define _MSVC_STL_UPDATE  202406L 
+#define _MSVC_STL_UPDATE  202406L
 
 #ifndef _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
 #if defined(__CUDACC__) && defined(__CUDACC_VER_MAJOR__)

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -880,7 +880,7 @@
 
 #define _CPPLIB_VER       650
 #define _MSVC_STL_VERSION 143
-#define _MSVC_STL_UPDATE  202405L
+#define _MSVC_STL_UPDATE  202406L 
 
 #ifndef _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
 #if defined(__CUDACC__) && defined(__CUDACC_VER_MAJOR__)


### PR DESCRIPTION
Fixes #4704

This pull request updates the _MSVC_STL_UPDATE macro value in yvals_core.h to the latest version. This change is intended to reflect the current state of the STL.