### PR TITLE
Update CodeQL warning suppressions

### DIFF
--- a/stl/inc/__msvc_string_view.hpp
+++ b/stl/inc/__msvc_string_view.hpp
@@ -676,7 +676,8 @@ public:
     }
 
     constexpr bool _Match(const _Elem _Ch) const noexcept { // test if _Ch is in the bitmap
-        return _Matches[static_cast<unsigned char>(_Ch)]; // lgtm [cpp/unclear-array-index-validation]
+        // CodeQL [SM01954] This index is valid: we cast to unsigned char and the array has 256 elements.
+        return _Matches[static_cast<unsigned char>(_Ch)];
     }
 
 private:
@@ -1337,7 +1338,9 @@ public:
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Off < _Mysize, "string_view subscript out of range");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-        return _Mydata[_Off]; // lgtm [cpp/unclear-array-index-validation]
+
+        // CodeQL [SM01954] This index is optionally validated above.
+        return _Mydata[_Off];
     }
 
     _NODISCARD constexpr const_reference at(const size_type _Off) const {

--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -228,7 +228,9 @@ _STL_INTERNAL_STATIC_ASSERT(_STD size(_Digit_from_byte) == 256);
 
 _NODISCARD _CONSTEXPR23 unsigned char _Digit_from_char(const char _Ch) noexcept {
     // convert ['0', '9'] ['A', 'Z'] ['a', 'z'] to [0, 35], everything else to 255
-    return _Digit_from_byte[static_cast<unsigned char>(_Ch)]; // lgtm [cpp/unclear-array-index-validation]
+
+    // CodeQL [SM01954] This index is valid: we cast to unsigned char and the array has 256 elements.
+    return _Digit_from_byte[static_cast<unsigned char>(_Ch)];
 }
 
 template <class _RawTy>
@@ -456,7 +458,9 @@ _NODISCARD inline uint32_t _Bit_scan_reverse(const _Big_integer_flt& _Xval) noex
     unsigned long _Index; // Intentionally uninitialized for better codegen
 
     _STL_INTERNAL_CHECK(_Xval._Mydata[_Bx] != 0); // _Big_integer_flt should always be trimmed
-    _BitScanReverse(&_Index, _Xval._Mydata[_Bx]); // lgtm [cpp/conditionallyuninitializedvariable]
+
+    // CodeQL [SM02313] _Index is always initialized: we've guaranteed that _Xval._Mydata[_Bx] is non-zero.
+    _BitScanReverse(&_Index, _Xval._Mydata[_Bx]);
 
     return _Index + 1 + _Bx * _Big_integer_flt::_Element_bits;
 }

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -573,13 +573,14 @@ public:
 
     _NODISCARD string message(int _Errcode) const override {
         const _System_error_message _Msg(static_cast<unsigned long>(_Errcode));
-        if (_Msg._Length == 0) {
+
+        if (_Msg._Str && _Msg._Length != 0) {
+            // CodeQL [SM02310] _Msg's ctor inits _Str(nullptr) before doing work, then we test _Msg._Str above.
+            return string{_Msg._Str, _Msg._Length};
+        } else {
             static constexpr char _Unknown_error[] = "unknown error";
             constexpr size_t _Unknown_error_length = sizeof(_Unknown_error) - 1; // TRANSITION, DevCom-906503
             return string{_Unknown_error, _Unknown_error_length};
-        } else {
-            _STL_INTERNAL_CHECK(_Msg._Str != nullptr);
-            return string{_Msg._Str, _Msg._Length}; // lgtm [cpp/uninitializedptrfield]
         }
     }
 

--- a/stl/inc/xbit_ops.h
+++ b/stl/inc/xbit_ops.h
@@ -37,9 +37,11 @@ _NODISCARD inline unsigned long _Floor_of_log_2(size_t _Value) noexcept { // ret
     }
 #else // ^^^ defined(_M_CEE_PURE) / !defined(_M_CEE_PURE) vvv
 #ifdef _WIN64
-    _BitScanReverse64(&_Result, _Value); // lgtm [cpp/conditionallyuninitializedvariable]
+    // CodeQL [SM02313] _Result is always initialized: the code above guarantees that _Value is non-zero.
+    _BitScanReverse64(&_Result, _Value);
 #else // ^^^ 64-bit / 32-bit vvv
-    _BitScanReverse(&_Result, _Value); // lgtm [cpp/conditionallyuninitializedvariable]
+    // CodeQL [SM02313] _Result is always initialized: the code above guarantees that _Value is non-zero.
+    _BitScanReverse(&_Result, _Value);
 #endif // ^^^ 32-bit ^^^
 #endif // ^^^ !defined(_M_CEE_PURE) ^^^
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4684,7 +4684,8 @@ _OutCtgIt _Copy_memmove(_CtgIt _First, _CtgIt _Last, _OutCtgIt _Dest) {
     const auto _Count           = static_cast<size_t>(_Last_ch - _First_ch);
     _CSTD memmove(_Dest_ch, _First_ch, _Count);
     if constexpr (is_pointer_v<_OutCtgIt>) {
-        return reinterpret_cast<_OutCtgIt>(_Dest_ch + _Count); // lgtm [cpp/incorrect-string-type-conversion]
+        // CodeQL [SM02986] This cast is correct: we're bypassing pointer arithmetic for performance.
+        return reinterpret_cast<_OutCtgIt>(_Dest_ch + _Count);
     } else {
         return _Dest + static_cast<_Iter_diff_t<_OutCtgIt>>(_LastPtr - _FirstPtr);
     }

--- a/stl/src/StlLCMapStringA.cpp
+++ b/stl/src/StlLCMapStringA.cpp
@@ -82,7 +82,8 @@ extern "C" _CRTIMP2 int __cdecl __crtLCMapStringA(_In_opt_z_ LPCWSTR LocaleName,
                 return retval;
             }
 
-            const auto wide_dest = reinterpret_cast<LPWSTR>(lpDestStr); // lgtm [cpp/incorrect-string-type-conversion]
+            // CodeQL [SM02986] This cast is correct: LCMAP_SORTKEY stores "an opaque array of bytes".
+            const auto wide_dest = reinterpret_cast<LPWSTR>(lpDestStr);
 
             // do string mapping
             if (0

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -1837,7 +1837,9 @@ namespace {
                             unsigned long _H_pos;
 
                             // Find the smallest horizontal index
-                            _BitScanForward(&_H_pos, _Mask); // lgtm [cpp/conditionallyuninitializedvariable]
+
+                            // CodeQL [SM02313] _H_pos is always initialized: element exists, so _Mask is non-zero.
+                            _BitScanForward(&_H_pos, _Mask);
 
                             const auto _V_pos = _Traits::_Get_v_pos(_Cur_idx_min, _H_pos); // Extract its vertical index
                             // Finally, compute the pointer
@@ -1869,7 +1871,9 @@ namespace {
                                 _Mask &= _Traits::_Mask(_Traits::_Cmp_eq_idx(_Idx_max, _Idx_max_val));
 
                                 // Find the largest horizontal index
-                                _BitScanReverse(&_H_pos, _Mask); // lgtm [cpp/conditionallyuninitializedvariable]
+
+                                // CodeQL [SM02313] _H_pos is always initialized: element exists, so _Mask is non-zero.
+                                _BitScanReverse(&_H_pos, _Mask);
 
                                 _H_pos -= sizeof(_Cur_max_val) - 1; // Correct from highest val bit to lowest
                             } else {
@@ -1882,7 +1886,9 @@ namespace {
                                 _Mask &= _Traits::_Mask(_Traits::_Cmp_eq_idx(_Idx_max, _Idx_max_val));
 
                                 // Find the smallest horizontal index
-                                _BitScanForward(&_H_pos, _Mask); // lgtm [cpp/conditionallyuninitializedvariable]
+
+                                // CodeQL [SM02313] _H_pos is always initialized: element exists, so _Mask is non-zero.
+                                _BitScanForward(&_H_pos, _Mask);
                             }
 
                             const auto _V_pos = _Traits::_Get_v_pos(_Cur_idx_max, _H_pos); // Extract its vertical index
@@ -2495,7 +2501,8 @@ namespace {
 
                 if (_Bingo != 0) {
                     unsigned long _Offset;
-                    _BitScanForward(&_Offset, _Bingo); // lgtm [cpp/conditionallyuninitializedvariable]
+                    // CodeQL [SM02313] _Offset is always initialized: we just tested `if (_Bingo != 0)`.
+                    _BitScanForward(&_Offset, _Bingo);
                     _Advance_bytes(_First, _Offset);
                     return _First;
                 }
@@ -2565,7 +2572,8 @@ namespace {
 
                 if (_Bingo != 0) {
                     unsigned long _Offset;
-                    _BitScanReverse(&_Offset, _Bingo); // lgtm [cpp/conditionallyuninitializedvariable]
+                    // CodeQL [SM02313] _Offset is always initialized: we just tested `if (_Bingo != 0)`.
+                    _BitScanReverse(&_Offset, _Bingo);
                     _Advance_bytes(_Last, _Offset - (sizeof(_Ty) - 1));
                     return _Last;
                 }
@@ -3242,7 +3250,8 @@ namespace {
                     static_cast<unsigned int>(_mm_movemask_epi8(_Traits::_Cmp_sse(_Elem1, _Elem2))) ^ 0xFFFF;
                 if (_Bingo != 0) {
                     unsigned long _Offset;
-                    _BitScanForward(&_Offset, _Bingo); // lgtm [cpp/conditionallyuninitializedvariable]
+                    // CodeQL [SM02313] _Offset is always initialized: we just tested `if (_Bingo != 0)`.
+                    _BitScanForward(&_Offset, _Bingo);
                     return (_Result + _Offset) / sizeof(_Ty);
                 }
             }


### PR DESCRIPTION
Our internal infrastructure that periodically runs CodeQL and creates automated bug reports is changing how it accepts warning suppressions.

## :derelict_house: Old suppression comments

The suppression comments that we've been using, of the form `// lgtm [cpp/too-many-puppies]`, are now rejected with:

> cpp/policy/alert-suppression-without-justification
> \[SM03936\] Alert Suppression Without Justification
> A legacy (LGTM) CodeQL suppression comment without a justification was detected.

## :magic_wand: New suppression comments

The new form that we must use is:

```cpp
// CodeQL [OpaqueID] Justification consisting of 25 or more characters
```

This comment can appear on the affected line, or immediately above it.

Note that the opaque ID SM03936 for Alert Suppression Without Justification isn't what we ever want to use - we need to use the opaque ID for the underlying warning. I believe I've correctly looked these up, but we'll have to wait for the next round of automated bug reports to confirm.

## :broom: Control flow cleanup

I'm changing how we handle `_System_error_message`. The behavior is unchanged, except that it replaces an `_STL_INTERNAL_CHECK` (can't happen) with emitting `"unknown error"`.

## :shushing_face: Original suppression PRs

* #3489
* #3585
* #4942

## :lady_beetle: Internal bugs fixed

* VSO-2255050 / AB#2255050
* VSO-2255054 / AB#2255054
* VSO-2255066 / AB#2255066
* VSO-2255071 / AB#2255071
* VSO-2255089 / AB#2255089
* VSO-2255098 / AB#2255098
* VSO-2255102 / AB#2255102
* VSO-2255103 / AB#2255103
* VSO-2255111 / AB#2255111
