### PR TITLE
Add MSVC-internal workaround for ARM64 `popcount` intrinsics

### DIFF
--- a/stl/inc/__msvc_bit_utils.hpp
+++ b/stl/inc/__msvc_bit_utils.hpp
@@ -300,8 +300,9 @@ _NODISCARD int _Checked_x86_x64_countr_zero(const _Ty _Val) noexcept {
 
 #endif // _HAS_TZCNT_BSF_INTRINSICS
 
-#if (defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM64)) && !defined(_M_CEE_PURE) && !defined(__CUDACC__) \
-    && !defined(__INTEL_COMPILER)
+// TRANSITION, remove `_MSC_VER > 1940` check after MSVC-internal toolset update
+#if (defined(_M_IX86) || defined(_M_X64) || (defined(_M_ARM64) && _MSC_VER > 1940)) && !defined(_M_CEE_PURE) \
+    && !defined(__CUDACC__) && !defined(__INTEL_COMPILER)
 #define _HAS_POPCNT_INTRINSICS 1
 #if defined(__AVX__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #define _POPCNT_INTRINSICS_ALWAYS_AVAILABLE 1


### PR DESCRIPTION
As mentioned in #4683, VS 2022 17.11 Preview 1 added ARM64 support for `__popcnt64` etc. intrinsics. When merging #4695, everything seemed to be okay during MSVC-internal PR checks, but post-merge CI noticed that the MSVC-internal build starts with a checked-in 17.10p4, which is too old to know about the new intrinsics.

I missed this because I forgot that MSVC-internal PR checks don't build ARM64 (only the CI does) and I didn't build ARM64 locally.

The workaround is to check the compiler version. I'll be able to remove this after we update the internal toolset, which should happen very soon.