### PR TITLE
Begin removing EDG workaround from `ranges::to` tests

### DIFF
--- a/tests/std/tests/P1206R7_ranges_to_mappish/test.cpp
+++ b/tests/std/tests/P1206R7_ranges_to_mappish/test.cpp
@@ -156,13 +156,13 @@ struct mappish_instantiator {
             assert(c5.get_allocator().state == 13);
             assert(ranges::is_permutation(c5, expected, any_pair_eq));
         }
-#ifndef __EDG__ // TRANSITION, VSO-2208356
+#if defined(_MSVC_INTERNAL_TESTING) || !defined(__EDG__) // TRANSITION, VS 17.12p3
         {
             std::same_as<T> auto c6 = R{some_pairs} | ranges::to<T>(Alloc{13});
             assert(c6.get_allocator().state == 13);
             assert(ranges::is_permutation(c6, expected, any_pair_eq));
         }
-#endif // ^^^ no workaround ^^^
+#endif
         {
             std::same_as<T> auto c7 = R{some_pairs} | ranges::to<C>(Alloc{13});
             assert(c7.get_allocator().state == 13);

--- a/tests/std/tests/P1206R7_ranges_to_misc/test.cpp
+++ b/tests/std/tests/P1206R7_ranges_to_misc/test.cpp
@@ -54,7 +54,7 @@ struct reservable {
 };
 
 constexpr bool test_reservable() {
-#ifndef __EDG__ // TRANSITION, VSO-2208356
+#if defined(_MSVC_INTERNAL_TESTING) || !defined(__EDG__) // TRANSITION, VS 17.12p3
     int some_ints[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     {
         std::same_as<reservable> auto r = some_ints | ranges::to<reservable>(secret_key);
@@ -62,7 +62,7 @@ constexpr bool test_reservable() {
         assert(r.cap_ == ranges::size(some_ints));
         assert(r.reserved_ == ranges::size(some_ints));
     }
-#endif // ^^^ no workaround ^^^
+#endif
 
     return true;
 }
@@ -93,14 +93,14 @@ constexpr bool test_common_constructible() {
         assert(c0.last_ == ranges::end(some_ints));
         assert(c0.args_ == 3);
     }
-#ifndef __EDG__ // TRANSITION, VSO-2208356
+#if defined(_MSVC_INTERNAL_TESTING) || !defined(__EDG__) // TRANSITION, VS 17.12p3
     {
         std::same_as<common_constructible> auto c1 = some_ints | ranges::to<common_constructible>(secret_key);
         assert(c1.first_ == ranges::begin(some_ints));
         assert(c1.last_ == ranges::end(some_ints));
         assert(c1.args_ == 3);
     }
-#endif // ^^^ no workaround ^^^
+#endif
 
     // Verify that more than one argument can be passed after the range:
     {
@@ -109,14 +109,14 @@ constexpr bool test_common_constructible() {
         assert(c2.last_ == ranges::end(some_ints));
         assert(c2.args_ == 4);
     }
-#ifndef __EDG__ // TRANSITION, VSO-2208356
+#if defined(_MSVC_INTERNAL_TESTING) || !defined(__EDG__) // TRANSITION, VS 17.12p3
     {
         std::same_as<common_constructible> auto c3 = some_ints | ranges::to<common_constructible>(secret_key, 3.14);
         assert(c3.first_ == ranges::begin(some_ints));
         assert(c3.last_ == ranges::end(some_ints));
         assert(c3.args_ == 4);
     }
-#endif // ^^^ no workaround ^^^
+#endif
 
     return true;
 }
@@ -302,7 +302,7 @@ constexpr void test_lwg4016_per_kind() {
         std::same_as<V> auto vec = std::views::iota(0, 42) | ranges::to<V>();
         assert(ranges::equal(vec, std::views::iota(0, 42)));
     }
-#ifndef __EDG__ // TRANSITION, VSO-2208356
+#if defined(_MSVC_INTERNAL_TESTING) || !defined(__EDG__) // TRANSITION, VS 17.12p3
     {
         std::same_as<V> auto vec = std::views::iota(0, 42) | ranges::to<V>(std::allocator<int>{});
         assert(ranges::equal(vec, std::views::iota(0, 42)));
@@ -315,7 +315,7 @@ constexpr void test_lwg4016_per_kind() {
         std::same_as<V> auto vec = std::views::empty<int> | ranges::to<V>(std::size_t{42}, std::allocator<int>{});
         assert(ranges::equal(vec, std::views::repeat(0, 42)));
     }
-#endif // ^^^ no workaround ^^^
+#endif
     {
         std::same_as<V> auto vec = ranges::to<V>(std::views::iota(0, 42), std::initializer_list<int>{-3, -2, -1});
         assert(ranges::equal(vec, std::views::iota(-3, 42)));

--- a/tests/std/tests/P1206R7_ranges_to_sequence/test.cpp
+++ b/tests/std/tests/P1206R7_ranges_to_sequence/test.cpp
@@ -145,13 +145,13 @@ struct sequence_instantiator {
             assert(c5.get_allocator().state == 13);
             assert(ranges::equal(c5, meow));
         }
-#ifndef __EDG__ // TRANSITION, VSO-2208356
+#if defined(_MSVC_INTERNAL_TESTING) || !defined(__EDG__) // TRANSITION, VS 17.12p3
         {
             std::same_as<T> auto c6 = R{meow} | ranges::to<T>(Alloc{13});
             assert(c6.get_allocator().state == 13);
             assert(ranges::equal(c6, meow));
         }
-#endif // ^^^ no workaround ^^^
+#endif
         {
             std::same_as<T> auto c7 = R{meow} | ranges::to<C>(Alloc{13});
             assert(c7.get_allocator().state == 13);

--- a/tests/std/tests/P1206R7_ranges_to_settish/test.cpp
+++ b/tests/std/tests/P1206R7_ranges_to_settish/test.cpp
@@ -150,13 +150,13 @@ struct settish_instantiator {
             assert(c5.get_allocator().state == 13);
             assert(ranges::is_permutation(c5, expected));
         }
-#ifndef __EDG__ // TRANSITION, VSO-2208356
+#if defined(_MSVC_INTERNAL_TESTING) || !defined(__EDG__) // TRANSITION, VS 17.12p3
         {
             std::same_as<T> auto c6 = R{some_ints} | ranges::to<T>(Alloc{13});
             assert(c6.get_allocator().state == 13);
             assert(ranges::is_permutation(c6, expected));
         }
-#endif // ^^^ no workaround ^^^
+#endif
         {
             std::same_as<T> auto c7 = R{some_ints} | ranges::to<C>(Alloc{13});
             assert(c7.get_allocator().state == 13);


### PR DESCRIPTION
VSO-2208356 has been fixed internally. Disable the workaround internally, and mark the workaround for cleanup when VS 17.12p3 releases.

This mirrors MSVC-PR-577053.
