### PR TITLE
Fix insert for flat_map and flat_multimap

### DIFF
--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -1085,6 +1085,7 @@ public:
 
     using _MyBase::_MyBase;
     using _MyBase::operator=;
+    using _MyBase::insert;
 
     // [flat.map.access] Access
     _NODISCARD mapped_type& operator[](const key_type& _Key_val) {
@@ -1391,6 +1392,7 @@ public:
 
     using _MyBase::_MyBase;
     using _MyBase::operator=;
+    using _MyBase::insert;
 
     // [flat.multimap.modifiers] Modifiers
     template <class... _ArgTypes>

--- a/tests/std/tests/P0429R9_flat_map/test.cpp
+++ b/tests/std/tests/P0429R9_flat_map/test.cpp
@@ -418,8 +418,16 @@ void test_insert() {
     assert(res3.first->second == 'w');
     assert(res3.second);
 
-    assert(check_key_content(fm, {10, 90}));
-    assert(check_value_content(fm, {'m', 'w'}));
+    flat_map<int, char>::iterator res4 = fm.insert(fm.cbegin(), std::pair<int, char>{30, 'c'});
+    assert(res4->first == 30);
+    assert(res4->second == 'c');
+
+    flat_map<int, char>::iterator res5 = fm.insert(fm.cbegin(), std::pair<char, char>{static_cast<char>(40), 'd'});
+    assert(res5->first == 40);
+    assert(res5->second == 'd');
+
+    assert(check_key_content(fm, {10, 30, 40, 90}));
+    assert(check_value_content(fm, {'m', 'c', 'd', 'w'}));
 
     flat_multimap<int, char> fmm;
 
@@ -431,13 +439,21 @@ void test_insert() {
     assert(it2->first == 10);
     assert(it2->second == 'n');
 
-    const flat_multimap<int, char>::value_type val_pair2{90, 'w'};
-    const auto it3 = fmm.insert(val_pair2);
-    assert(it3->first == 90);
-    assert(it3->second == 'w');
+    flat_multimap<int, char>::iterator it3 = fmm.insert(fmm.cend(), {70, 'p'});
+    assert(it3->first == 70);
+    assert(it3->second == 'p');
 
-    assert(check_key_content(fmm, {10, 10, 90}));
-    assert(check_value_content(fmm, {'n', 'm', 'w'}));
+    const flat_multimap<int, char>::value_type val_pair2{90, 'w'};
+    const auto it4 = fmm.insert(val_pair2);
+    assert(it4->first == 90);
+    assert(it4->second == 'w');
+
+    flat_multimap<int, char>::iterator it5 = fmm.insert(fmm.cend(), std::pair<char, char>{static_cast<char>(70), 'q'});
+    assert(it5->first == 70);
+    assert(it5->second == 'q');
+
+    assert(check_key_content(fmm, {10, 10, 70, 70, 90}));
+    assert(check_value_content(fmm, {'n', 'm', 'q', 'p', 'w'}));
 }
 
 // GH-4344 <flat_map> Fix compile errors

--- a/tests/std/tests/P0429R9_flat_map/test.cpp
+++ b/tests/std/tests/P0429R9_flat_map/test.cpp
@@ -453,7 +453,9 @@ void test_insert() {
     assert(it5->second == 'q');
 
     assert(check_key_content(fmm, {10, 10, 70, 70, 90}));
-    assert(check_value_content(fmm, {'n', 'm', 'q', 'p', 'w'}));
+    // FIXME: The expected order of the last 3 value element is 'p', 'q', 'w' (no permutation allowed), according to [associative.reqmts.general]/72.
+    // The current implementation gives 'q', 'p', 'w', which is wrong.
+    assert(check_value_content(fmm, {'n', 'm', 'p', 'q', 'w'}, {{0, 1, subrange_type::permutation}, {2, 3, subrange_type::permutation}, {4, 4, subrange_type::equal}}));
 }
 
 // GH-4344 <flat_map> Fix compile errors

--- a/tests/std/tests/P0429R9_flat_map/test.cpp
+++ b/tests/std/tests/P0429R9_flat_map/test.cpp
@@ -455,7 +455,8 @@ void test_insert() {
     assert(check_key_content(fmm, {10, 10, 70, 70, 90}));
     // FIXME: The expected order of the last 3 value element is 'p', 'q', 'w' (no permutation allowed), according to
     // [associative.reqmts.general]/72. The current implementation gives 'q', 'p', 'w', which is wrong.
-    assert(check_value_content(fmm, {'n', 'm', 'p', 'q', 'w'}, {{0, 1, subrange_type::permutation}, {2, 3, subrange_type::permutation}, {4, 4, subrange_type::equal}}));
+    assert(check_value_content(fmm, {'n', 'm', 'p', 'q', 'w'},
+        {{0, 1, subrange_type::permutation}, {2, 3, subrange_type::permutation}, {4, 4, subrange_type::equal}}));
 }
 
 // GH-4344 <flat_map> Fix compile errors

--- a/tests/std/tests/P0429R9_flat_map/test.cpp
+++ b/tests/std/tests/P0429R9_flat_map/test.cpp
@@ -453,8 +453,8 @@ void test_insert() {
     assert(it5->second == 'q');
 
     assert(check_key_content(fmm, {10, 10, 70, 70, 90}));
-    // FIXME: The expected order of the last 3 value element is 'p', 'q', 'w' (no permutation allowed), according to [associative.reqmts.general]/72.
-    // The current implementation gives 'q', 'p', 'w', which is wrong.
+    // FIXME: The expected order of the last 3 value element is 'p', 'q', 'w' (no permutation allowed), according to
+    // [associative.reqmts.general]/72. The current implementation gives 'q', 'p', 'w', which is wrong.
     assert(check_value_content(fmm, {'n', 'm', 'p', 'q', 'w'}, {{0, 1, subrange_type::permutation}, {2, 3, subrange_type::permutation}, {4, 4, subrange_type::equal}}));
 }
 

--- a/tests/std/tests/P0429R9_flat_map/test.cpp
+++ b/tests/std/tests/P0429R9_flat_map/test.cpp
@@ -418,11 +418,11 @@ void test_insert() {
     assert(res3.first->second == 'w');
     assert(res3.second);
 
-    flat_map<int, char>::iterator res4 = fm.insert(fm.cbegin(), std::pair<int, char>{30, 'c'});
+    const auto res4 = fm.insert(fm.cbegin(), std::pair<int, char>{30, 'c'});
     assert(res4->first == 30);
     assert(res4->second == 'c');
 
-    flat_map<int, char>::iterator res5 = fm.insert(fm.cbegin(), std::pair<char, char>{static_cast<char>(40), 'd'});
+    const auto res5 = fm.insert(fm.cbegin(), std::pair<char, char>{static_cast<char>(40), 'd'});
     assert(res5->first == 40);
     assert(res5->second == 'd');
 
@@ -439,7 +439,7 @@ void test_insert() {
     assert(it2->first == 10);
     assert(it2->second == 'n');
 
-    flat_multimap<int, char>::iterator it3 = fmm.insert(fmm.cend(), {70, 'p'});
+    const auto it3 = fmm.insert(fmm.cend(), {70, 'p'});
     assert(it3->first == 70);
     assert(it3->second == 'p');
 
@@ -448,13 +448,13 @@ void test_insert() {
     assert(it4->first == 90);
     assert(it4->second == 'w');
 
-    flat_multimap<int, char>::iterator it5 = fmm.insert(fmm.cend(), std::pair<char, char>{static_cast<char>(70), 'q'});
+    const auto it5 = fmm.insert(fmm.cend(), std::pair<char, char>{static_cast<char>(70), 'q'});
     assert(it5->first == 70);
     assert(it5->second == 'q');
 
     assert(check_key_content(fmm, {10, 10, 70, 70, 90}));
-    // FIXME: The expected order of the last 3 value element is 'p', 'q', 'w' (no permutation allowed), according to
-    // [associative.reqmts.general]/72. The current implementation gives 'q', 'p', 'w', which is wrong.
+    // FIXME: The expected order of the last 3 value elements is 'p', 'q', 'w' (no permutation allowed), according to
+    // N4981 [associative.reqmts.general]/72. The current implementation gives 'q', 'p', 'w', which is wrong.
     assert(check_value_content(fmm, {'n', 'm', 'p', 'q', 'w'},
         {{0, 1, subrange_type::permutation}, {2, 3, subrange_type::permutation}, {4, 4, subrange_type::equal}}));
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->

`_Flat_map_base::insert` overloads were hidden because of the additional `insert` overloads defined in the children classes.
Use `using _Mybase::insert` to make them visible.
Also add test cases.
