### PR TITLE
Auto-vectorize  minmax instead of manual vectorization

### DIFF
--- a/stl/inc/__msvc_minmax.hpp
+++ b/stl/inc/__msvc_minmax.hpp
@@ -21,61 +21,6 @@ struct _Min_max_element_t {
     const void* _Min;
     const void* _Max;
 };
-
-struct _Min_max_1i {
-    int8_t _Min;
-    int8_t _Max;
-};
-
-struct _Min_max_1u {
-    uint8_t _Min;
-    uint8_t _Max;
-};
-
-struct _Min_max_2i {
-    int16_t _Min;
-    int16_t _Max;
-};
-
-struct _Min_max_2u {
-    uint16_t _Min;
-    uint16_t _Max;
-};
-
-struct _Min_max_4i {
-    int32_t _Min;
-    int32_t _Max;
-};
-
-struct _Min_max_4u {
-    uint32_t _Min;
-    uint32_t _Max;
-};
-
-struct _Min_max_8i {
-    int64_t _Min;
-    int64_t _Max;
-};
-
-struct _Min_max_8u {
-    uint64_t _Min;
-    uint64_t _Max;
-};
-
-struct _Min_max_f {
-    float _Min;
-    float _Max;
-};
-
-struct _Min_max_d {
-    double _Min;
-    double _Max;
-};
-
-struct _Min_max_p {
-    void* _Min;
-    void* _Max;
-};
 } // extern "C"
 
 #pragma pop_macro("new")

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -59,17 +59,6 @@ const void* __stdcall __std_find_last_trivial_2(const void* _First, const void* 
 const void* __stdcall __std_find_last_trivial_4(const void* _First, const void* _Last, uint32_t _Val) noexcept;
 const void* __stdcall __std_find_last_trivial_8(const void* _First, const void* _Last, uint64_t _Val) noexcept;
 
-__declspec(noalias) _Min_max_1i __stdcall __std_minmax_1i(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) _Min_max_1u __stdcall __std_minmax_1u(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) _Min_max_2i __stdcall __std_minmax_2i(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) _Min_max_2u __stdcall __std_minmax_2u(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) _Min_max_4i __stdcall __std_minmax_4i(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) _Min_max_4u __stdcall __std_minmax_4u(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) _Min_max_8i __stdcall __std_minmax_8i(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) _Min_max_8u __stdcall __std_minmax_8u(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) _Min_max_f __stdcall __std_minmax_f(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) _Min_max_d __stdcall __std_minmax_d(const void* _First, const void* _Last) noexcept;
-
 // TRANSITION, DevCom-10610477
 __declspec(noalias) void __stdcall __std_replace_4(
     void* _First, void* _Last, uint32_t _Old_val, uint32_t _New_val) noexcept;
@@ -116,50 +105,6 @@ pair<_Ty*, _Ty*> _Minmax_element_vectorized(_Ty* const _First, _Ty* const _Last)
     }
 
     return {const_cast<_Ty*>(static_cast<const _Ty*>(_Res._Min)), const_cast<_Ty*>(static_cast<const _Ty*>(_Res._Max))};
-}
-
-template <class _Ty>
-auto _Minmax_vectorized(_Ty* const _First, _Ty* const _Last) noexcept {
-    constexpr bool _Signed = is_signed_v<_Ty>;
-
-    if constexpr (is_pointer_v<_Ty>) {
-#ifdef _WIN64
-        const auto _Result = ::__std_minmax_8u(_First, _Last);
-#else
-        const auto _Result = ::__std_minmax_4u(_First, _Last);
-#endif
-        return _Min_max_p{reinterpret_cast<void*>(_Result._Min), reinterpret_cast<void*>(_Result._Max)};
-    } else if constexpr (is_same_v<remove_const_t<_Ty>, float>) {
-        return ::__std_minmax_f(_First, _Last);
-    } else if constexpr (_Is_any_of_v<remove_const_t<_Ty>, double, long double>) {
-        return ::__std_minmax_d(_First, _Last);
-    } else if constexpr (sizeof(_Ty) == 1) {
-        if constexpr (_Signed) {
-            return ::__std_minmax_1i(_First, _Last);
-        } else {
-            return ::__std_minmax_1u(_First, _Last);
-        }
-    } else if constexpr (sizeof(_Ty) == 2) {
-        if constexpr (_Signed) {
-            return ::__std_minmax_2i(_First, _Last);
-        } else {
-            return ::__std_minmax_2u(_First, _Last);
-        }
-    } else if constexpr (sizeof(_Ty) == 4) {
-        if constexpr (_Signed) {
-            return ::__std_minmax_4i(_First, _Last);
-        } else {
-            return ::__std_minmax_4u(_First, _Last);
-        }
-    } else if constexpr (sizeof(_Ty) == 8) {
-        if constexpr (_Signed) {
-            return ::__std_minmax_8i(_First, _Last);
-        } else {
-            return ::__std_minmax_8u(_First, _Last);
-        }
-    } else {
-        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
-    }
 }
 
 template <class _Ty, class _TVal>
