### PR TITLE
Fix and improve `array` and `mdspan` static analysis warnings

### DIFF
--- a/stl/inc/array
+++ b/stl/inc/array
@@ -500,7 +500,7 @@ public:
         return _Elems + _Size;
     }
 
-    _NODISCARD constexpr size_type size() const noexcept {
+    _NODISCARD _Ret_range_(==, _Size) constexpr size_type size() const noexcept {
         return _Size;
     }
 
@@ -528,7 +528,7 @@ public:
         return _Elems[_Pos];
     }
 
-    _NODISCARD _CONSTEXPR17 reference operator[](_In_range_(0, _Size - 1) size_type _Pos) noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 reference operator[](_In_range_(<, _Size) size_type _Pos) noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Pos < _Size, "array subscript out of range");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
@@ -536,7 +536,7 @@ public:
         return _Elems[_Pos];
     }
 
-    _NODISCARD constexpr const_reference operator[](_In_range_(0, _Size - 1) size_type _Pos) const noexcept
+    _NODISCARD constexpr const_reference operator[](_In_range_(<, _Size) size_type _Pos) const noexcept
     /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Pos < _Size, "array subscript out of range");

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -81,7 +81,7 @@ private:
         rank_type _Counter = 0;
         for (rank_type _Idx = 0; _Idx < _Rank; ++_Idx) {
             if (_Static_extents[_Idx] == dynamic_extent) {
-                _Analysis_assume_(_Counter < _Rank_dynamic); // TRANSITION, DevCom-923103
+                _Analysis_assume_(_Counter < _Rank_dynamic); // guaranteed by how _Rank_dynamic is calculated
                 _Result[_Counter] = _Idx;
                 ++_Counter;
             }
@@ -174,7 +174,7 @@ private:
     }
 
 public:
-    _NODISCARD static constexpr rank_type rank() noexcept {
+    _NODISCARD _Ret_range_(==, _Rank) static constexpr rank_type rank() noexcept {
         return _Rank;
     }
 
@@ -182,14 +182,14 @@ public:
         return _Rank_dynamic;
     }
 
-    _NODISCARD static constexpr size_t static_extent(const rank_type _Idx) noexcept {
+    _NODISCARD static constexpr size_t static_extent(_In_range_(<, _Rank) const rank_type _Idx) noexcept {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Idx < _Rank, "Index must be less than rank() (N4950 [mdspan.extents.obs]/1)");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
         return _Static_extents[_Idx];
     }
 
-    _NODISCARD constexpr index_type extent(const rank_type _Idx) const noexcept {
+    _NODISCARD constexpr index_type extent(_In_range_(<, _Rank) const rank_type _Idx) const noexcept {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Idx < _Rank, "Index must be less than rank() (N4950 [mdspan.extents.obs]/3)");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
@@ -591,7 +591,7 @@ public:
         return true;
     }
 
-    _NODISCARD constexpr index_type stride(const rank_type _Idx) const noexcept
+    _NODISCARD constexpr index_type stride(_In_range_(<, extents_type::_Rank) const rank_type _Idx) const noexcept
         requires (extents_type::rank() > 0)
     {
 #if _CONTAINER_DEBUG_LEVEL > 0
@@ -744,7 +744,7 @@ public:
         return true;
     }
 
-    _NODISCARD constexpr index_type stride(const rank_type _Idx) const noexcept
+    _NODISCARD constexpr index_type stride(_In_range_(<, extents_type::_Rank) const rank_type _Idx) const noexcept
         requires (extents_type::rank() > 0)
     {
 #if _CONTAINER_DEBUG_LEVEL > 0
@@ -975,10 +975,14 @@ public:
         return true;
     }
 
