### PR TITLE
C++26 freestanding feature-test macros: Partial Classes and `inout` `expected` `span`

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -75,6 +75,8 @@
 // P2338R4 Freestanding Library: Character Primitives And The C Library
 //     (except for __cpp_lib_freestanding_charconv)
 // P2401R0 Conditional noexcept For exchange()
+// P2407R5 Freestanding Library: Partial Classes
+//     (__cpp_lib_freestanding_algorithm and __cpp_lib_freestanding_array only)
 // P2937R0 Freestanding Library: Remove strtok
 
 // _HAS_CXX17 directly controls:
@@ -132,6 +134,9 @@
 //     (basic_string_view always provides this behavior)
 // P2338R4 Freestanding Library: Character Primitives And The C Library
 //     (including __cpp_lib_freestanding_charconv)
+// P2407R5 Freestanding Library: Partial Classes
+//     (including __cpp_lib_freestanding_optional, __cpp_lib_freestanding_string_view, and
+//     __cpp_lib_freestanding_variant)
 // P2517R1 Conditional noexcept For apply()
 // P2875R4 Undeprecate polymorphic_allocator::destroy
 
@@ -383,6 +388,8 @@
 // P2693R1 Formatting thread::id And stacktrace
 // P2713R1 Escaping Improvements In std::format
 // P2763R1 Fixing layout_stride's Default Constructor For Fully Static Extents
+// P2833R2 Freestanding Library: inout expected span
+//     (except for __cpp_lib_span which also covers C++26 span::at)
 // P2836R1 basic_const_iterator Should Follow Its Underlying Type's Convertibility
 // P3142R0 Printing Blank Lines With println()
 
@@ -1562,6 +1569,8 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_chrono_udls                      201304L
 #define __cpp_lib_complex_udls                     201309L
 #define __cpp_lib_exchange_function                201304L
+#define __cpp_lib_freestanding_algorithm           202311L
+#define __cpp_lib_freestanding_array               202311L
 #define __cpp_lib_freestanding_char_traits         202306L
 #define __cpp_lib_freestanding_cstdlib             202306L
 #define __cpp_lib_freestanding_cstring             202311L
@@ -1625,6 +1634,9 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_clamp                             201603L
 #define __cpp_lib_filesystem                        201703L
 #define __cpp_lib_freestanding_charconv             202306L
+#define __cpp_lib_freestanding_optional             202311L
+#define __cpp_lib_freestanding_string_view          202311L
+#define __cpp_lib_freestanding_variant              202311L
 #define __cpp_lib_gcd_lcm                           201606L
 #define __cpp_lib_hardware_interference_size        201703L
 #define __cpp_lib_has_unique_object_representations 201606L
@@ -1749,12 +1761,14 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_expected                          202211L
 #define __cpp_lib_formatters                        202302L
 #define __cpp_lib_forward_like                      202207L
+#define __cpp_lib_freestanding_expected             202311L
+#define __cpp_lib_freestanding_mdspan               202311L
 #define __cpp_lib_invoke_r                          202106L
 #define __cpp_lib_ios_noreplace                     202207L
 #define __cpp_lib_is_scoped_enum                    202011L
 #define __cpp_lib_mdspan                            202207L
 #define __cpp_lib_move_only_function                202110L
-#define __cpp_lib_out_ptr                           202106L
+#define __cpp_lib_out_ptr                           202311L
 #define __cpp_lib_print                             202207L
 #define __cpp_lib_ranges_as_const                   202311L
 #define __cpp_lib_ranges_as_rvalue                  202207L

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -99,8 +99,17 @@ std/utilities/function.objects/range.cmp/less.pass.cpp FAIL
 std/utilities/function.objects/range.cmp/less_equal.pass.cpp FAIL
 std/utilities/function.objects/range.cmp/not_equal_to.pass.cpp FAIL
 
+# libc++ has not implemented P2407R5: "Freestanding Library: Partial Classes"
+std/language.support/support.limits/support.limits.general/array.version.compile.pass.cpp FAIL
+std/language.support/support.limits/support.limits.general/optional.version.compile.pass.cpp FAIL
+std/language.support/support.limits/support.limits.general/string_view.version.compile.pass.cpp FAIL
+
 # libc++ doesn't implement P2588R3 barrier's Phase Completion Guarantees
 std/language.support/support.limits/support.limits.general/barrier.version.compile.pass.cpp FAIL
