### PR TITLE
Update _MSVC_STL_UPDATE to August 2024

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -884,7 +884,7 @@
 
 #define _CPPLIB_VER       650
 #define _MSVC_STL_VERSION 143
-#define _MSVC_STL_UPDATE  202407L
+#define _MSVC_STL_UPDATE  202408L
 
 #ifndef _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
 #if defined(__CUDACC__) && defined(__CUDACC_VER_MAJOR__)


### PR DESCRIPTION
resolves #4871, change  to `202408L`
