### PR TITLE
Implement P2787R1 `pmr::generator`

### DIFF
--- a/stl/inc/generator
+++ b/stl/inc/generator
@@ -16,6 +16,9 @@ _EMIT_STL_WARNING(STL4038, "The contents of <generator> are available only with 
 #include <coroutine>
 #include <exception>
 #include <xmemory>
+#ifdef __cpp_lib_byte
+#include <xpolymorphic_allocator.h>
+#endif // defined(__cpp_lib_byte)
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
@@ -504,6 +507,12 @@ private:
     explicit generator(_Gen_secret_tag, coroutine_handle<promise_type> _Coro_) noexcept : _Coro(_Coro_) {}
 };
 
+#ifdef __cpp_lib_byte
+namespace pmr {
+    _EXPORT_STD template <class _Rty, class _Vty = void>
+    using generator = _STD generator<_Rty, _Vty, polymorphic_allocator<>>;
+} // namespace pmr
+#endif // defined(__cpp_lib_byte)
 _STD_END
 
 // TRANSITION, non-_Ugly attribute tokens

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -392,6 +392,7 @@
 // P2693R1 Formatting thread::id And stacktrace
 // P2713R1 Escaping Improvements In std::format
 // P2763R1 Fixing layout_stride's Default Constructor For Fully Static Extents
+// P2787R1 pmr::generator
 // P2833R2 Freestanding Library: inout expected span
 //     (except for __cpp_lib_span which also covers C++26 span::at)
 // P2836R1 basic_const_iterator Should Follow Its Underlying Type's Convertibility


### PR DESCRIPTION
Towards #2936. Makes `pmr::generator` available when `__cpp_lib_byte` is defined (i.e. when `polymorphic_allocator<>` is itself valid).

Test coverage is initially added. Perhaps more stateful-allocator-related stuffs should be tested later.