### PR TITLE
`move_iterator` visualizer should use `_Current`

### DIFF
--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -1520,9 +1520,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 
   <Type Name="std::move_iterator&lt;*&gt;">
-      <DisplayString>move_iterator {current}</DisplayString>
+      <DisplayString>move_iterator {_Current}</DisplayString>
       <Expand>
-          <Item Name="current">current</Item>
+          <Item Name="[current]">_Current</Item>
       </Expand>
   </Type>
 


### PR DESCRIPTION
Fixes #4829

Test code:
```c++
#include <iterator>
#include <string>
#include <vector>

int main()
{
    std::vector<std::string> v{ "This", "_", "is", "_", "an", "_", "example" };
    auto begin = std::make_move_iterator(v.begin());
    return 0;
}
```

Result:
![изображение](https://github.com/user-attachments/assets/f41f6f5b-e22c-4141-bdbe-284deacbdb08)
