### PR TITLE
Build the x86 STL with `/arch:SSE2` instead of `/arch:IA32`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,6 @@ if("${VCLIBS_TARGET_ARCHITECTURE}" STREQUAL "x86")
     # Note that we set _WIN32_WINNT to a high level to make declarations available, but still engage downlevel
     # runtime dynamic linking by setting our own _STL_WIN32_WINNT back to Windows XP.
     add_compile_definitions(_X86_ _VCRT_WIN32_WINNT=0x0501 _STL_WIN32_WINNT=0x0501)
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/arch:IA32>)
 elseif(VCLIBS_TARGET_ARCHITECTURE STREQUAL "x64")
     set(VCLIBS_TARGET_ARCHITECTURE "x64")
     set(VCLIBS_I386_OR_AMD64 "amd64")

--- a/tests/std/tests/GH_002431_byte_range_find_with_unreachable_sentinel/test.cpp
+++ b/tests/std/tests/GH_002431_byte_range_find_with_unreachable_sentinel/test.cpp
@@ -65,10 +65,6 @@ int main() {
     disable_instructions(__ISA_AVAILABLE_SSE42);
     test_all_element_sizes(p, page);
 #endif // defined(_M_IX86) || defined(_M_X64)
-#if defined(_M_IX86)
-    disable_instructions(__ISA_AVAILABLE_SSE2);
-    test_all_element_sizes(p, page);
-#endif // defined(_M_IX86)
 
     VirtualFree(p, 0, MEM_RELEASE);
 }

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -1180,11 +1180,5 @@ int main() {
     test_various_containers();
     test_bitset(gen);
 #endif // defined(_M_IX86) || defined(_M_X64)
-#if defined(_M_IX86)
-    disable_instructions(__ISA_AVAILABLE_SSE2);
-    test_vector_algorithms(gen);
-    test_various_containers();
-    test_bitset(gen);
-#endif // defined(_M_IX86)
 #endif // _M_CEE_PURE
 }

--- a/tests/std/tests/floating_point_model_matrix.lst
+++ b/tests/std/tests/floating_point_model_matrix.lst
@@ -6,7 +6,6 @@ RUNALL_CROSSLIST
 *	PM_CL="/FIfenv_prefix.hpp /w14640 /Zc:threadSafeInit- /EHsc /std:c++latest"
 RUNALL_CROSSLIST
 *	PM_CL=""
-*	PM_CL="/arch:IA32"
 *	PM_CL="/arch:AVX2"
 *	PM_CL="/arch:VFPv4"
 RUNALL_CROSSLIST

--- a/tests/utils/stl/test/features.py
+++ b/tests/utils/stl/test/features.py
@@ -50,7 +50,6 @@ def getDefaultFeatures(config, litConfig):
         DEFAULT_FEATURES.append(Feature(name='edg_drop'))
 
     if litConfig.target_arch.casefold() == 'x86'.casefold():
-        DEFAULT_FEATURES.append(Feature(name='arch_ia32'))
         DEFAULT_FEATURES.append(Feature(name='arch_avx2'))
         DEFAULT_FEATURES.append(Feature(name='x86'))
 

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -290,8 +290,6 @@ class STLTest(Test):
                 self.requires.append('edg') # available for x64, see features.py
             elif flag[1:] == 'arch:AVX2':
                 self.requires.append('arch_avx2') # available for x86 and x64, see features.py
-            elif flag[1:] == 'arch:IA32':
-                self.requires.append('arch_ia32') # available for x86, see features.py
             elif flag[1:] == 'arch:VFPv4':
                 self.requires.append('arch_vfpv4') # available for arm, see features.py
             elif flag[1:] == 'MDd':


### PR DESCRIPTION
Fixes #3118. Fixes #3922. See [`/arch` (x86)](https://learn.microsoft.com/en-us/cpp/build/reference/arch-x86?view=msvc-170) on Microsoft Learn.

On x86, the STL (and indeed the entire VCRedist) was historically built with `/arch:IA32` because it had to be capable of running on ancient OSes and potato chips. Now, Win7 / Server 2008 R2 are unsupported and no longer receiving security updates - but before they reached end-of-life, even they were patched to require SSE2. That was [KB4103718](https://support.microsoft.com/en-us/topic/may-8-2018-kb4103718-monthly-rollup-c4c01989-faca-af5f-46f4-2bdc2d0171fd) in May 2018, **over 6 years ago**. (Note: I am well aware of the single exception that paid security updates for the highly obscure Windows Embedded POSReady 7 will end in Oct 2024. More on that in another PR, but the point here is that *even Windows 7* requires SSE2 now.)

The STL can now begin assuming unconditional support for SSE2. The compiler now defaults to `/arch:SSE2`, so all we need to do is remove `/arch:IA32`.

Why make this change? It slightly simplifies our build system and may slightly improve performance (although I don't expect it to be observable, so the PR label is honorary). It also means that our separately compiled code will be exercising the same compiler codepaths used by the vast majority of x86 builds everywhere. If the status quo were reversed and we were currently building with `/arch:SSE2`, we would never want to change to `/arch:IA32`.

This affects the VCRedist, but (1) VS 2022 17.12 will be an "unlocked" long-term support release, and (2) there are no coordinated header changes, so we don't need to worry here.

Note that although we can now assume that SSE2 is unconditionally available (as it has always been for x64), we aren't taking advantage of that in manually vectorized algorithms. See #4536 - attempting to maintain distinct codepaths for SSE2 and SSE4.2 was extremely difficult and we no longer take that risk.

We can also drop test coverage that disables SSE2 (in a partial, simulated way), because we'll never run on such processors.

Finally, I don't think we need to bother testing `GH_000935_complex_numerical_accuracy` with `/arch:IA32`. The STL's headers aren't blocking the option, so while users must be running SSE2-capable processors, they can still limit their own codegen to IA32 (unless and until the compiler deprecates and removes the option, of which I am aware of no plans). However, I think this option is sufficiently obscure that we don't need to bother testing it, and we haven't had any bugs involving it either.