### PR TITLE
Use `requires`-clauses for `pair` and `tuple` since C++20 

### DIFF
--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -87,11 +87,7 @@ public:
     }
 
     friend constexpr void swap(unexpected& _Left, unexpected& _Right) noexcept(is_nothrow_swappable_v<_Err>)
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, /permissive
-        requires is_swappable_v<_Err>
-#else // ^^^ no workaround / workaround vvv
-        requires is_swappable<_Err>::value
-#endif // ^^^ workaround ^^^
+        requires is_swappable<_Err>::value // TRANSITION, /permissive needs ::value
     {
         _Left.swap(_Right);
     }
@@ -612,11 +608,7 @@ public:
     friend constexpr void swap(expected& _Lhs, expected& _Rhs) noexcept(
         is_nothrow_move_constructible_v<_Ty> && is_nothrow_swappable_v<_Ty> && is_nothrow_move_constructible_v<_Err>
         && is_nothrow_swappable_v<_Err>)
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, /permissive
-        requires is_swappable_v<_Ty> && is_swappable_v<_Err>
-#else // ^^^ no workaround / workaround vvv
-        requires is_swappable<_Ty>::value && is_swappable<_Err>::value
-#endif // ^^^ workaround ^^^
+        requires is_swappable<_Ty>::value && is_swappable<_Err>::value // TRANSITION, /permissive needs ::value
               && is_move_constructible_v<_Ty> && is_move_constructible_v<_Err>
               && (is_nothrow_move_constructible_v<_Ty> || is_nothrow_move_constructible_v<_Err>)
     {

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -351,9 +351,9 @@ public:
     tuple(tuple&&)      = default;
 
 #if _HAS_CXX23
-    template <class... _Other, enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, _Other&...>,
-                                               _STD _Tuple_convert_val<tuple, tuple<_Other...>&, _Other...>>,
-                                   int> = 0>
+    template <class... _Other>
+        requires _Tuple_constructible_v<tuple, _Other&...>
+              && _Tuple_convert_val<tuple, tuple<_Other...>&, _Other...>::value
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, _Other&...>)
         tuple(tuple<_Other...>& _Right) noexcept(_Tuple_nothrow_constructible_v<tuple, _Other&...>) // strengthened
         : tuple(_Unpack_tuple_t{}, _Right) {}
@@ -375,15 +375,16 @@ public:
         : tuple(_Unpack_tuple_t{}, _STD move(_Right)) {}
 
 #if _HAS_CXX23
-    template <class... _Other, enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, const _Other...>,
-                                               _STD _Tuple_convert_val<tuple, const tuple<_Other...>, _Other...>>,
-                                   int> = 0>
+    template <class... _Other>
+        requires _Tuple_constructible_v<tuple, const _Other...>
+              && _Tuple_convert_val<tuple, const tuple<_Other...>, _Other...>::value
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, const _Other...>)
         tuple(const tuple<_Other...>&& _Right) noexcept(
             _Tuple_nothrow_constructible_v<tuple, const _Other...>) // strengthened
         : tuple(_Unpack_tuple_t{}, _STD move(_Right)) {}
 
-    template <class _First, class _Second, enable_if_t<_Tuple_constructible_v<tuple, _First&, _Second&>, int> = 0>
+    template <class _First, class _Second>
+        requires _Tuple_constructible_v<tuple, _First&, _Second&>
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, _First&, _Second&>)
         tuple(pair<_First, _Second>& _Right) noexcept(
             _Tuple_nothrow_constructible_v<tuple, _First&, _Second&>) // strengthened
@@ -403,8 +404,8 @@ public:
         : tuple(_Unpack_tuple_t{}, _STD move(_Right)) {}
 
 #if _HAS_CXX23
-    template <class _First, class _Second,
-        enable_if_t<_Tuple_constructible_v<tuple, const _First, const _Second>, int> = 0>
+    template <class _First, class _Second>
+        requires _Tuple_constructible_v<tuple, const _First, const _Second>
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, const _First, const _Second>)
         tuple(const pair<_First, _Second>&& _Right) noexcept(
             _Tuple_nothrow_constructible_v<tuple, const _First, const _Second>) // strengthened
@@ -419,7 +420,7 @@ public:
             is_convertible<decltype(_STD get<_Indices + 1>(_STD declval<_Other>())), _Rest>...>>;
 
 #if defined(__clang__) || defined(__EDG__) // TRANSITION, LLVM-59827 and VSO-1900279
