### PR TITLE
Standard Library Modules: Add compiler workarounds for `<random>`

### DIFF
--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -1024,9 +1024,9 @@ struct _Signed128 : _Base128 {
     using _Signed_type   = _Signed128;
     using _Unsigned_type = _Unsigned128;
 
-#if !_HAS_CXX17
+#if !_HAS_CXX17 || (_HAS_CXX20 && !defined(__clang__) && !defined(__EDG__)) // TRANSITION, DevCom-10729775
     constexpr _Signed128() noexcept : _Base128{} {}
-#endif // !_HAS_CXX17
+#endif // ^^^ workaround for C++20 MSVC modules and header units; should be guarded for !_HAS_CXX17 only ^^^
 
     using _Base128::_Base128;
     constexpr explicit _Signed128(const _Base128& _That) noexcept : _Base128{_That} {}

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -707,9 +707,9 @@ struct _Unsigned128 : _Base128 {
     using _Signed_type   = _Signed128;
     using _Unsigned_type = _Unsigned128;
 
-#if !_HAS_CXX17
+#if !_HAS_CXX17 || (_HAS_CXX20 && !defined(__clang__) && !defined(__EDG__)) // TRANSITION, DevCom-10729775
     constexpr _Unsigned128() noexcept : _Base128{} {}
-#endif // !_HAS_CXX17
+#endif // ^^^ workaround for C++20 MSVC modules and header units; should be guarded for !_HAS_CXX17 only ^^^
 
     using _Base128::_Base128;
     constexpr explicit _Unsigned128(const _Base128& _That) noexcept : _Base128{_That} {}

--- a/tests/std/include/test_header_units_and_modules.hpp
+++ b/tests/std/include/test_header_units_and_modules.hpp
@@ -593,6 +593,12 @@ void test_random() {
     minstd_rand0 lcg;
     lcg.discard(9999);
     assert(lcg() == 1043618065); // N4868 [rand.predef]/1
+
+    // Test coverage for GH-4899 "Standard Library Modules: uniform_real_distribution emits
+    // error C2512: 'std::_Unsigned128': no appropriate default constructor available":
+    const double val = generate_canonical<double, 53>(lcg);
+    assert(val >= 0.0);
+    assert(val < 1.0);
 }
 
 void test_ranges() {

--- a/tests/std/include/test_header_units_and_modules.hpp
+++ b/tests/std/include/test_header_units_and_modules.hpp
@@ -594,11 +594,13 @@ void test_random() {
     lcg.discard(9999);
     assert(lcg() == 1043618065); // N4868 [rand.predef]/1
 
+#ifndef _MSVC_INTERNAL_TESTING // TRANSITION, VSO-2226569
     // Test coverage for GH-4899 "Standard Library Modules: uniform_real_distribution emits
     // error C2512: 'std::_Unsigned128': no appropriate default constructor available":
     const double val = generate_canonical<double, 53>(lcg);
     assert(val >= 0.0);
     assert(val < 1.0);
+#endif // ^^^ no workaround ^^^
 }
 
 void test_ranges() {


### PR DESCRIPTION
Fixes #4899 by adding workarounds for DevCom-10729775.

I slightly reduced the test case from `uniform_real_distribution`, then verified that the `generate_canonical` test coverage fails without the workaround (for both Standard Library Modules and Standard Library Header Units), before passing with the workaround.

`_Signed128` has the same code pattern, and I was able to craft a highly contrived repro demonstrating that it needs the same workaround. I don't think we need to add automated test coverage for it, though.

<details><summary>Click to expand bonus repro:</summary>

```
C:\Temp>"C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Auxiliary\Build\vcvarsall.bat" x64
**********************************************************************
** Visual Studio 2022 Developer Command Prompt v17.12.0-pre.1.0
** Copyright (c) 2022 Microsoft Corporation
**********************************************************************
[vcvarsall.bat] Environment initialized for: 'x64'

C:\Temp>type meow.cpp
```
```cpp
import std;
using namespace std;

constexpr long long meow() {
    const auto v = views::iota(0ll, 1729ll);
    const auto b = ranges::begin(v);
    const auto e = ranges::end(v);
    return static_cast<long long>(e - b);
}

int main() {
    constexpr long long value = meow();
    static_assert(value == 1729ll);
}
```
```
C:\Temp>cl /EHsc /nologo /W4 /std:c++latest /MTd /Od /c "%VCToolsInstallDir%\modules\std.ixx"
std.ixx

C:\Temp>cl /EHsc /nologo /W4 /std:c++latest /MTd /Od meow.cpp std.obj
meow.cpp
C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.42.34226\include\__msvc_int128.hpp(1184): error C2512: 'std::_Signed128': no appropriate default constructor available
C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.42.34226\include\ranges(887): note: while evaluating constexpr function 'std::operator -'
meow.cpp(8): note: while evaluating constexpr function 'std::ranges::operator -'
meow.cpp(12): note: while evaluating constexpr function 'meow'
meow.cpp(12): error C2131: expression did not evaluate to a constant
C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.42.34226\include\__msvc_int128.hpp(1184): note: a non-constant (sub-)expression was encountered
meow.cpp(13): error C2131: expression did not evaluate to a constant
C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.42.34226\include\__msvc_int128.hpp(1184): note: a non-constant (sub-)expression was encountered
```
</details>
