### PR TITLE
Remove `_NODISCARD_FRIEND` workaround

### DIFF
--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -328,18 +328,18 @@ struct
     }
 
 #if _HAS_CXX20
-    _NODISCARD_FRIEND constexpr bool operator==(const _Base128&, const _Base128&) noexcept = default;
+    _NODISCARD friend constexpr bool operator==(const _Base128&, const _Base128&) noexcept = default;
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
-    _NODISCARD_FRIEND constexpr bool operator==(const _Base128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD friend constexpr bool operator==(const _Base128& _Left, const _Base128& _Right) noexcept {
         return _Left._Word[0] == _Right._Word[0] && _Left._Word[1] == _Right._Word[1];
     }
 
-    _NODISCARD_FRIEND constexpr bool operator!=(const _Base128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD friend constexpr bool operator!=(const _Base128& _Left, const _Base128& _Right) noexcept {
         return !(_Left == _Right);
     }
 #endif // ^^^ !_HAS_CXX20 ^^^
 
-    _NODISCARD_FRIEND constexpr bool operator<(const _Base128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD friend constexpr bool operator<(const _Base128& _Left, const _Base128& _Right) noexcept {
         if (_Left._Word[1] < _Right._Word[1]) {
             return true;
         }
@@ -349,23 +349,23 @@ struct
         }
         return _Left._Word[0] < _Right._Word[0];
     }
-    _NODISCARD_FRIEND constexpr bool operator>(const _Base128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD friend constexpr bool operator>(const _Base128& _Left, const _Base128& _Right) noexcept {
         return _Right < _Left;
     }
-    _NODISCARD_FRIEND constexpr bool operator<=(const _Base128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD friend constexpr bool operator<=(const _Base128& _Left, const _Base128& _Right) noexcept {
         return !(_Right < _Left);
     }
-    _NODISCARD_FRIEND constexpr bool operator>=(const _Base128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD friend constexpr bool operator>=(const _Base128& _Left, const _Base128& _Right) noexcept {
         return !(_Left < _Right);
     }
 
     _TEMPLATE_CLASS_INTEGRAL(_Ty)
-    _NODISCARD_FRIEND constexpr _Ty operator<<(const _Ty _Left, const _Base128& _Right) noexcept {
+    _NODISCARD friend constexpr _Ty operator<<(const _Ty _Left, const _Base128& _Right) noexcept {
         return _Left << _Right._Word[0];
     }
 
     _TEMPLATE_CLASS_INTEGRAL(_Ty)
-    _NODISCARD_FRIEND constexpr _Ty operator>>(const _Ty _Left, const _Base128& _Right) noexcept {
+    _NODISCARD friend constexpr _Ty operator>>(const _Ty _Left, const _Base128& _Right) noexcept {
         return _Left >> _Right._Word[0];
     }
 
@@ -720,7 +720,7 @@ struct _Unsigned128 : _Base128 {
     }
 
 #if _HAS_CXX20
-    _NODISCARD_FRIEND constexpr strong_ordering operator<=>(
+    _NODISCARD friend constexpr strong_ordering operator<=>(
         const _Unsigned128& _Left, const _Unsigned128& _Right) noexcept {
         strong_ordering _Ord = _Left._Word[1] <=> _Right._Word[1];
         if (_Ord == strong_ordering::equal) {
@@ -729,7 +729,7 @@ struct _Unsigned128 : _Base128 {
         return _Ord;
     }
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
-    _NODISCARD_FRIEND constexpr bool operator<(const _Unsigned128& _Left, const _Unsigned128& _Right) noexcept {
+    _NODISCARD friend constexpr bool operator<(const _Unsigned128& _Left, const _Unsigned128& _Right) noexcept {
         if (_Left._Word[1] < _Right._Word[1]) {
             return true;
         }
@@ -741,20 +741,20 @@ struct _Unsigned128 : _Base128 {
         return _Left._Word[0] < _Right._Word[0];
     }
 
-    _NODISCARD_FRIEND constexpr bool operator>(const _Unsigned128& _Left, const _Unsigned128& _Right) noexcept {
+    _NODISCARD friend constexpr bool operator>(const _Unsigned128& _Left, const _Unsigned128& _Right) noexcept {
         return _Right < _Left;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator<=(const _Unsigned128& _Left, const _Unsigned128& _Right) noexcept {
+    _NODISCARD friend constexpr bool operator<=(const _Unsigned128& _Left, const _Unsigned128& _Right) noexcept {
         return !(_Right < _Left);
     }
 
-    _NODISCARD_FRIEND constexpr bool operator>=(const _Unsigned128& _Left, const _Unsigned128& _Right) noexcept {
+    _NODISCARD friend constexpr bool operator>=(const _Unsigned128& _Left, const _Unsigned128& _Right) noexcept {
         return !(_Left < _Right);
     }
 #endif // ^^^ !_HAS_CXX20 ^^^
 
-    _NODISCARD_FRIEND constexpr _Unsigned128 operator<<(const _Unsigned128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD friend constexpr _Unsigned128 operator<<(const _Unsigned128& _Left, const _Base128& _Right) noexcept {
         auto _Tmp{_Left};
         _Tmp._Left_shift(static_cast<unsigned char>(_Right._Word[0]));
         return _Tmp;
@@ -770,7 +770,7 @@ struct _Unsigned128 : _Base128 {
         return *this;
     }
 
-    _NODISCARD_FRIEND constexpr _Unsigned128 operator>>(const _Unsigned128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD friend constexpr _Unsigned128 operator>>(const _Unsigned128& _Left, const _Base128& _Right) noexcept {
         auto _Tmp{_Left};
         _Tmp._Unsigned_right_shift(static_cast<unsigned char>(_Right._Word[0]));
         return _Tmp;
@@ -822,7 +822,7 @@ struct _Unsigned128 : _Base128 {
         return _Unsigned128{~_Word[0], ~_Word[1]};
     }
 
-    _NODISCARD_FRIEND constexpr _Unsigned128 operator+(const _Base128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD friend constexpr _Unsigned128 operator+(const _Base128& _Left, const _Base128& _Right) noexcept {
         _Unsigned128 _Result;
         const auto _Carry = _AddCarry64(0, _Left._Word[0], _Right._Word[0], _Result._Word[0]);
         _AddCarry64(_Carry, _Left._Word[1], _Right._Word[1], _Result._Word[1]);
@@ -840,7 +840,7 @@ struct _Unsigned128 : _Base128 {
         return _Left;
     }
 
-    _NODISCARD_FRIEND constexpr _Unsigned128 operator-(const _Base128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD friend constexpr _Unsigned128 operator-(const _Base128& _Left, const _Base128& _Right) noexcept {
         _Unsigned128 _Result;
         const auto _Borrow = _SubBorrow64(0, _Left._Word[0], _Right._Word[0], _Result._Word[0]);
         _SubBorrow64(_Borrow, _Left._Word[1], _Right._Word[1], _Result._Word[1]);
@@ -858,7 +858,7 @@ struct _Unsigned128 : _Base128 {
         return _Left;
     }
 
-    _NODISCARD_FRIEND constexpr _Unsigned128 operator*(const _Base128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD friend constexpr _Unsigned128 operator*(const _Base128& _Left, const _Base128& _Right) noexcept {
         return _Unsigned128{_Base128::_Multiply(_Left, _Right)};
     }
 
@@ -873,7 +873,7 @@ struct _Unsigned128 : _Base128 {
     }
 
     _TEMPLATE_CLASS_INTEGRAL(_Ty)
-    _NODISCARD_FRIEND constexpr _Unsigned128 operator/(const _Unsigned128& _Num, const _Ty _Den) noexcept {
+    _NODISCARD friend constexpr _Unsigned128 operator/(const _Unsigned128& _Num, const _Ty _Den) noexcept {
 #if !_STL_128_DIV_INTRINSICS
         if constexpr (sizeof(_Ty) <= 4) {
             return _Unsigned128{_Base128::_Divide(_Num, static_cast<uint32_t>(_Den))};
@@ -883,7 +883,7 @@ struct _Unsigned128 : _Base128 {
             return _Unsigned128{_Base128::_Divide(_Num, static_cast<uint64_t>(_Den))};
         }
     }
-    _NODISCARD_FRIEND constexpr _Unsigned128 operator/(const _Base128& _Num, const _Base128& _Den) noexcept {
+    _NODISCARD friend constexpr _Unsigned128 operator/(const _Base128& _Num, const _Base128& _Den) noexcept {
         return _Unsigned128{_Base128::_Divide(_Num, _Den)};
     }
 
@@ -914,7 +914,7 @@ struct _Unsigned128 : _Base128 {
     }
 
     _TEMPLATE_CLASS_INTEGRAL(_Ty)
-    _NODISCARD_FRIEND constexpr _Unsigned128 operator%(const _Base128& _Num, const _Ty _Den) noexcept {
+    _NODISCARD friend constexpr _Unsigned128 operator%(const _Base128& _Num, const _Ty _Den) noexcept {
 #if !_STL_128_DIV_INTRINSICS
         if constexpr (sizeof(_Ty) <= 4) {
             return _Unsigned128{_Base128::_Modulo(_Num, static_cast<uint32_t>(_Den))};
@@ -924,7 +924,7 @@ struct _Unsigned128 : _Base128 {
             return _Unsigned128{_Base128::_Modulo(_Num, static_cast<uint64_t>(_Den))};
         }
     }
-    _NODISCARD_FRIEND constexpr _Unsigned128 operator%(const _Base128& _Num, const _Base128& _Den) noexcept {
+    _NODISCARD friend constexpr _Unsigned128 operator%(const _Base128& _Num, const _Base128& _Den) noexcept {
         return _Unsigned128{_Base128::_Modulo(_Num, _Den)};
     }
 
@@ -945,7 +945,7 @@ struct _Unsigned128 : _Base128 {
         return _Left;
     }
 
-    _NODISCARD_FRIEND constexpr _Unsigned128 operator&(const _Base128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD friend constexpr _Unsigned128 operator&(const _Base128& _Left, const _Base128& _Right) noexcept {
         return _Unsigned128{_Left._Word[0] & _Right._Word[0], _Left._Word[1] & _Right._Word[1]};
     }
 
@@ -955,7 +955,7 @@ struct _Unsigned128 : _Base128 {
         return *this;
     }
 
-    _NODISCARD_FRIEND constexpr _Unsigned128 operator^(const _Base128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD friend constexpr _Unsigned128 operator^(const _Base128& _Left, const _Base128& _Right) noexcept {
         return _Unsigned128{_Left._Word[0] ^ _Right._Word[0], _Left._Word[1] ^ _Right._Word[1]};
     }
 
@@ -965,7 +965,7 @@ struct _Unsigned128 : _Base128 {
         return *this;
     }
 
-    _NODISCARD_FRIEND constexpr _Unsigned128 operator|(const _Base128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD friend constexpr _Unsigned128 operator|(const _Base128& _Left, const _Base128& _Right) noexcept {
         return _Unsigned128{_Left._Word[0] | _Right._Word[0], _Left._Word[1] | _Right._Word[1]};
     }
 
@@ -1037,7 +1037,7 @@ struct _Signed128 : _Base128 {
     }
 
 #if _HAS_CXX20
-    _NODISCARD_FRIEND constexpr strong_ordering operator<=>(
+    _NODISCARD friend constexpr strong_ordering operator<=>(
         const _Signed128& _Left, const _Signed128& _Right) noexcept {
         strong_ordering _Ord = static_cast<int64_t>(_Left._Word[1]) <=> static_cast<int64_t>(_Right._Word[1]);
         if (_Ord == strong_ordering::equal) {
@@ -1046,7 +1046,7 @@ struct _Signed128 : _Base128 {
         return _Ord;
     }
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
-    _NODISCARD_FRIEND constexpr bool operator<(const _Signed128& _Left, const _Signed128& _Right) noexcept {
+    _NODISCARD friend constexpr bool operator<(const _Signed128& _Left, const _Signed128& _Right) noexcept {
         if (static_cast<int64_t>(_Left._Word[1]) < static_cast<int64_t>(_Right._Word[1])) {
             return true;
         }
@@ -1058,20 +1058,20 @@ struct _Signed128 : _Base128 {
         return _Left._Word[0] < _Right._Word[0];
     }
 
-    _NODISCARD_FRIEND constexpr bool operator>(const _Signed128& _Left, const _Signed128& _Right) noexcept {
+    _NODISCARD friend constexpr bool operator>(const _Signed128& _Left, const _Signed128& _Right) noexcept {
         return _Right < _Left;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator<=(const _Signed128& _Left, const _Signed128& _Right) noexcept {
+    _NODISCARD friend constexpr bool operator<=(const _Signed128& _Left, const _Signed128& _Right) noexcept {
         return !(_Right < _Left);
     }
 
-    _NODISCARD_FRIEND constexpr bool operator>=(const _Signed128& _Left, const _Signed128& _Right) noexcept {
+    _NODISCARD friend constexpr bool operator>=(const _Signed128& _Left, const _Signed128& _Right) noexcept {
         return !(_Left < _Right);
     }
 #endif // ^^^ !_HAS_CXX20 ^^^
 
-    _NODISCARD_FRIEND constexpr _Signed128 operator<<(const _Signed128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD friend constexpr _Signed128 operator<<(const _Signed128& _Left, const _Base128& _Right) noexcept {
         auto _Tmp{_Left};
         _Tmp._Left_shift(static_cast<unsigned char>(_Right._Word[0]));
         return _Tmp;
@@ -1110,7 +1110,7 @@ struct _Signed128 : _Base128 {
         _Word[1] = static_cast<uint64_t>(static_cast<int64_t>(_Word[1]) >> _Count);
     }
 
-    _NODISCARD_FRIEND constexpr _Signed128 operator>>(const _Signed128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD friend constexpr _Signed128 operator>>(const _Signed128& _Left, const _Base128& _Right) noexcept {
         auto _Tmp{_Left};
         _Tmp._Signed_right_shift(static_cast<unsigned char>(_Right._Word[0]));
         return _Tmp;
@@ -1162,7 +1162,7 @@ struct _Signed128 : _Base128 {
         return _Signed128{~_Word[0], ~_Word[1]};
     }
 
-    _NODISCARD_FRIEND constexpr _Signed128 operator+(const _Signed128& _Left, const _Signed128& _Right) noexcept {
+    _NODISCARD friend constexpr _Signed128 operator+(const _Signed128& _Left, const _Signed128& _Right) noexcept {
         _Signed128 _Result;
         const auto _Carry = _AddCarry64(0, _Left._Word[0], _Right._Word[0], _Result._Word[0]);
         _AddCarry64(_Carry, _Left._Word[1], _Right._Word[1], _Result._Word[1]);
@@ -1180,7 +1180,7 @@ struct _Signed128 : _Base128 {
         return _Left;
     }
 
-    _NODISCARD_FRIEND constexpr _Signed128 operator-(const _Signed128& _Left, const _Signed128& _Right) noexcept {
+    _NODISCARD friend constexpr _Signed128 operator-(const _Signed128& _Left, const _Signed128& _Right) noexcept {
         _Signed128 _Result;
         const auto _Borrow = _SubBorrow64(0, _Left._Word[0], _Right._Word[0], _Result._Word[0]);
         _SubBorrow64(_Borrow, _Left._Word[1], _Right._Word[1], _Result._Word[1]);
@@ -1205,7 +1205,7 @@ struct _Signed128 : _Base128 {
         }
     }
 
-    _NODISCARD_FRIEND constexpr _Signed128 operator*(_Signed128 _Left, _Signed128 _Right) noexcept {
+    _NODISCARD friend constexpr _Signed128 operator*(_Signed128 _Left, _Signed128 _Right) noexcept {
         bool _Negative = false;
         _Left._Strip_negative(_Negative);
         _Right._Strip_negative(_Negative);
@@ -1236,7 +1236,7 @@ struct _Signed128 : _Base128 {
     }
 
     _TEMPLATE_CLASS_INTEGRAL(_Ty)
-    _NODISCARD_FRIEND constexpr _Signed128 operator/(_Signed128 _Num, _Ty _Den) noexcept {
+    _NODISCARD friend constexpr _Signed128 operator/(_Signed128 _Num, _Ty _Den) noexcept {
         bool _Negative = false;
         _Num._Strip_negative(_Negative);
         if constexpr (is_signed_v<_Ty>) {
@@ -1261,7 +1261,7 @@ struct _Signed128 : _Base128 {
         }
         return _Result;
     }
-    _NODISCARD_FRIEND constexpr _Signed128 operator/(_Signed128 _Num, _Signed128 _Den) noexcept {
+    _NODISCARD friend constexpr _Signed128 operator/(_Signed128 _Num, _Signed128 _Den) noexcept {
         bool _Negative = false;
         _Num._Strip_negative(_Negative);
         _Den._Strip_negative(_Negative);
@@ -1291,7 +1291,7 @@ struct _Signed128 : _Base128 {
         return _Left;
     }
 
-    _NODISCARD_FRIEND constexpr _Signed128 operator%(_Signed128 _Left, _Signed128 _Right) noexcept {
+    _NODISCARD friend constexpr _Signed128 operator%(_Signed128 _Left, _Signed128 _Right) noexcept {
         bool _Negative = false;
         _Left._Strip_negative(_Negative);
 
@@ -1308,7 +1308,7 @@ struct _Signed128 : _Base128 {
     }
 
     _TEMPLATE_CLASS_INTEGRAL(_Ty)
-    _NODISCARD_FRIEND constexpr _Signed128 operator%(_Signed128 _Left, const _Ty _Right) noexcept {
+    _NODISCARD friend constexpr _Signed128 operator%(_Signed128 _Left, const _Ty _Right) noexcept {
         return _Left % _Signed128{_Right};
     }
 
@@ -1331,7 +1331,7 @@ struct _Signed128 : _Base128 {
         return _Left;
     }
 
-    _NODISCARD_FRIEND constexpr _Signed128 operator&(const _Signed128& _Left, const _Signed128& _Right) noexcept {
+    _NODISCARD friend constexpr _Signed128 operator&(const _Signed128& _Left, const _Signed128& _Right) noexcept {
         return _Signed128{_Left._Word[0] & _Right._Word[0], _Left._Word[1] & _Right._Word[1]};
     }
 
@@ -1341,7 +1341,7 @@ struct _Signed128 : _Base128 {
         return *this;
     }
 
-    _NODISCARD_FRIEND constexpr _Signed128 operator^(const _Signed128& _Left, const _Signed128& _Right) noexcept {
+    _NODISCARD friend constexpr _Signed128 operator^(const _Signed128& _Left, const _Signed128& _Right) noexcept {
         return _Signed128{_Left._Word[0] ^ _Right._Word[0], _Left._Word[1] ^ _Right._Word[1]};
     }
 
@@ -1351,7 +1351,7 @@ struct _Signed128 : _Base128 {
         return *this;
     }
 
-    _NODISCARD_FRIEND constexpr _Signed128 operator|(const _Signed128& _Left, const _Signed128& _Right) noexcept {
+    _NODISCARD friend constexpr _Signed128 operator|(const _Signed128& _Left, const _Signed128& _Right) noexcept {
         return _Signed128{_Left._Word[0] | _Right._Word[0], _Left._Word[1] | _Right._Word[1]};
     }
 

--- a/stl/inc/__msvc_ranges_to.hpp
+++ b/stl/inc/__msvc_ranges_to.hpp
@@ -827,7 +827,7 @@ namespace ranges {
                 return _STD invoke(*_Parent->_Fun, _Current[_Idx]);
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current == _Right._Current)) /* strengthened */
                 requires equality_comparable<iterator_t<_Base>>
             {
@@ -837,7 +837,7 @@ namespace ranges {
                 return _Left._Current == _Right._Current;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current < _Right._Current)) /* strengthened */
                 requires random_access_range<_Base>
             {
@@ -846,25 +846,25 @@ namespace ranges {
 #endif // _ITERATOR_DEBUG_LEVEL != 0
                 return _Left._Current < _Right._Current;
             }
-            _NODISCARD_FRIEND constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current < _Right._Current)) /* strengthened */
                 requires random_access_range<_Base>
             {
                 return _Right < _Left;
             }
-            _NODISCARD_FRIEND constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current < _Right._Current)) /* strengthened */
                 requires random_access_range<_Base>
             {
                 return !(_Right < _Left);
             }
-            _NODISCARD_FRIEND constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current < _Right._Current)) /* strengthened */
                 requires random_access_range<_Base>
             {
                 return !(_Left < _Right);
             }
-            _NODISCARD_FRIEND constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current <=> _Right._Current)) /* strengthened */
                 requires random_access_range<_Base> && three_way_comparable<iterator_t<_Base>>
             {
@@ -874,7 +874,7 @@ namespace ranges {
                 return _Left._Current <=> _Right._Current;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(_Iterator _It, const difference_type _Off) noexcept(
+            _NODISCARD friend constexpr _Iterator operator+(_Iterator _It, const difference_type _Off) noexcept(
                 noexcept(_It._Current += _Off)) /* strengthened */
                 requires random_access_range<_Base>
             {
@@ -884,7 +884,7 @@ namespace ranges {
                 _It._Current += _Off;
                 return _It;
             }
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const difference_type _Off, _Iterator _It) noexcept(
+            _NODISCARD friend constexpr _Iterator operator+(const difference_type _Off, _Iterator _It) noexcept(
                 noexcept(_It._Current += _Off)) /* strengthened */
                 requires random_access_range<_Base>
             {
@@ -895,7 +895,7 @@ namespace ranges {
                 return _It;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator-(_Iterator _It, const difference_type _Off) noexcept(
+            _NODISCARD friend constexpr _Iterator operator-(_Iterator _It, const difference_type _Off) noexcept(
                 noexcept(_It._Current -= _Off)) /* strengthened */
                 requires random_access_range<_Base>
             {
@@ -907,7 +907,7 @@ namespace ranges {
                 return _It;
             }
 
-            _NODISCARD_FRIEND constexpr difference_type operator-(const _Iterator& _Left,
+            _NODISCARD friend constexpr difference_type operator-(const _Iterator& _Left,
                 const _Iterator& _Right) noexcept(noexcept(_Left._Current - _Right._Current)) /* strengthened */
                 requires sized_sentinel_for<iterator_t<_Base>, iterator_t<_Base>>
             {
@@ -958,14 +958,14 @@ namespace ranges {
 
             template <bool _OtherConst>
                 requires sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator<_OtherConst>& _Left,
+            _NODISCARD friend constexpr bool operator==(const _Iterator<_OtherConst>& _Left,
                 const _Sentinel& _Right) noexcept(noexcept(_Get_current(_Left) == _Right._Last)) /* strengthened */ {
                 return _Get_current(_Left) == _Right._Last;
             }
 
             template <bool _OtherConst>
                 requires sized_sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
-            _NODISCARD_FRIEND constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>> operator-(
+            _NODISCARD friend constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>> operator-(
                 const _Iterator<_OtherConst>& _Left,
                 const _Sentinel& _Right) noexcept(noexcept(_Get_current(_Left) - _Right._Last)) /* strengthened */ {
                 return _Get_current(_Left) - _Right._Last;
@@ -973,7 +973,7 @@ namespace ranges {
 
             template <bool _OtherConst>
                 requires sized_sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
-            _NODISCARD_FRIEND constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>>
+            _NODISCARD friend constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>>
                 operator-(const _Sentinel& _Left, const _Iterator<_OtherConst>& _Right) noexcept(
                     noexcept(_Left._Last - _Get_current(_Right))) /* strengthened */ {
                 return _Left._Last - _Get_current(_Right);

--- a/stl/inc/__msvc_string_view.hpp
+++ b/stl/inc/__msvc_string_view.hpp
@@ -990,7 +990,7 @@ public:
         return _Tmp;
     }
 
-    _NODISCARD_FRIEND constexpr _String_view_iterator operator+(
+    _NODISCARD friend constexpr _String_view_iterator operator+(
         const difference_type _Off, _String_view_iterator _Right) noexcept {
         _Right += _Off;
         return _Right;

--- a/stl/inc/array
+++ b/stl/inc/array
@@ -252,7 +252,7 @@ public:
         return _Tmp;
     }
 
-    _NODISCARD_FRIEND _CONSTEXPR17 _Array_const_iterator operator+(
+    _NODISCARD friend _CONSTEXPR17 _Array_const_iterator operator+(
         const ptrdiff_t _Off, _Array_const_iterator _Next) noexcept {
         _Next += _Off;
         return _Next;
@@ -360,7 +360,7 @@ public:
         return _Tmp;
     }
 
-    _NODISCARD_FRIEND _CONSTEXPR17 _Array_iterator operator+(const ptrdiff_t _Off, _Array_iterator _Next) noexcept {
+    _NODISCARD friend _CONSTEXPR17 _Array_iterator operator+(const ptrdiff_t _Off, _Array_iterator _Next) noexcept {
         _Next += _Off;
         return _Next;
     }

--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -208,7 +208,7 @@ _EXPORT_STD struct from_chars_result {
     const char* ptr;
     errc ec;
 #if _HAS_CXX20
-    _NODISCARD_FRIEND bool operator==(const from_chars_result&, const from_chars_result&) = default;
+    _NODISCARD friend bool operator==(const from_chars_result&, const from_chars_result&) = default;
 #endif // _HAS_CXX20
 };
 

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -47,52 +47,52 @@ _EXPORT_STD struct partial_ordering {
     static const partial_ordering greater;
     static const partial_ordering unordered;
 
-    _NODISCARD_FRIEND constexpr bool operator==(const partial_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator==(const partial_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value == 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator==(partial_ordering, partial_ordering) noexcept = default;
+    _NODISCARD friend constexpr bool operator==(partial_ordering, partial_ordering) noexcept = default;
 
-    _NODISCARD_FRIEND constexpr bool operator<(const partial_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator<(const partial_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value == static_cast<_Compare_t>(_Compare_ord::less);
     }
 
-    _NODISCARD_FRIEND constexpr bool operator>(const partial_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator>(const partial_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value > 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator<=(const partial_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator<=(const partial_ordering _Val, _Literal_zero) noexcept {
         // The stored value is either less (0xff), equivalent (0x00), greater (0x01), or unordered (0x80).
         // Subtracting from 0 produces either 0x01, 0x00, 0xff, or 0x80. The result is greater than or equal to 0
         // if and only if the initial value was less or equivalent, for which we want to return true.
         return static_cast<signed char>(0 - static_cast<unsigned int>(_Val._Value)) >= 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator>=(const partial_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator>=(const partial_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value >= 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator<(_Literal_zero, const partial_ordering _Val) noexcept {
+    _NODISCARD friend constexpr bool operator<(_Literal_zero, const partial_ordering _Val) noexcept {
         return _Val > 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator>(_Literal_zero, const partial_ordering _Val) noexcept {
+    _NODISCARD friend constexpr bool operator>(_Literal_zero, const partial_ordering _Val) noexcept {
         return _Val < 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator<=(_Literal_zero, const partial_ordering _Val) noexcept {
+    _NODISCARD friend constexpr bool operator<=(_Literal_zero, const partial_ordering _Val) noexcept {
         return _Val >= 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator>=(_Literal_zero, const partial_ordering _Val) noexcept {
+    _NODISCARD friend constexpr bool operator>=(_Literal_zero, const partial_ordering _Val) noexcept {
         return _Val <= 0;
     }
 
-    _NODISCARD_FRIEND constexpr partial_ordering operator<=>(const partial_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr partial_ordering operator<=>(const partial_ordering _Val, _Literal_zero) noexcept {
         return _Val;
     }
 
-    _NODISCARD_FRIEND constexpr partial_ordering operator<=>(_Literal_zero, const partial_ordering _Val) noexcept {
+    _NODISCARD friend constexpr partial_ordering operator<=>(_Literal_zero, const partial_ordering _Val) noexcept {
         // The stored value is either less (0xff), equivalent (0x00), greater (0x01), or unordered (0x80).
         // Subtracting from 0 produces either 0x01, 0x00, 0xff, or 0x80. Note that the effect is to
         // exchange less for greater (and vice versa), while leaving equivalent and unordered unchanged.
@@ -116,49 +116,49 @@ _EXPORT_STD struct weak_ordering {
         return {static_cast<_Compare_t>(_Value)};
     }
 
-    _NODISCARD_FRIEND constexpr bool operator==(const weak_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator==(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value == 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator==(weak_ordering, weak_ordering) noexcept = default;
+    _NODISCARD friend constexpr bool operator==(weak_ordering, weak_ordering) noexcept = default;
 
-    _NODISCARD_FRIEND constexpr bool operator<(const weak_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator<(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value < 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator>(const weak_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator>(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value > 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator<=(const weak_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator<=(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value <= 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator>=(const weak_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator>=(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value >= 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator<(_Literal_zero, const weak_ordering _Val) noexcept {
+    _NODISCARD friend constexpr bool operator<(_Literal_zero, const weak_ordering _Val) noexcept {
         return _Val > 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator>(_Literal_zero, const weak_ordering _Val) noexcept {
+    _NODISCARD friend constexpr bool operator>(_Literal_zero, const weak_ordering _Val) noexcept {
         return _Val < 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator<=(_Literal_zero, const weak_ordering _Val) noexcept {
+    _NODISCARD friend constexpr bool operator<=(_Literal_zero, const weak_ordering _Val) noexcept {
         return _Val >= 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator>=(_Literal_zero, const weak_ordering _Val) noexcept {
+    _NODISCARD friend constexpr bool operator>=(_Literal_zero, const weak_ordering _Val) noexcept {
         return _Val <= 0;
     }
 
-    _NODISCARD_FRIEND constexpr weak_ordering operator<=>(const weak_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr weak_ordering operator<=>(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val;
     }
 
-    _NODISCARD_FRIEND constexpr weak_ordering operator<=>(_Literal_zero, const weak_ordering _Val) noexcept {
+    _NODISCARD friend constexpr weak_ordering operator<=>(_Literal_zero, const weak_ordering _Val) noexcept {
         return {static_cast<_Compare_t>(-_Val._Value)};
     }
 
@@ -183,49 +183,49 @@ _EXPORT_STD struct strong_ordering {
         return {static_cast<_Compare_t>(_Value)};
     }
 
-    _NODISCARD_FRIEND constexpr bool operator==(const strong_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator==(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value == 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator==(strong_ordering, strong_ordering) noexcept = default;
+    _NODISCARD friend constexpr bool operator==(strong_ordering, strong_ordering) noexcept = default;
 
-    _NODISCARD_FRIEND constexpr bool operator<(const strong_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator<(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value < 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator>(const strong_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator>(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value > 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator<=(const strong_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator<=(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value <= 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator>=(const strong_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr bool operator>=(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value >= 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator<(_Literal_zero, const strong_ordering _Val) noexcept {
+    _NODISCARD friend constexpr bool operator<(_Literal_zero, const strong_ordering _Val) noexcept {
         return _Val > 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator>(_Literal_zero, const strong_ordering _Val) noexcept {
+    _NODISCARD friend constexpr bool operator>(_Literal_zero, const strong_ordering _Val) noexcept {
         return _Val < 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator<=(_Literal_zero, const strong_ordering _Val) noexcept {
+    _NODISCARD friend constexpr bool operator<=(_Literal_zero, const strong_ordering _Val) noexcept {
         return _Val >= 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator>=(_Literal_zero, const strong_ordering _Val) noexcept {
+    _NODISCARD friend constexpr bool operator>=(_Literal_zero, const strong_ordering _Val) noexcept {
         return _Val <= 0;
     }
 
-    _NODISCARD_FRIEND constexpr strong_ordering operator<=>(const strong_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD friend constexpr strong_ordering operator<=>(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val;
     }
 
-    _NODISCARD_FRIEND constexpr strong_ordering operator<=>(_Literal_zero, const strong_ordering _Val) noexcept {
+    _NODISCARD friend constexpr strong_ordering operator<=>(_Literal_zero, const strong_ordering _Val) noexcept {
         return {static_cast<_Compare_t>(-_Val._Value)};
     }
 

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -82,7 +82,7 @@ public:
         return _Tmp;
     }
 
-    _NODISCARD_FRIEND _Deque_unchecked_const_iterator operator+(
+    _NODISCARD friend _Deque_unchecked_const_iterator operator+(
         const difference_type _Off, _Deque_unchecked_const_iterator _Next) noexcept {
         _Next += _Off;
         return _Next;
@@ -202,7 +202,7 @@ public:
         return _Tmp;
     }
 
-    _NODISCARD_FRIEND _Deque_unchecked_iterator operator+(
+    _NODISCARD friend _Deque_unchecked_iterator operator+(
         const difference_type _Off, _Deque_unchecked_iterator _Next) noexcept {
         _Next += _Off;
         return _Next;
@@ -323,7 +323,7 @@ public:
         return _Tmp;
     }
 
-    _NODISCARD_FRIEND _Deque_const_iterator operator+(
+    _NODISCARD friend _Deque_const_iterator operator+(
         const difference_type _Off, _Deque_const_iterator _Next) noexcept {
         _Next += _Off;
         return _Next;
@@ -484,7 +484,7 @@ public:
         return _Tmp;
     }
 
-    _NODISCARD_FRIEND _Deque_iterator operator+(const difference_type _Off, _Deque_iterator _Next) noexcept {
+    _NODISCARD friend _Deque_iterator operator+(const difference_type _Off, _Deque_iterator _Next) noexcept {
         _Next += _Off;
         return _Next;
     }

--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -269,28 +269,28 @@ public:
         __ExceptionPtrSwap(&_Lhs, &_Rhs);
     }
 
-    _NODISCARD_FRIEND bool operator==(const exception_ptr& _Lhs, const exception_ptr& _Rhs) noexcept {
+    _NODISCARD friend bool operator==(const exception_ptr& _Lhs, const exception_ptr& _Rhs) noexcept {
         return __ExceptionPtrCompare(&_Lhs, &_Rhs);
     }
 
-    _NODISCARD_FRIEND bool operator==(const exception_ptr& _Lhs, nullptr_t) noexcept {
+    _NODISCARD friend bool operator==(const exception_ptr& _Lhs, nullptr_t) noexcept {
         return !_Lhs;
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator==(nullptr_t, const exception_ptr& _Rhs) noexcept {
+    _NODISCARD friend bool operator==(nullptr_t, const exception_ptr& _Rhs) noexcept {
         return !_Rhs;
     }
 
-    _NODISCARD_FRIEND bool operator!=(const exception_ptr& _Lhs, const exception_ptr& _Rhs) noexcept {
+    _NODISCARD friend bool operator!=(const exception_ptr& _Lhs, const exception_ptr& _Rhs) noexcept {
         return !(_Lhs == _Rhs);
     }
 
-    _NODISCARD_FRIEND bool operator!=(const exception_ptr& _Lhs, nullptr_t) noexcept {
+    _NODISCARD friend bool operator!=(const exception_ptr& _Lhs, nullptr_t) noexcept {
         return !(_Lhs == nullptr);
     }
 
-    _NODISCARD_FRIEND bool operator!=(nullptr_t, const exception_ptr& _Rhs) noexcept {
+    _NODISCARD friend bool operator!=(nullptr_t, const exception_ptr& _Rhs) noexcept {
         return !(nullptr == _Rhs);
     }
 #endif // !_HAS_CXX20

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -98,7 +98,7 @@ public:
 
     // [expected.un.eq]
     template <class _UErr>
-    _NODISCARD_FRIEND constexpr bool operator==(const unexpected& _Left, const unexpected<_UErr>& _Right) noexcept(
+    _NODISCARD friend constexpr bool operator==(const unexpected& _Left, const unexpected<_UErr>& _Right) noexcept(
         noexcept(_STD _Fake_copy_init<bool>(_Left._Unexpected == _Right.error()))) /* strengthened */ {
         return _Left._Unexpected == _Right.error();
     }
@@ -1140,7 +1140,7 @@ public:
     // [expected.object.eq]
     template <class _Uty, class _UErr>
         requires (!is_void_v<_Uty>)
-    _NODISCARD_FRIEND constexpr bool operator==(const expected& _Left, const expected<_Uty, _UErr>& _Right) noexcept(
+    _NODISCARD friend constexpr bool operator==(const expected& _Left, const expected<_Uty, _UErr>& _Right) noexcept(
         noexcept(_STD _Fake_copy_init<bool>(_Left._Value == *_Right)) && noexcept(
             _STD _Fake_copy_init<bool>(_Left._Unexpected == _Right.error()))) /* strengthened */ {
         if (_Left._Has_value != _Right.has_value()) {
@@ -1153,7 +1153,7 @@ public:
     }
 
     template <class _Uty>
-    _NODISCARD_FRIEND constexpr bool operator==(const expected& _Left, const _Uty& _Right) noexcept(
+    _NODISCARD friend constexpr bool operator==(const expected& _Left, const _Uty& _Right) noexcept(
         noexcept(static_cast<bool>(_Left._Value == _Right))) /* strengthened */ {
         if (_Left._Has_value) {
             return static_cast<bool>(_Left._Value == _Right);
@@ -1163,7 +1163,7 @@ public:
     }
 
     template <class _UErr>
-    _NODISCARD_FRIEND constexpr bool operator==(const expected& _Left, const unexpected<_UErr>& _Right) noexcept(
+    _NODISCARD friend constexpr bool operator==(const expected& _Left, const unexpected<_UErr>& _Right) noexcept(
         noexcept(static_cast<bool>(_Left._Unexpected == _Right.error()))) /* strengthened */ {
         if (_Left._Has_value) {
             return false;
@@ -1876,7 +1876,7 @@ public:
     // [expected.void.eq]
     template <class _Uty, class _UErr>
         requires is_void_v<_Uty>
-    _NODISCARD_FRIEND constexpr bool operator==(const expected& _Left, const expected<_Uty, _UErr>& _Right) noexcept(
+    _NODISCARD friend constexpr bool operator==(const expected& _Left, const expected<_Uty, _UErr>& _Right) noexcept(
         noexcept(static_cast<bool>(_Left._Unexpected == _Right.error()))) /* strengthened */ {
         if (_Left._Has_value != _Right.has_value()) {
             return false;
@@ -1886,7 +1886,7 @@ public:
     }
 
     template <class _UErr>
-    _NODISCARD_FRIEND constexpr bool operator==(const expected& _Left, const unexpected<_UErr>& _Right) noexcept(
+    _NODISCARD friend constexpr bool operator==(const expected& _Left, const unexpected<_UErr>& _Right) noexcept(
         noexcept(static_cast<bool>(_Left._Unexpected == _Right.error()))) /* strengthened */ {
         if (_Left._Has_value) {
             return false;

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -1346,37 +1346,37 @@ namespace filesystem {
             return _Istr;
         }
 
-        _NODISCARD_FRIEND bool operator==(const path& _Left, const path& _Right) noexcept {
+        _NODISCARD friend bool operator==(const path& _Left, const path& _Right) noexcept {
             return _Left.compare(_Right._Text) == 0;
         }
 
 #if _HAS_CXX20
-        _NODISCARD_FRIEND strong_ordering operator<=>(const path& _Left, const path& _Right) noexcept {
+        _NODISCARD friend strong_ordering operator<=>(const path& _Left, const path& _Right) noexcept {
             return _Left.compare(_Right._Text) <=> 0;
         }
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
-        _NODISCARD_FRIEND bool operator!=(const path& _Left, const path& _Right) noexcept {
+        _NODISCARD friend bool operator!=(const path& _Left, const path& _Right) noexcept {
             return _Left.compare(_Right) != 0;
         }
 
-        _NODISCARD_FRIEND bool operator<(const path& _Left, const path& _Right) noexcept {
+        _NODISCARD friend bool operator<(const path& _Left, const path& _Right) noexcept {
             return _Left.compare(_Right) < 0;
         }
 
-        _NODISCARD_FRIEND bool operator>(const path& _Left, const path& _Right) noexcept {
+        _NODISCARD friend bool operator>(const path& _Left, const path& _Right) noexcept {
             return _Left.compare(_Right) > 0;
         }
 
-        _NODISCARD_FRIEND bool operator<=(const path& _Left, const path& _Right) noexcept {
+        _NODISCARD friend bool operator<=(const path& _Left, const path& _Right) noexcept {
             return _Left.compare(_Right) <= 0;
         }
 
-        _NODISCARD_FRIEND bool operator>=(const path& _Left, const path& _Right) noexcept {
+        _NODISCARD friend bool operator>=(const path& _Left, const path& _Right) noexcept {
             return _Left.compare(_Right) >= 0;
         }
 #endif // ^^^ !_HAS_CXX20 ^^^
 
-        _NODISCARD_FRIEND path operator/(const path& _Left, const path& _Right) { // append a pair of paths together
+        _NODISCARD friend path operator/(const path& _Left, const path& _Right) { // append a pair of paths together
             const auto _Right_size  = _Right._Text.size();
             const auto _Right_first = _Right._Text.data();
             const auto _Right_last  = _Right_first + _Right_size;
@@ -1578,12 +1578,12 @@ namespace filesystem {
             return _Tmp;
         }
 
-        _NODISCARD_FRIEND bool operator==(const _Path_iterator& _Lhs, const _Path_iterator& _Rhs) {
+        _NODISCARD friend bool operator==(const _Path_iterator& _Lhs, const _Path_iterator& _Rhs) {
             return _Lhs._Position == _Rhs._Position;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const _Path_iterator& _Lhs, const _Path_iterator& _Rhs) {
+        _NODISCARD friend bool operator!=(const _Path_iterator& _Lhs, const _Path_iterator& _Rhs) {
             return _Lhs._Position != _Rhs._Position;
         }
 #endif // !_HAS_CXX20
@@ -1981,7 +1981,7 @@ namespace filesystem {
         }
 
 #if _HAS_CXX20
-        _NODISCARD_FRIEND bool operator==(const file_status& _Lhs, const file_status& _Rhs) noexcept {
+        _NODISCARD friend bool operator==(const file_status& _Lhs, const file_status& _Rhs) noexcept {
             return _Lhs._Myftype == _Rhs._Myftype && _Lhs._Myperms == _Rhs._Myperms;
         }
 #endif // _HAS_CXX20
@@ -3719,7 +3719,7 @@ namespace filesystem {
         uintmax_t available;
 
 #if _HAS_CXX20
-        _NODISCARD_FRIEND constexpr bool operator==(const space_info&, const space_info&) noexcept = default;
+        _NODISCARD friend constexpr bool operator==(const space_info&, const space_info&) noexcept = default;
 #endif // _HAS_CXX20
     };
 

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -2050,8 +2050,8 @@ struct _Select_fixer<_Cv_TiD, false, false, _Jx> { // placeholder fixer
 
 template <class _Cv_TiD, class _Untuple>
 constexpr auto _Fix_arg(_Cv_TiD& _Tid, _Untuple&& _Ut) noexcept(
-    noexcept(_Select_fixer<_Cv_TiD>::_Fix(_Tid, _STD move(_Ut)))) -> decltype(_Select_fixer<_Cv_TiD>::_Fix(_Tid,
-    _STD move(_Ut))) { // translate an argument for bind
+    noexcept(_Select_fixer<_Cv_TiD>::_Fix(_Tid, _STD move(_Ut))))
+    -> decltype(_Select_fixer<_Cv_TiD>::_Fix(_Tid, _STD move(_Ut))) { // translate an argument for bind
     return _Select_fixer<_Cv_TiD>::_Fix(_Tid, _STD move(_Ut));
 }
 

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1946,7 +1946,7 @@ public:
         _Fn1._Swap(_Fn2);
     }
 
-    _NODISCARD_FRIEND bool operator==(const move_only_function& _This, nullptr_t) noexcept {
+    _NODISCARD friend bool operator==(const move_only_function& _This, nullptr_t) noexcept {
         return _This._Is_null();
     }
 };
@@ -2050,8 +2050,8 @@ struct _Select_fixer<_Cv_TiD, false, false, _Jx> { // placeholder fixer
 
 template <class _Cv_TiD, class _Untuple>
 constexpr auto _Fix_arg(_Cv_TiD& _Tid, _Untuple&& _Ut) noexcept(
-    noexcept(_Select_fixer<_Cv_TiD>::_Fix(_Tid, _STD move(_Ut))))
-    -> decltype(_Select_fixer<_Cv_TiD>::_Fix(_Tid, _STD move(_Ut))) { // translate an argument for bind
+    noexcept(_Select_fixer<_Cv_TiD>::_Fix(_Tid, _STD move(_Ut)))) -> decltype(_Select_fixer<_Cv_TiD>::_Fix(_Tid,
+    _STD move(_Ut))) { // translate an argument for bind
     return _Select_fixer<_Cv_TiD>::_Fix(_Tid, _STD move(_Ut));
 }
 

--- a/stl/inc/iosfwd
+++ b/stl/inc/iosfwd
@@ -98,13 +98,13 @@ public:
     }
 
     template <class _Int, enable_if_t<is_integral_v<_Int>, int> = 0>
-    _NODISCARD_FRIEND bool operator==(const fpos& _Left, const _Int _Right) noexcept /* strengthened */ {
+    _NODISCARD friend bool operator==(const fpos& _Left, const _Int _Right) noexcept /* strengthened */ {
         return static_cast<streamoff>(_Left) == _Right;
     }
 
 #if !_HAS_CXX20
     template <class _Int, enable_if_t<is_integral_v<_Int>, int> = 0>
-    _NODISCARD_FRIEND bool operator==(const _Int _Left, const fpos& _Right) noexcept /* strengthened */ {
+    _NODISCARD friend bool operator==(const _Int _Left, const fpos& _Right) noexcept /* strengthened */ {
         return _Left == static_cast<streamoff>(_Right);
     }
 
@@ -113,12 +113,12 @@ public:
     }
 
     template <class _Int, enable_if_t<is_integral_v<_Int>, int> = 0>
-    _NODISCARD_FRIEND bool operator!=(const fpos& _Left, const _Int _Right) noexcept /* strengthened */ {
+    _NODISCARD friend bool operator!=(const fpos& _Left, const _Int _Right) noexcept /* strengthened */ {
         return static_cast<streamoff>(_Left) != _Right;
     }
 
     template <class _Int, enable_if_t<is_integral_v<_Int>, int> = 0>
-    _NODISCARD_FRIEND bool operator!=(const _Int _Left, const fpos& _Right) noexcept /* strengthened */ {
+    _NODISCARD friend bool operator!=(const _Int _Left, const fpos& _Right) noexcept /* strengthened */ {
         return _Left != static_cast<streamoff>(_Right);
     }
 #endif // !_HAS_CXX20

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -285,7 +285,7 @@ public:
     }
 
 #if _HAS_CXX20
-    _NODISCARD_FRIEND bool operator==(const istream_iterator& _Left, default_sentinel_t) noexcept /* strengthened */ {
+    _NODISCARD friend bool operator==(const istream_iterator& _Left, default_sentinel_t) noexcept /* strengthened */ {
         return !_Left._Myistr;
     }
 #endif // _HAS_CXX20
@@ -448,7 +448,7 @@ public:
     }
 
 #if _HAS_CXX20
-    _NODISCARD_FRIEND bool operator==(const istreambuf_iterator& _Left, default_sentinel_t) {
+    _NODISCARD friend bool operator==(const istreambuf_iterator& _Left, default_sentinel_t) {
         if (!_Left._Got) {
             _Left._Peek();
         }
@@ -997,7 +997,7 @@ public:
 
     template <class _OIter, sentinel_for<_Iter> _OSe>
         requires sentinel_for<_Se, _OIter>
-    _NODISCARD_FRIEND constexpr bool operator==(
+    _NODISCARD friend constexpr bool operator==(
         const common_iterator& _Left, const common_iterator<_OIter, _OSe>& _Right) {
         auto& _Right_val = _Right._Get_val();
 #if _ITERATOR_DEBUG_LEVEL != 0
@@ -1027,7 +1027,7 @@ public:
 
     template <sized_sentinel_for<_Iter> _OIter, sized_sentinel_for<_Iter> _OSe>
         requires sized_sentinel_for<_Se, _OIter>
-    _NODISCARD_FRIEND constexpr iter_difference_t<_OIter> operator-(
+    _NODISCARD friend constexpr iter_difference_t<_OIter> operator-(
         const common_iterator& _Left, const common_iterator<_OIter, _OSe>& _Right) {
         auto& _Right_val = _Right._Get_val();
 #if _ITERATOR_DEBUG_LEVEL != 0
@@ -1051,7 +1051,7 @@ public:
         }
     }
 
-    _NODISCARD_FRIEND constexpr decltype(auto) iter_move(const common_iterator& _Right) noexcept(
+    _NODISCARD friend constexpr decltype(auto) iter_move(const common_iterator& _Right) noexcept(
         noexcept(_RANGES iter_move(_Right._Val._Get_first())))
         requires input_iterator<_Iter>
     {
@@ -1288,7 +1288,7 @@ public:
         return counted_iterator{_Current + _Diff, static_cast<iter_difference_t<_Iter>>(_Length - _Diff)};
     }
 
-    _NODISCARD_FRIEND constexpr counted_iterator operator+(
+    _NODISCARD friend constexpr counted_iterator operator+(
         const iter_difference_t<_Iter> _Diff, const counted_iterator& _Right)
         requires random_access_iterator<_Iter>
     {
@@ -1313,7 +1313,7 @@ public:
     }
 
     template <common_with<_Iter> _Other>
-    _NODISCARD_FRIEND constexpr iter_difference_t<_Other> operator-(
+    _NODISCARD friend constexpr iter_difference_t<_Other> operator-(
         const counted_iterator& _Left, const counted_iterator<_Other>& _Right) noexcept /* strengthened */ {
 #if _ITERATOR_DEBUG_LEVEL != 0
         _Same_sequence(_Left, _Right);
@@ -1321,12 +1321,12 @@ public:
         return _Right.count() - _Left._Length;
     }
 
-    _NODISCARD_FRIEND constexpr iter_difference_t<_Iter> operator-(
+    _NODISCARD friend constexpr iter_difference_t<_Iter> operator-(
         const counted_iterator& _Left, default_sentinel_t) noexcept /* strengthened */ {
         return -_Left._Length;
     }
 
-    _NODISCARD_FRIEND constexpr iter_difference_t<_Iter> operator-(
+    _NODISCARD friend constexpr iter_difference_t<_Iter> operator-(
         default_sentinel_t, const counted_iterator& _Right) noexcept /* strengthened */ {
         return _Right._Length;
     }
@@ -1344,7 +1344,7 @@ public:
 
     // [counted.iter.cmp]
     template <common_with<_Iter> _Other>
-    _NODISCARD_FRIEND constexpr bool operator==(
+    _NODISCARD friend constexpr bool operator==(
         const counted_iterator& _Left, const counted_iterator<_Other>& _Right) noexcept /* strengthened */ {
 #if _ITERATOR_DEBUG_LEVEL != 0
         _Same_sequence(_Left, _Right);
@@ -1352,13 +1352,13 @@ public:
         return _Left._Length == _Right.count();
     }
 
-    _NODISCARD_FRIEND constexpr bool operator==(const counted_iterator& _Left, default_sentinel_t) noexcept
+    _NODISCARD friend constexpr bool operator==(const counted_iterator& _Left, default_sentinel_t) noexcept
     /* strengthened */ {
         return _Left._Length == 0;
     }
 
     template <common_with<_Iter> _Other>
-    _NODISCARD_FRIEND constexpr strong_ordering operator<=>(
+    _NODISCARD friend constexpr strong_ordering operator<=>(
         const counted_iterator& _Left, const counted_iterator<_Other>& _Right) noexcept /* strengthened */ {
 #if _ITERATOR_DEBUG_LEVEL != 0
         _Same_sequence(_Left, _Right);
@@ -1367,7 +1367,7 @@ public:
     }
 
     // [counted.iter.cust]
-    _NODISCARD_FRIEND constexpr decltype(auto) iter_move(const counted_iterator& _Right) noexcept(
+    _NODISCARD friend constexpr decltype(auto) iter_move(const counted_iterator& _Right) noexcept(
         noexcept(_RANGES iter_move(_Right._Current)))
         requires input_iterator<_Iter>
     {
@@ -1585,7 +1585,7 @@ public:
         return _Tmp;
     }
 
-    _NODISCARD_FRIEND constexpr checked_array_iterator operator+(
+    _NODISCARD friend constexpr checked_array_iterator operator+(
         const difference_type _Off, const checked_array_iterator<_Ptr>& _Next) noexcept {
         return _Next + _Off;
     }
@@ -1776,7 +1776,7 @@ public:
         return _Tmp;
     }
 
-    _NODISCARD_FRIEND constexpr unchecked_array_iterator operator+(
+    _NODISCARD friend constexpr unchecked_array_iterator operator+(
         const difference_type _Off, const unchecked_array_iterator& _Next) noexcept {
         return _Next + _Off;
     }

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -253,7 +253,7 @@ public:
         : extents(span{_Exts}, make_index_sequence<rank_dynamic()>{}) {}
 
     template <class _OtherIndexType, size_t... _OtherExtents>
-    _NODISCARD_FRIEND constexpr bool operator==(
+    _NODISCARD friend constexpr bool operator==(
         const extents& _Left, const extents<_OtherIndexType, _OtherExtents...>& _Right) noexcept {
         if constexpr (rank() != sizeof...(_OtherExtents)) {
             return false;
@@ -603,7 +603,7 @@ public:
 
     template <class _OtherExtents>
         requires (extents_type::rank() == _OtherExtents::rank())
-    _NODISCARD_FRIEND constexpr bool operator==(const mapping& _Left, const mapping<_OtherExtents>& _Right) noexcept {
+    _NODISCARD friend constexpr bool operator==(const mapping& _Left, const mapping<_OtherExtents>& _Right) noexcept {
         return _Left._Exts == _Right.extents();
     }
 
@@ -756,7 +756,7 @@ public:
 
     template <class _OtherExtents>
         requires (extents_type::rank() == _OtherExtents::rank())
-    _NODISCARD_FRIEND constexpr bool operator==(const mapping& _Left, const mapping<_OtherExtents>& _Right) noexcept {
+    _NODISCARD friend constexpr bool operator==(const mapping& _Left, const mapping<_OtherExtents>& _Right) noexcept {
         return _Left._Exts == _Right.extents();
     }
 
@@ -986,7 +986,7 @@ public:
     template <class _OtherMapping>
         requires _Layout_mapping_alike<_OtherMapping> && (extents_type::rank() == _OtherMapping::extents_type::rank())
               && (_OtherMapping::is_always_strided())
-    _NODISCARD_FRIEND constexpr bool operator==(const mapping& _Left, const _OtherMapping& _Right) noexcept {
+    _NODISCARD friend constexpr bool operator==(const mapping& _Left, const _OtherMapping& _Right) noexcept {
         if constexpr (extents_type::rank() != 0) {
             if (_Left.extents() != _Right.extents()) {
                 return false;

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -620,14 +620,14 @@ public:
         _Prev = _Temp;
     }
 
-    _NODISCARD_FRIEND bool operator==(
+    _NODISCARD friend bool operator==(
         const linear_congruential_engine& _Lhs, const linear_congruential_engine& _Rhs) noexcept
     /* strengthened */ {
         return _Lhs._Prev == _Rhs._Prev;
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(
+    _NODISCARD friend bool operator!=(
         const linear_congruential_engine& _Lhs, const linear_congruential_engine& _Rhs) noexcept
     /* strengthened */ {
         return _Lhs._Prev != _Rhs._Prev;
@@ -711,13 +711,13 @@ public:
         _Prev = _Temp;
     }
 
-    _NODISCARD_FRIEND bool operator==(const linear_congruential& _Lhs, const linear_congruential& _Rhs) noexcept
+    _NODISCARD friend bool operator==(const linear_congruential& _Lhs, const linear_congruential& _Rhs) noexcept
     /* strengthened */ {
         return _Lhs._Prev == _Rhs._Prev;
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const linear_congruential& _Lhs, const linear_congruential& _Rhs) noexcept
+    _NODISCARD friend bool operator!=(const linear_congruential& _Lhs, const linear_congruential& _Rhs) noexcept
     /* strengthened */ {
         return _Lhs._Prev != _Rhs._Prev;
     }
@@ -864,12 +864,12 @@ public:
         }
     }
 
-    _NODISCARD_FRIEND bool operator==(const _Swc_base& _Left, const _Swc_base& _Right) noexcept /* strengthened */ {
+    _NODISCARD friend bool operator==(const _Swc_base& _Left, const _Swc_base& _Right) noexcept /* strengthened */ {
         return static_cast<const _Swc_base::_Mybase&>(_Left)._Equals(_Right) && _Left._Carry == _Right._Carry;
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const _Swc_base& _Left, const _Swc_base& _Right) noexcept /* strengthened */ {
+    _NODISCARD friend bool operator!=(const _Swc_base& _Left, const _Swc_base& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -1099,13 +1099,13 @@ public:
         return _Mx - 1;
     }
 
-    _NODISCARD_FRIEND bool operator==(
+    _NODISCARD friend bool operator==(
         const subtract_with_carry_engine& _Left, const subtract_with_carry_engine& _Right) noexcept /* strengthened */ {
         return static_cast<const _Mybase&>(_Left) == static_cast<const _Mybase&>(_Right);
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(
+    _NODISCARD friend bool operator!=(
         const subtract_with_carry_engine& _Left, const subtract_with_carry_engine& _Right) noexcept /* strengthened */ {
         return static_cast<const _Mybase&>(_Left) != static_cast<const _Mybase&>(_Right);
     }
@@ -1298,13 +1298,13 @@ public:
         this->_Idx = _Nx;
     }
 
-    _NODISCARD_FRIEND bool operator==(const mersenne_twister& _Left, const mersenne_twister& _Right) noexcept
+    _NODISCARD friend bool operator==(const mersenne_twister& _Left, const mersenne_twister& _Right) noexcept
     /* strengthened */ {
         return _Left._Equals(_Right);
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const mersenne_twister& _Left, const mersenne_twister& _Right) noexcept
+    _NODISCARD friend bool operator!=(const mersenne_twister& _Left, const mersenne_twister& _Right) noexcept
     /* strengthened */ {
         return !_Left._Equals(_Right);
     }
@@ -1501,13 +1501,13 @@ public:
         return _Mybase::_WMSK;
     }
 
-    _NODISCARD_FRIEND bool operator==(
+    _NODISCARD friend bool operator==(
         const mersenne_twister_engine& _Left, const mersenne_twister_engine& _Right) noexcept /* strengthened */ {
         return static_cast<const _Mybase&>(_Left) == static_cast<const _Mybase&>(_Right);
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(
+    _NODISCARD friend bool operator!=(
         const mersenne_twister_engine& _Left, const mersenne_twister_engine& _Right) noexcept /* strengthened */ {
         return static_cast<const _Mybase&>(_Left) != static_cast<const _Mybase&>(_Right);
     }
@@ -1604,12 +1604,12 @@ public:
         }
     }
 
-    _NODISCARD_FRIEND bool operator==(const discard_block& _Left, const discard_block& _Right) {
+    _NODISCARD friend bool operator==(const discard_block& _Left, const discard_block& _Right) {
         return _Left._Eng == _Right._Eng && _Left._Nx == _Right._Nx;
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const discard_block& _Left, const discard_block& _Right) {
+    _NODISCARD friend bool operator!=(const discard_block& _Left, const discard_block& _Right) {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -1685,12 +1685,12 @@ public:
         }
     }
 
-    _NODISCARD_FRIEND bool operator==(const _Discard_block_base& _Left, const _Discard_block_base& _Right) {
+    _NODISCARD friend bool operator==(const _Discard_block_base& _Left, const _Discard_block_base& _Right) {
         return _Left._Eng == _Right._Eng && _Left._Nx == _Right._Nx;
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const _Discard_block_base& _Left, const _Discard_block_base& _Right) {
+    _NODISCARD friend bool operator!=(const _Discard_block_base& _Left, const _Discard_block_base& _Right) {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -1771,12 +1771,12 @@ public:
         return (_Engine::max)();
     }
 
-    _NODISCARD_FRIEND bool operator==(const discard_block_engine& _Left, const discard_block_engine& _Right) {
+    _NODISCARD friend bool operator==(const discard_block_engine& _Left, const discard_block_engine& _Right) {
         return static_cast<const _Mybase&>(_Left) == static_cast<const _Mybase&>(_Right);
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const discard_block_engine& _Left, const discard_block_engine& _Right) {
+    _NODISCARD friend bool operator!=(const discard_block_engine& _Left, const discard_block_engine& _Right) {
         return static_cast<const _Mybase&>(_Left) != static_cast<const _Mybase&>(_Right);
     }
 #endif // !_HAS_CXX20
@@ -1886,12 +1886,12 @@ public:
         }
     }
 
-    _NODISCARD_FRIEND bool operator==(const independent_bits_engine& _Left, const independent_bits_engine& _Right) {
+    _NODISCARD friend bool operator==(const independent_bits_engine& _Left, const independent_bits_engine& _Right) {
         return _Left.base() == _Right.base();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const independent_bits_engine& _Left, const independent_bits_engine& _Right) {
+    _NODISCARD friend bool operator!=(const independent_bits_engine& _Left, const independent_bits_engine& _Right) {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -2016,12 +2016,12 @@ public:
         }
     }
 
-    _NODISCARD_FRIEND bool operator==(const shuffle_order_engine& _Left, const shuffle_order_engine& _Right) {
+    _NODISCARD friend bool operator==(const shuffle_order_engine& _Left, const shuffle_order_engine& _Right) {
         return _Left.base() == _Right.base();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const shuffle_order_engine& _Left, const shuffle_order_engine& _Right) {
+    _NODISCARD friend bool operator!=(const shuffle_order_engine& _Left, const shuffle_order_engine& _Right) {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -2205,13 +2205,13 @@ public:
             _Init(_Min0, _Max0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return _Left._Min == _Right._Min && _Left._Max == _Right._Max;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return !(_Left == _Right);
         }
@@ -2413,13 +2413,13 @@ public:
         return _Ostr << static_cast<const _Mybase&>(_Dist);
     }
 
-    _NODISCARD_FRIEND bool operator==(
+    _NODISCARD friend bool operator==(
         const uniform_int_distribution& _Left, const uniform_int_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(
+    _NODISCARD friend bool operator!=(
         const uniform_int_distribution& _Left, const uniform_int_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
@@ -2442,13 +2442,13 @@ public:
             _Init(_Px0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return _Left._Px == _Right._Px;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return !(_Left == _Right);
         }
@@ -2508,13 +2508,13 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(
+    _NODISCARD friend bool operator==(
         const bernoulli_distribution& _Left, const bernoulli_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(
+    _NODISCARD friend bool operator!=(
         const bernoulli_distribution& _Left, const bernoulli_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
@@ -2602,13 +2602,13 @@ public:
             _Init(_Px0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return _Left._Px == _Right._Px;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return !(_Left == _Right);
         }
@@ -2669,13 +2669,13 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(
+    _NODISCARD friend bool operator==(
         const geometric_distribution& _Left, const geometric_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(
+    _NODISCARD friend bool operator!=(
         const geometric_distribution& _Left, const geometric_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
@@ -2758,13 +2758,13 @@ public:
             _Init(_Mean0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return _Left._Mean == _Right._Mean;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return !(_Left == _Right);
         }
@@ -2832,13 +2832,13 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const poisson_distribution& _Left, const poisson_distribution& _Right) noexcept
+    _NODISCARD friend bool operator==(const poisson_distribution& _Left, const poisson_distribution& _Right) noexcept
     /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const poisson_distribution& _Left, const poisson_distribution& _Right) noexcept
+    _NODISCARD friend bool operator!=(const poisson_distribution& _Left, const poisson_distribution& _Right) noexcept
     /* strengthened */ {
         return !(_Left == _Right);
     }
@@ -2913,13 +2913,13 @@ public:
             _Init(_Tx0, _Px0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return _Left._Tx == _Right._Tx && _Left._Px == _Right._Px;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return !(_Left == _Right);
         }
@@ -3004,13 +3004,13 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const binomial_distribution& _Left, const binomial_distribution& _Right) noexcept
+    _NODISCARD friend bool operator==(const binomial_distribution& _Left, const binomial_distribution& _Right) noexcept
     /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const binomial_distribution& _Left, const binomial_distribution& _Right) noexcept
+    _NODISCARD friend bool operator!=(const binomial_distribution& _Left, const binomial_distribution& _Right) noexcept
     /* strengthened */ {
         return !(_Left == _Right);
     }
@@ -3114,13 +3114,13 @@ public:
             _Init(_Min0, _Max0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return _Left._Min == _Right._Min && _Left._Max == _Right._Max;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return !(_Left == _Right);
         }
@@ -3304,13 +3304,13 @@ public:
         return _Ostr << static_cast<const _Mybase&>(_Dist);
     }
 
-    _NODISCARD_FRIEND bool operator==(
+    _NODISCARD friend bool operator==(
         const uniform_real_distribution& _Left, const uniform_real_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(
+    _NODISCARD friend bool operator!=(
         const uniform_real_distribution& _Left, const uniform_real_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
@@ -3336,13 +3336,13 @@ public:
             _Init(_Lambda0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return _Left._Lambda == _Right._Lambda;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return !(_Left == _Right);
         }
@@ -3401,13 +3401,13 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(
+    _NODISCARD friend bool operator==(
         const exponential_distribution& _Left, const exponential_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(
+    _NODISCARD friend bool operator!=(
         const exponential_distribution& _Left, const exponential_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
@@ -3456,13 +3456,13 @@ public:
             _Init(_Mean0, _Sigma0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return _Left._Mean == _Right._Mean && _Left._Sigma == _Right._Sigma;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return !(_Left == _Right);
         }
@@ -3542,13 +3542,13 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const normal_distribution& _Left, const normal_distribution& _Right) noexcept
+    _NODISCARD friend bool operator==(const normal_distribution& _Left, const normal_distribution& _Right) noexcept
     /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const normal_distribution& _Left, const normal_distribution& _Right) noexcept
+    _NODISCARD friend bool operator!=(const normal_distribution& _Left, const normal_distribution& _Right) noexcept
     /* strengthened */ {
         return !(_Left == _Right);
     }
@@ -3648,13 +3648,13 @@ public:
             _Init(_Alpha0, _Beta0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return _Left._Alpha == _Right._Alpha && _Left._Beta == _Right._Beta;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return !(_Left == _Right);
         }
@@ -3729,13 +3729,13 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const gamma_distribution& _Left, const gamma_distribution& _Right) noexcept
+    _NODISCARD friend bool operator==(const gamma_distribution& _Left, const gamma_distribution& _Right) noexcept
     /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const gamma_distribution& _Left, const gamma_distribution& _Right) noexcept
+    _NODISCARD friend bool operator!=(const gamma_distribution& _Left, const gamma_distribution& _Right) noexcept
     /* strengthened */ {
         return !(_Left == _Right);
     }
@@ -3842,13 +3842,13 @@ public:
             _Init(_Ax0, _Bx0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return _Left._Ax == _Right._Ax && _Left._Bx == _Right._Bx;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return !(_Left == _Right);
         }
@@ -3918,13 +3918,13 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const weibull_distribution& _Left, const weibull_distribution& _Right) noexcept
+    _NODISCARD friend bool operator==(const weibull_distribution& _Left, const weibull_distribution& _Right) noexcept
     /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const weibull_distribution& _Left, const weibull_distribution& _Right) noexcept
+    _NODISCARD friend bool operator!=(const weibull_distribution& _Left, const weibull_distribution& _Right) noexcept
     /* strengthened */ {
         return !(_Left == _Right);
     }
@@ -3977,13 +3977,13 @@ public:
             _Init(_Ax0, _Bx0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return _Left._Ax == _Right._Ax && _Left._Bx == _Right._Bx;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return !(_Left == _Right);
         }
@@ -4052,13 +4052,13 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(
+    _NODISCARD friend bool operator==(
         const extreme_value_distribution& _Left, const extreme_value_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(
+    _NODISCARD friend bool operator!=(
         const extreme_value_distribution& _Left, const extreme_value_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
@@ -4111,13 +4111,13 @@ public:
             _Init(_Mx0, _Sx0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return _Left._Mx == _Right._Mx && _Left._Sx == _Right._Sx;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return !(_Left == _Right);
         }
@@ -4186,13 +4186,13 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(
+    _NODISCARD friend bool operator==(
         const lognormal_distribution& _Left, const lognormal_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(
+    _NODISCARD friend bool operator!=(
         const lognormal_distribution& _Left, const lognormal_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
@@ -4245,13 +4245,13 @@ public:
             _Init(_Nx0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return _Left._Nx == _Right._Nx;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return !(_Left == _Right);
         }
@@ -4310,13 +4310,13 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(
+    _NODISCARD friend bool operator==(
         const chi_squared_distribution& _Left, const chi_squared_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(
+    _NODISCARD friend bool operator!=(
         const chi_squared_distribution& _Left, const chi_squared_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
@@ -4365,13 +4365,13 @@ public:
             _Init(_Ax0, _Bx0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return _Left._Ax == _Right._Ax && _Left._Bx == _Right._Bx;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return !(_Left == _Right);
         }
@@ -4440,13 +4440,13 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const cauchy_distribution& _Left, const cauchy_distribution& _Right) noexcept
+    _NODISCARD friend bool operator==(const cauchy_distribution& _Left, const cauchy_distribution& _Right) noexcept
     /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const cauchy_distribution& _Left, const cauchy_distribution& _Right) noexcept
+    _NODISCARD friend bool operator!=(const cauchy_distribution& _Left, const cauchy_distribution& _Right) noexcept
     /* strengthened */ {
         return !(_Left == _Right);
     }
@@ -4558,13 +4558,13 @@ public:
             _Init(_Mx0, _Nx0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return _Left._Mx == _Right._Mx && _Left._Nx == _Right._Nx;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return !(_Left == _Right);
         }
@@ -4634,13 +4634,13 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const fisher_f_distribution& _Left, const fisher_f_distribution& _Right) noexcept
+    _NODISCARD friend bool operator==(const fisher_f_distribution& _Left, const fisher_f_distribution& _Right) noexcept
     /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const fisher_f_distribution& _Left, const fisher_f_distribution& _Right) noexcept
+    _NODISCARD friend bool operator!=(const fisher_f_distribution& _Left, const fisher_f_distribution& _Right) noexcept
     /* strengthened */ {
         return !(_Left == _Right);
     }
@@ -4704,13 +4704,13 @@ public:
             _Init(_Nx0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return _Left._Nx == _Right._Nx;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return !(_Left == _Right);
         }
@@ -4769,13 +4769,13 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(
+    _NODISCARD friend bool operator==(
         const student_t_distribution& _Left, const student_t_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(
+    _NODISCARD friend bool operator!=(
         const student_t_distribution& _Left, const student_t_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
@@ -4839,13 +4839,13 @@ public:
             _Init(_Kx0, _Px0);
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return _Left._Kx == _Right._Kx && _Left._Px == _Right._Px;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) noexcept
         /* strengthened */ {
             return !(_Left == _Right);
         }
@@ -4915,13 +4915,13 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const negative_binomial_distribution& _Left,
+    _NODISCARD friend bool operator==(const negative_binomial_distribution& _Left,
         const negative_binomial_distribution& _Right) noexcept /* strengthened */ {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const negative_binomial_distribution& _Left,
+    _NODISCARD friend bool operator!=(const negative_binomial_distribution& _Left,
         const negative_binomial_distribution& _Right) noexcept /* strengthened */ {
         return !(_Left == _Right);
     }
@@ -5004,12 +5004,12 @@ public:
             _Init();
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) {
             return _Left._Pvec == _Right._Pvec;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
@@ -5121,12 +5121,12 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(const discrete_distribution& _Left, const discrete_distribution& _Right) {
+    _NODISCARD friend bool operator==(const discrete_distribution& _Left, const discrete_distribution& _Right) {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const discrete_distribution& _Left, const discrete_distribution& _Right) {
+    _NODISCARD friend bool operator!=(const discrete_distribution& _Left, const discrete_distribution& _Right) {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20
@@ -5213,13 +5213,13 @@ public:
             }
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) {
             return static_cast<const _Mypbase&>(_Left) == static_cast<const _Mypbase&>(_Right)
                 && _Left._Bvec == _Right._Bvec;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
@@ -5297,13 +5297,13 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(
+    _NODISCARD friend bool operator==(
         const piecewise_constant_distribution& _Left, const piecewise_constant_distribution& _Right) {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(
+    _NODISCARD friend bool operator!=(
         const piecewise_constant_distribution& _Left, const piecewise_constant_distribution& _Right) {
         return !(_Left == _Right);
     }
@@ -5410,13 +5410,13 @@ public:
             _Init();
         }
 
-        _NODISCARD_FRIEND bool operator==(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD friend bool operator==(const param_type& _Left, const param_type& _Right) {
             return static_cast<const _Mypbase&>(_Left) == static_cast<const _Mypbase&>(_Right)
                 && _Left._Bvec == _Right._Bvec;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(const param_type& _Left, const param_type& _Right) {
+        _NODISCARD friend bool operator!=(const param_type& _Left, const param_type& _Right) {
             return !(_Left == _Right);
         }
 #endif // !_HAS_CXX20
@@ -5521,13 +5521,13 @@ public:
         return _Eval(_Eng, _Par0);
     }
 
-    _NODISCARD_FRIEND bool operator==(
+    _NODISCARD friend bool operator==(
         const piecewise_linear_distribution& _Left, const piecewise_linear_distribution& _Right) {
         return _Left.param() == _Right.param();
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(
+    _NODISCARD friend bool operator!=(
         const piecewise_linear_distribution& _Left, const piecewise_linear_distribution& _Right) {
         return !(_Left == _Right);
     }

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -813,46 +813,46 @@ namespace ranges {
             }
         }
 
-        _NODISCARD_FRIEND constexpr bool operator==(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
+        _NODISCARD friend constexpr bool operator==(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
             noexcept(_Left._Current == _Right._Current))
             requires equality_comparable<_Wi>
         {
             return _Left._Current == _Right._Current;
         }
 
-        _NODISCARD_FRIEND constexpr bool operator<(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
+        _NODISCARD friend constexpr bool operator<(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
             noexcept(_Left._Current < _Right._Current)) /* strengthened */
             requires totally_ordered<_Wi>
         {
             return _Left._Current < _Right._Current;
         }
-        _NODISCARD_FRIEND constexpr bool operator>(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
+        _NODISCARD friend constexpr bool operator>(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
             noexcept(_Right._Current < _Left._Current)) /* strengthened */
             requires totally_ordered<_Wi>
         {
             return _Right._Current < _Left._Current;
         }
-        _NODISCARD_FRIEND constexpr bool operator<=(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
+        _NODISCARD friend constexpr bool operator<=(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
             noexcept(!(_Right._Current < _Left._Current))) /* strengthened */
             requires totally_ordered<_Wi>
         {
             return !(_Right._Current < _Left._Current);
         }
-        _NODISCARD_FRIEND constexpr bool operator>=(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
+        _NODISCARD friend constexpr bool operator>=(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
             noexcept(!(_Left._Current < _Right._Current))) /* strengthened */
             requires totally_ordered<_Wi>
         {
             return !(_Left._Current < _Right._Current);
         }
 
-        _NODISCARD_FRIEND constexpr auto operator<=>(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
+        _NODISCARD friend constexpr auto operator<=>(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
             noexcept(_Left._Current <=> _Right._Current))
             requires totally_ordered<_Wi> && three_way_comparable<_Wi>
         {
             return _Left._Current <=> _Right._Current;
         }
 
-        _NODISCARD_FRIEND constexpr _Ioterator operator+(_Ioterator _It, const difference_type _Off) noexcept(
+        _NODISCARD friend constexpr _Ioterator operator+(_Ioterator _It, const difference_type _Off) noexcept(
             is_nothrow_move_constructible_v<_Ioterator> //
                 && noexcept(_It += _Off)) /* strengthened */
             requires _Advanceable<_Wi>
@@ -860,7 +860,7 @@ namespace ranges {
             _It += _Off;
             return _It;
         }
-        _NODISCARD_FRIEND constexpr _Ioterator operator+(const difference_type _Off, _Ioterator _It) noexcept(
+        _NODISCARD friend constexpr _Ioterator operator+(const difference_type _Off, _Ioterator _It) noexcept(
             is_nothrow_move_constructible_v<_Wi> //
                 && noexcept(static_cast<_Wi>(_It._Current + _Off))) /* strengthened */
             requires _Advanceable<_Wi>
@@ -868,7 +868,7 @@ namespace ranges {
             return _Ioterator{static_cast<_Wi>(_It._Current + _Off)};
         }
 
-        _NODISCARD_FRIEND constexpr _Ioterator operator-(_Ioterator _It, const difference_type _Off) noexcept(
+        _NODISCARD friend constexpr _Ioterator operator-(_Ioterator _It, const difference_type _Off) noexcept(
             is_nothrow_move_constructible_v<_Ioterator> //
                 && noexcept(_It -= _Off)) /* strengthened */
             requires _Advanceable<_Wi>
@@ -877,7 +877,7 @@ namespace ranges {
             return _It;
         }
 
-        _NODISCARD_FRIEND constexpr difference_type operator-(const _Ioterator& _Left,
+        _NODISCARD friend constexpr difference_type operator-(const _Ioterator& _Left,
             const _Ioterator& _Right) noexcept(noexcept(_Left._Current - _Right._Current)) /* strengthened */
             requires _Advanceable<_Wi>
         {
@@ -916,19 +916,19 @@ namespace ranges {
     public:
         /* [[no_unique_address]] */ _Bo _Last{};
 
-        _NODISCARD_FRIEND constexpr bool operator==(const _It& _Left, const _Iotinel& _Right) noexcept(
+        _NODISCARD friend constexpr bool operator==(const _It& _Left, const _Iotinel& _Right) noexcept(
             noexcept(_Right._Equal(_Left))) /* strengthened */ {
             return _Right._Equal(_Left);
         }
 
-        _NODISCARD_FRIEND constexpr iter_difference_t<_Wi> operator-(const _It& _Left, const _Iotinel& _Right) noexcept(
+        _NODISCARD friend constexpr iter_difference_t<_Wi> operator-(const _It& _Left, const _Iotinel& _Right) noexcept(
             noexcept(_Right._Delta(_Left))) /* strengthened */
             requires sized_sentinel_for<_Bo, _Wi>
         {
             return -_Right._Delta(_Left);
         }
 
-        _NODISCARD_FRIEND constexpr iter_difference_t<_Wi> operator-(const _Iotinel& _Left, const _It& _Right) noexcept(
+        _NODISCARD friend constexpr iter_difference_t<_Wi> operator-(const _Iotinel& _Left, const _It& _Right) noexcept(
             noexcept(_Left._Delta(_Right))) /* strengthened */
             requires sized_sentinel_for<_Bo, _Wi>
         {
@@ -1197,32 +1197,32 @@ namespace ranges {
                 return *(*this + _Idx);
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept
             /* strengthened */ {
                 return _Left._Current == _Right._Current;
             }
-            _NODISCARD_FRIEND constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept
+            _NODISCARD friend constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept
             /* strengthened */ {
                 return _Left._Current <=> _Right._Current;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(_Iterator _Iter, difference_type _Off) noexcept
+            _NODISCARD friend constexpr _Iterator operator+(_Iterator _Iter, difference_type _Off) noexcept
             /* strengthened */ {
                 _Iter += _Off;
                 return _Iter;
             }
-            _NODISCARD_FRIEND constexpr _Iterator operator+(difference_type _Off, _Iterator _Iter) noexcept
+            _NODISCARD friend constexpr _Iterator operator+(difference_type _Off, _Iterator _Iter) noexcept
             /* strengthened */ {
                 _Iter += _Off;
                 return _Iter;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator-(_Iterator _Iter, difference_type _Off) noexcept
+            _NODISCARD friend constexpr _Iterator operator-(_Iterator _Iter, difference_type _Off) noexcept
             /* strengthened */ {
                 _Iter -= _Off;
                 return _Iter;
             }
-            _NODISCARD_FRIEND constexpr difference_type operator-(
+            _NODISCARD friend constexpr difference_type operator-(
                 const _Iterator& _Left, const _Iterator& _Right) noexcept /* strengthened */ {
                 return static_cast<difference_type>(
                     static_cast<difference_type>(_Left._Current) - static_cast<difference_type>(_Right._Current));
@@ -1365,7 +1365,7 @@ namespace ranges {
                 return _Parent->_Val;
             }
 
-            _NODISCARD_FRIEND bool operator==(const _Iterator& _Left, default_sentinel_t) noexcept /* strengthened */ {
+            _NODISCARD friend bool operator==(const _Iterator& _Left, default_sentinel_t) noexcept /* strengthened */ {
                 return _Left._Parent->_Stream_at_end();
             }
         };
@@ -1686,7 +1686,7 @@ namespace ranges {
                 return _Tmp;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right)
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right)
                 requires equality_comparable<iterator_t<_Vw>>
             {
 #if _ITERATOR_DEBUG_LEVEL != 0
@@ -1696,7 +1696,7 @@ namespace ranges {
                 return _Left._Current == _Right._Current;
             }
 
-            _NODISCARD_FRIEND constexpr range_rvalue_reference_t<_Vw> iter_move(const _Iterator& _It) noexcept(
+            _NODISCARD friend constexpr range_rvalue_reference_t<_Vw> iter_move(const _Iterator& _It) noexcept(
                 noexcept(_RANGES iter_move(_It._Current))) {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _It._Check_dereference();
@@ -1737,7 +1737,7 @@ namespace ranges {
                 return _Last;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _It, const _Sentinel& _Se) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _It, const _Sentinel& _Se) noexcept(
                 noexcept(_It._Equal(_Se._Last))) /* strengthened */ {
                 return _It._Equal(_Se._Last);
             }
@@ -1870,13 +1870,13 @@ namespace ranges {
                 return _Last;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Counted_iter<_Const>& _Left, const _Sentinel& _Right) {
+            _NODISCARD friend constexpr bool operator==(const _Counted_iter<_Const>& _Left, const _Sentinel& _Right) {
                 return _Left.count() == 0 || _Left.base() == _Right._Last;
             }
 
             template <bool _OtherConst = !_Const>
                 requires sentinel_for<_Base_sentinel, _Base_iterator<_OtherConst>>
-            _NODISCARD_FRIEND constexpr bool operator==(
+            _NODISCARD friend constexpr bool operator==(
                 const _Counted_iter<_OtherConst>& _Left, const _Sentinel& _Right) {
                 return _Left.count() == 0 || _Left.base() == _Right._Last;
             }
@@ -2167,13 +2167,13 @@ namespace ranges {
                 return _Last;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Base_iterator& _Left, const _Sentinel& _Right) {
+            _NODISCARD friend constexpr bool operator==(const _Base_iterator& _Left, const _Sentinel& _Right) {
                 return _Right._Last == _Left || !_STD invoke(*_Right._Pred, *_Left);
             }
 
             template <bool _OtherConst = !_Const>
                 requires sentinel_for<_Base_sentinel, _Maybe_const_iter<_OtherConst>>
-            _NODISCARD_FRIEND constexpr bool operator==(
+            _NODISCARD friend constexpr bool operator==(
                 const _Maybe_const_iter<_OtherConst>& _Left, const _Sentinel& _Right) {
                 return _Right._Last == _Left || !_STD invoke(*_Right._Pred, *_Left);
             }
@@ -2882,7 +2882,7 @@ namespace ranges {
                 return _Tmp;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Outer == _Right._Outer && _Left._Inner == _Right._Inner)) /* strengthened */
                 requires _Deref_is_glvalue && forward_range<_Base> && equality_comparable<_InnerIter>
             {
@@ -2892,7 +2892,7 @@ namespace ranges {
                 return _Left._Outer == _Right._Outer && _Left._Inner == _Right._Inner;
             }
 
-            _NODISCARD_FRIEND constexpr decltype(auto) iter_move(const _Iterator& _It) noexcept(
+            _NODISCARD friend constexpr decltype(auto) iter_move(const _Iterator& _It) noexcept(
                 noexcept(_RANGES iter_move(*_It._Inner))) {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _It._Check_dereference();
@@ -2946,7 +2946,7 @@ namespace ranges {
 
             template <bool _OtherConst>
                 requires sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator<_OtherConst>& _Left,
+            _NODISCARD friend constexpr bool operator==(const _Iterator<_OtherConst>& _Left,
                 const _Sentinel& _Right) noexcept(noexcept(_Right._Equal(_Left))) /* strengthened */ {
                 return _Right._Equal(_Left);
             }
@@ -3362,7 +3362,7 @@ namespace ranges {
                 return _Tmp;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right)
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right)
                 requires _Deref_is_glvalue && forward_range<_Base> && equality_comparable<_InnerIter>
             {
                 if (_Left._Outer_it != _Right._Outer_it) {
@@ -3385,7 +3385,7 @@ namespace ranges {
                 _STL_UNREACHABLE;
             }
 
-            _NODISCARD_FRIEND constexpr decltype(auto) iter_move(const _Iterator& _It) {
+            _NODISCARD friend constexpr decltype(auto) iter_move(const _Iterator& _It) {
                 using _Rvalue_ref =
                     common_reference_t<iter_rvalue_reference_t<_InnerIter>, iter_rvalue_reference_t<_PatternIter>>;
                 return _It._Visit_inner_it<_Rvalue_ref>(_RANGES iter_move);
@@ -3456,7 +3456,7 @@ namespace ranges {
 
             template <bool _OtherConst>
                 requires sentinel_for<sentinel_t<_Base>, iterator_t<_Maybe_const<_OtherConst, _Vw>>>
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator<_OtherConst>& _Left,
+            _NODISCARD friend constexpr bool operator==(const _Iterator<_OtherConst>& _Left,
                 const _Sentinel& _Right) noexcept(noexcept(_Right._Equal(_Left))) /* strengthened */ {
                 return _Right._Equal(_Left);
             }
@@ -3756,13 +3756,13 @@ namespace ranges {
                 }
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Outer_iter& _Left, const _Outer_iter& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Outer_iter& _Left, const _Outer_iter& _Right) noexcept(
                 noexcept(_Left._Current == _Right._Current)) /* strengthened */
                 requires forward_range<_BaseTy>
             {
                 return _Left._Current == _Right._Current && _Left._Trailing_empty == _Right._Trailing_empty;
             }
-            _NODISCARD_FRIEND constexpr bool operator==(const _Outer_iter& _Left, default_sentinel_t) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Outer_iter& _Left, default_sentinel_t) noexcept(
                 noexcept(_Left._At_end())) /* strengthened */ {
                 return _Left._At_end() && !_Left._Trailing_empty;
             }
@@ -3886,17 +3886,17 @@ namespace ranges {
                 }
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Inner_iter& _Left, const _Inner_iter& _Right)
+            _NODISCARD friend constexpr bool operator==(const _Inner_iter& _Left, const _Inner_iter& _Right)
                 requires forward_range<_BaseTy>
             {
                 return _Left._Equal(_Right);
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Inner_iter& _Left, default_sentinel_t) {
+            _NODISCARD friend constexpr bool operator==(const _Inner_iter& _Left, default_sentinel_t) {
                 return _Left._At_end();
             }
 
-            _NODISCARD_FRIEND constexpr decltype(auto) iter_move(const _Inner_iter& _Iter) noexcept(
+            _NODISCARD friend constexpr decltype(auto) iter_move(const _Inner_iter& _Iter) noexcept(
                 noexcept(_RANGES iter_move(_Iter._Get_current()))) {
                 return _RANGES iter_move(_Iter._Get_current());
             }
@@ -4073,7 +4073,7 @@ namespace ranges {
                 return _Tmp;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current == _Right._Current)) /* strengthened */ {
                 return _Left._Current == _Right._Current && _Left._Trailing_empty == _Right._Trailing_empty;
             }
@@ -4095,7 +4095,7 @@ namespace ranges {
                 && is_nothrow_move_constructible_v<sentinel_t<_Vw>>) // strengthened
                 : _Last(_RANGES end(_Parent._Range)) {}
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _It, const _Sentinel& _Se) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _It, const _Sentinel& _Se) noexcept(
                 noexcept(_Se._Equal(_It))) /* strengthened */ {
                 return _Se._Equal(_It);
             }
@@ -4845,46 +4845,46 @@ namespace ranges {
                 return static_cast<_ElemTy>(_STD get<_Index>(*(_Current + _Idx)));
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current == _Right._Current)) /* strengthened */
                 requires equality_comparable<iterator_t<_Base>>
             {
                 return _Left._Current == _Right._Current;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current < _Right._Current)) /* strengthened */
                 requires random_access_range<_Base>
             {
                 return _Left._Current < _Right._Current;
             }
-            _NODISCARD_FRIEND constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current < _Right._Current)) /* strengthened */
                 requires random_access_range<_Base>
             {
                 return _Right < _Left;
             }
-            _NODISCARD_FRIEND constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current < _Right._Current)) /* strengthened */
                 requires random_access_range<_Base>
             {
                 return !(_Right < _Left);
             }
-            _NODISCARD_FRIEND constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current < _Right._Current)) /* strengthened */
                 requires random_access_range<_Base>
             {
                 return !(_Left < _Right);
             }
 
-            _NODISCARD_FRIEND constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current <=> _Right._Current)) /* strengthened */
                 requires random_access_range<_Base> && three_way_comparable<iterator_t<_Base>>
             {
                 return _Left._Current <=> _Right._Current;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off) noexcept(
+            _NODISCARD friend constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off) noexcept(
                 noexcept(_STD declval<iterator_t<_Base>&>() += _Off)
                 && is_nothrow_copy_constructible_v<iterator_t<_Base>>) /* strengthened */
                 requires random_access_range<_Base>
@@ -4897,7 +4897,7 @@ namespace ranges {
                 return _Copy;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It) noexcept(
+            _NODISCARD friend constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It) noexcept(
                 noexcept(_STD declval<iterator_t<_Base>&>() += _Off)
                 && is_nothrow_copy_constructible_v<iterator_t<_Base>>) /* strengthened */
                 requires random_access_range<_Base>
@@ -4910,7 +4910,7 @@ namespace ranges {
                 return _Copy;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off) noexcept(
+            _NODISCARD friend constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off) noexcept(
                 noexcept(_STD declval<iterator_t<_Base>&>() -= _Off)
                 && is_nothrow_copy_constructible_v<iterator_t<_Base>>) /* strengthened */
                 requires random_access_range<_Base>
@@ -4924,7 +4924,7 @@ namespace ranges {
                 return _Copy;
             }
 
-            _NODISCARD_FRIEND constexpr difference_type operator-(const _Iterator& _Left,
+            _NODISCARD friend constexpr difference_type operator-(const _Iterator& _Left,
                 const _Iterator& _Right) noexcept(noexcept(_Left._Current - _Right._Current)) /* strengthened */
                 requires sized_sentinel_for<iterator_t<_Base>, iterator_t<_Base>>
             {
@@ -4967,14 +4967,14 @@ namespace ranges {
 
             template <bool _OtherConst>
                 requires sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator<_OtherConst>& _Left,
+            _NODISCARD friend constexpr bool operator==(const _Iterator<_OtherConst>& _Left,
                 const _Sentinel& _Right) noexcept(noexcept(_Get_current(_Left) == _Right._Last)) /* strengthened */ {
                 return _Get_current(_Left) == _Right._Last;
             }
 
             template <bool _OtherConst>
                 requires sized_sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
-            _NODISCARD_FRIEND constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>> operator-(
+            _NODISCARD friend constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>> operator-(
                 const _Iterator<_OtherConst>& _Left,
                 const _Sentinel& _Right) noexcept(noexcept(_Get_current(_Left) - _Right._Last)) /* strengthened */ {
                 return _Get_current(_Left) - _Right._Last;
@@ -4982,7 +4982,7 @@ namespace ranges {
 
             template <bool _OtherConst>
                 requires sized_sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
-            _NODISCARD_FRIEND constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>>
+            _NODISCARD friend constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>>
                 operator-(const _Sentinel& _Left, const _Iterator<_OtherConst>& _Right) noexcept(
                     noexcept(_Left._Last - _Get_current(_Right))) /* strengthened */ {
                 return _Left._Last - _Get_current(_Right);
@@ -5214,16 +5214,16 @@ namespace ranges {
                 return _Reference_type{static_cast<difference_type>(_Pos + _Off), _Current[_Off]};
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept {
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept {
                 return _Left._Pos == _Right._Pos;
             }
 
-            _NODISCARD_FRIEND constexpr strong_ordering operator<=>(
+            _NODISCARD friend constexpr strong_ordering operator<=>(
                 const _Iterator& _Left, const _Iterator& _Right) noexcept {
                 return _Left._Pos <=> _Right._Pos;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off) noexcept(
+            _NODISCARD friend constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off) noexcept(
                 is_nothrow_copy_constructible_v<_Iterator> //
                     && noexcept(_STD declval<_Iterator&>() += _Off)) // strengthened
                 requires random_access_range<_Base_t>
@@ -5233,14 +5233,14 @@ namespace ranges {
                 return _Tmp;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It) noexcept(
+            _NODISCARD friend constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It) noexcept(
                 noexcept(_It + _Off)) // strengthened
                 requires random_access_range<_Base_t>
             {
                 return _It + _Off;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off) noexcept(
+            _NODISCARD friend constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off) noexcept(
                 is_nothrow_copy_constructible_v<_Iterator> //
                     && noexcept(_STD declval<_Iterator&>() -= _Off)) // strengthened
                 requires random_access_range<_Base_t>
@@ -5250,12 +5250,12 @@ namespace ranges {
                 return _Tmp;
             }
 
-            _NODISCARD_FRIEND constexpr difference_type operator-(
+            _NODISCARD friend constexpr difference_type operator-(
                 const _Iterator& _Left, const _Iterator& _Right) noexcept {
                 return _Left._Pos - _Right._Pos;
             }
 
-            _NODISCARD_FRIEND constexpr auto iter_move(const _Iterator& _It) noexcept(
+            _NODISCARD friend constexpr auto iter_move(const _Iterator& _It) noexcept(
                 noexcept(_RANGES iter_move(_It._Current))
                 && is_nothrow_move_constructible_v<range_rvalue_reference_t<_Base_t>>) {
                 return tuple<difference_type, range_rvalue_reference_t<_Base_t>>{
@@ -5306,14 +5306,14 @@ namespace ranges {
 
             template <bool _OtherConst>
                 requires sentinel_for<_Base_sentinel, iterator_t<_Maybe_const<_OtherConst, _Vw>>>
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator<_OtherConst>& _It,
+            _NODISCARD friend constexpr bool operator==(const _Iterator<_OtherConst>& _It,
                 const _Sentinel& _Se) noexcept(noexcept(_Se._Equal(_It))) /* strengthened */ {
                 return _Se._Equal(_It);
             }
 
             template <bool _OtherConst>
                 requires sized_sentinel_for<_Base_sentinel, iterator_t<_Maybe_const<_OtherConst, _Vw>>>
-            _NODISCARD_FRIEND constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>> operator-(
+            _NODISCARD friend constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>> operator-(
                 const _Iterator<_OtherConst>& _It, const _Sentinel& _Se) //
                 noexcept(noexcept(_Se._Distance_from(_It))) /* strengthened */ {
                 return -_Se._Distance_from(_It);
@@ -5321,7 +5321,7 @@ namespace ranges {
 
             template <bool _OtherConst>
                 requires sized_sentinel_for<_Base_sentinel, iterator_t<_Maybe_const<_OtherConst, _Vw>>>
-            _NODISCARD_FRIEND constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>> operator-(
+            _NODISCARD friend constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>> operator-(
                 const _Sentinel& _Se, const _Iterator<_OtherConst>& _It) //
                 noexcept(noexcept(_Se._Distance_from(_It))) /* strengthened */ {
                 return _Se._Distance_from(_It);
@@ -5516,26 +5516,26 @@ namespace ranges {
                 }
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Inner_iterator& _Left, default_sentinel_t) noexcept
+            _NODISCARD friend constexpr bool operator==(const _Inner_iterator& _Left, default_sentinel_t) noexcept
             /* strengthened */ {
                 return _Left._Get_remainder() == 0;
             }
 
-            _NODISCARD_FRIEND constexpr difference_type operator-(default_sentinel_t,
+            _NODISCARD friend constexpr difference_type operator-(default_sentinel_t,
                 const _Inner_iterator& _Right) noexcept(noexcept(_Right._Get_size())) /* strengthened */
                 requires sized_sentinel_for<sentinel_t<_Vw>, iterator_t<_Vw>>
             {
                 return _Right._Get_size();
             }
 
-            _NODISCARD_FRIEND constexpr difference_type operator-(const _Inner_iterator& _Left,
+            _NODISCARD friend constexpr difference_type operator-(const _Inner_iterator& _Left,
                 default_sentinel_t) noexcept(noexcept(_Left._Get_size())) /* strengthened */
                 requires sized_sentinel_for<sentinel_t<_Vw>, iterator_t<_Vw>>
             {
                 return -_Left._Get_size();
             }
 
-            _NODISCARD_FRIEND constexpr range_rvalue_reference_t<_Vw> iter_move(const _Inner_iterator& _It) noexcept(
+            _NODISCARD friend constexpr range_rvalue_reference_t<_Vw> iter_move(const _Inner_iterator& _It) noexcept(
                 noexcept(_RANGES iter_move(_It._Get_current()))) {
                 return _RANGES iter_move(_It._Get_current());
             }
@@ -5625,19 +5625,19 @@ namespace ranges {
                 _Parent->_Remainder = _Parent->_Count;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Outer_iterator& _Left, default_sentinel_t) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Outer_iterator& _Left, default_sentinel_t) noexcept(
                 noexcept(_Left._Is_end())) /* strengthened */ {
                 return _Left._Is_end();
             }
 
-            _NODISCARD_FRIEND constexpr difference_type operator-(default_sentinel_t,
+            _NODISCARD friend constexpr difference_type operator-(default_sentinel_t,
                 const _Outer_iterator& _Right) noexcept(noexcept(_Right._Get_size())) /* strengthened */
                 requires sized_sentinel_for<sentinel_t<_Vw>, iterator_t<_Vw>>
             {
                 return _Right._Get_size();
             }
 
-            _NODISCARD_FRIEND constexpr difference_type operator-(const _Outer_iterator& _Left,
+            _NODISCARD friend constexpr difference_type operator-(const _Outer_iterator& _Left,
                 default_sentinel_t) noexcept(noexcept(_Left._Get_size())) /* strengthened */
                 requires sized_sentinel_for<sentinel_t<_Vw>, iterator_t<_Vw>>
             {
@@ -5821,52 +5821,52 @@ namespace ranges {
                 return *(*this + _Off);
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(_Left._Current == _Right._Current))) /* strengthened */ {
                 return _Left._Current == _Right._Current;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, default_sentinel_t) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, default_sentinel_t) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(_Left._Current == _Left._End))) /* strengthened */ {
                 return _Left._Current == _Left._End;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(_Left._Current < _Right._Current))) /* strengthened */
                 requires random_access_range<_Base>
             {
                 return _Left._Current < _Right._Current;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(_Right._Current < _Left._Current))) /* strengthened */
                 requires random_access_range<_Base>
             {
                 return _Right._Current < _Left._Current;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(!(_Right._Current < _Left._Current)))) /* strengthened */
                 requires random_access_range<_Base>
             {
                 return !(_Right._Current < _Left._Current);
             }
 
-            _NODISCARD_FRIEND constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(!(_Left._Current < _Right._Current)))) /* strengthened */
                 requires random_access_range<_Base>
             {
                 return !(_Left._Current < _Right._Current);
             }
 
-            _NODISCARD_FRIEND constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current <=> _Right._Current)) /* strengthened */
                 requires random_access_range<_Base> && three_way_comparable<_Base_iterator>
             {
                 return _Left._Current <=> _Right._Current;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off) noexcept(
+            _NODISCARD friend constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off) noexcept(
                 is_nothrow_copy_constructible_v<_Iterator> //
                     && noexcept(_STD declval<_Iterator&>() += _Off)) /* strengthened */
                 requires random_access_range<_Base>
@@ -5876,7 +5876,7 @@ namespace ranges {
                 return _Copy;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It) noexcept(
+            _NODISCARD friend constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It) noexcept(
                 is_nothrow_copy_constructible_v<_Iterator> //
                     && noexcept(_STD declval<_Iterator&>() += _Off)) /* strengthened */
                 requires random_access_range<_Base>
@@ -5886,7 +5886,7 @@ namespace ranges {
                 return _Copy;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off) noexcept(
+            _NODISCARD friend constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off) noexcept(
                 is_nothrow_copy_constructible_v<_Iterator> //
                     && noexcept(_STD declval<_Iterator&>() -= _Off)) /* strengthened */
                 requires random_access_range<_Base>
@@ -5896,21 +5896,21 @@ namespace ranges {
                 return _Copy;
             }
 
-            _NODISCARD_FRIEND constexpr difference_type operator-(const _Iterator& _Left,
+            _NODISCARD friend constexpr difference_type operator-(const _Iterator& _Left,
                 const _Iterator& _Right) noexcept(noexcept(_Left._Current - _Right._Current)) /* strengthened */
                 requires sized_sentinel_for<_Base_iterator, _Base_iterator>
             {
                 return (_Left._Current - _Right._Current + _Left._Missing - _Right._Missing) / _Left._Count;
             }
 
-            _NODISCARD_FRIEND constexpr difference_type operator-(default_sentinel_t, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr difference_type operator-(default_sentinel_t, const _Iterator& _Right) noexcept(
                 noexcept(_Right._End - _Right._Current)) /* strengthened */
                 requires sized_sentinel_for<_Base_sentinel, _Base_iterator>
             {
                 return _Div_ceil(_Right._End - _Right._Current, _Right._Count);
             }
 
-            _NODISCARD_FRIEND constexpr difference_type operator-(const _Iterator& _Left, default_sentinel_t) noexcept(
+            _NODISCARD friend constexpr difference_type operator-(const _Iterator& _Left, default_sentinel_t) noexcept(
                 noexcept(_Left._End - _Left._Current)) /* strengthened */
                 requires sized_sentinel_for<_Base_sentinel, _Base_iterator>
             {
@@ -6178,7 +6178,7 @@ namespace ranges {
                 return views::counted(_Current + _Off, _Count);
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(_Left._Current == _Right._Current))) /* strengthened */ {
                 if constexpr (_Slide_caches_first<_Base>) {
                     return _Left._Last_element == _Right._Last_element;
@@ -6187,42 +6187,42 @@ namespace ranges {
                 }
             }
 
-            _NODISCARD_FRIEND constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(_Left._Current < _Right._Current))) /* strengthened */
                 requires random_access_range<_Base>
             {
                 return _Left._Current < _Right._Current;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(_Right._Current < _Left._Current))) /* strengthened */
                 requires random_access_range<_Base>
             {
                 return _Right._Current < _Left._Current;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(!(_Right._Current < _Left._Current)))) /* strengthened */
                 requires random_access_range<_Base>
             {
                 return !(_Right._Current < _Left._Current);
             }
 
-            _NODISCARD_FRIEND constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(!(_Left._Current < _Right._Current)))) /* strengthened */
                 requires random_access_range<_Base>
             {
                 return !(_Left._Current < _Right._Current);
             }
 
-            _NODISCARD_FRIEND constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current <=> _Right._Current)) /* strengthened */
                 requires random_access_range<_Base> && three_way_comparable<_Base_iterator>
             {
                 return _Left._Current <=> _Right._Current;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off) noexcept(
+            _NODISCARD friend constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off) noexcept(
                 noexcept(_STD declval<_Iterator&>() += _Off)) /* strengthened */
                 requires random_access_range<_Base>
             {
@@ -6231,7 +6231,7 @@ namespace ranges {
                 return _Copy;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It) noexcept(
+            _NODISCARD friend constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It) noexcept(
                 noexcept(_STD declval<_Iterator&>() += _Off)) /* strengthened */
                 requires random_access_range<_Base>
             {
@@ -6240,7 +6240,7 @@ namespace ranges {
                 return _Copy;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off) noexcept(
+            _NODISCARD friend constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off) noexcept(
                 noexcept(_STD declval<_Iterator&>() -= _Off)) /* strengthened */
                 requires random_access_range<_Base>
             {
@@ -6249,7 +6249,7 @@ namespace ranges {
                 return _Copy;
             }
 
-            _NODISCARD_FRIEND constexpr difference_type operator-(const _Iterator& _Left,
+            _NODISCARD friend constexpr difference_type operator-(const _Iterator& _Left,
                 const _Iterator& _Right) noexcept(noexcept(_Left._Current - _Right._Current)) /* strengthened */
                 requires sized_sentinel_for<_Base_iterator, _Base_iterator>
             {
@@ -6273,20 +6273,20 @@ namespace ranges {
         public:
             _Sentinel() = default;
 
-            _NODISCARD_FRIEND constexpr bool
+            _NODISCARD friend constexpr bool
                 operator==(const _Iterator<false>& _Left, const _Sentinel& _Right) noexcept(noexcept(
                     _STD _Fake_copy_init<bool>(_Left._Get_last_element() == _Right._Last))) /* strengthened */ {
                 return _Left._Get_last_element() == _Right._Last;
             }
 
-            _NODISCARD_FRIEND constexpr range_difference_t<_Vw> operator-(const _Iterator<false>& _Left,
+            _NODISCARD friend constexpr range_difference_t<_Vw> operator-(const _Iterator<false>& _Left,
                 const _Sentinel& _Right) noexcept(noexcept(_Left._Get_last_element() - _Right._Last)) /* strengthened */
                 requires sized_sentinel_for<sentinel_t<_Vw>, iterator_t<_Vw>>
             {
                 return _Left._Get_last_element() - _Right._Last;
             }
 
-            _NODISCARD_FRIEND constexpr range_difference_t<_Vw>
+            _NODISCARD friend constexpr range_difference_t<_Vw>
                 operator-(const _Sentinel& _Left, const _Iterator<false>& _Right) noexcept(
                     noexcept(_Left._Last - _Right._Get_last_element())) /* strengthened */
                 requires sized_sentinel_for<sentinel_t<_Vw>, iterator_t<_Vw>>
@@ -6524,12 +6524,12 @@ namespace ranges {
                 return _Tmp;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(_Left._Current == _Right._Current))) /* strengthened */ {
                 return _Left._Current == _Right._Current;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, default_sentinel_t) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, default_sentinel_t) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(_Left._Current == _Left._Next))) /* strengthened */ {
                 return _Left._Current == _Left._Next;
             }
@@ -6789,54 +6789,54 @@ namespace ranges {
                 return *(*this + _Off);
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _It, default_sentinel_t) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _It, default_sentinel_t) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(_It._Current == _It._End))) /* strengthened */ {
                 return _It._Current == _It._End;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(_Left._Current == _Right._Current))) // strengthened
                 requires equality_comparable<_Base_iterator>
             {
                 return _Left._Current == _Right._Current;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(_Left._Current < _Right._Current))) // strengthened
                 requires random_access_range<_Base>
             {
                 return _Left._Current < _Right._Current;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(_Right._Current < _Left._Current))) // strengthened
                 requires random_access_range<_Base>
             {
                 return _Right._Current < _Left._Current;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(!(_Right._Current < _Left._Current)))) // strengthened
                 requires random_access_range<_Base>
             {
                 return !(_Right._Current < _Left._Current);
             }
 
-            _NODISCARD_FRIEND constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(!(_Left._Current < _Right._Current)))) // strengthened
                 requires random_access_range<_Base>
             {
                 return !(_Left._Current < _Right._Current);
             }
 
-            _NODISCARD_FRIEND constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current <=> _Right._Current)) // strengthened
                 requires random_access_range<_Base> && three_way_comparable<_Base_iterator>
             {
                 return _Left._Current <=> _Right._Current;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off)
+            _NODISCARD friend constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off)
                 requires random_access_range<_Base>
             {
                 auto _Copy = _It;
@@ -6844,7 +6844,7 @@ namespace ranges {
                 return _Copy;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It)
+            _NODISCARD friend constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It)
                 requires random_access_range<_Base>
             {
                 auto _Copy = _It;
@@ -6852,7 +6852,7 @@ namespace ranges {
                 return _Copy;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off)
+            _NODISCARD friend constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off)
                 requires random_access_range<_Base>
             {
                 auto _Copy = _It;
@@ -6860,7 +6860,7 @@ namespace ranges {
                 return _Copy;
             }
 
-            _NODISCARD_FRIEND constexpr difference_type operator-(const _Iterator& _Left, const _Iterator& _Right) //
+            _NODISCARD friend constexpr difference_type operator-(const _Iterator& _Left, const _Iterator& _Right) //
                 noexcept(noexcept(_Left._Current - _Right._Current)) // strengthened
                 requires sized_sentinel_for<_Base_iterator, _Base_iterator>
             {
@@ -6876,21 +6876,21 @@ namespace ranges {
                 }
             }
 
-            _NODISCARD_FRIEND constexpr difference_type operator-(default_sentinel_t, const _Iterator& _It) noexcept(
+            _NODISCARD friend constexpr difference_type operator-(default_sentinel_t, const _Iterator& _It) noexcept(
                 noexcept(_It._End - _It._Current)) // strengthened
                 requires sized_sentinel_for<_Base_sentinel, _Base_iterator>
             {
                 return _Div_ceil(_It._End - _It._Current, _It._Stride);
             }
 
-            _NODISCARD_FRIEND constexpr difference_type operator-(const _Iterator& _It, default_sentinel_t) noexcept(
+            _NODISCARD friend constexpr difference_type operator-(const _Iterator& _It, default_sentinel_t) noexcept(
                 noexcept(_It._End - _It._Current)) // strengthened
                 requires sized_sentinel_for<_Base_sentinel, _Base_iterator>
             {
                 return -_Div_ceil(_It._End - _It._Current, _It._Stride);
             }
 
-            _NODISCARD_FRIEND constexpr range_rvalue_reference_t<_Base> iter_move(const _Iterator& _It) noexcept(
+            _NODISCARD friend constexpr range_rvalue_reference_t<_Base> iter_move(const _Iterator& _It) noexcept(
                 noexcept(_RANGES iter_move(_It._Current))) {
                 return _RANGES iter_move(_It._Current);
             }
@@ -7264,7 +7264,7 @@ namespace ranges {
                     _Current);
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Lhs, const _Iterator& _Rhs) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _Lhs, const _Iterator& _Rhs) noexcept(
                 noexcept(_Zip_iterator_sentinel_equal(_Lhs._Current, _Rhs._Current))) // strengthened
                 requires (equality_comparable<iterator_t<_Maybe_const<_IsConst, _ViewTypes>>> && ...)
             {
@@ -7276,13 +7276,13 @@ namespace ranges {
                 }
             }
 
-            _NODISCARD_FRIEND constexpr auto operator<=>(const _Iterator& _Lhs, const _Iterator& _Rhs)
+            _NODISCARD friend constexpr auto operator<=>(const _Iterator& _Lhs, const _Iterator& _Rhs)
                 requires _All_random_access<_IsConst, _ViewTypes...>
             {
                 return _Lhs._Current <=> _Rhs._Current;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const _Iterator& _Lhs, const difference_type _Rhs) noexcept(
+            _NODISCARD friend constexpr _Iterator operator+(const _Iterator& _Lhs, const difference_type _Rhs) noexcept(
                 noexcept(_STD declval<_Iterator&>() += _Rhs)
                 && is_nothrow_copy_constructible_v<_Iterator>) // strengthened
                 requires _All_random_access<_IsConst, _ViewTypes...>
@@ -7293,14 +7293,14 @@ namespace ranges {
                 return _Modified_iterator;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const difference_type _Lhs, const _Iterator& _Rhs) noexcept(
+            _NODISCARD friend constexpr _Iterator operator+(const difference_type _Lhs, const _Iterator& _Rhs) noexcept(
                 noexcept(_Rhs + _Lhs)) /* strengthened */
                 requires _All_random_access<_IsConst, _ViewTypes...>
             {
                 return _Rhs + _Lhs;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator-(const _Iterator& _Lhs, const difference_type _Rhs) noexcept(
+            _NODISCARD friend constexpr _Iterator operator-(const _Iterator& _Lhs, const difference_type _Rhs) noexcept(
                 noexcept(_STD declval<_Iterator&>() -= _Rhs)
                 && is_nothrow_copy_constructible_v<_Iterator>) // strengthened
                 requires _All_random_access<_IsConst, _ViewTypes...>
@@ -7311,7 +7311,7 @@ namespace ranges {
                 return _Modified_iterator;
             }
 
-            _NODISCARD_FRIEND constexpr difference_type
+            _NODISCARD friend constexpr difference_type
                 operator-(const _Iterator& _Lhs, const _Iterator& _Rhs) noexcept(
                     noexcept(_Zip_get_smallest_distance<difference_type>(_STD declval<_My_tuple>(),
                         _STD declval<_My_tuple>()))) // strengthened
@@ -7322,7 +7322,7 @@ namespace ranges {
                 return _Zip_get_smallest_distance<difference_type>(_Lhs._Current, _Rhs._Current);
             }
 
-            _NODISCARD_FRIEND constexpr auto iter_move(const _Iterator& _Itr) noexcept(
+            _NODISCARD friend constexpr auto iter_move(const _Iterator& _Itr) noexcept(
                 (noexcept(_RANGES iter_move(_STD declval<const iterator_t<_Maybe_const<_IsConst, _ViewTypes>>&>()))
                     && ...)
                 && (is_nothrow_move_constructible_v<range_rvalue_reference_t<_Maybe_const<_IsConst, _ViewTypes>>>
@@ -7383,7 +7383,7 @@ namespace ranges {
                 requires (sentinel_for<sentinel_t<_Maybe_const<_IsConst, _ViewTypes>>,
                               iterator_t<_Maybe_const<_IteratorConst, _ViewTypes>>>
                           && ...)
-            _NODISCARD_FRIEND constexpr bool
+            _NODISCARD friend constexpr bool
                 operator==(const _Iterator<_IteratorConst>& _Lhs, const _Sentinel& _Rhs) noexcept(
                     noexcept(_Zip_iterator_sentinel_equal(_Get_iterator_tuple(_Lhs), _Rhs._End))) /* strengthened */ {
                 return _Zip_iterator_sentinel_equal(_Get_iterator_tuple(_Lhs), _Rhs._End);
@@ -7393,7 +7393,7 @@ namespace ranges {
                 requires (sized_sentinel_for<sentinel_t<_Maybe_const<_IsConst, _ViewTypes>>,
                               iterator_t<_Maybe_const<_IteratorConst, _ViewTypes>>>
                           && ...)
-            _NODISCARD_FRIEND constexpr common_type_t<range_difference_t<_Maybe_const<_IteratorConst, _ViewTypes>>...>
+            _NODISCARD friend constexpr common_type_t<range_difference_t<_Maybe_const<_IteratorConst, _ViewTypes>>...>
                 operator-(const _Iterator<_IteratorConst>& _Lhs, const _Sentinel& _Rhs) noexcept(
                     noexcept(_Zip_get_smallest_distance<
                         common_type_t<range_difference_t<_Maybe_const<_IteratorConst, _ViewTypes>>...>>(
@@ -7406,7 +7406,7 @@ namespace ranges {
                 requires (sized_sentinel_for<sentinel_t<_Maybe_const<_IsConst, _ViewTypes>>,
                               iterator_t<_Maybe_const<_IteratorConst, _ViewTypes>>>
                           && ...)
-            _NODISCARD_FRIEND constexpr common_type_t<range_difference_t<_Maybe_const<_IteratorConst, _ViewTypes>>...>
+            _NODISCARD friend constexpr common_type_t<range_difference_t<_Maybe_const<_IteratorConst, _ViewTypes>>...>
                 operator-(const _Sentinel& _Lhs, const _Iterator<_IteratorConst>& _Rhs) noexcept(
                     noexcept(-(_Rhs - _Lhs))) /* strengthened */ {
                 return -(_Rhs - _Lhs);
@@ -7679,42 +7679,42 @@ namespace ranges {
                 return _STD apply(_Subscript_closure(_Where), _Inner._Current);
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Lhs, const _Iterator& _Rhs) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _Lhs, const _Iterator& _Rhs) noexcept(
                 noexcept(_Lhs._Inner == _Rhs._Inner)) // strengthened
                 requires equality_comparable<_Ziperator<_IsConst>>
             {
                 return _Lhs._Inner == _Rhs._Inner;
             }
 
-            _NODISCARD_FRIEND constexpr auto operator<=>(const _Iterator& _Lhs, const _Iterator& _Rhs) noexcept(
+            _NODISCARD friend constexpr auto operator<=>(const _Iterator& _Lhs, const _Iterator& _Rhs) noexcept(
                 noexcept(_Lhs._Inner <=> _Rhs._Inner)) // strengthened
                 requires random_access_range<_Base_t>
             {
                 return _Lhs._Inner <=> _Rhs._Inner;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const _Iterator& _Lhs, const difference_type _Rhs) noexcept(
+            _NODISCARD friend constexpr _Iterator operator+(const _Iterator& _Lhs, const difference_type _Rhs) noexcept(
                 noexcept(_Iterator{*_Lhs._Parent, _Lhs._Inner + _Rhs})) // strengthened
                 requires random_access_range<_Base_t>
             {
                 return _Iterator{*_Lhs._Parent, _Lhs._Inner + _Rhs};
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const difference_type _Lhs, const _Iterator& _Rhs) noexcept(
+            _NODISCARD friend constexpr _Iterator operator+(const difference_type _Lhs, const _Iterator& _Rhs) noexcept(
                 noexcept(_Iterator{*_Rhs._Parent, _Rhs._Inner + _Lhs})) // strengthened
                 requires random_access_range<_Base_t>
             {
                 return _Iterator{*_Rhs._Parent, _Rhs._Inner + _Lhs};
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator-(const _Iterator& _Lhs, const difference_type _Rhs) noexcept(
+            _NODISCARD friend constexpr _Iterator operator-(const _Iterator& _Lhs, const difference_type _Rhs) noexcept(
                 noexcept(_Iterator{*_Lhs._Parent, _Lhs._Inner - _Rhs})) // strengthened
                 requires random_access_range<_Base_t>
             {
                 return _Iterator{*_Lhs._Parent, _Lhs._Inner - _Rhs};
             }
 
-            _NODISCARD_FRIEND constexpr difference_type operator-(const _Iterator& _Lhs,
+            _NODISCARD friend constexpr difference_type operator-(const _Iterator& _Lhs,
                 const _Iterator& _Rhs) noexcept(noexcept(_Lhs._Inner - _Rhs._Inner)) // strengthened
                 requires sized_sentinel_for<_Ziperator<_IsConst>, _Ziperator<_IsConst>>
             {
@@ -7768,14 +7768,14 @@ namespace ranges {
 
             template <bool _IteratorConst>
                 requires sentinel_for<_Zentinel<_IsConst>, _Ziperator<_IteratorConst>>
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator<_IteratorConst>& _Lhs,
+            _NODISCARD friend constexpr bool operator==(const _Iterator<_IteratorConst>& _Lhs,
                 const _Sentinel& _Rhs) noexcept(noexcept(_Get_iterator_inner(_Lhs) == _Rhs._Inner)) /* strengthened */ {
                 return _Get_iterator_inner(_Lhs) == _Rhs._Inner;
             }
 
             template <bool _IteratorConst>
                 requires sized_sentinel_for<_Zentinel<_IsConst>, _Ziperator<_IteratorConst>>
-            _NODISCARD_FRIEND constexpr _Iter_sent_difference_type<_IteratorConst> // TRANSITION, DevCom-10253131
+            _NODISCARD friend constexpr _Iter_sent_difference_type<_IteratorConst> // TRANSITION, DevCom-10253131
                 operator-(const _Iterator<_IteratorConst>& _Lhs, const _Sentinel & _Rhs) noexcept(
                     noexcept(_Get_iterator_inner(_Lhs) - _Rhs._Inner)) /* strengthened */ {
                 return _Get_iterator_inner(_Lhs) - _Rhs._Inner;
@@ -7783,7 +7783,7 @@ namespace ranges {
 
             template <bool _IteratorConst>
                 requires sized_sentinel_for<_Zentinel<_IsConst>, _Ziperator<_IteratorConst>>
-            _NODISCARD_FRIEND constexpr _Iter_sent_difference_type<_IteratorConst> // TRANSITION, DevCom-10253131
+            _NODISCARD friend constexpr _Iter_sent_difference_type<_IteratorConst> // TRANSITION, DevCom-10253131
                 operator-(const _Sentinel & _Lhs, const _Iterator<_IteratorConst>& _Rhs) noexcept(
                     noexcept(_Lhs._Inner - _Get_iterator_inner(_Rhs))) /* strengthened */ {
                 return _Lhs._Inner - _Get_iterator_inner(_Rhs);
@@ -8085,48 +8085,48 @@ namespace ranges {
                 return _RANGES _Tuple_transform([&](auto& _It) -> decltype(auto) { return _It[_Off]; }, _Current);
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(_Left._Current.back() == _Right._Current.back()))) // strengthened
             {
                 return _Left._Current.back() == _Right._Current.back();
             }
 
-            _NODISCARD_FRIEND constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_STD _Fake_copy_init<bool>(_Left._Current.back() < _Right._Current.back()))) // strengthened
                 requires random_access_range<_Base>
             {
                 return _Left._Current.back() < _Right._Current.back();
             }
 
-            _NODISCARD_FRIEND constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Right < _Left)) // strengthened
                 requires random_access_range<_Base>
             {
                 return _Right < _Left;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(!(_Right < _Left))) // strengthened
                 requires random_access_range<_Base>
             {
                 return !(_Right < _Left);
             }
 
-            _NODISCARD_FRIEND constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(!(_Left < _Right))) // strengthened
                 requires random_access_range<_Base>
             {
                 return !(_Left < _Right);
             }
 
-            _NODISCARD_FRIEND constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current.back() <=> _Right._Current.back())) // strengthened
                 requires random_access_range<_Base> && three_way_comparable<_Base_iterator>
             {
                 return _Left._Current.back() <=> _Right._Current.back();
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off) noexcept(
+            _NODISCARD friend constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off) noexcept(
                 noexcept(_STD declval<_Iterator&>() += _Off)
                 && is_nothrow_copy_constructible_v<_Iterator>) // strengthened
                 requires random_access_range<_Base>
@@ -8136,7 +8136,7 @@ namespace ranges {
                 return _Tmp;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It) noexcept(
+            _NODISCARD friend constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It) noexcept(
                 noexcept(_STD declval<_Iterator&>() += _Off)
                 && is_nothrow_copy_constructible_v<_Iterator>) // strengthened
                 requires random_access_range<_Base>
@@ -8146,7 +8146,7 @@ namespace ranges {
                 return _Tmp;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off) noexcept(
+            _NODISCARD friend constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off) noexcept(
                 noexcept(_STD declval<_Iterator&>() -= _Off)
                 && is_nothrow_copy_constructible_v<_Iterator>) // strengthened
                 requires random_access_range<_Base>
@@ -8156,7 +8156,7 @@ namespace ranges {
                 return _Tmp;
             }
 
-            _NODISCARD_FRIEND constexpr difference_type
+            _NODISCARD friend constexpr difference_type
                 operator-(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                     noexcept(_Left._Current.back() - _Right._Current.back())) // strengthened
                 requires sized_sentinel_for<_Base_iterator, _Base_iterator>
@@ -8164,7 +8164,7 @@ namespace ranges {
                 return _Left._Current.back() - _Right._Current.back();
             }
 
-            _NODISCARD_FRIEND constexpr auto iter_move(const _Iterator& _It) noexcept(
+            _NODISCARD friend constexpr auto iter_move(const _Iterator& _It) noexcept(
                 noexcept(_RANGES iter_move(_STD declval<const _Base_iterator&>()))
                 && is_nothrow_move_constructible_v<range_rvalue_reference_t<_Base>>) {
                 return _RANGES _Tuple_transform(_RANGES iter_move, _It._Current);
@@ -8218,14 +8218,14 @@ namespace ranges {
 
             template <bool _OtherConst>
                 requires sentinel_for<_Base_sentinel, iterator_t<_Maybe_const<_OtherConst, _Vw>>>
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator<_OtherConst>& _It,
+            _NODISCARD friend constexpr bool operator==(const _Iterator<_OtherConst>& _It,
                 const _Sentinel& _Se) noexcept(noexcept(_Se._Equal(_It))) /* strengthened */ {
                 return _Se._Equal(_It);
             }
 
             template <bool _OtherConst>
                 requires sized_sentinel_for<_Base_sentinel, iterator_t<_Maybe_const<_OtherConst, _Vw>>>
-            _NODISCARD_FRIEND constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>> operator-(
+            _NODISCARD friend constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>> operator-(
                 const _Iterator<_OtherConst>& _It, const _Sentinel& _Se) noexcept( //
                 noexcept(_Se._Distance_from(_It))) /* strengthened */ {
                 return -_Se._Distance_from(_It);
@@ -8233,7 +8233,7 @@ namespace ranges {
 
             template <bool _OtherConst>
                 requires sized_sentinel_for<_Base_sentinel, iterator_t<_Maybe_const<_OtherConst, _Vw>>>
-            _NODISCARD_FRIEND constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>> operator-(
+            _NODISCARD friend constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>> operator-(
                 const _Sentinel& _Se, const _Iterator<_OtherConst>& _It) noexcept( //
                 noexcept(_Se._Distance_from(_It))) /* strengthened */ {
                 return _Se._Distance_from(_It);
@@ -8481,68 +8481,68 @@ namespace ranges {
                     _Inner._Current);
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Inner == _Right._Inner)) /* strengthened */ {
                 return _Left._Inner == _Right._Inner;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Inner < _Right._Inner)) // strengthened
                 requires random_access_range<_Base>
             {
                 return _Left._Inner < _Right._Inner;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Inner > _Right._Inner)) // strengthened
                 requires random_access_range<_Base>
             {
                 return _Left._Inner > _Right._Inner;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Inner <= _Right._Inner)) // strengthened
                 requires random_access_range<_Base>
             {
                 return _Left._Inner <= _Right._Inner;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Inner >= _Right._Inner)) // strengthened
                 requires random_access_range<_Base>
             {
                 return _Left._Inner >= _Right._Inner;
             }
 
-            _NODISCARD_FRIEND constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD friend constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Inner <=> _Right._Inner)) // strengthened
                 requires random_access_range<_Base> && three_way_comparable<_Inner_iterator<_Const>>
             {
                 return _Left._Inner <=> _Right._Inner;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off) noexcept(
+            _NODISCARD friend constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off) noexcept(
                 noexcept(_It._Inner + _Off) && is_nothrow_move_constructible_v<_Inner_iterator<_Const>>) // strengthened
                 requires random_access_range<_Base>
             {
                 return _Iterator{*_It._Parent, _It._Inner + _Off};
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It) noexcept(
+            _NODISCARD friend constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It) noexcept(
                 noexcept(_It._Inner + _Off) && is_nothrow_move_constructible_v<_Inner_iterator<_Const>>) // strengthened
                 requires random_access_range<_Base>
             {
                 return _Iterator{*_It._Parent, _It._Inner + _Off};
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off) noexcept(
+            _NODISCARD friend constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off) noexcept(
                 noexcept(_It._Inner - _Off) && is_nothrow_move_constructible_v<_Inner_iterator<_Const>>) // strengthened
                 requires random_access_range<_Base>
             {
                 return _Iterator{*_It._Parent, _It._Inner - _Off};
             }
 
-            _NODISCARD_FRIEND constexpr difference_type operator-(const _Iterator& _Left, const _Iterator& _Right) //
+            _NODISCARD friend constexpr difference_type operator-(const _Iterator& _Left, const _Iterator& _Right) //
                 noexcept(noexcept(_Left._Inner - _Right._Inner)) // strengthened
                 requires sized_sentinel_for<_Inner_iterator<_Const>, _Inner_iterator<_Const>>
             {
@@ -8582,14 +8582,14 @@ namespace ranges {
 
             template <bool _OtherConst>
                 requires sentinel_for<_Inner_sentinel<_Const>, _Inner_iterator<_OtherConst>>
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator<_OtherConst>& _It,
+            _NODISCARD friend constexpr bool operator==(const _Iterator<_OtherConst>& _It,
                 const _Sentinel& _Se) noexcept(noexcept(_Se._Equal(_It))) /* strengthened */ {
                 return _Se._Equal(_It);
             }
 
             template <bool _OtherConst>
                 requires sized_sentinel_for<_Inner_sentinel<_Const>, _Inner_iterator<_OtherConst>>
-            _NODISCARD_FRIEND constexpr range_difference_t<_Maybe_const<_OtherConst, _Inner_view>> operator-(
+            _NODISCARD friend constexpr range_difference_t<_Maybe_const<_OtherConst, _Inner_view>> operator-(
                 const _Iterator<_OtherConst>& _It, const _Sentinel& _Se) noexcept( //
                 noexcept(_Se._Distance_from(_It))) /* strengthened */ {
                 return -_Se._Distance_from(_It);
@@ -8597,7 +8597,7 @@ namespace ranges {
 
             template <bool _OtherConst>
                 requires sized_sentinel_for<_Inner_sentinel<_Const>, _Inner_iterator<_OtherConst>>
-            _NODISCARD_FRIEND constexpr range_difference_t<_Maybe_const<_OtherConst, _Inner_view>> operator-(
+            _NODISCARD friend constexpr range_difference_t<_Maybe_const<_OtherConst, _Inner_view>> operator-(
                 const _Sentinel& _Se, const _Iterator<_OtherConst>& _It) noexcept( //
                 noexcept(_Se._Distance_from(_It))) /* strengthened */ {
                 return _Se._Distance_from(_It);
@@ -9004,59 +9004,59 @@ namespace ranges {
                 return *(*this + _Off);
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right)
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right)
                 requires equality_comparable<iterator_t<_Maybe_const<_Const, _First>>>
             {
                 return _Left._Current == _Right._Current;
             }
 
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _It, default_sentinel_t) {
+            _NODISCARD friend constexpr bool operator==(const _Iterator& _It, default_sentinel_t) {
                 return _It._Is_end(make_index_sequence<1 + sizeof...(_Rest)>{});
             }
 
-            _NODISCARD_FRIEND constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right)
+            _NODISCARD friend constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right)
                 requires _All_random_access<_Const, _First, _Rest...>
             {
                 return _Left._Current <=> _Right._Current;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off)
+            _NODISCARD friend constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off)
                 requires _Cartesian_product_is_random_access<_Const, _First, _Rest...>
             {
                 return _Iterator{_It} += _Off;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It)
+            _NODISCARD friend constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It)
                 requires _Cartesian_product_is_random_access<_Const, _First, _Rest...>
             {
                 return _It + _Off;
             }
 
-            _NODISCARD_FRIEND constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off)
+            _NODISCARD friend constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off)
                 requires _Cartesian_product_is_random_access<_Const, _First, _Rest...>
             {
                 return _Iterator{_It} -= _Off;
             }
 
-            _NODISCARD_FRIEND constexpr difference_type operator-(const _Iterator& _Left, const _Iterator& _Right)
+            _NODISCARD friend constexpr difference_type operator-(const _Iterator& _Left, const _Iterator& _Right)
                 requires _Cartesian_is_sized_sentinel<_Const, iterator_t, _First, _Rest...>
             {
                 return _Left._Distance_from(_Right._Current);
             }
 
-            _NODISCARD_FRIEND constexpr difference_type operator-(const _Iterator& _It, default_sentinel_t)
+            _NODISCARD friend constexpr difference_type operator-(const _Iterator& _It, default_sentinel_t)
                 requires _Cartesian_is_sized_sentinel<_Const, sentinel_t, _First, _Rest...>
             {
                 return _It._Distance_from(_It._End_tuple(make_index_sequence<sizeof...(_Rest)>{}));
             }
 
-            _NODISCARD_FRIEND constexpr difference_type operator-(default_sentinel_t _Se, const _Iterator& _It)
+            _NODISCARD friend constexpr difference_type operator-(default_sentinel_t _Se, const _Iterator& _It)
                 requires _Cartesian_is_sized_sentinel<_Const, sentinel_t, _First, _Rest...>
             {
                 return -(_It - _Se);
             }
 
-            _NODISCARD_FRIEND constexpr auto iter_move(const _Iterator& _It) noexcept(
+            _NODISCARD friend constexpr auto iter_move(const _Iterator& _It) noexcept(
                 _Is_iter_move_nothrow(make_index_sequence<1 + sizeof...(_Rest)>{})) {
                 return _RANGES _Tuple_transform(_RANGES iter_move, _It._Current);
             }

--- a/stl/inc/span
+++ b/stl/inc/span
@@ -110,7 +110,7 @@ struct _Span_iterator {
         return _Tmp;
     }
 
-    _NODISCARD_FRIEND constexpr _Span_iterator operator+(const difference_type _Off, _Span_iterator _Next) noexcept {
+    _NODISCARD friend constexpr _Span_iterator operator+(const difference_type _Off, _Span_iterator _Next) noexcept {
         _Next += _Off;
         return _Next;
     }

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -107,9 +107,9 @@ public:
         return __std_stacktrace_source_line(_Address);
     }
 
-    _NODISCARD_FRIEND constexpr bool operator==(const stacktrace_entry&, const stacktrace_entry&) noexcept = default;
+    _NODISCARD friend constexpr bool operator==(const stacktrace_entry&, const stacktrace_entry&) noexcept = default;
 
-    _NODISCARD_FRIEND constexpr strong_ordering operator<=>(
+    _NODISCARD friend constexpr strong_ordering operator<=>(
         const stacktrace_entry&, const stacktrace_entry&) noexcept = default;
 
 private:
@@ -253,12 +253,12 @@ public:
     }
 
     template <class _Al2>
-    _NODISCARD_FRIEND bool operator==(const basic_stacktrace& _Lhs, const basic_stacktrace<_Al2>& _Rhs) noexcept {
+    _NODISCARD friend bool operator==(const basic_stacktrace& _Lhs, const basic_stacktrace<_Al2>& _Rhs) noexcept {
         return _Lhs._Hash == _Rhs._Hash && _STD equal(_Lhs.begin(), _Lhs.end(), _Rhs.begin(), _Rhs.end());
     }
 
     template <class _Al2>
-    _NODISCARD_FRIEND strong_ordering operator<=>(
+    _NODISCARD friend strong_ordering operator<=>(
         const basic_stacktrace& _Lhs, const basic_stacktrace<_Al2>& _Rhs) noexcept {
         const auto _Result = _Lhs._Frames.size() <=> _Rhs._Frames.size();
         if (_Result != strong_ordering::equal) {

--- a/stl/inc/stop_token
+++ b/stl/inc/stop_token
@@ -162,7 +162,7 @@ public:
         return _Local != nullptr && _Local->_Stop_possible();
     }
 
-    _NODISCARD_FRIEND bool operator==(const stop_token& _Lhs, const stop_token& _Rhs) noexcept = default;
+    _NODISCARD friend bool operator==(const stop_token& _Lhs, const stop_token& _Rhs) noexcept = default;
 
     friend void swap(stop_token& _Lhs, stop_token& _Rhs) noexcept {
         _STD swap(_Lhs._State, _Rhs._State);
@@ -234,7 +234,7 @@ public:
         return _Local && _Local->_Request_stop();
     }
 
-    _NODISCARD_FRIEND bool operator==(const stop_source& _Lhs, const stop_source& _Rhs) noexcept = default;
+    _NODISCARD friend bool operator==(const stop_source& _Lhs, const stop_source& _Rhs) noexcept = default;
 
     friend void swap(stop_source& _Lhs, stop_source& _Rhs) noexcept {
         _STD swap(_Lhs._State, _Rhs._State);

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -212,39 +212,39 @@ public:
     }
 
 #if _STL_OPTIMIZE_SYSTEM_ERROR_OPERATORS
-    _NODISCARD_FRIEND bool operator==(const error_code& _Left, const error_code& _Right) noexcept {
+    _NODISCARD friend bool operator==(const error_code& _Left, const error_code& _Right) noexcept {
         return _Left.category() == _Right.category() && _Left.value() == _Right.value();
     }
 
-    _NODISCARD_FRIEND bool operator==(const error_code& _Left, const error_condition& _Right) noexcept {
+    _NODISCARD friend bool operator==(const error_code& _Left, const error_condition& _Right) noexcept {
         return _System_error_equal(_Left, _Right);
     }
 
 #if _HAS_CXX20
-    _NODISCARD_FRIEND strong_ordering operator<=>(const error_code& _Left, const error_code& _Right) noexcept {
+    _NODISCARD friend strong_ordering operator<=>(const error_code& _Left, const error_code& _Right) noexcept {
         if (const auto _Result = _Left.category() <=> _Right.category(); _Result != 0) {
             return _Result;
         }
         return _Left.value() <=> _Right.value();
     }
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
-    _NODISCARD_FRIEND bool operator<(const error_code& _Left, const error_code& _Right) noexcept {
+    _NODISCARD friend bool operator<(const error_code& _Left, const error_code& _Right) noexcept {
         return _Left.category() < _Right.category()
             || (_Left.category() == _Right.category() && _Left.value() < _Right.value());
     }
-    _NODISCARD_FRIEND bool operator==(const error_condition& _Left, const error_code& _Right) noexcept {
+    _NODISCARD friend bool operator==(const error_condition& _Left, const error_code& _Right) noexcept {
         return _System_error_equal(_Right, _Left);
     }
 
-    _NODISCARD_FRIEND bool operator!=(const error_code& _Left, const error_code& _Right) noexcept {
+    _NODISCARD friend bool operator!=(const error_code& _Left, const error_code& _Right) noexcept {
         return !(_Left == _Right);
     }
 
-    _NODISCARD_FRIEND bool operator!=(const error_code& _Left, const error_condition& _Right) noexcept {
+    _NODISCARD friend bool operator!=(const error_code& _Left, const error_condition& _Right) noexcept {
         return !_System_error_equal(_Left, _Right);
     }
 
-    _NODISCARD_FRIEND bool operator!=(const error_condition& _Left, const error_code& _Right) noexcept {
+    _NODISCARD friend bool operator!=(const error_condition& _Left, const error_code& _Right) noexcept {
         return !_System_error_equal(_Right, _Left);
     }
 #endif // ^^^ !_HAS_CXX20 ^^^
@@ -301,12 +301,12 @@ public:
     }
 
 #if _STL_OPTIMIZE_SYSTEM_ERROR_OPERATORS
-    _NODISCARD_FRIEND bool operator==(const error_condition& _Left, const error_condition& _Right) noexcept {
+    _NODISCARD friend bool operator==(const error_condition& _Left, const error_condition& _Right) noexcept {
         return _Left.category() == _Right.category() && _Left.value() == _Right.value();
     }
 
 #if _HAS_CXX20
-    _NODISCARD_FRIEND strong_ordering operator<=>(
+    _NODISCARD friend strong_ordering operator<=>(
         const error_condition& _Left, const error_condition& _Right) noexcept {
         if (const auto _Result = _Left.category() <=> _Right.category(); _Result != 0) {
             return _Result;
@@ -314,11 +314,11 @@ public:
         return _Left.value() <=> _Right.value();
     }
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
-    _NODISCARD_FRIEND bool operator<(const error_condition& _Left, const error_condition& _Right) noexcept {
+    _NODISCARD friend bool operator<(const error_condition& _Left, const error_condition& _Right) noexcept {
         return _Left.category() < _Right.category()
             || (_Left.category() == _Right.category() && _Left.value() < _Right.value());
     }
-    _NODISCARD_FRIEND bool operator!=(const error_condition& _Left, const error_condition& _Right) noexcept {
+    _NODISCARD friend bool operator!=(const error_condition& _Left, const error_condition& _Right) noexcept {
         return !(_Left == _Right);
     }
 #endif // ^^^ !_HAS_CXX20 ^^^

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -288,14 +288,14 @@ public:
 
 #if _HAS_CXX23
     template <_Tuple_like_non_tuple _Other>
-    _NODISCARD_FRIEND constexpr bool operator==(const tuple&, const _Other&) noexcept /* strengthened */ {
+    _NODISCARD friend constexpr bool operator==(const tuple&, const _Other&) noexcept /* strengthened */ {
         static_assert(tuple_size_v<_Other> == 0, "Cannot compare tuples of different sizes (N4950 [tuple.rel]/2).");
         return true;
     }
 
     template <_Tuple_like_non_tuple _Other>
         requires (tuple_size_v<remove_cvref_t<_Other>> == 0)
-    _NODISCARD_FRIEND constexpr strong_ordering operator<=>(const tuple&, const _Other&) noexcept /* strengthened */ {
+    _NODISCARD friend constexpr strong_ordering operator<=>(const tuple&, const _Other&) noexcept /* strengthened */ {
         return strong_ordering::equal;
     }
 #endif // _HAS_CXX23
@@ -781,7 +781,7 @@ public:
     }
 
     template <_Tuple_like_non_tuple _Other>
-    _NODISCARD_FRIEND constexpr bool operator==(const tuple& _Left, const _Other& _Right) {
+    _NODISCARD friend constexpr bool operator==(const tuple& _Left, const _Other& _Right) {
         static_assert(1 + sizeof...(_Rest) == tuple_size_v<_Other>,
             "Cannot compare tuples of different sizes (N4950 [tuple.rel]/2).");
         static_assert(_Can_equal_compare_with_tuple_like_v<_Other>,
@@ -799,7 +799,7 @@ public:
     }
 
     template <_Tuple_like_non_tuple _Other>
-    _NODISCARD_FRIEND constexpr auto operator<=>(const tuple& _Left, const _Other& _Right)
+    _NODISCARD friend constexpr auto operator<=>(const tuple& _Left, const _Other& _Right)
         -> _Three_way_comparison_result_with_tuple_like_t<tuple, _Other> {
         return _Left._Three_way_compare_with_tuple_like(_Right, make_index_sequence<1 + sizeof...(_Rest)>{});
     }

--- a/stl/inc/valarray
+++ b/stl/inc/valarray
@@ -1439,7 +1439,7 @@ public:
     }
 
 #if _HAS_CXX20
-    _NODISCARD_FRIEND bool operator==(const slice& _Left, const slice& _Right) noexcept /* strengthened */ {
+    _NODISCARD friend bool operator==(const slice& _Left, const slice& _Right) noexcept /* strengthened */ {
         return _Left.start() == _Right.start() && _Left.size() == _Right.size() && _Left.stride() == _Right.stride();
     }
 #endif // _HAS_CXX20

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -136,7 +136,7 @@ public:
         return _Tmp;
     }
 
-    _NODISCARD_FRIEND _CONSTEXPR20 _Vector_const_iterator operator+(
+    _NODISCARD friend _CONSTEXPR20 _Vector_const_iterator operator+(
         const difference_type _Off, _Vector_const_iterator _Next) noexcept {
         _Next += _Off;
         return _Next;
@@ -316,7 +316,7 @@ public:
         return _Tmp;
     }
 
-    _NODISCARD_FRIEND _CONSTEXPR20 _Vector_iterator operator+(
+    _NODISCARD friend _CONSTEXPR20 _Vector_iterator operator+(
         const difference_type _Off, _Vector_iterator _Next) noexcept {
         _Next += _Off;
         return _Next;
@@ -2568,7 +2568,7 @@ public:
         return _Tmp;
     }
 
-    _NODISCARD_FRIEND _CONSTEXPR20 _Vb_const_iterator operator+(
+    _NODISCARD friend _CONSTEXPR20 _Vb_const_iterator operator+(
         const difference_type _Off, _Vb_const_iterator _Right) noexcept {
         _Right += _Off;
         return _Right;
@@ -2741,7 +2741,7 @@ public:
         return _Tmp;
     }
 
-    _NODISCARD_FRIEND _CONSTEXPR20 _Vb_iterator operator+(const difference_type _Off, _Vb_iterator _Right) noexcept {
+    _NODISCARD friend _CONSTEXPR20 _Vb_iterator operator+(const difference_type _Off, _Vb_iterator _Right) noexcept {
         _Right += _Off;
         return _Right;
     }

--- a/stl/inc/xcharconv.h
+++ b/stl/inc/xcharconv.h
@@ -37,7 +37,7 @@ _EXPORT_STD struct to_chars_result {
     char* ptr;
     errc ec;
 #if _HAS_CXX20
-    _NODISCARD_FRIEND bool operator==(const to_chars_result&, const to_chars_result&) = default;
+    _NODISCARD friend bool operator==(const to_chars_result&, const to_chars_result&) = default;
 #endif // _HAS_CXX20
 };
 

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -199,12 +199,12 @@ struct _Reinterpret_move_iter {
 
     // post ++ intentionally omitted
 
-    _NODISCARD_FRIEND bool operator==(const _Reinterpret_move_iter& _Lhs, const _Reinterpret_move_iter& _Rhs) {
+    _NODISCARD friend bool operator==(const _Reinterpret_move_iter& _Lhs, const _Reinterpret_move_iter& _Rhs) {
         return _Lhs._Base == _Rhs._Base;
     }
 
 #if !_HAS_CXX20
-    _NODISCARD_FRIEND bool operator!=(const _Reinterpret_move_iter& _Lhs, const _Reinterpret_move_iter& _Rhs) {
+    _NODISCARD friend bool operator!=(const _Reinterpret_move_iter& _Lhs, const _Reinterpret_move_iter& _Rhs) {
         return _Lhs._Base != _Rhs._Base;
     }
 #endif // !_HAS_CXX20

--- a/stl/inc/xpolymorphic_allocator.h
+++ b/stl/inc/xpolymorphic_allocator.h
@@ -310,13 +310,13 @@ namespace pmr {
             return _Resource;
         }
 
-        _NODISCARD_FRIEND bool operator==(
+        _NODISCARD friend bool operator==(
             const polymorphic_allocator& _Lhs, const polymorphic_allocator& _Rhs) noexcept {
             return *_Lhs._Resource == *_Rhs._Resource;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD_FRIEND bool operator!=(
+        _NODISCARD friend bool operator!=(
             const polymorphic_allocator& _Lhs, const polymorphic_allocator& _Rhs) noexcept {
             return *_Lhs._Resource != *_Rhs._Resource;
         }

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -141,7 +141,7 @@ public:
         return _Tmp;
     }
 
-    _NODISCARD_FRIEND _CONSTEXPR20 _String_const_iterator operator+(
+    _NODISCARD friend _CONSTEXPR20 _String_const_iterator operator+(
         const difference_type _Off, _String_const_iterator _Next) noexcept {
         _Next += _Off;
         return _Next;
@@ -318,7 +318,7 @@ public:
         return _Tmp;
     }
 
-    _NODISCARD_FRIEND _CONSTEXPR20 _String_iterator operator+(
+    _NODISCARD friend _CONSTEXPR20 _String_iterator operator+(
         const difference_type _Off, _String_iterator _Next) noexcept {
         _Next += _Off;
         return _Next;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1783,7 +1783,7 @@ public:
     }
 
 #if _HAS_CXX20
-    _NODISCARD_FRIEND constexpr iter_rvalue_reference_t<_BidIt> iter_move(const reverse_iterator& _It) noexcept(
+    _NODISCARD friend constexpr iter_rvalue_reference_t<_BidIt> iter_move(const reverse_iterator& _It) noexcept(
         is_nothrow_copy_constructible_v<_BidIt> //
             && noexcept(_RANGES iter_move(--_STD declval<_BidIt&>()))) {
         auto _Tmp = _It.current;
@@ -2386,47 +2386,47 @@ public:
 
     template <_Not_a_const_iterator _Other>
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
-    _NODISCARD_FRIEND constexpr bool operator<(const _Other& _Left, const basic_const_iterator& _Right) noexcept(
+    _NODISCARD friend constexpr bool operator<(const _Other& _Left, const basic_const_iterator& _Right) noexcept(
         noexcept(_STD _Fake_copy_init<bool>(_Left < _Right._Current))) /* strengthened */ {
         return _Left < _Right._Current;
     }
 
     template <_Not_a_const_iterator _Other>
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
-    _NODISCARD_FRIEND constexpr bool operator>(const _Other& _Left, const basic_const_iterator& _Right) noexcept(
+    _NODISCARD friend constexpr bool operator>(const _Other& _Left, const basic_const_iterator& _Right) noexcept(
         noexcept(_STD _Fake_copy_init<bool>(_Left > _Right._Current))) /* strengthened */ {
         return _Left > _Right._Current;
     }
 
     template <_Not_a_const_iterator _Other>
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
-    _NODISCARD_FRIEND constexpr bool operator<=(const _Other& _Left, const basic_const_iterator& _Right) noexcept(
+    _NODISCARD friend constexpr bool operator<=(const _Other& _Left, const basic_const_iterator& _Right) noexcept(
         noexcept(_STD _Fake_copy_init<bool>(_Left <= _Right._Current))) /* strengthened */ {
         return _Left <= _Right._Current;
     }
 
     template <_Not_a_const_iterator _Other>
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
-    _NODISCARD_FRIEND constexpr bool operator>=(const _Other& _Left, const basic_const_iterator& _Right) noexcept(
+    _NODISCARD friend constexpr bool operator>=(const _Other& _Left, const basic_const_iterator& _Right) noexcept(
         noexcept(_STD _Fake_copy_init<bool>(_Left >= _Right._Current))) /* strengthened */ {
         return _Left >= _Right._Current;
     }
 
-    _NODISCARD_FRIEND constexpr basic_const_iterator operator+(const basic_const_iterator& _It,
+    _NODISCARD friend constexpr basic_const_iterator operator+(const basic_const_iterator& _It,
         const difference_type _Off) noexcept(noexcept(basic_const_iterator{_It._Current + _Off})) // strengthened
         requires random_access_iterator<_Iter>
     {
         return basic_const_iterator{_It._Current + _Off};
     }
 
-    _NODISCARD_FRIEND constexpr basic_const_iterator operator+(const difference_type _Off,
+    _NODISCARD friend constexpr basic_const_iterator operator+(const difference_type _Off,
         const basic_const_iterator& _It) noexcept(noexcept(basic_const_iterator{_It._Current + _Off})) // strengthened
         requires random_access_iterator<_Iter>
     {
         return basic_const_iterator{_It._Current + _Off};
     }
 
-    _NODISCARD_FRIEND constexpr basic_const_iterator operator-(const basic_const_iterator& _It,
+    _NODISCARD friend constexpr basic_const_iterator operator-(const basic_const_iterator& _It,
         const difference_type _Off) noexcept(noexcept(basic_const_iterator{_It._Current - _Off})) // strengthened
         requires random_access_iterator<_Iter>
     {
@@ -2441,12 +2441,12 @@ public:
 
     template <_Not_a_const_iterator _Sent>
         requires sized_sentinel_for<_Sent, _Iter>
-    _NODISCARD_FRIEND constexpr difference_type operator-(const _Sent& _Se, const basic_const_iterator& _It) noexcept(
+    _NODISCARD friend constexpr difference_type operator-(const _Sent& _Se, const basic_const_iterator& _It) noexcept(
         noexcept(_Se - _It._Current)) /* strengthened */ {
         return _Se - _It._Current;
     }
 
-    _NODISCARD_FRIEND constexpr _Rvalue_reference iter_move(const basic_const_iterator& _It) noexcept(
+    _NODISCARD friend constexpr _Rvalue_reference iter_move(const basic_const_iterator& _It) noexcept(
         noexcept(static_cast<_Rvalue_reference>(_RANGES iter_move(_It._Current)))) {
         return static_cast<_Rvalue_reference>(_RANGES iter_move(_It._Current));
     }
@@ -4313,25 +4313,25 @@ public:
 
 #if _HAS_CXX20
     template <sentinel_for<_Iter> _Sent>
-    _NODISCARD_FRIEND constexpr bool
+    _NODISCARD friend constexpr bool
         operator==(const move_iterator& _Left, const move_sentinel<_Sent>& _Right) noexcept(
             noexcept(_STD _Fake_copy_init<bool>(_Left._Current == _Right._Get_last()))) /* strengthened */ {
         return _Left._Current == _Right._Get_last();
     }
 
     template <sized_sentinel_for<_Iter> _Sent>
-    _NODISCARD_FRIEND constexpr difference_type operator-(const move_sentinel<_Sent>& _Left,
+    _NODISCARD friend constexpr difference_type operator-(const move_sentinel<_Sent>& _Left,
         const move_iterator& _Right) noexcept(noexcept(_Left._Get_last() - _Right._Current)) /* strengthened */ {
         return _Left._Get_last() - _Right._Current;
     }
 
     template <sized_sentinel_for<_Iter> _Sent>
-    _NODISCARD_FRIEND constexpr difference_type operator-(const move_iterator& _Left,
+    _NODISCARD friend constexpr difference_type operator-(const move_iterator& _Left,
         const move_sentinel<_Sent>& _Right) noexcept(noexcept(_Left._Current - _Right._Get_last())) /* strengthened */ {
         return _Left._Current - _Right._Get_last();
     }
 
-    _NODISCARD_FRIEND constexpr reference iter_move(const move_iterator& _It) noexcept(
+    _NODISCARD friend constexpr reference iter_move(const move_iterator& _It) noexcept(
         noexcept(_RANGES iter_move(_It._Current))) {
         return _RANGES iter_move(_It._Current);
     }
@@ -4500,7 +4500,7 @@ _EXPORT_STD struct unreachable_sentinel_t;
 namespace _Unreachable_sentinel_detail {
     struct _Base {
         template <weakly_incrementable _Winc>
-        _NODISCARD_FRIEND constexpr bool operator==(const unreachable_sentinel_t&, const _Winc&) noexcept {
+        _NODISCARD friend constexpr bool operator==(const unreachable_sentinel_t&, const _Winc&) noexcept {
             return false;
         }
     };

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -591,12 +591,6 @@
 #define _NODISCARD_CTOR_MSG(_Msg)
 #endif // ^^^ defined(__has_cpp_attribute) && __has_cpp_attribute(nodiscard) < 201907L ^^^
 
-#if defined(__CUDACC__) && !defined(__clang__) // TRANSITION, VSO-568006
-#define _NODISCARD_FRIEND friend
-#else // ^^^ workaround / no workaround vvv
-#define _NODISCARD_FRIEND _NODISCARD friend
-#endif // ^^^ no workaround ^^^
-
 #define _NODISCARD_REMOVE_ALG                                                                                    \
     _NODISCARD_MSG("The 'remove' and 'remove_if' algorithms return the iterator past the last element "          \
                    "that should be kept. You need to call container.erase(result, container.end()) afterwards. " \


### PR DESCRIPTION
Fixes #4104 

I believe the workaround is not needed since CUDA 11.3.0: https://gcc.godbolt.org/z/bPh1av5f9

```
C:\Dev\STL\playground>type main.cpp
template<int>
struct test {
    int i;
     [[nodiscard]] friend bool operator==(const test& lhs, const test& rhs) {
        return lhs.i == rhs.i;
    }
};

int main() {
    test<1> t1{1};
    test<1> t2{1};
    t1 == t2;
}

C:\Dev\STL\playground>nvcc main.cpp
main.cpp
main.cpp(12): warning C4834: discarding return value of function with [[nodiscard]] attribute

C:\Dev\STL\playground>nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2024 NVIDIA Corporation
Built on Tue_Feb_27_16:28:36_Pacific_Standard_Time_2024
Cuda compilation tools, release 12.4, V12.4.99
Build cuda_12.4.r12.4/compiler.33961263_0
```

![изображение](https://github.com/microsoft/STL/assets/4289847/b07ada3d-288e-43e0-bd8d-19a0ff954354)

I used this version Cuda 12.4.0: https://developer.download.nvidia.com/compute/cuda/12.4.0/network_installers/cuda_12.4.0_windows_network.exe