### PR TITLE
Remove google/benchmark workaround

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -104,8 +104,6 @@ function(add_benchmark name)
     target_compile_features(benchmark-${name} PRIVATE cxx_std_${arg_CXX_STANDARD})
     target_include_directories(benchmark-${name} PRIVATE inc)
     target_link_libraries(benchmark-${name} PRIVATE benchmark::benchmark)
-    # TRANSITION, google/benchmark#1450
-    target_compile_definitions(benchmark-${name} PRIVATE BENCHMARK_STATIC_DEFINE)
 endfunction()
 
 add_benchmark(bitset_to_string src/bitset_to_string.cpp)


### PR DESCRIPTION
google/benchmark#1450 was fixed by google/benchmark#1470 on 2022-08-18.