### PR TITLE
Implement LWG-3944 Formatters converting sequences of `char` to sequences of `wchar_t`

### DIFF
--- a/stl/inc/__msvc_formatter.hpp
+++ b/stl/inc/__msvc_formatter.hpp
@@ -271,6 +271,41 @@ struct formatter<basic_string_view<_CharT, _Traits>, _CharT>
 };
 
 #if _HAS_CXX23
+template <>
+struct formatter<char*, wchar_t> {
+    formatter()                            = delete;
+    formatter(const formatter&)            = delete;
+    formatter& operator=(const formatter&) = delete;
+};
+
+template <>
+struct formatter<const char*, wchar_t> {
+    formatter()                            = delete;
+    formatter(const formatter&)            = delete;
+    formatter& operator=(const formatter&) = delete;
+};
+
+template <size_t _Size>
+struct formatter<char[_Size], wchar_t> {
+    formatter()                            = delete;
+    formatter(const formatter&)            = delete;
+    formatter& operator=(const formatter&) = delete;
+};
+
+template <class _Traits, class _Allocator>
+struct formatter<basic_string<char, _Traits, _Allocator>, wchar_t> {
+    formatter()                            = delete;
+    formatter(const formatter&)            = delete;
+    formatter& operator=(const formatter&) = delete;
+};
+
+template <class _Traits>
+struct formatter<basic_string_view<char, _Traits>, wchar_t> {
+    formatter()                            = delete;
+    formatter(const formatter&)            = delete;
+    formatter& operator=(const formatter&) = delete;
+};
+
 _EXPORT_STD enum class range_format { disabled, map, set, sequence, string, debug_string };
 
 template <class _Ty>

--- a/tests/std/tests/P2286R8_text_formatting_formattable/test.compile.pass.cpp
+++ b/tests/std/tests/P2286R8_text_formatting_formattable/test.compile.pass.cpp
@@ -269,7 +269,11 @@ enum class ec { a };
 template <class CharT>
 void test_disabled() {
     if constexpr (!same_as<CharT, char>) {
+        assert_is_not_formattable<char*, CharT>();
         assert_is_not_formattable<const char*, CharT>();
+        assert_is_not_formattable<char[42], CharT>();
+        assert_is_not_formattable<string, CharT>();
+        assert_is_not_formattable<string_view, CharT>();
     }
 
     assert_is_not_formattable<c, CharT>();


### PR DESCRIPTION
Fixes #4760.

I guess resulted error messages (e.g. in the case of `std::format("L{}", "")`, pre-existing for `std::format("{}", L"")`) still need to be improved, which can be done in another PR.