### PR TITLE
Speculatively implement LWG-4139 [time.zone.leap] recursive constraint in `<=>`

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -1944,65 +1944,75 @@ namespace chrono {
             return _Elapsed_offset;
         }
 
+        _NODISCARD friend constexpr bool operator==(const leap_second& _Left, const leap_second& _Right) noexcept {
+            return _Left.date() == _Right.date();
+        }
+        template <class _Duration>
+        _NODISCARD friend constexpr bool operator==(
+            const leap_second& _Left, const sys_time<_Duration>& _Right) noexcept {
+            return _Left.date() == _Right;
+        }
+
+        template <class _Duration>
+        _NODISCARD friend constexpr bool operator<(
+            const leap_second& _Left, const sys_time<_Duration>& _Right) noexcept {
+            return _Left.date() < _Right;
+        }
+        template <class _Duration>
+        _NODISCARD friend constexpr bool operator<(
+            const sys_time<_Duration>& _Left, const leap_second& _Right) noexcept {
+            return _Left < _Right.date();
+        }
+
+        template <class _Duration>
+        _NODISCARD friend constexpr bool operator>(
+            const leap_second& _Left, const sys_time<_Duration>& _Right) noexcept {
+            return _Right < _Left.date();
+        }
+        template <class _Duration>
+        _NODISCARD friend constexpr bool operator>(
+            const sys_time<_Duration>& _Left, const leap_second& _Right) noexcept {
+            return _Right.date() < _Left;
+        }
+
+        template <class _Duration>
+        _NODISCARD friend constexpr bool operator<=(
+            const leap_second& _Left, const sys_time<_Duration>& _Right) noexcept {
+            return !(_Right < _Left.date());
+        }
+        template <class _Duration>
+        _NODISCARD friend constexpr bool operator<=(
+            const sys_time<_Duration>& _Left, const leap_second& _Right) noexcept {
+            return !(_Right.date() < _Left);
+        }
+
+        template <class _Duration>
+        _NODISCARD friend constexpr bool operator>=(
+            const leap_second& _Left, const sys_time<_Duration>& _Right) noexcept {
+            return !(_Left.date() < _Right);
+        }
+        template <class _Duration>
+        _NODISCARD friend constexpr bool operator>=(
+            const sys_time<_Duration>& _Left, const leap_second& _Right) noexcept {
+            return !(_Left < _Right.date());
+        }
+
+        template <class _Duration>
+            requires three_way_comparable_with<sys_seconds, sys_time<_Duration>>
+        _NODISCARD friend constexpr auto operator<=>(
+            const leap_second& _Left, const sys_time<_Duration>& _Right) noexcept {
+            return _Left.date() <=> _Right;
+        }
+        _NODISCARD friend constexpr strong_ordering operator<=>(
+            const leap_second& _Left, const leap_second& _Right) noexcept {
+            return _Left.date() <=> _Right.date();
+        }
+
     private:
         sys_seconds _Date;
         bool _Is_positive;
         seconds _Elapsed_offset;
     };
-
-    _EXPORT_STD _NODISCARD constexpr bool operator==(const leap_second& _Left, const leap_second& _Right) noexcept {
-        return _Left.date() == _Right.date();
-    }
-    _EXPORT_STD template <class _Duration>
-    _NODISCARD constexpr bool operator==(const leap_second& _Left, const sys_time<_Duration>& _Right) noexcept {
-        return _Left.date() == _Right;
-    }
-
-    _EXPORT_STD template <class _Duration>
-    _NODISCARD constexpr bool operator<(const leap_second& _Left, const sys_time<_Duration>& _Right) noexcept {
-        return _Left.date() < _Right;
-    }
-    _EXPORT_STD template <class _Duration>
-    _NODISCARD constexpr bool operator<(const sys_time<_Duration>& _Left, const leap_second& _Right) noexcept {
-        return _Left < _Right.date();
-    }
-
-    _EXPORT_STD template <class _Duration>
-    _NODISCARD constexpr bool operator>(const leap_second& _Left, const sys_time<_Duration>& _Right) noexcept {
-        return _Right < _Left.date();
-    }
-    _EXPORT_STD template <class _Duration>
-    _NODISCARD constexpr bool operator>(const sys_time<_Duration>& _Left, const leap_second& _Right) noexcept {
-        return _Right.date() < _Left;
-    }
-
-    _EXPORT_STD template <class _Duration>
-    _NODISCARD constexpr bool operator<=(const leap_second& _Left, const sys_time<_Duration>& _Right) noexcept {
-        return !(_Right < _Left.date());
-    }
-    _EXPORT_STD template <class _Duration>
-    _NODISCARD constexpr bool operator<=(const sys_time<_Duration>& _Left, const leap_second& _Right) noexcept {
-        return !(_Right.date() < _Left);
-    }
-
-    _EXPORT_STD template <class _Duration>
-    _NODISCARD constexpr bool operator>=(const leap_second& _Left, const sys_time<_Duration>& _Right) noexcept {
-        return !(_Left.date() < _Right);
-    }
-    _EXPORT_STD template <class _Duration>
-    _NODISCARD constexpr bool operator>=(const sys_time<_Duration>& _Left, const leap_second& _Right) noexcept {
-        return !(_Left < _Right.date());
-    }
-
-    _EXPORT_STD template <class _Duration>
-        requires three_way_comparable_with<sys_seconds, sys_time<_Duration>>
-    _NODISCARD constexpr auto operator<=>(const leap_second& _Left, const sys_time<_Duration>& _Right) noexcept {
-        return _Left.date() <=> _Right;
-    }
-    _EXPORT_STD _NODISCARD constexpr strong_ordering operator<=>(
-        const leap_second& _Left, const leap_second& _Right) noexcept {
-        return _Left.date() <=> _Right.date();
-    }
 
     // [time.zone.link]
 

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_clocks/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_clocks/test.cpp
@@ -476,7 +476,7 @@ void test() {
     }
 }
 
