### PR TITLE
`<deque>`: Add missed masking of `_First_used_block_idx` in `deque::shrink_to_fit` to correctly end the loop

### DIFF
--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -997,7 +997,8 @@ public:
 
         const auto _Mask = static_cast<size_type>(_Mapsize() - 1);
 
-        const auto _First_used_block_idx = static_cast<size_type>(_Myoff() / _Block_size);
+        const auto _Unmasked_first_used_block_idx = static_cast<size_type>(_Myoff() / _Block_size);
+        const auto _First_used_block_idx          = static_cast<size_type>(_Unmasked_first_used_block_idx & _Mask);
 
         // (_Myoff() + _Mysize() - 1) is for the last element, i.e. the back() of the deque.
         // Divide by _Block_size to get the unmasked index of the last used block.
@@ -1017,7 +1018,8 @@ public:
             }
         }
 
-        const auto _Used_block_count = static_cast<size_type>(_Unmasked_first_unused_block_idx - _First_used_block_idx);
+        const auto _Used_block_count =
+            static_cast<size_type>(_Unmasked_first_unused_block_idx - _Unmasked_first_used_block_idx);
 
         size_type _New_block_count = _Minimum_map_size; // should be power of 2
 

--- a/tests/std/tests/GH_002769_handle_deque_block_pointers/test.cpp
+++ b/tests/std/tests/GH_002769_handle_deque_block_pointers/test.cpp
@@ -4,10 +4,10 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <cstdlib>
 #include <deque>
 #include <iterator>
 #include <memory>
+#include <random>
 #include <type_traits>
 
 using namespace std;
@@ -332,23 +332,22 @@ void test_inconsistent_difference_types() {
 // Also test GH-4954: Endless loop in deque::shrink_to_fit()
 void test_gh_4954() {
     deque<int> qu;
+    mt19937_64 mteng;
 
-    int it = 0;
-    while (it < 1024) {
-        const auto numAlloc = static_cast<size_t>(rand() + 1);
-        for (size_t i = 0; i < numAlloc; i++) {
+    for (int i = 0; i < 256; ++i) {
+        const auto push_count = static_cast<size_t>((mteng() & 32767U) + 1);
+        for (size_t j = 0; j < push_count; ++j) {
             qu.push_back(0);
         }
 
-        auto numDealloc = static_cast<size_t>(rand() + 1);
-        if (it % 100 == 0 || numDealloc > qu.size()) {
-            numDealloc = qu.size();
+        auto pop_count = static_cast<size_t>((mteng() & 32767U) + 1);
+        if (i % 100 == 0 || pop_count > qu.size()) {
+            pop_count = qu.size();
         }
-        for (size_t i = 0; i < numDealloc; i++) {
+        for (size_t j = 0; j < pop_count; ++j) {
             qu.pop_front();
         }
         qu.shrink_to_fit();
-        ++it;
     }
 }
 

--- a/tests/std/tests/GH_002769_handle_deque_block_pointers/test.cpp
+++ b/tests/std/tests/GH_002769_handle_deque_block_pointers/test.cpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <deque>
 #include <iterator>
 #include <memory>
@@ -328,8 +329,32 @@ void test_inconsistent_difference_types() {
     assert(counter == 0);
 }
 
+// Also test GH-4954: Endless loop in deque::shrink_to_fit()
+void test_gh_4954() {
+    deque<int> qu;
+
+    int it = 0;
+    while (it < 1024) {
+        const auto numAlloc = static_cast<size_t>(rand() + 1);
+        for (size_t i = 0; i < numAlloc; i++) {
+            qu.push_back(0);
+        }
+
+        auto numDealloc = static_cast<size_t>(rand() + 1);
+        if (it % 100 == 0 || numDealloc > qu.size()) {
+            numDealloc = qu.size();
+        }
+        for (size_t i = 0; i < numDealloc; i++) {
+            qu.pop_front();
+        }
+        qu.shrink_to_fit();
+        ++it;
+    }
+}
+
 int main() {
     test_gh_2769();
     test_gh_3717();
+    test_gh_4954();
     test_inconsistent_difference_types();
 }


### PR DESCRIPTION
Fixes #4954.

In #4091, `_First_used_block_idx` was incorrectly unmasked. In some problematic cases, `_First_used_block_idx` can become larger than `_Mask`, which could render the loop infinite.