### PR TITLE
Fix `put_time()` crash on invalid format specifier

### DIFF
--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -651,8 +651,9 @@ protected:
     __CLR_OR_THIS_CALL ~time_get_byname() noexcept override {}
 };
 
+_INLINE_VAR constexpr char _Valid_specifiers[] = "aAbBcCdDeFgGhHIjmMnprRStTuUVwWxXyYzZ";
+
 constexpr bool _Is_valid_fmt_specifier(const char _Specifier) {
-    constexpr char _Valid_specifiers[] = "aAbBcCdDeFgGhHIjmMnprRStTuUVwWxXyYzZ";
     for (const char _Valid_specifier : _Valid_specifiers) {
         if (_Valid_specifier == _Specifier) {
             return true;

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -651,6 +651,7 @@ protected:
     __CLR_OR_THIS_CALL ~time_get_byname() noexcept override {}
 };
 
+// C23 7.29.3.5 "The strftime function"/3
 _INLINE_VAR constexpr char _Valid_strftime_specifiers[] = {'a', 'A', 'b', 'B', 'c', 'C', 'd', 'D', 'e', 'F', 'g', 'G',
     'h', 'H', 'I', 'j', 'm', 'M', 'n', 'p', 'r', 'R', 'S', 't', 'T', 'u', 'U', 'V', 'w', 'W', 'x', 'X', 'y', 'Y', 'z',
     'Z'};

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -658,7 +658,7 @@ _INLINE_VAR constexpr char _Valid_strftime_specifiers[] = {'a', 'A', 'b', 'B', '
 
 _NODISCARD constexpr bool _Is_valid_strftime_specifier(const char _Specifier) {
     for (const char _Valid_specifier : _Valid_strftime_specifiers) {
-        if (_Valid_specifier == _Specifier) {
+        if (_Specifier == _Valid_specifier) {
             return true;
         }
     }

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -656,7 +656,7 @@ _INLINE_VAR constexpr char _Valid_strftime_specifiers[] = {'a', 'A', 'b', 'B', '
     'h', 'H', 'I', 'j', 'm', 'M', 'n', 'p', 'r', 'R', 'S', 't', 'T', 'u', 'U', 'V', 'w', 'W', 'x', 'X', 'y', 'Y', 'z',
     'Z'};
 
-constexpr bool _Is_valid_strftime_specifier(const char _Specifier) {
+_NODISCARD constexpr bool _Is_valid_strftime_specifier(const char _Specifier) {
     for (const char _Valid_specifier : _Valid_strftime_specifiers) {
         if (_Valid_specifier == _Specifier) {
             return true;

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -657,7 +657,7 @@ _INLINE_VAR constexpr char _Valid_strftime_specifiers[] = {'a', 'A', 'b', 'B', '
     'Z'};
 
 _NODISCARD constexpr bool _Is_valid_strftime_specifier(const char _Specifier) {
-    for (const char _Valid_specifier : _Valid_strftime_specifiers) {
+    for (const auto& _Valid_specifier : _Valid_strftime_specifiers) {
         if (_Specifier == _Valid_specifier) {
             return true;
         }

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -966,14 +966,15 @@ public:
                 *_Dest++ = _Fmtfirst[-1];
                 break;
             } else { // get specifier after %
-                char _Specifier = _Ctype_fac.narrow(*_Fmtfirst);
+                _Elem _Raw      = *_Fmtfirst;
+                char _Specifier = _Ctype_fac.narrow(_Raw);
                 char _Modifier  = '\0';
                 _Elem _Percent  = _Fmtfirst[-1];
 
                 if (_Specifier == 'E' || _Specifier == 'O' || _Specifier == 'Q' || _Specifier == '#') {
                     if (++_Fmtfirst == _Fmtlast) { // no specifier, copy %[E0Q#] as literal elements
                         *_Dest++ = _Percent;
-                        *_Dest++ = _Specifier;
+                        *_Dest++ = _Raw;
                         break;
                     }
 
@@ -989,9 +990,9 @@ public:
                     // no valid specifier, directly copy as literal elements
                     *_Dest++ = _Percent;
                     if (_Modifier != '\0') {
-                        *_Dest++ = _Modifier;
+                        *_Dest++ = _Raw;
                     }
-                    *_Dest++ = _Specifier;
+                    *_Dest++ = *_Fmtfirst;
                 } else {
                     _Dest = do_put(_Dest, _Iosbase, _Fill, _Pt, _Specifier, _Modifier); // convert a single field
                 }

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -651,11 +651,12 @@ protected:
     __CLR_OR_THIS_CALL ~time_get_byname() noexcept override {}
 };
 
-_INLINE_VAR constexpr char _Valid_specifiers[] = {'a', 'A', 'b', 'B', 'c', 'C', 'd', 'D', 'e', 'F', 'g', 'G', 'h', 'H',
-    'I', 'j', 'm', 'M', 'n', 'p', 'r', 'R', 'S', 't', 'T', 'u', 'U', 'V', 'w', 'W', 'x', 'X', 'y', 'Y', 'z', 'Z'};
+_INLINE_VAR constexpr char _Valid_strftime_specifiers[] = {'a', 'A', 'b', 'B', 'c', 'C', 'd', 'D', 'e', 'F', 'g', 'G',
+    'h', 'H', 'I', 'j', 'm', 'M', 'n', 'p', 'r', 'R', 'S', 't', 'T', 'u', 'U', 'V', 'w', 'W', 'x', 'X', 'y', 'Y', 'z',
+    'Z'};
 
-constexpr bool _Is_valid_fmt_specifier(const char _Specifier) {
-    for (const char _Valid_specifier : _Valid_specifiers) {
+constexpr bool _Is_valid_strftime_specifier(const char _Specifier) {
+    for (const char _Valid_specifier : _Valid_strftime_specifiers) {
         if (_Valid_specifier == _Specifier) {
             return true;
         }
@@ -703,7 +704,7 @@ public:
                 if (_Specifier == '%' && _Modifier == '\0') {
                     // if the specifier is percent and no modifier is set, just append it
                     *_Dest++ = _Percent;
-                } else if (!_Is_valid_fmt_specifier(_Specifier)) {
+                } else if (!_Is_valid_strftime_specifier(_Specifier)) {
                     // no valid specifier, directly copy as literal elements
                     *_Dest++ = _Percent;
                     if (_Modifier != '\0') {
@@ -839,7 +840,7 @@ public:
                 if (_Specifier == '%' && _Modifier == '\0') {
                     // if the specifier is percent and no modifier is set, just append it
                     *_Dest++ = _Percent;
-                } else if (!_Is_valid_fmt_specifier(_Specifier)) {
+                } else if (!_Is_valid_strftime_specifier(_Specifier)) {
                     // no valid specifier, directly copy as literal elements
                     *_Dest++ = _Percent;
                     *_Dest++ = _Raw;
@@ -983,7 +984,7 @@ public:
                 if (_Specifier == '%' && _Modifier == '\0') {
                     // if the specifier is percent and no modifier is set, just append it
                     *_Dest++ = _Percent;
-                } else if (!_Is_valid_fmt_specifier(_Specifier)) {
+                } else if (!_Is_valid_strftime_specifier(_Specifier)) {
                     // no valid specifier, directly copy as literal elements
                     *_Dest++ = _Percent;
                     if (_Modifier != '\0') {

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -651,7 +651,8 @@ protected:
     __CLR_OR_THIS_CALL ~time_get_byname() noexcept override {}
 };
 
-_INLINE_VAR constexpr char _Valid_specifiers[] = "aAbBcCdDeFgGhHIjmMnprRStTuUVwWxXyYzZ";
+_INLINE_VAR constexpr char _Valid_specifiers[] = {'a', 'A', 'b', 'B', 'c', 'C', 'd', 'D', 'e', 'F', 'g', 'G', 'h', 'H',
+    'I', 'j', 'm', 'M', 'n', 'p', 'r', 'R', 'S', 't', 'T', 'u', 'U', 'V', 'w', 'W', 'x', 'X', 'y', 'Y', 'z', 'Z'};
 
 constexpr bool _Is_valid_fmt_specifier(const char _Specifier) {
     for (const char _Valid_specifier : _Valid_specifiers) {

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -844,10 +844,10 @@ public:
                 } else if (!_Is_valid_strftime_specifier(_Specifier)) {
                     // no valid specifier, directly copy as literal elements
                     *_Dest++ = _Percent;
-                    *_Dest++ = _Raw;
                     if (_Modifier != '\0') {
-                        *_Dest++ = *_Fmtfirst;
+                        *_Dest++ = _Raw;
                     }
+                    *_Dest++ = *_Fmtfirst;
                 } else {
                     _Dest = do_put(_Dest, _Iosbase, _Fill, _Pt, _Specifier, _Modifier); // convert a single field
                 }

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -651,6 +651,17 @@ protected:
     __CLR_OR_THIS_CALL ~time_get_byname() noexcept override {}
 };
 
+constexpr bool _Is_valid_fmt_specifier(const char _Specifier) {
+    constexpr char _Valid_specifiers[] = "aAbBcCdDeFgGhHIjmMnprRStTuUVwWxXyYzZ";
+    for (const char _Valid_specifier : _Valid_specifiers) {
+        if (_Valid_specifier == _Specifier) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 _EXPORT_STD extern "C++" template <class _Elem, class _OutIt = ostreambuf_iterator<_Elem, char_traits<_Elem>>>
 class time_put : public locale::facet { // facet for converting encoded times to text
 public:
@@ -687,7 +698,19 @@ public:
                     _Specifier = _Ctype_fac.narrow(*_Fmtfirst);
                 }
 
-                _Dest = do_put(_Dest, _Iosbase, _Fill, _Pt, _Specifier, _Modifier); // convert a single field
+                if (_Specifier == '%' && _Modifier == '\0') {
+                    // if the specifier is percent and no modifier is set, just append it
+                    *_Dest++ = _Percent;
+                } else if (!_Is_valid_fmt_specifier(_Specifier)) {
+                    // no valid specifier, directly copy as literal elements
+                    *_Dest++ = _Percent;
+                    if (_Modifier != '\0') {
+                        *_Dest++ = _Modifier;
+                    }
+                    *_Dest++ = _Specifier;
+                } else {
+                    _Dest = do_put(_Dest, _Iosbase, _Fill, _Pt, _Specifier, _Modifier); // convert a single field
+                }
             }
         }
 
@@ -811,7 +834,19 @@ public:
                     _Specifier = _Ctype_fac.narrow(*_Fmtfirst);
                 }
 
-                _Dest = do_put(_Dest, _Iosbase, _Fill, _Pt, _Specifier, _Modifier); // convert a single field
+                if (_Specifier == '%' && _Modifier == '\0') {
+                    // if the specifier is percent and no modifier is set, just append it
+                    *_Dest++ = _Percent;
+                } else if (!_Is_valid_fmt_specifier(_Specifier)) {
+                    // no valid specifier, directly copy as literal elements
+                    *_Dest++ = _Percent;
+                    *_Dest++ = _Raw;
+                    if (_Modifier != '\0') {
+                        *_Dest++ = *_Fmtfirst;
+                    }
+                } else {
+                    _Dest = do_put(_Dest, _Iosbase, _Fill, _Pt, _Specifier, _Modifier); // convert a single field
+                }
             }
         }
 
@@ -943,7 +978,19 @@ public:
                     _Specifier = _Ctype_fac.narrow(*_Fmtfirst);
                 }
 
-                _Dest = do_put(_Dest, _Iosbase, _Fill, _Pt, _Specifier, _Modifier); // convert a single field
+                if (_Specifier == '%' && _Modifier == '\0') {
+                    // if the specifier is percent and no modifier is set, just append it
+                    *_Dest++ = _Percent;
+                } else if (!_Is_valid_fmt_specifier(_Specifier)) {
+                    // no valid specifier, directly copy as literal elements
+                    *_Dest++ = _Percent;
+                    if (_Modifier != '\0') {
+                        *_Dest++ = _Modifier;
+                    }
+                    *_Dest++ = _Specifier;
+                } else {
+                    _Dest = do_put(_Dest, _Iosbase, _Fill, _Pt, _Specifier, _Modifier); // convert a single field
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #4820. The test case also verifies the situation where an invalid specifier is given when a modifier is being used. For example "%E% some text"

This is my first PR, so sorry if something is wrong in formatting or ABI terms.