+
+# libc++ has not implemented P2833R2: "Freestanding Library: inout expected span"
+std/language.support/support.limits/support.limits.general/expected.version.compile.pass.cpp FAIL
+std/language.support/support.limits/support.limits.general/mdspan.version.compile.pass.cpp FAIL
 
 # libc++ has not implemented P2937R0: "Freestanding Library: Remove strtok"
 std/language.support/support.limits/support.limits.general/cstring.version.compile.pass.cpp FAIL

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -377,6 +377,10 @@ STATIC_ASSERT(__cpp_lib_forward_like == 202207L);
 #error __cpp_lib_forward_like is defined
 #endif
 
+STATIC_ASSERT(__cpp_lib_freestanding_algorithm == 202311L);
+
+STATIC_ASSERT(__cpp_lib_freestanding_array == 202311L);
+
 STATIC_ASSERT(__cpp_lib_freestanding_char_traits == 202306L);
 
 #if _HAS_CXX17
@@ -393,15 +397,33 @@ STATIC_ASSERT(__cpp_lib_freestanding_cwchar == 202306L);
 
 STATIC_ASSERT(__cpp_lib_freestanding_errc == 202306L);
 
+#if _HAS_CXX23
+STATIC_ASSERT(__cpp_lib_freestanding_expected == 202311L);
+#elif defined(__cpp_lib_freestanding_expected)
+#error __cpp_lib_freestanding_expected is defined
+#endif
+
 STATIC_ASSERT(__cpp_lib_freestanding_feature_test_macros == 202306L);
 
 STATIC_ASSERT(__cpp_lib_freestanding_functional == 202306L);
 
 STATIC_ASSERT(__cpp_lib_freestanding_iterator == 202306L);
 
+#if _HAS_CXX23
+STATIC_ASSERT(__cpp_lib_freestanding_mdspan == 202311L);
+#elif defined(__cpp_lib_freestanding_mdspan)
+#error __cpp_lib_freestanding_mdspan is defined
+#endif
+
 STATIC_ASSERT(__cpp_lib_freestanding_memory == 202306L);
 
 STATIC_ASSERT(__cpp_lib_freestanding_operator_new == 202306L);
+
+#if _HAS_CXX17
+STATIC_ASSERT(__cpp_lib_freestanding_optional == 202311L);
+#elif defined(__cpp_lib_freestanding_optional)
+#error __cpp_lib_freestanding_optional is defined
+#endif
 
 #if _HAS_CXX20
 STATIC_ASSERT(__cpp_lib_freestanding_ranges == 202306L);
@@ -411,9 +433,21 @@ STATIC_ASSERT(__cpp_lib_freestanding_ranges == 202306L);
 
 STATIC_ASSERT(__cpp_lib_freestanding_ratio == 202306L);
 
+#if _HAS_CXX17
+STATIC_ASSERT(__cpp_lib_freestanding_string_view == 202311L);
+#elif defined(__cpp_lib_freestanding_string_view)
+#error __cpp_lib_freestanding_string_view is defined
+#endif
+
 STATIC_ASSERT(__cpp_lib_freestanding_tuple == 202306L);
 
 STATIC_ASSERT(__cpp_lib_freestanding_utility == 202306L);
+
+#if _HAS_CXX17
+STATIC_ASSERT(__cpp_lib_freestanding_variant == 202311L);
+#elif defined(__cpp_lib_freestanding_variant)
+#error __cpp_lib_freestanding_variant is defined
+#endif
 
 #if _HAS_CXX17
 STATIC_ASSERT(__cpp_lib_gcd_lcm == 201606L);
@@ -644,7 +678,7 @@ STATIC_ASSERT(__cpp_lib_optional == 201606L);
 #endif
 
 #if _HAS_CXX23
-STATIC_ASSERT(__cpp_lib_out_ptr == 202106L);
+STATIC_ASSERT(__cpp_lib_out_ptr == 202311L);
 #elif defined(__cpp_lib_out_ptr)
 #error __cpp_lib_out_ptr is defined
 #endif


### PR DESCRIPTION
Fixes #4172. Fixes #4177.

Blocked libcxx tests:
- `std/language.support/support.limits/support.limits.general/array.version.compile.pass.cpp`
- `std/language.support/support.limits/support.limits.general/expected.version.compile.pass.cpp`
- `std/language.support/support.limits/support.limits.general/mdspan.version.compile.pass.cpp`
- `std/language.support/support.limits/support.limits.general/optional.version.compile.pass.cpp`
- `std/language.support/support.limits/support.limits.general/string_view.version.compile.pass.cpp`

Some related tests are already marked `FAIL` for other reasons.