### PR TITLE
Avoid `rand()` in the legacy `tr1` test suite

### DIFF
--- a/tests/tr1/tests/algorithm/test.cpp
+++ b/tests/tr1/tests/algorithm/test.cpp
@@ -429,11 +429,12 @@ void test_mutate(char* first, char* last, char* dest) { // test mutating templat
 
     STD random_shuffle(first, last);
 
-    auto rng_func = [mt = STD mt19937{}](CSTD size_t nmax) mutable { // return random value in [0, nmax)
+    STD mt19937 mt;
+    auto rng_func = [&mt](CSTD size_t nmax) { // return random value in [0, nmax)
         STD uniform_int_distribution<CSTD size_t> dist{0, nmax - 1};
         return dist(mt);
     };
-    STD random_shuffle(first, last, STD ref(rng_func));
+    STD random_shuffle(first, last, rng_func);
 
     rand_gen urng;
     STD shuffle(first, last, urng);

--- a/tests/tr1/tests/algorithm/test.cpp
+++ b/tests/tr1/tests/algorithm/test.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <ctype.h>
 #include <functional>
+#include <random>
 #include <string.h>
 
 // FUNCTION OBJECTS
@@ -294,15 +295,13 @@ void test_copy(char* first, char* last, char* dest) { // test copying template f
     CHECK_STR(array2, "aaxx");
 }
 
-CSTD size_t frand(CSTD size_t nmax) { // return random value in [0, nmax)
-    return CSTD rand() % nmax;
-}
-
 struct rand_gen { // uniform random number generator
+    STD mt19937 mt;
+
     typedef CSTD size_t result_type;
 
     result_type operator()() { // get random value
-        return CSTD rand() & 0xfffff;
+        return mt() & 0xfffff;
     }
 
     static result_type(min)() { // get minimum value
@@ -429,8 +428,12 @@ void test_mutate(char* first, char* last, char* dest) { // test mutating templat
     CHECK_STR(array, "ebgf");
 
     STD random_shuffle(first, last);
-    CSTD size_t (*prand)(CSTD size_t) = &frand;
-    STD random_shuffle(first, last, prand);
+
+    auto rng_func = [mt = STD mt19937{}](CSTD size_t nmax) mutable { // return random value in [0, nmax)
+        STD uniform_int_distribution<CSTD size_t> dist{0, nmax - 1};
+        return dist(mt);
+    };
+    STD random_shuffle(first, last, STD ref(rng_func));
 
     rand_gen urng;
     STD shuffle(first, last, urng);

--- a/tests/tr1/tests/memory2/test.cpp
+++ b/tests/tr1/tests/memory2/test.cpp
@@ -7,7 +7,7 @@
 #include "tdefs.h"
 #include <memory>
 #include <mutex>
-#include <stdlib.h>
+#include <random>
 #include <thread>
 #include <vector>
 
@@ -15,6 +15,7 @@ using STD shared_ptr;
 using STD weak_ptr;
 
 using STD lock_guard;
+using STD mt19937;
 using STD mutex;
 using STD thread;
 using STD vector;
@@ -27,6 +28,7 @@ static shared_ptr<int> sp;
 static mutex start_mtx;
 
 static void ctors() { // construct a gazillion shared and weak pointers
+    mt19937 mt;
 
     { // wait for access
         lock_guard<mutex> lock(start_mtx);
@@ -34,7 +36,7 @@ static void ctors() { // construct a gazillion shared and weak pointers
 
     for (int i = 0; i < NSETS; ++i) {
         for (int j = 0; j < NREPS; ++j) {
-            if (rand() % 2 != 0) {
+            if (mt() % 2 != 0) {
                 shared_ptr<int> sp0(sp);
             } else {
                 weak_ptr<int> wp0(sp);


### PR DESCRIPTION
Our bosses and boss-like entities heard that [`rand()` is considered harmful](https://learn.microsoft.com/en-us/shows/goingnative-2013/rand-considered-harmful) and are starting a push to avoid unnecessary use.

Almost all of our mentions of `rand` are Standard-mandated (or Standard stable name citations), but I found a few unnecessary uses in our legacy `tr1` test suite. We avoid cleaning up its code unless there's a specific reason to mess with it, and this easily qualifies.

* `tr1/tests/algorithm`
  + Give `rand_gen` an `mt19937` data member. (Default construction is fine; we weren't attempting to seed `rand()` before.) This is purely masking bits with `& 0xfffff`, so there's no need for a `uniform_int_distribution`.
  + Replace the `frand()` wrapper with an `rng_func` lambda. To avoid `/clr:pure` problems with init-captures, I'm capturing `mt` by reference (so the lambda doesn't need to be `mutable` and doesn't need to be passed via `ref()`). We need to adapt the half-open interface to `uniform_int_distribution`'s fully-closed range.
* `tr1/tests/memory2`
  + Construct a local `mt19937 mt;` within the `static void ctors()` worker function. (It's important to not use a global engine with multiple threads!) Again, we weren't attempting to seed `rand()`, so default-constructing `mt19937` is fine. And because we're just looking at a bit, we don't need a `uniform_int_distribution`.