### PR TITLE
Call CRT `wmemcmp`/`wmemchr` when possible in `char_traits` for better performance

### DIFF
--- a/stl/inc/__msvc_string_view.hpp
+++ b/stl/inc/__msvc_string_view.hpp
@@ -220,6 +220,7 @@ public:
         _In_reads_(_Count) const _Elem* const _First2, const size_t _Count) noexcept /* strengthened */ {
         // compare [_First1, _First1 + _Count) with [_First2, ...)
 #if _HAS_CXX17
+        if constexpr (is_same_v<_Elem, wchar_t>) {
 #if _HAS_CXX20
             if (_STD _Is_constant_evaluated()) {
                 return __builtin_wmemcmp(_First1, _First2, _Count);
@@ -229,6 +230,9 @@ public:
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
             return __builtin_wmemcmp(_First1, _First2, _Count);
 #endif // ^^^ !_HAS_CXX20 ^^^
+        } else {
+            return _Primary_char_traits::compare(_First1, _First2, _Count);
+        }
 #else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
         return _CSTD wmemcmp(
             reinterpret_cast<const wchar_t*>(_First1), reinterpret_cast<const wchar_t*>(_First2), _Count);
@@ -255,12 +259,12 @@ public:
         if constexpr (is_same_v<_Elem, wchar_t>) {
 #if _HAS_CXX20
             if (_STD _Is_constant_evaluated()) {
-                return __builtin_wmemchr(_First1, _Ch, _Count);
+                return __builtin_wmemchr(_First, _Ch, _Count);
             } else {
-                return _CSTD wmemchr(_First1, _Ch, _Count);
+                return _CSTD wmemchr(_First, _Ch, _Count);
             }
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
-            return __builtin_wmemchr(_First1, _Ch, _Count);
+            return __builtin_wmemchr(_First, _Ch, _Count);
 #endif // ^^^ !_HAS_CXX20 ^^^
         } else {
             return _Primary_char_traits::find(_First, _Count, _Ch);

--- a/stl/inc/__msvc_string_view.hpp
+++ b/stl/inc/__msvc_string_view.hpp
@@ -220,19 +220,17 @@ public:
         _In_reads_(_Count) const _Elem* const _First2, const size_t _Count) noexcept /* strengthened */ {
         // compare [_First1, _First1 + _Count) with [_First2, ...)
 #if _HAS_CXX17
-        if constexpr (is_same_v<_Elem, wchar_t>) {
-            if (_STD _Is_constant_evaluated()) {
+        if (_STD _Is_constant_evaluated()) {
+            if constexpr (is_same_v<_Elem, wchar_t>) {
                 return __builtin_wmemcmp(_First1, _First2, _Count);
             } else {
-                return _CSTD wmemcmp(_First1, _First2, _Count);
+                return _Primary_char_traits::compare(_First1, _First2, _Count);
             }
-        } else {
-            return _Primary_char_traits::compare(_First1, _First2, _Count);
         }
-#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
+#endif // _HAS_CXX17
+
         return _CSTD wmemcmp(
             reinterpret_cast<const wchar_t*>(_First1), reinterpret_cast<const wchar_t*>(_First2), _Count);
-#endif // ^^^ !_HAS_CXX17 ^^^
     }
 
     _NODISCARD static _CONSTEXPR17 size_t length(_In_z_ const _Elem* _First) noexcept /* strengthened */ {
@@ -252,18 +250,16 @@ public:
         _In_reads_(_Count) const _Elem* _First, const size_t _Count, const _Elem& _Ch) noexcept /* strengthened */ {
         // look for _Ch in [_First, _First + _Count)
 #if _HAS_CXX17
-        if constexpr (is_same_v<_Elem, wchar_t>) {
-            if (_STD _Is_constant_evaluated()) {
+        if (_STD _Is_constant_evaluated()) {
+            if constexpr (is_same_v<_Elem, wchar_t>) {
                 return __builtin_wmemchr(_First, _Ch, _Count);
             } else {
-                return _CSTD wmemchr(_First, _Ch, _Count);
+                return _Primary_char_traits::find(_First, _Count, _Ch);
             }
-        } else {
-            return _Primary_char_traits::find(_First, _Count, _Ch);
         }
-#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
+#endif // _HAS_CXX17
+
         return reinterpret_cast<const _Elem*>(_CSTD wmemchr(reinterpret_cast<const wchar_t*>(_First), _Ch, _Count));
-#endif // ^^^ !_HAS_CXX17 ^^^
     }
 
     static _CONSTEXPR20 _Elem* assign(

--- a/stl/inc/__msvc_string_view.hpp
+++ b/stl/inc/__msvc_string_view.hpp
@@ -236,14 +236,16 @@ public:
     _NODISCARD static _CONSTEXPR17 size_t length(_In_z_ const _Elem* _First) noexcept /* strengthened */ {
         // find length of null-terminated sequence
 #if _HAS_CXX17
-        if constexpr (is_same_v<_Elem, wchar_t>) {
-            return __builtin_wcslen(_First);
-        } else {
-            return _Primary_char_traits::length(_First);
+        if (_STD _Is_constant_evaluated()) {
+            if constexpr (is_same_v<_Elem, wchar_t>) {
+                return __builtin_wcslen(_First);
+            } else {
+                return _Primary_char_traits::length(_First);
+            }
         }
-#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
+#endif // _HAS_CXX17
+
         return _CSTD wcslen(reinterpret_cast<const wchar_t*>(_First));
-#endif // ^^^ !_HAS_CXX17 ^^^
     }
 
     _NODISCARD static _CONSTEXPR17 const _Elem* find(

--- a/stl/inc/__msvc_string_view.hpp
+++ b/stl/inc/__msvc_string_view.hpp
@@ -222,7 +222,7 @@ public:
 #if _HAS_CXX17
         if constexpr (is_same_v<_Elem, wchar_t>) {
 #if _HAS_CXX20
-            if (_STD _Is_constant_evaluated()) {
+            if (_STD is_constant_evaluated()) {
                 return __builtin_wmemcmp(_First1, _First2, _Count);
             } else {
                 return _CSTD wmemcmp(_First1, _First2, _Count);
@@ -258,7 +258,7 @@ public:
 #if _HAS_CXX17
         if constexpr (is_same_v<_Elem, wchar_t>) {
 #if _HAS_CXX20
-            if (_STD _Is_constant_evaluated()) {
+            if (_STD is_constant_evaluated()) {
                 return __builtin_wmemchr(_First, _Ch, _Count);
             } else {
                 return _CSTD wmemchr(_First, _Ch, _Count);

--- a/stl/inc/__msvc_string_view.hpp
+++ b/stl/inc/__msvc_string_view.hpp
@@ -220,11 +220,15 @@ public:
         _In_reads_(_Count) const _Elem* const _First2, const size_t _Count) noexcept /* strengthened */ {
         // compare [_First1, _First1 + _Count) with [_First2, ...)
 #if _HAS_CXX17
-        if constexpr (is_same_v<_Elem, wchar_t>) {
+#if _HAS_CXX20
+            if (_STD _Is_constant_evaluated()) {
+                return __builtin_wmemcmp(_First1, _First2, _Count);
+            } else {
+                return _CSTD wmemcmp(_First1, _First2, _Count);
+            }
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
             return __builtin_wmemcmp(_First1, _First2, _Count);
-        } else {
-            return _Primary_char_traits::compare(_First1, _First2, _Count);
-        }
+#endif // ^^^ !_HAS_CXX20 ^^^
 #else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
         return _CSTD wmemcmp(
             reinterpret_cast<const wchar_t*>(_First1), reinterpret_cast<const wchar_t*>(_First2), _Count);
@@ -249,7 +253,15 @@ public:
         // look for _Ch in [_First, _First + _Count)
 #if _HAS_CXX17
         if constexpr (is_same_v<_Elem, wchar_t>) {
-            return __builtin_wmemchr(_First, _Ch, _Count);
+#if _HAS_CXX20
+            if (_STD _Is_constant_evaluated()) {
+                return __builtin_wmemchr(_First1, _Ch, _Count);
+            } else {
+                return _CSTD wmemchr(_First1, _Ch, _Count);
+            }
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
+            return __builtin_wmemchr(_First1, _Ch, _Count);
+#endif // ^^^ !_HAS_CXX20 ^^^
         } else {
             return _Primary_char_traits::find(_First, _Count, _Ch);
         }

--- a/stl/inc/__msvc_string_view.hpp
+++ b/stl/inc/__msvc_string_view.hpp
@@ -221,15 +221,11 @@ public:
         // compare [_First1, _First1 + _Count) with [_First2, ...)
 #if _HAS_CXX17
         if constexpr (is_same_v<_Elem, wchar_t>) {
-#if _HAS_CXX20
-            if (_STD is_constant_evaluated()) {
+            if (_STD _Is_constant_evaluated()) {
                 return __builtin_wmemcmp(_First1, _First2, _Count);
             } else {
                 return _CSTD wmemcmp(_First1, _First2, _Count);
             }
-#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
-            return __builtin_wmemcmp(_First1, _First2, _Count);
-#endif // ^^^ !_HAS_CXX20 ^^^
         } else {
             return _Primary_char_traits::compare(_First1, _First2, _Count);
         }
@@ -257,15 +253,11 @@ public:
         // look for _Ch in [_First, _First + _Count)
 #if _HAS_CXX17
         if constexpr (is_same_v<_Elem, wchar_t>) {
-#if _HAS_CXX20
-            if (_STD is_constant_evaluated()) {
+            if (_STD _Is_constant_evaluated()) {
                 return __builtin_wmemchr(_First, _Ch, _Count);
             } else {
                 return _CSTD wmemchr(_First, _Ch, _Count);
             }
-#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
-            return __builtin_wmemchr(_First, _Ch, _Count);
-#endif // ^^^ !_HAS_CXX20 ^^^
         } else {
             return _Primary_char_traits::find(_First, _Count, _Ch);
         }


### PR DESCRIPTION
__builtin_wmemcmp and __builtin_wmemchr are simply lowered to wchar-by-wchar loops by MSVC backend, which may perform poorly than vectorized CRT wmemcmp and wmemchr. Therefore, for non-constexpr cases in string view, we call CRT functions instead of the builtins.  