### PR TITLE
Build with the conformant preprocessor, improve validator

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 set(CMAKE_BUILD_TYPE RelWithDebInfo)
 
 # /utf-8 affects <format>.
-add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/diagnostics:caret;/W4;/WX;/w14265;/w15038;/w15262;/utf-8>")
+add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/diagnostics:caret;/W4;/WX;/w14265;/w15038;/w15262;/utf-8;/Zc:preprocessor>")
 
 if(NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/google-benchmark/.git")
     message(FATAL_ERROR "google-benchmark is not checked out; make sure to run\n    git submodule update --init benchmarks/google-benchmark")

--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -421,7 +421,7 @@ add_compile_definitions(_CRTBLD _VCRT_ALLOW_INTERNALS _HAS_OLD_IOSTREAMS_MEMBERS
 set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "Embedded")
 
 add_compile_options(/WX /Gy
-    "$<$<COMPILE_LANGUAGE:CXX>:/diagnostics:caret;/W4;/w14265;/w15038;/fastfail;/guard:cf;/Zp8;/std:c++latest;/permissive-;/Zc:threadSafeInit-;/Zl>"
+    "$<$<COMPILE_LANGUAGE:CXX>:/diagnostics:caret;/W4;/w14265;/w15038;/fastfail;/guard:cf;/Zp8;/std:c++latest;/permissive-;/Zc:preprocessor;/Zc:threadSafeInit-;/Zl>"
     "$<$<COMPILE_LANGUAGE:ASM_MASM>:/W3;/nologo;/quiet>"
 )
 

--- a/tools/validate/CMakeLists.txt
+++ b/tools/validate/CMakeLists.txt
@@ -5,7 +5,6 @@ cmake_minimum_required(VERSION 3.29.0)
 project(msvc_standard_libraries_validate LANGUAGES CXX)
 
 add_executable(validate-binary validate.cpp)
-# we use SAL annotations, so pass /analyze
 target_compile_options(validate-binary PRIVATE /W4 /WX /analyze /Zc:preprocessor)
 set_target_properties(validate-binary
     PROPERTIES

--- a/tools/validate/CMakeLists.txt
+++ b/tools/validate/CMakeLists.txt
@@ -6,7 +6,7 @@ project(msvc_standard_libraries_validate LANGUAGES CXX)
 
 add_executable(validate-binary validate.cpp)
 # we use SAL annotations, so pass /analyze
-target_compile_options(validate-binary PRIVATE /W4 /WX /analyze)
+target_compile_options(validate-binary PRIVATE /W4 /WX /analyze /Zc:preprocessor)
 set_target_properties(validate-binary
     PROPERTIES
         CXX_STANDARD 23

--- a/tools/validate/validate.cpp
+++ b/tools/validate/validate.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#define _CRT_SECURE_NO_WARNINGS
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -21,8 +20,10 @@ constexpr size_t max_line_length = 120;
 
 class BinaryFile {
 public:
-    explicit BinaryFile(const filesystem::path& filepath) : m_file(_wfopen(filepath.c_str(), L"rb")) {
-        if (!m_file) {
+    explicit BinaryFile(const filesystem::path& filepath) {
+        const auto err = _wfopen_s(&m_file, filepath.c_str(), L"rb");
+
+        if (err != 0 || !m_file) {
             println(stderr, "Validation failed: {} couldn't be opened.", filepath.string());
         }
     }
@@ -40,7 +41,7 @@ public:
     }
 
     ~BinaryFile() {
-        if (fclose(m_file) != 0) {
+        if (m_file && fclose(m_file) != 0) {
             println(stderr, "fclose() failed.");
             abort();
         }


### PR DESCRIPTION
[`/std:c++latest`][] implies [`/permissive-`][] but not [`/Zc:preprocessor`][], so we have to manually enable it.

[`/std:c++latest`]: https://learn.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version?view=msvc-170
[`/permissive-`]: https://learn.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-170
[`/Zc:preprocessor`]: https://learn.microsoft.com/en-us/cpp/build/reference/zc-preprocessor?view=msvc-170

* Build the STL, benchmarks, and validator with the conformant preprocessor.
  + I've verified that the compiler option is active in each directory.
* Drop "we use SAL annotations" comment.
  + This was added by #2671 on 2022-05-01, then `_Printf_format_string_` was removed by #3919 on 2023-08-03.
  + We can keep using `/analyze`, though. It adds ~4.5 seconds on my machine, but it's not part of the dev inner loop, and Code Format Validation isn't on the critical path (the Early Builds take longer).
* Use `_wfopen_s()` instead of defining `_CRT_SECURE_NO_WARNINGS`.
  + Also avoid crashing in `~BinaryFile()` if the file wasn't successfully opened.
  + Note that `m_file` already has a data member initializer, so it's null before we call `_wfopen_s()`.