### PR TITLE
Adjust tests relying on CWG-1351 noexcept behavior

### DIFF
--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -285,7 +285,9 @@ void test_const_lvalue_get() {
   {
     using V = std::variant<int, const long>;
     constexpr V v(42);
-    static_assert(noexcept(std::get<0>(v)) == is_permissive);
+#if defined(_MSVC_INTERNAL_TESTING) || defined(__clang__) || defined(__EDG__) // TRANSITION, vs17.12p3
+    ASSERT_NOT_NOEXCEPT(std::get<0>(v));
+#endif // ^^^ no workaround ^^^
     ASSERT_SAME_TYPE(decltype(std::get<0>(v)), const int &);
     static_assert(std::get<0>(v) == 42, "");
   }
@@ -299,7 +301,9 @@ void test_const_lvalue_get() {
   {
     using V = std::variant<int, const long>;
     constexpr V v(42l);
-    static_assert(noexcept(std::get<1>(v)) == is_permissive);
+#if defined(_MSVC_INTERNAL_TESTING) || defined(__clang__) || defined(__EDG__) // TRANSITION, vs17.12p3
+    ASSERT_NOT_NOEXCEPT(std::get<1>(v));
+#endif // ^^^ no workaround ^^^
     ASSERT_SAME_TYPE(decltype(std::get<1>(v)), const long &);
     static_assert(std::get<1>(v) == 42, "");
   }
@@ -447,7 +451,9 @@ void test_const_lvalue_get() {
   {
     using V = std::variant<int, const long>;
     constexpr V v(42);
-    static_assert(noexcept(std::get<int>(v)) == is_permissive);
+#if defined(_MSVC_INTERNAL_TESTING) || defined(__clang__) || defined(__EDG__) // TRANSITION, vs17.12p3
+    ASSERT_NOT_NOEXCEPT(std::get<int>(v));
+#endif // ^^^ no workaround ^^^
     ASSERT_SAME_TYPE(decltype(std::get<int>(v)), const int &);
     static_assert(std::get<int>(v) == 42, "");
   }
@@ -461,7 +467,9 @@ void test_const_lvalue_get() {
   {
     using V = std::variant<int, const long>;
     constexpr V v(42l);
-    static_assert(noexcept(std::get<const long>(v)) == is_permissive);
+#if defined(_MSVC_INTERNAL_TESTING) || defined(__clang__) || defined(__EDG__) // TRANSITION, vs17.12p3
+    ASSERT_NOT_NOEXCEPT(std::get<const long>(v));
+#endif // ^^^ no workaround ^^^
     ASSERT_SAME_TYPE(decltype(std::get<const long>(v)), const long &);
     static_assert(std::get<const long>(v) == 42, "");
   }

--- a/tests/std/tests/P2136R3_invoke_r/test.cpp
+++ b/tests/std/tests/P2136R3_invoke_r/test.cpp
@@ -50,9 +50,10 @@ constexpr bool test_invoke_r() {
     static_assert(is_same_v<decltype(v2), double>);
     static_assert(is_void_v<decltype(invoke_r<void>(square, 1))>);
 
-    // TRANSITION, DevCom-1457457
-    static_assert(noexcept(invoke_r<int>(square, 3)) == is_permissive);
-    static_assert(noexcept(invoke(square, 3)) == is_permissive);
+#if defined(_MSVC_INTERNAL_TESTING) || defined(__clang__) || defined(__EDG__) // TRANSITION, vs17.12p3
+    static_assert(!noexcept(invoke_r<int>(square, 3)));
+    static_assert(!noexcept(invoke(square, 3)));
+#endif // ^^^ no workaround ^^^
 
     constexpr bool has_noexcept_in_type =
 #ifdef __cpp_noexcept_function_type


### PR DESCRIPTION
Update some noexcept tests in variant and invoke to remove old permissive behavior. This is guarded in a check for an as-yet unreleased MSVC compiler.

This mirrors the STL portion of MSVC-PR-566073.