### PR TITLE
Update boost-math to 1.86.0.

### DIFF
--- a/docs/cgmanifest.json
+++ b/docs/cgmanifest.json
@@ -6,7 +6,7 @@
                 "type": "git",
                 "git": {
                     "repositoryUrl": "https://github.com/boostorg/math",
-                    "commitHash": "4d0885ae44f7d4ce94568339b2ae5501eb234e8f"
+                    "commitHash": "4c2cdc2cf67060db2053a5db10da344cf7d42681"
                 }
             }
         },


### PR DESCRIPTION
https://github.com/boostorg/math/releases/tag/boost-1.86.0