### PR TITLE
`<ranges>`: rename `views::iota` and `views::repeat` parameters

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1051,11 +1051,12 @@ namespace ranges {
             }
 
             template <class _Ty1, class _Ty2>
-            _NODISCARD _STATIC_CALL_OPERATOR constexpr auto operator()(_Ty1&& _Val1, _Ty2&& _Val2) _CONST_CALL_OPERATOR
-                noexcept(noexcept(iota_view(static_cast<_Ty1&&>(_Val1), static_cast<_Ty2&&>(_Val2))))
-                requires requires { iota_view(static_cast<_Ty1&&>(_Val1), static_cast<_Ty2&&>(_Val2)); }
+            _NODISCARD _STATIC_CALL_OPERATOR constexpr auto operator()(
+                _Ty1&& _Start, _Ty2&& _Bound) _CONST_CALL_OPERATOR
+                noexcept(noexcept(iota_view(static_cast<_Ty1&&>(_Start), static_cast<_Ty2&&>(_Bound))))
+                requires requires { iota_view(static_cast<_Ty1&&>(_Start), static_cast<_Ty2&&>(_Bound)); }
             {
-                return iota_view(static_cast<_Ty1&&>(_Val1), static_cast<_Ty2&&>(_Val2));
+                return iota_view(static_cast<_Ty1&&>(_Start), static_cast<_Ty2&&>(_Bound));
             }
         };
 
@@ -1306,11 +1307,12 @@ namespace ranges {
             }
 
             template <class _Ty1, class _Ty2>
-            _NODISCARD _STATIC_CALL_OPERATOR constexpr auto operator()(_Ty1&& _Val1, _Ty2&& _Val2) _CONST_CALL_OPERATOR
-                noexcept(noexcept(repeat_view(_STD forward<_Ty1>(_Val1), _STD forward<_Ty2>(_Val2))))
-                requires requires { repeat_view(_STD forward<_Ty1>(_Val1), _STD forward<_Ty2>(_Val2)); }
+            _NODISCARD _STATIC_CALL_OPERATOR constexpr auto operator()(
+                _Ty1&& _Value, _Ty2&& _Count) _CONST_CALL_OPERATOR
+                noexcept(noexcept(repeat_view(_STD forward<_Ty1>(_Value), _STD forward<_Ty2>(_Count))))
+                requires requires { repeat_view(_STD forward<_Ty1>(_Value), _STD forward<_Ty2>(_Count)); }
             {
-                return repeat_view(_STD forward<_Ty1>(_Val1), _STD forward<_Ty2>(_Val2));
+                return repeat_view(_STD forward<_Ty1>(_Value), _STD forward<_Ty2>(_Count));
             }
         };
 


### PR DESCRIPTION
The Visual Studio IDE has an "inline parameter hint" feature which will show the parameter names inline.  The STL generally has nice descriptive names which can make this feature helpful.
When I went to use `views::iota` I forgot if the second arg is a count or not, I was hoping the parameter names would save me a trip to cppreference, but alas, I was greeted with useless names.

`views::repeat` has the same issue (which is my fault; I just copied and pasted iota)

![image](https://github.com/user-attachments/assets/ad11f0b4-53d2-47b0-a80a-9378c8730cbc)


I also have a [feature request](https://developercommunity.visualstudio.com/t/De-uglify-STL-identifiers-in-inline-hint/10697009) to de-uglify them (might make another to not show the type information for these views, or I guess more generally, long nested templated types)