### PR TITLE
Deduce the return type of `queue::emplace` and `stack::emplace`

### DIFF
--- a/stl/inc/queue
+++ b/stl/inc/queue
@@ -135,7 +135,7 @@ public:
 #endif // _HAS_CXX23
 
     template <class... _Valty>
-    _CONTAINER_EMPLACE_RETURN emplace(_Valty&&... _Val) {
+    _ADAPTOR_EMPLACE_RETURN emplace(_Valty&&... _Val) {
 #if _HAS_CXX17
         return c.emplace_back(_STD forward<_Valty>(_Val)...);
 #else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv

--- a/stl/inc/stack
+++ b/stl/inc/stack
@@ -120,7 +120,7 @@ public:
 #endif // _HAS_CXX23
 
     template <class... _Valty>
-    _CONTAINER_EMPLACE_RETURN emplace(_Valty&&... _Val) {
+    _ADAPTOR_EMPLACE_RETURN emplace(_Valty&&... _Val) {
 #if _HAS_CXX17
         return c.emplace_back(_STD forward<_Valty>(_Val)...);
 #else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2644,6 +2644,12 @@ _NODISCARD _Elem* _UIntegral_to_buff(_Elem* _RNext, _UTy _UVal) { // used by bot
 _STD_END
 
 #if _HAS_CXX17
+#define _ADAPTOR_EMPLACE_RETURN decltype(auto)
+#else // ^^^ _HAS_CXX17 ^^^ / vvv !_HAS_CXX17 vvv
+#define _ADAPTOR_EMPLACE_RETURN void
+#endif // ^^^ !_HAS_CXX17 ^^^
+
+#if _HAS_CXX17
 #define _CONTAINER_EMPLACE_RETURN reference
 #else // ^^^ _HAS_CXX17 ^^^ / vvv !_HAS_CXX17 vvv
 #define _CONTAINER_EMPLACE_RETURN void

--- a/tests/std/tests/VSO_2252142_wrong_C5046/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_2252142_wrong_C5046/test.compile.pass.cpp
@@ -4,8 +4,6 @@
 #include <deque>
 #include <forward_list>
 #include <list>
-#include <queue>
-#include <stack>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -20,12 +18,6 @@ template <class T>
 struct convertible_to_any {
     operator T() &&; // not defined, only used in unevaluated context
 };
-
-template <class Cont, class = void>
-constexpr bool has_emplace = false;
-template <class Cont>
-constexpr bool has_emplace<Cont,
-    void_t<decltype(declval<Cont&>().emplace(declval<convertible_to_any<typename Cont::value_type>>()))>> = true;
 
 template <class Cont, class = void>
 constexpr bool has_emplace_back = false;
@@ -51,6 +43,7 @@ STATIC_ASSERT(has_emplace_front<deque<S2>>);
 STATIC_ASSERT(has_emplace_front<forward_list<S2>>);
 STATIC_ASSERT(has_emplace_back<list<S2>>);
 STATIC_ASSERT(has_emplace_front<list<S2>>);
-STATIC_ASSERT(has_emplace<queue<S2>>);
-STATIC_ASSERT(has_emplace<stack<S2>>);
 STATIC_ASSERT(has_emplace_back<vector<bool>>); // Cannot trigger this bug, but for consistency
+
+// N4988 [queue.defn] and [stack.defn] require the container adaptors to have `decltype(auto) emplace(Args&&... args)`,
+// allowing them to adapt both C++14-era and C++17-era containers.


### PR DESCRIPTION
Followup to #4963. Fixes VSO-2261359 / AB#2261359 "\[VCPKG\] rocksdb installation failed with error C2440":

```
stack(125): error C2440: 'return': cannot convert from 'void' to 'rocksdb::TransactionBaseImpl::SavePoint &'
```

As the container adaptors are required to use `decltype(auto)` in C++17, the "warning C5046: Symbol involving type with internal linkage not defined" in the `convertible_to_any` scenario and the ODR violation when mixing C++14 and C++17 TUs are unavoidable.

In `<xmemory>`, I'm lexicographically sorting `_ADAPTOR_EMPLACE_RETURN` before `_CONTAINER_EMPLACE_RETURN`, which will avoid an adjacent-add conflict with #4975 adding `_LIST_REMOVE_RETURN` (also in lex order).