### PR TITLE
`<generator>`: Cleanup `P2502R2_generator/test.cpp`

### DIFF
--- a/tests/std/include/test_generator_support.hpp
+++ b/tests/std/include/test_generator_support.hpp
@@ -5,6 +5,7 @@
 
 #include <concepts>
 #include <cstddef>
+#include <cstdlib>
 #include <memory>
 #include <memory_resource>
 #include <new>
@@ -28,7 +29,7 @@ public:
         if constexpr (alignof(T) > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
             vp = ::_aligned_malloc(s * sizeof(T), alignof(T));
         } else {
-            vp = malloc(s * sizeof(T));
+            vp = std::malloc(s * sizeof(T));
         }
 
         if (vp) {
@@ -42,7 +43,7 @@ public:
         if constexpr (alignof(T) > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
             ::_aligned_free(p);
         } else {
-            free(p);
+            std::free(p);
         }
     }
 

--- a/tests/std/tests/P2502R2_generator/test.cpp
+++ b/tests/std/tests/P2502R2_generator/test.cpp
@@ -272,8 +272,7 @@ int main() {
     }
     assert(ranges::equal(co_upto(6), views::iota(0, 6)));
 
-    {
-        // test with mutable lvalue reference type
+    { // Test with mutable lvalue reference type
         auto r   = co_upto<int&>(32);
         auto pos = r.begin();
         for (int i = 0; i < 16; ++i, ++*pos, ++pos) {
@@ -284,8 +283,7 @@ int main() {
     }
 
 #if !(defined(__clang__) && defined(_M_IX86)) // TRANSITION, LLVM-56507
-    {
-        // test with mutable xvalue reference type
+    { // Test with mutable xvalue reference type
         auto woof = [](size_t size, size_t count) -> generator<vector<int>&&> {
             random_device rd{};
             uniform_int_distribution dist{0, 99};
@@ -295,7 +293,8 @@ int main() {
                 ranges::generate(vec, [&] { return dist(rd); });
                 co_yield move(vec);
             }
-            // test yielding lvalue
+
+            // Test yielding lvalue
             vec.resize(size);
             ranges::generate(vec, [&] { return dist(rd); });
             const auto tmp = vec;

--- a/tests/std/tests/P2502R2_generator/test.cpp
+++ b/tests/std/tests/P2502R2_generator/test.cpp
@@ -8,9 +8,12 @@
 #include <cstdlib>
 #include <forward_list>
 #include <generator>
+#include <memory>
+#include <new>
 #include <random>
 #include <ranges>
 #include <sstream>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>

--- a/tests/std/tests/P2502R2_generator/test.cpp
+++ b/tests/std/tests/P2502R2_generator/test.cpp
@@ -74,7 +74,7 @@ generator<tuple<ranges::range_reference_t<Rng1>, ranges::range_reference_t<Rng2>
 
 // Not from the proposal:
 template <class Reference = const int&>
-generator<Reference, int> meow(const int hi) {
+generator<Reference, int> co_upto(const int hi) {
     for (int i = 0; i < hi; ++i) {
         co_yield i;
     }
@@ -232,7 +232,7 @@ generator<int> iota_repeater(const int hi, const int depth) {
         co_yield ranges::elements_of(iota_repeater(hi, depth - 1));
         co_yield ranges::elements_of(iota_repeater(hi, depth - 1));
     } else {
-        co_yield ranges::elements_of(meow<int>(hi));
+        co_yield ranges::elements_of(co_upto<int>(hi));
     }
 }
 
@@ -307,11 +307,11 @@ int main() {
         f(ss);
         assert(ss.str() == "0 1 2 ");
     }
-    assert(ranges::equal(meow(6), views::iota(0, 6)));
+    assert(ranges::equal(co_upto(6), views::iota(0, 6)));
 
     {
         // test with mutable lvalue reference type
-        auto r   = meow<int&>(32);
+        auto r   = co_upto<int&>(32);
         auto pos = r.begin();
         for (int i = 0; i < 16; ++i, ++*pos, ++pos) {
             assert(pos != r.end());

--- a/tests/std/tests/P2502R2_generator/test.cpp
+++ b/tests/std/tests/P2502R2_generator/test.cpp
@@ -13,6 +13,7 @@
 #include <random>
 #include <ranges>
 #include <sstream>
+#include <stdexcept>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -200,17 +201,16 @@ generator<int> iota_repeater(const int hi, const int depth) {
 }
 
 void recursive_test() {
-    struct some_error {};
-
     static constexpr auto might_throw = []() -> generator<int> {
         co_yield 0;
-        throw some_error{};
+        throw runtime_error{"error"};
     };
 
     static constexpr auto nested_ints = []() -> generator<int> {
         try {
             co_yield ranges::elements_of(might_throw());
-        } catch (const some_error&) {
+        } catch (const runtime_error& e) {
+            assert(e.what() == "error"sv);
         }
         co_yield 1;
     };

--- a/tests/std/tests/P2502R2_generator/test.cpp
+++ b/tests/std/tests/P2502R2_generator/test.cpp
@@ -43,20 +43,17 @@ static_assert(static_checks<std::generator<int&&>, int, int&&, int&&>());
 static_assert(static_checks<std::generator<int&>, int, int&, int&&>());
 static_assert(static_checks<std::generator<int, int>, int, int, int>());
 
-// From the proposal:
-std::generator<int> iota(int start = 0) {
+// [coroutine.generator.overview] Example 1:
+std::generator<int> ints(int start = 0) {
     while (true) {
-        co_yield start;
-        ++start;
+        co_yield start++;
     }
 }
 
 void f(std::ostream& os) {
-    os << '"';
-    for (auto i : iota() | std::views::take(3)) {
-        os << i << ' '; // prints "0 1 2 "
+    for (auto i : ints() | std::views::take(3)) {
+        os << i << ' ';
     }
-    os << "\"\n";
 }
 
 template <ranges::input_range Rng1, ranges::input_range Rng2>
@@ -322,7 +319,7 @@ int main() {
     {
         std::stringstream ss;
         f(ss);
-        assert(ss.str() == "\"0 1 2 \"\n");
+        assert(ss.str() == "0 1 2 ");
     }
     assert(ranges::equal(meow(6), ranges::views::iota(0, 6)));
 

--- a/tests/std/tests/P2502R2_generator/test.cpp
+++ b/tests/std/tests/P2502R2_generator/test.cpp
@@ -21,7 +21,7 @@
 using namespace std;
 
 template <class G, class V, class R, class RR>
-constexpr bool static_checks() {
+consteval bool static_checks() {
     static_assert(ranges::input_range<G>);
     static_assert(ranges::view<G>);
     static_assert(!ranges::forward_range<G>);

--- a/tests/std/tests/P2502R2_generator/test.cpp
+++ b/tests/std/tests/P2502R2_generator/test.cpp
@@ -77,21 +77,6 @@ std::generator<Reference, int> meow(const int hi) {
     }
 }
 
-template <ranges::input_range R>
-void dump(std::ostream& os, R&& r) {
-    os << '{';
-    bool first = true;
-    for (auto&& e : r) {
-        if (first) {
-            first = false;
-        } else {
-            os << ", ";
-        }
-        os << e;
-    }
-    os << "}\n";
-}
-
 template <class T>
 struct stateless_alloc {
     using value_type = T;

--- a/tests/std/tests/P2502R2_generator/test.cpp
+++ b/tests/std/tests/P2502R2_generator/test.cpp
@@ -170,7 +170,7 @@ void static_allocator_test() {
             }
         };
 
-        assert(ranges::equal(g(1024), ranges::views::iota(0, 1024)));
+        assert(ranges::equal(g(1024), views::iota(0, 1024)));
     }
 
     {
@@ -182,7 +182,7 @@ void static_allocator_test() {
             }
         };
 
-        assert(ranges::equal(g(allocator_arg, {}, 1024), ranges::views::iota(0, 1024)));
+        assert(ranges::equal(g(allocator_arg, {}, 1024), views::iota(0, 1024)));
     }
 
 #ifndef __EDG__ // TRANSITION, VSO-1951821
@@ -195,7 +195,7 @@ void static_allocator_test() {
             }
         };
 
-        assert(ranges::equal(g(allocator_arg, stateful_alloc<int>{42}, 1024), ranges::views::iota(0, 1024)));
+        assert(ranges::equal(g(allocator_arg, stateful_alloc<int>{42}, 1024), views::iota(0, 1024)));
     }
 #endif // ^^^ no workaround ^^^
 }
@@ -209,10 +209,10 @@ void dynamic_allocator_test() {
         }
     };
 
-    assert(ranges::equal(g(allocator_arg, allocator<float>{}, 1024), ranges::views::iota(0, 1024)));
-    assert(ranges::equal(g(allocator_arg, stateless_alloc<float>{}, 1024), ranges::views::iota(0, 1024)));
+    assert(ranges::equal(g(allocator_arg, allocator<float>{}, 1024), views::iota(0, 1024)));
+    assert(ranges::equal(g(allocator_arg, stateless_alloc<float>{}, 1024), views::iota(0, 1024)));
 #ifndef __EDG__ // TRANSITION, VSO-1951821
-    assert(ranges::equal(g(allocator_arg, stateful_alloc<float>{1729}, 1024), ranges::views::iota(0, 1024)));
+    assert(ranges::equal(g(allocator_arg, stateful_alloc<float>{1729}, 1024), views::iota(0, 1024)));
 #endif // ^^^ no workaround ^^^
 }
 
@@ -259,7 +259,7 @@ void recursive_test() {
 void arbitrary_range_test() {
     auto yield_arbitrary_ranges = []() -> generator<const int&> {
         co_yield ranges::elements_of(vector<int>{40, 30, 20, 10});
-        co_yield ranges::elements_of(ranges::views::iota(0, 4));
+        co_yield ranges::elements_of(views::iota(0, 4));
         forward_list<int> fl{500, 400, 300};
         co_yield ranges::elements_of(fl);
     };
@@ -279,7 +279,7 @@ void adl_proof_test() {
     using validator  = holder<incomplete>*;
     auto yield_range = []() -> generator<validator> {
         co_yield ranges::elements_of(
-            ranges::views::repeat(nullptr, 42) | ranges::views::transform([](nullptr_t) { return validator{}; }));
+            views::repeat(nullptr, 42) | views::transform([](nullptr_t) { return validator{}; }));
     };
 
     using R = decltype(yield_range());
@@ -307,7 +307,7 @@ int main() {
         f(ss);
         assert(ss.str() == "0 1 2 ");
     }
-    assert(ranges::equal(meow(6), ranges::views::iota(0, 6)));
+    assert(ranges::equal(meow(6), views::iota(0, 6)));
 
     {
         // test with mutable lvalue reference type

--- a/tests/std/tests/P2502R2_generator/test.cpp
+++ b/tests/std/tests/P2502R2_generator/test.cpp
@@ -10,6 +10,7 @@
 #include <generator>
 #include <memory>
 #include <new>
+#include <ostream>
 #include <random>
 #include <ranges>
 #include <sstream>

--- a/tests/std/tests/P2502R2_generator/test.cpp
+++ b/tests/std/tests/P2502R2_generator/test.cpp
@@ -18,7 +18,7 @@
 #include <utility>
 #include <vector>
 
-namespace ranges = std::ranges;
+using namespace std;
 
 template <class G, class V, class R, class RR>
 constexpr bool static_checks() {
@@ -28,10 +28,10 @@ constexpr bool static_checks() {
     static_assert(!ranges::borrowed_range<G>);
     static_assert(!ranges::common_range<G>);
 
-    static_assert(std::same_as<ranges::range_value_t<G>, V>);
-    static_assert(std::same_as<ranges::range_difference_t<G>, std::ptrdiff_t>);
-    static_assert(std::same_as<ranges::range_reference_t<G>, R>);
-    static_assert(std::same_as<ranges::range_rvalue_reference_t<G>, RR>);
+    static_assert(same_as<ranges::range_value_t<G>, V>);
+    static_assert(same_as<ranges::range_difference_t<G>, ptrdiff_t>);
+    static_assert(same_as<ranges::range_reference_t<G>, R>);
+    static_assert(same_as<ranges::range_rvalue_reference_t<G>, RR>);
 
     // Non-portable size checks
     static_assert(sizeof(G) == sizeof(void*));
@@ -40,28 +40,28 @@ constexpr bool static_checks() {
     return true;
 }
 
-static_assert(static_checks<std::generator<int>, int, int&&, int&&>());
-static_assert(static_checks<std::generator<const int&>, int, const int&, const int&&>());
-static_assert(static_checks<std::generator<int&&>, int, int&&, int&&>());
-static_assert(static_checks<std::generator<int&>, int, int&, int&&>());
-static_assert(static_checks<std::generator<int, int>, int, int, int>());
+static_assert(static_checks<generator<int>, int, int&&, int&&>());
+static_assert(static_checks<generator<const int&>, int, const int&, const int&&>());
+static_assert(static_checks<generator<int&&>, int, int&&, int&&>());
+static_assert(static_checks<generator<int&>, int, int&, int&&>());
+static_assert(static_checks<generator<int, int>, int, int, int>());
 
 // [coroutine.generator.overview] Example 1:
-std::generator<int> ints(int start = 0) {
+generator<int> ints(int start = 0) {
     while (true) {
         co_yield start++;
     }
 }
 
-void f(std::ostream& os) {
-    for (auto i : ints() | std::views::take(3)) {
+void f(ostream& os) {
+    for (auto i : ints() | views::take(3)) {
         os << i << ' ';
     }
 }
 
 template <ranges::input_range Rng1, ranges::input_range Rng2>
-std::generator<std::tuple<ranges::range_reference_t<Rng1>, ranges::range_reference_t<Rng2>>,
-    std::tuple<ranges::range_value_t<Rng1>, ranges::range_value_t<Rng2>>>
+generator<tuple<ranges::range_reference_t<Rng1>, ranges::range_reference_t<Rng2>>,
+    tuple<ranges::range_value_t<Rng1>, ranges::range_value_t<Rng2>>>
     zip(Rng1 r1, Rng2 r2) {
     auto it1        = ranges::begin(r1);
     auto it2        = ranges::begin(r2);
@@ -74,7 +74,7 @@ std::generator<std::tuple<ranges::range_reference_t<Rng1>, ranges::range_referen
 
 // Not from the proposal:
 template <class Reference = const int&>
-std::generator<Reference, int> meow(const int hi) {
+generator<Reference, int> meow(const int hi) {
     for (int i = 0; i < hi; ++i) {
         co_yield i;
     }
@@ -89,26 +89,26 @@ struct stateless_alloc {
     template <class U>
     constexpr stateless_alloc(const stateless_alloc<U>&) noexcept {}
 
-    T* allocate(const std::size_t n) {
+    T* allocate(const size_t n) {
         void* vp;
         if constexpr (alignof(T) > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
             vp = ::_aligned_malloc(n * sizeof(T), alignof(T));
         } else {
-            vp = std::malloc(n * sizeof(T));
+            vp = malloc(n * sizeof(T));
         }
 
         if (vp) {
             return static_cast<T*>(vp);
         }
 
-        throw std::bad_alloc{};
+        throw bad_alloc{};
     }
 
-    void deallocate(void* const vp, [[maybe_unused]] const std::size_t n) noexcept {
+    void deallocate(void* const vp, [[maybe_unused]] const size_t n) noexcept {
         if constexpr (alignof(T) > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
             ::_aligned_free(vp);
         } else {
-            std::free(vp);
+            free(vp);
         }
     }
 
@@ -117,7 +117,7 @@ struct stateless_alloc {
         return true;
     }
 };
-static_assert(std::default_initializable<stateless_alloc<int>>);
+static_assert(default_initializable<stateless_alloc<int>>);
 
 template <class T>
 struct stateful_alloc {
@@ -130,26 +130,26 @@ struct stateful_alloc {
     template <class U>
     constexpr stateful_alloc(const stateful_alloc<U>& that) noexcept : domain{that.domain} {}
 
-    T* allocate(const std::size_t n) {
+    T* allocate(const size_t n) {
         void* vp;
         if constexpr (alignof(T) > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
             vp = ::_aligned_malloc(n * sizeof(T), alignof(T));
         } else {
-            vp = std::malloc(n * sizeof(T));
+            vp = malloc(n * sizeof(T));
         }
 
         if (vp) {
             return static_cast<T*>(vp);
         }
 
-        throw std::bad_alloc{};
+        throw bad_alloc{};
     }
 
-    void deallocate(void* const vp, [[maybe_unused]] const std::size_t n) noexcept {
+    void deallocate(void* const vp, [[maybe_unused]] const size_t n) noexcept {
         if constexpr (alignof(T) > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
             ::_aligned_free(vp);
         } else {
-            std::free(vp);
+            free(vp);
         }
     }
 
@@ -158,12 +158,12 @@ struct stateful_alloc {
         return this->domain == that.domain;
     }
 };
-static_assert(!std::default_initializable<stateful_alloc<int>>);
+static_assert(!default_initializable<stateful_alloc<int>>);
 
 void static_allocator_test() {
     {
-        auto g = [](const int hi) -> std::generator<int, int, stateless_alloc<char>> {
-            constexpr std::size_t n = 64;
+        auto g = [](const int hi) -> generator<int, int, stateless_alloc<char>> {
+            constexpr size_t n = 64;
             int some_ints[n];
             for (int i = 0; i < hi; ++i) {
                 co_yield some_ints[i % n] = i;
@@ -174,62 +174,60 @@ void static_allocator_test() {
     }
 
     {
-        auto g = [](std::allocator_arg_t, stateless_alloc<int>,
-                     const int hi) -> std::generator<int, int, stateless_alloc<char>> {
-            constexpr std::size_t n = 64;
+        auto g = [](allocator_arg_t, stateless_alloc<int>, const int hi) -> generator<int, int, stateless_alloc<char>> {
+            constexpr size_t n = 64;
             int some_ints[n];
             for (int i = 0; i < hi; ++i) {
                 co_yield some_ints[i % n] = i;
             }
         };
 
-        assert(ranges::equal(g(std::allocator_arg, {}, 1024), ranges::views::iota(0, 1024)));
+        assert(ranges::equal(g(allocator_arg, {}, 1024), ranges::views::iota(0, 1024)));
     }
 
 #ifndef __EDG__ // TRANSITION, VSO-1951821
     {
-        auto g = [](std::allocator_arg_t, stateful_alloc<int>,
-                     const int hi) -> std::generator<int, int, stateful_alloc<char>> {
-            constexpr std::size_t n = 64;
+        auto g = [](allocator_arg_t, stateful_alloc<int>, const int hi) -> generator<int, int, stateful_alloc<char>> {
+            constexpr size_t n = 64;
             int some_ints[n];
             for (int i = 0; i < hi; ++i) {
                 co_yield some_ints[i % n] = i;
             }
         };
 
-        assert(ranges::equal(g(std::allocator_arg, stateful_alloc<int>{42}, 1024), ranges::views::iota(0, 1024)));
+        assert(ranges::equal(g(allocator_arg, stateful_alloc<int>{42}, 1024), ranges::views::iota(0, 1024)));
     }
 #endif // ^^^ no workaround ^^^
 }
 
 void dynamic_allocator_test() {
-    auto g = [](std::allocator_arg_t, const auto&, const int hi) -> std::generator<int> {
-        constexpr std::size_t n = 64;
+    auto g = [](allocator_arg_t, const auto&, const int hi) -> generator<int> {
+        constexpr size_t n = 64;
         int some_ints[n];
         for (int i = 0; i < hi; ++i) {
             co_yield some_ints[i % n] = i;
         }
     };
 
-    assert(ranges::equal(g(std::allocator_arg, std::allocator<float>{}, 1024), ranges::views::iota(0, 1024)));
-    assert(ranges::equal(g(std::allocator_arg, stateless_alloc<float>{}, 1024), ranges::views::iota(0, 1024)));
+    assert(ranges::equal(g(allocator_arg, allocator<float>{}, 1024), ranges::views::iota(0, 1024)));
+    assert(ranges::equal(g(allocator_arg, stateless_alloc<float>{}, 1024), ranges::views::iota(0, 1024)));
 #ifndef __EDG__ // TRANSITION, VSO-1951821
-    assert(ranges::equal(g(std::allocator_arg, stateful_alloc<float>{1729}, 1024), ranges::views::iota(0, 1024)));
+    assert(ranges::equal(g(allocator_arg, stateful_alloc<float>{1729}, 1024), ranges::views::iota(0, 1024)));
 #endif // ^^^ no workaround ^^^
 }
 
 void zip_example() {
     int length = 0;
-    for (auto x : zip(std::array{1, 2, 3}, std::vector{10, 20, 30, 40, 50})) {
-        static_assert(std::same_as<decltype(x), std::tuple<int&, int&>>);
-        assert(std::get<0>(x) * 10 == std::get<1>(x));
+    for (auto x : zip(array{1, 2, 3}, vector{10, 20, 30, 40, 50})) {
+        static_assert(same_as<decltype(x), tuple<int&, int&>>);
+        assert(get<0>(x) * 10 == get<1>(x));
         ++length;
     }
     assert(length == 3);
 }
 
 #if !(defined(__clang__) && defined(_M_IX86)) // TRANSITION, LLVM-56507
-std::generator<int> iota_repeater(const int hi, const int depth) {
+generator<int> iota_repeater(const int hi, const int depth) {
     if (depth > 0) {
         co_yield ranges::elements_of(iota_repeater(hi, depth - 1));
         co_yield ranges::elements_of(iota_repeater(hi, depth - 1));
@@ -241,12 +239,12 @@ std::generator<int> iota_repeater(const int hi, const int depth) {
 void recursive_test() {
     struct some_error {};
 
-    static constexpr auto might_throw = []() -> std::generator<int> {
+    static constexpr auto might_throw = []() -> generator<int> {
         co_yield 0;
         throw some_error{};
     };
 
-    static constexpr auto nested_ints = []() -> std::generator<int> {
+    static constexpr auto nested_ints = []() -> generator<int> {
         try {
             co_yield ranges::elements_of(might_throw());
         } catch (const some_error&) {
@@ -254,19 +252,19 @@ void recursive_test() {
         co_yield 1;
     };
 
-    assert(ranges::equal(iota_repeater(3, 2), std::array{0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2}));
-    assert(ranges::equal(nested_ints(), std::array{0, 1}));
+    assert(ranges::equal(iota_repeater(3, 2), array{0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2}));
+    assert(ranges::equal(nested_ints(), array{0, 1}));
 }
 
 void arbitrary_range_test() {
-    auto yield_arbitrary_ranges = []() -> std::generator<const int&> {
-        co_yield ranges::elements_of(std::vector<int>{40, 30, 20, 10});
+    auto yield_arbitrary_ranges = []() -> generator<const int&> {
+        co_yield ranges::elements_of(vector<int>{40, 30, 20, 10});
         co_yield ranges::elements_of(ranges::views::iota(0, 4));
-        std::forward_list<int> fl{500, 400, 300};
+        forward_list<int> fl{500, 400, 300};
         co_yield ranges::elements_of(fl);
     };
 
-    assert(ranges::equal(yield_arbitrary_ranges(), std::array{40, 30, 20, 10, 0, 1, 2, 3, 500, 400, 300}));
+    assert(ranges::equal(yield_arbitrary_ranges(), array{40, 30, 20, 10, 0, 1, 2, 3, 500, 400, 300}));
 }
 
 #ifndef _M_CEE // TRANSITION, VSO-1659496
@@ -279,21 +277,21 @@ struct incomplete;
 
 void adl_proof_test() {
     using validator  = holder<incomplete>*;
-    auto yield_range = []() -> std::generator<validator> {
+    auto yield_range = []() -> generator<validator> {
         co_yield ranges::elements_of(
-            ranges::views::repeat(nullptr, 42) | ranges::views::transform([](std::nullptr_t) { return validator{}; }));
+            ranges::views::repeat(nullptr, 42) | ranges::views::transform([](nullptr_t) { return validator{}; }));
     };
 
     using R = decltype(yield_range());
     static_assert(ranges::input_range<R>);
 
     using It = ranges::iterator_t<R>;
-    static_assert(std::is_same_v<decltype(&std::declval<It&>()), It*>);
+    static_assert(is_same_v<decltype(&declval<It&>()), It*>);
 
     using Promise = R::promise_type;
-    static_assert(std::is_same_v<decltype(&std::declval<Promise&>()), Promise*>);
+    static_assert(is_same_v<decltype(&declval<Promise&>()), Promise*>);
 
-    std::size_t i = 0;
+    size_t i = 0;
     for (const auto elem : yield_range()) {
         ++i;
         assert(elem == nullptr);
@@ -305,7 +303,7 @@ void adl_proof_test() {
 
 int main() {
     {
-        std::stringstream ss;
+        stringstream ss;
         f(ss);
         assert(ss.str() == "0 1 2 ");
     }
@@ -325,14 +323,14 @@ int main() {
 #if !(defined(__clang__) && defined(_M_IX86)) // TRANSITION, LLVM-56507
     {
         // test with mutable xvalue reference type
-        auto woof = [](std::size_t size, std::size_t count) -> std::generator<std::vector<int>&&> {
-            std::random_device rd{};
-            std::uniform_int_distribution dist{0, 99};
-            std::vector<int> vec;
+        auto woof = [](size_t size, size_t count) -> generator<vector<int>&&> {
+            random_device rd{};
+            uniform_int_distribution dist{0, 99};
+            vector<int> vec;
             while (count-- > 0) {
                 vec.resize(size);
                 ranges::generate(vec, [&] { return dist(rd); });
-                co_yield std::move(vec);
+                co_yield move(vec);
             }
             // test yielding lvalue
             vec.resize(size);
@@ -345,7 +343,7 @@ int main() {
         constexpr size_t size = 16;
         auto r                = woof(size, 4);
         for (auto i = r.begin(); i != r.end(); ++i) {
-            std::vector<int> vec = *i;
+            vector<int> vec = *i;
             assert(vec.size() == size);
             assert((*i).empty());
         }

--- a/tests/std/tests/P2502R2_generator/test.cpp
+++ b/tests/std/tests/P2502R2_generator/test.cpp
@@ -62,7 +62,7 @@ void f(ostream& os) {
 template <ranges::input_range Rng1, ranges::input_range Rng2>
 generator<tuple<ranges::range_reference_t<Rng1>, ranges::range_reference_t<Rng2>>,
     tuple<ranges::range_value_t<Rng1>, ranges::range_value_t<Rng2>>>
-    zip(Rng1 r1, Rng2 r2) {
+    co_zip(Rng1 r1, Rng2 r2) {
     auto it1        = ranges::begin(r1);
     auto it2        = ranges::begin(r2);
     const auto end1 = ranges::end(r1);
@@ -218,7 +218,7 @@ void dynamic_allocator_test() {
 
 void zip_example() {
     int length = 0;
-    for (auto x : zip(array{1, 2, 3}, vector{10, 20, 30, 40, 50})) {
+    for (auto x : co_zip(array{1, 2, 3}, vector{10, 20, 30, 40, 50})) {
         static_assert(same_as<decltype(x), tuple<int&, int&>>);
         assert(get<0>(x) * 10 == get<1>(x));
         ++length;

--- a/tests/std/tests/P2502R2_generator/test.cpp
+++ b/tests/std/tests/P2502R2_generator/test.cpp
@@ -59,7 +59,7 @@ generator<int> ints(int start = 0) {
 
 void f(ostream& os) {
     for (auto i : ints() | views::take(3)) {
-        os << i << ' ';
+        os << i << ' '; // prints '0 1 2 '
     }
 }
 

--- a/tests/std/tests/P2502R2_generator_iterator/test.cpp
+++ b/tests/std/tests/P2502R2_generator_iterator/test.cpp
@@ -151,7 +151,7 @@ void test_with_allocator() {
     test_one<Ref, V>();
     test_one<Ref, V, allocator<void>>();
     test_one<Ref, V, pmr::polymorphic_allocator<void>>();
-    test_one<Ref, V, TestAllocator<void>>();
+    test_one<Ref, V, StatelessAlloc<void>>();
 }
 
 template <class T>

--- a/tests/std/tests/P2502R2_generator_promise/test.cpp
+++ b/tests/std/tests/P2502R2_generator_promise/test.cpp
@@ -178,11 +178,11 @@ void test_one() {
     // Test 'operator new(size_t, ARGS...)'
     test_operator_new<Gen, allocator<void>>(p);
     test_operator_new<Gen, pmr::polymorphic_allocator<void>>(p);
-    test_operator_new<Gen, TestAllocator<void, false_type, int>>(p);
+    test_operator_new<Gen, StatelessAlloc<void, false_type, int>>(p);
     if constexpr (same_as<Alloc, void>) {
-        test_operator_new<Gen, TestAllocator<void>>(p);
-        test_operator_new<Gen, TestAllocator<void, false_type>>(p);
-        test_operator_new<Gen, TestAllocator<void, true_type, int>>(p);
+        test_operator_new<Gen, StatelessAlloc<void>>(p);
+        test_operator_new<Gen, StatelessAlloc<void, false_type>>(p);
+        test_operator_new<Gen, StatelessAlloc<void, true_type, int>>(p);
     }
 }
 
@@ -191,10 +191,10 @@ void test_with_allocator() {
     test_one<Ref, V>();
     test_one<Ref, V, allocator<void>>();
     test_one<Ref, V, pmr::polymorphic_allocator<void>>();
-    test_one<Ref, V, TestAllocator<void>>();
-    test_one<Ref, V, TestAllocator<void, false_type>>();
-    test_one<Ref, V, TestAllocator<void, true_type, int>>();
-    test_one<Ref, V, TestAllocator<void, false_type, int>>();
+    test_one<Ref, V, StatelessAlloc<void>>();
+    test_one<Ref, V, StatelessAlloc<void, false_type>>();
+    test_one<Ref, V, StatelessAlloc<void, true_type, int>>();
+    test_one<Ref, V, StatelessAlloc<void, false_type, int>>();
 }
 
 template <class T>


### PR DESCRIPTION
* Add `using namespace std`
* Rename some functions (e.g. `zip` -> `co_zip`, `meow` -> `co_upto`)
* Add missing includes
* Other minor changes (see commit messages)