### PR TITLE
`locale0.cpp`: Protect memory integrity of `_Fac_node`

### DIFF
--- a/stl/src/locale0.cpp
+++ b/stl/src/locale0.cpp
@@ -30,7 +30,6 @@ struct _Fac_node { // node for lazy facet recording
         delete _Facptr->_Decref();
     }
 
-#ifdef _DEBUG
     void* operator new(size_t _Size) { // replace operator new
         void* _Ptr = _malloc_dbg(_Size > 0 ? _Size : 1, _CRT_BLOCK, __FILE__, __LINE__);
         if (!_Ptr) {
@@ -43,20 +42,6 @@ struct _Fac_node { // node for lazy facet recording
     void operator delete(void* _Ptr) noexcept { // replace operator delete
         _free_dbg(_Ptr, _CRT_BLOCK);
     }
-#else
-    void* operator new(size_t _Size) { // ensure operator new is not tainted by global replacement, if any
-        void* _Ptr = malloc(_Size);
-        if (!_Ptr) {
-            _Xbad_alloc();
-        }
-
-        return _Ptr;
-    }
-
-    void operator delete(void* _Ptr) noexcept { // ensure operator new is not tainted by global replacement, if any
-        free(_Ptr);
-    }
-#endif // defined(_DEBUG)
 
     _Fac_node* _Next;
     _Facet_base* _Facptr;

--- a/stl/src/locale0.cpp
+++ b/stl/src/locale0.cpp
@@ -52,6 +52,7 @@ struct _Fac_node { // node for lazy facet recording
 
         return _Ptr;
     }
+
     void operator delete(void* _Ptr) noexcept { // ensure operator new is not tainted by global replacement, if any
         free(_Ptr);
     }

--- a/stl/src/locale0.cpp
+++ b/stl/src/locale0.cpp
@@ -43,6 +43,18 @@ struct _Fac_node { // node for lazy facet recording
     void operator delete(void* _Ptr) noexcept { // replace operator delete
         _free_dbg(_Ptr, _CRT_BLOCK);
     }
+#else
+    void* operator new(size_t _Size) { // ensure operator new is not tainted by global replacement, if any
+        void* _Ptr = malloc(_Size);
+        if (!_Ptr) {
+            _Xbad_alloc();
+        }
+
+        return _Ptr;
+    }
+    void operator delete(void* _Ptr) noexcept { // ensure operator new is not tainted by global replacement, if any
+        free(_Ptr);
+    }
 #endif // defined(_DEBUG)
 
     _Fac_node* _Next;


### PR DESCRIPTION
locale0.cpp has a global static linked list: 

https://github.com/microsoft/STL/blob/8af2cc499c94271c8d12baeb45e840f7160e082d/stl/src/locale0.cpp#L52

whose memory is released when another global variable,

https://github.com/microsoft/STL/blob/8af2cc499c94271c8d12baeb45e840f7160e082d/stl/src/locale0.cpp#L64

, is destructed: 

https://github.com/microsoft/STL/blob/8af2cc499c94271c8d12baeb45e840f7160e082d/stl/src/locale0.cpp#L54-L62

This is fine, except when `new` and `delete` are replaced globally by application code. In our application code (a fairly old codebase that is hard to refactor), we replace `new` and `delete` operators globally and use our private custom heap to manage the memory. The problem is `_Fac_node` linked list's memory is allocated on our private heap, but when the destructor of `_Fac_tidy_reg_t` is invoked, our private heap has already been destroyed, causing read access violation. This crash doesn't happen in DEBUG build, where `_Fac_node` has its own implementation of `new` and `delete` implementation.

This PR proposes that `_Fac_node` overrides `new` and `delete` in non-DEBUG mode as well, not only for consistency with DEBUG mode, but also for integrity and control of its memory usage.