### PR TITLE
Casey's accumulated miscellaneous changes

### DIFF
--- a/stl/inc/__msvc_iter_core.hpp
+++ b/stl/inc/__msvc_iter_core.hpp
@@ -456,8 +456,10 @@ _EXPORT_STD using ranges::get;
 template <class _It, class _Se, ranges::subrange_kind _Ki>
 constexpr bool _Is_subrange_v<ranges::subrange<_It, _Se, _Ki>> = true;
 
+#if _HAS_CXX23
 template <class _It, class _Se, ranges::subrange_kind _Ki>
 constexpr bool _Tuple_like_impl<ranges::subrange<_It, _Se, _Ki>> = true;
+#endif // _HAS_CXX23
 
 template <class _It, class _Se, ranges::subrange_kind _Ki>
 struct tuple_size<ranges::subrange<_It, _Se, _Ki>> : integral_constant<size_t, 2> {};

--- a/stl/inc/__msvc_iter_core.hpp
+++ b/stl/inc/__msvc_iter_core.hpp
@@ -457,6 +457,9 @@ template <class _It, class _Se, ranges::subrange_kind _Ki>
 constexpr bool _Is_subrange_v<ranges::subrange<_It, _Se, _Ki>> = true;
 
 template <class _It, class _Se, ranges::subrange_kind _Ki>
+constexpr bool _Tuple_like_impl<ranges::subrange<_It, _Se, _Ki>> = true;
+
+template <class _It, class _Se, ranges::subrange_kind _Ki>
 struct tuple_size<ranges::subrange<_It, _Se, _Ki>> : integral_constant<size_t, 2> {};
 
 template <class _It, class _Se, ranges::subrange_kind _Ki>

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -1209,7 +1209,7 @@ public:
     };
 
     auto remove(const _Ty& _Val) { // erase each element matching _Val
-        return remove_if([&](const _Ty& _Other) { return _Other == _Val; });
+        return remove_if([&](const _Ty& _Other) -> bool { return _Other == _Val; });
     }
 
     template <class _Pr1>
@@ -1614,7 +1614,7 @@ _NODISCARD bool operator>=(const forward_list<_Ty, _Alloc>& _Left, const forward
 #if _HAS_CXX20
 _EXPORT_STD template <class _Ty, class _Alloc, class _Uty>
 forward_list<_Ty, _Alloc>::size_type erase(forward_list<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
-    return _Cont.remove_if([&](_Ty& _Elem) { return _Elem == _Val; });
+    return _Cont.remove_if([&](_Ty& _Elem) -> bool { return _Elem == _Val; });
 }
 
 _EXPORT_STD template <class _Ty, class _Alloc, class _Pr>

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -1663,7 +1663,7 @@ public:
     };
 
     auto remove(const _Ty& _Val) { // erase each element matching _Val
-        return remove_if([&](const _Ty& _Other) { return _Other == _Val; });
+        return remove_if([&](const _Ty& _Other) -> bool { return _Other == _Val; });
     }
 
     template <class _Pr1>
