### PR TITLE
Overhaul how we search for clang-format

### DIFF
--- a/tools/format/CMakeLists.txt
+++ b/tools/format/CMakeLists.txt
@@ -6,7 +6,7 @@ project(msvc_standard_libraries_format NONE)
 
 find_program(CLANG_FORMAT
     NAMES clang-format
-    HINTS "$ENV{VCINSTALLDIR}/Tools/Llvm/$ENV{VSCMD_ARG_HOST_ARCH}/bin"
+    HINTS "$ENV{VCINSTALLDIR}/Tools/Llvm/x64/bin"
     DOC "The clang-format program to use"
     REQUIRED
 )

--- a/tools/format/CMakeLists.txt
+++ b/tools/format/CMakeLists.txt
@@ -6,6 +6,7 @@ project(msvc_standard_libraries_format NONE)
 
 find_program(CLANG_FORMAT
     NAMES clang-format
+    HINTS "$ENV{VCINSTALLDIR}/Tools/Llvm/$ENV{VSCMD_ARG_HOST_ARCH}/bin"
     DOC "The clang-format program to use"
     REQUIRED
 )

--- a/tools/format/CMakeLists.txt
+++ b/tools/format/CMakeLists.txt
@@ -4,76 +4,67 @@
 cmake_minimum_required(VERSION 3.29.0)
 project(msvc_standard_libraries_format NONE)
 
-set(did_search OFF)
-
-if(NOT DEFINED CLANG_FORMAT)
-    message(STATUS "Searching for VS clang-format")
-    set(did_search ON)
-endif()
-
-if(PROJECT_IS_TOP_LEVEL)
-    set(message_level FATAL_ERROR)
-else()
-    set(message_level WARNING)
-endif()
-
 find_program(CLANG_FORMAT
     NAMES clang-format
-    PATHS "C:/Program Files/Microsoft Visual Studio/2022/Preview/VC/Tools/Llvm/bin"
     DOC "The clang-format program to use"
-    NO_DEFAULT_PATH
-    NO_CMAKE_PATH
-    NO_CMAKE_ENVIRONMENT_PATH
-    NO_SYSTEM_ENVIRONMENT_PATH
-    NO_CMAKE_SYSTEM_PATH
+    REQUIRED
 )
 
