### PR TITLE
Do not deduce the return type of `unique,remove[_if]` of `[forward_]list`

### DIFF
--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -1208,12 +1208,12 @@ public:
         _Nodeptr* _Tail;
     };
 
-    auto remove(const _Ty& _Val) { // erase each element matching _Val
+    _LIST_REMOVE_RETURN remove(const _Ty& _Val) { // erase each element matching _Val
         return remove_if([&](const _Ty& _Other) -> bool { return _Other == _Val; });
     }
 
     template <class _Pr1>
-    auto remove_if(_Pr1 _Pred) { // erase each element satisfying _Pr1
+    _LIST_REMOVE_RETURN remove_if(_Pr1 _Pred) { // erase each element satisfying _Pr1
         _Flist_node_remove_op _Op(*this);
         auto _Firstb       = _Unchecked_before_begin();
         size_type _Removed = 0;
@@ -1235,12 +1235,12 @@ public:
 #endif
     }
 
-    auto unique() { // erase each element matching previous
+    _LIST_REMOVE_RETURN unique() { // erase each element matching previous
         return unique(equal_to<>{});
     }
 
     template <class _Pr2>
-    auto unique(_Pr2 _Pred) { // erase each element satisfying _Pred with previous
+    _LIST_REMOVE_RETURN unique(_Pr2 _Pred) { // erase each element satisfying _Pred with previous
         _Flist_node_remove_op _Op(*this);
         auto _First        = _Unchecked_begin();
         size_type _Removed = 0;

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -1662,12 +1662,12 @@ public:
         _Nodeptr* _Tail;
     };
 
-    auto remove(const _Ty& _Val) { // erase each element matching _Val
+    _LIST_REMOVE_RETURN remove(const _Ty& _Val) { // erase each element matching _Val
         return remove_if([&](const _Ty& _Other) -> bool { return _Other == _Val; });
     }
 
     template <class _Pr1>
-    auto remove_if(_Pr1 _Pred) { // erase each element satisfying _Pred
+    _LIST_REMOVE_RETURN remove_if(_Pr1 _Pred) { // erase each element satisfying _Pred
         auto& _My_data = _Mypair._Myval2;
         _List_node_remove_op _Op(*this);
         const auto _Last         = _My_data._Myhead;
@@ -1688,12 +1688,12 @@ public:
 #endif
     }
 
-    auto unique() { // erase each element matching previous
+    _LIST_REMOVE_RETURN unique() { // erase each element matching previous
         return unique(equal_to<>{});
     }
 
     template <class _Pr2>
-    auto unique(_Pr2 _Pred) { // erase each element satisfying _Pred with previous
+    _LIST_REMOVE_RETURN unique(_Pr2 _Pred) { // erase each element satisfying _Pred with previous
         _List_node_remove_op _Op(*this);
         const _Nodeptr _Phead    = _Mypair._Myval2._Myhead;
         _Nodeptr _Pprev          = _Phead->_Next;

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2649,6 +2649,12 @@ _STD_END
 #define _CONTAINER_EMPLACE_RETURN void
 #endif // ^^^ !_HAS_CXX17 ^^^
 
+#if _HAS_CXX20
+#define _LIST_REMOVE_RETURN size_type
+#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+#define _LIST_REMOVE_RETURN void
+#endif // ^^^ !_HAS_CXX20 ^^^
+
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
fixes #4968. It's similar to #4963.