-    template <class _Other, enable_if_t<_Can_construct_from_tuple_like<_Other, tuple>, int> = 0>
+    template <_Can_construct_from_tuple_like<tuple> _Other>
 #else // ^^^ workaround / no workaround vvv
     template <_Different_from<tuple> _Other>
         requires _Tuple_like<_Other> && (!_Is_subrange_v<remove_cvref_t<_Other>>)
@@ -464,10 +465,9 @@ public:
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
 
 #if _HAS_CXX23
-    template <class _Alloc, class... _Other,
-        enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, _Other&...>,
-                        _STD _Tuple_convert_val<tuple, tuple<_Other...>&, _Other...>>,
-            int> = 0>
+    template <class _Alloc, class... _Other>
+        requires _Tuple_constructible_v<tuple, _Other&...>
+              && _Tuple_convert_val<tuple, tuple<_Other...>&, _Other...>::value
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, _Other&...>)
         tuple(allocator_arg_t, const _Alloc& _Al, tuple<_Other...>& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _Right) {}
@@ -490,16 +490,15 @@ public:
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
 
 #if _HAS_CXX23
-    template <class _Alloc, class... _Other,
-        enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, const _Other...>,
-                        _STD _Tuple_convert_val<tuple, const tuple<_Other...>, _Other...>>,
-            int> = 0>
+    template <class _Alloc, class... _Other>
+        requires _Tuple_constructible_v<tuple, const _Other...>
+              && _Tuple_convert_val<tuple, const tuple<_Other...>, _Other...>::value
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, const _Other...>)
         tuple(allocator_arg_t, const _Alloc& _Al, const tuple<_Other...>&& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
 
-    template <class _Alloc, class _First, class _Second,
-        enable_if_t<_Tuple_constructible_v<tuple, _First&, _Second&>, int> = 0>
+    template <class _Alloc, class _First, class _Second>
+        requires _Tuple_constructible_v<tuple, _First&, _Second&>
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, _First&, _Second&>)
         tuple(allocator_arg_t, const _Alloc& _Al, pair<_First, _Second>& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _Right) {}
@@ -518,14 +517,14 @@ public:
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
 
 #if _HAS_CXX23
-    template <class _Alloc, class _First, class _Second,
-        enable_if_t<_Tuple_constructible_v<tuple, const _First, const _Second>, int> = 0>
+    template <class _Alloc, class _First, class _Second>
+        requires _Tuple_constructible_v<tuple, const _First, const _Second>
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, const _First, const _Second>)
         tuple(allocator_arg_t, const _Alloc& _Al, const pair<_First, _Second>&& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
 
 #if defined(__clang__) || defined(__EDG__) // TRANSITION, LLVM-59827 (Clang), VSO-1900279 (EDG)
-    template <class _Alloc, class _Other, enable_if_t<_Can_construct_from_tuple_like<_Other, tuple>, int> = 0>
+    template <class _Alloc, _Can_construct_from_tuple_like<tuple> _Other>
 #else // ^^^ workaround / no workaround vvv
     template <class _Alloc, _Different_from<tuple> _Other>
         requires _Tuple_like<_Other> && (!_Is_subrange_v<remove_cvref_t<_Other>>)
@@ -553,12 +552,11 @@ public:
     }
 
 #if _HAS_CXX23
-    template <class _Myself = tuple, class _This2 = _This,
-        enable_if_t<conjunction_v<_STD _Is_copy_assignable_no_precondition_check<const _This2>,
-                        _STD _Is_copy_assignable_no_precondition_check<const _Rest>...>,
-            int> = 0>
+    template <class _Myself = tuple>
+        requires conjunction_v<_STD _Is_copy_assignable_no_precondition_check<const _This>,
+            _STD _Is_copy_assignable_no_precondition_check<const _Rest>...>
     constexpr const tuple& operator=(_Identity_t<const _Myself&> _Right) const
