### PR TITLE
Implement LWG-4061 Should `std::basic_format_context` be default-constructible/copyable/movable?

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2208,6 +2208,9 @@ private:
         _Out&& _OutputIt_, const basic_format_args<basic_format_context>& _Ctx_args, const _Lazy_locale& _Loc_)
         : _OutputIt(_STD move(_OutputIt_)), _Args(_Ctx_args), _Loc(_Loc_) {}
 
+    basic_format_context(const basic_format_context&)            = delete;
+    basic_format_context& operator=(const basic_format_context&) = delete;
+
 public:
     using iterator  = _Out;
     using char_type = _CharT;

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -168,6 +168,9 @@ std/utilities/memory/specialized.algorithms/uninitialized.move/ranges_uninitiali
 std/ranges/range.adaptors/range.lazy.split/range.lazy.split.outer.value/ctor.default.pass.cpp FAIL
 std/ranges/range.adaptors/range.lazy.split/range.lazy.split.outer.value/ctor.iter.pass.cpp FAIL
 
+# libc++ doesn't implement LWG-4061
+std/utilities/format/format.functions/bug_81590.compile.pass.cpp FAIL
+
 # If any feature-test macro test is failing, this consolidated test will also fail.
 std/language.support/support.limits/support.limits.general/version.version.compile.pass.cpp FAIL
 

--- a/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
@@ -266,8 +266,13 @@ void test_basic_format_context_construction() {
     using context = basic_format_context<OutIt, CharT>;
 
     static_assert(!is_default_constructible_v<context>);
-    static_assert(is_copy_constructible_v<context> == is_copy_constructible_v<OutIt>);
-    static_assert(is_move_constructible_v<context>);
+    static_assert(!is_copy_constructible_v<context>);
+    static_assert(!is_move_constructible_v<context>);
+
+    // Also test the deleted copy assignment operator
+    // from LWG-4061 "Should std::basic_format_context be default-constructible/copyable/movable?"
+    static_assert(!is_copy_assignable_v<context>);
+    static_assert(!is_move_assignable_v<context>);
 
     static_assert(!is_constructible_v<context, OutIt, basic_format_args<context>>);
     static_assert(!is_constructible_v<context, OutIt, const basic_format_args<context>&>);


### PR DESCRIPTION
See LWG-4061 and WG21-P3341R0.

Blocked libcxx test
- `std/utilities/format/format.functions/bug_81590.compile.pass.cpp`