### PR TITLE
`<utility>`: Privatize `pair`'s internal non-Standard constructor

### DIFF
--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -315,16 +315,9 @@ struct pair { // store a pair of values
     }
 #endif // _HAS_CXX23
 
-    template <class _Tuple1, class _Tuple2, size_t... _Indices1, size_t... _Indices2>
-    constexpr pair(_Tuple1& _Val1, _Tuple2& _Val2, index_sequence<_Indices1...>, index_sequence<_Indices2...>)
-        : first(_STD _Tuple_get<_Indices1>(_STD move(_Val1))...),
-          second(_STD _Tuple_get<_Indices2>(_STD move(_Val2))...) {}
-
     template <class... _Types1, class... _Types2>
     _CONSTEXPR20 pair(piecewise_construct_t, tuple<_Types1...> _Val1, tuple<_Types2...> _Val2)
         : pair(_Val1, _Val2, index_sequence_for<_Types1...>{}, index_sequence_for<_Types2...>{}) {}
-
-    pair& operator=(const volatile pair&) = delete;
 
     template <class _Myself = pair,
         enable_if_t<conjunction_v<_Is_copy_assignable_no_precondition_check<typename _Myself::first_type>,
@@ -466,6 +459,14 @@ struct pair { // store a pair of values
 
     _Ty1 first; // the first stored value
     _Ty2 second; // the second stored value
+
+private:
+    template <class _Tuple1, class _Tuple2, size_t... _Indices1, size_t... _Indices2>
+    constexpr pair(_Tuple1& _Val1, _Tuple2& _Val2, index_sequence<_Indices1...>, index_sequence<_Indices2...>)
+        : first(_STD _Tuple_get<_Indices1>(_STD move(_Val1))...),
+          second(_STD _Tuple_get<_Indices2>(_STD move(_Val2))...) {}
+
+    pair& operator=(const volatile pair&) = delete;
 };
 
 #if _HAS_CXX17

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -319,6 +319,8 @@ struct pair { // store a pair of values
     _CONSTEXPR20 pair(piecewise_construct_t, tuple<_Types1...> _Val1, tuple<_Types2...> _Val2)
         : pair(_Val1, _Val2, index_sequence_for<_Types1...>{}, index_sequence_for<_Types2...>{}) {}
 
+    pair& operator=(const volatile pair&) = delete;
+
     template <class _Myself = pair,
         enable_if_t<conjunction_v<_Is_copy_assignable_no_precondition_check<typename _Myself::first_type>,
                         _Is_copy_assignable_no_precondition_check<typename _Myself::second_type>>,
@@ -465,8 +467,6 @@ private:
     constexpr pair(_Tuple1& _Val1, _Tuple2& _Val2, index_sequence<_Indices1...>, index_sequence<_Indices2...>)
         : first(_STD _Tuple_get<_Indices1>(_STD move(_Val1))...),
           second(_STD _Tuple_get<_Indices2>(_STD move(_Val2))...) {}
-
-    pair& operator=(const volatile pair&) = delete;
 };
 
 #if _HAS_CXX17

--- a/tests/std/tests/VSO_0000000_more_pair_tuple_sfinae/test.cpp
+++ b/tests/std/tests/VSO_0000000_more_pair_tuple_sfinae/test.cpp
@@ -558,6 +558,13 @@ STATIC_ASSERT(!is_constructible_v<tuple<A>, allocator_arg_t, allocator<int>, pai
 STATIC_ASSERT(is_constructible_v<tuple<A, A>, allocator_arg_t, allocator<int>, pair<Ex, Ex>>);
 STATIC_ASSERT(!is_constructible_v<tuple<A, A, A>, allocator_arg_t, allocator<int>, pair<Ex, Ex>>);
 
+// Also test that the internal constructor used for the piecewise_construct_t constructor of pair is not public.
+STATIC_ASSERT(!is_constructible_v<pair<int, int>, tuple<>&, tuple<>&, make_index_sequence<0>, make_index_sequence<0>>);
+STATIC_ASSERT(
+    !is_constructible_v<pair<int, int>, tuple<int>&, tuple<>&, make_index_sequence<1>, make_index_sequence<0>>);
+STATIC_ASSERT(
+    !is_constructible_v<pair<int, int>, tuple<int>&, tuple<int>&, make_index_sequence<1>, make_index_sequence<1>>);
+
 
 pair<int, int> func1() {
     const int x = 17;


### PR DESCRIPTION
In #4961 we made an internal secret constructor private. It's arguably conforming to leave the internal constructor of `pair` public, because it must be called with 4 arguments, and no Standard constructor would be selected in such a call. However, it's possibly better to prevent accident calls to implementation details.

~Also move the deleted `operator=` overload to the private section for consistency, which should affect nothing.~ Edit: reverted.