@@ -1916,7 +1916,7 @@ _NODISCARD bool operator>=(const list<_Ty, _Alloc>& _Left, const list<_Ty, _Allo
 #if _HAS_CXX20
 _EXPORT_STD template <class _Ty, class _Alloc, class _Uty>
 list<_Ty, _Alloc>::size_type erase(list<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
-    return _Cont.remove_if([&](_Ty& _Elem) { return _Elem == _Val; });
+    return _Cont.remove_if([&](_Ty& _Elem) -> bool { return _Elem == _Val; });
 }
 
 _EXPORT_STD template <class _Ty, class _Alloc, class _Pr>

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -9091,9 +9091,8 @@ namespace ranges {
                 requires (indirectly_swappable<iterator_t<_Maybe_const<_Const, _First>>> && ...
                           && indirectly_swappable<iterator_t<_Maybe_const<_Const, _Rest>>>)
             {
-                return [&]<size_t... _Indices>(index_sequence<_Indices...>) {
-                    return (_RANGES iter_swap(_STD get<_Indices>(_Left._Current), _STD get<_Indices>(_Right._Current)),
-                        ...);
+                [&]<size_t... _Indices>(index_sequence<_Indices...>) {
+                    (_RANGES iter_swap(_STD get<_Indices>(_Left._Current), _STD get<_Indices>(_Right._Current)), ...);
                 }(make_index_sequence<1 + sizeof...(_Rest)>{});
             }
         };

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -7455,6 +7455,11 @@ namespace ranges {
             }
         }
 
+        static constexpr auto _Size_closure = [](auto... _Sizes) _STATIC_CALL_OPERATOR noexcept {
+            using _Common_unsigned_type = _Make_unsigned_like_t<common_type_t<decltype(_Sizes)...>>;
+            return (_RANGES min)({static_cast<_Common_unsigned_type>(_Sizes)...});
+        };
+
     public:
         zip_view() noexcept((is_nothrow_default_constructible_v<_ViewTypes> && ...)) = default;
 
@@ -7501,25 +7506,17 @@ namespace ranges {
         }
 
         _NODISCARD constexpr auto size() noexcept(
-            noexcept(_STD apply(_Size_closure(), _Tuple_transform(_RANGES size, _Views)))) // strengthened
+            noexcept(_STD apply(_Size_closure, _Tuple_transform(_RANGES size, _Views)))) // strengthened
             requires (sized_range<_ViewTypes> && ...)
         {
-            return _STD apply(_Size_closure(), _Tuple_transform(_RANGES size, _Views));
+            return _STD apply(_Size_closure, _Tuple_transform(_RANGES size, _Views));
         }
 
         _NODISCARD constexpr auto size() const
