### PR TITLE
Work around a compiler back-end assertion in vectorized minmax

### DIFF
--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2087,6 +2087,7 @@ namespace {
             _Advance_bytes(_First, sizeof(_Ty));
         }
 
+#pragma loop(no_vector) // TRANSITION, VSO-2093761: work around a compiler back-end assertion
         for (auto _Ptr = static_cast<const _Ty*>(_First); _Ptr != _Last; ++_Ptr) {
             if constexpr ((_Mode & _Mode_min) != 0) {
                 if (*_Ptr < _Cur_min_val) {


### PR DESCRIPTION
After merging #4659, the MSVC-internal "selfbuild" CI (where the freshly built compiler is used to build itself again) failed. I've reported VSO-2093761 "amd64chk vect_opcode.cpp assertion `entryIsaRequirement <= isaRequirement` when compiling the STL's vectorized minmax".

Thanks to @AlexGuteniev for suggesting [`#pragma loop(no_vector)`](https://learn.microsoft.com/en-us/cpp/preprocessor/loop?view=msvc-170) as a workaround. (The problem involves the optimizer getting confused by manually vectorized code followed by auto-vectorized code.)
