### PR TITLE
Implement LWG-4096 `views::iota(views::iota(0))` should be rejected

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1044,10 +1044,10 @@ namespace ranges {
         struct _Iota_fn {
             template <class _Ty>
             _NODISCARD _STATIC_CALL_OPERATOR constexpr auto operator()(_Ty&& _Val) _CONST_CALL_OPERATOR
-                noexcept(noexcept(iota_view(static_cast<_Ty&&>(_Val))))
-                requires requires { iota_view(static_cast<_Ty&&>(_Val)); }
+                noexcept(noexcept(iota_view<decay_t<_Ty>>(static_cast<_Ty&&>(_Val))))
+                requires requires { iota_view<decay_t<_Ty>>(static_cast<_Ty&&>(_Val)); }
             {
-                return iota_view(static_cast<_Ty&&>(_Val));
+                return iota_view<decay_t<_Ty>>(static_cast<_Ty&&>(_Val));
             }
 
             template <class _Ty1, class _Ty2>

--- a/tests/std/tests/P0896R4_views_iota/test.cpp
+++ b/tests/std/tests/P0896R4_views_iota/test.cpp
@@ -19,6 +19,9 @@ static_assert(ranges::_Advanceable<long long>);
 template <class W, class B>
 concept CanViewIota = requires(W w, B b) { views::iota(w, b); };
 
+template <class W>
+concept CanUnaryViewsIota = requires(W&& w) { views::iota(forward<W>(w)); };
+
 template <class R>
 concept CanSize = requires(R& r) { ranges::size(r); };
 
@@ -332,6 +335,18 @@ constexpr bool test_gh_3025() {
 
     return true;
 }
+
+// LWG-4096 "views::iota(views::iota(0)) should be rejected"
+static_assert(CanUnaryViewsIota<int>);
+static_assert(CanUnaryViewsIota<const char*>);
+static_assert(CanUnaryViewsIota<ranges::iterator_t<ranges::iota_view<long long>>>);
+static_assert(!CanUnaryViewsIota<ranges::iota_view<int>>);
+static_assert(!CanUnaryViewsIota<ranges::iota_view<const char*>>);
+static_assert(!CanUnaryViewsIota<ranges::iota_view<ranges::iterator_t<ranges::iota_view<long long>>>>);
+static_assert(!CanUnaryViewsIota<ranges::iota_view<int, int>>);
+static_assert(!CanUnaryViewsIota<ranges::iota_view<const char*, const char*>>);
+static_assert(!CanUnaryViewsIota<ranges::iota_view<ranges::iterator_t<ranges::iota_view<long long>>,
+                  ranges::iterator_t<ranges::iota_view<long long>>>>);
 
 int main() {
     // Validate standard signed integer types


### PR DESCRIPTION
Fixes #4763.