-        noexcept(conjunction_v<is_nothrow_copy_assignable<const _This2>,
+        noexcept(conjunction_v<is_nothrow_copy_assignable<const _This>,
             is_nothrow_copy_assignable<const _Rest>...>) /* strengthened */ {
         _Myfirst._Val = _Right._Myfirst._Val;
         _Get_rest()   = _Right._Get_rest();
@@ -578,12 +576,11 @@ public:
     }
 
 #if _HAS_CXX23
-    template <class _Myself = tuple, class _This2 = _This,
-        enable_if_t<conjunction_v<_STD _Is_assignable_no_precondition_check<const _This2&, _This2>,
-                        _STD _Is_assignable_no_precondition_check<const _Rest&, _Rest>...>,
-            int> = 0>
+    template <class _Myself = tuple>
+        requires conjunction_v<_STD _Is_assignable_no_precondition_check<const _This&, _This>,
+            _STD _Is_assignable_no_precondition_check<const _Rest&, _Rest>...>
     constexpr const tuple& operator=(_Identity_t<_Myself&&> _Right) const
-        noexcept(conjunction_v<is_nothrow_assignable<const _This2&, _This2>,
+        noexcept(conjunction_v<is_nothrow_assignable<const _This&, _This>,
             is_nothrow_assignable<const _Rest&, _Rest>...>) /* strengthened */ {
         _Myfirst._Val = _STD forward<_This>(_Right._Myfirst._Val);
         _Get_rest()   = _STD forward<_Mybase>(_Right._Get_rest());
@@ -602,9 +599,8 @@ public:
     }
 
 #if _HAS_CXX23
-    template <class... _Other, enable_if_t<conjunction_v<_STD negation<_STD is_same<tuple, _STD tuple<_Other...>>>,
-                                               _STD _Tuple_assignable_val<const tuple, const _Other&...>>,
-                                   int> = 0>
+    template <class... _Other>
+        requires (!is_same_v<tuple, _STD tuple<_Other...>>) && _Tuple_assignable_v<const tuple, const _Other&...>
     constexpr const tuple& operator=(const tuple<_Other...>& _Right) const
         noexcept(_Tuple_nothrow_assignable_v<const tuple, const _Other&...>) /* strengthened */ {
         _Myfirst._Val = _Right._Myfirst._Val;
@@ -624,9 +620,8 @@ public:
     }
 
 #if _HAS_CXX23
-    template <class... _Other, enable_if_t<conjunction_v<_STD negation<_STD is_same<tuple, _STD tuple<_Other...>>>,
-                                               _STD _Tuple_assignable_val<const tuple, _Other...>>,
-                                   int> = 0>
+    template <class... _Other>
+        requires (!is_same_v<tuple, _STD tuple<_Other...>>) && _Tuple_assignable_v<const tuple, _Other...>
     constexpr const tuple& operator=(tuple<_Other...>&& _Right) const
         noexcept(_Tuple_nothrow_assignable_v<const tuple, _Other...>) /* strengthened */ {
         _Myfirst._Val = _STD forward<typename tuple<_Other...>::_This_type>(_Right._Myfirst._Val);
@@ -645,8 +640,8 @@ public:
     }
 
 #if _HAS_CXX23
-    template <class _First, class _Second,
-        enable_if_t<_Tuple_assignable_v<const tuple, const _First&, const _Second&>, int> = 0>
+    template <class _First, class _Second>
+        requires _Tuple_assignable_v<const tuple, const _First&, const _Second&>
     constexpr const tuple& operator=(const pair<_First, _Second>& _Right) const
         noexcept(_Tuple_nothrow_assignable_v<const tuple, const _First&, const _Second&>) /* strengthened */ {
         _Myfirst._Val             = _Right.first;
@@ -664,7 +659,8 @@ public:
     }
 
 #if _HAS_CXX23
-    template <class _First, class _Second, enable_if_t<_Tuple_assignable_v<const tuple, _First, _Second>, int> = 0>
+    template <class _First, class _Second>
+        requires _Tuple_assignable_v<const tuple, _First, _Second>
     constexpr const tuple& operator=(pair<_First, _Second>&& _Right) const
         noexcept(_Tuple_nothrow_assignable_v<const tuple, _First, _Second>) /* strengthened */ {
         _Myfirst._Val             = _STD forward<_First>(_Right.first);
@@ -896,7 +892,8 @@ _CONSTEXPR20 void swap(tuple<_Types...>& _Left, tuple<_Types...>& _Right) noexce
 }
 
 #if _HAS_CXX23
-_EXPORT_STD template <class... _Types, enable_if_t<conjunction_v<is_swappable<const _Types>...>, int> = 0>
+_EXPORT_STD template <class... _Types>
+    requires conjunction_v<is_swappable<const _Types>...>
 constexpr void swap(const tuple<_Types...>& _Left, const tuple<_Types...>& _Right) noexcept(
     noexcept(_Left.swap(_Right))) {
     _Left.swap(_Right);

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -351,9 +351,9 @@ public:
     tuple(tuple&&)      = default;
 
 #if _HAS_CXX23
-    template <class... _Other>
-        requires _Tuple_constructible_v<tuple, _Other&...>
-              && _Tuple_convert_val<tuple, tuple<_Other...>&, _Other...>::value
+    template <class... _Other, enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, _Other&...>,
+                                               _STD _Tuple_convert_val<tuple, tuple<_Other...>&, _Other...>>,
+                                   int> = 0>
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, _Other&...>)
         tuple(tuple<_Other...>& _Right) noexcept(_Tuple_nothrow_constructible_v<tuple, _Other&...>) // strengthened
         : tuple(_Unpack_tuple_t{}, _Right) {}
@@ -375,16 +375,15 @@ public:
         : tuple(_Unpack_tuple_t{}, _STD move(_Right)) {}
 
 #if _HAS_CXX23
-    template <class... _Other>
-        requires _Tuple_constructible_v<tuple, const _Other...>
-              && _Tuple_convert_val<tuple, const tuple<_Other...>, _Other...>::value
+    template <class... _Other, enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, const _Other...>,
+                                               _STD _Tuple_convert_val<tuple, const tuple<_Other...>, _Other...>>,
+                                   int> = 0>
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, const _Other...>)
         tuple(const tuple<_Other...>&& _Right) noexcept(
             _Tuple_nothrow_constructible_v<tuple, const _Other...>) // strengthened
         : tuple(_Unpack_tuple_t{}, _STD move(_Right)) {}
 
-    template <class _First, class _Second>
-        requires _Tuple_constructible_v<tuple, _First&, _Second&>
+    template <class _First, class _Second, enable_if_t<_Tuple_constructible_v<tuple, _First&, _Second&>, int> = 0>
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, _First&, _Second&>)
         tuple(pair<_First, _Second>& _Right) noexcept(
             _Tuple_nothrow_constructible_v<tuple, _First&, _Second&>) // strengthened
