### PR TITLE
`<expected>`: Add deleted copy function overloads

### DIFF
--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -258,6 +258,8 @@ public:
         is_trivially_copy_constructible_v<_Ty> && is_trivially_copy_constructible_v<_Err> = default;
     // clang-format on
 
+    expected(const expected&) = delete;
+
     constexpr expected(expected&& _Other) noexcept(
         is_nothrow_move_constructible_v<_Ty> && is_nothrow_move_constructible_v<_Err>)
         requires (!(is_trivially_move_constructible_v<_Ty> && is_trivially_move_constructible_v<_Err>)
@@ -440,6 +442,8 @@ public:
                   && _Trivially_copy_constructible_assignable_destructible<_Ty>
                   && _Trivially_copy_constructible_assignable_destructible<_Err>
     = default;
+
+    expected& operator=(const expected&) = delete;
 
     constexpr expected& operator=(expected&& _Other) noexcept(
         is_nothrow_move_constructible_v<_Ty> && is_nothrow_move_constructible_v<_Err>
@@ -1243,6 +1247,8 @@ public:
     expected(const expected&) requires is_trivially_copy_constructible_v<_Err> = default;
     // clang-format on
 
+    expected(const expected&) = delete;
+
     constexpr expected(expected&& _Other) noexcept(is_nothrow_move_constructible_v<_Err>)
         requires (!is_trivially_move_constructible_v<_Err> && is_move_constructible_v<_Err>)
         : _Has_value(_Other._Has_value) {
@@ -1343,6 +1349,8 @@ public:
     expected& operator=(const expected&)
         requires _Expected_unary_copy_assignable<_Err> && _Trivially_copy_constructible_assignable_destructible<_Err>
     = default;
+
+    expected& operator=(const expected&) = delete;
 
     constexpr expected& operator=(expected&& _Other) noexcept(
         is_nothrow_move_constructible_v<_Err> && is_nothrow_move_assignable_v<_Err>)

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -2385,8 +2385,10 @@ static_assert(
 static_assert(!is_assignable_v<expected<int, char>&, ambiguating_expected_assignment_source<int, char>>);
 static_assert(!is_assignable_v<expected<void, int>&, ambiguating_expected_assignment_source<void, int>>);
 #endif // ^^^ no workaround ^^^
+#ifndef __EDG__ // TRANSITION, VSO-2188364
 static_assert(!is_assignable_v<expected<move_only, char>&, ambiguating_expected_assignment_source<move_only, char>>);
 static_assert(!is_assignable_v<expected<void, move_only>&, ambiguating_expected_assignment_source<void, move_only>>);
+#endif // ^^^ no workaround ^^^
 
 int main() {
     test_unexpected::test_all();

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -2343,6 +2343,51 @@ constexpr bool test_inherited_constructors() {
 
 static_assert(test_inherited_constructors());
 
+// Test GH-4279 "Add deleted function overloads to expected"
+
+template <class T, class E>
+struct ambiguating_expected_copy_constructor_caller {
+    struct const_lvalue_taker {
+        const_lvalue_taker(const expected<T, E>&) {}
+    };
+
+    void operator()(expected<T, E>) {}
+    void operator()(const_lvalue_taker) {}
+};
+
+template <class T, class E>
+struct ambiguating_expected_assignment_source {
+    operator const expected<T, E>&() && {
+        return ex;
+    }
+
+    operator expected<T, E>&&() && {
+        return move(ex);
+    }
+
+    expected<T, E> ex;
+};
+
+struct move_only {
+    move_only()                       = default;
+    move_only(move_only&&)            = default;
+    move_only& operator=(move_only&&) = default;
+};
+
+static_assert(is_invocable_v<ambiguating_expected_copy_constructor_caller<int, char>, const expected<int, char>&>);
+static_assert(is_invocable_v<ambiguating_expected_copy_constructor_caller<void, int>, const expected<void, int>&>);
+static_assert(
+    !is_invocable_v<ambiguating_expected_copy_constructor_caller<move_only, char>, const expected<move_only, char>&>);
+static_assert(
+    !is_invocable_v<ambiguating_expected_copy_constructor_caller<void, move_only>, const expected<void, move_only>&>);
+
+#ifndef __EDG__ // TRANSITION, VSO-1601179
+static_assert(!is_assignable_v<expected<int, char>&, ambiguating_expected_assignment_source<int, char>>);
+static_assert(!is_assignable_v<expected<void, int>&, ambiguating_expected_assignment_source<void, int>>);
+#endif // ^^^ no workaround ^^^
+static_assert(!is_assignable_v<expected<move_only, char>&, ambiguating_expected_assignment_source<move_only, char>>);
+static_assert(!is_assignable_v<expected<void, move_only>&, ambiguating_expected_assignment_source<void, move_only>>);
+
 int main() {
     test_unexpected::test_all();
     static_assert(test_unexpected::test_all());


### PR DESCRIPTION
Fixes #4279.

Some test cases are skipped for EDG, due to the bug which is probably VSO-1601179 (encountered in #3057 previously).