### PR TITLE
Allow spectre build of debug libraries

### DIFF
--- a/stl/msbuild/stl_1/xmd/dirs.proj
+++ b/stl/msbuild/stl_1/xmd/dirs.proj
@@ -6,9 +6,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\..\crt-common.settings.targets" />
 
-    <ItemGroup Condition="('$(SpectreBuildMode)' == '' or
-                           '$(Configuration)' == 'chk' or
-                           '$(Configuration)' == 'dbg')">
+    <ItemGroup>
         <ProjectFile Include="msvcp_1_xmd_app.vcxproj" />
         <ProjectFile Include="msvcp_1_xmd_kernel32.vcxproj" />
         <ProjectFile Include="msvcp_1_xmd_onecore.vcxproj" />

--- a/stl/msbuild/stl_2/xmd/dirs.proj
+++ b/stl/msbuild/stl_2/xmd/dirs.proj
@@ -6,9 +6,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\..\crt-common.settings.targets" />
 
-    <ItemGroup Condition="('$(SpectreBuildMode)' == '' or
-                           '$(Configuration)' == 'chk' or
-                           '$(Configuration)' == 'dbg')">
+    <ItemGroup>
         <ProjectFile Include="msvcp_2_xmd_app.vcxproj" />
         <ProjectFile Include="msvcp_2_xmd_kernel32.vcxproj" />
         <ProjectFile Include="msvcp_2_xmd_onecore.vcxproj" />

--- a/stl/msbuild/stl_atomic_wait/xmd/dirs.proj
+++ b/stl/msbuild/stl_atomic_wait/xmd/dirs.proj
@@ -6,9 +6,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\..\crt-common.settings.targets" />
 
-    <ItemGroup Condition="('$(SpectreBuildMode)' == '' or
-                           '$(Configuration)' == 'chk' or
-                           '$(Configuration)' == 'dbg')">
+    <ItemGroup>
         <ProjectFile Include="msvcp_atomic_wait_xmd_app.vcxproj" />
         <ProjectFile Include="msvcp_atomic_wait_xmd_kernel32.vcxproj" />
         <ProjectFile Include="msvcp_atomic_wait_xmd_onecore.vcxproj" />

--- a/stl/msbuild/stl_base/dirs.proj
+++ b/stl/msbuild/stl_base/dirs.proj
@@ -12,8 +12,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Condition="'$(CrtBuildMT)'  != 'false'" Include="mt\dirs.proj" />
         <ProjectFile Condition="'$(CrtBuildMT)'  != 'false'" Include="mt1\dirs.proj" />
         <ProjectFile Condition="'$(CrtBuildXMT)' != 'false'" Include="xmt\dirs.proj" />
-        <ProjectFile Condition="'$(CrtBuildXMT)' != 'false' and '$(SpectreBuildMode)' == ''" Include="xmt0\dirs.proj" />
-        <ProjectFile Condition="'$(CrtBuildXMT)' != 'false' and '$(SpectreBuildMode)' == ''" Include="xmt1\dirs.proj" />
+        <ProjectFile Condition="'$(CrtBuildXMT)' != 'false'" Include="xmt0\dirs.proj" />
+        <ProjectFile Condition="'$(CrtBuildXMT)' != 'false'" Include="xmt1\dirs.proj" />
     </ItemGroup>
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Traversal.targets))" />

--- a/stl/msbuild/stl_base/xmd/dirs.proj
+++ b/stl/msbuild/stl_base/xmd/dirs.proj
@@ -6,10 +6,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\..\crt-common.settings.targets" />
 
-    <ItemGroup Condition="('$(SpectreBuildMode)' == '' or
-                           '$(Configuration)' == 'chk' or
-                           '$(Configuration)' == 'dbg')">
-        <!-- Other components in dbg and chk builds depend on msvcprtd.lib -->
+    <ItemGroup>
         <ProjectFile Include="msvcp_base_xmd_app.vcxproj" />
         <ProjectFile Include="msvcp_base_xmd_kernel32.vcxproj" />
         <ProjectFile Include="msvcp_base_xmd_onecore.vcxproj" />

--- a/stl/msbuild/stl_base/xmt/dirs.proj
+++ b/stl/msbuild/stl_base/xmt/dirs.proj
@@ -7,11 +7,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\..\crt-common.settings.targets" />
 
     <ItemGroup>
-        <ProjectFile Condition="'$(SpectreBuildMode)' == '' or
-                                '$(Configuration)' == 'chk' or
-                                '$(Configuration)' == 'dbg'"
-                     Include="libcpmt_xmt_kernel32.vcxproj" />
-        <ProjectFile Condition="'$(SpectreBuildMode)' == ''" Include="libcpmt_xmt_onecore.vcxproj" />
+        <ProjectFile Include="libcpmt_xmt_kernel32.vcxproj" />
+        <ProjectFile Include="libcpmt_xmt_onecore.vcxproj" />
     </ItemGroup>
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove(VCTools.Traversal.targets))" />

--- a/stl/msbuild/stl_codecvt_ids/xmd/dirs.proj
+++ b/stl/msbuild/stl_codecvt_ids/xmd/dirs.proj
@@ -6,9 +6,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\..\crt-common.settings.targets" />
 
-    <ItemGroup Condition="('$(SpectreBuildMode)' == '' or
-                           '$(Configuration)' == 'chk' or
-                           '$(Configuration)' == 'dbg')">
+    <ItemGroup>
         <ProjectFile Include="msvcp_codecvt_ids_xmd_app.vcxproj" />
         <ProjectFile Include="msvcp_codecvt_ids_xmd_kernel32.vcxproj" />
         <ProjectFile Include="msvcp_codecvt_ids_xmd_onecore.vcxproj" />

--- a/stl/msbuild/stl_post/xmd/dirs.proj
+++ b/stl/msbuild/stl_post/xmd/dirs.proj
@@ -6,9 +6,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\..\crt-common.settings.targets" />
 
-    <ItemGroup Condition="('$(SpectreBuildMode)' == '' or
-                           '$(Configuration)' == 'chk' or
-                           '$(Configuration)' == 'dbg')">
+    <ItemGroup>
         <ProjectFile Include="msvcp_post_xmd_app.vcxproj" />
         <ProjectFile Include="msvcp_post_xmd_kernel32.vcxproj" />
         <ProjectFile Include="msvcp_post_xmd_onecore.vcxproj" />


### PR DESCRIPTION
Historically, /Qspectre was only supported in optimized code so spectre-mitigated debug builds were disabled. This is now supported, so this PR enables the build path. Spectre-mitigated debug libraries are useful primarily to reduce friction for customers that would like to release debug versions of their binaries, but have policies preventing production or publication of binaries that are not spectre-mitigated.

Mirrored as MSVC-PR-569343.