@@ -10184,22 +10129,38 @@ _NODISCARD constexpr pair<const _Ty&, const _Ty&> minmax(
     return {_Left, _Right};
 }
 
+template <class _Rx, class _Ty>
+constexpr _Rx _Minmax(const _Ty* _First, const _Ty* const _Last) {
+    // Vectorization-friendly minmax
+    // Performs more comparisons than standard requires, but it it not observable
+    _Ty _Min_val = *_First;
+    _Ty _Max_val = *_First;
+
+    for (++_First; _First != _Last; ++_First) {
+        if (_Min_val < *_First) {
+            _Min_val = *_First;
+        }
+
+        if (_Max_val <= *_First) {
+            _Max_val = *_First;
+        }
+    }
+
+    return _Rx{_Min_val, _Max_val};
+}
+
 _EXPORT_STD template <class _Ty, class _Pr>
 _NODISCARD constexpr pair<_Ty, _Ty> minmax(initializer_list<_Ty> _Ilist, _Pr _Pred) {
     // return {leftmost/smallest, rightmost/largest}
     _STL_ASSERT(
         _Ilist.size() != 0, "An initializer_list passed to std::minmax must not be empty. (N4971 [alg.min.max]/21)");
-#if _USE_STD_VECTOR_ALGORITHMS
     if constexpr (_Is_min_max_value_optimization_safe<const _Ty*, _Pr>) {
-        if (!_STD _Is_constant_evaluated()) {
-            const auto _Result = _STD _Minmax_vectorized(_Ilist.begin(), _Ilist.end());
-            return {static_cast<_Ty>(_Result._Min), static_cast<_Ty>(_Result._Max)};
-        }
+        return _STD _Minmax<pair<_Ty, _Ty>>(_Ilist.begin(), _Ilist.end());
+    } else {
+        pair<const _Ty*, const _Ty*> _Res =
+            _STD _Minmax_element_unchecked(_Ilist.begin(), _Ilist.end(), _STD _Pass_fn(_Pred));
+        return pair<_Ty, _Ty>(*_Res.first, *_Res.second);
     }
-#endif // _USE_STD_VECTOR_ALGORITHMS
-    pair<const _Ty*, const _Ty*> _Res =
-        _STD _Minmax_element_unchecked(_Ilist.begin(), _Ilist.end(), _STD _Pass_fn(_Pred));
-    return pair<_Ty, _Ty>(*_Res.first, *_Res.second);
 }
 
 _EXPORT_STD template <class _Ty>
