### PR TITLE
Implement LWG-4083 `views::as_rvalue` should reject non-input ranges

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1532,7 +1532,7 @@ namespace ranges {
 
             template <class _Rng>
             _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
-                if constexpr (same_as<range_rvalue_reference_t<_Rng>, range_reference_t<_Rng>>) {
+                if constexpr (input_range<_Rng> && same_as<range_rvalue_reference_t<_Rng>, range_reference_t<_Rng>>) {
                     return {_St::_All, noexcept(views::all(_STD declval<_Rng>()))};
                 } else if constexpr (_Can_as_rvalue<_Rng>) {
                     return {_St::_As_rvalue, noexcept(as_rvalue_view{_STD declval<_Rng>()})};

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1523,7 +1523,7 @@ namespace ranges {
     constexpr auto _Compile_time_max_size<const as_rvalue_view<_Rng>> = _Compile_time_max_size<const _Rng>;
 
     namespace views {
-        // direct-intialization is specified in the Standard (N4981 [range.as.rvalue.overview]/2.2)
+        // direct-non-list-initialization is specified in the Standard (N4981 [range.as.rvalue.overview]/2.2)
         // and needed for EDG, DevCom-10698021
         template <class _Rng>
         concept _Can_as_rvalue = requires(_Rng&& __r) { as_rvalue_view(static_cast<_Rng&&>(__r)); };
@@ -1537,7 +1537,7 @@ namespace ranges {
                 if constexpr (input_range<_Rng> && same_as<range_rvalue_reference_t<_Rng>, range_reference_t<_Rng>>) {
                     return {_St::_All, noexcept(views::all(_STD declval<_Rng>()))};
                 } else if constexpr (_Can_as_rvalue<_Rng>) {
-                    return {_St::_As_rvalue, noexcept(as_rvalue_view{_STD declval<_Rng>()})};
+                    return {_St::_As_rvalue, noexcept(as_rvalue_view(_STD declval<_Rng>()))};
                 } else {
                     return {_St::_None};
                 }
@@ -1555,7 +1555,7 @@ namespace ranges {
                 if constexpr (_Strat == _St::_All) {
                     return views::all(_STD forward<_Rng>(_Range));
                 } else if constexpr (_Strat == _St::_As_rvalue) {
-                    return as_rvalue_view{_STD forward<_Rng>(_Range)};
+                    return as_rvalue_view(_STD forward<_Rng>(_Range));
                 } else {
                     _STL_INTERNAL_STATIC_ASSERT(false); // unexpected strategy
                 }

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1523,12 +1523,10 @@ namespace ranges {
     constexpr auto _Compile_time_max_size<const as_rvalue_view<_Rng>> = _Compile_time_max_size<const _Rng>;
 
     namespace views {
+        // direct-intialization is specified in the Standard (N4981 [range.as.rvalue.overview]/2.2)
+        // and needed for EDG, DevCom-10698021
         template <class _Rng>
-#ifdef __EDG__ // TRANSITION, DevCom-10698021
         concept _Can_as_rvalue = requires(_Rng&& __r) { as_rvalue_view(static_cast<_Rng&&>(__r)); };
-#else // ^^^ workaround / no workaround vvv
-        concept _Can_as_rvalue = requires(_Rng&& __r) { as_rvalue_view{static_cast<_Rng&&>(__r)}; };
-#endif // ^^^ no workaround ^^^
 
         class _As_rvalue_fn : public _Pipe::_Base<_As_rvalue_fn> {
         private:

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1524,7 +1524,11 @@ namespace ranges {
 
     namespace views {
         template <class _Rng>
+#ifdef __EDG__ // TRANSITION, DevCom-10698021
+        concept _Can_as_rvalue = requires(_Rng&& __r) { as_rvalue_view(static_cast<_Rng&&>(__r)); };
+#else // ^^^ workaround / no workaround vvv
         concept _Can_as_rvalue = requires(_Rng&& __r) { as_rvalue_view{static_cast<_Rng&&>(__r)}; };
+#endif // ^^^ no workaround ^^^
 
         class _As_rvalue_fn : public _Pipe::_Base<_As_rvalue_fn> {
         private:

--- a/tests/std/tests/P2446R2_views_as_rvalue/test.cpp
+++ b/tests/std/tests/P2446R2_views_as_rvalue/test.cpp
@@ -401,6 +401,17 @@ void test_example_from_p2446r2() {
     assert(ranges::all_of(words, ranges::empty)); // all strings from words are empty (implementation assumption)
 }
 
+// LWG-4083 "views::as_rvalue should reject non-input ranges"
+struct OutputRvalueIterator {
+    using difference_type = int;
+    int operator*() const;
+    OutputRvalueIterator& operator++();
+    void operator++(int);
+};
+using OutputRvalueRange = decltype(ranges::subrange{OutputRvalueIterator{}, unreachable_sentinel});
+
+static_assert(!CanViewAsRvalue<OutputRvalueRange>);
+
 int main() {
     { // Validate views
         // ... copyable


### PR DESCRIPTION
Fixes #4762.

Reported a related EDG bug: DevCom-10698021.