-    _NODISCARD constexpr index_type stride(const rank_type _Idx) const noexcept {
+    _NODISCARD constexpr index_type stride(_In_range_(<, extents_type::_Rank) const rank_type _Idx) const noexcept {
         if constexpr (extents_type::rank() == 0) {
             _STL_VERIFY(false, "The argument to stride must be nonnegative and less than extents_type::rank().");
         } else {
+#if _CONTAINER_DEBUG_LEVEL > 0
+            _STL_VERIFY(_Idx < extents_type::_Rank,
+                "The argument to stride must be nonnegative and less than extents_type::rank().");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
             return this->_Array[_Idx];
         }
     }
@@ -1187,7 +1191,7 @@ private:
         "[mdspan.mdspan.overview]/2.3).");
 
 public:
-    _NODISCARD static constexpr rank_type rank() noexcept {
+    _NODISCARD _Ret_range_(==, extents_type::_Rank) static constexpr rank_type rank() noexcept {
         return extents_type::_Rank;
     }
 
@@ -1195,14 +1199,14 @@ public:
         return extents_type::_Rank_dynamic;
     }
 
-    _NODISCARD static constexpr size_t static_extent(const rank_type _Idx) noexcept {
+    _NODISCARD static constexpr size_t static_extent(_In_range_(<, extents_type::_Rank) const rank_type _Idx) noexcept {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Idx < extents_type::_Rank, "Index must be less than rank() (N4950 [mdspan.extents.obs]/1)");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
         return extents_type::_Static_extents[_Idx];
     }
 
