### PR TITLE
Fix constraint on `unique_ptr<T, D>(auto_ptr<U>&&)`

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -3380,7 +3380,7 @@ public:
 
 #if _HAS_AUTO_PTR_ETC
     template <class _Ty2,
-        enable_if_t<conjunction_v<is_convertible<_Ty2*, _Ty*>, is_same<_Dx, default_delete<_Ty>>>, int> = 0>
+        enable_if_t<conjunction_v<is_convertible<_Ty2*, pointer>, is_same<_Dx, default_delete<_Ty>>>, int> = 0>
     unique_ptr(auto_ptr<_Ty2>&& _Right) noexcept : _Mypair(_Zero_then_variadic_args_t{}, _Right.release()) {}
 #endif // _HAS_AUTO_PTR_ETC
 


### PR DESCRIPTION
Per suggestion of Howard Hinnant on the LWG reflector. We initialize `unique_ptr`'s stored `pointer` with the result of calling `release()` on the `auto_ptr`. `release()` has type `U*`, so the correct constraint is to require `U*` to be convertible to `pointer`.

STL will probably laugh himself to tears before rejecting this PR, but it's probably the only chance I'll ever get to fix an `auto_ptr`-related bug so here it is =)