### PR TITLE
Fix `filesystem::weakly_canonical()` on Win11 24H2

### DIFF
--- a/stl/inc/xfilesystem_abi.h
+++ b/stl/inc/xfilesystem_abi.h
@@ -53,6 +53,7 @@ _NODISCARD inline bool __std_is_file_not_found(const __std_win_error _Error) noe
     case __std_win_error::_Path_not_found:
     case __std_win_error::_Error_bad_netpath:
     case __std_win_error::_Invalid_name:
+    case __std_win_error::_Directory_name_is_invalid: // Windows 11 24H2
         return true;
     default:
         return false;

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -3950,7 +3950,7 @@ void test_devcom_953628() { // COMPILE-ONLY
     path{S{}};
 }
 
-int wmain(int argc, wchar_t* argv[]) {
+int run_all_tests(int argc, wchar_t* argv[]) {
     error_code ec;
 
     // Store old path and change current path to a temporary path
@@ -4077,4 +4077,20 @@ int wmain(int argc, wchar_t* argv[]) {
     EXPECT(good(ec));
 
     assert(pass);
+
+    return 0;
+}
+
+int wmain(int argc, wchar_t* argv[]) {
+    try {
+        return run_all_tests(argc, argv);
+    } catch (const filesystem_error& fe) {
+        cout << "filesystem_error: " << fe.what() << endl;
+    } catch (const exception& e) {
+        cout << "exception: " << e.what() << endl;
+    } catch (...) {
+        cout << "Unknown exception." << endl;
+    }
+
+    return EXIT_FAILURE;
 }


### PR DESCRIPTION
We have a regression test for DevCom-538510 (internal VSO-850856) "`std::filesystem::weakly_canonical` erroneously throws an exception":

https://github.com/microsoft/STL/blob/ecbc1efa09936f4ef5af529e770a95a29a4290d3/tests/std/tests/P0218R1_filesystem/test.cpp#L3233-L3237

This has regressed on the upcoming Win11 24H2, where we throw an exception (again). The relevant code is:

https://github.com/microsoft/STL/blob/ecbc1efa09936f4ef5af529e770a95a29a4290d3/stl/inc/filesystem#L4127-L4144

After calling `_Canonical()`, anything other than `_Err == __std_win_error::_Success` or `__std_is_file_not_found(_Err)` is considered a hard error (which will cause the non-`error_code` overload to throw a `filesystem_error`).

In current OSes, the `fileWithSuffix` scenario results in `_Invalid_name` here. (Locally verified on Win11 23H2. Presumably we get the same behavior in the GitHub PR/CI system running Server 2022 21H2, although I didn't verify that.)

In Win11 24H2, we get `_Directory_name_is_invalid`, which isn't recognized by `__std_is_file_not_found`. :boom:

The fix is backwards-compatible and a simple one-liner: add this error code enumerator to the list of synonyms that `__std_is_file_not_found` recognizes. The plain meaning of `_Directory_name_is_invalid` is clearly a subset of `_Invalid_name`.

I've manually verified this (with significant but perhaps not surprising logistical difficulty) in an Azure VM with Win11 24H2. Regular test coverage will be provided by the MSVC-internal test harness (which is how we found this), and eventually by the GitHub test harness once Server 2025 24H2 is officially released.

Additionally, this uncaught exception from a non-`error_code` overload manifested itself as an `abort()` with no useful logs. To aid in future investigations, I'm including a simple change to the filesystem test. Now, we wrap the whole test in `try ... catch` and print the contents of any exception before failing.