-// LWG-4139 "§[time.zone.leap] recursive constraint in <=>"
+// LWG-4139 "[time.zone.leap] recursive constraint in <=>"
 namespace lwg_4139 {
     struct conv_to_leap_second : local_t {
         operator leap_second() const noexcept;

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_clocks/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_clocks/test.cpp
@@ -12,6 +12,7 @@
 #include <type_traits>
 #include <utility>
 
+#include <is_permissive.hpp>
 #include <timezone_data.hpp>
 
 using namespace std;
@@ -482,12 +483,12 @@ namespace lwg_4139 {
         operator leap_second() const noexcept;
     };
 
-    static_assert(!equality_comparable<conv_to_leap_second>);
-    static_assert(!equality_comparable_with<conv_to_leap_second, leap_second>);
-    static_assert(!totally_ordered<conv_to_leap_second>);
-    static_assert(!totally_ordered_with<conv_to_leap_second, leap_second>);
-    static_assert(!three_way_comparable<conv_to_leap_second>);
-    static_assert(!three_way_comparable_with<conv_to_leap_second, leap_second>);
+    static_assert(equality_comparable<conv_to_leap_second> == is_permissive);
+    static_assert(equality_comparable_with<conv_to_leap_second, leap_second> == is_permissive);
+    static_assert(totally_ordered<conv_to_leap_second> == is_permissive);
+    static_assert(totally_ordered_with<conv_to_leap_second, leap_second> == is_permissive);
+    static_assert(three_way_comparable<conv_to_leap_second> == is_permissive);
+    static_assert(three_way_comparable_with<conv_to_leap_second, leap_second> == is_permissive);
 
     using ref_leap_second = reference_wrapper<leap_second>;
 

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_clocks/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_clocks/test.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <compare>
 #include <filesystem>
+#include <functional>
 #include <iterator>
 #include <type_traits>
 #include <utility>
@@ -474,6 +475,63 @@ void test() {
         assert(leap._Elapsed() == offset);
     }
 }
+
+// LWG-4139 "§[time.zone.leap] recursive constraint in <=>"
+namespace lwg_4139 {
+    struct conv_to_leap_second : local_t {
+        operator leap_second() const noexcept;
+    };
+
+    static_assert(!equality_comparable<conv_to_leap_second>);
+    static_assert(!equality_comparable_with<conv_to_leap_second, leap_second>);
+    static_assert(!totally_ordered<conv_to_leap_second>);
+    static_assert(!totally_ordered_with<conv_to_leap_second, leap_second>);
+    static_assert(!three_way_comparable<conv_to_leap_second>);
+    static_assert(!three_way_comparable_with<conv_to_leap_second, leap_second>);
+
+    using ref_leap_second = reference_wrapper<leap_second>;
+
+    static_assert(equality_comparable<ref_leap_second>);
+    static_assert(equality_comparable_with<ref_leap_second, leap_second>);
+    static_assert(totally_ordered<ref_leap_second>);
+    static_assert(totally_ordered_with<ref_leap_second, leap_second>);
+    static_assert(three_way_comparable<ref_leap_second>);
+    static_assert(three_way_comparable_with<ref_leap_second, leap_second>);
+
+    template <class T, class U>
+    concept can_equality_compare_with = requires(const remove_reference_t<T>& t, const remove_reference_t<U>& u) {
+        t == u;
+        t != u;
+        u == t;
+        u != t;
+    };
+
+    template <class T, class U>
+    concept can_relation_compare_with = requires(const remove_reference_t<T>& t, const remove_reference_t<U>& u) {
+        t < u;
+        t > u;
+        t <= u;
+        t >= u;
+        u < t;
+        u > t;
+        u <= t;
+        u >= t;
+    };
+
+    template <class T, class U>
+    concept can_three_way_compare_with = requires(const remove_reference_t<T>& t, const remove_reference_t<U>& u) {
+        t <=> u;
+        u <=> t;
+    };
+
+    static_assert(!can_equality_compare_with<conv_to_leap_second, sys_seconds>);
+    static_assert(!can_relation_compare_with<conv_to_leap_second, sys_seconds>);
+    static_assert(!can_three_way_compare_with<conv_to_leap_second, sys_seconds>);
+
+    static_assert(can_equality_compare_with<ref_leap_second, sys_seconds>);
+    static_assert(can_relation_compare_with<ref_leap_second, sys_seconds>);
+    static_assert(can_three_way_compare_with<ref_leap_second, sys_seconds>);
+} // namespace lwg_4139
 
 int main() {
     run_tz_test([] { test(); });


### PR DESCRIPTION
LWG-4139 indicated constraint recursion in the current specification of the `operator<=>` for `leap_second` and `sys_time`, which is not yet revealed due to the bugs in MSVC and (old versions of) Clang.

Although the proposed resolution is not shown in the LWG issue, I think the necessary changes are clear enough - just moving the operator functions from the synopsis of `<chrono>` to that of `std::chrono::leap_second` and adding `friend`.

This has been done in libstdc++ years ago (https://github.com/gcc-mirror/gcc/commit/1736bf5a61c7364c5da6fa52e5e2bfdbc9507c97), and recently in libc++ via LLVM-104713.