-            noexcept(noexcept(_STD apply(_Size_closure(), _Tuple_transform(_RANGES size, _Views)))) // strengthened
+            noexcept(noexcept(_STD apply(_Size_closure, _Tuple_transform(_RANGES size, _Views)))) // strengthened
             requires (sized_range<const _ViewTypes> && ...)
         {
-            return _STD apply(_Size_closure(), _Tuple_transform(_RANGES size, _Views));
-        }
-
-    private:
-        _NODISCARD static constexpr auto _Size_closure() noexcept {
-            return [](auto... _Sizes) _STATIC_CALL_OPERATOR noexcept {
-                using _Common_unsigned_type = _Make_unsigned_like_t<common_type_t<decltype(_Sizes)...>>;
-                return (_RANGES min)({static_cast<_Common_unsigned_type>(_Sizes)...});
-            };
+            return _STD apply(_Size_closure, _Tuple_transform(_RANGES size, _Views));
         }
     };
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -7134,7 +7134,7 @@ namespace ranges {
         const auto _Evaluate_equality_closure =
             [&_Lhs_tuple, &_Rhs_tuple]<size_t... _Indices>(index_sequence<_Indices...>) noexcept(
                 (noexcept(_STD declval<const _LHSTupleTypes&>() == _STD declval<const _RHSTupleTypes&>())&&...)) {
-                return ((_STD get<_Indices>(_Lhs_tuple) == _STD get<_Indices>(_Rhs_tuple)) || ...);
+                return ((_STD get<_Indices>(_Lhs_tuple) == _STD get<_Indices>(_Rhs_tuple)) || ... || false);
             };
 
         return _Evaluate_equality_closure(index_sequence_for<_LHSTupleTypes...>{});
@@ -9141,7 +9141,7 @@ namespace ranges {
             requires ((!_Simple_view<_First> || ... || !_Simple_view<_Rest>) && _Cartesian_product_is_common<_First>)
         {
             const bool _Is_empty = [&]<size_t... _Indices>(index_sequence<_Indices...>) {
-                return (_RANGES empty(_STD get<_Indices + 1>(_Bases)) || ...);
+                return (_RANGES empty(_STD get<_Indices + 1>(_Bases)) || ... || false);
             }(make_index_sequence<sizeof...(_Rest)>{});
 
             const auto _Make_iter_tuple = [&]<size_t... _Indices>(index_sequence<_Indices...>) {
@@ -9154,7 +9154,7 @@ namespace ranges {
             requires _Cartesian_product_is_common<const _First>
         {
             const bool _Is_empty = [&]<size_t... _Indices>(index_sequence<_Indices...>) {
-                return (_RANGES empty(_STD get<_Indices + 1>(_Bases)) || ...);
+                return (_RANGES empty(_STD get<_Indices + 1>(_Bases)) || ... || false);
             }(make_index_sequence<sizeof...(_Rest)>{});
 
             const auto _Make_iter_tuple = [&]<size_t... _Indices>(index_sequence<_Indices...>) {

--- a/stl/inc/span
+++ b/stl/inc/span
@@ -235,6 +235,12 @@ constexpr bool _Is_span_v = false;
 template <class _Ty, size_t _Extent>
 constexpr bool _Is_span_v<span<_Ty, _Extent>> = true;
 
+template <class>
+constexpr bool _Is_std_array_v = false;
+
+template <class _Ty, size_t _Size>
+constexpr bool _Is_std_array_v<array<_Ty, _Size>> = true;
+
 // clang-format off
 template <class _It, class _Ty>
 concept _Span_compatible_iterator = contiguous_iterator<_It>

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -201,18 +201,20 @@ template <class _Ty1, class _Ty2>
 concept _Different_from = !same_as<remove_cvref_t<_Ty1>, remove_cvref_t<_Ty2>>;
 
 template <class>
-constexpr bool _Is_std_array_v = false;
-
-template <class _Ty, size_t _Size>
-constexpr bool _Is_std_array_v<array<_Ty, _Size>> = true;
-
-template <class>
 constexpr bool _Is_subrange_v = false;
 
 #if _HAS_CXX23
-template <class _Ty>
-constexpr bool _Tuple_like_impl =
-    _Is_specialization_v<_Ty, tuple> || _Is_specialization_v<_Ty, pair> || _Is_std_array_v<_Ty> || _Is_subrange_v<_Ty>;
+template <class>
+constexpr bool _Tuple_like_impl = false;
+
+template <class... _Types>
+constexpr bool _Tuple_like_impl<tuple<_Types...>> = true;
+
+template <class _Ty1, class _Ty2>
+constexpr bool _Tuple_like_impl<pair<_Ty1, _Ty2>> = true;
+
+template <class _Ty, size_t _Size>
+constexpr bool _Tuple_like_impl<array<_Ty, _Size>> = true;
 
 template <class _Ty>
 concept _Tuple_like = _Tuple_like_impl<remove_cvref_t<_Ty>>;

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -2232,8 +2232,8 @@ void test_reinit_regression() {
     }
 }
 
-// Defend against regression of llvm-project#59854, in which clang is confused
-// by the explicit `noexcept` on `expected`'s destructors.
+// Defend against regression of LLVM-59854, in which clang is confused by the
+// explicit `noexcept` on `expected`'s destructors.
 struct Data {
     vector<int> vec_;
     constexpr Data(initializer_list<int> il) : vec_(il) {}


### PR DESCRIPTION
A grab bag of minor changes broken down for quick-and-easy commit-wise review:

* `<ranges>`: simplify `zip_view::_Size_closure` by making it a `static constexpr` data member instead of a function
* Use conventional LLVM issue linking style
* Simplify `_Tuple_like` metaprogramming: implements `_Tuple_like_impl` as a variable template with four partial specializations instead of as a disjunction of four other variable template specializations. Consequently, each evaluation of `_Tuple_like` causes the compiler to memoize one constexpr variable instead of five.
* Don't return a decayed *boolean-testable* since the exposition-only concept doesn't allow for construction of an object of decayed type from a model of *boolean-testable*. Note that the changes in `erase_if(forward_list, pred)` and `erase_if(list, pred)` are the proposed resolution of LWG-4135, which I feel is a no-brainer and can be implemented without comments. I audited for other occurrences after noticing we do the same thing in `forward_list::remove` and `list::remove`.
  The fold expressions in `<ranges>` are a weird case: they are only problematic when the pack has one element. For zero or more than one elements, the fold expression has type `bool`, but with exactly one element it's a *boolean-testable* that the lambda implicitly decays on return. I think it's a bit more elegant to fix these by adding `|| false` to the fold expressions to make them binary than to explicitly specify the return type of the lambda.
* Don't `return` in `cartesian_product_view::_Iterator::iter_swap`. We _can_ `return` an expression with `void` type in a function with return type `void`, but we typically don't do so when the types are concrete.

I could be convinced that the *boolean-testable* change deserves to be in a separate PR with some test coverage. 