### PR TITLE
P2968R2 Make std::ignore A First-Class Object

### DIFF
--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -119,15 +119,7 @@ struct _Tuple_perfect_val<tuple<_Ty0, _Ty1, _Ty2>, _Uty0, _Uty1, _Uty2>
     : bool_constant<disjunction_v<negation<is_same<_Remove_cvref_t<_Uty0>, allocator_arg_t>>,
           is_same<_Remove_cvref_t<_Ty0>, allocator_arg_t>>> {};
 
-struct _Ignore { // struct that ignores assignments
-    template <class _Ty>
-    constexpr const _Ignore& operator=(const _Ty&) const noexcept {
-        // do nothing
-        return *this;
-    }
-};
-
-_EXPORT_STD _INLINE_VAR constexpr _Ignore ignore{};
+//
 
 // Note: To improve throughput, this file uses extra _STD qualification for names that appear in the
 // arguments of enable_if_t. Specifically, we qualify names which appear anywhere in the STL as members of

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -121,7 +121,7 @@ struct _Tuple_perfect_val<tuple<_Ty0, _Ty1, _Ty2>, _Uty0, _Uty1, _Uty2>
 
 struct _Ignore { // struct that ignores assignments
     template <class _Ty>
-    constexpr const _Ignore& operator=(const _Ty&) const noexcept /* strengthened */ {
+    constexpr const _Ignore& operator=(const _Ty&) const noexcept {
         // do nothing
         return *this;
     }

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -119,8 +119,6 @@ struct _Tuple_perfect_val<tuple<_Ty0, _Ty1, _Ty2>, _Uty0, _Uty1, _Uty2>
     : bool_constant<disjunction_v<negation<is_same<_Remove_cvref_t<_Uty0>, allocator_arg_t>>,
           is_same<_Remove_cvref_t<_Ty0>, allocator_arg_t>>> {};
 
-//
-
 // Note: To improve throughput, this file uses extra _STD qualification for names that appear in the
 // arguments of enable_if_t. Specifically, we qualify names which appear anywhere in the STL as members of
 // some class - including injected-class-names! - that we know are not members of the class being defined.

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -134,7 +134,7 @@ _EXPORT_STD struct piecewise_construct_t { // tag type for pair tuple arguments
 
 _EXPORT_STD _INLINE_VAR constexpr piecewise_construct_t piecewise_construct{};
 
-_EXPORT_STD struct _Ignore { // struct that ignores assignments
+struct _Ignore { // struct that ignores assignments
     template <class _Ty>
     constexpr const _Ignore& operator=(const _Ty&) const noexcept {
         // do nothing

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -134,7 +134,7 @@ _EXPORT_STD struct piecewise_construct_t { // tag type for pair tuple arguments
 
 _EXPORT_STD _INLINE_VAR constexpr piecewise_construct_t piecewise_construct{};
 
-_EXPORT_STD  struct _Ignore { // struct that ignores assignments
+_EXPORT_STD struct _Ignore { // struct that ignores assignments
     template <class _Ty>
     constexpr const _Ignore& operator=(const _Ty&) const noexcept {
         // do nothing

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -132,6 +132,8 @@ _EXPORT_STD struct piecewise_construct_t { // tag type for pair tuple arguments
     explicit piecewise_construct_t() = default;
 };
 
+_EXPORT_STD _INLINE_VAR constexpr _Ignore ignore{};
+
 _EXPORT_STD _INLINE_VAR constexpr piecewise_construct_t piecewise_construct{};
 
 _EXPORT_STD template <class... _Types>

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -134,7 +134,7 @@ _EXPORT_STD struct piecewise_construct_t { // tag type for pair tuple arguments
 
 _EXPORT_STD _INLINE_VAR constexpr piecewise_construct_t piecewise_construct{};
 
-struct _Ignore { // struct that ignores assignments
+_EXPORT_STD  struct _Ignore { // struct that ignores assignments
     template <class _Ty>
     constexpr const _Ignore& operator=(const _Ty&) const noexcept {
         // do nothing
@@ -143,7 +143,6 @@ struct _Ignore { // struct that ignores assignments
 };
 
 _EXPORT_STD _INLINE_VAR constexpr _Ignore ignore{};
-
 
 _EXPORT_STD template <class... _Types>
 class tuple;

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -132,9 +132,18 @@ _EXPORT_STD struct piecewise_construct_t { // tag type for pair tuple arguments
     explicit piecewise_construct_t() = default;
 };
 
+_EXPORT_STD _INLINE_VAR constexpr piecewise_construct_t piecewise_construct{};
+
+struct _Ignore { // struct that ignores assignments
+    template <class _Ty>
+    constexpr const _Ignore& operator=(const _Ty&) const noexcept {
+        // do nothing
+        return *this;
+    }
+};
+
 _EXPORT_STD _INLINE_VAR constexpr _Ignore ignore{};
 
-_EXPORT_STD _INLINE_VAR constexpr piecewise_construct_t piecewise_construct{};
 
 _EXPORT_STD template <class... _Types>
 class tuple;

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -79,7 +79,7 @@
 // P2407R5 Freestanding Library: Partial Classes
 //     (__cpp_lib_freestanding_algorithm and __cpp_lib_freestanding_array only)
 // P2937R0 Freestanding Library: Remove strtok
-
+// P2968R2 Make std::ignore A First-Class Object
 // _HAS_CXX17 directly controls:
 // P0005R4 not_fn()
 // P0024R2 Parallel Algorithms

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -80,6 +80,7 @@
 //     (__cpp_lib_freestanding_algorithm and __cpp_lib_freestanding_array only)
 // P2937R0 Freestanding Library: Remove strtok
 // P2968R2 Make std::ignore A First-Class Object
+
 // _HAS_CXX17 directly controls:
 // P0005R4 not_fn()
 // P0024R2 Parallel Algorithms


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
As requested moved  class deinition of _Ignore and ignore to the utility header file
removed the /* strengthened */ comment from the operator=, and
added the // P2968R2 Make std::ignore A First-Class Object comment to <yvals_core.h> 

Fixes #4756 
