### PR TITLE
Silence CodeQL false positive warnings

### DIFF
--- a/stl/inc/__msvc_string_view.hpp
+++ b/stl/inc/__msvc_string_view.hpp
@@ -665,7 +665,7 @@ public:
     }
 
     constexpr bool _Match(const _Elem _Ch) const noexcept { // test if _Ch is in the bitmap
-        return _Matches[static_cast<unsigned char>(_Ch)];
+        return _Matches[static_cast<unsigned char>(_Ch)]; // lgtm [cpp/unclear-array-index-validation]
     }
 
 private:
@@ -1331,7 +1331,7 @@ public:
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Off < _Mysize, "string_view subscript out of range");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-        return _Mydata[_Off];
+        return _Mydata[_Off]; // lgtm [cpp/unclear-array-index-validation]
     }
 
     _NODISCARD constexpr const_reference at(const size_type _Off) const {

--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -228,7 +228,7 @@ _STL_INTERNAL_STATIC_ASSERT(_STD size(_Digit_from_byte) == 256);
 
 _NODISCARD _CONSTEXPR23 unsigned char _Digit_from_char(const char _Ch) noexcept {
     // convert ['0', '9'] ['A', 'Z'] ['a', 'z'] to [0, 35], everything else to 255
-    return _Digit_from_byte[static_cast<unsigned char>(_Ch)];
+    return _Digit_from_byte[static_cast<unsigned char>(_Ch)]; // lgtm [cpp/unclear-array-index-validation]
 }
 
 template <class _RawTy>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4690,7 +4690,7 @@ _OutCtgIt _Copy_memmove(_CtgIt _First, _CtgIt _Last, _OutCtgIt _Dest) {
     const auto _Count           = static_cast<size_t>(_Last_ch - _First_ch);
     _CSTD memmove(_Dest_ch, _First_ch, _Count);
     if constexpr (is_pointer_v<_OutCtgIt>) {
-        return reinterpret_cast<_OutCtgIt>(_Dest_ch + _Count);
+        return reinterpret_cast<_OutCtgIt>(_Dest_ch + _Count); // lgtm [cpp/incorrect-string-type-conversion]
     } else {
         return _Dest + static_cast<_Iter_diff_t<_OutCtgIt>>(_LastPtr - _FirstPtr);
     }

--- a/stl/src/StlLCMapStringA.cpp
+++ b/stl/src/StlLCMapStringA.cpp
@@ -82,10 +82,12 @@ extern "C" _CRTIMP2 int __cdecl __crtLCMapStringA(_In_opt_z_ LPCWSTR LocaleName,
                 return retval;
             }
 
+            const auto wide_dest = reinterpret_cast<LPWSTR>(lpDestStr); // lgtm [cpp/incorrect-string-type-conversion]
+
             // do string mapping
             if (0
-                == LCMapStringEx(LocaleName, dwMapFlags, inwbuffer.get(), inbuff_size,
-                    reinterpret_cast<LPWSTR>(lpDestStr), cchDest, nullptr, nullptr, 0)) {
+                == LCMapStringEx(
+                    LocaleName, dwMapFlags, inwbuffer.get(), inbuff_size, wide_dest, cchDest, nullptr, nullptr, 0)) {
                 return retval;
             }
         }


### PR DESCRIPTION
* "Unclear validation of array index" silenced by `// lgtm [cpp/unclear-array-index-validation]`
  + `__msvc_string_view.hpp` 668: We have `bool _Matches[256]` and the index is cast to `unsigned char`.
  + `__msvc_string_view.hpp` 1334: `basic_string_view::operator[]` has optional validation controlled by `_CONTAINER_DEBUG_LEVEL` and intentionally doesn't validate by default.
  + `charconv`: `_Digit_from_byte` has 256 elements (enforced by `_STL_INTERNAL_STATIC_ASSERT`) and the index is cast to `unsigned char`.
* "Cast from `char*` to `wchar_t*`" silenced by `// lgtm [cpp/incorrect-string-type-conversion]`
  + `xutility`: `_Copy_memmove()` is correctly bypassing pointer arithmetic for performance.
  + `StlLCMapStringA.cpp`: This function has [`LCMapStringA`][]'s narrow interface, but implements `LCMAP_SORTKEY` with wide [`LCMapStringEx`][]. "The sort key is stored in the buffer and treated as an opaque array of bytes" so there is no correctness issue.

[`LCMapStringA`]: https://learn.microsoft.com/en-us/windows/win32/api/winnls/nf-winnls-lcmapstringa
[`LCMapStringEx`]: https://learn.microsoft.com/en-us/windows/win32/api/winnls/nf-winnls-lcmapstringex
