### PR TITLE
Fix warning C26818 about `switch` statements needing `default` cases

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -4177,6 +4177,8 @@ namespace chrono {
             case '+':
                 ++_First;
                 break;
+            default:
+                break;
             }
 
             // For a regular offset hh[mm], simply read four digits, with the option of an EOF or non-digit after

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -276,6 +276,8 @@ _NODISCARD constexpr _Decode_result<char> _Decode_utf(const char* _First, const 
             return {_First + 1, false};
         }
         break;
+    default:
+        break;
     }
 
     // mask out the "value bits" in the leading byte,
@@ -1260,6 +1262,8 @@ _NODISCARD constexpr const _CharT* _Parse_align(
             break;
         case '^':
             _Parsed_align = _Fmt_align::_Center;
+            break;
+        default:
             break;
         }
 
@@ -2851,6 +2855,8 @@ _NODISCARD _OutputIt _Write_integral(
         break;
     case 'o':
         _Base = 8;
+        break;
+    default:
         break;
     }
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -292,6 +292,9 @@ _NODISCARD constexpr _Decode_result<char> _Decode_utf(const char* _First, const 
     case 4:
         _Val &= 0b111u;
         break;
+    default:
+        _STL_INTERNAL_CHECK(false); // can't happen, see how the value of _Num_bytes is determined
+        break;
     }
 
     for (int _Idx = 1; _Idx < _Num_bytes; ++_Idx) {

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -4456,6 +4456,8 @@ _NODISCARD constexpr const _CharT* _Parse_range_specs(
         _Callbacks._On_type(_Maybe_type);
         ++_Begin;
         break;
+    default:
+        break;
     }
 
     return _Begin;
@@ -4542,6 +4544,10 @@ public:
                 _Throw_format_error("Range-types 's' and '?s' require type T to be charT.");
             }
 
+            break;
+
+        default:
+            _STL_INTERNAL_CHECK(false); // can't happen, we've handled all possible outputs from _Parse_range_specs()
             break;
         }
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -295,7 +295,7 @@ _NODISCARD constexpr _Decode_result<char> _Decode_utf(const char* _First, const 
         _Val &= 0b111u;
         break;
     default:
-        _STL_INTERNAL_CHECK(false); // can't happen, see how the value of _Num_bytes is determined
+        _STL_UNREACHABLE; // can't happen, see how the value of _Num_bytes is determined
         break;
     }
 
@@ -4547,7 +4547,7 @@ public:
             break;
 
         default:
-            _STL_INTERNAL_CHECK(false); // can't happen, we've handled all possible outputs from _Parse_range_specs()
+            _STL_UNREACHABLE; // can't happen, we've handled all possible outputs from _Parse_range_specs()
             break;
         }
 

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -3922,6 +3922,9 @@ void _Parser<_FwdIt, _Elem, _RxTraits>::_Trans() { // map character to meta-char
         }
 
         break;
+
+    default:
+        break;
     }
 }
 

--- a/stl/inc/xlocmon
+++ b/stl/inc/xlocmon
@@ -567,7 +567,9 @@ private:
                     if (_Pattern.field[_Off] == money_base::space && !_Seen) {
                         _Bad = true; // fail if no space seen
                     }
-                } // parse optional space
+
+                    break;
+                }
             } // switch
         }
 
@@ -840,6 +842,7 @@ private:
                     _Dest      = _Rep(_Dest, _Fill, _Fillcount);
                     _Fillcount = 0;
                 }
+                break;
             }
         }
 

--- a/stl/inc/xlocmon
+++ b/stl/inc/xlocmon
@@ -570,6 +570,12 @@ private:
 
                     break;
                 }
+
+            default:
+                _STL_ASSERT(false, "Invalid money_base::pattern, see N4981 [locale.moneypunct.general]/1: "
+                                   "In the field member of a pattern object, each value symbol, sign, value, "
+                                   "and either space or none appears exactly once.");
+                break;
             } // switch
         }
 
@@ -789,6 +795,12 @@ private:
                 }
 
                 break;
+
+            default:
+                _STL_ASSERT(false, "Invalid money_base::pattern, see N4981 [locale.moneypunct.general]/1: "
+                                   "In the field member of a pattern object, each value symbol, sign, value, "
+                                   "and either space or none appears exactly once.");
+                break;
             }
         }
 
@@ -842,6 +854,12 @@ private:
                     _Dest      = _Rep(_Dest, _Fill, _Fillcount);
                     _Fillcount = 0;
                 }
+                break;
+
+            default:
+                _STL_ASSERT(false, "Invalid money_base::pattern, see N4981 [locale.moneypunct.general]/1: "
+                                   "In the field member of a pattern object, each value symbol, sign, value, "
+                                   "and either space or none appears exactly once.");
                 break;
             }
         }

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -563,6 +563,7 @@ protected:
 
         default:
             _State |= ios_base::failbit; // unknown specifier