@@ -404,8 +403,8 @@ public:
         : tuple(_Unpack_tuple_t{}, _STD move(_Right)) {}
 
 #if _HAS_CXX23
-    template <class _First, class _Second>
-        requires _Tuple_constructible_v<tuple, const _First, const _Second>
+    template <class _First, class _Second,
+        enable_if_t<_Tuple_constructible_v<tuple, const _First, const _Second>, int> = 0>
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, const _First, const _Second>)
         tuple(const pair<_First, _Second>&& _Right) noexcept(
             _Tuple_nothrow_constructible_v<tuple, const _First, const _Second>) // strengthened
@@ -420,7 +419,7 @@ public:
             is_convertible<decltype(_STD get<_Indices + 1>(_STD declval<_Other>())), _Rest>...>>;
 
 #if defined(__clang__) || defined(__EDG__) // TRANSITION, LLVM-59827 and VSO-1900279
-    template <_Can_construct_from_tuple_like<tuple> _Other>
+    template <class _Other, enable_if_t<_Can_construct_from_tuple_like<_Other, tuple>, int> = 0>
 #else // ^^^ workaround / no workaround vvv
     template <_Different_from<tuple> _Other>
         requires _Tuple_like<_Other> && (!_Is_subrange_v<remove_cvref_t<_Other>>)
@@ -465,9 +464,10 @@ public:
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
 
 #if _HAS_CXX23
-    template <class _Alloc, class... _Other>
-        requires _Tuple_constructible_v<tuple, _Other&...>
-              && _Tuple_convert_val<tuple, tuple<_Other...>&, _Other...>::value
+    template <class _Alloc, class... _Other,
+        enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, _Other&...>,
+                        _STD _Tuple_convert_val<tuple, tuple<_Other...>&, _Other...>>,
+            int> = 0>
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, _Other&...>)
         tuple(allocator_arg_t, const _Alloc& _Al, tuple<_Other...>& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _Right) {}
@@ -490,15 +490,16 @@ public:
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
 
 #if _HAS_CXX23