-if(CLANG_FORMAT)
-    if(did_search)
-        message(STATUS "Searching for VS clang-format - found")
+execute_process(
+    COMMAND "${CLANG_FORMAT}" --version
+    OUTPUT_VARIABLE clang_format_version
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if(clang_format_version MATCHES "clang-format version ([0-9]+\.[0-9]+\.[0-9]+)")
+    set(expected_version "17.0.3")
+    if(CMAKE_MATCH_1 VERSION_LESS expected_version)
+        message(FATAL_ERROR "Found clang-format ${CMAKE_MATCH_1}, older than expected ${expected_version}.")
+    elseif(CMAKE_MATCH_1 VERSION_EQUAL expected_version)
+        message(STATUS "Found clang-format ${CMAKE_MATCH_1}.")
+    elseif(CMAKE_MATCH_1 VERSION_GREATER expected_version)
+        message(WARNING "Found clang-format ${CMAKE_MATCH_1}, newer than expected ${expected_version}.")
     endif()
-
-    file(GLOB_RECURSE maybe_clang_format_files
-        "../../benchmarks/inc/*"
-        "../../benchmarks/src/*"
-        "../../stl/inc/*"
-        "../../stl/modules/*"
-        "../../stl/src/*"
-        "../../tests/*"
-        "../../tools/*"
-    )
-    set(clang_format_files "")
-
-    foreach(maybe_file IN LISTS maybe_clang_format_files)
-        cmake_path(GET maybe_file FILENAME filename)
-        cmake_path(GET maybe_file EXTENSION LAST_ONLY extension)
-
-        if(extension MATCHES [[^(|\.cpp|\.h|\.hpp|\.ixx)$]] AND NOT filename MATCHES [[^\.]])
-            list(APPEND clang_format_files "${maybe_file}")
-        endif()
-    endforeach()
-
-    if(NOT clang_format_files)
-        message("${message_level}" "Could not find any files to clang-format!")
-    endif()
-
-    add_custom_target(run-format)
-
-    foreach(file IN LISTS clang_format_files)
-        cmake_path(RELATIVE_PATH file
-            BASE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../.."
-            OUTPUT_VARIABLE relative-file
-        )
-        string(REPLACE "/" "_" relative-file "${relative-file}")
-        set(target_name "clang-format.${relative-file}")
-        add_custom_target("${target_name}"
-            COMMAND "${CLANG_FORMAT}" -style=file -i "${file}"
-            WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../.."
-        )
-        add_dependencies(run-format "${target_name}")
-    endforeach()
 else()
-    if(did_search)
-        message("${message_level}" "Searching for VS clang-format - not found.")
-    endif()
+    message(FATAL_ERROR "Unexpected `clang-format --version` output: '${clang_format_version}'")
 endif()
+
+file(GLOB_RECURSE maybe_clang_format_files
+    "../../benchmarks/inc/*"
+    "../../benchmarks/src/*"
+    "../../stl/inc/*"
+    "../../stl/modules/*"
+    "../../stl/src/*"
+    "../../tests/*"
+    "../../tools/*"
+)
+set(clang_format_files "")
+
+foreach(maybe_file IN LISTS maybe_clang_format_files)
+    cmake_path(GET maybe_file FILENAME filename)
+    cmake_path(GET maybe_file EXTENSION LAST_ONLY extension)
+
+    if(extension MATCHES [[^(|\.cpp|\.h|\.hpp|\.ixx)$]] AND NOT filename MATCHES [[^\.]])
+        list(APPEND clang_format_files "${maybe_file}")
+    endif()
+endforeach()
+
+if(NOT clang_format_files)
+    message(FATAL_ERROR "Could not find any files to clang-format!")
+endif()
+
+add_custom_target(run-format)
+
+foreach(file IN LISTS clang_format_files)
+    cmake_path(RELATIVE_PATH file
+        BASE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../.."
+        OUTPUT_VARIABLE relative-file
+    )
+    string(REPLACE "/" "_" relative-file "${relative-file}")
+    set(target_name "clang-format.${relative-file}")
+    add_custom_target("${target_name}"
+        COMMAND "${CLANG_FORMAT}" -style=file -i "${file}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../.."
+    )
+    add_dependencies(run-format "${target_name}")
+endforeach()


### PR DESCRIPTION
Our CMake machinery for clang-format is awesome, but it's remained largely unchanged since being added by #2671 on 2022-05-01. Thanks to @TheStormN for bringing my attention to issues here.

The first problem is that we're looking for the clang-format executable in a hardcoded path. That's easily broken if a contributor has installed VS Preview to a non-default location.

Second, during configuration of the STL build, we're simply warning about clang-format being missing. This isn't really helpful - to be successful, contributors really need to have both Clang installed (for testing) and clang-format (to make all but the most trivial source changes without over-relying on PR checks).

Third, we weren't validating what version of clang-format we're picking up. clang-format routinely changes behavior between different major versions, so it's important for all contributors to use the same version that the PR checks are validating.

I'm still a CMake novice, but I've managed to overhaul how we handle clang-format here.

* I'm dropping the machinery that verbosely printed "Searching for VS clang-format". We'll still print something at the very end. CMake's own caching machinery will ensure that we run the search only once.
* I'm dropping the "if project is top-level" logic. We're going to search for clang-format when configuring the STL as a whole, so we'll be ready if the `format` target is invoked later, and this isn't going to affect whether we emit warnings or errors.
* Instead of telling CMake [`find_program`](https://cmake.org/cmake/help/latest/command/find_program.html) to search hardcoded `PATHS` with no defaults (aside: just `NO_DEFAULT_PATH` would have been sufficient, everything below was redundant), actually use CMake's default behavior, which will search the environment's `PATH` (among other things). This is how we expect to pick up `cl.exe`, `clang-cl.exe`, etc.
* Additionally, mark it as `REQUIRED`. This will emit a hard error if `clang-format` isn't found. (Tested by temporarily removing LLVM from my `PATH`.)
* Then, use CMake [`execute_process`](https://cmake.org/cmake/help/latest/command/execute_process.html) to run `clang-format --version` and inspect the output.
  + `OUTPUT_STRIP_TRAILING_WHITESPACE` is necessary to strip newlines.
  + If we don't recognize the output at all, emit a fatal error and print what it was. (Tested by temporarily damaging the expected string.)
  + If we do recognize it, use a regex to extract the version number, and perform version-aware comparisons (this is cool).
    - See CMake's documentation for [Comparisons](https://cmake.org/cmake/help/latest/command/if.html#comparisons) and [Version Comparisons](https://cmake.org/cmake/help/latest/command/if.html#version-comparisons).
  + If we found an *older* clang-format, there's no excuse - emit a hard error. Print what we found and expected. (Tested by manually adjusting the expected version.)
  + If we found the exact version, then print a status message mentioning it. (Like before, just less verbose.)
  + If we found a *newer* clang-format, emit a warning mentioning the version numbers (similarly tested). There are a couple of reasons why this might happen - perhaps someone has gotten clever and installed a newer Clang/LLVM than the one that's shipping in VS. Or, VS might have just upgraded its Clang version, but we're in the (typically very brief) window between the release of a new VS Preview and when we merge a toolset update that re-formats the codebase. In this case, a contributor or maintainer with a freshly upgraded VS Preview will be running a newer clang-format than what the repo expects. This shouldn't be a fatal error, but the warning will let the contributor/maintainer know to look out for unexpected formatting diffs and manually deal with them.
* If our search for files to clang-format doesn't find anything, that should always be a fatal error. Something would be seriously wrong there.
