### PR TITLE
Remove `std::ranges::view_interface` visualizer.

### DIFF
--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -2001,19 +2001,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     </Expand>
   </Type>
 
-  <Type Name="std::ranges::view_interface&lt;*&gt;">
-    <!-- the view_interface has size() -->
-    <DisplayString Optional="true">{{ size={size()} }}</DisplayString>
-    <!-- the view_interface doesn't have size() -->
-    <DisplayString Optional="true">unknown size</DisplayString>
-    <Expand>
-      <Item Optional="true" Name="empty">empty()</Item>
-      <Item Optional="true" Name="front">front()</Item>
-      <Item Optional="true" Name="back">back()</Item>
-      <Item Optional="true" Name="data">data()</Item>
-    </Expand>
-  </Type>
-
   <Type Name="std::ranges::dangling">
     <DisplayString>dangling</DisplayString>
   </Type>

--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -2002,7 +2002,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   </Type>
 
   <Type Name="std::ranges::view_interface&lt;*&gt;">
-    <DisplayString>{{ size={size()} }}</DisplayString>
+    <!-- the view_interface has size() -->
+    <DisplayString Optional="true">{{ size={size()} }}</DisplayString>
+    <!-- the view_interface doesn't have size() -->
+    <DisplayString Optional="true">unknown size</DisplayString>
     <Expand>
       <Item Optional="true" Name="empty">empty()</Item>
       <Item Optional="true" Name="front">front()</Item>


### PR DESCRIPTION
Fixes #4830 

Actually I tested it and I think `std::ranges::view_interface` natvis may be useless.

My test code:
```
#include <iostream>
#include <ranges>
#include <vector>
#include <sstream>

template<class T, class A>
class VectorView : public std::ranges::view_interface<VectorView<T, A>>
{
public:
    VectorView() = default;

    VectorView(const std::vector<T, A>& vec) :
        m_begin(vec.cbegin()), m_end(vec.cend())
    {}

    auto begin() const { return m_begin; }

    auto end() const { return m_end; }

private:
    typename std::vector<T, A>::const_iterator m_begin{}, m_end{};
};

int main()
{
    std::vector<int> v = { 1, 4, 9, 16 };

    VectorView view1{ v };
    view1.size();
    view1.front();
    view1.empty();
    view1.back();
    view1.data();

    auto words = std::istringstream{ "today is yesterday’s tomorrow" };
    auto istream_view = std::views::istream<std::string>(words);;
    std::ranges::view_interface<std::ranges::basic_istream_view<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, char, std::char_traits<char> > > view2 = istream_view;

    return 0;
}
```

For `std::ranges::view_interface` without `size()` I used `istream_view`.

For `std::ranges::view_interface` with`size()` I used `VectorView` from https://en.cppreference.com/w/cpp/ranges/view_interface 
I also called `size()`, `front()`, `empty()`, `back()`,  `data()` because the compiler didn't generate these methods by default and Natvis showed `unknown size`.

My results:
![изображение](https://github.com/user-attachments/assets/61b3dd6d-4e5e-4cf4-9c86-38d432778cc9)

As I can see Natvis never calls methods. It works great only for memory variables and intrinsics.
iota_view example: 
```
<Intrinsic Optional="true" Name="size" Expression="(size_t)(_Bound - _Value)" />
```

And because `std::ranges::view_interface` is dependent from `_Derived`, we can't create an intrinsic for its size.
Am I correct and we always will receive "???" or "This expression has side effects and will not be evaluate"?