### PR TITLE
Avoid squirrelly `memcpy()` call in `filesystem.cpp`

### DIFF
--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -142,7 +142,8 @@ namespace {
         BY_HANDLE_FILE_INFORMATION _Info;
         if (GetFileInformationByHandle(_Handle, &_Info)) {
             _Id->VolumeSerialNumber = _Info.dwVolumeSerialNumber;
-            _CSTD memcpy(&_Id->FileId.Identifier[0], &_Info.nFileIndexHigh, 8); // copying from 2 consecutive DWORDs
+            _CSTD memcpy(&_Id->FileId.Identifier[0], &_Info.nFileIndexHigh, 4);
+            _CSTD memcpy(&_Id->FileId.Identifier[4], &_Info.nFileIndexLow, 4);
             _CSTD memset(&_Id->FileId.Identifier[8], 0, 8);
             return __std_win_error::_Success;
         }


### PR DESCRIPTION
We have an extremely squirrelly line of code that's `memcpy`ing two consecutive `DWORD`s into the beginning of a buffer. There's no reason for this weirdness - it isn't perf-critical, and the optimizer should understand `memcpy`. Now, code analysis tools (specifically CodeQL) are noticing that this code is a :chipmunk: read overrun. Let's avoid this by splitting it up into two separate reads.

For the destination, `_Id` points to [`FILE_ID_INFO`][]. Its `FileId` is [`FILE_ID_128`][], which contains `BYTE Identifier[16];`.

For the source, `_Info` is [`BY_HANDLE_FILE_INFORMATION`][]:

```cpp
typedef struct _BY_HANDLE_FILE_INFORMATION {
  DWORD    dwFileAttributes;
  FILETIME ftCreationTime;
  FILETIME ftLastAccessTime;
  FILETIME ftLastWriteTime;
  DWORD    dwVolumeSerialNumber;
  DWORD    nFileSizeHigh;
  DWORD    nFileSizeLow;
  DWORD    nNumberOfLinks;
  DWORD    nFileIndexHigh;
  DWORD    nFileIndexLow;
} BY_HANDLE_FILE_INFORMATION, *PBY_HANDLE_FILE_INFORMATION, *LPBY_HANDLE_FILE_INFORMATION;
```

[`FILE_ID_INFO`]: https://learn.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-file_id_info
[`FILE_ID_128`]: https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-file_id_128
[`BY_HANDLE_FILE_INFORMATION`]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/ns-fileapi-by_handle_file_information
