### PR TITLE
Polish `std::generator`

### DIFF
--- a/stl/inc/generator
+++ b/stl/inc/generator
@@ -409,12 +409,16 @@ public:
 
     _NODISCARD _Ref operator*() const
         noexcept(noexcept(static_cast<_Ref>(*_Coro.promise()._Get_top().promise()._Ptr))) {
-        _STL_ASSERT(!_Coro.done(), "Can't dereference generator end iterator");
+#if _CONTAINER_DEBUG_LEVEL > 0
+        _STL_VERIFY(!_Coro.done(), "Can't dereference generator end iterator");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
         return static_cast<_Ref>(*_Coro.promise()._Get_top().promise()._Ptr);
     }
 
     _Iterator& operator++() {
-        _STL_ASSERT(!_Coro.done(), "Can't increment generator end iterator");
+#if _CONTAINER_DEBUG_LEVEL > 0
+        _STL_VERIFY(!_Coro.done(), "Can't increment generator end iterator");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
         _Coro.promise()._Get_top().resume();
         return *this;
     }
@@ -491,7 +495,9 @@ public:
 
     _NODISCARD _Gen_iter_provider<_Value, _Ref>::_Iterator begin() {
         // Pre: _Coro is suspended at its initial suspend point
-        _STL_ASSERT(_Coro, "Can't call begin on moved-from generator");
+#if _CONTAINER_DEBUG_LEVEL > 0
+        _STL_VERIFY(_Coro, "Can't call begin on moved-from generator");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
         _Coro.resume();
         return typename _Gen_iter_provider<_Value, _Ref>::_Iterator{
             _Gen_secret_tag{}, coroutine_handle<_Gen_promise_base<yielded>>::from_address(_Coro.address())};

--- a/stl/inc/generator
+++ b/stl/inc/generator
@@ -40,22 +40,38 @@ struct alignas(__STDCPP_DEFAULT_NEW_ALIGNMENT__) _Aligned_block {
 template <class _Alloc>
 concept _Has_real_pointers = same_as<_Alloc, void> || is_pointer_v<typename allocator_traits<_Alloc>::pointer>;
 
-template <class _Allocator>
-class _Promise_allocator { // statically specified allocator type
+template <class _Proto_allocator>
+class _Coro_promise_allocator { // statically specified allocator type
 private:
-    using _Alloc           = _Rebind_alloc_t<_Allocator, _Aligned_block>;
+    using _Alloc           = _Rebind_alloc_t<_Proto_allocator, _Aligned_block>;
     using _Alloc_size_type = allocator_traits<_Alloc>::size_type;
 
+    static size_t _Allocation_block_size(const size_t _Size) noexcept {
+        // Compute the number of _Aligned_blocks needed to store a coroutine
+        // frame of _Size bytes and, if necessary, an _Alloc.
+        if constexpr (default_initializable<_Alloc> && allocator_traits<_Alloc>::is_always_equal::value) {
+            // allocator is stateless, we need no additional space
+            return (_Size + sizeof(_Aligned_block) - 1) / sizeof(_Aligned_block);
+        } else {
+            // allocator is stateful, we need space for it
+            constexpr size_t _Align = (_STD max)(alignof(_Alloc), sizeof(_Aligned_block));
+            return (_Size + sizeof(_Alloc) + _Align - 1) / sizeof(_Aligned_block);
+        }
+    }
+
     static void* _Allocate(_Alloc _Al, const size_t _Size) {
+        // memory layout:
+        // |--- coroutine frame --|- alignment padding -|---- _Alloc -----|
+        // |--- always present ---|----------- stateful only -------------|
+        // all rounded up to a multiple of sizeof(_Aligned_block)
+
+        const size_t _Size_in_blocks = _Allocation_block_size(_Size);
         if constexpr (default_initializable<_Alloc> && allocator_traits<_Alloc>::is_always_equal::value) {
             // do not store stateless allocator
-            const size_t _Count = (_Size + sizeof(_Aligned_block) - 1) / sizeof(_Aligned_block);
-            return _Al.allocate(_Convert_size<_Alloc_size_type>(_Count));
+            return _Al.allocate(_Convert_size<_Alloc_size_type>(_Size_in_blocks));
         } else {
             // store stateful allocator
-            constexpr size_t _Align = (_STD max)(alignof(_Alloc), sizeof(_Aligned_block));
-            const size_t _Count     = (_Size + sizeof(_Alloc) + _Align - 1) / sizeof(_Aligned_block);
-            void* const _Ptr        = _Al.allocate(_Convert_size<_Alloc_size_type>(_Count));
+            void* const _Ptr = _Al.allocate(_Convert_size<_Alloc_size_type>(_Size_in_blocks));
             const auto _Al_address =
                 (reinterpret_cast<uintptr_t>(_Ptr) + _Size + alignof(_Alloc) - 1) & ~(alignof(_Alloc) - 1);
             ::new (reinterpret_cast<void*>(_Al_address)) _Alloc(_STD move(_Al));
@@ -71,23 +87,23 @@ public:
     }
 
     template <class _Alloc2, class... _Args>
-        requires convertible_to<const _Alloc2&, _Allocator>
+        requires convertible_to<const _Alloc2&, _Proto_allocator>
     static void* operator new(const size_t _Size, allocator_arg_t, const _Alloc2& _Al, const _Args&...) {
-        return _Allocate(static_cast<_Alloc>(static_cast<_Allocator>(_Al)), _Size);
+        return _Allocate(static_cast<_Alloc>(static_cast<_Proto_allocator>(_Al)), _Size);
     }
 
     template <class _This, class _Alloc2, class... _Args>
-        requires convertible_to<const _Alloc2&, _Allocator>
+        requires convertible_to<const _Alloc2&, _Proto_allocator>
     static void* operator new(const size_t _Size, const _This&, allocator_arg_t, const _Alloc2& _Al, const _Args&...) {
-        return _Allocate(static_cast<_Alloc>(static_cast<_Allocator>(_Al)), _Size);
+        return _Allocate(static_cast<_Alloc>(static_cast<_Proto_allocator>(_Al)), _Size);
     }
 
     static void operator delete(void* const _Ptr, const size_t _Size) noexcept {
         if constexpr (default_initializable<_Alloc> && allocator_traits<_Alloc>::is_always_equal::value) {
-            // make stateless allocator
+            // recreate stateless allocator
             _Alloc _Al{};
-            const size_t _Count = (_Size + sizeof(_Aligned_block) - 1) / sizeof(_Aligned_block);
-            _Al.deallocate(static_cast<_Aligned_block*>(_Ptr), static_cast<_Alloc_size_type>(_Count));
+            const size_t _Size_in_blocks = _Allocation_block_size(_Size);
+            _Al.deallocate(static_cast<_Aligned_block*>(_Ptr), static_cast<_Alloc_size_type>(_Size_in_blocks));
         } else {
             // retrieve stateful allocator
             const auto _Al_address =
@@ -96,23 +112,35 @@ public:
             _Alloc _Al{_STD move(_Stored_al)};
             _Stored_al.~_Alloc();
 
-            constexpr size_t _Align = (_STD max)(alignof(_Alloc), sizeof(_Aligned_block));
-            const size_t _Count     = (_Size + sizeof(_Alloc) + _Align - 1) / sizeof(_Aligned_block);
-            _Al.deallocate(static_cast<_Aligned_block*>(_Ptr), static_cast<_Alloc_size_type>(_Count));
+            const size_t _Size_in_blocks = _Allocation_block_size(_Size);
+            _Al.deallocate(static_cast<_Aligned_block*>(_Ptr), static_cast<_Alloc_size_type>(_Size_in_blocks));
         }
     }
 };
 
 template <>
-class _Promise_allocator<void> { // type-erased allocator
+class _Coro_promise_allocator<void> { // type-erased allocator
 private:
     using _Dealloc_fn = void(__stdcall*)(void*, size_t) _NOEXCEPT_FNPTR;
 
     template <class _Alloc>
+    static size_t _Allocation_block_size(const size_t _Size) noexcept {
+        size_t _Blocks = _Size + sizeof(_Dealloc_fn);
+        if constexpr (default_initializable<_Alloc> && allocator_traits<_Alloc>::is_always_equal::value) {
+            _Blocks += sizeof(_Aligned_block) - 1;
+        } else {
+            constexpr size_t _Align = (_STD max)(alignof(_Alloc), sizeof(_Aligned_block));
+            _Blocks += sizeof(_Alloc) + _Align - 1;
+        }
+        return _Blocks / sizeof(_Aligned_block);
+    }
+
+    template <class _Alloc>
     static void __stdcall _Dealloc_stateless(void* const _Ptr, const size_t _Size) noexcept {
         _Alloc _Al{};
-        const size_t _Count = (_Size + sizeof(_Dealloc_fn) + sizeof(_Aligned_block) - 1) / sizeof(_Aligned_block);
-        _Al.deallocate(static_cast<_Aligned_block*>(_Ptr), static_cast<allocator_traits<_Alloc>::size_type>(_Count));
+        const size_t _Size_in_blocks = _Allocation_block_size<_Alloc>(_Size);
+        _Al.deallocate(
+            static_cast<_Aligned_block*>(_Ptr), static_cast<allocator_traits<_Alloc>::size_type>(_Size_in_blocks));
     }
 
     template <class _Alloc>
@@ -126,38 +154,40 @@ private:
         _Alloc _Al{_STD move(_Stored_al)};
         _Stored_al.~_Alloc();
 
-        const size_t _Count = (_Size + sizeof(_Al) + _Align - 1) / sizeof(_Aligned_block);
-        _Al.deallocate(static_cast<_Aligned_block*>(_Ptr), static_cast<allocator_traits<_Alloc>::size_type>(_Count));
+        const size_t _Size_in_blocks = (_Size + sizeof(_Alloc) + _Align - 1) / sizeof(_Aligned_block);
+        _Al.deallocate(
+            static_cast<_Aligned_block*>(_Ptr), static_cast<allocator_traits<_Alloc>::size_type>(_Size_in_blocks));
     }
 
-    static void __stdcall _Dealloc_delete(void* const _Ptr, const size_t _Size) noexcept {
+    static void __stdcall _Dealloc_default(void* const _Ptr, const size_t _Size) noexcept {
         ::operator delete(_Ptr, _Size + sizeof(_Dealloc_fn));
     }
 
     template <class _ProtoAlloc>
     static void* _Allocate(const _ProtoAlloc& _Proto, size_t _Size) {
+        // memory layout:
+        // |--- coroutine frame (_Size bytes) ---|--- _Dealloc_fn ---|-- alignment padding --|--- _Alloc ---|
+        // |-------------------- always present -----(not aligned)---|------------ stateful only -----------|
+        // all rounded up to a multiple of sizeof(_Aligned_block)
+
         using _Alloc           = _Rebind_alloc_t<_ProtoAlloc, _Aligned_block>;
         using _Alloc_size_type = allocator_traits<_Alloc>::size_type;
-        auto _Al               = static_cast<_Alloc>(_Proto);
+
+        _Alloc _Al{_Proto};
+        const size_t _Size_in_blocks = _Allocation_block_size<_Alloc>(_Size);
+        void* const _Ptr             = _Al.allocate(_Convert_size<_Alloc_size_type>(_Size_in_blocks));
 
         if constexpr (default_initializable<_Alloc> && allocator_traits<_Alloc>::is_always_equal::value) {
             // don't store stateless allocator
             const _Dealloc_fn _Dealloc = _Dealloc_stateless<_Alloc>;
-
-            const size_t _Count = (_Size + sizeof(_Dealloc_fn) + sizeof(_Aligned_block) - 1) / sizeof(_Aligned_block);
-            void* const _Ptr    = _Al.allocate(_Convert_size<_Alloc_size_type>(_Count));
             _CSTD memcpy(static_cast<char*>(_Ptr) + _Size, &_Dealloc, sizeof(_Dealloc));
             return _Ptr;
         } else {
             // store stateful allocator
-            constexpr size_t _Align = (_STD max)(alignof(_Alloc), sizeof(_Aligned_block));
-
             const _Dealloc_fn _Dealloc = _Dealloc_stateful<_Alloc>;
-
-            const size_t _Count = (_Size + sizeof(_Dealloc_fn) + sizeof(_Al) + _Align - 1) / sizeof(_Aligned_block);
-            void* const _Ptr    = _Al.allocate(_Convert_size<_Alloc_size_type>(_Count));
             _CSTD memcpy(static_cast<char*>(_Ptr) + _Size, &_Dealloc, sizeof(_Dealloc));
             _Size += sizeof(_Dealloc_fn);
+
             const auto _Al_address =
                 (reinterpret_cast<uintptr_t>(_Ptr) + _Size + alignof(_Alloc) - 1) & ~(alignof(_Alloc) - 1);
             ::new (reinterpret_cast<void*>(_Al_address)) _Alloc{_STD move(_Al)};
@@ -166,22 +196,24 @@ private:
     }
 
 public:
-    static void* operator new(const size_t _Size) { // default: new/delete
+    static void* operator new(const size_t _Size) {
         void* const _Ptr           = ::operator new(_Size + sizeof(_Dealloc_fn));
-        const _Dealloc_fn _Dealloc = _Dealloc_delete;
+        const _Dealloc_fn _Dealloc = _Dealloc_default;
         _CSTD memcpy(static_cast<char*>(_Ptr) + _Size, &_Dealloc, sizeof(_Dealloc_fn));
         return _Ptr;
     }
 
     template <class _Alloc, class... _Args>
     static void* operator new(const size_t _Size, allocator_arg_t, const _Alloc& _Al, const _Args&...) {
-        static_assert(_Has_real_pointers<_Alloc>, "coroutine allocators must use raw pointers");
+        static_assert(_Has_real_pointers<_Alloc>, "generator allocators must use raw pointers "
+                                                  "(N4988 [coro.generator.class]/1.1)");
         return _Allocate(_Al, _Size);
     }
 
     template <class _This, class _Alloc, class... _Args>
     static void* operator new(const size_t _Size, const _This&, allocator_arg_t, const _Alloc& _Al, const _Args&...) {
-        static_assert(_Has_real_pointers<_Alloc>, "coroutine allocators must use raw pointers");
+        static_assert(_Has_real_pointers<_Alloc>, "generator allocators must use raw pointers "
+                                                  "(N4988 [coro.generator.class]/1.1)");
         return _Allocate(_Al, _Size);
     }
 
@@ -470,7 +502,7 @@ public:
 
     friend _Gen_promise_base<yielded>;
 
-    struct __declspec(empty_bases) promise_type : _Promise_allocator<_Alloc>, _Gen_promise_base<yielded> {
+    struct __declspec(empty_bases) promise_type : _Coro_promise_allocator<_Alloc>, _Gen_promise_base<yielded> {
         _NODISCARD generator get_return_object() noexcept {
             return generator{_Gen_secret_tag{}, coroutine_handle<promise_type>::from_promise(*this)};
         }

--- a/stl/inc/generator
+++ b/stl/inc/generator
@@ -40,6 +40,10 @@ struct alignas(__STDCPP_DEFAULT_NEW_ALIGNMENT__) _Aligned_block {
 template <class _Alloc>
 concept _Has_real_pointers = same_as<_Alloc, void> || is_pointer_v<typename allocator_traits<_Alloc>::pointer>;
 
+template <class _Alloc>
+constexpr bool _Allocator_is_stateless =
+    default_initializable<_Alloc> && allocator_traits<_Alloc>::is_always_equal::value;
+
 template <class _Proto_allocator>
 class _Coro_promise_allocator { // statically specified allocator type
 private:
@@ -49,7 +53,7 @@ private:
     static size_t _Allocation_block_size(const size_t _Size) noexcept {
         // Compute the number of _Aligned_blocks needed to store a coroutine
         // frame of _Size bytes and, if necessary, an _Alloc.
-        if constexpr (default_initializable<_Alloc> && allocator_traits<_Alloc>::is_always_equal::value) {
+        if constexpr (_Allocator_is_stateless<_Alloc>) {
             // allocator is stateless, we need no additional space
             return (_Size + sizeof(_Aligned_block) - 1) / sizeof(_Aligned_block);
         } else {
@@ -63,19 +67,30 @@ private:
         // memory layout:
         // |--- coroutine frame --|- alignment padding -|---- _Alloc -----|
         // |--- always present ---|----------- stateful only -------------|
-        // all rounded up to a multiple of sizeof(_Aligned_block)
+        // all rounded up to an integral number of _Aligned_blocks
 
         const size_t _Size_in_blocks = _Allocation_block_size(_Size);
-        if constexpr (default_initializable<_Alloc> && allocator_traits<_Alloc>::is_always_equal::value) {
-            // do not store stateless allocator
-            return _Al.allocate(_Convert_size<_Alloc_size_type>(_Size_in_blocks));
-        } else {
-            // store stateful allocator
-            void* const _Ptr = _Al.allocate(_Convert_size<_Alloc_size_type>(_Size_in_blocks));
+        void* const _Ptr             = _Al.allocate(_Convert_size<_Alloc_size_type>(_Size_in_blocks));
+
+        if constexpr (!_Allocator_is_stateless<_Alloc>) {
+            // store only stateful allocators
             const auto _Al_address =
                 (reinterpret_cast<uintptr_t>(_Ptr) + _Size + alignof(_Alloc) - 1) & ~(alignof(_Alloc) - 1);
             ::new (reinterpret_cast<void*>(_Al_address)) _Alloc(_STD move(_Al));
-            return _Ptr;
+        }
+
+        return _Ptr;
+    }
+
+    _NODISCARD static _Alloc _Get_allocator(
+        [[maybe_unused]] void* const _Ptr, [[maybe_unused]] const size_t _Size) noexcept {
+        // recreate or retrieve a copy of the allocator used to allocate _Ptr
+        if constexpr (_Allocator_is_stateless<_Alloc>) {
+            return _Alloc{};
+        } else {
+            const auto _Al_address =
+                (reinterpret_cast<uintptr_t>(_Ptr) + _Size + alignof(_Alloc) - 1) & ~(alignof(_Alloc) - 1);
+            return *reinterpret_cast<_Alloc*>(_Al_address);
         }
     }
 
@@ -99,22 +114,9 @@ public:
     }
 
     static void operator delete(void* const _Ptr, const size_t _Size) noexcept {
-        if constexpr (default_initializable<_Alloc> && allocator_traits<_Alloc>::is_always_equal::value) {
-            // recreate stateless allocator
-            _Alloc _Al{};
-            const size_t _Size_in_blocks = _Allocation_block_size(_Size);
-            _Al.deallocate(static_cast<_Aligned_block*>(_Ptr), static_cast<_Alloc_size_type>(_Size_in_blocks));
-        } else {
-            // retrieve stateful allocator
-            const auto _Al_address =
-                (reinterpret_cast<uintptr_t>(_Ptr) + _Size + alignof(_Alloc) - 1) & ~(alignof(_Alloc) - 1);
-            auto& _Stored_al = *reinterpret_cast<_Alloc*>(_Al_address);
-            _Alloc _Al{_STD move(_Stored_al)};
-            _Stored_al.~_Alloc();
-
-            const size_t _Size_in_blocks = _Allocation_block_size(_Size);
-            _Al.deallocate(static_cast<_Aligned_block*>(_Ptr), static_cast<_Alloc_size_type>(_Size_in_blocks));
-        }
+        _Alloc _Al                   = _Get_allocator(_Ptr, _Size);
+        const size_t _Size_in_blocks = _Allocation_block_size(_Size);
+        _Al.deallocate(static_cast<_Aligned_block*>(_Ptr), static_cast<_Alloc_size_type>(_Size_in_blocks));
     }
 };
 
@@ -125,38 +127,35 @@ private:
 
     template <class _Alloc>
     static size_t _Allocation_block_size(const size_t _Size) noexcept {
-        size_t _Blocks = _Size + sizeof(_Dealloc_fn);
-        if constexpr (default_initializable<_Alloc> && allocator_traits<_Alloc>::is_always_equal::value) {
-            _Blocks += sizeof(_Aligned_block) - 1;
+        size_t _Bytes = _Size + sizeof(_Dealloc_fn);
+        if constexpr (_Allocator_is_stateless<_Alloc>) {
+            _Bytes += sizeof(_Aligned_block) - 1;
         } else {
             constexpr size_t _Align = (_STD max)(alignof(_Alloc), sizeof(_Aligned_block));
-            _Blocks += sizeof(_Alloc) + _Align - 1;
+            _Bytes += sizeof(_Alloc) + _Align - 1;
         }
-        return _Blocks / sizeof(_Aligned_block);
+        return _Bytes / sizeof(_Aligned_block);
     }
 
     template <class _Alloc>
     static void __stdcall _Dealloc_stateless(void* const _Ptr, const size_t _Size) noexcept {
         _Alloc _Al{};
         const size_t _Size_in_blocks = _Allocation_block_size<_Alloc>(_Size);
-        _Al.deallocate(
-            static_cast<_Aligned_block*>(_Ptr), static_cast<allocator_traits<_Alloc>::size_type>(_Size_in_blocks));
+        const auto _Alloc_size       = static_cast<allocator_traits<_Alloc>::size_type>(_Size_in_blocks);
+        _Al.deallocate(static_cast<_Aligned_block*>(_Ptr), _Alloc_size);
     }
 
     template <class _Alloc>
-    static void __stdcall _Dealloc_stateful(void* const _Ptr, size_t _Size) noexcept {
-        constexpr size_t _Align = (_STD max)(alignof(_Alloc), sizeof(_Aligned_block));
-
-        _Size += sizeof(_Dealloc_fn);
-        const auto _Al_address =
-            (reinterpret_cast<uintptr_t>(_Ptr) + _Size + alignof(_Alloc) - 1) & ~(alignof(_Alloc) - 1);
+    static void __stdcall _Dealloc_stateful(void* const _Ptr, const size_t _Size) noexcept {
+        const auto _Al_address = (reinterpret_cast<uintptr_t>(_Ptr) + _Size + sizeof(_Dealloc_fn) + alignof(_Alloc) - 1)
+                               & ~(alignof(_Alloc) - 1);
         auto& _Stored_al = *reinterpret_cast<_Alloc*>(_Al_address);
         _Alloc _Al{_STD move(_Stored_al)};
         _Stored_al.~_Alloc();
 
-        const size_t _Size_in_blocks = (_Size + sizeof(_Alloc) + _Align - 1) / sizeof(_Aligned_block);
-        _Al.deallocate(
-            static_cast<_Aligned_block*>(_Ptr), static_cast<allocator_traits<_Alloc>::size_type>(_Size_in_blocks));
+        const size_t _Size_in_blocks = _Allocation_block_size<_Alloc>(_Size);
+        const auto _Alloc_size       = static_cast<allocator_traits<_Alloc>::size_type>(_Size_in_blocks);
+        _Al.deallocate(static_cast<_Aligned_block*>(_Ptr), _Alloc_size);
     }
 
     static void __stdcall _Dealloc_default(void* const _Ptr, const size_t _Size) noexcept {
@@ -168,16 +167,17 @@ private:
         // memory layout:
         // |--- coroutine frame (_Size bytes) ---|--- _Dealloc_fn ---|-- alignment padding --|--- _Alloc ---|
         // |-------------------- always present -----(not aligned)---|------------ stateful only -----------|
-        // all rounded up to a multiple of sizeof(_Aligned_block)
+        // all rounded up to an integral number of _Aligned_blocks
 
         using _Alloc           = _Rebind_alloc_t<_ProtoAlloc, _Aligned_block>;
         using _Alloc_size_type = allocator_traits<_Alloc>::size_type;
 
         _Alloc _Al{_Proto};
         const size_t _Size_in_blocks = _Allocation_block_size<_Alloc>(_Size);
-        void* const _Ptr             = _Al.allocate(_Convert_size<_Alloc_size_type>(_Size_in_blocks));
+        const auto _Alloc_size       = _Convert_size<_Alloc_size_type>(_Size_in_blocks);
+        void* const _Ptr             = _Al.allocate(_Alloc_size);
 
-        if constexpr (default_initializable<_Alloc> && allocator_traits<_Alloc>::is_always_equal::value) {
+        if constexpr (_Allocator_is_stateless<_Alloc>) {
             // don't store stateless allocator
             const _Dealloc_fn _Dealloc = _Dealloc_stateless<_Alloc>;
             _CSTD memcpy(static_cast<char*>(_Ptr) + _Size, &_Dealloc, sizeof(_Dealloc));
@@ -307,7 +307,7 @@ private:
     struct _Element_awaiter {
         remove_cvref_t<_Yielded> _Val;
 
-        _Element_awaiter(const remove_reference_t<_Yielded>& _Val_)
+        explicit _Element_awaiter(const remove_reference_t<_Yielded>& _Val_)
             noexcept(is_nothrow_constructible_v<remove_cvref_t<_Yielded>, const remove_reference_t<_Yielded>&>)
             : _Val(_Val_) {}
 

--- a/stl/inc/generator
+++ b/stl/inc/generator
@@ -565,7 +565,7 @@ public:
 private:
     coroutine_handle<promise_type> _Coro = nullptr;
     // The stack of coroutine handles depicted in the Standard is realized by a linked structure of promises and
-    // awaitable objects so all necessary storage is allocated in coroutine frames. See the description in the body of
+    // awaitable objects, so all necessary storage is allocated in coroutine frames. See the description in the body of
     // _Gen_promise_base.
 
     explicit generator(_Gen_secret_tag, coroutine_handle<promise_type> _Coro_) noexcept : _Coro(_Coro_) {}

--- a/stl/inc/generator
+++ b/stl/inc/generator
@@ -441,25 +441,25 @@ private:
 _EXPORT_STD template <class _Rty, class _Vty, class _Alloc>
 class generator : public _RANGES view_interface<generator<_Rty, _Vty, _Alloc>> {
 private:
+    static_assert(_Has_real_pointers<_Alloc>, "generator allocators must use raw pointers "
+                                              "(N4988 [coro.generator.class]/1.1)");
+
     using _Value = _Gen_value_t<_Rty, _Vty>;
     static_assert(same_as<remove_cvref_t<_Value>, _Value> && is_object_v<_Value>,
-        "generator's value type must be a cv-unqualified object type (N4971 [coro.generator.class]/1.2)");
+        "generator's value type must be a cv-unqualified object type (N4988 [coro.generator.class]/1.2)");
 
     using _Ref = _Gen_reference_t<_Rty, _Vty>;
     static_assert(
         is_reference_v<_Ref> || (is_object_v<_Ref> && same_as<remove_cv_t<_Ref>, _Ref> && copy_constructible<_Ref>),
         "generator's selected reference type must be an actual reference type "
-        "or a cv-unqualified copy-constructible object type (N4971 [coro.generator.class]/1.3)");
+        "or a cv-unqualified copy-constructible object type (N4988 [coro.generator.class]/1.3)");
 
-    using _RRef = conditional_t<is_lvalue_reference_v<_Ref>, remove_reference_t<_Ref>&&, _Ref>;
+    using _RRef = conditional_t<is_reference_v<_Ref>, remove_reference_t<_Ref>&&, _Ref>;
 
     static_assert(common_reference_with<_Ref&&, _Value&> && common_reference_with<_Ref&&, _RRef&&>
                       && common_reference_with<_RRef&&, const _Value&>,
         "generator's iterator type must model indirectly_readable, "
-        "but that's impossible with the selected value and reference types (N4971 [coro.generator.class]/1.4)");
-
-    static_assert(_Has_real_pointers<_Alloc>, "generator allocators must use raw pointers "
-                                              "(N4971 [coro.generator.class]/1.1)");
+        "but that's impossible with the selected value and reference types (N4988 [coro.generator.class]/1.4)");
 
 public:
     using yielded = _Gen_yield_t<_Ref>;

--- a/stl/inc/generator
+++ b/stl/inc/generator
@@ -307,6 +307,10 @@ private:
     struct _Element_awaiter {
         remove_cvref_t<_Yielded> _Val;
 
+        _Element_awaiter(const remove_reference_t<_Yielded>& _Val_)
+            noexcept(is_nothrow_constructible_v<remove_cvref_t<_Yielded>, const remove_reference_t<_Yielded>&>)
+            : _Val(_Val_) {}
+
         _NODISCARD constexpr bool await_ready() const noexcept {
             return false;
         }

--- a/stl/inc/generator
+++ b/stl/inc/generator
@@ -328,6 +328,23 @@ private:
         constexpr void await_resume() const noexcept {}
     };
 
+    // generator's stack of nested coroutines is realized as a linked list of promises. The "root" promise is the
+    // original that existed before any nested yields. The "top" promise is the one currently being iterated over.
+    // Iterators hold handles for the root's coroutine and the root promise holds a link to the top promise so iterators
+    // can resume it to generate the next element when incremented. Each promise keeps a link to the root so they can
+    // update the top link as promises are pushed and popped. It looks a bit like:
+    //
+    //    +--------------------------- Top ---------------------------+
+    //    v                                                           |
+    // +=====+             +=====+             +=====+             +=====+
+    // |     |-- Parent -->|     |-- Parent -->|     |-- Parent -->|     |
+    // +=====+             +=====+             +=====+             +=====+
+    //    |                   |                   |                   ^
+    //    +------- Root ------+------- Root ------+------- Root ------+
+    //
+    // The parent and root links are actually stored out-of-line in a _Nest_info. Since a promise is either a root or is
+    // nested, the single promise member _Data can be used to store either a top link or a pointer to a _Nest_info.
+
     struct _Nest_info {
         exception_ptr _Except;
         coroutine_handle<_Gen_promise_base> _Parent;
@@ -341,6 +358,7 @@ private:
 
         template <class _CoroPromise>
         _NODISCARD coroutine_handle<> await_suspend(coroutine_handle<_CoroPromise> _Handle) noexcept {
+            // Resume _Handle's parent coroutine, if any.
 #ifdef __cpp_lib_is_pointer_interconvertible // TRANSITION, LLVM-48860
             _STL_INTERNAL_STATIC_ASSERT(is_pointer_interconvertible_base_of_v<_Gen_promise_base, _CoroPromise>);
 #endif // ^^^ no workaround ^^^
@@ -374,6 +392,7 @@ private:
             template <class _CoroPromise>
             _NODISCARD coroutine_handle<_Gen_promise_base> await_suspend(
                 coroutine_handle<_CoroPromise> _Current) noexcept {
+                // Push _Gen's coroutine onto the coroutine stack that _Current is at the top of.
 #ifdef __cpp_lib_is_pointer_interconvertible // TRANSITION, LLVM-48860
                 _STL_INTERNAL_STATIC_ASSERT(is_pointer_interconvertible_base_of_v<_Gen_promise_base, _CoroPromise>);
 #endif // ^^^ no workaround ^^^
@@ -545,6 +564,9 @@ public:
 
 private:
     coroutine_handle<promise_type> _Coro = nullptr;
+    // The stack of coroutine handles depicted in the Standard is realized by a linked structure of promises and
+    // awaitable objects so all necessary storage is allocated in coroutine frames. See the description in the body of
+    // _Gen_promise_base.
 
     explicit generator(_Gen_secret_tag, coroutine_handle<promise_type> _Coro_) noexcept : _Coro(_Coro_) {}
 };

--- a/tests/std/include/test_generator_support.hpp
+++ b/tests/std/include/test_generator_support.hpp
@@ -64,10 +64,6 @@ public:
         std::allocator<T>{}.deallocate(p, n);
     }
 
-    operator std::pmr::polymorphic_allocator<void>() const {
-        return {};
-    }
-
     template <class U>
     bool operator==(const StatelessAlloc<U, AlwaysEqual, DifferenceType>&) const noexcept {
         return true;
@@ -77,15 +73,14 @@ public:
 static_assert(std::default_initializable<StatelessAlloc<int>>);
 
 template <class T>
-struct StatefulAlloc {
+class StatefulAlloc {
+public:
     using value_type = T;
-
-    int domain;
 
     explicit StatefulAlloc(int dom) noexcept : domain{dom} {}
 
     template <class U>
-    constexpr StatefulAlloc(const StatefulAlloc<U>& that) noexcept : domain{that.domain} {}
+    StatefulAlloc(const StatefulAlloc<U>& that) noexcept : domain{that.domain} {}
 
     T* allocate(const size_t n) {
         return std::allocator<T>{}.allocate(n);
@@ -96,9 +91,15 @@ struct StatefulAlloc {
     }
 
     template <class U>
-    constexpr bool operator==(const StatefulAlloc<U>& that) noexcept {
+    bool operator==(const StatefulAlloc<U>& that) noexcept {
         return domain == that.domain;
     }
+
+private:
+    int domain;
+
+    template <class U>
+    friend class StatefulAlloc;
 };
 
 static_assert(!std::default_initializable<StatefulAlloc<int>>);

--- a/tests/std/include/test_generator_support.hpp
+++ b/tests/std/include/test_generator_support.hpp
@@ -12,9 +12,8 @@
 #include <type_traits>
 
 template <class R, class V = void, class A = void>
-struct gen_traits : gen_traits<R, V> {
-    using generator = std::generator<R, V, A>;
-};
+struct gen_traits;
+
 template <class R>
 struct gen_traits<R> {
     using generator = std::generator<R>;
@@ -35,6 +34,10 @@ struct gen_traits<R, V> {
 
     // Ditto verify default template arguments
     static_assert(std::same_as<std::generator<R, V>, std::generator<R, V, void>>);
+};
+template <class R, class V, class A>
+struct gen_traits : gen_traits<R, V> {
+    using generator = std::generator<R, V, A>;
 };
 
 template <class Ref, class V>

--- a/tests/std/include/test_generator_support.hpp
+++ b/tests/std/include/test_generator_support.hpp
@@ -6,9 +6,42 @@
 #include <concepts>
 #include <cstddef>
 #include <cstdlib>
+#include <generator>
 #include <memory>
 #include <memory_resource>
 #include <type_traits>
+
+template <class R, class V = void, class A = void>
+struct gen_traits : gen_traits<R, V> {
+    using generator = std::generator<R, V, A>;
+};
+template <class R>
+struct gen_traits<R> {
+    using generator = std::generator<R>;
+    using value     = std::remove_cvref_t<R>;
+    using reference = R&&;
+    using yielded   = reference;
+
+    // Verify the default template arguments
+    static_assert(std::same_as<std::generator<R>, std::generator<R, void>>);
+    static_assert(std::same_as<std::generator<R, void>, std::generator<R, void, void>>);
+};
+template <class R, class V>
+struct gen_traits<R, V> {
+    using generator = std::generator<R, V>;
+    using value     = V;
+    using reference = R;
+    using yielded   = std::conditional_t<std::is_reference_v<R>, R, const R&>;
+
+    // Ditto verify default template arguments
+    static_assert(std::same_as<std::generator<R, V>, std::generator<R, V, void>>);
+};
+
+template <class Ref, class V>
+using gen_value_t = gen_traits<Ref, V>::value;
+
+template <class Ref, class V>
+using gen_reference_t = gen_traits<Ref, V>::reference;
 
 template <class T, class AlwaysEqual = std::true_type, std::signed_integral DifferenceType = std::ptrdiff_t>
 class StatelessAlloc {

--- a/tests/std/tests/P2502R2_generator_death/test.cpp
+++ b/tests/std/tests/P2502R2_generator_death/test.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#define _CONTAINER_DEBUG_LEVEL 1
+
 #include <generator>
 #include <utility>
 
@@ -37,14 +39,12 @@ void test_end_iterator_incrementation() {
 int main(int argc, char** argv) {
     std_testing::death_test_executive exec;
 
-#ifdef _DEBUG
     exec.add_death_tests({
         test_begin_after_initial_suspend_point,
         test_begin_after_moving_from,
         test_end_iterator_dereference,
         test_end_iterator_incrementation,
     });
-#endif // _DEBUG
 
     return exec.run(argc, argv);
 }

--- a/tests/std/tests/P2502R2_generator_iterator/test.cpp
+++ b/tests/std/tests/P2502R2_generator_iterator/test.cpp
@@ -18,12 +18,6 @@ generator<Ref, V, Alloc> generate_zero() {
     co_return;
 }
 
-template <class Ref, class V>
-using gen_value_t = conditional_t<is_void_v<V>, remove_cvref_t<Ref>, V>;
-
-template <class Ref, class V>
-using gen_reference_t = conditional_t<is_void_v<V>, Ref&&, Ref>;
-
 template <class Ref, class V, class Alloc, class ValueType = gen_value_t<Ref, V>>
     requires default_initializable<ValueType>
           && (same_as<remove_cvref_t<Ref>, ValueType> || constructible_from<remove_cvref_t<Ref>, ValueType&>)

--- a/tests/std/tests/P2502R2_generator_promise/test.cpp
+++ b/tests/std/tests/P2502R2_generator_promise/test.cpp
@@ -53,12 +53,12 @@ void test_yield_elements_of_range(typename Gen::promise_type& p) {
 
     {
         using Awaitable = decltype(p.yield_value(ranges::elements_of{declval<Range&>()}));
-        static_assert(convertible_to<decltype(declval<Awaitable&>().await_ready()), bool>);
+        static_assert(same_as<decltype(declval<Awaitable&>().await_ready()), bool>);
     }
 
     if constexpr (!is_void_v<Alloc>) {
         using Awaitable = decltype(p.yield_value(ranges::elements_of{declval<Range&>(), declval<Alloc&>()}));
-        static_assert(convertible_to<decltype(declval<Awaitable&>().await_ready()), bool>);
+        static_assert(same_as<decltype(declval<Awaitable&>().await_ready()), bool>);
     }
 }
 
@@ -189,6 +189,9 @@ void test_one() {
         test_operator_new<Gen, StatelessAlloc<void, false_type>>(p);
         test_operator_new<Gen, StatelessAlloc<void, true_type, int>>(p);
     }
+
+    // Non-portable size check
+    static_assert(sizeof(Promise) == 2 * sizeof(void*));
 }
 
 template <class Ref, class V, bool TestingIncomplete = false>


### PR DESCRIPTION
This should complete the `generator` feature branch and get it ready to merge. There are very few product code changes here, it's mostly expanded test coverage with some cleanup and reorganization. There's also some documentation of the "stack of coroutines" and the memory layout of allocations that will make it easier for folks to get up to speed on how the code works under the covers.

It's broken down nicely by commit for ease of review; I'll replicate the commit messages here as an overview. Comments without specific context refer to `P2502R2_generator` where most changes were made. The `P2502R2_generator_iterator` and `P2502R2_generator_promise` tests were already very nicely complete.

* Update `generator` template argument mandates
  * Update citations to WG21-N4988
  * Reorder checks to specification order
  * Make `_RRef` more obviously reflect the wording for `RRef` in WG21-N4988 [coro.generator.class]/1.4.
* Allocator testing updates
  * Simplify and correct `StatelessAlloc`
    * Deriving publicly from `std::allocator` not a great idea, as witnessed by the recent addition of `allocate_at_least`.
    * `deallocate` should be `noexcept` for a `Cpp17Allocator`.
    * We don't need to reimplement `std::allocator` when we can simply use it.
    * The domain of equality for `Cpp17Allocators` is an entire `rebind` family, i.e., `StatelessAlloc<T>` and `allocator_traits<StatelessAlloc<T>>::rebind_alloc<U>` must be comparable.
  * PascalCase `stateful_alloc` for consistency and move into the header with `StatelessAlloc`.
* Promise test tweaks
  * "whose member `await_ready` returns `false`" in WG21-N4988 [coro.generator.promise]/11 implies the return type is exactly `bool`, not "convertible to `bool`". Update `test_yield_elements_of_range` accordingly.
  * Move non-portable size check from `P2502R2_generator` into `P2502R2_generator_promise`
* Expand and complete `static_checks`: Implement a complete `generator` traits in the header to use in both `P2502R2_generator_iterator` and `P2502R2_generator`'s `static_checks`.
* Create generic `test_one` template which takes a generator, a description of its static properties, and the expected result of piping the generator through a provided range adaptor. `test_one` validates the static properties with `static_checks`, and confirms the output is as expected.
* Extract test cases for weird reference types (mutable lvalue and rvalue references) from `main` into new function `test_weird_reference_types`.
* Several small tweaks:
  * It's no longer significant that `co_upto` wasn't an example in the proposal; strike the comment.
  * Enforce `co_upto`'s precondition so it's nicely documented.
  * Consistently prefer `same_as` to `is_same_v`.
  * Regroup calls to test cases in `main` topically and title each category.
* Reorganize test code to agree with call order in `main`. [This is the largest individual commit; it is a pure reordering.]
* All product code assertions now depend on `_CONTAINER_DEBUG_LEVEL`. These are all simple O(1) checks, there's no reason not to promote them from `_DEBUG` to `_CONTAINER_DEBUG_LEVEL`.
* Clarify allocation mechanisms, including some fancy memory layout diagrams.
  * Rename `_Promise_allocator` to `_Coro_promise_allocator` to avoid any confusion with `_Promise`. Rename its template parameter `_Allocator` to `_Proto_allocator` to avoid confusion with the rebound allocator type `_Alloc`.
  * Expand `static_assert` message in `operator new`. If and when `_Coro_promise_allocator` is reused by other coroutine types we can worry about making the message more generic.
  * Extract block size computations.
* `Element_awaiter` must direct-non-list-initialize its stored object, per WG21-N4988 [coro.generator.promise]/7.
* Document the "stack of coroutine handles" in a code comment with another work of art.
