### PR TITLE
Implement LWG-4106 `basic_format_args` should not be default-constructible

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2079,8 +2079,6 @@ class _Format_arg_store<_Context> {};
 _EXPORT_STD template <class _Context>
 class basic_format_args {
 public:
-    basic_format_args() noexcept = default;
-
     basic_format_args(const _Format_arg_store<_Context>&) noexcept {}
 
     template <class... _Args>

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -168,6 +168,10 @@ std/utilities/memory/specialized.algorithms/uninitialized.move/ranges_uninitiali
 std/ranges/range.adaptors/range.lazy.split/range.lazy.split.outer.value/ctor.default.pass.cpp FAIL
 std/ranges/range.adaptors/range.lazy.split/range.lazy.split.outer.value/ctor.iter.pass.cpp FAIL
 
+# libc++ doesn't implement LWG-4106
+std/utilities/format/format.arguments/format.args/ctor.pass.cpp FAIL
+std/utilities/format/format.arguments/format.args/get.pass.cpp FAIL
+
 # If any feature-test macro test is failing, this consolidated test will also fail.
 std/language.support/support.limits/support.limits.general/version.version.compile.pass.cpp FAIL
 

--- a/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
@@ -275,6 +275,9 @@ void test_basic_format_context_construction() {
     static_assert(!is_constructible_with_trailing_empty_brace_impl<context>);
     static_assert(!is_constructible_with_trailing_empty_brace_impl<context, OutIt, basic_format_args<context>>);
     static_assert(!is_constructible_with_trailing_empty_brace_impl<context, OutIt, const basic_format_args<context>&>);
+
+    // Also test LWG-4106 "basic_format_args should not be default-constructible"
+    static_assert(!is_default_constructible_v<basic_format_args<context>>);
 }
 
 // Test GH-4636 "<format>: Call to next_arg_id may result in unexpected error (regression)"


### PR DESCRIPTION
See LWG-4106 and WG21-P3341R0.

Blocked libcxx tests
- `std/utilities/format/format.arguments/format.args/ctor.pass.cpp`
- `std/utilities/format/format.arguments/format.args/get.pass.cpp`