### PR TITLE
`<algorithm>`: Relax const-ness requirements on `ranges::_Meow_bound_unchecked`

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -7064,9 +7064,9 @@ namespace ranges {
 
     template <class _It, class _Ty, class _Pr, class _Pj>
     _NODISCARD constexpr _It _Lower_bound_unchecked(
-        _It _First, iter_difference_t<_It> _Count, const _Ty& _Val, _Pr _Pred, _Pj _Proj) {
+        _It _First, iter_difference_t<_It> _Count, _Ty&& _Val, _Pr _Pred, _Pj _Proj) {
         _STL_INTERNAL_STATIC_ASSERT(forward_iterator<_It>);
-        _STL_INTERNAL_STATIC_ASSERT(indirect_strict_weak_order<_Pr, const _Ty*, projected<_It, _Pj>>);
+        _STL_INTERNAL_STATIC_ASSERT(indirect_strict_weak_order<_Pr, add_pointer_t<_Ty>, projected<_It, _Pj>>);
 
         using _Diff = iter_difference_t<_It>;
 
@@ -7115,9 +7115,9 @@ namespace ranges {
 
     template <class _It, class _Ty, class _Pr, class _Pj>
     _NODISCARD constexpr _It _Upper_bound_unchecked(
-        _It _First, iter_difference_t<_It> _Count, const _Ty& _Val, _Pr _Pred, _Pj _Proj) {
+        _It _First, iter_difference_t<_It> _Count, _Ty&& _Val, _Pr _Pred, _Pj _Proj) {
         _STL_INTERNAL_STATIC_ASSERT(forward_iterator<_It>);
-        _STL_INTERNAL_STATIC_ASSERT(indirect_strict_weak_order<_Pr, const _Ty*, projected<_It, _Pj>>);
+        _STL_INTERNAL_STATIC_ASSERT(indirect_strict_weak_order<_Pr, add_pointer_t<_Ty>, projected<_It, _Pj>>);
 
         using _Diff = iter_difference_t<_It>;
 

--- a/tests/std/tests/P0896R4_ranges_alg_inplace_merge/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_inplace_merge/test.cpp
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// Copyright (c) Microsoft Corporation.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-
 #include <algorithm>
 #include <cassert>
 #include <concepts>

--- a/tests/std/tests/P0896R4_ranges_alg_inplace_merge/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_inplace_merge/test.cpp
@@ -1,12 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #include <algorithm>
 #include <cassert>
 #include <concepts>
+#include <cstddef>
 #include <ranges>
 #include <span>
 #include <utility>
+#include <vector>
 
 #include <range_algorithm_support.hpp>
 
@@ -55,6 +60,26 @@ struct instantiator {
         }
     }
 };
+
+// Test GH-4863: <algorithm>: ranges::inplace_merge doesn't seem to be able to utilize ranges::upper_bound
+void test_gh_4863() { // COMPILE-ONLY
+    {
+        vector<int> v;
+        auto cmp = [](int&, int&) { return false; };
+        ranges::sort(v, cmp);
+        ranges::inplace_merge(v, v.begin(), cmp);
+    }
+    {
+        struct S {
+            operator nullptr_t() {
+                return nullptr;
+            }
+        };
+        vector<int> v;
+        auto cmp = [](const nullptr_t&, const nullptr_t&) { return false; };
+        ranges::inplace_merge(v, v.begin(), cmp, [](int) { return S{}; });
+    }
+}
 
 int main() {
     test_bidi<instantiator, P>();


### PR DESCRIPTION
Fixes #4863.

----
I _guess_ it would be better to require `const&` for the checking in `std::sortable` to make `ranges::inplace_merge` able to use `ranges::upper_bound` like this:

```C++
template<dereferenceable I>
  struct const_lvalue_adaptor { // exposition only
    const iter_reference_t<I>& operator*(); // not defined
  };

template<class I, class R = ranges::less, class P = identity>
  concept sortable =
    permutable<I> &&
    indirect_strict_weak_order<R, const_lvalue_adaptor<projected<I, P>>>;
```

But at this moment I decide just not to require `const&` for internal checking.