### PR TITLE
Always use cmpxchg16b on x64 for `atomic_ref<16 bytes>`

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -30,7 +30,6 @@ _STL_DISABLE_CLANG_WARNINGS
 
 #ifdef _WIN64
 #if _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1
-#define _STD_COMPARE_EXCHANGE_128 _InterlockedCompareExchange128
 #else // ^^^ _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1 / _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0 vvv
 // 16-byte atomics are separately compiled for x64, as not all x64 hardware has the cmpxchg16b
 // instruction; in the event this instruction is not available, the fallback is a global
@@ -38,7 +37,6 @@ _STL_DISABLE_CLANG_WARNINGS
 // (Note: machines without this instruction typically have 2 cores or fewer, so this isn't too bad)
 // All pointer parameters must be 16-byte aligned.
 extern "C" _NODISCARD char __stdcall __std_atomic_has_cmpxchg16b() noexcept;
-#define _STD_COMPARE_EXCHANGE_128 _InterlockedCompareExchange128
 #endif // ^^^ _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0 ^^^
 #endif // defined(_WIN64)
 
@@ -600,7 +598,7 @@ inline bool __stdcall _Atomic_wait_compare_16_bytes(const void* _Storage, void* 
     const auto _Cmp               = static_cast<const long long*>(_Comparand);
     alignas(16) long long _Tmp[2] = {_Cmp[0], _Cmp[1]};
 #if defined(_M_X64) && !defined(_M_ARM64EC)
-    return _STD_COMPARE_EXCHANGE_128(_Dest, _Tmp[1], _Tmp[0], _Tmp) != 0;
+    return _InterlockedCompareExchange128(_Dest, _Tmp[1], _Tmp[0], _Tmp) != 0;
 #else // ^^^ _M_X64 / ARM64, _M_ARM64EC vvv
     return _InterlockedCompareExchange128_nf(_Dest, _Tmp[1], _Tmp[0], _Tmp) != 0;
 #endif // ^^^ ARM64, _M_ARM64EC ^^^
@@ -1196,7 +1194,7 @@ struct _Atomic_storage<_Ty&, 16> { // lock-free using 16-byte intrinsics
     _NODISCARD _TVal load() const noexcept { // load with sequential consistency
         long long* const _Storage_ptr = const_cast<long long*>(_STD _Atomic_address_as<const long long>(_Storage));
         _Int128 _Result{}; // atomic CAS 0 with 0
-        (void) _STD_COMPARE_EXCHANGE_128(_Storage_ptr, 0, 0, &_Result._Low);
+        (void) _InterlockedCompareExchange128(_Storage_ptr, 0, 0, &_Result._Low);
         return reinterpret_cast<_TVal&>(_Result);
     }
 
@@ -1267,7 +1265,7 @@ struct _Atomic_storage<_Ty&, 16> { // lock-free using 16-byte intrinsics
                     &_Expected_temp._Low);
 #else // ^^^ _M_ARM64, _M_ARM64EC / _M_X64 vvv
                 (void) _Order;
-                _Result = _STD_COMPARE_EXCHANGE_128(&reinterpret_cast<long long&>(_Storage), _Desired_bytes._High,
+                _Result = _InterlockedCompareExchange128(&reinterpret_cast<long long&>(_Storage), _Desired_bytes._High,
                     _Desired_bytes._Low, &_Expected_temp._Low);
 #endif // ^^^ _M_X64 ^^^
                 if (_Result) {
@@ -1293,7 +1291,7 @@ struct _Atomic_storage<_Ty&, 16> { // lock-free using 16-byte intrinsics
             &_Expected_temp._Low);
 #else // ^^^ _M_ARM64, _M_ARM64EC / _M_X64 vvv
         (void) _Order;
-        _Result = _STD_COMPARE_EXCHANGE_128(
+        _Result = _InterlockedCompareExchange128(
             &reinterpret_cast<long long&>(_Storage), _Desired_bytes._High, _Desired_bytes._Low, &_Expected_temp._Low);
 #endif // ^^^ _M_X64 ^^^
         if (_Result == 0) {
@@ -3053,7 +3051,6 @@ _STD_END
 #undef __STORE_RELEASE
 #undef _STD_ATOMIC_USE_ARM64_LDAR_STLR
 
-#undef _STD_COMPARE_EXCHANGE_128
 #undef _INVALID_MEMORY_ORDER
 
 #pragma pop_macro("new")

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -28,18 +28,6 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-#ifdef _WIN64
-#if _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1
-#else // ^^^ _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1 / _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0 vvv
-// 16-byte atomics are separately compiled for x64, as not all x64 hardware has the cmpxchg16b
-// instruction; in the event this instruction is not available, the fallback is a global
-// synchronization object shared by all 16-byte atomics.
-// (Note: machines without this instruction typically have 2 cores or fewer, so this isn't too bad)
-// All pointer parameters must be 16-byte aligned.
-extern "C" _NODISCARD char __stdcall __std_atomic_has_cmpxchg16b() noexcept;
-#endif // ^^^ _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0 ^^^
-#endif // defined(_WIN64)
-
 // Allow _InterlockedCompareExchange128 to be used:
 #if defined(__clang__) && defined(_M_X64)
 #pragma clang attribute _STD_ATOMIC_HEADER.push([[gnu::target("cx16")]], apply_to = function)

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -40,13 +40,6 @@ extern "C" _NODISCARD char __stdcall __std_atomic_has_cmpxchg16b() noexcept;
 #endif // ^^^ _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0 ^^^
 #endif // defined(_WIN64)
 
-// Controls whether atomic::is_always_lock_free triggers for sizeof(void *) or 2 * sizeof(void *)
-#if _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1 || !defined(_M_X64) || defined(_M_ARM64EC)
-#define _ATOMIC_HAS_DCAS 1
-#else // ^^^ We always have DCAS / We only sometimes have DCAS vvv
-#define _ATOMIC_HAS_DCAS 0
-#endif // ^^^ We only sometimes have DCAS ^^^
-
 // Allow _InterlockedCompareExchange128 to be used:
 #if defined(__clang__) && defined(_M_X64)
 #pragma clang attribute _STD_ATOMIC_HEADER.push([[gnu::target("cx16")]], apply_to = function)
@@ -3014,7 +3007,6 @@ _STD_END
 #undef _ATOMIC_STORE_32_SEQ_CST
 #undef _ATOMIC_STORE_64_SEQ_CST
 #undef _ATOMIC_STORE_64_SEQ_CST_IX86
-#undef _ATOMIC_HAS_DCAS
 #undef _ATOMIC_STORE_SEQ_CST_ARM64
 #undef __LOAD_ACQUIRE_ARM64
 #undef _ATOMIC_LOAD_ARM64

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2353,7 +2353,7 @@ public:
         if constexpr (is_always_lock_free) {
             return true;
         } else if constexpr (_Is_potentially_lock_free) {
-            return __std_atomic_has_cmpxchg16b() != 0;
+            return true;
         } else {
             return false;
         }

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2171,11 +2171,7 @@ public:
 #endif // _HAS_CXX17
 
     _NODISCARD bool is_lock_free() const volatile noexcept {
-#if 1 // TRANSITION, ABI
-        return sizeof(_Ty) <= 8 && (sizeof(_Ty) & (sizeof(_Ty) - 1)) == 0;
-#else // ^^^ don't break ABI / break ABI vvv
-        return sizeof(_Ty) <= 2 * sizeof(void*);
-#endif // ^^^ break ABI ^^^
+        return _Is_always_lock_free<sizeof(_Ty)>;
     }
 
     _NODISCARD bool is_lock_free() const noexcept {

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2323,7 +2323,7 @@ public:
     using value_type = _Ty;
 
     explicit atomic_ref(_Ty& _Value) noexcept /* strengthened */ : _Base(_Value) {
-        if constexpr (_Is_potentially_lock_free) {
+        if constexpr (is_always_lock_free) {
             _Check_alignment(_Value);
         } else {
             this->_Init_spinlock_for_ref();
@@ -2334,24 +2334,13 @@ public:
 
     atomic_ref& operator=(const atomic_ref&) = delete;
 
-    static constexpr bool _Is_potentially_lock_free =
+    static constexpr bool is_always_lock_free =
         sizeof(_Ty) <= 2 * sizeof(void*) && (sizeof(_Ty) & (sizeof(_Ty) - 1)) == 0;
 
-    static constexpr bool is_always_lock_free =
-#if _ATOMIC_HAS_DCAS
-        _Is_potentially_lock_free;
-#else // ^^^ _ATOMIC_HAS_DCAS / !_ATOMIC_HAS_DCAS vvv
-        _Is_potentially_lock_free;
-#endif // ^^^ !_ATOMIC_HAS_DCAS ^^^
-
-    static constexpr size_t required_alignment = _Is_potentially_lock_free ? sizeof(_Ty) : alignof(_Ty);
+    static constexpr size_t required_alignment = is_always_lock_free ? sizeof(_Ty) : alignof(_Ty);
 
     _NODISCARD bool is_lock_free() const noexcept {
-#if _ATOMIC_HAS_DCAS
         return is_always_lock_free;
-#else // ^^^ _ATOMIC_HAS_DCAS / !_ATOMIC_HAS_DCAS vvv
-        return _Is_potentially_lock_free;
-#endif // ^^^ !_ATOMIC_HAS_DCAS ^^^
     }
 
     void store(const _Ty _Value) const noexcept {

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -47,6 +47,11 @@ extern "C" _NODISCARD char __stdcall __std_atomic_has_cmpxchg16b() noexcept;
 #define _ATOMIC_HAS_DCAS 0
 #endif // ^^^ We only sometimes have DCAS ^^^
 
+// Allow _InterlockedCompareExchange128 to be used:
+#if defined(__clang__) && defined(_M_X64)
+#pragma clang attribute _STD_ATOMIC_HEADER.push([[gnu::target("cx16")]], apply_to = function)
+#endif // ^^^ defined(__clang__) && defined(_M_X64) ^^^
+
 // Controls whether ARM64 ldar/ldapr/stlr should be used
 #ifndef _STD_ATOMIC_USE_ARM64_LDAR_STLR
 #if defined(_M_ARM64) || defined(_M_ARM64EC) || defined(_M_HYBRID_X86_ARM64)
@@ -3052,6 +3057,10 @@ _STD_END
 #undef _STD_ATOMIC_USE_ARM64_LDAR_STLR
 
 #undef _INVALID_MEMORY_ORDER
+
+#if defined(__clang__) && defined(_M_X64)
+#pragma clang attribute _STD_ATOMIC_HEADER.pop
+#endif // ^^^ defined(__clang__) && defined(_M_X64) ^^^
 
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2341,7 +2341,7 @@ public:
 #if _ATOMIC_HAS_DCAS
         _Is_potentially_lock_free;
 #else // ^^^ _ATOMIC_HAS_DCAS / !_ATOMIC_HAS_DCAS vvv
-        _Is_potentially_lock_free && sizeof(_Ty) <= sizeof(void*);
+        _Is_potentially_lock_free;
 #endif // ^^^ !_ATOMIC_HAS_DCAS ^^^
 
     static constexpr size_t required_alignment = _Is_potentially_lock_free ? sizeof(_Ty) : alignof(_Ty);

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2184,11 +2184,7 @@ public:
 #else // ^^^ don't break ABI / break ABI vvv
 
     _NODISCARD bool is_lock_free() const volatile noexcept {
-#if _ATOMIC_HAS_DCAS
         return sizeof(_Ty) <= 2 * sizeof(void*);
-#else // ^^^ _ATOMIC_HAS_DCAS / !_ATOMIC_HAS_DCAS vvv
-        return sizeof(_Ty) <= sizeof(void*) || (sizeof(_Ty) <= 2 * sizeof(void*) && __std_atomic_has_cmpxchg16b());
-#endif // ^^^ !_ATOMIC_HAS_DCAS ^^^
     }
 #endif // ^^^ break ABI ^^^
 

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -1649,13 +1649,8 @@ struct _Atomic_integral<_Ty, 8> : _Atomic_storage<_Ty> { // atomic integral oper
 template <size_t _TypeSize>
 constexpr bool _Is_always_lock_free = _TypeSize <= 8 && (_TypeSize & (_TypeSize - 1)) == 0;
 #else // ^^^ don't break ABI / break ABI vvv
-#if _ATOMIC_HAS_DCAS
 template <size_t _TypeSize>
 constexpr bool _Is_always_lock_free = _TypeSize <= 2 * sizeof(void*);
-#else // ^^^ _ATOMIC_HAS_DCAS / !_ATOMIC_HAS_DCAS vvv
-template <size_t _TypeSize>
-constexpr bool _Is_always_lock_free = _TypeSize <= sizeof(void*);
-#endif // ^^^ !_ATOMIC_HAS_DCAS ^^^
 #endif // ^^^ break ABI ^^^
 
 template <class _Ty, bool _Is_lock_free = _Is_always_lock_free<sizeof(_Ty)>>

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2177,7 +2177,7 @@ public:
 
 #if 1 // TRANSITION, ABI
     _NODISCARD bool is_lock_free() const volatile noexcept {
-        constexpr bool _Result = sizeof(_Ty) <= 8 && (sizeof(_Ty) & sizeof(_Ty) - 1) == 0;
+        constexpr bool _Result = sizeof(_Ty) <= 8 && (sizeof(_Ty) & (sizeof(_Ty) - 1)) == 0;
         return _Result;
     }
 

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -37,11 +37,8 @@ _STL_DISABLE_CLANG_WARNINGS
 // synchronization object shared by all 16-byte atomics.
 // (Note: machines without this instruction typically have 2 cores or fewer, so this isn't too bad)
 // All pointer parameters must be 16-byte aligned.
-extern "C" _NODISCARD unsigned char __stdcall __std_atomic_compare_exchange_128(
-    _Inout_bytecount_(16) long long* _Destination, _In_ long long _ExchangeHigh, _In_ long long _ExchangeLow,
-    _Inout_bytecount_(16) long long* _ComparandResult) noexcept;
 extern "C" _NODISCARD char __stdcall __std_atomic_has_cmpxchg16b() noexcept;
-#define _STD_COMPARE_EXCHANGE_128 __std_atomic_compare_exchange_128
+#define _STD_COMPARE_EXCHANGE_128 _InterlockedCompareExchange128
 #endif // ^^^ _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0 ^^^
 #endif // defined(_WIN64)
 

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2175,18 +2175,13 @@ public:
     static constexpr bool is_always_lock_free = _Is_always_lock_free<sizeof(_Ty)>;
 #endif // _HAS_CXX17
 
+    _NODISCARD bool is_lock_free() const volatile noexcept {
 #if 1 // TRANSITION, ABI
-    _NODISCARD bool is_lock_free() const volatile noexcept {
-        constexpr bool _Result = sizeof(_Ty) <= 8 && (sizeof(_Ty) & (sizeof(_Ty) - 1)) == 0;
-        return _Result;
-    }
-
+        return sizeof(_Ty) <= 8 && (sizeof(_Ty) & (sizeof(_Ty) - 1)) == 0;
 #else // ^^^ don't break ABI / break ABI vvv
-
-    _NODISCARD bool is_lock_free() const volatile noexcept {
         return sizeof(_Ty) <= 2 * sizeof(void*);
-    }
 #endif // ^^^ break ABI ^^^
+    }
 
     _NODISCARD bool is_lock_free() const noexcept {
         return static_cast<const volatile atomic*>(this)->is_lock_free();

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2350,13 +2350,7 @@ public:
 #if _ATOMIC_HAS_DCAS
         return is_always_lock_free;
 #else // ^^^ _ATOMIC_HAS_DCAS / !_ATOMIC_HAS_DCAS vvv
-        if constexpr (is_always_lock_free) {
-            return true;
-        } else if constexpr (_Is_potentially_lock_free) {
-            return true;
-        } else {
-            return false;
-        }
+        return _Is_potentially_lock_free;
 #endif // ^^^ !_ATOMIC_HAS_DCAS ^^^
     }
 

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -315,22 +315,6 @@ _EMIT_STL_WARNING(STL4001, "/clr:pure is deprecated and will be REMOVED.");
 #define _LOCK_STREAM 2
 #define _LOCK_DEBUG  3
 
-#ifndef _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B
-#if _STL_WIN32_WINNT >= _STL_WIN32_WINNT_WINBLUE && defined(_WIN64)
-#define _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B 1
-#else // ^^^ modern 64-bit / less modern or 32-bit vvv
-#define _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B 0
-#endif // _STL_WIN32_WINNT >= _STL_WIN32_WINNT_WINBLUE && defined(_WIN64)
-#endif // !defined(_STD_ATOMIC_ALWAYS_USE_CMPXCHG16B)
-
-#if _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0 && defined(_M_ARM64)
-#error ARM64 requires _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B to be 1.
-#endif // _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0 && defined(_M_ARM64)
-
-#if _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1 && !defined(_WIN64)
-#error _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1 requires 64-bit.
-#endif // _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1 && !defined(_WIN64)
-
 _STD_BEGIN
 enum _Uninitialized { // tag for suppressing initialization
     _Noinit

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1941,10 +1941,9 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 #error In yvals_core.h, defined(MRTDLL) implies defined(_M_CEE_PURE); !defined(_M_CEE_PURE) implies !defined(MRTDLL)
 #endif // defined(MRTDLL) && !defined(_M_CEE_PURE)
 
-#define _STL_WIN32_WINNT_VISTA   0x0600 // _WIN32_WINNT_VISTA from sdkddkver.h
-#define _STL_WIN32_WINNT_WIN8    0x0602 // _WIN32_WINNT_WIN8 from sdkddkver.h
-#define _STL_WIN32_WINNT_WINBLUE 0x0603 // _WIN32_WINNT_WINBLUE from sdkddkver.h
-#define _STL_WIN32_WINNT_WIN10   0x0A00 // _WIN32_WINNT_WIN10 from sdkddkver.h
+#define _STL_WIN32_WINNT_VISTA 0x0600 // _WIN32_WINNT_VISTA from sdkddkver.h
+#define _STL_WIN32_WINNT_WIN8  0x0602 // _WIN32_WINNT_WIN8 from sdkddkver.h
+#define _STL_WIN32_WINNT_WIN10 0x0A00 // _WIN32_WINNT_WIN10 from sdkddkver.h
 
 // Note that the STL DLL builds will set this to XP for ABI compatibility with VS2015 which supported XP.
 #ifndef _STL_WIN32_WINNT

--- a/stl/src/atomic_wait.cpp
+++ b/stl/src/atomic_wait.cpp
@@ -243,6 +243,7 @@ _Smtx_t* __stdcall __std_atomic_get_mutex(const void* const _Key) noexcept {
 #endif
 }
 
+// TRANSITION, ABI: preserved for binary compatibility
 [[nodiscard]] char __stdcall __std_atomic_has_cmpxchg16b() noexcept {
 #ifdef _WIN64
     return true;

--- a/stl/src/atomic_wait.cpp
+++ b/stl/src/atomic_wait.cpp
@@ -5,6 +5,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <cstdlib>
 #include <new>
 #include <thread>
 
@@ -89,24 +90,6 @@ namespace {
             _CSTD abort();
         }
 #endif // defined(_DEBUG)
-    }
-
-    [[nodiscard]] unsigned char __std_atomic_compare_exchange_128_fallback(
-        _Inout_bytecount_(16) long long* _Destination, _In_ long long _ExchangeHigh, _In_ long long _ExchangeLow,
-        _Inout_bytecount_(16) long long* _ComparandResult) noexcept {
-        static SRWLOCK _Mtx = SRWLOCK_INIT;
-        _SrwLock_guard _Guard{_Mtx};
-        if (_Destination[0] == _ComparandResult[0] && _Destination[1] == _ComparandResult[1]) {
-            _ComparandResult[0] = _Destination[0];
-            _ComparandResult[1] = _Destination[1];
-            _Destination[0]     = _ExchangeLow;
-            _Destination[1]     = _ExchangeHigh;
-            return static_cast<unsigned char>(true);
-        } else {
-            _ComparandResult[0] = _Destination[0];
-            _ComparandResult[1] = _Destination[1];
-            return static_cast<unsigned char>(false);
-        }
     }
 } // unnamed namespace
 
@@ -255,7 +238,7 @@ _Smtx_t* __stdcall __std_atomic_get_mutex(const void* const _Key) noexcept {
 #ifdef _WIN64
     return _InterlockedCompareExchange128(_Destination, _ExchangeHigh, _ExchangeLow, _ComparandResult);
 #else
-    return __std_atomic_compare_exchange_128_fallback(_Destination, _ExchangeHigh, _ExchangeLow, _ComparandResult);
+    _CSTD abort();
 #endif
 }
 
@@ -263,7 +246,7 @@ _Smtx_t* __stdcall __std_atomic_get_mutex(const void* const _Key) noexcept {
 #ifdef _WIN64
     return true;
 #else
-    return false;
+    _CSTD abort();
 #endif
 }
 } // extern "C"

--- a/stl/src/atomic_wait.cpp
+++ b/stl/src/atomic_wait.cpp
@@ -252,17 +252,11 @@ _Smtx_t* __stdcall __std_atomic_get_mutex(const void* const _Key) noexcept {
 [[nodiscard]] unsigned char __stdcall __std_atomic_compare_exchange_128(_Inout_bytecount_(16) long long* _Destination,
     _In_ long long _ExchangeHigh, _In_ long long _ExchangeLow,
     _Inout_bytecount_(16) long long* _ComparandResult) noexcept {
-#if !defined(_WIN64)
-    return __std_atomic_compare_exchange_128_fallback(_Destination, _ExchangeHigh, _ExchangeLow, _ComparandResult);
-#elif _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1
+#ifdef _WIN64
     return _InterlockedCompareExchange128(_Destination, _ExchangeHigh, _ExchangeLow, _ComparandResult);
-#else // ^^^ _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1 / _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0 vvv
-    if (__std_atomic_has_cmpxchg16b()) {
-        return _InterlockedCompareExchange128(_Destination, _ExchangeHigh, _ExchangeLow, _ComparandResult);
-    }
-
+#else
     return __std_atomic_compare_exchange_128_fallback(_Destination, _ExchangeHigh, _ExchangeLow, _ComparandResult);
-#endif // ^^^ _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0 ^^^
+#endif
 }
 
 [[nodiscard]] char __stdcall __std_atomic_has_cmpxchg16b() noexcept {

--- a/stl/src/atomic_wait.cpp
+++ b/stl/src/atomic_wait.cpp
@@ -266,24 +266,10 @@ _Smtx_t* __stdcall __std_atomic_get_mutex(const void* const _Key) noexcept {
 }
 
 [[nodiscard]] char __stdcall __std_atomic_has_cmpxchg16b() noexcept {
-#if !defined(_WIN64)
-    return false;
-#elif _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1
+#ifdef _WIN64
     return true;
-#else // ^^^ _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1 / _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0 vvv
-    constexpr char _Cmpxchg_Absent  = 0;
-    constexpr char _Cmpxchg_Present = 1;
-    constexpr char _Cmpxchg_Unknown = 2;
-
-    static std::atomic<char> _Cached_value{_Cmpxchg_Unknown};
-
-    char _Value = _Cached_value.load(std::memory_order_relaxed);
-    if (_Value == _Cmpxchg_Unknown) {
-        _Value = IsProcessorFeaturePresent(PF_COMPARE_EXCHANGE128) ? _Cmpxchg_Present : _Cmpxchg_Absent;
-        _Cached_value.store(_Value, std::memory_order_relaxed);
-    }
-
-    return _Value;
-#endif // ^^^ _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0 ^^^
+#else
+    return false;
+#endif
 }
 } // extern "C"

--- a/stl/src/atomic_wait.cpp
+++ b/stl/src/atomic_wait.cpp
@@ -232,6 +232,7 @@ _Smtx_t* __stdcall __std_atomic_get_mutex(const void* const _Key) noexcept {
 }
 #pragma warning(pop)
 
+// TRANSITION, ABI: preserved for binary compatibility
 [[nodiscard]] unsigned char __stdcall __std_atomic_compare_exchange_128(_Inout_bytecount_(16) long long* _Destination,
     _In_ long long _ExchangeHigh, _In_ long long _ExchangeLow,
     _Inout_bytecount_(16) long long* _ComparandResult) noexcept {

--- a/stl/src/atomic_wait.cpp
+++ b/stl/src/atomic_wait.cpp
@@ -238,9 +238,13 @@ _Smtx_t* __stdcall __std_atomic_get_mutex(const void* const _Key) noexcept {
     _Inout_bytecount_(16) long long* _ComparandResult) noexcept {
 #ifdef _WIN64
     return _InterlockedCompareExchange128(_Destination, _ExchangeHigh, _ExchangeLow, _ComparandResult);
-#else
+#else // ^^^ 64-bit / 32-bit vvv
+    (void) _Destination;
+    (void) _ExchangeHigh;
+    (void) _ExchangeLow;
+    (void) _ComparandResult;
     _CSTD abort();
-#endif
+#endif // ^^^ 32-bit ^^^
 }
 
 // TRANSITION, ABI: preserved for binary compatibility

--- a/tests/std/tests/P0019R8_atomic_ref/env.lst
+++ b/tests/std/tests/P0019R8_atomic_ref/env.lst
@@ -2,6 +2,3 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 RUNALL_INCLUDE ..\usual_20_matrix.lst
-RUNALL_CROSSLIST
-*	PM_CL=""
-*	PM_CL="/D_STD_ATOMIC_ALWAYS_USE_CMPXCHG16B=1 /DTEST_CMPXCHG16B"

--- a/tests/std/tests/P0019R8_atomic_ref/test.cpp
+++ b/tests/std/tests/P0019R8_atomic_ref/test.cpp
@@ -1,12 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#if defined(TEST_CMPXCHG16B) && (defined(__clang__) || !defined(_M_X64))
-// Skip Clang because it would require the -mcx16 compiler option.
-// Skip non-x64 because _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B is always 1 for ARM64, and is forbidden to be 1 for 32-bit.
-int main() {}
-#else // ^^^ skip test / run test vvv
-
 #include <atomic>
 #include <cassert>
 #include <cstddef>
@@ -436,13 +430,8 @@ void test_gh_4472() {
 
     static_assert(std::atomic_ref<two_pointers_t>::required_alignment == sizeof(two_pointers_t));
 
-#ifdef _WIN64
-    static_assert(std::atomic_ref<two_pointers_t>::is_always_lock_free == _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B);
-#else
     static_assert(std::atomic_ref<two_pointers_t>::is_always_lock_free);
-#endif
 
-    // We expect tests to run on machines that support DCAS, which is required by Win8+.
     std::atomic_ref<two_pointers_t> ar{two_pointers};
     assert(ar.is_lock_free());
 }
@@ -518,5 +507,3 @@ int main() {
     test_gh_4472();
     test_gh_4728();
 }
-
-#endif // ^^^ run test ^^^


### PR DESCRIPTION
Fixes #4481.

# :scroll: Overview

The cmpxchg16b instruction (aka the `_InterlockedCompareExchange128` intrinsic) was missing from the earliest x64 processors, but was quickly added and is now required by all modern OSes. This intrinsic (emitting an equivalent instruction sequence) has always been supported by ARM64.

Our implementation of C++11 `atomic` didn't attempt to take advantage of the then-fairly-new cmpxchg16b instruction. By the time our ABI was frozen in VS 2015, cmpxchg16b was more widespread, but we were still learning about concurrency and hadn't realized the potential for optimization here. Shortly after the ABI freeze, we added some (highly unusual for our conventions) preprocessor-disabled logic, indicating how we could take advantage of cmpxchg16b when we could break ABI, which still hasn't happened yet. So, while this disabled logic appears in `atomic`, it currently never uses `_InterlockedCompareExchange128` (for either x64 or ARM64), and `atomic<16 bytes>` is always locking.

Adding to the complexity, our codebase referred to "DCAS", Double Compare-And-Swap, i.e. double the size of a pointer. For 32-bit architectures, that's a 64-bit compare-and-swap, which is always available. So the codebase said that DCAS was always available on x86, ARM32, and ARM64, but only sometimes available on x64.

When we merged #843 implementing C++20 `atomic_ref` on 2020-08-12 for VS 2019 16.8, cmpxchg16b was even more widespread. I now believe that we should have unconditionally used cmpxchg16b, giving the feature a processor requirement (similar to how `shared_mutex` and C++20 `<chrono>` had OS requirements). At the time, it seemed tempting to implement fallback logic. So, on 64-bit systems, `atomic_ref<16 bytes>` doesn't store any space for a lock, but if at runtime the STL discovers that it's running on x64 without cmpxchg16b, it uses a global lock.

All of this machinery makes our sources very complicated, and it also degrades `atomic_ref<16 bytes>` performance on 64-bit systems. I believe it's finally time to rip out this machinery, simplifying our codebase and improving performance. I've talked to @MahmoudGSaleh and he agrees.

# :dart: Impact

I carefully performed these changes step-by-step, although they're easier to review as a whole. These changes preserve bincompat, in the sense that old and new object files can be freely mixed. (We always require that the final link be performed by the newest toolset and that the VCRedist is also the newest version, but this PR isn't exercising those requirements.)

As previously mentioned, while `atomic`'s preprocessor-disabled logic is being cleaned up, `atomic` is physically unaffected by this PR. `atomic<16 bytes>` is always locking (with a per-object lock), and will remain so for the stable ABI era.

On 64-bit systems, C++20 `atomic_ref<16 bytes>` now uses `_InterlockedCompareExchange128` header-only. This improves performance by eliminating a separately compiled function call (for both x64 and ARM64), and by eliminating a cached runtime support check (for x64).

The old dllexports are preserved for bincompat, but they now unconditionally use cmpxchg16b. (This affects the VCRedist, which is unlocked for VS 2022 17.12, but we don't require close coordination between the header and DLL changes.)

Together, these changes theoretically break one scenario, but it is so vanishingly improbable that I don't believe we need to worry about it now (and Mahmoud agreed). Because this is using a processor instruction, not an OS API, the code has to actually be executed on an old processor to cause problems - merely loading the STL DLL won't be blocked.

# :potato: New Code + Ancient OS + Potato Chip = Won't Happen

Win8.1 / Server 2012 R2 [require cmpxchg16b](https://support.microsoft.com/en-us/windows/system-requirements-2f327e5a-2bae-4011-8848-58180a4353a7) on x64.

Win7 / Server 2008 R2 are no longer supported by the STL after #4742.

Win8.0 client is no longer supported by Microsoft. As [Wikipedia mentions](https://en.wikipedia.org/wiki/Windows_8), support for [Win8.0](https://learn.microsoft.com/en-us/lifecycle/products/windows-8) ended in Jan 2016, with the exception of [Windows Embedded 8 Standard](https://learn.microsoft.com/en-us/lifecycle/products/windows-embedded-8-standard) which ended in Jul 2023.

That leaves [Server 2012 classic](https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2012), which is receiving (paid) extended security updates until Oct 2026.

Consider how many stars would have to align for this PR to be a problem:

* A machine would have to be running Server 2012 classic.
  + It was released in Sep 2012 and was the latest version for only one year, before Server 2012 R2 was released in Oct 2013.
* It would have to be 64-bit.
  + 32-bit servers, while nonsensical today, were a thing back then.
* It would have to be running on an absolute potato chip, old even when Server 2012 classic was new.
  + Support for cmpxchg16b appeared in Intel Nehalem released in Nov 2008, and AMD Bulldozer released in Oct 2011. (It may have appeared in even earlier processor architectures, I didn't do exhaustive research here.)
* That hardware would need to still be working today - most such machines have simply failed by now.
* Then, that ancient OS running on a potato chip would need to be getting bleeding-edge software deployments, with new code using:
  + `/std:c++20` (not a common option yet),
  + `atomic_ref` (not a commonly used feature, even in C++20 codebases),
  + `atomic_ref<16 bytes>` specifically (no other size is affected).

In this highly specific case, this PR will attempt to unconditionally use the cmpxchg16b instruction, which will fail.

I believe that this scenario is sufficiently implausible that we don't need to worry about it (i.e. I don't believe anyone is actually doing this), even with the caveat that deploying an updated VCRedist would be sufficient to cause it, because it would still require C++20 `atomic_ref<16 bytes>`-using code to have been deployed to the server. (And remember, such code would have gotten terrible performance from the fallback due to the global mutex.)

As previously mentioned, because this PR is using a new instruction and not a new OS API, its impact is limited to this specific scenario only. In general, Server 2012 classic will still be supported by the STL, for the 2 years that this OS has remaining.

# :gear: Source Changes

My individual commits have detailed changelogs, but as previously mentioned it's simpler to review the diff as a whole, and look for these notable things:

## `<yvals_core.h>`
* `_STL_WIN32_WINNT_WINBLUE` (i.e. Win8.1) will be unused after these changes.

## `<yvals.h>`
* `_STD_ATOMIC_ALWAYS_USE_CMPXCHG16B` is going away - effectively, it will be `1` iff we're 64-bit.
  + Note that despite the name mentioning CMPXCHG16B, it also applied to ARM64.
  + This is where we compared against `_STL_WIN32_WINNT_WINBLUE`.

## `<atomic>`
*  `_STD_COMPARE_EXCHANGE_128` is going away - we're going to use `_InterlockedCompareExchange128` directly in the header.
* `__std_atomic_compare_exchange_128()` and `__std_atomic_has_cmpxchg16b()` are being preserved for bincompat, so we don't need to declare them anymore.
  + They're still dllexported by `stl/src/msvcp_atomic_wait.src`.
  + Observe that their declarations were guarded by `#ifdef _WIN64`, so 32-bit code never saw these declarations. This will be relevant below.
  + Their declarations were also guarded by `_STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0`, so ARM64 never saw these declarations either.
* `_ATOMIC_HAS_DCAS` is going away - effectively, it will always be `1`.
  + Note that the comment "Controls whether `atomic::is_always_lock_free` triggers for `sizeof(void *)` or `2 * sizeof(void *)`" was inaccurate - it affected `atomic` only in the preprocessor-disabled "break ABI" codepaths. It actively affected `atomic_ref`, though.
* By default, Clang requires the `-mcx16` compiler option to use the `_InterlockedCompareExchange128` intrinsic. Fortunately, there's a way to make this work without requiring users to alter their command lines. We can apply the [`target` attribute](https://clang.llvm.org/docs/AttributeReference.html#target) to functions, making them effectively compiled with `-mcx16`. We could manually mark each usage this way, but there's an even more convenient technique - Clang has a push/pop [`#pragma clang attribute`](https://clang.llvm.org/docs/LanguageExtensions.html#specifying-an-attribute-for-multiple-declarations-pragma-clang-attribute) that will apply the attribute to all functions in a region. For hygiene, I'm inventing a `_STD_ATOMIC_HEADER` "namespace" for this.
* 1632-1635: As previously mentioned, only the "break ABI" codepaths for `atomic` are being changed, with DCAS always being used.
* 2154-2156: Now that we never query for cmpxchg16b's availability at runtime, the current "don't break ABI" and future "break ABI" paths for `is_lock_free()` report the same answer as `is_always_lock_free` (which varies above), so this all collapses away. Again, this leaves the current ABI behavior unaffected (it's `true` for exactly 1, 2, 4, and 8).
* 2307, 2318-2325: For `atomic_ref`, "potentially lock-free" becomes "always lock-free", greatly simplifying this code.
* 2998, 3004: Drop `#undef`s for removed macros.
* 3005-3008: Pop the Clang pragma.

## `atomic_wait.cpp`
* 8: We were already calling `abort()` in this file, but let's be good kitties and include `<cstdlib>` for it.
* 94: Drop the fallback implementation. This was in an unnamed namespace, so no ABI impact.
* 235-256: Mark `__std_atomic_compare_exchange_128()` and `__std_atomic_has_cmpxchg16b()` as preserved for bincompat, and simplify their implementations.
  + They were never declared for 32-bit users, so we can simply `abort()`.
  + They were also never declared for `_M_ARM64`. However, I don't understand ARM64EC well enough to be absolutely confident that we could further restrict the implementations here to `_M_X64`, and there would be little value in doing so.

## `P0019R8_atomic_ref/env.lst`
* No more ~~mutants~~ modes.

## `P0019R8_atomic_ref/test.cpp`
* We don't need to skip this test in certain modes anymore.
* `atomic_ref<two_pointers_t>` is always lock-free now.
* Drop a comment about our tests assuming Win8+.