-    template <class _Alloc, class... _Other>
-        requires _Tuple_constructible_v<tuple, const _Other...>
-              && _Tuple_convert_val<tuple, const tuple<_Other...>, _Other...>::value
+    template <class _Alloc, class... _Other,
+        enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, const _Other...>,
+                        _STD _Tuple_convert_val<tuple, const tuple<_Other...>, _Other...>>,
+            int> = 0>
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, const _Other...>)
         tuple(allocator_arg_t, const _Alloc& _Al, const tuple<_Other...>&& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
 
-    template <class _Alloc, class _First, class _Second>
-        requires _Tuple_constructible_v<tuple, _First&, _Second&>
+    template <class _Alloc, class _First, class _Second,
+        enable_if_t<_Tuple_constructible_v<tuple, _First&, _Second&>, int> = 0>
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, _First&, _Second&>)
         tuple(allocator_arg_t, const _Alloc& _Al, pair<_First, _Second>& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _Right) {}
@@ -517,14 +518,14 @@ public:
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
 
 #if _HAS_CXX23
-    template <class _Alloc, class _First, class _Second>
-        requires _Tuple_constructible_v<tuple, const _First, const _Second>
+    template <class _Alloc, class _First, class _Second,
+        enable_if_t<_Tuple_constructible_v<tuple, const _First, const _Second>, int> = 0>
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, const _First, const _Second>)
         tuple(allocator_arg_t, const _Alloc& _Al, const pair<_First, _Second>&& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
 
 #if defined(__clang__) || defined(__EDG__) // TRANSITION, LLVM-59827 (Clang), VSO-1900279 (EDG)
-    template <class _Alloc, _Can_construct_from_tuple_like<tuple> _Other>
+    template <class _Alloc, class _Other, enable_if_t<_Can_construct_from_tuple_like<_Other, tuple>, int> = 0>
 #else // ^^^ workaround / no workaround vvv
     template <class _Alloc, _Different_from<tuple> _Other>
         requires _Tuple_like<_Other> && (!_Is_subrange_v<remove_cvref_t<_Other>>)

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -261,8 +261,8 @@ struct pair { // store a pair of values
     pair(pair&&)      = default;
 
 #if _HAS_CXX23
-    template <class _Other1, class _Other2,
-        enable_if_t<conjunction_v<is_constructible<_Ty1, _Other1&>, is_constructible<_Ty2, _Other2&>>, int> = 0>
+    template <class _Other1, class _Other2>
+        requires is_constructible_v<_Ty1, _Other1&> && is_constructible_v<_Ty2, _Other2&>
     constexpr explicit(!conjunction_v<is_convertible<_Other1&, _Ty1>, is_convertible<_Other2&, _Ty2>>)
         pair(pair<_Other1, _Other2>& _Right) noexcept(
             is_nothrow_constructible_v<_Ty1, _Other1&> && is_nothrow_constructible_v<_Ty2, _Other2&>) // strengthened
@@ -286,9 +286,8 @@ struct pair { // store a pair of values
         : first(_STD forward<_Other1>(_Right.first)), second(_STD forward<_Other2>(_Right.second)) {}
 
 #if _HAS_CXX23
-    template <class _Other1, class _Other2,
-        enable_if_t<conjunction_v<is_constructible<_Ty1, const _Other1>, is_constructible<_Ty2, const _Other2>>, int> =
-            0>
+    template <class _Other1, class _Other2>
+        requires is_constructible_v<_Ty1, const _Other1> && is_constructible_v<_Ty2, const _Other2>
     constexpr explicit(!conjunction_v<is_convertible<const _Other1, _Ty1>, is_convertible<const _Other2, _Ty2>>)
         pair(const pair<_Other1, _Other2>&& _Right) noexcept(
             is_nothrow_constructible_v<_Ty1, const _Other1>
@@ -335,10 +334,9 @@ struct pair { // store a pair of values
     }
 
 #if _HAS_CXX23
-    template <class _Myself = pair,
-        enable_if_t<conjunction_v<_Is_copy_assignable_no_precondition_check<const typename _Myself::first_type>,
-                        _Is_copy_assignable_no_precondition_check<const typename _Myself::second_type>>,
-            int>            = 0>
+    template <class _Myself = pair>
+        requires _Is_copy_assignable_unchecked_v<const typename _Myself::first_type>
+              && _Is_copy_assignable_unchecked_v<const typename _Myself::second_type>
     constexpr const pair& operator=(_Identity_t<const _Myself&> _Right) const
         noexcept(conjunction_v<is_nothrow_copy_assignable<const _Ty1>,
             is_nothrow_copy_assignable<const _Ty2>>) /* strengthened */ {
@@ -360,10 +358,9 @@ struct pair { // store a pair of values
     }
 
 #if _HAS_CXX23
-    template <class _Myself = pair,
-        enable_if_t<conjunction_v<_Is_assignable_no_precondition_check<const typename _Myself::first_type&, _Ty1>,
-                        _Is_assignable_no_precondition_check<const typename _Myself::second_type&, _Ty2>>,
-            int>            = 0>
+    template <class _Myself = pair>
+        requires _Is_assignable_no_precondition_check<const typename _Myself::first_type&, _Ty1>::value
+              && _Is_assignable_no_precondition_check<const typename _Myself::second_type&, _Ty2>::value
     constexpr const pair& operator=(_Identity_t<_Myself&&> _Right) const
         noexcept(conjunction_v<is_nothrow_assignable<const _Ty1&, _Ty1>,
             is_nothrow_assignable<const _Ty2&, _Ty2>>) /* strengthened */ {
@@ -386,10 +383,9 @@ struct pair { // store a pair of values
     }
 
 #if _HAS_CXX23
-    template <class _Other1, class _Other2,
-        enable_if_t<conjunction_v<negation<is_same<pair, pair<_Other1, _Other2>>>,
-                        is_assignable<const _Ty1&, const _Other1&>, is_assignable<const _Ty2&, const _Other2&>>,
-            int> = 0>
+    template <class _Other1, class _Other2>
+        requires (!is_same_v<pair, pair<_Other1, _Other2>>)
+              && is_assignable_v<const _Ty1&, const _Other1&> && is_assignable_v<const _Ty2&, const _Other2&>
     constexpr const pair& operator=(const pair<_Other1, _Other2>& _Right) const
         noexcept(is_nothrow_assignable_v<const _Ty1&, const _Other1&>
                  && is_nothrow_assignable_v<const _Ty2&, const _Other2&>) /* strengthened */ {
@@ -411,10 +407,9 @@ struct pair { // store a pair of values
     }
 
 #if _HAS_CXX23
-    template <class _Other1, class _Other2,
-        enable_if_t<conjunction_v<negation<is_same<pair, pair<_Other1, _Other2>>>, is_assignable<const _Ty1&, _Other1>,
-                        is_assignable<const _Ty2&, _Other2>>,
-            int> = 0>
+    template <class _Other1, class _Other2>
+        requires (!is_same_v<pair, pair<_Other1, _Other2>>)
+              && is_assignable_v<const _Ty1&, _Other1> && is_assignable_v<const _Ty2&, _Other2>
     constexpr const pair& operator=(pair<_Other1, _Other2>&& _Right) const
         noexcept(is_nothrow_assignable_v<const _Ty1&, _Other1>
                  && is_nothrow_assignable_v<const _Ty2&, _Other2>) /* strengthened */ {
@@ -481,8 +476,8 @@ _CONSTEXPR20 void swap(pair<_Ty1, _Ty2>& _Left, pair<_Ty1, _Ty2>& _Right) noexce
 }
 
 #if _HAS_CXX23
-_EXPORT_STD template <class _Ty1, class _Ty2,
-    enable_if_t<is_swappable_v<const _Ty1> && is_swappable_v<const _Ty2>, int> = 0>
+_EXPORT_STD template <class _Ty1, class _Ty2>
+    requires is_swappable<const _Ty1>::value && is_swappable<const _Ty2>::value // TRANSITION, /permissive needs ::value
 constexpr void swap(const pair<_Ty1, _Ty2>& _Left, const pair<_Ty1, _Ty2>& _Right) noexcept(
     noexcept(_Left.swap(_Right))) {
     _Left.swap(_Right);


### PR DESCRIPTION
Towards #602. Also unconditionally uses `is_swappable<T>::value` workaround for `expected` as suggested in https://github.com/microsoft/STL/pull/4658#discussion_r1601027519.

Notes:
- some occurences of `conjunction_v` are preserved for `tuple` because fold expressions are not yet decomposed for associated constraints until C++26 (and thus doesn't short-circuit, see WG21-P2963R2);
- changes for `tuple` constructors were attempted but are currently given up due to LLVM-59827.