### PR TITLE
Use `char_traits` in streaming `operator>>` of `bitset`

### DIFF
--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -589,15 +589,20 @@ basic_istream<_Elem, _Tr>& operator>>(basic_istream<_Elem, _Tr>& _Istr, bitset<_
             if (_Tr::eq_int_type(_Tr::eof(), _Meta)) { // end of file, quit
                 _State |= _Istr_t::eofbit;
                 break;
-            } else if (!_Tr::eq((_Char = _Tr::to_char_type(_Meta)), _Elem0) && !_Tr::eq(_Char, _Elem1)) {
+            }
+
+            if (!_Tr::eq((_Char = _Tr::to_char_type(_Meta)), _Elem0) && !_Tr::eq(_Char, _Elem1)) {
                 break; // invalid element
-            } else if (_Str.max_size() <= _Str.size()) { // no room in string, give up (unlikely)
+            }
+
+            if (_Str.max_size() <= _Str.size()) { // no room in string, give up (unlikely)
                 _State |= _Istr_t::failbit;
                 break;
-            } else { // valid, append '0' or '1'
-                _Str.push_back('0' + _Tr::eq(_Char, _Elem1));
-                _Changed = true;
             }
+
+            // valid, append '0' or '1'
+            _Str.push_back('0' + _Tr::eq(_Char, _Elem1));
+            _Changed = true;
         }
         _CATCH_IO_(_Istr_t, _Istr)
     }

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -585,13 +585,14 @@ basic_istream<_Elem, _Tr>& operator>>(basic_istream<_Elem, _Tr>& _Istr, bitset<_
         typename _Tr::int_type _Meta = _Istr.rdbuf()->sgetc();
         for (size_t _Count = _Right.size(); 0 < _Count; _Meta = _Istr.rdbuf()->snextc(), (void) --_Count) {
             // test _Meta
-            _Elem _Char;
             if (_Tr::eq_int_type(_Tr::eof(), _Meta)) { // end of file, quit
                 _State |= _Istr_t::eofbit;
                 break;
             }
 
-            if (!_Tr::eq((_Char = _Tr::to_char_type(_Meta)), _Elem0) && !_Tr::eq(_Char, _Elem1)) {
+            const _Elem _Char = _Tr::to_char_type(_Meta);
+
+            if (!_Tr::eq(_Char, _Elem0) && !_Tr::eq(_Char, _Elem1)) {
                 break; // invalid element
             }
 

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -589,13 +589,13 @@ basic_istream<_Elem, _Tr>& operator>>(basic_istream<_Elem, _Tr>& _Istr, bitset<_
             if (_Tr::eq_int_type(_Tr::eof(), _Meta)) { // end of file, quit
                 _State |= _Istr_t::eofbit;
                 break;
-            } else if ((_Char = _Tr::to_char_type(_Meta)) != _Elem0 && _Char != _Elem1) {
+            } else if (!_Tr::eq((_Char = _Tr::to_char_type(_Meta)), _Elem0) && !_Tr::eq(_Char, _Elem1)) {
                 break; // invalid element
             } else if (_Str.max_size() <= _Str.size()) { // no room in string, give up (unlikely)
                 _State |= _Istr_t::failbit;
                 break;
             } else { // valid, append '0' or '1'
-                _Str.push_back('0' + (_Char == _Elem1));
+                _Str.push_back('0' + _Tr::eq(_Char, _Elem1));
                 _Changed = true;
             }
         }

--- a/tests/std/tests/GH_004930_char_traits_user_specialization/test.cpp
+++ b/tests/std/tests/GH_004930_char_traits_user_specialization/test.cpp
@@ -291,9 +291,10 @@ static_assert(test_gh_4930());
 void test_gh_4956() {
     // bitset's stream extraction operator was using `!=` to compare characters instead of `traits::eq`
     basic_string<char, odd_char_traits<char>> s("QQPPQ", 5);
+    basic_istringstream<char, odd_char_traits<char>> iss(s);
 
     bitset<7> bs;
-    std::basic_stringstream<char, odd_char_traits<char>>(s) >> bs;
+    iss >> bs;
 
     assert(bs.to_ulong() == 0b11001);
 }

--- a/tests/std/tests/GH_004930_char_traits_user_specialization/test.cpp
+++ b/tests/std/tests/GH_004930_char_traits_user_specialization/test.cpp
@@ -166,6 +166,8 @@ enum odd_char : unsigned char {};
 template <>
 class char_traits<odd_char> : public odd_char_traits<odd_char> {};
 
+// GH-4930 "<string>: basic_string<unicorn>::find_meow_of family
+// with std::char_traits<unicorn> specialization are not supported"
 CONSTEXPR20 bool test_gh_4930() {
     constexpr odd_char s_init[]{static_cast<odd_char>(0x55), static_cast<odd_char>(0x44), static_cast<odd_char>(0x33),
         static_cast<odd_char>(0x22), static_cast<odd_char>(0x11), static_cast<odd_char>(0)};
@@ -285,7 +287,9 @@ CONSTEXPR20 bool test_gh_4930() {
 static_assert(test_gh_4930());
 #endif // _HAS_CXX20
 
+// GH-4956 "<bitset>: streaming operator >> does not use character traits"
 void test_gh_4956() {
+    // bitset's stream extraction operator was using `!=` to compare characters instead of `traits::eq`
     basic_string<char, odd_char_traits<char>> s("QQPPQ", 5);
 
     bitset<7> bs;


### PR DESCRIPTION
Fixes #4956