### PR TITLE
Add visualizer for `std::chrono::system_clock::time_point`

### DIFF
--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -2312,4 +2312,57 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     </Expand>
   </Type>
 
+  <Type Name="std::chrono::time_point&lt;std::chrono::system_clock,std::chrono::duration&lt;__int64,std::ratio&lt;1,10000000&gt; &gt; &gt;">
+    <!--
+      Same computation as in std::chrono::year_month_day::_Civil_from_days
+      and https://howardhinnant.github.io/date_algorithms.html#civil_from_days.
+    -->
+    <Intrinsic Name="z"     Expression="(_MyDur._MyRep / (24 * 60 * 60 * 10000000ull)) + 719468"/>
+    <Intrinsic Name="era"   Expression="(z() &gt;= 0 ? z() : z() - 146096) / 146097"/>
+    <Intrinsic Name="doe"   Expression="(unsigned)(z() - era() * 146097)"/>
+    <Intrinsic Name="yoe"   Expression="(doe() - doe()/1460 + doe()/36524 - doe()/146096) / 365"/>
+    <Intrinsic Name="doy"   Expression="doe() - (365*yoe() + yoe()/4 - yoe()/100)"/>
+    <Intrinsic Name="mp"    Expression="(5*doy() + 2)/153"/>
+    <Intrinsic Name="day"   Expression="doy() - (153*mp()+2)/5 + 1"/>
+    <Intrinsic Name="month" Expression="mp() &lt; 10 ? mp()+3 : mp()-9"/>
+    <Intrinsic Name="year"  Expression="((long long)yoe()) + era() * 400 + (month() &lt; 2)"/>
+
+    <DisplayString Condition="_MyDur._MyRep &gt;= 0">
+      {year(),d}-{month()/10,d}{month()%10,d}-{day()/10,d}{day()%10,d} {
+        (_MyDur._MyRep % (24 * 60 * 60 * 10000000ull))/(10 * 60 * 60 * 10000000ull),d
+      }{
+        ((_MyDur._MyRep % (24 * 60 * 60 * 10000000ull))/(60 * 60 * 10000000ull)) % 10,d
+      }:{
+        (_MyDur._MyRep % (60 * 60 * 10000000ull))/(10 * 60 * 10000000ull),d
+      }{
+        (_MyDur._MyRep % (10 * 60 * 10000000ull)) / (60 * 10000000ull),d
+      }:{
+        (_MyDur._MyRep % (60 * 10000000ull)) / (10 * 10000000ull),d
+      }{
+        (_MyDur._MyRep % (10 * 10000000ull)) / 10000000ull,d
+      }.{
+        (_MyDur._MyRep % 10000000) / 1000000,d
+      }{
+        (_MyDur._MyRep % 1000000) / 100000,d
+      }{
+        (_MyDur._MyRep % 100000) / 10000,d
+      }{
+        (_MyDur._MyRep % 10000) / 1000,d
+      }{
+        (_MyDur._MyRep % 1000) / 100,d
+      }{
+        (_MyDur._MyRep % 100) / 10,d
+      }{
+        _MyDur._MyRep % 10,d
+      }
+    </DisplayString>
+    <Expand>
+      <Item Name="[ns/100]">_MyDur._MyRep</Item>
+      <Item Name="[us]">_MyDur._MyRep/10</Item>
+      <Item Name="[ms]">_MyDur._MyRep/(10 * 1000)</Item>
+      <Item Name="[s]">_MyDur._MyRep/(10 * 1000 * 1000)</Item>
+      <Synthetic Name="[clock]"><DisplayString>UTC</DisplayString></Synthetic>
+    </Expand>
+  </Type>
+
 </AutoVisualizer>


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->

Adds a visualizer for `std::chrono::system_clock::time_point`. To compute the date representation, it uses the same algorithm as [`_Civil_from_days`](https://github.com/microsoft/STL/blob/faccf0084ed9b8b58df103358174537233b178c7/stl/inc/chrono#L823-L959) (with the same "variables" as https://howardhinnant.github.io/date_algorithms.html#civil_from_days).
The time is displayed as hh:mm:ss.ssssss. Additionally, the visualizer shows `ns/100` (the actual value of the time-point), `us`, `ms`, and `s`.

Unfortunately, the [format specifiers](https://learn.microsoft.com/en-us/visualstudio/debugger/format-specifiers-in-cpp?view=vs-2022#BKMK_Visual_Studio_2012_format_specifiers) don't provide a way of formatting numbers with padding, so they're formatted "manually" (e.g. a 2-digit `v` is formatted as `{v/10}{v%10}`).

See also: https://github.com/microsoft/STL/issues/314