### PR TITLE
Toolset update: VS 2022 17.11 Preview 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.28.0)
+cmake_minimum_required(VERSION 3.29.0)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.11 Preview 2 or later.
+1. Install Visual Studio 2022 17.11 Preview 3 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
@@ -156,7 +156,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.11 Preview 2 or later.
+1. Install Visual Studio 2022 17.11 Preview 3 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.28.0 or later, and [Ninja][] 1.11.0 or later.
+    * Otherwise, install [CMake][] 3.29.0 or later, and [Ninja][] 1.11.0 or later.
     * Make sure [Python][] 3.12 or later is available to CMake.
 2. Open Visual Studio, and choose the "Clone or check out code" option. Enter the URL of this repository,
    `https://github.com/microsoft/STL`.
@@ -160,7 +160,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.28.0 or later, and [Ninja][] 1.11.0 or later.
+    * Otherwise, install [CMake][] 3.29.0 or later, and [Ninja][] 1.11.0 or later.
     * Make sure [Python][] 3.12 or later is available to CMake.
 2. Open a command prompt.
 3. Change directories to a location where you'd like a clone of this STL repository.

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,7 +5,7 @@
 
 variables:
 - name: poolName
-  value: 'StlBuild-2024-06-11T1315-Pool'
+  value: 'StlBuild-2024-07-09T1614-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -13,7 +13,7 @@ $ErrorActionPreference = 'Stop'
 
 $CurrentDate = Get-Date
 
-$Location = 'eastus'
+$Location = 'eastus2'
 $VMSize = 'Standard_D32ads_v5'
 $ProtoVMName = 'PROTOTYPE'
 $ImagePublisher = 'MicrosoftWindowsServer'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -40,7 +40,7 @@ foreach ($workload in $VisualStudioWorkloads) {
 }
 
 # https://github.com/PowerShell/PowerShell/releases/latest
-$PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.4.2/PowerShell-7.4.2-win-x64.msi'
+$PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.4.3/PowerShell-7.4.3-win-x64.msi'
 $PowerShellArgs = @('/quiet', '/norestart')
 
 $PythonUrl = 'https://www.python.org/ftp/python/3.12.4/python-3.12.4-amd64.exe'

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.28.0)
+cmake_minimum_required(VERSION 3.29.0)
 project(msvc_standard_libraries_benchmarks LANGUAGES CXX)
 
 if(DEFINED STL_BINARY_DIR)

--- a/stl/inc/__msvc_bit_utils.hpp
+++ b/stl/inc/__msvc_bit_utils.hpp
@@ -300,9 +300,8 @@ _NODISCARD int _Checked_x86_x64_countr_zero(const _Ty _Val) noexcept {
 
 #endif // _HAS_TZCNT_BSF_INTRINSICS
 
-// TRANSITION, remove `_MSC_VER > 1940` check after MSVC-internal toolset update
-#if (defined(_M_IX86) || defined(_M_X64) || (defined(_M_ARM64) && _MSC_VER > 1940)) && !defined(_M_CEE_PURE) \
-    && !defined(__CUDACC__) && !defined(__INTEL_COMPILER)
+#if (defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM64)) && !defined(_M_CEE_PURE) && !defined(__CUDACC__) \
+    && !defined(__INTEL_COMPILER)
 #define _HAS_POPCNT_INTRINSICS 1
 #if defined(__AVX__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #define _POPCNT_INTRINSICS_ALWAYS_AVAILABLE 1

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -897,8 +897,8 @@ _EMIT_STL_ERROR(STL1002, "Unexpected compiler version, expected CUDA 12.4 or new
 _EMIT_STL_ERROR(STL1000, "Unexpected compiler version, expected Clang 17.0.0 or newer.");
 #endif // ^^^ old Clang ^^^
 #elif defined(_MSC_VER)
-#if _MSC_VER < 1940 // Coarse-grained, not inspecting _MSC_FULL_VER
-_EMIT_STL_ERROR(STL1001, "Unexpected compiler version, expected MSVC 19.40 or newer.");
+#if _MSC_VER < 1941 // Coarse-grained, not inspecting _MSC_FULL_VER
+_EMIT_STL_ERROR(STL1001, "Unexpected compiler version, expected MSVC 19.41 or newer.");
 #endif // ^^^ old MSVC ^^^
 #else // vvv other compilers vvv
 // not attempting to detect other compilers

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.28.0)
+cmake_minimum_required(VERSION 3.29.0)
 project(msvc_standard_libraries_tools LANGUAGES CXX)
 
 add_subdirectory(format)

--- a/tools/format/CMakeLists.txt
+++ b/tools/format/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.28.0)
+cmake_minimum_required(VERSION 3.29.0)
 project(msvc_standard_libraries_format NONE)
 
 set(did_search OFF)

--- a/tools/validate/CMakeLists.txt
+++ b/tools/validate/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.28.0)
+cmake_minimum_required(VERSION 3.29.0)
 project(msvc_standard_libraries_validate LANGUAGES CXX)
 
 add_executable(validate-binary validate.cpp)


### PR DESCRIPTION
# :scroll: Changelog
- Infrastructure improvements:
  * Updated dependencies. [#4824](https://github.com/microsoft/STL/pull/4824)
    + Updated build compiler to VS 2022 17.11 Preview 3 (now required).
    + Updated CMake to 3.29 (now required).

# :gear: Commits
* PowerShell 7.4.3.
* Move to eastus2.
  + This is required for 1ES Hosted Pools quota.
* VS 2022 17.11 Preview 3, now required.
* CMake 3.29, now required.
* Remove workaround for the MSVC-internal toolset.
* New pool.