+            break;
         }
 
         if (_First == _Last) {

--- a/tests/std/rulesets/stl.ruleset
+++ b/tests/std/rulesets/stl.ruleset
@@ -7,5 +7,7 @@
     <Rule Id="C26815" Action="Warning" />
     <!-- The pointer points to memory allocated on the stack (ES.65) -->
     <Rule Id="C26816" Action="Warning" />
+    <!-- Switch statement does not cover all cases. Consider adding a 'default' label (es.79). -->
+    <Rule Id="C26818" Action="Warning" />
   </Rules>
 </RuleSet>

--- a/tests/std/tests/GH_002094_cpp_core_guidelines/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002094_cpp_core_guidelines/test.compile.pass.cpp
@@ -2,3 +2,36 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <__msvc_all_public_headers.hpp>
+
+using namespace std;
+
+#if _HAS_CXX23
+template <class T>
+struct WrappedVector : vector<T> {
+    using vector<T>::vector;
+};
+
+template <class T>
+struct std::formatter<WrappedVector<T>, char> {
+public:
+    template <class ParseContext>
+    constexpr auto parse(ParseContext& ctx) {
+        return underlying.parse(ctx);
+    }
+
+    template <class FormatContext>
+    auto format(const WrappedVector<T>& rng, FormatContext& ctx) const {
+        return underlying.format(rng, ctx);
+    }
+
+private:
+    range_formatter<T, char> underlying;
+};
+
+void instantiate_range_formatter_machinery() {
+    const WrappedVector<int> v{11, 22, 33, 44};
+    assert(format("{}", v) == "[11, 22, 33, 44]");
+    assert(format("{:}", v) == "[11, 22, 33, 44]");
+    assert(format("{:n}", v) == "11, 22, 33, 44");
+}
+#endif // ^^^ _HAS_CXX23 ^^^

--- a/tests/std/tests/GH_002094_cpp_core_guidelines/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002094_cpp_core_guidelines/test.compile.pass.cpp
@@ -5,6 +5,11 @@
 
 using namespace std;
 
+void instantiate_regex_machinery() {
+    const regex r{R"(.+meow.+)"};
+    assert(regex_match("homeowner", r));
+}
+
 #if _HAS_CXX20
 void instantiate_chrono_parse_machinery() {
     istringstream iss{"10:02:07"};

--- a/tests/std/tests/GH_002094_cpp_core_guidelines/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002094_cpp_core_guidelines/test.compile.pass.cpp
@@ -5,6 +5,15 @@
 
 using namespace std;
 
+#if _HAS_CXX20
+void instantiate_chrono_parse_machinery() {
+    istringstream iss{"10:02:07"};
+    chrono::seconds s{};
+    iss >> chrono::parse("%H:%M:%S", s);
+    assert(s == 36127s);
+}
+#endif // ^^^ _HAS_CXX20 ^^^
+
 #if _HAS_CXX23
 template <class T>
 struct WrappedVector : vector<T> {


### PR DESCRIPTION
Fixes DevCom-10670613 VSO-2081258 / AB#2081258.

In general, we haven't attempted to be clean with respect to Core Guidelines warnings, as many of them are noisy and/or inappropriate for Standard Library code. However, warning C26818 "Switch statement does not cover all cases. Consider adding a 'default' label ([es.79][])." aligns with our conventions. We always like to have a `default` as a reminder to think about what happens when none of the `case`s are selected (this is one of the relatively few scenarios where we like to write code that isn't necessary). The only exception to this convention is when we're switching on an enum and we've handled all of the enumerators (it can still be okay to have a "can't happen" `default`, but sometimes we don't bother), which fortunately this warning doesn't complain about.

[es.79]: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-default

I added test coverage for all of these fixes, i.e. removing any fix will cause `GH_002094_cpp_core_guidelines` to fail.

All of the empty `default: break;` cases being added are used, i.e. making them `abort()` will cause other tests to fail.

In `<format>`, we have a couple of "can't happen" cases, where I've added `_STL_UNREACHABLE` with comments explaining why.

In `<xlocmon>`, we have `default` cases that can only be activated by users giving us a bogus `money_base::pattern`, so I've added `_STL_ASSERT(false, "message")` citing the same Standardese each time.

While auditing all of our `switch` statements (which is how I found half of these), I found a few cases in old code where we weren't obeying our syntax convention: a `switch`'s last `case` or `default` must always `break`. Falling off of the end is an unacceptable maintenance hazard.

Finally, I removed an unnecessary, inconsistent comment in `<xlocmon>`.