-    _NODISCARD constexpr index_type extent(const rank_type _Idx) const noexcept {
+    _NODISCARD constexpr index_type extent(_In_range_(<, extents_type::_Rank) const rank_type _Idx) const noexcept {
         return this->_Map.extents().extent(_Idx);
     }
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1006,22 +1006,15 @@ std/utilities/format/format.range/format.range.fmtset/format.pass.cpp FAIL
 std/utilities/format/format.range/format.range.fmtstr/format.pass.cpp FAIL
 std/utilities/format/format.tuple/format.pass.cpp FAIL
 
-# Not analyzed. Apparent false positives from static analysis where it thinks that array indexing is out of bounds.
-# warning C28020: The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call.
+# Not analyzed. Static analysis thinks that array indexing is out of bounds because it can't prove otherwise.
+# warning C28020: The expression '_Param_(1)<1' is not true at this call.
 # Note: The :1 (ASAN) configuration doesn't run static analysis.
 std/containers/views/mdspan/extents/ctor_default.pass.cpp:0 FAIL
 std/containers/views/mdspan/extents/ctor_from_array.pass.cpp:0 FAIL
 std/containers/views/mdspan/extents/ctor_from_integral.pass.cpp:0 FAIL
 std/containers/views/mdspan/extents/ctor_from_span.pass.cpp:0 FAIL
-std/containers/views/mdspan/layout_left/ctor.layout_stride.pass.cpp:0 FAIL
-std/containers/views/mdspan/layout_left/stride.pass.cpp:0 FAIL
-std/containers/views/mdspan/layout_right/ctor.layout_stride.pass.cpp:0 FAIL
-std/containers/views/mdspan/layout_right/stride.pass.cpp:0 FAIL
-std/containers/views/mdspan/layout_stride/ctor.default.pass.cpp:0 FAIL
-std/containers/views/mdspan/layout_stride/ctor.extents_array.pass.cpp:0 FAIL
-std/containers/views/mdspan/layout_stride/ctor.extents_span.pass.cpp:0 FAIL
+std/containers/views/mdspan/layout_stride/comparison.pass.cpp:0 FAIL
 std/containers/views/mdspan/layout_stride/ctor.strided_mapping.pass.cpp:0 FAIL
-std/containers/views/mdspan/layout_stride/stride.pass.cpp:0 FAIL
 std/containers/views/mdspan/mdspan/conversion.pass.cpp:0 FAIL
 std/containers/views/mdspan/mdspan/ctor.dh_array.pass.cpp:0 FAIL
 std/containers/views/mdspan/mdspan/ctor.dh_span.pass.cpp:0 FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1092,6 +1092,8 @@ std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.ra
 std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.range.pass.cpp:1 SKIPPED
 std/algorithms/alg.nonmodifying/alg.ends_with/ranges.ends_with.pass.cpp:0 SKIPPED
 std/algorithms/alg.nonmodifying/alg.ends_with/ranges.ends_with.pass.cpp:1 SKIPPED
+std/algorithms/alg.sorting/alg.lex.comparison/ranges.lexicographical_compare.pass.cpp:0 SKIPPED
+std/algorithms/alg.sorting/alg.lex.comparison/ranges.lexicographical_compare.pass.cpp:1 SKIPPED
 std/algorithms/alg.sorting/alg.merge/ranges_merge.pass.cpp:0 SKIPPED
 std/algorithms/alg.sorting/alg.merge/ranges_merge.pass.cpp:1 SKIPPED
 std/algorithms/alg.sorting/alg.set.operations/includes/ranges_includes.pass.cpp:0 SKIPPED

--- a/tests/std/include/test_mdspan_support.hpp
+++ b/tests/std/include/test_mdspan_support.hpp
@@ -251,7 +251,10 @@ MappingProperties<Mapping> get_mapping_properties(const Mapping& mapping) {
     constexpr auto rank = Mapping::extents_type::rank();
     constexpr std::make_index_sequence<rank> rank_indices;
 
-    auto get_extent       = [&](size_t i) { return mapping.extents().extent(i); };
+    auto get_extent = [&](size_t i) {
+        assert(i < rank);
+        return mapping.extents().extent(i);
+    };
     auto multidim_indices = [&]<size_t... Indices>(std::index_sequence<Indices...>) {
         return std::views::cartesian_product(std::views::iota(IndexType{0}, get_extent(Indices))...);
     }(rank_indices);

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -755,4 +755,5 @@ tests\VSO_0849827_multicontainer_emplace_hint_position
 tests\VSO_0938757_attribute_order
 tests\VSO_0961751_hash_range_erase
 tests\VSO_0971246_legacy_await_headers
+tests\VSO_1804139_static_analysis_warning_with_single_element_array
 tests\VSO_1925201_iter_traits

--- a/tests/std/tests/P0009R18_mdspan_extents_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_extents_death/test.cpp
@@ -16,13 +16,19 @@ using namespace std;
 void test_static_extent_function_with_invalid_index() {
     using E = extents<int, 3>;
     // Index must be less than rank()
+#pragma warning(push)
+#pragma warning(disable : 28020) // yay, /analyze catches this mistake at compile time!
     (void) E::static_extent(1);
+#pragma warning(pop)
 }
 
 void test_extent_function_with_invalid_index() {
     extents<int, 3> e;
     // Index must be less than rank()
+#pragma warning(push)
+#pragma warning(disable : 28020) // yay, /analyze catches this mistake at compile time!
     (void) e.extent(1);
+#pragma warning(pop)
 }
 
 void test_construction_from_other_extents_with_invalid_values() {

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -90,10 +90,7 @@ constexpr void check_members(const extents<IndexType, Extents...>& ext, index_se
         if constexpr (Ext::rank() > 0) {
             strides.front() = 1;
             for (size_t i = 1; i < Ext::rank(); ++i) {
-#pragma warning(push)
-#pragma warning(disable : 28020) // TRANSITION, DevCom-923103
                 strides[i] = static_cast<IndexType>(strides[i - 1] * ext.extent(i - 1));
-#pragma warning(pop)
             }
         }
 

--- a/tests/std/tests/P0009R18_mdspan_layout_left_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left_death/test.cpp
@@ -59,7 +59,10 @@ void test_call_operator() {
 void test_stride_function() {
     layout_left::mapping<extents<int, 3>> m;
     // Value of i must be less than extents_type::rank()
+#pragma warning(push)
+#pragma warning(disable : 28020) // yay, /analyze catches this mistake at compile time!
     (void) m.stride(1);
+#pragma warning(pop)
 }
 
 int main(int argc, char* argv[]) {

--- a/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
@@ -90,10 +90,7 @@ constexpr void check_members(const extents<IndexType, Extents...>& ext, index_se
         if constexpr (Ext::rank() > 0) {
             strides.back() = 1;
             for (size_t i = Ext::rank() - 1; i-- > 0;) {
-#pragma warning(push)
-#pragma warning(disable : 28020) // TRANSITION, DevCom-923103
                 strides[i] = static_cast<IndexType>(strides[i + 1] * ext.extent(i + 1));
-#pragma warning(pop)
             }
         }
 

--- a/tests/std/tests/P0009R18_mdspan_layout_right_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_right_death/test.cpp
@@ -59,7 +59,10 @@ void test_call_operator() {
 void test_stride_function() {
     layout_right::mapping<extents<int, 3>> m;
     // Value of i must be less than extents_type::rank()
+#pragma warning(push)
+#pragma warning(disable : 28020) // yay, /analyze catches this mistake at compile time!
     (void) m.stride(1);
+#pragma warning(pop)
 }
 
 int main(int argc, char* argv[]) {

--- a/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
@@ -210,12 +210,9 @@ constexpr void do_check_members(const extents<IndexType, Extents...>& ext,
     }
 
     { // Check 'stride' function
-        for (size_t i = 0; i < strs.size(); ++i) {
+        for (size_t i = 0; i < Ext::rank(); ++i) {
             same_as<IndexType> decltype(auto) s = m.stride(i);
-#pragma warning(push)
-#pragma warning(disable : 28020) // TRANSITION, DevCom-923103
             assert(cmp_equal(strs[i], s));
-#pragma warning(pop)
         }
     }
 

--- a/tests/std/tests/P0009R18_mdspan_layout_stride_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride_death/test.cpp
@@ -61,7 +61,10 @@ void test_call_operator() {
 void test_stride_with_empty_extents() {
     layout_stride::mapping<extents<int>> m;
     // The argument to stride must be nonnegative and less than extents_type::rank()
+#pragma warning(push)
+#pragma warning(disable : 28020) // yay, /analyze catches this mistake at compile time!
     (void) m.stride(0);
+#pragma warning(pop)
 }
 
 int main(int argc, char* argv[]) {

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -3859,11 +3859,12 @@ basic_ostream<Elem, Traits>& operator<<(basic_ostream<Elem, Traits>& ostr, const
         L"symlink"sv, L"block"sv, L"character"sv, L"fifo"sv, L"socket"sv, L"unknown"sv, L"junction"sv}};
 
     const size_t index = static_cast<size_t>(ft);
-    if (!EXPECT(index < names.size())) {
+    if (index < names.size()) {
+        return ostr << L"file_type::" << names[index];
+    } else {
+        EXPECT(false);
         return ostr << L"!!! INVALID file_type(" << index << L") !!!!";
     }
-
-    return ostr << L"file_type::" << names[index];
 }
 
 template <typename Elem, typename Traits>

--- a/tests/std/tests/P2321R2_views_adjacent/test.cpp
+++ b/tests/std/tests/P2321R2_views_adjacent/test.cpp
@@ -352,8 +352,10 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
             same_as<I&> decltype(auto) i2 = ++i;
             assert(&i2 == &i);
             if (i != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                 assert(*i == expected[1]);
+#pragma warning(pop)
             }
             i = r.begin();
         }
@@ -362,8 +364,10 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
             same_as<I> decltype(auto) i2 = i++;
             assert(*i2 == expected[0]);
             if (i != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                 assert(*i == expected[1]);
+#pragma warning(pop)
             }
             i = r.begin();
         }
@@ -391,8 +395,10 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
 
                 same_as<I> decltype(auto) i2 = i--;
                 if (i2 != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                     assert(*i2 == expected[1]);
+#pragma warning(pop)
                 }
                 assert(*i == expected[0]);
             }
@@ -403,8 +409,10 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
                 same_as<I&> decltype(auto) i2 = (i += 1);
                 assert(&i2 == &i);
                 if (i != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                     assert(*i == expected[1]);
+#pragma warning(pop)
                 }
 
                 same_as<I&> decltype(auto) i3 = (i -= 1);
@@ -442,14 +450,18 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
             { // Check operator+
                 same_as<I> auto i2 = i + 1;
                 if (i2 != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                     assert(*i2 == expected[1]);
+#pragma warning(pop)
                 }
 
                 same_as<I> auto i3 = 1 + i;
                 if (i3 != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                     assert(*i3 == expected[1]);
+#pragma warning(pop)
                 }
             }
 
@@ -537,8 +549,10 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
             same_as<CI&> decltype(auto) ci2 = ++ci;
             assert(&ci2 == &ci);
             if (ci != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                 assert(*ci == expected[1]);
+#pragma warning(pop)
             }
             ci = r.begin();
         }
@@ -547,8 +561,10 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
             same_as<CI> decltype(auto) ci2 = ci++;
             assert(*ci2 == expected[0]);
             if (ci != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                 assert(*ci == expected[1]);
+#pragma warning(pop)
             }
             ci = r.begin();
         }
@@ -585,8 +601,10 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
 
                 same_as<CI> decltype(auto) ci2 = ci--;
                 if (ci2 != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                     assert(*ci2 == expected[1]);
+#pragma warning(pop)
                 }
                 assert(*ci == expected[0]);
             }
@@ -597,8 +615,10 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
                 same_as<CI&> decltype(auto) ci2 = (ci += 1);
                 assert(&ci2 == &ci);
                 if (ci != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                     assert(*ci == expected[1]);
+#pragma warning(pop)
                 }
 
                 same_as<CI&> decltype(auto) ci3 = (ci -= 1);
@@ -659,14 +679,18 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
             { // Check operator+
                 same_as<CI> auto ci2 = ci + 1;
                 if (ci2 != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                     assert(*ci2 == expected[1]);
+#pragma warning(pop)
                 }
 
                 same_as<CI> auto ci3 = 1 + ci;
                 if (ci3 != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                     assert(*ci3 == expected[1]);
+#pragma warning(pop)
                 }
             }
 

--- a/tests/std/tests/P2321R2_views_adjacent_transform/test.cpp
+++ b/tests/std/tests/P2321R2_views_adjacent_transform/test.cpp
@@ -427,8 +427,10 @@ constexpr bool test_one(Rng&& rng, Fn func, Expected&& expected_rng) {
             same_as<I&> decltype(auto) i2 = ++i;
             assert(&i2 == &i);
             if (i != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                 assert(*i == expected_rng[1]);
+#pragma warning(pop)
             }
             i = r.begin();
         }
@@ -437,8 +439,10 @@ constexpr bool test_one(Rng&& rng, Fn func, Expected&& expected_rng) {
             same_as<I> decltype(auto) i2 = i++;
             assert(*i2 == expected_rng[0]);
             if (i != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                 assert(*i == expected_rng[1]);
+#pragma warning(pop)
             }
             i = r.begin();
         }
@@ -466,8 +470,10 @@ constexpr bool test_one(Rng&& rng, Fn func, Expected&& expected_rng) {
 
                 same_as<I> decltype(auto) i2 = i--;
                 if (i2 != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                     assert(*i2 == expected_rng[1]);
+#pragma warning(pop)
                 }
                 assert(*i == expected_rng[0]);
             }
@@ -478,8 +484,10 @@ constexpr bool test_one(Rng&& rng, Fn func, Expected&& expected_rng) {
                 same_as<I&> decltype(auto) i2 = (i += 1);
                 assert(&i2 == &i);
                 if (i != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                     assert(*i == expected_rng[1]);
+#pragma warning(pop)
                 }
 
                 same_as<I&> decltype(auto) i3 = (i -= 1);
@@ -517,14 +525,18 @@ constexpr bool test_one(Rng&& rng, Fn func, Expected&& expected_rng) {
             { // Check operator+
                 same_as<I> auto i2 = i + 1;
                 if (i2 != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                     assert(*i2 == expected_rng[1]);
+#pragma warning(pop)
                 }
 
                 same_as<I> auto i3 = 1 + i;
                 if (i3 != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                     assert(*i3 == expected_rng[1]);
+#pragma warning(pop)
                 }
             }
 
@@ -609,8 +621,10 @@ constexpr bool test_one(Rng&& rng, Fn func, Expected&& expected_rng) {
             same_as<CI&> decltype(auto) ci2 = ++ci;
             assert(&ci2 == &ci);
             if (ci != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                 assert(*ci == expected_rng[1]);
+#pragma warning(pop)
             }
             ci = r.begin();
         }
@@ -619,8 +633,10 @@ constexpr bool test_one(Rng&& rng, Fn func, Expected&& expected_rng) {
             same_as<CI> decltype(auto) ci2 = ci++;
             assert(*ci2 == expected_rng[0]);
             if (ci != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                 assert(*ci == expected_rng[1]);
+#pragma warning(pop)
             }
             ci = r.begin();
         }
@@ -657,8 +673,10 @@ constexpr bool test_one(Rng&& rng, Fn func, Expected&& expected_rng) {
 
                 same_as<CI> decltype(auto) ci2 = ci--;
                 if (ci2 != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                     assert(*ci2 == expected_rng[1]);
+#pragma warning(pop)
                 }
                 assert(*ci == expected_rng[0]);
             }
@@ -669,8 +687,10 @@ constexpr bool test_one(Rng&& rng, Fn func, Expected&& expected_rng) {
                 same_as<CI&> decltype(auto) ci2 = (ci += 1);
                 assert(&ci2 == &ci);
                 if (ci != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                     assert(*ci == expected_rng[1]);
+#pragma warning(pop)
                 }
 
                 same_as<CI&> decltype(auto) ci3 = (ci -= 1);
@@ -732,14 +752,18 @@ constexpr bool test_one(Rng&& rng, Fn func, Expected&& expected_rng) {
             { // Check operator+
                 same_as<CI> auto ci2 = ci + 1;
                 if (ci2 != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                     assert(*ci2 == expected_rng[1]);
+#pragma warning(pop)
                 }
 
                 same_as<CI> auto ci3 = 1 + ci;
                 if (ci3 != r.end()) {
-#pragma warning(suppress : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+#pragma warning(push)
+#pragma warning(disable : 28020) // The expression '_Param_(1)<1' is not true at this call.
                     assert(*ci3 == expected_rng[1]);
+#pragma warning(pop)
                 }
             }
 

--- a/tests/std/tests/VSO_1804139_static_analysis_warning_with_single_element_array/env.lst
+++ b/tests/std/tests/VSO_1804139_static_analysis_warning_with_single_element_array/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/VSO_1804139_static_analysis_warning_with_single_element_array/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_1804139_static_analysis_warning_with_single_element_array/test.compile.pass.cpp
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// DevCom-10342063 VSO-1804139 False positive C28020 iterating over single element std::array
+
+#include <array>
+#include <cstddef>
+using namespace std;
+
+bool IsSmallPrime(const int val) {
+    static constexpr array<int, 1> small_primes{2};
+
+    for (size_t i = 0; i < small_primes.size(); ++i) {
+        if (val == small_primes[i]) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool IsPrime(const int val) {
+    static constexpr array<int, 10> primes{2, 3, 5, 7, 11, 13, 17, 19, 23, 29};
+
+    for (size_t i = 0; i < primes.size(); ++i) {
+        if (val == primes[i]) {
+            return true;
+        }
+    }
+
+    return false;
+}


### PR DESCRIPTION
# :world_map: Overview
Fixes DevCom-10342063 VSO-1804139 "False positive C28020 iterating over single element `std::array`". Thanks to Hwi-sung Im from the static analysis team for explaining how to fix this with `_Ret_range_(==, _Size)`.

The issue is that we had SAL annotations on `array::operator[]` explaining its precondition, but static analysis didn't know that `array<T, N>::size()` always returns `N`. (By design, it doesn't do interprocedural analysis.) Adding a return annotation allows `/analyze` to understand loops that are guarded by `arr.size()`.

Updating `array` then revealed that `<mdspan>` (which uses `array` extensively) should be updated accordingly.

# :scroll: Commits
* Update product code.
  + Mark `array::size()` with `_Ret_range_(==, _Size)`, which is what fixes the reported bug.
  + As a cleanup, replace `_In_range_(0, _Size - 1)` with `_In_range_(<, _Size)`. I wasn't previously aware of this form, but it appears elsewhere in the MSVC codebase, and is *much* more natural as it aligns with our `_STL_VERIFY` checks.
    - Note: For `array` and `<mdspan>` below, we're always working with `size_t`, so we don't need to worry about negative numbers.
  + In `<mdspan>`, update a comment from citing DevCom-923103 to saying "guaranteed by how `_Rank_dynamic` is calculated". We have an ironclad guarantee here, but the proof is way more subtle than static analysis can reasonably be expected to understand, so this isn't a compiler bug workaround.
  + Update `rank()` with `_Ret_range_` and `static_extent()`, `extent()`, and `stride()` with `_In_range_`.
  + Add a missing check to `layout_stride::mapping::stride()`.
  + Note that `mdspan::extent()` isn't missing a check, it's just performed by `this->_Map.extents().extent(_Idx)` and the message will be sufficiently relevant.
* Update libcxx skips.
  + Update the comment to explain that static analysis isn't exactly wrong here, it just can't see the guarantees. It's not immediately clear to me whether we can improve things further without suppressing the warning, hence it's still "Not analyzed".
  + Update the quoted warning message, affected by the new usage of `_In_range_(<, _Rank)`.
  + Several tests no longer need to be marked as `FAIL`, but one needs to be added (because we have more precondition annotations).
* Add new test coverage.
  + Simplified from the original report. I added both the 1-element case (which warned) and a many-element case (which didn't), to be comprehensive. I verified that this emitted the analysis warning before the product code changes. This is a compile-only test.
* Update std test coverage.
  + In `test_mdspan_support.hpp`, add `assert(i < rank)` so static analysis is happy with the precondition. (Attempting to propagate the annotation to the lambda led to more warnings, since it's used with `invoke()` and `iota_view`.)
  + In the mdspan layout tests, we no longer need to suppress the warning, since `Ext::rank()` is now understood.
  + Change `P0009R18_mdspan_layout_stride` to use `Ext::rank()` instead of the equivalent `strs.size()` so `/analyze` can see the guarantee.
  + In `P0218R1_filesystem`, the `EXPECT` macro calls a function that returns the given `bool`, but `/analyze` doesn't see that, so it doesn't realize we're checking the validity of `index`. Restructure this with a direct test and `EXPECT(false)` (which will still result in decent logging since the line number is captured).
* Update death test coverage.
  + As in a couple of pre-existing cases, we now need to suppress the `/analyze` warning when intentionally making out-of-bounds calls. I mention `/analyze` instead of the internal "PREfast" terminology here.
* Cleanup std test coverage.
  + These suppressions are still necessary because the iterator-based checking doesn't let the static analyzer understand the bounds guarantees. I'm updating the quoted warning messages as previously mentioned. I'm also replacing `suppress` with `push`/`disable`/`pop`, as we've already completely done in the product code, since `suppress` is annoyingly fragile and we should avoid it, despite the additional lines needed to push/disable/pop.