@@ -10247,22 +10208,20 @@ namespace ranges {
             const auto _Last  = _Range.end();
             _STL_ASSERT(_First != _Last,
                 "An initializer_list passed to std::ranges::minmax must not be empty. (N4971 [alg.min.max]/21)");
+
+            if constexpr (is_same_v<_Pj, identity> && _Is_min_max_value_optimization_safe<const _Ty*, _Pr>) {
+                return _STD _Minmax<minmax_result<_Ty>>(_First, _Last);
+            } else {
 #if _USE_STD_VECTOR_ALGORITHMS
-            if constexpr (is_same_v<_Pj, identity>) {
-                if constexpr (_Is_min_max_value_optimization_safe<const _Ty*, _Pr>) {
-                    if (!_STD is_constant_evaluated()) {
-                        const auto _Result = _STD _Minmax_vectorized(_First, _Last);
-                        return {static_cast<_Ty>(_Result._Min), static_cast<_Ty>(_Result._Max)};
-                    }
-                } else if constexpr (_Is_min_max_optimization_safe<const _Ty*, _Pr>) {
+                if constexpr (is_same_v<_Pj, identity> && _Is_min_max_optimization_safe<const _Ty*, _Pr>) {
                     if (!_STD is_constant_evaluated()) {
                         const auto _Result = _STD _Minmax_element_vectorized(_First, _Last);
                         return {*static_cast<const _Ty*>(_Result.first), *static_cast<const _Ty*>(_Result.second)};
                     }
                 }
-            }
 #endif // _USE_STD_VECTOR_ALGORITHMS
-            return _Minmax_fwd_unchecked(_First, _Last, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                return _Minmax_fwd_unchecked(_First, _Last, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+            }
         }
 
         template <input_range _Rng, class _Pj = identity,
@@ -10275,16 +10234,15 @@ namespace ranges {
             _STL_ASSERT(
                 _UFirst != _ULast, "A range passed to std::ranges::minmax must not be empty. (N4971 [alg.min.max]/21)");
             using _Vty = range_value_t<_Rng>;
+            if constexpr (is_same_v<_Pj, identity> && sized_sentinel_for<decltype(_ULast), decltype(_UFirst)>
+                          && _Is_min_max_value_optimization_safe<decltype(_UFirst), _Pr>) {
+                const auto _First_ptr = _STD to_address(_UFirst);
+                const auto _Last_ptr  = _First_ptr + (_ULast - _UFirst);
+                return _STD _Minmax<minmax_result<range_value_t<_Rng>>>(_First_ptr, _Last_ptr);
+            } else {
 #if _USE_STD_VECTOR_ALGORITHMS
-            if constexpr (is_same_v<_Pj, identity> && sized_sentinel_for<decltype(_ULast), decltype(_UFirst)>) {
-                if constexpr (_Is_min_max_value_optimization_safe<decltype(_UFirst), _Pr>) {
-                    if (!_STD is_constant_evaluated()) {
-                        const auto _First_ptr = _STD to_address(_UFirst);
-                        const auto _Last_ptr  = _First_ptr + (_ULast - _UFirst);
-                        const auto _Result    = _STD _Minmax_vectorized(_First_ptr, _Last_ptr);
-                        return {static_cast<_Vty>(_Result._Min), static_cast<_Vty>(_Result._Max)};
-                    }
-                } else if constexpr (_Is_min_max_optimization_safe<decltype(_UFirst), _Pr>) {
+                if constexpr (is_same_v<_Pj, identity> && sized_sentinel_for<decltype(_ULast), decltype(_UFirst)>
+                              && _Is_min_max_optimization_safe<decltype(_UFirst), _Pr>) {
                     if (!_STD is_constant_evaluated()) {
                         const auto _First_ptr = _STD to_address(_UFirst);
                         const auto _Last_ptr  = _First_ptr + (_ULast - _UFirst);
@@ -10292,52 +10250,52 @@ namespace ranges {
                         return {*static_cast<const _Vty*>(_Result.first), *static_cast<const _Vty*>(_Result.second)};
                     }
                 }
-            }
 #endif // _USE_STD_VECTOR_ALGORITHMS
-            if constexpr (forward_range<_Rng> && _Prefer_iterator_copies<decltype(_UFirst)>) {
-                return _Minmax_fwd_unchecked(
-                    _STD move(_UFirst), _STD move(_ULast), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
-            } else {
-                // This initialization is correct, similar to the N4950 [dcl.init.aggr]/6 example
-                minmax_result<_Vty> _Found = {static_cast<_Vty>(*_UFirst), _Found.min};
-                if (_UFirst == _ULast) {
+                if constexpr (forward_range<_Rng> && _Prefer_iterator_copies<decltype(_UFirst)>) {
+                    return _Minmax_fwd_unchecked(
+                        _STD move(_UFirst), _STD move(_ULast), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                } else {
+                    // This initialization is correct, similar to the N4950 [dcl.init.aggr]/6 example
+                    minmax_result<_Vty> _Found = {static_cast<_Vty>(*_UFirst), _Found.min};
+                    if (_UFirst == _ULast) {
+                        return _Found;
+                    }
+
+                    while (++_UFirst != _ULast) { // process one or two elements
+                        _Vty _Prev(*_UFirst);
+                        if (++_UFirst == _ULast) { // process last element
+                            if (_STD invoke(_Pred, _STD invoke(_Proj, _Prev), _STD invoke(_Proj, _Found.min))) {
+                                _Found.min = _STD move(_Prev);
+                            } else if (!_STD invoke(_Pred, _STD invoke(_Proj, _Prev), _STD invoke(_Proj, _Found.max))) {
+                                _Found.max = _STD move(_Prev);
+                            }
+
+                            break;
+                        }
+
+                        // process next two elements
+                        if (_STD invoke(_Pred, _STD invoke(_Proj, *_UFirst), _STD invoke(_Proj, _Prev))) {
+                            // test _UFirst for new smallest
+                            if (_STD invoke(_Pred, _STD invoke(_Proj, *_UFirst), _STD invoke(_Proj, _Found.min))) {
+                                _Found.min = *_UFirst;
+                            }
+
+                            if (!_STD invoke(_Pred, _STD invoke(_Proj, _Prev), _STD invoke(_Proj, _Found.max))) {
+                                _Found.max = _STD move(_Prev);
+                            }
+                        } else { // test _Prev for new smallest
+                            if (_STD invoke(_Pred, _STD invoke(_Proj, _Prev), _STD invoke(_Proj, _Found.min))) {
+                                _Found.min = _STD move(_Prev);
+                            }
+
+                            if (!_STD invoke(_Pred, _STD invoke(_Proj, *_UFirst), _STD invoke(_Proj, _Found.max))) {
+                                _Found.max = *_UFirst;
+                            }
+                        }
+                    }
+
                     return _Found;
                 }
-
-                while (++_UFirst != _ULast) { // process one or two elements
-                    _Vty _Prev(*_UFirst);
-                    if (++_UFirst == _ULast) { // process last element
-                        if (_STD invoke(_Pred, _STD invoke(_Proj, _Prev), _STD invoke(_Proj, _Found.min))) {
-                            _Found.min = _STD move(_Prev);
-                        } else if (!_STD invoke(_Pred, _STD invoke(_Proj, _Prev), _STD invoke(_Proj, _Found.max))) {
-                            _Found.max = _STD move(_Prev);
-                        }
-
-                        break;
-                    }
-
-                    // process next two elements
-                    if (_STD invoke(_Pred, _STD invoke(_Proj, *_UFirst), _STD invoke(_Proj, _Prev))) {
-                        // test _UFirst for new smallest
-                        if (_STD invoke(_Pred, _STD invoke(_Proj, *_UFirst), _STD invoke(_Proj, _Found.min))) {
-                            _Found.min = *_UFirst;
-                        }
-
-                        if (!_STD invoke(_Pred, _STD invoke(_Proj, _Prev), _STD invoke(_Proj, _Found.max))) {
-                            _Found.max = _STD move(_Prev);
-                        }
-                    } else { // test _Prev for new smallest
-                        if (_STD invoke(_Pred, _STD invoke(_Proj, _Prev), _STD invoke(_Proj, _Found.min))) {
-                            _Found.min = _STD move(_Prev);
-                        }
-
-                        if (!_STD invoke(_Pred, _STD invoke(_Proj, *_UFirst), _STD invoke(_Proj, _Found.max))) {
-                            _Found.max = *_UFirst;
-                        }
-                    }
-                }
-
-                return _Found;
             }
         }
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -10137,7 +10137,7 @@ constexpr _Rx _Minmax(const _Ty* _First, const _Ty* const _Last) {
     _Ty _Max_val = *_First;
 
     for (++_First; _First != _Last; ++_First) {
-        if (_Min_val < *_First) {
+        if (*_First < _Min_val) {
             _Min_val = *_First;
         }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -121,27 +121,6 @@ const void* __stdcall __std_max_element_8(const void* _First, const void* _Last,
 const void* __stdcall __std_max_element_f(const void* _First, const void* _Last, bool _Unused) noexcept;
 const void* __stdcall __std_max_element_d(const void* _First, const void* _Last, bool _Unused) noexcept;
 
-__declspec(noalias) int8_t __stdcall __std_min_1i(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) uint8_t __stdcall __std_min_1u(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) int16_t __stdcall __std_min_2i(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) uint16_t __stdcall __std_min_2u(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) int32_t __stdcall __std_min_4i(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) uint32_t __stdcall __std_min_4u(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) int64_t __stdcall __std_min_8i(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) uint64_t __stdcall __std_min_8u(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) float __stdcall __std_min_f(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) double __stdcall __std_min_d(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) int8_t __stdcall __std_max_1i(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) uint8_t __stdcall __std_max_1u(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) int16_t __stdcall __std_max_2i(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) uint16_t __stdcall __std_max_2u(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) int32_t __stdcall __std_max_4i(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) uint32_t __stdcall __std_max_4u(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) int64_t __stdcall __std_max_8i(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) uint64_t __stdcall __std_max_8u(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) float __stdcall __std_max_f(const void* _First, const void* _Last) noexcept;
-__declspec(noalias) double __stdcall __std_max_d(const void* _First, const void* _Last) noexcept;
-
 __declspec(noalias) size_t __stdcall __std_mismatch_1(const void* _First1, const void* _First2, size_t _Count) noexcept;
 __declspec(noalias) size_t __stdcall __std_mismatch_2(const void* _First1, const void* _First2, size_t _Count) noexcept;
 __declspec(noalias) size_t __stdcall __std_mismatch_4(const void* _First1, const void* _First2, size_t _Count) noexcept;
@@ -327,49 +306,6 @@ auto _Min_vectorized(_Ty* const _First, _Ty* const _Last) noexcept {
             return ::__std_min_8i(_First, _Last);
         } else {
             return ::__std_min_8u(_First, _Last);
-        }
-    } else {
-        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
-    }
-}
-
-template <class _Ty>
-auto _Max_vectorized(_Ty* const _First, _Ty* const _Last) noexcept {
-    constexpr bool _Signed = is_signed_v<_Ty>;
-
-    if constexpr (is_pointer_v<_Ty>) {
-#ifdef _WIN64
-        return reinterpret_cast<void*>(::__std_max_8u(_First, _Last));
-#else
-        return reinterpret_cast<void*>(::__std_max_4u(_First, _Last));
-#endif
-    } else if constexpr (is_same_v<remove_const_t<_Ty>, float>) {
-        return ::__std_max_f(_First, _Last);
-    } else if constexpr (_Is_any_of_v<remove_const_t<_Ty>, double, long double>) {
-        return ::__std_max_d(_First, _Last);
-    } else if constexpr (sizeof(_Ty) == 1) {
-        if constexpr (_Signed) {
-            return ::__std_max_1i(_First, _Last);
-        } else {
-            return ::__std_max_1u(_First, _Last);
-        }
-    } else if constexpr (sizeof(_Ty) == 2) {
-        if constexpr (_Signed) {
-            return ::__std_max_2i(_First, _Last);
-        } else {
-            return ::__std_max_2u(_First, _Last);
-        }
-    } else if constexpr (sizeof(_Ty) == 4) {
-        if constexpr (_Signed) {
-            return ::__std_max_4i(_First, _Last);
-        } else {
-            return ::__std_max_4u(_First, _Last);
-        }
-    } else if constexpr (sizeof(_Ty) == 8) {
-        if constexpr (_Signed) {
-            return ::__std_max_8i(_First, _Last);
-        } else {
-            return ::__std_max_8u(_First, _Last);
         }
     } else {
         _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
@@ -7030,20 +6966,31 @@ namespace ranges {
 #endif // _HAS_CXX20
 #endif // _HAS_CXX17
 
+template <class _Ty>
+constexpr _Ty _Max(const _Ty* _First, const _Ty* const _Last) {
+    // Vectorization-friendly maximum valiue
+    _Ty _Max_val = *_First;
+
+    for (++_First; _First != _Last; ++_First) {
+        if (_Max_val < *_First) {
+            _Max_val = *_First;
+        }
+    }
+
+    return _Max_val;
+}
+
 _EXPORT_STD template <class _Ty, class _Pr>
 _NODISCARD constexpr _Ty(max)(initializer_list<_Ty> _Ilist, _Pr _Pred) {
     // return leftmost/largest
     _STL_ASSERT(
         _Ilist.size() != 0, "An initializer_list passed to std::max must not be empty. (N4971 [alg.min.max]/13)");
-#if _USE_STD_VECTOR_ALGORITHMS
     if constexpr (_Is_min_max_value_optimization_safe<const _Ty*, _Pr>) {
-        if (!_Is_constant_evaluated()) {
-            return static_cast<_Ty>(_STD _Max_vectorized(_Ilist.begin(), _Ilist.end()));
-        }
+        return _STD _Max(_Ilist.begin(), _Ilist.end());
+    } else {
+        const _Ty* _Res = _STD _Max_element_unchecked(_Ilist.begin(), _Ilist.end(), _STD _Pass_fn(_Pred));
+        return *_Res;
     }
-#endif // _USE_STD_VECTOR_ALGORITHMS
-    const _Ty* _Res = _STD _Max_element_unchecked(_Ilist.begin(), _Ilist.end(), _STD _Pass_fn(_Pred));
-    return *_Res;
 }
 
 _EXPORT_STD template <class _Ty>
@@ -7081,14 +7028,11 @@ namespace ranges {
             const auto _Last  = _Range.end();
             _STL_ASSERT(_First != _Last,
                 "An initializer_list passed to std::ranges::max must not be empty. (N4971 [alg.min.max]/13)");
-#if _USE_STD_VECTOR_ALGORITHMS
             if constexpr (is_same_v<_Pj, identity> && _Is_min_max_value_optimization_safe<const _Ty*, _Pr>) {
-                if (!_STD is_constant_evaluated()) {
-                    return static_cast<_Ty>(_STD _Max_vectorized(_First, _Last));
-                }
+                return _STD _Max(_First, _Last);
+            } else {
+                return *_RANGES _Max_element_unchecked(_First, _Last, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
             }
-#endif // _USE_STD_VECTOR_ALGORITHMS
-            return *_RANGES _Max_element_unchecked(_First, _Last, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
         }
 
         template <input_range _Rng, class _Pj = identity,
@@ -7100,17 +7044,12 @@ namespace ranges {
             auto _ULast  = _Uend(_Range);
             _STL_ASSERT(
                 _UFirst != _ULast, "A range passed to std::ranges::max must not be empty. (N4971 [alg.min.max]/13)");
-#if _USE_STD_VECTOR_ALGORITHMS
             if constexpr (is_same_v<_Pj, identity> && _Is_min_max_value_optimization_safe<decltype(_UFirst), _Pr>
                           && sized_sentinel_for<decltype(_ULast), decltype(_UFirst)>) {
-                if (!_STD is_constant_evaluated()) {
-                    const auto _First_ptr = _STD to_address(_UFirst);
-                    const auto _Last_ptr  = _First_ptr + (_ULast - _UFirst);
-                    return static_cast<range_value_t<_Rng>>(_STD _Max_vectorized(_First_ptr, _Last_ptr));
-                }
-            }
-#endif // _USE_STD_VECTOR_ALGORITHMS
-            if constexpr (forward_range<_Rng> && _Prefer_iterator_copies<decltype(_UFirst)>) {
+                const auto _First_ptr = _STD to_address(_UFirst);
+                const auto _Last_ptr  = _First_ptr + (_ULast - _UFirst);
+                return static_cast<range_value_t<_Rng>>(_STD _Max(_First_ptr, _Last_ptr));
+            } else if constexpr (forward_range<_Rng> && _Prefer_iterator_copies<decltype(_UFirst)>) {
                 return static_cast<range_value_t<_Rng>>(*_RANGES _Max_element_unchecked(
                     _STD move(_UFirst), _STD move(_ULast), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj)));
             } else {
@@ -7254,20 +7193,31 @@ namespace ranges {
 #endif // _HAS_CXX20
 #endif // _HAS_CXX17
 
+template <class _Ty>
+constexpr _Ty _Min(const _Ty* _First, const _Ty* const _Last) {
+    // Vectorization-friendly minimum valiue
+    _Ty _Min_val = *_First;
+
+    for (++_First; _First != _Last; ++_First) {
+        if (*_First < _Min_val) {
+            _Min_val = *_First;
+        }
+    }
+
+    return _Min_val;
+}
+
 _EXPORT_STD template <class _Ty, class _Pr>
 _NODISCARD constexpr _Ty(min)(initializer_list<_Ty> _Ilist, _Pr _Pred) {
     // return leftmost/smallest
     _STL_ASSERT(
         _Ilist.size() != 0, "An initializer_list passed to std::min must not be empty. (N4971 [alg.min.max]/5)");
-#if _USE_STD_VECTOR_ALGORITHMS
     if constexpr (_Is_min_max_value_optimization_safe<const _Ty*, _Pr>) {
-        if (!_Is_constant_evaluated()) {
-            return static_cast<_Ty>(_STD _Min_vectorized(_Ilist.begin(), _Ilist.end()));
-        }
+        return _STD _Min(_Ilist.begin(), _Ilist.end());
+    } else {
+        const _Ty* _Res = _STD _Min_element_unchecked(_Ilist.begin(), _Ilist.end(), _STD _Pass_fn(_Pred));
+        return *_Res;
     }
-#endif // _USE_STD_VECTOR_ALGORITHMS
-    const _Ty* _Res = _STD _Min_element_unchecked(_Ilist.begin(), _Ilist.end(), _STD _Pass_fn(_Pred));
-    return *_Res;
 }
 
 _EXPORT_STD template <class _Ty>
@@ -7299,14 +7249,11 @@ namespace ranges {
             const auto _Last  = _Range.end();
             _STL_ASSERT(_First != _Last,
                 "An initializer_list passed to std::ranges::min must not be empty. (N4971 [alg.min.max]/5)");
-#if _USE_STD_VECTOR_ALGORITHMS
             if constexpr (is_same_v<_Pj, identity> && _Is_min_max_value_optimization_safe<const _Ty*, _Pr>) {
-                if (!_STD is_constant_evaluated()) {
-                    return static_cast<_Ty>(_STD _Min_vectorized(_First, _Last));
-                }
+                return static_cast<_Ty>(_STD _Min(_First, _Last));
+            } else {
+                return *_RANGES _Min_element_unchecked(_First, _Last, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
             }
-#endif // _USE_STD_VECTOR_ALGORITHMS
-            return *_RANGES _Min_element_unchecked(_First, _Last, _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
         }
 
         template <input_range _Rng, class _Pj = identity,
@@ -7318,17 +7265,12 @@ namespace ranges {
             auto _ULast  = _Uend(_Range);
             _STL_ASSERT(
                 _UFirst != _ULast, "A range passed to std::ranges::min must not be empty. (N4971 [alg.min.max]/5)");
-#if _USE_STD_VECTOR_ALGORITHMS
             if constexpr (is_same_v<_Pj, identity> && _Is_min_max_value_optimization_safe<decltype(_UFirst), _Pr>
                           && sized_sentinel_for<decltype(_ULast), decltype(_UFirst)>) {
-                if (!_STD is_constant_evaluated()) {
-                    const auto _First_ptr = _STD to_address(_UFirst);
-                    const auto _Last_ptr  = _First_ptr + (_ULast - _UFirst);
-                    return static_cast<range_value_t<_Rng>>(_STD _Min_vectorized(_First_ptr, _Last_ptr));
-                }
-            }
-#endif // _USE_STD_VECTOR_ALGORITHMS
-            if constexpr (forward_range<_Rng> && _Prefer_iterator_copies<decltype(_UFirst)>) {
+                const auto _First_ptr = _STD to_address(_UFirst);
+                const auto _Last_ptr  = _First_ptr + (_ULast - _UFirst);
+                return static_cast<range_value_t<_Rng>>(_STD _Min(_First_ptr, _Last_ptr));
+            } else if constexpr (forward_range<_Rng> && _Prefer_iterator_copies<decltype(_UFirst)>) {
                 return static_cast<range_value_t<_Rng>>(*_RANGES _Min_element_unchecked(
                     _STD move(_UFirst), _STD move(_ULast), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj)));
             } else {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -269,49 +269,6 @@ _Ty* _Max_element_vectorized(_Ty* const _First, _Ty* const _Last) noexcept {
     }
 }
 
-template <class _Ty>
-auto _Min_vectorized(_Ty* const _First, _Ty* const _Last) noexcept {
-    constexpr bool _Signed = is_signed_v<_Ty>;
-
-    if constexpr (is_pointer_v<_Ty>) {
-#ifdef _WIN64
-        return reinterpret_cast<void*>(::__std_min_8u(_First, _Last));
-#else
-        return reinterpret_cast<void*>(::__std_min_4u(_First, _Last));
-#endif
-    } else if constexpr (is_same_v<remove_const_t<_Ty>, float>) {
-        return ::__std_min_f(_First, _Last);
-    } else if constexpr (_Is_any_of_v<remove_const_t<_Ty>, double, long double>) {
-        return ::__std_min_d(_First, _Last);
-    } else if constexpr (sizeof(_Ty) == 1) {
-        if constexpr (_Signed) {
-            return ::__std_min_1i(_First, _Last);
-        } else {
-            return ::__std_min_1u(_First, _Last);
-        }
-    } else if constexpr (sizeof(_Ty) == 2) {
-        if constexpr (_Signed) {
-            return ::__std_min_2i(_First, _Last);
-        } else {
-            return ::__std_min_2u(_First, _Last);
-        }
-    } else if constexpr (sizeof(_Ty) == 4) {
-        if constexpr (_Signed) {
-            return ::__std_min_4i(_First, _Last);
-        } else {
-            return ::__std_min_4u(_First, _Last);
-        }
-    } else if constexpr (sizeof(_Ty) == 8) {
-        if constexpr (_Signed) {
-            return ::__std_min_8i(_First, _Last);
-        } else {
-            return ::__std_min_8u(_First, _Last);
-        }
-    } else {
-        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
-    }
-}
-
 template <size_t _Element_size>
 inline size_t // TRANSITION, GH-4496
     _Mismatch_vectorized(const void* const _First1, const void* const _First2, const size_t _Count) noexcept {

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -488,6 +488,61 @@ __declspec(noalias) void __cdecl __std_reverse_copy_trivially_copyable_8(
         static_cast<unsigned long long*>(_Dest));
 }
 
+struct _Min_max_1i {
+    int8_t _Min;
+    int8_t _Max;
+};
+
+struct _Min_max_1u {
+    uint8_t _Min;
+    uint8_t _Max;
+};
+
+struct _Min_max_2i {
+    int16_t _Min;
+    int16_t _Max;
+};
+
+struct _Min_max_2u {
+    uint16_t _Min;
+    uint16_t _Max;
+};
+
+struct _Min_max_4i {
+    int32_t _Min;
+    int32_t _Max;
+};
+
+struct _Min_max_4u {
+    uint32_t _Min;
+    uint32_t _Max;
+};
+
+struct _Min_max_8i {
+    int64_t _Min;
+    int64_t _Max;
+};
+
+struct _Min_max_8u {
+    uint64_t _Min;
+    uint64_t _Max;
+};
+
+struct _Min_max_f {
+    float _Min;
+    float _Max;
+};
+
+struct _Min_max_d {
+    double _Min;
+    double _Max;
+};
+
+struct _Min_max_p {
+    void* _Min;
+    void* _Max;
+};
+
 } // extern "C"
 
 namespace {


### PR DESCRIPTION
Closes #4453

# 🤔 Should this be done?

I'm not sure.

In #4453 there's a decision we should.

#4673 was closed without merging.

The benchmark results are ambiguous.

# 🏁 Benchmark results

All benchmarks were ran with `/fp:fast` to make the floating versions affected too. (This optimization is only engaged with `/fp;fast`)

Since auto-vectorization doesn't do runtime dispatch, it was separately ran with `/arch:AVX2` and with default options

Benchmark                           | main + /fp:fast | this + /fp:fast| this + /fp:fast+ AVX2
------------------------------------|-----------------|----------------|-------------------
bm<uint8_t, Op::Min_val>/8021       |  68.2 ns        |  93.5 ns       |   72.2 ns    
bm<uint8_t, Op::Min_val>/63         |  4.52 ns        |  15.3 ns       |   22.3 ns    
bm<uint8_t, Op::Max_val>/8021       |  77.9 ns        |  90.9 ns       |   70.9 ns    
bm<uint8_t, Op::Max_val>/63         |  4.41 ns        |  17.9 ns       |   22.3 ns    
bm<uint8_t, Op::Both_val>/8021      |  94.9 ns        |   143 ns       |    145 ns    
bm<uint8_t, Op::Both_val>/63        |  5.86 ns        |  21.2 ns       |   39.3 ns    
bm<uint16_t, Op::Min_val>/8021      |   129 ns        |   177 ns       |    135 ns    
bm<uint16_t, Op::Min_val>/31        |  3.61 ns        |  6.93 ns       |   12.5 ns    
bm<uint16_t, Op::Max_val>/8021      |   147 ns        |   157 ns       |    137 ns    
bm<uint16_t, Op::Max_val>/31        |  3.59 ns        |  12.6 ns       |   12.4 ns    
bm<uint16_t, Op::Both_val>/8021     |   166 ns        |   244 ns       |    276 ns    
bm<uint16_t, Op::Both_val>/31       |  4.53 ns        |  13.2 ns       |   24.3 ns    
bm<uint32_t, Op::Min_val>/8021      |   267 ns        |   310 ns       |    224 ns    
bm<uint32_t, Op::Min_val>/15        |  3.18 ns        |  4.23 ns       |   5.94 ns    
bm<uint32_t, Op::Max_val>/8021      |   243 ns        |   334 ns       |    238 ns    
bm<uint32_t, Op::Max_val>/15        |  3.13 ns        |  4.11 ns       |   7.77 ns    
bm<uint32_t, Op::Both_val>/8021     |   334 ns        |   489 ns       |    422 ns    
bm<uint32_t, Op::Both_val>/15       |  3.93 ns        |  6.25 ns       |   8.69 ns    
bm<uint64_t, Op::Min_val>/8021      |  2829 ns        |  3840 ns       |   3793 ns    
bm<uint64_t, Op::Min_val>/7         |  4.59 ns        |  3.10 ns       |   3.34 ns    
bm<uint64_t, Op::Max_val>/8021      |  2849 ns        |  3835 ns       |   3791 ns    
bm<uint64_t, Op::Max_val>/7         |  4.66 ns        |  3.10 ns       |   3.35 ns    
bm<uint64_t, Op::Both_val>/8021     |  3027 ns        |  5719 ns       |   5761 ns    
bm<uint64_t, Op::Both_val>/7        |  9.24 ns        |  4.50 ns       |   4.47 ns    
bm<int8_t, Op::Min_val>/8021        |  76.4 ns        |  90.2 ns       |   69.6 ns    
bm<int8_t, Op::Min_val>/63          |  4.63 ns        |  15.1 ns       |   20.1 ns    
bm<int8_t, Op::Max_val>/8021        |  69.0 ns        |   106 ns       |   72.1 ns    
bm<int8_t, Op::Max_val>/63          |  4.59 ns        |  11.2 ns       |   24.2 ns    
bm<int8_t, Op::Both_val>/8021       |  87.2 ns        |   141 ns       |    142 ns    
bm<int8_t, Op::Both_val>/63         |  7.11 ns        |  18.3 ns       |   34.6 ns    
bm<int16_t, Op::Min_val>/8021       |   124 ns        |   163 ns       |    137 ns    
bm<int16_t, Op::Min_val>/31         |  4.06 ns        |  7.83 ns       |   12.4 ns    
bm<int16_t, Op::Max_val>/8021       |   132 ns        |   154 ns       |    137 ns    
bm<int16_t, Op::Max_val>/31         |  4.07 ns        |  7.85 ns       |   12.4 ns    
bm<int16_t, Op::Both_val>/8021      |   176 ns        |   248 ns       |    271 ns    
bm<int16_t, Op::Both_val>/31        |  5.11 ns        |  12.6 ns       |   20.1 ns    
bm<int32_t, Op::Min_val>/8021       |   247 ns        |   332 ns       |    235 ns    
bm<int32_t, Op::Min_val>/15         |  3.62 ns        |  3.78 ns       |   6.83 ns    
bm<int32_t, Op::Max_val>/8021       |   263 ns        |   306 ns       |    233 ns    
bm<int32_t, Op::Max_val>/15         |  3.70 ns        |  3.97 ns       |   7.15 ns    
bm<int32_t, Op::Both_val>/8021      |   328 ns        |   486 ns       |    433 ns    
bm<int32_t, Op::Both_val>/15        |  4.18 ns        |  5.89 ns       |   8.47 ns    
bm<int64_t, Op::Min_val>/8021       |  2866 ns        |  3837 ns       |   3789 ns    
bm<int64_t, Op::Min_val>/7          |  3.83 ns        |  3.21 ns       |   3.46 ns    
bm<int64_t, Op::Max_val>/8021       |  2821 ns        |  3792 ns       |   3786 ns    
bm<int64_t, Op::Max_val>/7          |  3.83 ns        |  3.15 ns       |   3.42 ns    
bm<int64_t, Op::Both_val>/8021      |  3105 ns        |  3802 ns       |   3796 ns    
bm<int64_t, Op::Both_val>/7         |  8.94 ns        |  4.01 ns       |   4.27 ns    
bm<float, Op::Min_val>/8021         |   864 ns        |   906 ns       |    440 ns    
bm<float, Op::Min_val>/15           |  3.35 ns        |  4.39 ns       |   6.50 ns    
bm<float, Op::Max_val>/8021         |   872 ns        |   911 ns       |    446 ns    
bm<float, Op::Max_val>/15           |  3.34 ns        |  3.76 ns       |   4.27 ns    
bm<float, Op::Both_val>/8021        |  1062 ns        |   946 ns       |    476 ns    
bm<float, Op::Both_val>/15          |   111 ns        |  4.97 ns       |   6.49 ns    
bm<double, Op::Min_val>/8021        |  1819 ns        |  1872 ns       |    967 ns    
bm<double, Op::Min_val>/7           |  3.21 ns        |  2.60 ns       |   2.67 ns    
bm<double, Op::Max_val>/8021        |  1826 ns        |  1851 ns       |    939 ns    
bm<double, Op::Max_val>/7           |  3.24 ns        |  2.61 ns       |   2.66 ns    
bm<double, Op::Both_val>/8021       |  1997 ns        |  1890 ns       |   1166 ns    
bm<double, Op::Both_val>/7          |   113 ns        |  3.32 ns       |   3.43 ns    

# 🥈 Results observations

On large arrays for integer types manual vectorization of `min` and `max` has significant advantage for 64-bit, and some disadvantage for 32-bit. For `minmax`, manual vectorization is clearly better.

Small tails cases are way better for manual vectorization most of the time.

However, auto vectorization does surprisingly well on floats. 

Very odd anomaly is seen on `bm<float, Op::Both_val>/15` and `bm<double, Op::Both_val>/7` cases, I double checked that it is a consistent result.
