### PR TITLE
Overhaul `condition_variable`

### DIFF
--- a/stl/inc/__msvc_threads_core.hpp
+++ b/stl/inc/__msvc_threads_core.hpp
@@ -52,6 +52,11 @@ struct _Mtx_internal_imp_t {
 
 using _Mtx_t = _Mtx_internal_imp_t*;
 
+struct _Stl_condition_variable {
+    void* _Unused = nullptr; // TRANSITION, ABI: was the vptr
+    void* _Win_cv = nullptr;
+};
+
 struct _Cnd_internal_imp_t {
 #if defined(_CRT_WINDOWS) // for Windows-internal code
     static constexpr size_t _Cnd_internal_imp_size = 2 * sizeof(void*);
@@ -61,7 +66,10 @@ struct _Cnd_internal_imp_t {
     static constexpr size_t _Cnd_internal_imp_size = 40;
 #endif // ^^^ ordinary 32-bit code ^^^
 
-    _STD _Aligned_storage_t<_Cnd_internal_imp_size, alignof(void*)> _Cv_storage;
+    union {
+        _Stl_condition_variable _Stl_cv{};
+        _STD _Aligned_storage_t<_Cnd_internal_imp_size, alignof(void*)> _Cv_storage;
+    };
 };
 
 using _Cnd_t = _Cnd_internal_imp_t*;

--- a/stl/inc/__msvc_threads_core.hpp
+++ b/stl/inc/__msvc_threads_core.hpp
@@ -57,6 +57,8 @@ struct _Stl_condition_variable {
     void* _Win_cv = nullptr;
 };
 
+#pragma warning(push)
+#pragma warning(disable : 26495) // Variable 'meow' is uninitialized. Always initialize a member variable (type.6).
 struct _Cnd_internal_imp_t {
 #if defined(_CRT_WINDOWS) // for Windows-internal code
     static constexpr size_t _Cnd_internal_imp_size = 2 * sizeof(void*);
@@ -71,6 +73,7 @@ struct _Cnd_internal_imp_t {
         _STD _Aligned_storage_t<_Cnd_internal_imp_size, alignof(void*)> _Cv_storage;
     };
 };
+#pragma warning(pop)
 
 using _Cnd_t = _Cnd_internal_imp_t*;
 } // extern "C"

--- a/stl/inc/condition_variable
+++ b/stl/inc/condition_variable
@@ -216,7 +216,7 @@ public:
 private:
     shared_ptr<mutex> _Myptr;
 
-    _Cnd_internal_imp_t _Cnd_storage;
+    _Cnd_internal_imp_t _Cnd_storage{};
 
     _NODISCARD _Cnd_t _Mycnd() noexcept {
         return &_Cnd_storage;

--- a/stl/inc/condition_variable
+++ b/stl/inc/condition_variable
@@ -52,7 +52,9 @@ private:
 _EXPORT_STD class condition_variable_any { // class for waiting for conditions with any kind of mutex
 public:
     condition_variable_any() : _Myptr{_STD make_shared<mutex>()} {
+#ifdef _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
         _Cnd_init_in_situ(_Mycnd());
+#endif // ^^^ defined(_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR) ^^^
     }
 
     ~condition_variable_any() noexcept = default;

--- a/stl/inc/condition_variable
+++ b/stl/inc/condition_variable
@@ -55,9 +55,7 @@ public:
         _Cnd_init_in_situ(_Mycnd());
     }
 
-    ~condition_variable_any() noexcept {
-        _Cnd_destroy_in_situ(_Mycnd());
-    }
+    ~condition_variable_any() noexcept = default;
 
     condition_variable_any(const condition_variable_any&)            = delete;
     condition_variable_any& operator=(const condition_variable_any&) = delete;

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -627,7 +627,7 @@ public:
     }
 
 private:
-    _Cnd_internal_imp_t _Cnd_storage;
+    _Cnd_internal_imp_t _Cnd_storage{};
 
     _Cnd_t _Mycnd() noexcept {
         return &_Cnd_storage;

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -531,9 +531,13 @@ _EXPORT_STD enum class cv_status { // names for wait returns
 
 _EXPORT_STD class condition_variable { // class for waiting for conditions
 public:
+#ifdef _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
     condition_variable() noexcept /* strengthened */ {
         _Cnd_init_in_situ(_Mycnd());
     }
+#else // ^^^ defined(_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR) / !defined(_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR) vvv
+    condition_variable() noexcept /* strengthened */ = default;
+#endif // ^^^ !defined(_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR) ^^^
 
     ~condition_variable() noexcept = default;
 

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -535,9 +535,7 @@ public:
         _Cnd_init_in_situ(_Mycnd());
     }
 
-    ~condition_variable() noexcept {
-        _Cnd_destroy_in_situ(_Mycnd());
-    }
+    ~condition_variable() noexcept = default;
 
     condition_variable(const condition_variable&)            = delete;
     condition_variable& operator=(const condition_variable&) = delete;

--- a/stl/inc/xthreads.h
+++ b/stl/inc/xthreads.h
@@ -59,7 +59,9 @@ void __cdecl _Smtx_unlock_shared(_Smtx_t*) noexcept;
 _CRTIMP2_PURE _Thrd_result __cdecl _Cnd_init(_Cnd_t*) noexcept;
 _CRTIMP2_PURE void __cdecl _Cnd_destroy(_Cnd_t) noexcept;
 #endif // _CRTBLD
+#ifdef _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
 _CRTIMP2_PURE void __cdecl _Cnd_init_in_situ(_Cnd_t) noexcept;
+#endif // ^^^ defined(_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR) ^^^
 _CRTIMP2_PURE _Thrd_result __cdecl _Cnd_wait(_Cnd_t, _Mtx_t) noexcept; // TRANSITION, ABI: Always succeeds
 _CRTIMP2_PURE _Thrd_result __cdecl _Cnd_broadcast(_Cnd_t) noexcept; // TRANSITION, ABI: Always succeeds
 _CRTIMP2_PURE _Thrd_result __cdecl _Cnd_signal(_Cnd_t) noexcept; // TRANSITION, ABI: Always succeeds

--- a/stl/inc/xthreads.h
+++ b/stl/inc/xthreads.h
@@ -35,10 +35,6 @@ enum { // mutex types
     _Mtx_recursive = 0x100
 };
 
-#ifdef _CRTBLD
-_CRTIMP2_PURE _Thrd_result __cdecl _Mtx_init(_Mtx_t*, int) noexcept;
-_CRTIMP2_PURE void __cdecl _Mtx_destroy(_Mtx_t) noexcept;
-#endif // _CRTBLD
 _CRTIMP2_PURE void __cdecl _Mtx_init_in_situ(_Mtx_t, int) noexcept;
 _CRTIMP2_PURE int __cdecl _Mtx_current_owns(_Mtx_t) noexcept;
 _CRTIMP2_PURE _Thrd_result __cdecl _Mtx_lock(_Mtx_t) noexcept;

--- a/stl/inc/xthreads.h
+++ b/stl/inc/xthreads.h
@@ -35,7 +35,9 @@ enum { // mutex types
     _Mtx_recursive = 0x100
 };
 
+#if defined(_CRTBLD) || defined(_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 _CRTIMP2_PURE void __cdecl _Mtx_init_in_situ(_Mtx_t, int) noexcept;
+#endif // ^^^ defined(_CRTBLD) || defined(_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR) ^^^
 _CRTIMP2_PURE int __cdecl _Mtx_current_owns(_Mtx_t) noexcept;
 _CRTIMP2_PURE _Thrd_result __cdecl _Mtx_lock(_Mtx_t) noexcept;
 _CRTIMP2_PURE _Thrd_result __cdecl _Mtx_trylock(_Mtx_t) noexcept;

--- a/stl/inc/xthreads.h
+++ b/stl/inc/xthreads.h
@@ -60,7 +60,6 @@ _CRTIMP2_PURE _Thrd_result __cdecl _Cnd_init(_Cnd_t*) noexcept;
 _CRTIMP2_PURE void __cdecl _Cnd_destroy(_Cnd_t) noexcept;
 #endif // _CRTBLD
 _CRTIMP2_PURE void __cdecl _Cnd_init_in_situ(_Cnd_t) noexcept;
-_CRTIMP2_PURE void __cdecl _Cnd_destroy_in_situ(_Cnd_t) noexcept;
 _CRTIMP2_PURE _Thrd_result __cdecl _Cnd_wait(_Cnd_t, _Mtx_t) noexcept; // TRANSITION, ABI: Always succeeds
 _CRTIMP2_PURE _Thrd_result __cdecl _Cnd_broadcast(_Cnd_t) noexcept; // TRANSITION, ABI: Always succeeds
 _CRTIMP2_PURE _Thrd_result __cdecl _Cnd_signal(_Cnd_t) noexcept; // TRANSITION, ABI: Always succeeds

--- a/stl/inc/xthreads.h
+++ b/stl/inc/xthreads.h
@@ -55,10 +55,6 @@ void __cdecl _Smtx_unlock_exclusive(_Smtx_t*) noexcept;
 void __cdecl _Smtx_unlock_shared(_Smtx_t*) noexcept;
 
 // condition variables
-#ifdef _CRTBLD
-_CRTIMP2_PURE _Thrd_result __cdecl _Cnd_init(_Cnd_t*) noexcept;
-_CRTIMP2_PURE void __cdecl _Cnd_destroy(_Cnd_t) noexcept;
-#endif // _CRTBLD
 #ifdef _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
 _CRTIMP2_PURE void __cdecl _Cnd_init_in_situ(_Cnd_t) noexcept;
 #endif // ^^^ defined(_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR) ^^^

--- a/stl/src/cond.cpp
+++ b/stl/src/cond.cpp
@@ -20,6 +20,7 @@ _CRTIMP2_PURE void __cdecl _Cnd_init_in_situ(const _Cnd_t cond) noexcept { // in
 // TRANSITION, ABI: preserved for binary compatibility
 _CRTIMP2_PURE void __cdecl _Cnd_destroy_in_situ(_Cnd_t) noexcept {} // destroy condition variable in situ
 
+// TRANSITION, ABI: preserved for binary compatibility
 _CRTIMP2_PURE _Thrd_result __cdecl _Cnd_init(_Cnd_t* const pcond) noexcept { // initialize
     *pcond = nullptr;
 
@@ -33,6 +34,7 @@ _CRTIMP2_PURE _Thrd_result __cdecl _Cnd_init(_Cnd_t* const pcond) noexcept { // 
     return _Thrd_result::_Success;
 }
 
+// TRANSITION, ABI: preserved for binary compatibility
 _CRTIMP2_PURE void __cdecl _Cnd_destroy(const _Cnd_t cond) noexcept { // clean up
     if (cond) { // something to do, do it
         _free_crt(cond);

--- a/stl/src/cond.cpp
+++ b/stl/src/cond.cpp
@@ -14,7 +14,7 @@ extern "C" {
 
 // TRANSITION, ABI: preserved for binary compatibility (and _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 _CRTIMP2_PURE void __cdecl _Cnd_init_in_situ(const _Cnd_t cond) noexcept { // initialize condition variable in situ
-    new (Concurrency::details::_Get_cond_var(cond)) Concurrency::details::stl_condition_variable_win7;
+    new (cond) _Cnd_internal_imp_t;
 }
 
 // TRANSITION, ABI: preserved for binary compatibility

--- a/stl/src/cond.cpp
+++ b/stl/src/cond.cpp
@@ -17,6 +17,7 @@ _CRTIMP2_PURE void __cdecl _Cnd_init_in_situ(const _Cnd_t cond) noexcept { // in
     new (Concurrency::details::_Get_cond_var(cond)) Concurrency::details::stl_condition_variable_win7;
 }
 
+// TRANSITION, ABI: preserved for binary compatibility
 _CRTIMP2_PURE void __cdecl _Cnd_destroy_in_situ(_Cnd_t) noexcept {} // destroy condition variable in situ
 
 _CRTIMP2_PURE _Thrd_result __cdecl _Cnd_init(_Cnd_t* const pcond) noexcept { // initialize
@@ -34,7 +35,6 @@ _CRTIMP2_PURE _Thrd_result __cdecl _Cnd_init(_Cnd_t* const pcond) noexcept { // 
 
 _CRTIMP2_PURE void __cdecl _Cnd_destroy(const _Cnd_t cond) noexcept { // clean up
     if (cond) { // something to do, do it
-        _Cnd_destroy_in_situ(cond);
         _free_crt(cond);
     }
 }

--- a/stl/src/cond.cpp
+++ b/stl/src/cond.cpp
@@ -12,7 +12,7 @@
 
 extern "C" {
 
-
+// TRANSITION, ABI: preserved for binary compatibility (and _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 _CRTIMP2_PURE void __cdecl _Cnd_init_in_situ(const _Cnd_t cond) noexcept { // initialize condition variable in situ
     new (Concurrency::details::_Get_cond_var(cond)) Concurrency::details::stl_condition_variable_win7;
 }

--- a/stl/src/cthread.cpp
+++ b/stl/src/cthread.cpp
@@ -113,9 +113,9 @@ _CRTIMP2_PURE _Thrd_result __cdecl _Thrd_create(_Thrd_t* thr, _Thrd_start_t func
     _Thrd_result res;
     _Thrd_binder b;
     int started = 0;
-    _Cnd_t cond;
+    _Cnd_internal_imp_t cond_var{};
+    _Cnd_t cond = &cond_var;
     _Mtx_t mtx;
-    _Cnd_init(&cond);
     _Mtx_init(&mtx, _Mtx_plain);
     b.func    = func;
     b.data    = d;
@@ -129,7 +129,6 @@ _CRTIMP2_PURE _Thrd_result __cdecl _Thrd_create(_Thrd_t* thr, _Thrd_start_t func
         }
     }
     _Mtx_unlock(mtx);
-    _Cnd_destroy(cond);
     _Mtx_destroy(mtx);
     return res;
 }

--- a/stl/src/cthread.cpp
+++ b/stl/src/cthread.cpp
@@ -115,8 +115,9 @@ _CRTIMP2_PURE _Thrd_result __cdecl _Thrd_create(_Thrd_t* thr, _Thrd_start_t func
     int started = 0;
     _Cnd_internal_imp_t cond_var{};
     _Cnd_t cond = &cond_var;
-    _Mtx_t mtx;
-    _Mtx_init(&mtx, _Mtx_plain);
+    _Mtx_internal_imp_t mtx_var{};
+    _Mtx_t mtx = &mtx_var;
+    _Mtx_init_in_situ(mtx, _Mtx_plain);
     b.func    = func;
     b.data    = d;
     b.cond    = &cond;
@@ -129,7 +130,6 @@ _CRTIMP2_PURE _Thrd_result __cdecl _Thrd_create(_Thrd_t* thr, _Thrd_start_t func
         }
     }
     _Mtx_unlock(mtx);
-    _Mtx_destroy(mtx);
     return res;
 }
 

--- a/stl/src/mutex.cpp
+++ b/stl/src/mutex.cpp
@@ -10,8 +10,6 @@
 #include <xthreads.h>
 #include <xtimec.h>
 
-#include "primitives.hpp"
-
 extern "C" {
 
 // TRANSITION, ABI: exported only for ABI compat

--- a/stl/src/mutex.cpp
+++ b/stl/src/mutex.cpp
@@ -35,7 +35,7 @@ _CRTIMP2 void __cdecl __set_stl_sync_api_mode(__stl_sync_api_modes_enum) noexcep
     return reinterpret_cast<PSRWLOCK>(&mtx->_Critical_section._M_srw_lock);
 }
 
-// TRANSITION, only used when constexpr mutex constructor is not enabled
+// TRANSITION, ABI: preserved for binary compatibility (and _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 _CRTIMP2_PURE void __cdecl _Mtx_init_in_situ(_Mtx_t mtx, int type) noexcept { // initialize mutex in situ
     new (&mtx->_Critical_section) _Stl_critical_section;
     mtx->_Thread_id = -1;

--- a/stl/src/mutex.cpp
+++ b/stl/src/mutex.cpp
@@ -49,6 +49,7 @@ _CRTIMP2_PURE void __cdecl _Mtx_destroy_in_situ(_Mtx_t mtx) noexcept { // destro
     (void) mtx;
 }
 
+// TRANSITION, ABI: preserved for binary compatibility
 _CRTIMP2_PURE _Thrd_result __cdecl _Mtx_init(_Mtx_t* mtx, int type) noexcept { // initialize mutex
     *mtx = nullptr;
 

--- a/stl/src/primitives.hpp
+++ b/stl/src/primitives.hpp
@@ -8,43 +8,24 @@
 
 #include <Windows.h>
 
-namespace Concurrency {
-    namespace details {
-        class stl_condition_variable_win7 {
-        public:
-            stl_condition_variable_win7() = default;
+inline bool _Primitive_wait_for(const _Cnd_t cond, _Stl_critical_section* lock, unsigned int timeout) noexcept {
+    const auto pcv  = reinterpret_cast<PCONDITION_VARIABLE>(&cond->_Stl_cv._Win_cv);
+    const auto psrw = reinterpret_cast<PSRWLOCK>(&lock->_M_srw_lock);
+    return SleepConditionVariableSRW(pcv, psrw, timeout, 0) != 0;
+}
 
-            ~stl_condition_variable_win7()                                             = delete;
-            stl_condition_variable_win7(const stl_condition_variable_win7&)            = delete;
-            stl_condition_variable_win7& operator=(const stl_condition_variable_win7&) = delete;
+inline void _Primitive_wait(const _Cnd_t cond, _Stl_critical_section* lock) noexcept {
+    if (!_Primitive_wait_for(cond, lock, INFINITE)) {
+        _CSTD abort();
+    }
+}
 
-            void wait(_Stl_critical_section* lock) {
-                if (!wait_for(lock, INFINITE)) {
-                    _CSTD abort();
-                }
-            }
+inline void _Primitive_notify_one(const _Cnd_t cond) noexcept {
+    const auto pcv = reinterpret_cast<PCONDITION_VARIABLE>(&cond->_Stl_cv._Win_cv);
+    WakeConditionVariable(pcv);
+}
 
-            bool wait_for(_Stl_critical_section* lock, unsigned int timeout) {
-                return SleepConditionVariableSRW(
-                           &m_condition_variable, reinterpret_cast<PSRWLOCK>(&lock->_M_srw_lock), timeout, 0)
-                    != 0;
-            }
-
-            void notify_one() {
-                WakeConditionVariable(&m_condition_variable);
-            }
-
-            void notify_all() {
-                WakeAllConditionVariable(&m_condition_variable);
-            }
-
-        private:
-            void* unused                            = nullptr; // TRANSITION, ABI: was the vptr
-            CONDITION_VARIABLE m_condition_variable = CONDITION_VARIABLE_INIT;
-        };
-
-        [[nodiscard]] inline stl_condition_variable_win7* _Get_cond_var(::_Cnd_internal_imp_t* _Cond) noexcept {
-            return reinterpret_cast<stl_condition_variable_win7*>(&_Cond->_Cv_storage);
-        }
-    } // namespace details
-} // namespace Concurrency
+inline void _Primitive_notify_all(const _Cnd_t cond) noexcept {
+    const auto pcv = reinterpret_cast<PCONDITION_VARIABLE>(&cond->_Stl_cv._Win_cv);
+    WakeAllConditionVariable(pcv);
+}

--- a/stl/src/primitives.hpp
+++ b/stl/src/primitives.hpp
@@ -5,7 +5,6 @@
 
 #include <__msvc_threads_core.hpp>
 #include <cstdlib>
-#include <type_traits>
 
 #include <Windows.h>
 

--- a/stl/src/primitives.hpp
+++ b/stl/src/primitives.hpp
@@ -8,14 +8,14 @@
 
 #include <Windows.h>
 
-inline bool _Primitive_wait_for(const _Cnd_t cond, _Stl_critical_section* lock, unsigned int timeout) noexcept {
+inline bool _Primitive_wait_for(const _Cnd_t cond, const _Mtx_t mtx, unsigned int timeout) noexcept {
     const auto pcv  = reinterpret_cast<PCONDITION_VARIABLE>(&cond->_Stl_cv._Win_cv);
-    const auto psrw = reinterpret_cast<PSRWLOCK>(&lock->_M_srw_lock);
+    const auto psrw = reinterpret_cast<PSRWLOCK>(&mtx->_Critical_section._M_srw_lock);
     return SleepConditionVariableSRW(pcv, psrw, timeout, 0) != 0;
 }
 
-inline void _Primitive_wait(const _Cnd_t cond, _Stl_critical_section* lock) noexcept {
-    if (!_Primitive_wait_for(cond, lock, INFINITE)) {
+inline void _Primitive_wait(const _Cnd_t cond, const _Mtx_t mtx) noexcept {
+    if (!_Primitive_wait_for(cond, mtx, INFINITE)) {
         _CSTD abort();
     }
 }

--- a/stl/src/sharedmutex.cpp
+++ b/stl/src/sharedmutex.cpp
@@ -50,7 +50,7 @@ _Thrd_result __stdcall _Cnd_timedwait_for(const _Cnd_t cond, const _Mtx_t mtx, c
     mtx->_Thread_id = -1;
     --mtx->_Count;
 
-    if (!Concurrency::details::_Get_cond_var(cond)->wait_for(cs, target_ms)) { // report timeout
+    if (!_Primitive_wait_for(cond, cs, target_ms)) { // report timeout
         const auto end_ms = GetTickCount64();
         if (end_ms - start_ms >= target_ms) {
             res = _Thrd_result::_Timedout;

--- a/stl/src/sharedmutex.cpp
+++ b/stl/src/sharedmutex.cpp
@@ -43,14 +43,13 @@ void __stdcall _Thrd_sleep_for(const unsigned long ms) noexcept { // suspend cur
 
 _Thrd_result __stdcall _Cnd_timedwait_for(const _Cnd_t cond, const _Mtx_t mtx, const unsigned int target_ms) noexcept {
     _Thrd_result res    = _Thrd_result::_Success;
-    const auto cs       = &mtx->_Critical_section;
     const auto start_ms = GetTickCount64();
 
     // TRANSITION: replace with _Mtx_clear_owner(mtx);
     mtx->_Thread_id = -1;
     --mtx->_Count;
 
-    if (!_Primitive_wait_for(cond, cs, target_ms)) { // report timeout
+    if (!_Primitive_wait_for(cond, mtx, target_ms)) { // report timeout
         const auto end_ms = GetTickCount64();
         if (end_ms - start_ms >= target_ms) {
             res = _Thrd_result::_Timedout;

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -26,6 +26,11 @@ std/time/time.syn/formatter.year_month_weekday.pass.cpp:1 FAIL
 std/utilities/memory/specialized.algorithms/uninitialized.copy/uninitialized_copy.pass.cpp FAIL
 std/utilities/memory/specialized.algorithms/uninitialized.move/uninitialized_move.pass.cpp FAIL
 
+# LLVM-94907: [libc++][test] Avoid -Wunused-variable warnings in mutex tests
+std/thread/thread.mutex/thread.mutex.requirements/thread.sharedtimedmutex.requirements/thread.sharedtimedmutex.class/default.pass.cpp:2 FAIL
+std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.class/default.pass.cpp:2 FAIL
+std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/default.pass.cpp:2 FAIL
+
 # Non-Standard regex behavior.
 # "It seems likely that the test is still non-conforming due to how libc++ handles the 'w' character class."
 std/re/re.traits/lookup_classname.pass.cpp FAIL


### PR DESCRIPTION
# Overview

This improves how we initialize `condition_variable` and `condition_variable_any`. It also eliminates layers of confusing machinery like `Concurrency::details::stl_condition_variable_win7`. I've been careful to preserve bincompat at each step. (All of the other `Concurrency::details` machinery was dllexported, but not this one.) This also respects the escape hatch macro `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR`, for users who aren't following our documented binary compatibility requirements and are mixing new STL headers with a very old STL DLL (older than VS 2022 17.8), so it doesn't affect that situation any further.

# Commits

mutex.cpp doesn't use anything from primitives.hpp.

---

primitives.hpp doesn't need `<type_traits>`.

---

Stop calling no-op `_Cnd_destroy_in_situ()`.

`~condition_variable()` can be defaulted, making it trivially destructible. (Note that this also makes `timed_mutex` and `recursive_timed_mutex` trivially destructible.)

`~condition_variable_any()` can also be defaulted. It's destroying a `shared_ptr`, so it's not trivially destructible.

Stop declaring `_Cnd_destroy_in_situ()` in xthreads.h. Note that this doesn't affect the dllexport surface, as we previously ensured that `_CRTIMP2_PURE` always appears on both declarations and definitions.

Comment the definition of `_Cnd_destroy_in_situ()` in cond.cpp as preserved for bincompat.

---
Statically initialize `_Cnd_internal_imp_t`.

This follows the example of `_Mtx_internal_imp_t` and `_Stl_critical_section` above.

Define `_Stl_condition_variable` mirroring `Concurrency::details::stl_condition_variable_win7`.

We can mirror `CONDITION_VARIABLE m_condition_variable = CONDITION_VARIABLE_INIT;` with `void* _Win_cv = nullptr;` because `CONDITION_VARIABLE` is just a struct wrapping `void*` (so it has the same size and alignment) and `CONDITION_VARIABLE_INIT` just initializes it to null.

Then, use the `union` pattern to keep the size and alignment of `_Cnd_internal_imp_t` unchanged, while initializing `_Stl_condition_variable _Stl_cv{};` with a default member initializer, so its two pointers will be null. (The size is unchanged because `_Cv_storage` is at least `2 * sizeof(void*)`. The alignment is unchanged because everything is `void*`-aligned here.)

Finally, add empty braces when we have `_Cnd_internal_imp_t _Cnd_storage{};` data members. These aren't necessary, but they serve as a reminder that we're getting null instead of garbage, and this is consistent with how we have `_Mtx_internal_imp_t _Mtx_storage{};`.

Note that I chose these names to avoid confusion between the different layers:

* `_Stl_cv` stores two pointers, including the unused vptr
* `_Win_cv` directly mirrors `CONDITION_VARIABLE`

---
Now we can stop calling `_Cnd_init_in_situ()`, with `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` as the escape hatch.

We just changed `condition_variable_any` and `condition_variable` to statically initialize `_Cnd_internal_imp_t`.

`condition_variable`'s default constructor can now be defaulted.

In xthreads.h, declare `_Cnd_init_in_situ()` only when needed for the escape hatch. (Again, this doesn't affect bincompat, the definition still has `_CRTIMP2_PURE`.)

Comment `_Cnd_init_in_situ()` as preserved for bincompat and the escape hatch. Its only caller is `_Cnd_init()` immediately below, which is only called by `_Thrd_create()`, which is preserved for bincompat.

We need the escape hatch for the same reason that `mutex` does. When a user hasn't followed our documented restrictions for binary compatibility, and mixes new headers with a very old STL DLL (older than VS 2022 17.8, which was the release that shipped #3770), the headers will initialize the vptr to null, but the old STL DLL will want to actually use the vptr. The escape hatch makes the headers call into the old STL DLL to set up a real vptr.

---
Simplify the definition of `_Cnd_init_in_situ()`.

Constructing `_Cnd_internal_imp_t` will now perform the initialization that we need.

---
Stop calling `_Cnd_init()` and `_Cnd_destroy()`.

We declared them in xthreads.h (guarded by `_CRTBLD`) because they were defined by cond.cpp and used by cthread.cpp. As usual, dropping these declarations won't affect bincompat, as the definitions are consistently marked `_CRTIMP2_PURE`.

Mark the definitions as preserved for bincompat.

In cthread.cpp `_Thrd_create()` (itself preserved for bincompat), we don't need to dynamically allocate and deallocate a condition variable. Locally initializing `_Cnd_internal_imp_t cond_var{};` and taking its address is sufficient.

---
Stop calling `_Mtx_init()` and `_Mtx_destroy()`.

We declared them in xthreads.h (guarded by `_CRTBLD`) because they were defined by mutex.cpp and used by cthread.cpp. As usual, dropping these declarations won't affect bincompat, as the definitions are consistently marked `_CRTIMP2_PURE`.

Mark the definition of `_Mtx_init()` as preserved for bincompat. `_Mtx_destroy()` was already marked.

In cthread.cpp `_Thrd_create()` (itself preserved for bincompat), we don't need to dynamically allocate and deallocate a mutex. Locally initializing `_Mtx_internal_imp_t mtx_var{};`, taking its address, and calling `_Mtx_init_in_situ()` is sufficient. We don't need to call `_Mtx_destroy_in_situ()` (which isn't declared). It's a no-op except for a debug check "mutex destroyed while busy". `std::mutex` doesn't bother with that anymore, and we're definitely calling `_Mtx_unlock()` so we're fine.

---
Declare `_Mtx_init_in_situ()` only when needed.

And update its comment accordingly.

---
Replace `Concurrency::details::stl_condition_variable_win7` with non-member functions.

This wasn't dllexported, and the changes are limited to stl/src, so there's no bincompat impact.

I chose the naming scheme `_Primitive_wait` to avoid confusion with `_Cnd_wait` which does more work.

The functions don't need to be `extern "C"`, because they don't interact with user code. (They do need to be ugly to avoid conflicts during static linking.)

They have to be `inline`. I also marked them as `noexcept`, although that wasn't necessary.

Because they aren't member functions anymore, I have to define `_Primitive_wait_for()` before `_Primitive_wait()` can call it.

---
Simplify `_Primitive_wait[_for]()` by taking `_Mtx_t mtx`.

Now that the originally-ConcRT-derived layer has been eradicated, we don't need to make every caller reach into `_Mtx_t` internals. This also increases consistency with the `_Cnd_t cond` parameter.

---
Skip 3 libcxx tests for Clang until LLVM-94907 is merged.