### PR TITLE
Fix MSVC-only compiler options for the internal test harness

### DIFF
--- a/tests/std/run.pl
+++ b/tests/std/run.pl
@@ -34,7 +34,7 @@ if ($ENV{PM_COMPILER} && $ENV{PM_COMPILER} eq "clang-cl" && $ENV{CLANG_TARGET} &
 # add additional compiler flags if the compiler is cl.exe.
 if (not $ENV{PM_COMPILER})
 {
-    $ENV{CL} .= " " . $ENV{PM_CL_MSVC};
+    $ENV{PM_CL} .= " " . $ENV{PM_CL_MSVC};
 }
 
 my $RunPL = "";

--- a/tests/tr1/run.pl
+++ b/tests/tr1/run.pl
@@ -34,7 +34,7 @@ if ($ENV{PM_COMPILER} && $ENV{PM_COMPILER} eq "clang-cl" && $ENV{CLANG_TARGET} &
 # add additional compiler flags if the compiler is cl.exe.
 if (not $ENV{PM_COMPILER})
 {
-    $ENV{CL} .= " " . $ENV{PM_CL_MSVC};
+    $ENV{PM_CL} .= " " . $ENV{PM_CL_MSVC};
 }
 
 my $RunPL = "";


### PR DESCRIPTION
Followup to #2830 merged on 2022-06-28, mirrored as MSVC-PR-407767 "Enable memory stressing in std/tr1 test suites".

That PR attempted to add an environment variable `PM_CL_MSVC` to our internal test harness, allowing the MSVC-only compiler option `/d1db178,179` (which stresses compiler memory somehow) to be added without affecting Clang (which wouldn't understand it).

Unfortunately, this never took effect, and we didn't notice for two years! Our compiler back-end dev Andrew Dean recently discovered this while attempting to use the mechanism to investigate sporadic compiler crashes (which, as an aside, we now have good reason to believe are being caused by bitflips in flaky hardware :scream_cat:).

The fix is simple: we need to update the `PM_CL` variable, which contains the set of compiler options we've built up. (It's apparently "too late" to update the `CL` variable in our accursed Perl scripts here; we use that variable to pass `/D_MSVC_INTERNAL_TESTING` to both `cl.exe` and `clang-cl.exe` which works, but apparently that's being handled before we get to this point.)

With an internal build, I positively verified that x86chk `std` and `tr1` pass, now that `/d1db178,179` is being properly picked up. I also negatively verified that this is actually taking effect, by temporarily altering `PM_CL_MSVC` in our internal `src/qa/distrib.yaml` to add `/RTCc`, which the STL forbids with a hard `#error` message, and that broke the tests as expected.