### PR TITLE
Fix `atomic_ref::is_lock_free()` on x64

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2370,8 +2370,10 @@ public:
 #else // ^^^ _ATOMIC_HAS_DCAS / !_ATOMIC_HAS_DCAS vvv
         if constexpr (is_always_lock_free) {
             return true;
+        } else if constexpr (_Is_potentially_lock_free) {
+            return __std_atomic_has_cmpxchg16b() != 0;
         } else {
-            return _Is_potentially_lock_free && __std_atomic_has_cmpxchg16b() != 0;
+            return false;
         }
 #endif // ^^^ !_ATOMIC_HAS_DCAS ^^^
     }

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2371,7 +2371,7 @@ public:
         if constexpr (is_always_lock_free) {
             return true;
         } else {
-            return __std_atomic_has_cmpxchg16b() != 0;
+            return _Is_potentially_lock_free && __std_atomic_has_cmpxchg16b() != 0;
         }
 #endif // ^^^ !_ATOMIC_HAS_DCAS ^^^
     }

--- a/tests/std/tests/P0019R8_atomic_ref/test.cpp
+++ b/tests/std/tests/P0019R8_atomic_ref/test.cpp
@@ -447,6 +447,22 @@ void test_gh_4472() {
     assert(ar.is_lock_free());
 }
 
+// GH-4728 "<atomic>: On x64, atomic_ref::is_lock_free() incorrectly returns true when it shouldn't"
+void test_gh_4728() {
+    struct Large {
+        char str[100]{};
+    };
+
+    alignas(std::atomic_ref<Large>::required_alignment) Large lg{};
+
+    static_assert(std::atomic_ref<Large>::required_alignment == alignof(Large));
+
+    static_assert(!std::atomic_ref<Large>::is_always_lock_free);
+
+    std::atomic_ref<Large> ar{lg};
+    assert(!ar.is_lock_free());
+}
+
 int main() {
     test_ops<false, char>();
     test_ops<false, signed char>();
@@ -500,6 +516,7 @@ int main() {
 
     test_gh_1497();
     test_gh_4472();
+    test_gh_4728();
 }
 
 #endif // ^^^ run test ^^^


### PR DESCRIPTION
Fixes #4728.

For `!_ATOMIC_HAS_DCAS`:

* If we're `is_always_lock_free` (power of two, at most 1 pointer), return true.
* Otherwise, we have to be `_Is_potentially_lock_free` (power of two, at most 2 pointers) and have cmpxchg16b.
