### PR TITLE
`<__msvc_int128.hpp>`: Fix warning C26437 about slicing

### DIFF
--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -444,8 +444,8 @@ struct
         return _Result;
     }
     _NODISCARD static constexpr _Base128 _Divide(const _Base128& _Num_arg, const _Base128& _Den_arg) noexcept {
-        _Base128 _Num{_Num_arg};
-        _Base128 _Den{_Den_arg};
+        _Base128 _Num{_Num_arg}; // Avoid warning C26437 by creating local (sliced) copies
+        _Base128 _Den{_Den_arg}; // instead of taking parameters by value.
 
         // establish _Den < _Num and _Num._Word[1] > 0
         if (_Den._Word[1] >= _Num._Word[1]) {
@@ -568,8 +568,8 @@ struct
         return _Rem;
     }
     _NODISCARD static constexpr _Base128 _Modulo(const _Base128& _Num_arg, const _Base128& _Den_arg) noexcept {
-        _Base128 _Num{_Num_arg};
-        _Base128 _Den{_Den_arg};
+        _Base128 _Num{_Num_arg}; // Avoid warning C26437 by creating local (sliced) copies
+        _Base128 _Den{_Den_arg}; // instead of taking parameters by value.
 
         // establish _Den < _Num and _Num._Word[1] > 0
         if (_Den._Word[1] >= _Num._Word[1]) {

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -443,7 +443,10 @@ struct
         _Result._Word[0] = _UDiv128(_Rem, _Num._Word[0], _Den, _Rem);
         return _Result;
     }
-    _NODISCARD static constexpr _Base128 _Divide(_Base128 _Num, _Base128 _Den) noexcept {
+    _NODISCARD static constexpr _Base128 _Divide(const _Base128& _Num_arg, const _Base128& _Den_arg) noexcept {
+        _Base128 _Num{_Num_arg};
+        _Base128 _Den{_Den_arg};
+
         // establish _Den < _Num and _Num._Word[1] > 0
         if (_Den._Word[1] >= _Num._Word[1]) {
             if (_Den._Word[1] > _Num._Word[1]) {
@@ -564,7 +567,10 @@ struct
         (void) _UDiv128(_Num._Word[1] % _Den, _Num._Word[0], _Den, _Rem);
         return _Rem;
     }
-    _NODISCARD static constexpr _Base128 _Modulo(_Base128 _Num, _Base128 _Den) noexcept {
+    _NODISCARD static constexpr _Base128 _Modulo(const _Base128& _Num_arg, const _Base128& _Den_arg) noexcept {
+        _Base128 _Num{_Num_arg};
+        _Base128 _Den{_Den_arg};
+
         // establish _Den < _Num and _Num._Word[1] > 0
         if (_Den._Word[1] >= _Num._Word[1]) {
             if (_Den._Word[1] > _Num._Word[1]) {

--- a/tests/std/rulesets/stl.ruleset
+++ b/tests/std/rulesets/stl.ruleset
@@ -3,6 +3,8 @@
 <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
 <RuleSet Name="STL Ruleset" Description="C++ Core Guidelines rules for microsoft/STL" ToolsVersion="15.0">
   <Rules AnalyzerId="Microsoft.Analyzers.NativeCodeAnalysis" RuleNamespace="Microsoft.Rules.Native">
+    <!-- Do not slice (es.63). -->
+    <Rule Id="C26437" Action="Warning" />
     <!-- The pointer is dangling because it points at a temporary instance that was destroyed. (ES.65) -->
     <Rule Id="C26815" Action="Warning" />
     <!-- The pointer points to memory allocated on the stack (ES.65) -->


### PR DESCRIPTION
In internal MSVC-PR-555396, @MahmoudGSaleh updated our checked-in toolset to VS 2022 17.11 Preview 2 and encountered a newly emitted [warning C26437](https://learn.microsoft.com/en-us/cpp/code-quality/c26437?view=msvc-170): "Do not slice (es.63)." One affected call:

https://github.com/microsoft/STL/blob/e36ee6c2b9bc6f5b1f70776c18cf5d3a93a69798/stl/inc/__msvc_int128.hpp#L902-L903

This can be avoided, for all callsites, by changing `_Base128`'s `_Divide()` and `_Modulo()` to copy their parameters locally. (This is still slicing, of course, just in a way that the compiler won't complain about. :smirk_cat:)

I'm also updating our test coverage to prevent regressions. Note that 17.11 Preview 2 newly warns about this code; 17.11 Preview 1 didn't warn.