### PR TITLE
Fix `<bitset>` benchmark correctness

### DIFF
--- a/benchmarks/src/bitset_to_string.cpp
+++ b/benchmarks/src/bitset_to_string.cpp
@@ -13,18 +13,18 @@
 using namespace std;
 
 namespace {
-    template <size_t N>
+    template <size_t Elems>
     auto random_bits_init() {
         mt19937_64 rnd{};
-        array<uint64_t, N> arr;
+        array<uint64_t, Elems> arr;
         for (auto& d : arr) {
             d = rnd();
         }
         return arr;
     }
 
-    template <size_t N = 32>
-    const auto random_bits = random_bits_init<N>();
+    template <size_t Elems = 32>
+    const auto random_bits = random_bits_init<Elems>();
 
     template <size_t N, class charT>
     void BM_bitset_to_string(benchmark::State& state) {

--- a/benchmarks/src/bitset_to_string.cpp
+++ b/benchmarks/src/bitset_to_string.cpp
@@ -26,6 +26,7 @@ namespace {
     void BM_bitset_to_string(benchmark::State& state) {
         for (auto _ : state) {
             for (const auto& bits : random_bits) {
+                benchmark::DoNotOptimize(bits);
                 bitset<N> bs{bits};
                 benchmark::DoNotOptimize(bs.to_string<charT>());
             }
@@ -36,6 +37,7 @@ namespace {
     void BM_bitset_to_string_large_single(benchmark::State& state) {
         const auto large_bitset = bit_cast<bitset<CHAR_BIT * sizeof(random_bits)>>(random_bits);
         for (auto _ : state) {
+            benchmark::DoNotOptimize(large_bitset);
             benchmark::DoNotOptimize(large_bitset.to_string<charT>());
         }
     }

--- a/benchmarks/src/bitset_to_string.cpp
+++ b/benchmarks/src/bitset_to_string.cpp
@@ -44,7 +44,7 @@ namespace {
         static_assert(N % 64 == 0 && N >= 64);
         const auto& bitset_data = random_bits<N / 64>;
 
-        const auto large_bitset = bit_cast<bitset<CHAR_BIT * sizeof(bitset_data)>>(bitset_data);
+        const auto large_bitset = bit_cast<bitset<N>>(bitset_data);
         for (auto _ : state) {
             benchmark::DoNotOptimize(large_bitset);
             benchmark::DoNotOptimize(large_bitset.to_string<charT>());

--- a/benchmarks/src/bitset_to_string.cpp
+++ b/benchmarks/src/bitset_to_string.cpp
@@ -13,19 +13,25 @@
 using namespace std;
 
 namespace {
-    const auto random_bits = [] {
+    template <size_t N>
+    const auto random_bits_init() {
         mt19937_64 rnd{};
-        array<uint64_t, 32> arr;
+        array<uint64_t, N> arr;
         for (auto& d : arr) {
             d = rnd();
         }
         return arr;
-    }();
+    }
+
+    template <size_t N = 32>
+    const auto random_bits = random_bits_init<N>();
 
     template <size_t N, class charT>
     void BM_bitset_to_string(benchmark::State& state) {
+        static_assert(N <= 64);
+
         for (auto _ : state) {
-            for (const auto& bits : random_bits) {
+            for (const auto& bits : random_bits<>) {
                 benchmark::DoNotOptimize(bits);
                 bitset<N> bs{bits};
                 benchmark::DoNotOptimize(bs.to_string<charT>());
@@ -33,9 +39,12 @@ namespace {
         }
     }
 
-    template <class charT>
+    template <size_t N, class charT>
     void BM_bitset_to_string_large_single(benchmark::State& state) {
-        const auto large_bitset = bit_cast<bitset<CHAR_BIT * sizeof(random_bits)>>(random_bits);
+        static_assert(N % 64 == 0 && N >= 64);
+        const auto& bitset_data = random_bits<N / 64>;
+
+        const auto large_bitset = bit_cast<bitset<CHAR_BIT * sizeof(bitset_data)>>(bitset_data);
         for (auto _ : state) {
             benchmark::DoNotOptimize(large_bitset);
             benchmark::DoNotOptimize(large_bitset.to_string<charT>());
@@ -45,11 +54,11 @@ namespace {
 
 BENCHMARK(BM_bitset_to_string<15, char>);
 BENCHMARK(BM_bitset_to_string<64, char>);
-BENCHMARK(BM_bitset_to_string<512, char>);
-BENCHMARK(BM_bitset_to_string_large_single<char>);
+BENCHMARK(BM_bitset_to_string_large_single<512, char>);
+BENCHMARK(BM_bitset_to_string_large_single<2048, char>);
 BENCHMARK(BM_bitset_to_string<7, wchar_t>);
 BENCHMARK(BM_bitset_to_string<64, wchar_t>);
-BENCHMARK(BM_bitset_to_string<512, wchar_t>);
-BENCHMARK(BM_bitset_to_string_large_single<wchar_t>);
+BENCHMARK(BM_bitset_to_string_large_single<512, wchar_t>);
+BENCHMARK(BM_bitset_to_string_large_single<2048, wchar_t>);
 
 BENCHMARK_MAIN();

--- a/benchmarks/src/bitset_to_string.cpp
+++ b/benchmarks/src/bitset_to_string.cpp
@@ -14,7 +14,7 @@ using namespace std;
 
 namespace {
     template <size_t N>
-    const auto random_bits_init() {
+    auto random_bits_init() {
         mt19937_64 rnd{};
         array<uint64_t, N> arr;
         for (auto& d : arr) {


### PR DESCRIPTION
I see more things to do with `bitset` regarding performance, but first let's fix the current benchmark.

Fortunately, the discovered issues didn't have impact on results, and on performance decisions.

## Add `DoNotOptimize` to input

Should use this to prevent compiler making the benchmarked function or its part constant.
Currently the compiler doesn't do this, but it might improve in the future

## Make 512 case as large

Small cases were initialized with `uint64_t` which was not enough to initialize 512 bit bitset.

The 512 rows in the benchmark improved, but it is gooseberries vs watermelons: small cases have inner loop whereas large doesn't. 

(The loop in small cases is to defeat branch prediction for the cases of branchy implementation activation. It is not needed for larger bitsets, as these would be vectorized, and if they wouldn't, the amount of bits should be enough to overflow the branch prediction)


