### PR TITLE
Don't deduce the return type of `emplace`{,`_back`,`_front`}

### DIFF
--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1160,7 +1160,7 @@ private:
 
 public:
     template <class... _Valty>
-    decltype(auto) emplace_front(_Valty&&... _Val) {
+    _CONTAINER_EMPLACE_RETURN emplace_front(_Valty&&... _Val) {
         _Orphan_all();
         _Emplace_front_internal(_STD forward<_Valty>(_Val)...);
 #if _HAS_CXX17
@@ -1169,7 +1169,7 @@ public:
     }
 
     template <class... _Valty>
-    decltype(auto) emplace_back(_Valty&&... _Val) {
+    _CONTAINER_EMPLACE_RETURN emplace_back(_Valty&&... _Val) {
         _Orphan_all();
         _Emplace_back_internal(_STD forward<_Valty>(_Val)...);
 

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -700,7 +700,7 @@ public:
     }
 
     template <class... _Valty>
-    decltype(auto) emplace_front(_Valty&&... _Val) { // insert element at beginning
+    _CONTAINER_EMPLACE_RETURN emplace_front(_Valty&&... _Val) { // insert element at beginning
         _Insert_after(_Mypair._Myval2._Before_head(), _STD forward<_Valty>(_Val)...);
 
 #if _HAS_CXX17

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -981,7 +981,7 @@ public:
     }
 
     template <class... _Valty>
-    decltype(auto) emplace_front(_Valty&&... _Val) { // insert element at beginning
+    _CONTAINER_EMPLACE_RETURN emplace_front(_Valty&&... _Val) { // insert element at beginning
         reference _Result = _Emplace(_Mypair._Myval2._Myhead->_Next, _STD forward<_Valty>(_Val)...)->_Myval;
 
 #if _HAS_CXX17
@@ -992,7 +992,7 @@ public:
     }
 
     template <class... _Valty>
-    decltype(auto) emplace_back(_Valty&&... _Val) { // insert element at end
+    _CONTAINER_EMPLACE_RETURN emplace_back(_Valty&&... _Val) { // insert element at end
         reference _Result = _Emplace(_Mypair._Myval2._Myhead, _STD forward<_Valty>(_Val)...)->_Myval;
 
 #if _HAS_CXX17

--- a/stl/inc/queue
+++ b/stl/inc/queue
@@ -135,7 +135,7 @@ public:
 #endif // _HAS_CXX23
 
     template <class... _Valty>
-    decltype(auto) emplace(_Valty&&... _Val) {
+    _CONTAINER_EMPLACE_RETURN emplace(_Valty&&... _Val) {
 #if _HAS_CXX17
         return c.emplace_back(_STD forward<_Valty>(_Val)...);
 #else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv

--- a/stl/inc/stack
+++ b/stl/inc/stack
@@ -120,7 +120,7 @@ public:
 #endif // _HAS_CXX23
 
     template <class... _Valty>
-    decltype(auto) emplace(_Valty&&... _Val) {
+    _CONTAINER_EMPLACE_RETURN emplace(_Valty&&... _Val) {
 #if _HAS_CXX17
         return c.emplace_back(_STD forward<_Valty>(_Val)...);
 #else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -853,7 +853,7 @@ private:
 
 public:
     template <class... _Valty>
-    _CONSTEXPR20 decltype(auto) emplace_back(_Valty&&... _Val) {
+    _CONSTEXPR20 _CONTAINER_EMPLACE_RETURN emplace_back(_Valty&&... _Val) {
         // insert by perfectly forwarding into element at end, provide strong guarantee
         _Ty& _Result = _Emplace_one_at_back(_STD forward<_Valty>(_Val)...);
 #if _HAS_CXX17
@@ -2979,7 +2979,7 @@ public:
     }
 
     template <class... _Valty>
-    _CONSTEXPR20 decltype(auto) emplace_back(_Valty&&... _Val) {
+    _CONSTEXPR20 _CONTAINER_EMPLACE_RETURN emplace_back(_Valty&&... _Val) {
         bool _Tmp(_STD forward<_Valty>(_Val)...);
         push_back(_Tmp);
 

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2621,6 +2621,12 @@ _NODISCARD _Elem* _UIntegral_to_buff(_Elem* _RNext, _UTy _UVal) { // used by bot
 }
 _STD_END
 
+#if _HAS_CXX17
+#define _CONTAINER_EMPLACE_RETURN reference
+#else // ^^^ _HAS_CXX17 ^^^ / vvv !_HAS_CXX17 vvv
+#define _CONTAINER_EMPLACE_RETURN void
+#endif // ^^^ _HAS_CXX17 ^^^
+
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2625,7 +2625,7 @@ _STD_END
 #define _CONTAINER_EMPLACE_RETURN reference
 #else // ^^^ _HAS_CXX17 ^^^ / vvv !_HAS_CXX17 vvv
 #define _CONTAINER_EMPLACE_RETURN void
-#endif // ^^^ _HAS_CXX17 ^^^
+#endif // ^^^ !_HAS_CXX17 ^^^
 
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -766,3 +766,4 @@ tests\VSO_0971246_legacy_await_headers
 tests\VSO_1775715_user_defined_modules
 tests\VSO_1804139_static_analysis_warning_with_single_element_array
 tests\VSO_1925201_iter_traits
+tests\VSO_2252142_wrong_C5046

--- a/tests/std/tests/VSO_2252142_wrong_C5046/env.lst
+++ b/tests/std/tests/VSO_2252142_wrong_C5046/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/VSO_2252142_wrong_C5046/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_2252142_wrong_C5046/test.compile.pass.cpp
@@ -43,8 +43,8 @@ namespace {
     struct S2 {};
 } // namespace
 
-// Was emitting "C5046 Symbol involving type with internal linkage not defined" as a consequence of our use of return
-// type deduction for the pertinent container functions.
+// Was emitting "warning C5046: Symbol involving type with internal linkage not defined"
+// as a consequence of our use of return type deduction for the pertinent container functions.
 STATIC_ASSERT(has_emplace_back<vector<S2>>);
 STATIC_ASSERT(has_emplace_back<deque<S2>>);
 STATIC_ASSERT(has_emplace_front<deque<S2>>);

--- a/tests/std/tests/VSO_2252142_wrong_C5046/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_2252142_wrong_C5046/test.compile.pass.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <deque>
+#include <forward_list>
+#include <list>
+#include <queue>
+#include <stack>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+// Test for DevCom-10745303 / VSO-2252142 "C5046 is wrongly triggered in unevaluated context"
+
+#define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
+
+using namespace std;
+
+template <class T>
+struct convertible_to_any {
+    operator T() &&; // not defined, only used in unevaluated context
+};
+
+template <class Cont, class = void>
+constexpr bool has_emplace = false;
+template <class Cont>
+constexpr bool has_emplace<Cont,
+    void_t<decltype(declval<Cont&>().emplace(declval<convertible_to_any<typename Cont::value_type>>()))>> = true;
+
+template <class Cont, class = void>
+constexpr bool has_emplace_back = false;
+template <class Cont>
+constexpr bool has_emplace_back<Cont,
+    void_t<decltype(declval<Cont&>().emplace_back(declval<convertible_to_any<typename Cont::value_type>>()))>> = true;
+
+template <class Cont, class = void>
+constexpr bool has_emplace_front = false;
+template <class Cont>
+constexpr bool has_emplace_front<Cont,
+    void_t<decltype(declval<Cont&>().emplace_front(declval<convertible_to_any<typename Cont::value_type>>()))>> = true;
+
+namespace {
+    struct S2 {};
+} // namespace
+
+// Was emitting "C5046 Symbol involving type with internal linkage not defined" as a consequence of our use of return
+// type deduction for the pertinent container functions.
+STATIC_ASSERT(has_emplace_back<vector<S2>>);
+STATIC_ASSERT(has_emplace_back<deque<S2>>);
+STATIC_ASSERT(has_emplace_front<deque<S2>>);
+STATIC_ASSERT(has_emplace_front<forward_list<S2>>);
+STATIC_ASSERT(has_emplace_back<list<S2>>);
+STATIC_ASSERT(has_emplace_front<list<S2>>);
+STATIC_ASSERT(has_emplace<queue<S2>>);
+STATIC_ASSERT(has_emplace<stack<S2>>);
+STATIC_ASSERT(has_emplace_back<vector<bool>>); // Cannot trigger this bug, but for consistency


### PR DESCRIPTION
The instantiation used to deduce the return types of template functions with placeholders in their declared return type happens outside the immediate context of any other template instantiation. Notably, that means the body of such an instantiation isn't an unevaluated context. 

Switching to concrete return types will:
1. Avoid return type deduction, correcting the problem described in DevCom-10745303, and
2. Correct the ODR problem described in #4962.

Fixes DevCom-10745303 / VSO-2252142 / AB#2252142
