### PR TITLE
Short-circuit some `variant` constraints

### DIFF
--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -934,12 +934,11 @@ public:
         : _Mybase(in_place_index<0>) {} // value-initialize alternative 0
 
     template <class _Ty,
-        enable_if_t<sizeof...(_Types) != 0 //
-                        && !is_same_v<_Remove_cvref_t<_Ty>, variant> //
-                        && !_Is_specialization_v<_Remove_cvref_t<_Ty>, in_place_type_t> //
-                        && !_Is_in_place_index_specialization<_Remove_cvref_t<_Ty>> //
-                        && is_constructible_v<_Variant_init_type<_Ty, _Types...>, _Ty>, //
-            int> = 0>
+        enable_if_t<sizeof...(_Types) != 0 && !is_same_v<_Remove_cvref_t<_Ty>, variant>
+                        && !_Is_specialization_v<_Remove_cvref_t<_Ty>, in_place_type_t>
+                        && !_Is_in_place_index_specialization<_Remove_cvref_t<_Ty>>,
+            int>                                                                      = 0,
+        enable_if_t<is_constructible_v<_Variant_init_type<_Ty, _Types...>, _Ty>, int> = 0>
     constexpr variant(_Ty&& _Obj) noexcept(is_nothrow_constructible_v<_Variant_init_type<_Ty, _Types...>, _Ty>)
         : _Mybase(in_place_index<_Variant_init_index<_Ty, _Types...>::value>, static_cast<_Ty&&>(_Obj)) {
         // initialize to the type selected by passing _Obj to the overload set f(Types)...
@@ -976,10 +975,10 @@ public:
         // initialize alternative _Idx from _Ilist and _Args...
     }
 
-    template <class _Ty, enable_if_t<!is_same_v<_Remove_cvref_t<_Ty>, variant>
-                                         && is_constructible_v<_Variant_init_type<_Ty, _Types...>, _Ty>
-                                         && is_assignable_v<_Variant_init_type<_Ty, _Types...>&, _Ty>,
-                             int> = 0>
+    template <class _Ty, enable_if_t<!is_same_v<_Remove_cvref_t<_Ty>, variant>, int> = 0,
+        enable_if_t<is_constructible_v<_Variant_init_type<_Ty, _Types...>, _Ty>
+                        && is_assignable_v<_Variant_init_type<_Ty, _Types...>&, _Ty>,
+            int> = 0>
     _CONSTEXPR20 variant& operator=(_Ty&& _Obj)
         noexcept(is_nothrow_assignable_v<_Variant_init_type<_Ty, _Types...>&, _Ty>
                  && is_nothrow_constructible_v<_Variant_init_type<_Ty, _Types...>, _Ty>) {

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -937,7 +937,9 @@ public:
         enable_if_t<sizeof...(_Types) != 0 && !is_same_v<_Remove_cvref_t<_Ty>, variant>
                         && !_Is_specialization_v<_Remove_cvref_t<_Ty>, in_place_type_t>
                         && !_Is_in_place_index_specialization<_Remove_cvref_t<_Ty>>,
-            int>                                                                      = 0,
+            int> = 0,
+        // These enable_if_t constraints are distinct to enable short-circuiting and avoid
+        // substitution into _Variant_init_type when the first constraint is not satisfied.
         enable_if_t<is_constructible_v<_Variant_init_type<_Ty, _Types...>, _Ty>, int> = 0>
     constexpr variant(_Ty&& _Obj) noexcept(is_nothrow_constructible_v<_Variant_init_type<_Ty, _Types...>, _Ty>)
         : _Mybase(in_place_index<_Variant_init_index<_Ty, _Types...>::value>, static_cast<_Ty&&>(_Obj)) {
@@ -976,6 +978,8 @@ public:
     }
 
     template <class _Ty, enable_if_t<!is_same_v<_Remove_cvref_t<_Ty>, variant>, int> = 0,
+        // These enable_if_t constraints are distinct to enable short-circuiting and avoid
+        // substitution into _Variant_init_type when the first constraint is not satisfied.
         enable_if_t<is_constructible_v<_Variant_init_type<_Ty, _Types...>, _Ty>
                         && is_assignable_v<_Variant_init_type<_Ty, _Types...>&, _Ty>,
             int> = 0>

--- a/tests/std/tests/P0088R3_variant_msvc/test.cpp
+++ b/tests/std/tests/P0088R3_variant_msvc/test.cpp
@@ -915,11 +915,11 @@ namespace msvc {
         // Test GH-4959 "P0608R3 breaks flang build with Clang"
         // Constraints on variant's converting constructor and assignment operator templates reject arguments of the
         // variant's type, but did not short-circuit to avoid evaluating the constructibility constraint. For this
-        // program, the constructibility constraint is ill-formed outside the immediate context when determing if
+        // program, the constructibility constraint is ill-formed outside the immediate context when determining if
         // variant<optional<GenericSpec>> can be initialized from an rvalue of the same type.
 
-        template <typename... RVREF>
-        using NoLvalue = std::enable_if_t<(... && !std::is_lvalue_reference_v<RVREF>)>;
+        template <typename... RvRef>
+        using NoLvalue = std::enable_if_t<(... && !std::is_lvalue_reference_v<RvRef>)>;
 
         struct Name {};
 


### PR DESCRIPTION
`variant`'s converting constructor and assignment operator templates are constrained to reject arguments of the `variant`'s type. In such a case, the templates instantiated to check the constructibility constraint might be ill-formed outside the immediate context of template instantiation causing a hard error. We should split the constraints into multiple `enable_if_t`s to enable short-circuiting of later constraints when the earlier constraints fail.

Fixes #4959.
