### PR TITLE
`<numeric>`: check for gcd / lcm overflows

### DIFF
--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -631,7 +631,7 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> gcd(const _Mt _Mx, const _Nt _Nx) n
         if (_STD is_constant_evaluated())
 #endif // ^^^ !defined(_DEBUG) ^^
         {
-            if (_Mx == _STD _Min_limit<_Common>() && _Nx == _STD _Min_limit<_Common>()) {
+            if (_Mx == _STD _Min_limit<_Common>() || _Nx == _STD _Min_limit<_Common>()) {
                 _STL_REPORT_ERROR("Preconditions: |m| and |n| are representable as a value of common_type_t<M, N>."
                                   "(N4981 [numeric.ops.gcd]/2, N4981 [numeric.ops.lcm]/2)");
             }

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -628,7 +628,7 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> gcd(const _Mt _Mx, const _Nt _Nx) n
     if constexpr (is_signed_v<_Common>) {
 #ifndef _DEBUG
         if (_STD _Is_constant_evaluated())
-#endif // ^^^ !defined(_DEBUG) ^^
+#endif // ^^^ !defined(_DEBUG) ^^^
         {
             if (_Mx == _STD _Min_limit<_Common>() || _Nx == _STD _Min_limit<_Common>()) {
                 _STL_REPORT_ERROR("Preconditions: |m| and |n| are representable as a value of common_type_t<M, N>. "

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -622,33 +622,22 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> gcd(const _Mt _Mx, const _Nt _Nx) n
     // calculate greatest common divisor
     static_assert(_Is_nonbool_integral<_Mt> && _Is_nonbool_integral<_Nt>, "GCD requires nonbool integral types");
 
+    using _Common          = common_type_t<_Mt, _Nt>;
+    using _Common_unsigned = make_unsigned_t<_Common>;
+
 #if _HAS_CXX20
-    if constexpr (is_signed_v<_Mt> || is_signed_v<_Nt>) {
+    if constexpr (is_signed_v<_Common>) {
 #ifndef _DEBUG
         if (_STD is_constant_evaluated())
 #endif // ^^^ !defined(_DEBUG) ^^
         {
-            if constexpr (is_signed_v<_Mt>) {
-                if (_Mx == _STD _Min_limit<_Mt>()) {
-                    _STL_REPORT_ERROR(
-                        "Preconditions: |m| and |n| are representable as a value of common_type_t<M, N>."
-                        "(N4981 [numeric.ops.gcd]/2, N4981 [numeric.ops.lcm]/2)"));
-                }
-            }
-
-            if constexpr (is_signed_v<_Nt>) {
-                if (_Nx == _STD _Min_limit<_Nt>()) {
-                    _STL_REPORT_ERROR(
-                        "Preconditions: |m| and |n| are representable as a value of common_type_t<M, N>."
-                        "(N4981 [numeric.ops.gcd]/2, N4981 [numeric.ops.lcm]/2)"));
-                }
+            if (_Mx == _STD _Min_limit<_Common>() && _Nx == _STD _Min_limit<_Common>()) {
+                _STL_REPORT_ERROR("Preconditions: |m| and |n| are representable as a value of common_type_t<M, N>."
+                                  "(N4981 [numeric.ops.gcd]/2, N4981 [numeric.ops.lcm]/2)");
             }
         }
     }
 #endif // _HAS_CXX20
-
-    using _Common          = common_type_t<_Mt, _Nt>;
-    using _Common_unsigned = make_unsigned_t<_Common>;
 
     return _Select_countr_zero_impl<_Common_unsigned>([=](auto _Countr_zero_impl) {
         _Common_unsigned _Mx_magnitude = _Abs_u(_Mx);

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -625,15 +625,15 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> gcd(const _Mt _Mx, const _Nt _Nx) n
     using _Common          = common_type_t<_Mt, _Nt>;
     using _Common_unsigned = make_unsigned_t<_Common>;
 
-    return _Select_countr_zero_impl<_Common_unsigned>([=](auto _Countr_zero_impl) {
+    _Common_unsigned _Result = _Select_countr_zero_impl<_Common_unsigned>([=](auto _Countr_zero_impl) {
         _Common_unsigned _Mx_magnitude = _Abs_u(_Mx);
         _Common_unsigned _Nx_magnitude = _Abs_u(_Nx);
         if (_Mx_magnitude == 0U) {
-            return static_cast<_Common>(_Nx_magnitude);
+            return _Nx_magnitude;
         }
 
         if (_Nx_magnitude == 0U) {
-            return static_cast<_Common>(_Mx_magnitude);
+            return _Mx_magnitude;
         }
 
         const auto _Mx_trailing_zeroes  = static_cast<unsigned long>(_Countr_zero_impl(_Mx_magnitude));
@@ -650,12 +650,25 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> gcd(const _Mt _Mx, const _Nt _Nx) n
 
             _Nx_magnitude -= _Mx_magnitude;
             if (_Nx_magnitude == 0U) {
-                return static_cast<_Common>(_Mx_magnitude << _Common_factors_of_2);
+                return static_cast<_Common_unsigned>(_Mx_magnitude << _Common_factors_of_2);
             }
 
             _Nx_trailing_zeroes = static_cast<unsigned long>(_Countr_zero_impl(_Nx_magnitude));
         }
     });
+
+#if _HAS_CXX20
+#ifndef _DEBUG
+    if (_STD _Is_constant_evaluated())
+#endif // ^^^ !defined(_DEBUG) ^^
+    {
+        if (!in_range<_Common>(_Result)) {
+            _STL_REPORT_ERROR("gcd overflow");
+        }
+    }
+#endif // _HAS_CXX20
+
+    return static_cast<_Common>(_Result);
 }
 
 _EXPORT_STD template <class _Mt, class _Nt>
@@ -670,7 +683,26 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> lcm(const _Mt _Mx, const _Nt _Nx) n
         return 0;
     }
 
-    return static_cast<_Common>((_Mx_magnitude / _STD gcd(_Mx_magnitude, _Nx_magnitude)) * _Nx_magnitude);
+#if _HAS_CXX20
+#ifdef _DEBUG
+    if constexpr (true)
+#else // ^^^ defined(_DEBUG) / !defined(_DEBUG) vvv
+    if (_STD _Is_constant_evaluated())
+#endif // ^^^ !defined(_DEBUG) ^^^
+    {
+        _Common_unsigned _Result = 0;
+        _Common_unsigned _Tmp    = _Mx_magnitude / _STD gcd(_Mx_magnitude, _Nx_magnitude);
+
+        if (_Mul_overflow(_Tmp, _Nx_magnitude, _Result) || !in_range<_Common>(_Result)) {
+            _STL_REPORT_ERROR("lcm overflow");
+        }
+
+        return static_cast<_Common>(_Result);
+    } else
+#endif // _HAS_CXX20
+    {
+        return static_cast<_Common>((_Mx_magnitude / _STD gcd(_Mx_magnitude, _Nx_magnitude)) * _Nx_magnitude);
+    }
 }
 #endif // _HAS_CXX17
 

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -686,19 +686,18 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> lcm(const _Mt _Mx, const _Nt _Nx) n
 #ifndef _DEBUG
     if (!_STD _Is_constant_evaluated()) {
         return static_cast<_Common>((_Mx_magnitude / _STD gcd(_Mx_magnitude, _Nx_magnitude)) * _Nx_magnitude);
-    } else
-#endif // ^^^ !defined(_DEBUG) ^^^
-    {
-        _Common_unsigned _Result = 0;
-        _Common_unsigned _Tmp    = _Mx_magnitude / _STD gcd(_Mx_magnitude, _Nx_magnitude);
-
-        if (_Mul_overflow(_Tmp, _Nx_magnitude, _Result) || !_In_range<_Common>(_Result)) {
-            _STL_REPORT_ERROR("Preconditions: The least common multiple of |m| and |n| is representable as a value of "
-                              "type common_type_t<M, N>. (N4981 [numeric.ops.lcm]/2)");
-        }
-
-        return static_cast<_Common>(_Result);
     }
+#endif // ^^^ !defined(_DEBUG) ^^^
+
+    _Common_unsigned _Result = 0;
+    _Common_unsigned _Tmp    = _Mx_magnitude / _STD gcd(_Mx_magnitude, _Nx_magnitude);
+
+    if (_Mul_overflow(_Tmp, _Nx_magnitude, _Result) || !_In_range<_Common>(_Result)) {
+        _STL_REPORT_ERROR("Preconditions: The least common multiple of |m| and |n| is representable as a value of "
+                          "type common_type_t<M, N>. (N4981 [numeric.ops.lcm]/2)");
+    }
+
+    return static_cast<_Common>(_Result);
 }
 #endif // _HAS_CXX17
 

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -637,7 +637,7 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> gcd(const _Mt _Mx, const _Nt _Nx) n
             }
 
             if constexpr (is_signed_v<_Nt>) {
-                if (_Nx == _STD _Min_limit<_Mt>()) {
+                if (_Nx == _STD _Min_limit<_Nt>()) {
                     _STL_REPORT_ERROR(
                         "Preconditions: |m| and |n| are representable as a value of common_type_t<M, N>."
                         "(N4981 [numeric.ops.gcd]/2, N4981 [numeric.ops.lcm]/2)"));

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -630,7 +630,8 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> gcd(const _Mt _Mx, const _Nt _Nx) n
         if (_STD _Is_constant_evaluated())
 #endif // ^^^ !defined(_DEBUG) ^^^
         {
-            if (_Mx == _STD _Min_limit<_Common>() || _Nx == _STD _Min_limit<_Common>()) {
+            constexpr auto _Min_common = _STD _Min_limit<_Common>();
+            if (_Mx == _Min_common || _Nx == _Min_common) {
                 _STL_REPORT_ERROR("Preconditions: |m| and |n| are representable as a value of common_type_t<M, N>. "
                                   "(N4981 [numeric.ops.gcd]/2, N4981 [numeric.ops.lcm]/2)");
             }

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -690,7 +690,7 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> lcm(const _Mt _Mx, const _Nt _Nx) n
 #endif // ^^^ !defined(_DEBUG) ^^^
 
     _Common_unsigned _Result = 0;
-    _Common_unsigned _Tmp    = _Mx_magnitude / _STD gcd(_Mx_magnitude, _Nx_magnitude);
+    _Common_unsigned _Tmp    = static_cast<_Common_unsigned>(_Mx_magnitude / _STD gcd(_Mx_magnitude, _Nx_magnitude));
 
     if (_Mul_overflow(_Tmp, _Nx_magnitude, _Result) || !_In_range<_Common>(_Result)) {
         _STL_REPORT_ERROR("Preconditions: The least common multiple of |m| and |n| is representable as a value of "

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -622,18 +622,43 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> gcd(const _Mt _Mx, const _Nt _Nx) n
     // calculate greatest common divisor
     static_assert(_Is_nonbool_integral<_Mt> && _Is_nonbool_integral<_Nt>, "GCD requires nonbool integral types");
 
+#if _HAS_CXX20
+    if constexpr (is_signed_v<_Mt> || is_signed_v<_Nt>) {
+#ifndef _DEBUG
+        if (_STD is_constant_evaluated())
+#endif // ^^^ !defined(_DEBUG) ^^
+        {
+            if constexpr (is_signed_v<_Mt>) {
+                if (_Mx == _STD _Min_limit<_Mt>()) {
+                    _STL_REPORT_ERROR(
+                        "Preconditions: |m| and |n| are representable as a value of common_type_t<M, N>."
+                        "(N4981 [numeric.ops.gcd]/2, N4981 [numeric.ops.lcm]/2)"));
+                }
+            }
+
+            if constexpr (is_signed_v<_Nt>) {
+                if (_Nx == _STD _Min_limit<_Mt>()) {
+                    _STL_REPORT_ERROR(
+                        "Preconditions: |m| and |n| are representable as a value of common_type_t<M, N>."
+                        "(N4981 [numeric.ops.gcd]/2, N4981 [numeric.ops.lcm]/2)"));
+                }
+            }
+        }
+    }
+#endif // _HAS_CXX20
+
     using _Common          = common_type_t<_Mt, _Nt>;
     using _Common_unsigned = make_unsigned_t<_Common>;
 
-    _Common_unsigned _Result = _Select_countr_zero_impl<_Common_unsigned>([=](auto _Countr_zero_impl) {
+    return _Select_countr_zero_impl<_Common_unsigned>([=](auto _Countr_zero_impl) {
         _Common_unsigned _Mx_magnitude = _Abs_u(_Mx);
         _Common_unsigned _Nx_magnitude = _Abs_u(_Nx);
         if (_Mx_magnitude == 0U) {
-            return _Nx_magnitude;
+            return static_cast<_Common>(_Nx_magnitude);
         }
 
         if (_Nx_magnitude == 0U) {
-            return _Mx_magnitude;
+            return static_cast<_Common>(_Mx_magnitude);
         }
 
         const auto _Mx_trailing_zeroes  = static_cast<unsigned long>(_Countr_zero_impl(_Mx_magnitude));
@@ -650,25 +675,12 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> gcd(const _Mt _Mx, const _Nt _Nx) n
 
             _Nx_magnitude -= _Mx_magnitude;
             if (_Nx_magnitude == 0U) {
-                return static_cast<_Common_unsigned>(_Mx_magnitude << _Common_factors_of_2);
+                return static_cast<_Common>(_Mx_magnitude << _Common_factors_of_2);
             }
 
             _Nx_trailing_zeroes = static_cast<unsigned long>(_Countr_zero_impl(_Nx_magnitude));
         }
     });
-
-#if _HAS_CXX20
-#ifndef _DEBUG
-    if (_STD _Is_constant_evaluated())
-#endif // ^^^ !defined(_DEBUG) ^^
-    {
-        if (!in_range<_Common>(_Result)) {
-            _STL_REPORT_ERROR("gcd overflow");
-        }
-    }
-#endif // _HAS_CXX20
-
-    return static_cast<_Common>(_Result);
 }
 
 _EXPORT_STD template <class _Mt, class _Nt>
@@ -687,14 +699,15 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> lcm(const _Mt _Mx, const _Nt _Nx) n
 #ifdef _DEBUG
     if constexpr (true)
 #else // ^^^ defined(_DEBUG) / !defined(_DEBUG) vvv
-    if (_STD _Is_constant_evaluated())
+    if (_STD is_constant_evaluated())
 #endif // ^^^ !defined(_DEBUG) ^^^
     {
         _Common_unsigned _Result = 0;
         _Common_unsigned _Tmp    = _Mx_magnitude / _STD gcd(_Mx_magnitude, _Nx_magnitude);
 
         if (_Mul_overflow(_Tmp, _Nx_magnitude, _Result) || !in_range<_Common>(_Result)) {
-            _STL_REPORT_ERROR("lcm overflow");
+            _STL_REPORT_ERROR("Preconditions: The least common multiple of |m| and |n| is representable as a value of "
+                              "type common_type_t<M, N>. (N4981 [numeric.ops.lcm]/2)");
         }
 
         return static_cast<_Common>(_Result);

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -682,10 +682,10 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> lcm(const _Mt _Mx, const _Nt _Nx) n
         return 0;
     }
 
-#ifdef _DEBUG
-    if constexpr (true)
-#else // ^^^ defined(_DEBUG) / !defined(_DEBUG) vvv
-    if (_STD _Is_constant_evaluated())
+#ifndef _DEBUG
+    if (!_STD _Is_constant_evaluated()) {
+        return static_cast<_Common>((_Mx_magnitude / _STD gcd(_Mx_magnitude, _Nx_magnitude)) * _Nx_magnitude);
+    } else
 #endif // ^^^ !defined(_DEBUG) ^^^
     {
         _Common_unsigned _Result = 0;
@@ -697,8 +697,6 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> lcm(const _Mt _Mx, const _Nt _Nx) n
         }
 
         return static_cast<_Common>(_Result);
-    } else {
-        return static_cast<_Common>((_Mx_magnitude / _STD gcd(_Mx_magnitude, _Nx_magnitude)) * _Nx_magnitude);
     }
 }
 #endif // _HAS_CXX17

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -691,7 +691,7 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> lcm(const _Mt _Mx, const _Nt _Nx) n
         _Common_unsigned _Result = 0;
         _Common_unsigned _Tmp    = _Mx_magnitude / _STD gcd(_Mx_magnitude, _Nx_magnitude);
 
-        if (_Mul_overflow(_Tmp, _Nx_magnitude, _Result) || !in_range<_Common>(_Result)) {
+        if (_Mul_overflow(_Tmp, _Nx_magnitude, _Result) || !_In_range<_Common>(_Result)) {
             _STL_REPORT_ERROR("Preconditions: The least common multiple of |m| and |n| is representable as a value of "
                               "type common_type_t<M, N>. (N4981 [numeric.ops.lcm]/2)");
         }

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -631,7 +631,7 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> gcd(const _Mt _Mx, const _Nt _Nx) n
 #endif // ^^^ !defined(_DEBUG) ^^
         {
             if (_Mx == _STD _Min_limit<_Common>() || _Nx == _STD _Min_limit<_Common>()) {
-                _STL_REPORT_ERROR("Preconditions: |m| and |n| are representable as a value of common_type_t<M, N>."
+                _STL_REPORT_ERROR("Preconditions: |m| and |n| are representable as a value of common_type_t<M, N>. "
                                   "(N4981 [numeric.ops.gcd]/2, N4981 [numeric.ops.lcm]/2)");
             }
         }

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -784,14 +784,9 @@ _EXPORT_STD template <size_t _Idx>
 constexpr in_place_index_t<_Idx> in_place_index{};
 #endif // _HAS_CXX17
 
-template <class _Ty>
-constexpr bool _Is_standard_integer = _Is_any_of_v<remove_cv_t<_Ty>, signed char, short, int, long, long long,
-    unsigned char, unsigned short, unsigned int, unsigned long, unsigned long long>;
-
 template <class _Ty1, class _Ty2>
 _NODISCARD constexpr bool _Cmp_equal(const _Ty1 _Left, const _Ty2 _Right) noexcept {
-    static_assert(_Is_standard_integer<_Ty1> && _Is_standard_integer<_Ty2>,
-        "The integer comparison functions only accept standard and extended integer types.");
+    _STL_INTERNAL_STATIC_ASSERT(_Is_nonbool_integral<_Ty1> && _Is_nonbool_integral<_Ty2>); // allows character types
     if constexpr (is_signed_v<_Ty1> == is_signed_v<_Ty2>) {
         return _Left == _Right;
     } else if constexpr (is_signed_v<_Ty2>) {
@@ -808,8 +803,7 @@ _NODISCARD constexpr bool _Cmp_not_equal(const _Ty1 _Left, const _Ty2 _Right) no
 
 template <class _Ty1, class _Ty2>
 _NODISCARD constexpr bool _Cmp_less(const _Ty1 _Left, const _Ty2 _Right) noexcept {
-    static_assert(_Is_standard_integer<_Ty1> && _Is_standard_integer<_Ty2>,
-        "The integer comparison functions only accept standard and extended integer types.");
+    _STL_INTERNAL_STATIC_ASSERT(_Is_nonbool_integral<_Ty1> && _Is_nonbool_integral<_Ty2>); // allows character types
     if constexpr (is_signed_v<_Ty1> == is_signed_v<_Ty2>) {
         return _Left < _Right;
     } else if constexpr (is_signed_v<_Ty2>) {
@@ -858,8 +852,7 @@ _NODISCARD constexpr _Ty _Max_limit() noexcept { // same as (numeric_limits<_Ty>
 
 template <class _Rx, class _Ty>
 _NODISCARD constexpr bool _In_range(const _Ty _Value) noexcept {
-    static_assert(_Is_standard_integer<_Rx> && _Is_standard_integer<_Ty>,
-        "The integer comparison functions only accept standard and extended integer types.");
+    _STL_INTERNAL_STATIC_ASSERT(_Is_nonbool_integral<_Rx> && _Is_nonbool_integral<_Ty>); // allows character types
 
     constexpr auto _Ty_min = _Min_limit<_Ty>();
     constexpr auto _Rx_min = _Min_limit<_Rx>();
@@ -883,38 +876,56 @@ _NODISCARD constexpr bool _In_range(const _Ty _Value) noexcept {
 }
 
 #if _HAS_CXX20
+template <class _Ty>
+constexpr bool _Is_standard_integer = _Is_any_of_v<remove_cv_t<_Ty>, signed char, short, int, long, long long,
+    unsigned char, unsigned short, unsigned int, unsigned long, unsigned long long>;
+
 _EXPORT_STD template <class _Ty1, class _Ty2>
 _NODISCARD constexpr bool cmp_equal(const _Ty1 _Left, const _Ty2 _Right) noexcept {
+    static_assert(_Is_standard_integer<_Ty1> && _Is_standard_integer<_Ty2>,
+        "The integer comparison functions only accept standard and extended integer types.");
     return _STD _Cmp_equal(_Left, _Right);
 }
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 _NODISCARD constexpr bool cmp_not_equal(const _Ty1 _Left, const _Ty2 _Right) noexcept {
+    static_assert(_Is_standard_integer<_Ty1> && _Is_standard_integer<_Ty2>,
+        "The integer comparison functions only accept standard and extended integer types.");
     return _STD _Cmp_not_equal(_Left, _Right);
 }
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 _NODISCARD constexpr bool cmp_less(const _Ty1 _Left, const _Ty2 _Right) noexcept {
+    static_assert(_Is_standard_integer<_Ty1> && _Is_standard_integer<_Ty2>,
+        "The integer comparison functions only accept standard and extended integer types.");
     return _STD _Cmp_less(_Left, _Right);
 }
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 _NODISCARD constexpr bool cmp_greater(const _Ty1 _Left, const _Ty2 _Right) noexcept {
+    static_assert(_Is_standard_integer<_Ty1> && _Is_standard_integer<_Ty2>,
+        "The integer comparison functions only accept standard and extended integer types.");
     return _STD _Cmp_greater(_Left, _Right);
 }
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 _NODISCARD constexpr bool cmp_less_equal(const _Ty1 _Left, const _Ty2 _Right) noexcept {
+    static_assert(_Is_standard_integer<_Ty1> && _Is_standard_integer<_Ty2>,
+        "The integer comparison functions only accept standard and extended integer types.");
     return _STD _Cmp_less_equal(_Left, _Right);
 }
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 _NODISCARD constexpr bool cmp_greater_equal(const _Ty1 _Left, const _Ty2 _Right) noexcept {
+    static_assert(_Is_standard_integer<_Ty1> && _Is_standard_integer<_Ty2>,
+        "The integer comparison functions only accept standard and extended integer types.");
     return _STD _Cmp_greater_equal(_Left, _Right);
 }
 
 _EXPORT_STD template <class _Rx, class _Ty>
 _NODISCARD constexpr bool in_range(const _Ty _Value) noexcept {
+    static_assert(_Is_standard_integer<_Rx> && _Is_standard_integer<_Ty>,
+        "The integer comparison functions only accept standard and extended integer types.");
     return _STD _In_range<_Rx>(_Value);
 }
 #endif // _HAS_CXX20

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -7372,7 +7372,9 @@ _NODISCARD constexpr bool _Add_overflow(const _Int _Left, const _Int _Right, _In
         }
     }
 }
+#endif // _HAS_CXX23
 
+#if _HAS_CXX20
 template <_Integer_like _Int>
 _NODISCARD constexpr bool _Mul_overflow(const _Int _Left, const _Int _Right, _Int& _Out) {
 #ifdef __clang__
@@ -7421,7 +7423,7 @@ _NODISCARD constexpr bool _Mul_overflow(const _Int _Left, const _Int _Right, _In
         }
     }
 }
-#endif // _HAS_CXX23
+#endif // _HAS_CXX20
 
 _STD_END
 

--- a/tests/std/tests/P0295R0_gcd_lcm/test.compile.pass.cpp
+++ b/tests/std/tests/P0295R0_gcd_lcm/test.compile.pass.cpp
@@ -49,3 +49,28 @@ static_assert(lcm(1, 0) == 0);
 static_assert(lcm(1073741824, 536870912) == 1073741824);
 static_assert(lcm(1073741824, -536870912) == 1073741824);
 static_assert(lcm(-1073741824, 536870912) == 1073741824);
+
+template <class T>
+constexpr bool test_nonbool_integral_type() {
+    static_assert(gcd(T{60}, T{24}) == T{12});
+    static_assert(lcm(T{60}, T{24}) == T{120});
+    return true;
+}
+
+static_assert(test_nonbool_integral_type<char>());
+static_assert(test_nonbool_integral_type<wchar_t>());
+#ifdef __cpp_char8_t
+static_assert(test_nonbool_integral_type<char8_t>());
+#endif // __cpp_char8_t
+static_assert(test_nonbool_integral_type<char16_t>());
+static_assert(test_nonbool_integral_type<char32_t>());
+static_assert(test_nonbool_integral_type<signed char>());
+static_assert(test_nonbool_integral_type<short>());
+static_assert(test_nonbool_integral_type<int>());
+static_assert(test_nonbool_integral_type<long>());
+static_assert(test_nonbool_integral_type<long long>());
+static_assert(test_nonbool_integral_type<unsigned char>());
+static_assert(test_nonbool_integral_type<unsigned short>());
+static_assert(test_nonbool_integral_type<unsigned int>());
+static_assert(test_nonbool_integral_type<unsigned long>());
+static_assert(test_nonbool_integral_type<unsigned long long>());

--- a/tests/std/tests/P0295R0_gcd_lcm/test.compile.pass.cpp
+++ b/tests/std/tests/P0295R0_gcd_lcm/test.compile.pass.cpp
@@ -36,7 +36,7 @@ static_assert(gcd(1073741824, 536870912) == 536870912);
 static_assert(gcd(1073741824, -536870912) == 536870912);
 static_assert(gcd(-1073741824, 536870912) == 536870912);
 static_assert(gcd(int_max, int_max) == int_max);
-static_assert(gcd(int_min, int_max) == 1);
+// gcd(int_min, int_max) -> undefined behavior
 // gcd(int_min, int_min) -> undefined behavior
 static_assert(gcd(int_min + 1, int_min + 1) == int_max);
 


### PR DESCRIPTION
In compile time or in debug.

Fixes #2300