### PR TITLE
Toolset update: VS 2022 17.12 Preview 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
     if you would like to build the ARM target.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.29.0 or later, and [Ninja][] 1.11.0 or later.
+    * Otherwise, install [CMake][] 3.29.0 or later, and [Ninja][] 1.12.1 or later.
     * Make sure [Python][] 3.12 or later is available to CMake.
 2. Open Visual Studio, and choose the "Clone or check out code" option. Enter the URL of this repository,
    `https://github.com/microsoft/STL`.
@@ -168,7 +168,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
     if you would like to build the ARM target.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.29.0 or later, and [Ninja][] 1.11.0 or later.
+    * Otherwise, install [CMake][] 3.29.0 or later, and [Ninja][] 1.12.1 or later.
     * Make sure [Python][] 3.12 or later is available to CMake.
 2. Open a command prompt.
 3. Change directories to a location where you'd like a clone of this STL repository.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.11 Preview 3 or later.
+1. Install Visual Studio 2022 17.12 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.
@@ -160,7 +160,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.11 Preview 3 or later.
+1. Install Visual Studio 2022 17.12 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,7 +5,7 @@
 
 variables:
 - name: poolName
-  value: 'StlBuild-2024-07-09T1614-Pool'
+  value: 'StlBuild-2024-08-14T0018-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -40,7 +40,7 @@ foreach ($workload in $VisualStudioWorkloads) {
 }
 
 # https://github.com/PowerShell/PowerShell/releases/latest
-$PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.4.3/PowerShell-7.4.3-win-x64.msi'
+$PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.4.4/PowerShell-7.4.4-win-x64.msi'
 $PowerShellArgs = @('/quiet', '/norestart')
 
 $PythonUrl = 'https://www.python.org/ftp/python/3.12.4/python-3.12.4-amd64.exe'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -43,7 +43,7 @@ foreach ($workload in $VisualStudioWorkloads) {
 $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.4.4/PowerShell-7.4.4-win-x64.msi'
 $PowerShellArgs = @('/quiet', '/norestart')
 
-$PythonUrl = 'https://www.python.org/ftp/python/3.12.4/python-3.12.4-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.12.5/python-3.12.5-amd64.exe'
 $PythonArgs = @('/quiet', 'InstallAllUsers=1', 'PrependPath=1', 'CompileAll=1', 'Include_doc=0')
 
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/12.4.0/local_installers/cuda_12.4.0_551.61_windows.exe'

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1295,23 +1295,14 @@ template <class _Ty1, class _Ty2>
 using _Conditional_type = decltype(false ? _STD declval<_Ty1>() : _STD declval<_Ty2>());
 
 #if _HAS_CXX20
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10648215
 template <class _Ty1, class _Ty2>
-#else // ^^^ no workaround / workaround vvv
-template <class _Ty1, class _Ty2, class = void>
-#endif // ^^^ workaround ^^^
-struct _Const_lvalue_cond_oper {
-};
+struct _Const_lvalue_cond_oper {};
 
 // N4950 [meta.trans.other]/3.3.4 (per the proposed resolution of LWG-3205): "Otherwise, if remove_cvref_t</**/> denotes
 // a type..."
 template <class _Ty1, class _Ty2>
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10648215
     requires requires { typename _Conditional_type<const _Ty1&, const _Ty2&>; }
 struct _Const_lvalue_cond_oper<_Ty1, _Ty2> {
-#else // ^^^ no workaround / workaround vvv
-struct _Const_lvalue_cond_oper<_Ty1, _Ty2, void_t<_Conditional_type<const _Ty1&, const _Ty2&>>> {
-#endif // ^^^ workaround ^^^
     using type = remove_cvref_t<_Conditional_type<const _Ty1&, const _Ty2&>>;
 };
 

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2087,7 +2087,6 @@ namespace {
             _Advance_bytes(_First, sizeof(_Ty));
         }
 
-#pragma loop(no_vector) // TRANSITION, VSO-2093761: work around a compiler back-end assertion
         for (auto _Ptr = static_cast<const _Ty*>(_First); _Ptr != _Last; ++_Ptr) {
             if constexpr ((_Mode & _Mode_min) != 0) {
                 if (*_Ptr < _Cur_min_val) {

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -348,7 +348,7 @@ std/concepts/concepts.compare/concept.equalitycomparable/equality_comparable_wit
 std/containers/sequences/array/array.cons/initialization.pass.cpp:0 FAIL
 std/containers/sequences/array/array.cons/initialization.pass.cpp:1 FAIL
 
-# DevCom-10456523: MSVC incorrectly raises constant evaluation failure in pointer comparison
+# DevCom-10456523 VSO-1880569: MSVC incorrectly raises constant evaluation failure in pointer comparison
 std/algorithms/robust_against_adl.compile.pass.cpp:0 FAIL
 std/algorithms/robust_against_adl.compile.pass.cpp:1 FAIL
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -321,7 +321,7 @@ std/utilities/utility/pairs/pairs.spec/three_way_comparison.pass.cpp:1 FAIL
 std/utilities/variant/variant.relops/three_way.pass.cpp:0 FAIL
 std/utilities/variant/variant.relops/three_way.pass.cpp:1 FAIL
 
-# DevCom-1626727 VSO-1457307: bogus "failure was caused by a conversion from void* to a pointer-to-object type" for conversion to void
+# VSO-2188243 constexpr ICE in C1XX adapt::to_prvalue
 std/algorithms/robust_re_difference_type.compile.pass.cpp:0 FAIL
 std/algorithms/robust_re_difference_type.compile.pass.cpp:1 FAIL
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -228,6 +228,9 @@ std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_strong.pa
 std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_weak.pass.cpp:1 SKIPPED
 std/input.output/syncstream/osyncstream/thread/several_threads.pass.cpp:1 SKIPPED
 
+# VSO-2164191 "[ASAN][STL] Interception breaks strtoll"
+std/strings/string.conversions/stoll.pass.cpp:1 FAIL
+
 
 # *** MISSING STL FEATURES ***
 # Missing mbrtoc8 and c8rtomb


### PR DESCRIPTION
# :scroll: Changelog
- Code cleanups:
  * Removed compiler bug workarounds.
- Infrastructure improvements:
  * Updated dependencies.
    + Updated build compiler to VS 2022 17.12 Preview 1.
    + Updated Ninja to 1.12.1.
    + Updated Python to 3.12.5.

# :gear: Commits
* PowerShell 7.4.4.
* Python 3.12.5.
* New pool.
* VS 2022 17.12 Preview 1.
  + Not yet required, because the MSVC-internal build is still using 17.11.
* Ninja 1.12.1.
* Remove workaround for DevCom-10648215 VSO-2048353.
* Remove workaround for VSO-2093761.
* Add workaround for VSO-2164191 "\[ASAN\]\[STL\] Interception breaks strtoll".
  + [AddressSanitizer-PR-566123](https://devdiv.visualstudio.com/DevDiv/_git/AddressSanitizer/pullrequest/566123) and MSVC-PR-566126 are fixing this, likely in VS 2022 17.12 Preview 3. (Thanks, @dmitrykobets-msft!)
  + This is very similar to VSO-1875597 "\[ASAN\]\[STL\] Interception breaks strtol"; #4492 removed that workaround.
* Update bug citation: DevCom-1626727 VSO-1457307 was fixed, VSO-2188243 is still active.
* Add VSO citation: DevCom-10456523 is VSO-1880569.
