### PR TITLE
`<variant>`: Workaround for LLVM-59854 in the case of destructor of `variant`

### DIFF
--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -378,7 +378,11 @@ public:
         _Variant_storage<_Rest...> _Tail;
     };
 
-    _CONSTEXPR20 ~_Variant_storage_() noexcept {
+    _CONSTEXPR20 ~_Variant_storage_()
+#ifndef __clang__ // TRANSITION, LLVM-59854
+        noexcept
+#endif // ^^^ no workaround ^^^
+    {
         // explicitly non-trivial destructor (which would otherwise be defined as deleted
         // since the class has a variant member with a non-trivial destructor)
     }

--- a/tests/std/tests/P0088R3_variant_msvc/test.cpp
+++ b/tests/std/tests/P0088R3_variant_msvc/test.cpp
@@ -777,7 +777,8 @@ namespace msvc {
         static_assert(std::is_nothrow_destructible_v<ZA>);
         static_assert(std::is_nothrow_destructible_v<ZB>);
 
-        // Verify that variant::~variant is always noexcept, per N4988 [res.on.exception.handling]/3.
+        // Verify that variant::~variant is noexcept even when an alternative has a potentially-throwing destructor,
+        // per N4988 [res.on.exception.handling]/3.
         struct X2 {
             CONSTEXPR20 ~X2() noexcept(false) {}
         };
@@ -820,6 +821,7 @@ namespace msvc {
 
         static_assert(std::is_nothrow_destructible_v<std::variant<Y, int, Y2>>);
         static_assert(std::is_nothrow_destructible_v<ZC>);
+#undef CONSTEXPR20
     } // namespace gh4901
 
     namespace assign_cv {


### PR DESCRIPTION
Fixes #4901. The workaround doesn't seem to affect conformance, as the destructor of derived classes and `variant` are always `noexcept`.