### PR TITLE
Unwrapping output iterators in range algorithms

### DIFF
--- a/stl/inc/__msvc_iter_core.hpp
+++ b/stl/inc/__msvc_iter_core.hpp
@@ -385,7 +385,7 @@ constexpr bool _Integer_class = requires {
 };
 
 template <class _Ty>
-concept _Integer_like = _Is_nonbool_integral<remove_cv_t<_Ty>> || _Integer_class<_Ty>;
+concept _Integer_like = _Is_nonbool_integral<_Ty> || _Integer_class<_Ty>;
 
 template <class _Ty>
 concept _Signed_integer_like = _Integer_like<_Ty> && static_cast<_Ty>(-1) < static_cast<_Ty>(0);
@@ -499,7 +499,7 @@ template <class _Ty>
 struct iterator_traits<_Ty*> : _Iterator_traits_pointer_base<_Ty> {}; // get traits from pointer, if possible
 
 template <class _Ty>
-constexpr bool _Integer_like = _Is_nonbool_integral<remove_cv_t<_Ty>>;
+constexpr bool _Integer_like = _Is_nonbool_integral<_Ty>;
 #endif // ^^^ !_HAS_CXX20 ^^^
 
 _INLINE_VAR constexpr auto _Meta_npos = ~size_t{0};

--- a/stl/inc/__msvc_iter_core.hpp
+++ b/stl/inc/__msvc_iter_core.hpp
@@ -497,6 +497,9 @@ struct iterator_traits : _Iterator_traits_base<_Iter> {}; // get traits from ite
 
 template <class _Ty>
 struct iterator_traits<_Ty*> : _Iterator_traits_pointer_base<_Ty> {}; // get traits from pointer, if possible
+
+template <class _Ty>
+constexpr bool _Integer_like = _Is_nonbool_integral<remove_cv_t<_Ty>>;
 #endif // ^^^ !_HAS_CXX20 ^^^
 
 _INLINE_VAR constexpr auto _Meta_npos = ~size_t{0};

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -4256,12 +4256,16 @@ namespace ranges {
         _STATIC_CALL_OPERATOR constexpr replace_copy_if_result<_It, _Out> operator()(
             _It _First, _Se _Last, _Out _Output, _Pr _Pred, const _Ty& _Newval, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
-            auto _UResult = _Replace_copy_if_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Output), _STD _Pass_fn(_Pred), _Newval,
-                _STD _Pass_fn(_Proj));
+            auto _UFirst      = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
+            auto _ULast       = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
+            const auto _Count = _STD _Idl_distance<_It>(_UFirst, _ULast);
+
+            auto _UResult = _Replace_copy_if_unchecked(_STD move(_UFirst), _STD move(_ULast),
+                _STD _Get_unwrapped_n(_STD move(_Output), _Count), _STD _Pass_fn(_Pred), _Newval, _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-            return {_STD move(_First), _STD move(_UResult.out)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
         template <input_range _Rng, class _Ty, output_iterator<const _Ty&> _Out, class _Pj = identity,
@@ -4269,12 +4273,15 @@ namespace ranges {
             requires indirectly_copyable<iterator_t<_Rng>, _Out>
         _STATIC_CALL_OPERATOR constexpr replace_copy_if_result<borrowed_iterator_t<_Rng>, _Out> operator()(
             _Rng&& _Range, _Out _Output, _Pr _Pred, const _Ty& _Newval, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
-            auto _First   = _RANGES begin(_Range);
-            auto _UResult = _Replace_copy_if_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)),
-                _Uend(_Range), _STD move(_Output), _STD _Pass_fn(_Pred), _Newval, _STD _Pass_fn(_Proj));
+            const auto _Count = _RANGES _Idl_distance(_Range);
+            auto _First       = _RANGES begin(_Range);
+            auto _UResult     = _Replace_copy_if_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)),
+                    _Uend(_Range), _STD _Get_unwrapped_n(_STD move(_Output), _Count), _STD _Pass_fn(_Pred), _Newval,
+                    _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-            return {_STD move(_First), _STD move(_UResult.out)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
     private:

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1770,7 +1770,10 @@ namespace ranges {
             auto _UFirst = _RANGES _Unwrap_iter<_Se1>(_STD move(_First));
             auto _ULast  = _RANGES _Get_final_iterator_unwrapped<_It1>(_UFirst, _STD move(_Last));
             _STD _Seek_wrapped(_First, _ULast);
-            _Output = _RANGES _Move_backward_common(_STD move(_UFirst), _STD move(_ULast), _STD move(_Output));
+            const auto _Count = _STD _Idl_distance<_It1>(_UFirst, _ULast);
+            auto _UOutput     = _RANGES _Move_backward_common(
+                    _STD move(_UFirst), _STD move(_ULast), _STD _Get_unwrapped_n(_STD move(_Output), -_Count));
+            _STD _Seek_wrapped(_Output, _STD move(_UOutput));
             return {_STD move(_First), _STD move(_Output)};
         }
 
@@ -1778,8 +1781,11 @@ namespace ranges {
             requires indirectly_movable<iterator_t<_Rng>, _It>
         _STATIC_CALL_OPERATOR constexpr move_backward_result<borrowed_iterator_t<_Rng>, _It> operator()(
             _Rng&& _Range, _It _Output) _CONST_CALL_OPERATOR {
-            auto _ULast = _RANGES _Get_final_iterator_unwrapped(_Range);
-            _Output     = _RANGES _Move_backward_common(_Ubegin(_Range), _ULast, _STD move(_Output));
+            auto _ULast       = _RANGES _Get_final_iterator_unwrapped(_Range);
+            const auto _Count = _RANGES _Idl_distance(_Range);
+            auto _UOutput     = _RANGES _Move_backward_common(
+                    _Ubegin(_Range), _ULast, _STD _Get_unwrapped_n(_STD move(_Output), -_Count));
+            _STD _Seek_wrapped(_Output, _STD move(_UOutput));
             return {_RANGES _Rewrap_iterator(_Range, _STD move(_ULast)), _STD move(_Output)};
         }
     };

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1712,23 +1712,29 @@ namespace ranges {
         _STATIC_CALL_OPERATOR constexpr move_result<_It, _Out> operator()(
             _It _First, _Se _Last, _Out _Output) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
-            auto _UResult = _RANGES _Move_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Output));
+            auto _UFirst      = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
+            auto _ULast       = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
+            const auto _Count = _STD _Idl_distance<_It>(_UFirst, _ULast);
+            auto _UResult     = _RANGES _Move_unchecked(
+                    _STD move(_UFirst), _STD move(_ULast), _STD _Get_unwrapped_n(_STD move(_Output), _Count));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-            return {_STD move(_First), _STD move(_UResult.out)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
         template <input_range _Rng, weakly_incrementable _Out>
             requires indirectly_movable<iterator_t<_Rng>, _Out>
         _STATIC_CALL_OPERATOR constexpr move_result<borrowed_iterator_t<_Rng>, _Out> operator()(
             _Rng&& _Range, _Out _Output) _CONST_CALL_OPERATOR {
-            auto _First   = _RANGES begin(_Range);
-            auto _UResult = _RANGES _Move_unchecked(
-                _RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD move(_Output));
+            const auto _Count = _RANGES _Idl_distance(_Range);
+            auto _First       = _RANGES begin(_Range);
+            auto _UResult = _RANGES _Move_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
+                _STD _Get_unwrapped_n(_STD move(_Output), _Count));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-            return {_STD move(_First), _STD move(_UResult.out)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First), _STD move(_Output)};
         }
     };
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -5178,7 +5178,10 @@ namespace ranges {
             auto _UFirst = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
             auto _ULast  = _RANGES _Get_final_iterator_unwrapped<_It>(_UFirst, _STD move(_Last));
             _STD _Seek_wrapped(_First, _ULast);
-            _Output = _Reverse_copy_common(_STD move(_UFirst), _STD move(_ULast), _STD move(_Output));
+            const auto _Count = _STD _Idl_distance<_It>(_UFirst, _ULast);
+            auto _UOutput     = _Reverse_copy_common(
+                _STD move(_UFirst), _STD move(_ULast), _STD _Get_unwrapped_n(_STD move(_Output), _Count));
+            _STD _Seek_wrapped(_Output, _STD move(_UOutput));
             return {_STD move(_First), _STD move(_Output)};
         }
 
@@ -5186,12 +5189,16 @@ namespace ranges {
             requires indirectly_copyable<iterator_t<_Rng>, _Out>
         _STATIC_CALL_OPERATOR constexpr reverse_copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(
             _Rng&& _Range, _Out _Output) _CONST_CALL_OPERATOR {
+            const auto _Count = _RANGES _Idl_distance(_Range);
+            auto _UOutput     = _STD _Get_unwrapped_n(_STD move(_Output), _Count);
             if constexpr (common_range<_Rng>) {
-                _Output = _Reverse_copy_common(_Ubegin(_Range), _Uend(_Range), _STD move(_Output));
+                _UOutput = _Reverse_copy_common(_Ubegin(_Range), _Uend(_Range), _STD move(_UOutput));
+                _STD _Seek_wrapped(_Output, _STD move(_UOutput));
                 return {_RANGES end(_Range), _STD move(_Output)};
             } else {
                 auto _ULast = _RANGES _Get_final_iterator_unwrapped(_Range);
-                _Output     = _Reverse_copy_common(_Ubegin(_Range), _ULast, _STD move(_Output));
+                _UOutput    = _Reverse_copy_common(_Ubegin(_Range), _ULast, _STD move(_UOutput));
+                _STD _Seek_wrapped(_Output, _STD move(_UOutput));
                 return {_RANGES _Rewrap_iterator(_Range, _STD move(_ULast)), _STD move(_Output)};
             }
         }

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -5603,9 +5603,9 @@ namespace ranges {
             if constexpr (forward_iterator<_It>) {
                 auto _UFirst   = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
                 auto _Pop_size = _RANGES distance(_UFirst, _RANGES _Unwrap_sent<_It>(_STD move(_Last)));
-                return _Sample_selection_unchecked(_STD move(_UFirst), _Pop_size, _STD move(_Output), _Count, _RngFunc);
+                return _Selection_sample(_STD move(_UFirst), _Pop_size, _STD move(_Output), _Count, _RngFunc);
             } else {
-                return _Sample_reservoir_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
+                return _Reservoir_sample(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
                     _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Output), _Count, _RngFunc);
             }
         }
@@ -5624,18 +5624,18 @@ namespace ranges {
             if constexpr (forward_range<_Rng>) {
                 auto _UFirst   = _Ubegin(_Range);
                 auto _Pop_size = _RANGES distance(_UFirst, _Uend(_Range));
-                return _Sample_selection_unchecked(_STD move(_UFirst), _Pop_size, _STD move(_Output), _Count, _RngFunc);
+                return _Selection_sample(_STD move(_UFirst), _Pop_size, _STD move(_Output), _Count, _RngFunc);
             } else {
-                return _Sample_reservoir_unchecked(
-                    _Ubegin(_Range), _Uend(_Range), _STD move(_Output), _Count, _RngFunc);
+                return _Reservoir_sample(_Ubegin(_Range), _Uend(_Range), _STD move(_Output), _Count, _RngFunc);
             }
         }
 
     private:
         template <class _It, class _Out, class _Rng>
-        _NODISCARD static _Out _Sample_selection_unchecked(
+        _NODISCARD static _Out _Selection_sample(
             _It _First, iter_difference_t<_It> _Pop_size, _Out _Output, iter_difference_t<_It> _Count, _Rng& _RngFunc) {
-            // randomly select _Count elements from [_First, _First + _Pop_size) into _Output
+            // Randomly select _Count elements from _First + [0, _Pop_size) into _Output.
+            // _First should be already unwrapped, _Output will be unwrapped locally.
             _STL_INTERNAL_STATIC_ASSERT(forward_iterator<_It>);
             _STL_INTERNAL_STATIC_ASSERT(weakly_incrementable<_Out>);
             _STL_INTERNAL_STATIC_ASSERT(indirectly_copyable<_It, _Out>);
@@ -5643,45 +5643,53 @@ namespace ranges {
             if (_Count > _Pop_size) {
                 _Count = _Pop_size;
             }
+            auto _UOutput = _STD _Get_unwrapped_n(_STD move(_Output), _Count);
 
             for (; _Pop_size > 0; ++_First, (void) --_Pop_size) {
                 if (_RngFunc(_Pop_size) < _Count) {
-                    *_Output = *_First;
-                    ++_Output;
+                    *_UOutput = *_First;
+                    ++_UOutput;
                     if (--_Count == 0) {
                         break;
                     }
                 }
             }
 
+            _STD _Seek_wrapped(_Output, _STD move(_UOutput));
             return _Output;
         }
 
         template <class _It, class _Se, class _Out, class _Rng>
-        _NODISCARD static _Out _Sample_reservoir_unchecked(
+        _NODISCARD static _Out _Reservoir_sample(
             _It _First, const _Se _Last, _Out _Output, const iter_difference_t<_It> _Count, _Rng& _RngFunc) {
-            // randomly select _Count elements from [_First, _Last) into _Output
+            // Randomly select _Count elements from [_First, _Last) into _Output.
+            // _First should be already unwrapped, _Output will be unwrapped locally.
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It>);
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se, _It>);
             _STL_INTERNAL_STATIC_ASSERT(random_access_iterator<_Out>);
             _STL_INTERNAL_STATIC_ASSERT(indirectly_copyable<_It, _Out>);
 
+            auto _UOutput = _STD _Get_unwrapped_unverified(_STD move(_Output));
             iter_difference_t<_It> _Pop_size{};
             for (; _Pop_size < _Count; ++_Pop_size, (void) ++_First) {
                 if (_First == _Last) {
-                    return _Output + _Pop_size;
+                    _UOutput += _Pop_size;
+                    _STD _Seek_wrapped(_Output, _STD move(_UOutput));
+                    return _Output;
                 }
 
-                *(_Output + _Pop_size) = *_First;
+                *(_UOutput + _Pop_size) = *_First;
             }
             for (; _First != _Last; ++_First) {
                 const auto _Idx = _RngFunc(++_Pop_size);
                 if (_Idx < _Count) {
-                    *(_Output + _Idx) = *_First;
+                    *(_UOutput + _Idx) = *_First;
                 }
             }
 
-            return _Output + _Count;
+            _UOutput += _Count;
+            _STD _Seek_wrapped(_Output, _STD move(_UOutput));
+            return _Output;
         }
     };
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -7362,7 +7362,7 @@ _CONSTEXPR20 _OutIt merge(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 
     _DEBUG_ORDER_SET_UNWRAPPED(_InIt1, _UFirst2, _ULast2, _Pred);
     const auto _Count1 = _STD _Idl_distance<_InIt1>(_UFirst1, _ULast1);
     const auto _Count2 = _STD _Idl_distance<_InIt2>(_UFirst2, _ULast2);
-    auto _UDest        = _STD _Get_unwrapped_n(_Dest, _Idl_dist_add(_Count1, _Count2));
+    auto _UDest        = _STD _Get_unwrapped_n(_Dest, _STD _Idl_dist_add(_Count1, _Count2));
     if (_UFirst1 != _ULast1 && _UFirst2 != _ULast2) {
         for (;;) {
             if (_DEBUG_LT_PRED(_Pred, *_UFirst2, *_UFirst1)) {
@@ -7436,13 +7436,20 @@ namespace ranges {
             _Pj2 _Proj2 = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First1, _Last1);
             _STD _Adl_verify_range(_First2, _Last2);
-            auto _UResult = _Merge_unchecked(_RANGES _Unwrap_iter<_Se1>(_STD move(_First1)),
-                _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)), _RANGES _Unwrap_iter<_Se2>(_STD move(_First2)),
-                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD move(_Output), _STD _Pass_fn(_Pred),
-                _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+            auto _UFirst1      = _RANGES _Unwrap_iter<_Se1>(_STD move(_First1));
+            auto _ULast1       = _RANGES _Unwrap_sent<_It1>(_STD move(_Last1));
+            const auto _Count1 = _STD _Idl_distance<_It1>(_UFirst1, _ULast1);
+            auto _UFirst2      = _RANGES _Unwrap_iter<_Se2>(_STD move(_First2));
+            auto _ULast2       = _RANGES _Unwrap_sent<_It2>(_STD move(_Last2));
+            const auto _Count2 = _STD _Idl_distance<_It2>(_UFirst2, _ULast2);
+            const auto _Count  = _STD _Idl_dist_add(_Count1, _Count2);
+            auto _UResult      = _Merge_unchecked(_STD move(_UFirst1), _STD move(_ULast1), _STD move(_UFirst2),
+                     _STD move(_ULast2), _STD _Get_unwrapped_n(_STD move(_Output), _Count), _STD _Pass_fn(_Pred),
+                     _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
             _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
-            return {_STD move(_First1), _STD move(_First2), _STD move(_UResult.out)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
         }
 
         template <input_range _Rng1, input_range _Rng2, weakly_incrementable _Out, class _Pr = ranges::less,
@@ -7451,14 +7458,19 @@ namespace ranges {
         _STATIC_CALL_OPERATOR constexpr merge_result<borrowed_iterator_t<_Rng1>, borrowed_iterator_t<_Rng2>, _Out>
             operator()(_Rng1&& _Range1, _Rng2&& _Range2, _Out _Output, _Pr _Pred = {}, _Pj1 _Proj1 = {},
                 _Pj2 _Proj2 = {}) _CONST_CALL_OPERATOR {
-            auto _First1  = _RANGES begin(_Range1);
-            auto _First2  = _RANGES begin(_Range2);
-            auto _UResult = _Merge_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1),
-                _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2), _STD move(_Output),
-                _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+            const auto _Count1 = _RANGES _Idl_distance(_Range1);
+            const auto _Count2 = _RANGES _Idl_distance(_Range2);
+            const auto _Count  = _STD _Idl_dist_add(_Count1, _Count2);
+            auto _First1       = _RANGES begin(_Range1);
+            auto _First2       = _RANGES begin(_Range2);
+            auto _UResult      = _Merge_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1),
+                     _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2),
+                     _STD _Get_unwrapped_n(_STD move(_Output), _Count), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1),
+                     _STD _Pass_fn(_Proj2));
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
             _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
-            return {_STD move(_First1), _STD move(_First2), _STD move(_UResult.out)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
         }
 
     private:

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -3819,26 +3819,55 @@ namespace ranges {
         _STATIC_CALL_OPERATOR constexpr unary_transform_result<_It, _Out> operator()(
             _It _First, _Se _Last, _Out _Output, _Fn _Func, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
-            auto _UResult = _Transform_unary_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Output), _STD _Pass_fn(_Func),
-                _STD _Pass_fn(_Proj));
+            auto _UFirst = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
+            auto _ULast  = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
 
-            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-            return {_STD move(_First), _STD move(_UResult.out)};
+            if constexpr (sized_sentinel_for<_Se, _It>) {
+                const auto _Count = _ULast - _UFirst;
+                auto _UResult     = _Transform_unary_n_unchecked(_STD move(_UFirst), _Count,
+                        _STD _Get_unwrapped_n(_STD move(_Output), _Count), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj));
+
+                _STD _Seek_wrapped(_First, _STD move(_UResult.in));
+                _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+                return {_STD move(_First), _STD move(_Output)};
+            } else {
+                auto _UResult = _Transform_unary_unchecked(_STD move(_UFirst), _STD move(_ULast),
+                    _STD _Get_unwrapped_unverified(_STD move(_Output)), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj));
+
+                _STD _Seek_wrapped(_First, _STD move(_UResult.in));
+                _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+                return {_STD move(_First), _STD move(_Output)};
+            }
         }
 
         template <input_range _Rng, weakly_incrementable _Out, copy_constructible _Fn, class _Pj = identity>
             requires indirectly_writable<_Out, indirect_result_t<_Fn&, projected<iterator_t<_Rng>, _Pj>>>
         _STATIC_CALL_OPERATOR constexpr unary_transform_result<borrowed_iterator_t<_Rng>, _Out> operator()(
             _Rng&& _Range, _Out _Output, _Fn _Func, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
-            auto _First   = _RANGES begin(_Range);
-            auto _UResult = _Transform_unary_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)),
-                _Uend(_Range), _STD move(_Output), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj));
+            if constexpr (sized_range<_Rng>) {
+                const auto _Count = _RANGES distance(_Range);
+                auto _First       = _RANGES begin(_Range);
+                auto _UResult =
+                    _Transform_unary_n_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Count,
+                        _STD _Get_unwrapped_n(_STD move(_Output), _Count), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj));
 
-            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-            return {_STD move(_First), _STD move(_UResult.out)};
+                _STD _Seek_wrapped(_First, _STD move(_UResult.in));
+                _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+                return {_STD move(_First), _STD move(_Output)};
+            } else {
+                auto _First = _RANGES begin(_Range);
+                auto _UResult =
+                    _Transform_unary_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
+                        _STD _Get_unwrapped_unverified(_STD move(_Output)), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj));
+
+                _STD _Seek_wrapped(_First, _STD move(_UResult.in));
+                _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+                return {_STD move(_First), _STD move(_Output)};
+            }
         }
 
+#pragma warning(push)
+#pragma warning(disable : 6287) // Redundant code
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             weakly_incrementable _Out, copy_constructible _Fn, class _Pj1 = identity, class _Pj2 = identity>
             requires indirectly_writable<_Out, indirect_result_t<_Fn&, projected<_It1, _Pj1>, projected<_It2, _Pj2>>>
@@ -3847,14 +3876,37 @@ namespace ranges {
             _Pj2 _Proj2 = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First1, _Last1);
             _STD _Adl_verify_range(_First2, _Last2);
-            auto _UResult = _Transform_binary_unchecked(_RANGES _Unwrap_iter<_Se1>(_STD move(_First1)),
-                _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)), _RANGES _Unwrap_iter<_Se2>(_STD move(_First2)),
-                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD move(_Output), _STD _Pass_fn(_Func),
-                _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
 
-            _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
-            _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
-            return {_STD move(_First1), _STD move(_First2), _STD move(_UResult.out)};
+            constexpr bool _Min_size_determinable =
+                (sized_sentinel_for<_Se1, _It1> && _Sized_or_unreachable_sentinel_for<_Se2, _It2>)
+                || (sized_sentinel_for<_Se2, _It2> && _Sized_or_unreachable_sentinel_for<_Se1, _It1>);
+
+            if constexpr (_Min_size_determinable) {
+                auto _UFirst1      = _RANGES _Unwrap_iter<_Se1>(_STD move(_First1));
+                const auto _Count1 = _STD _Idl_distance<_It1>(_UFirst1, _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)));
+                auto _UFirst2      = _RANGES _Unwrap_iter<_Se2>(_STD move(_First2));
+                const auto _Count2 = _STD _Idl_distance<_It2>(_UFirst2, _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)));
+                const auto _Count  = _STD _Idl_dist_min(_Count1, _Count2);
+
+                auto _UResult = _Transform_binary_n_unchecked(_STD move(_UFirst1), _STD move(_UFirst2), _Count,
+                    _STD _Get_unwrapped_n(_STD move(_Output), _Count), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj1),
+                    _STD _Pass_fn(_Proj2));
+
+                _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
+                _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
+                _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+                return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
+            } else {
+                auto _UResult = _Transform_binary_unchecked(_RANGES _Unwrap_iter<_Se1>(_STD move(_First1)),
+                    _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)), _RANGES _Unwrap_iter<_Se2>(_STD move(_First2)),
+                    _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD _Get_unwrapped_unverified(_STD move(_Output)),
+                    _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+
+                _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
+                _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
+                _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+                return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
+            }
         }
 
         template <input_range _Rng1, input_range _Rng2, weakly_incrementable _Out, copy_constructible _Fn,
@@ -3865,16 +3917,36 @@ namespace ranges {
             _Out>
             operator()(_Rng1&& _Range1, _Rng2&& _Range2, _Out _Output, _Fn _Func, _Pj1 _Proj1 = {},
                 _Pj2 _Proj2 = {}) _CONST_CALL_OPERATOR {
-            auto _First1  = _RANGES begin(_Range1);
-            auto _First2  = _RANGES begin(_Range2);
-            auto _UResult = _Transform_binary_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)),
-                _Uend(_Range1), _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2),
-                _STD move(_Output), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+            constexpr bool _Min_size_determinable = (sized_range<_Rng1> && _Sized_or_infinite_range<_Rng2>)
+                                                 || (sized_range<_Rng2> && _Sized_or_infinite_range<_Rng1>);
+            if constexpr (_Min_size_determinable) {
+                const auto _Count = _STD _Idl_dist_min(_RANGES _Idl_distance(_Range1), _RANGES _Idl_distance(_Range2));
+                auto _First1      = _RANGES begin(_Range1);
+                auto _First2      = _RANGES begin(_Range2);
+                auto _UResult     = _Transform_binary_n_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)),
+                        _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Count,
+                        _STD _Get_unwrapped_n(_STD move(_Output), _Count), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj1),
+                        _STD _Pass_fn(_Proj2));
 
-            _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
-            _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
-            return {_STD move(_First1), _STD move(_First2), _STD move(_UResult.out)};
+                _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
+                _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
+                _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+                return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
+            } else {
+                auto _First1  = _RANGES begin(_Range1);
+                auto _First2  = _RANGES begin(_Range2);
+                auto _UResult = _Transform_binary_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)),
+                    _Uend(_Range1), _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2),
+                    _STD _Get_unwrapped_unverified(_STD move(_Output)), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj1),
+                    _STD _Pass_fn(_Proj2));
+
+                _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
+                _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
+                _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+                return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
+            }
         }
+#pragma warning(pop)
 
     private:
         template <class _It, class _Se, class _Out, class _Fn, class _Pj>
@@ -3892,6 +3964,30 @@ namespace ranges {
             return {_STD move(_First), _STD move(_Output)};
         }
 
+        template <class _It, class _Out, class _Fn, class _Pj>
+        _NODISCARD static constexpr unary_transform_result<_It, _Out> _Transform_unary_n_unchecked(
+            _It _First, iter_difference_t<_It> _Count, _Out _Output, _Fn _Func, _Pj _Proj) {
+            // transform projected _First + [0, _Count) with _Func
+            _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It>);
+            _STL_INTERNAL_STATIC_ASSERT(weakly_incrementable<_Out>);
+            _STL_INTERNAL_STATIC_ASSERT(indirectly_writable<_Out, indirect_result_t<_Fn&, projected<_It, _Pj>>>);
+
+            if constexpr (random_access_iterator<_It>
+                          && random_access_iterator<_Out>) { // FIXME: justify this with benchmarks
+                for (iter_difference_t<_It> _Idx = 0; _Idx < _Count; ++_Idx) {
+                    _Output[_Idx] = _STD invoke(_Func, _STD invoke(_Proj, _First[_Idx]));
+                }
+
+                return {_First + _Count, _Output + _Count};
+            } else {
+                for (; _Count > 0; ++_First, (void) ++_Output, --_Count) {
+                    *_Output = _STD invoke(_Func, _STD invoke(_Proj, *_First));
+                }
+
+                return {_STD move(_First), _STD move(_Output)};
+            }
+        }
+
         template <class _It1, class _Se1, class _It2, class _Se2, class _Out, class _Fn, class _Pj1, class _Pj2>
         _NODISCARD static constexpr binary_transform_result<_It1, _It2, _Out> _Transform_binary_unchecked(_It1 _First1,
             const _Se1 _Last1, _It2 _First2, const _Se2 _Last2, _Out _Output, _Fn _Func, _Pj1 _Proj1, _Pj2 _Proj2) {
@@ -3907,6 +4003,34 @@ namespace ranges {
             }
 
             return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
+        }
+
+        template <class _It1, class _It2, class _Diff, class _Out, class _Fn, class _Pj1, class _Pj2>
+        _NODISCARD static constexpr binary_transform_result<_It1, _It2, _Out> _Transform_binary_n_unchecked(
+            _It1 _First1, _It2 _First2, _Diff _Count, _Out _Output, _Fn _Func, _Pj1 _Proj1, _Pj2 _Proj2) {
+            // transform projected _First1 + [0, _Count) and projected _First2 + [0, _Count) with _Func
+            _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It1>);
+            _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It2>);
+            _STL_INTERNAL_STATIC_ASSERT(_Signed_integer_like<_Diff>);
+            _STL_INTERNAL_STATIC_ASSERT(weakly_incrementable<_Out>);
+            _STL_INTERNAL_STATIC_ASSERT(
+                indirectly_writable<_Out, indirect_result_t<_Fn&, projected<_It1, _Pj1>, projected<_It2, _Pj2>>>);
+
+            if constexpr (random_access_iterator<_It1> && random_access_iterator<_It2>
+                          && random_access_iterator<_Out>) { // FIXME: justify this with benchmarks
+                for (_Diff _Idx = 0; _Idx < _Count; ++_Idx) {
+                    _Output[_Idx] =
+                        _STD invoke(_Func, _STD invoke(_Proj1, _First1[_Idx]), _STD invoke(_Proj2, _First2[_Idx]));
+                }
+
+                return {_First1 + _Count, _First2 + _Count, _Output + _Count};
+            } else {
+                for (; _Count > 0; ++_First1, (void) ++_First2, (void) ++_Output, --_Count) {
+                    *_Output = _STD invoke(_Func, _STD invoke(_Proj1, *_First1), _STD invoke(_Proj2, *_First2));
+                }
+
+                return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
+            }
         }
     };
 
@@ -7388,7 +7512,7 @@ _NODISCARD constexpr auto _Idl_dist_add(_Diff1 _Lhs, _Diff2 _Rhs) {
     } else if constexpr (is_same_v<_Diff1, _Distance_unknown> || is_same_v<_Diff2, _Distance_unknown>) {
         return _Distance_unknown{};
     } else {
-    return _Lhs + _Rhs;
+        return _Lhs + _Rhs;
     }
 }
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1639,10 +1639,11 @@ namespace ranges {
             _It _First, _Se _Last, _Out _Output, _Pr _Pred, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _Copy_if_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Output), _STD _Pass_fn(_Pred),
-                _STD _Pass_fn(_Proj));
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Get_unwrapped_unverified(_STD move(_Output)),
+                _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-            return {_STD move(_First), _STD move(_UResult.out)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
         template <input_range _Rng, weakly_incrementable _Out, class _Pj = identity,
@@ -1652,9 +1653,10 @@ namespace ranges {
             _Rng&& _Range, _Out _Output, _Pr _Pred, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             auto _First   = _RANGES begin(_Range);
             auto _UResult = _Copy_if_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
-                _STD move(_Output), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                _STD _Get_unwrapped_unverified(_STD move(_Output)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-            return {_STD move(_First), _STD move(_UResult.out)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
     private:

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -3763,6 +3763,24 @@ _FwdIt3 transform(_ExPo&& _Exec, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First
 #endif // _HAS_CXX17
 
 #if _HAS_CXX20
+template <class _Diff1, class _Diff2>
+_NODISCARD constexpr auto _Idl_dist_min([[maybe_unused]] const _Diff1 _Lhs, [[maybe_unused]] const _Diff2 _Rhs) {
+    // returns the minumum of two results from _Idl_distance calls
+    if constexpr (is_same_v<_Diff1, _Distance_unknown> || is_same_v<_Diff2, _Distance_unknown>) {
+        return _Distance_unknown{};
+    } else if constexpr (is_same_v<_Diff1, _Distance_unbounded>) {
+        return _Rhs;
+    } else if constexpr (is_same_v<_Diff2, _Distance_unbounded>) {
+        return _Lhs;
+    } else {
+        if (_Rhs < _Lhs) {
+            return static_cast<_Diff1>(_Rhs);
+        } else {
+            return _Lhs;
+        }
+    }
+}
+
 namespace ranges {
     _EXPORT_STD template <class _In, class _Out>
     using unary_transform_result = in_out_result<_In, _Out>;
@@ -7307,23 +7325,17 @@ namespace ranges {
 } // namespace ranges
 #endif // _HAS_CXX20
 
-_NODISCARD constexpr _Distance_unknown _Idl_dist_add(_Distance_unknown, _Distance_unknown) {
-    return {};
-}
-
-template <class _Diff1>
-_NODISCARD constexpr _Distance_unknown _Idl_dist_add(_Diff1, _Distance_unknown) {
-    return {};
-}
-
-template <class _Diff2>
-_NODISCARD constexpr _Distance_unknown _Idl_dist_add(_Distance_unknown, _Diff2) {
-    return {};
-}
-
 template <class _Diff1, class _Diff2>
 _NODISCARD constexpr auto _Idl_dist_add(_Diff1 _Lhs, _Diff2 _Rhs) {
+    (void) _Lhs;
+    (void) _Rhs;
+    if constexpr (is_same_v<_Diff1, _Distance_unbounded> || is_same_v<_Diff2, _Distance_unbounded>) {
+        return _Distance_unbounded{};
+    } else if constexpr (is_same_v<_Diff1, _Distance_unknown> || is_same_v<_Diff2, _Distance_unknown>) {
+        return _Distance_unknown{};
+    } else {
     return _Lhs + _Rhs;
+    }
 }
 
 _EXPORT_STD template <class _InIt1, class _InIt2, class _OutIt, class _Pr>

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -4150,12 +4150,15 @@ namespace ranges {
         _STATIC_CALL_OPERATOR constexpr replace_copy_result<_It, _Out> operator()(_It _First, _Se _Last, _Out _Output,
             const _Ty1& _Oldval, const _Ty2& _Newval, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
-            auto _UResult = _Replace_copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Output), _Oldval, _Newval,
-                _STD _Pass_fn(_Proj));
+            auto _UFirst      = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
+            auto _ULast       = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
+            const auto _Count = _STD _Idl_distance<_It>(_UFirst, _ULast);
+            auto _UResult     = _Replace_copy_unchecked(_STD move(_UFirst), _STD move(_ULast),
+                    _STD _Get_unwrapped_n(_STD move(_Output), _Count), _Oldval, _Newval, _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-            return {_STD move(_First), _STD move(_UResult.out)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
         template <input_range _Rng, class _Ty1, class _Ty2, output_iterator<const _Ty2&> _Out, class _Pj = identity>
@@ -4163,12 +4166,14 @@ namespace ranges {
                   && indirect_binary_predicate<ranges::equal_to, projected<iterator_t<_Rng>, _Pj>, const _Ty1*>
         _STATIC_CALL_OPERATOR constexpr replace_copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(_Rng&& _Range,
             _Out _Output, const _Ty1& _Oldval, const _Ty2& _Newval, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
-            auto _First   = _RANGES begin(_Range);
+            const auto _Count = _RANGES _Idl_distance(_Range);
+            auto _First       = _RANGES begin(_Range);
             auto _UResult = _Replace_copy_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
-                _STD move(_Output), _Oldval, _Newval, _STD _Pass_fn(_Proj));
+                _STD _Get_unwrapped_n(_STD move(_Output), _Count), _Oldval, _Newval, _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-            return {_STD move(_First), _STD move(_UResult.out)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
     private:

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1539,21 +1539,24 @@ namespace ranges {
             requires indirectly_copyable<_It, _Out>
         _STATIC_CALL_OPERATOR constexpr copy_n_result<_It, _Out> operator()(
             _It _First, iter_difference_t<_It> _Count, _Out _Output) _CONST_CALL_OPERATOR {
-            auto _UFirst = _STD _Get_unwrapped_n(_STD move(_First), _Count);
-            if constexpr (_Iter_copy_cat<decltype(_UFirst), _Out>::_Bitcopy_assignable) {
+            auto _UFirst  = _STD _Get_unwrapped_n(_STD move(_First), _Count);
+            auto _UOutput = _STD _Get_unwrapped_n(_STD move(_Output), _Count);
+            if constexpr (_Iter_copy_cat<decltype(_UFirst), decltype(_UOutput)>::_Bitcopy_assignable) {
                 if (!_STD is_constant_evaluated()) {
-                    _Output = _STD _Copy_memmove_n(_UFirst, static_cast<size_t>(_Count), _STD move(_Output));
+                    _UOutput = _STD _Copy_memmove_n(_UFirst, static_cast<size_t>(_Count), _STD move(_UOutput));
                     _UFirst += _Count;
                     _STD _Seek_wrapped(_First, _STD move(_UFirst));
+                    _STD _Seek_wrapped(_Output, _STD move(_UOutput));
                     return {_STD move(_First), _STD move(_Output)};
                 }
             }
 
-            for (; _Count > 0; ++_UFirst, (void) ++_Output, --_Count) {
-                *_Output = *_UFirst;
+            for (; _Count > 0; ++_UFirst, (void) ++_UOutput, --_Count) {
+                *_UOutput = *_UFirst;
             }
 
             _STD _Seek_wrapped(_First, _STD move(_UFirst));
+            _STD _Seek_wrapped(_Output, _STD move(_UOutput));
             return {_STD move(_First), _STD move(_Output)};
         }
     };

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1573,7 +1573,10 @@ namespace ranges {
             auto _UFirst = _RANGES _Unwrap_iter<_Se1>(_STD move(_First));
             auto _ULast  = _RANGES _Get_final_iterator_unwrapped<_It1>(_UFirst, _STD move(_Last));
             _STD _Seek_wrapped(_First, _ULast);
-            _Output = _STD _Copy_backward_unchecked(_STD move(_UFirst), _STD move(_ULast), _STD move(_Output));
+            const auto _Count = _STD _Idl_distance<_It1>(_UFirst, _ULast);
+            auto _UOutput     = _STD _Copy_backward_unchecked(
+                    _STD move(_UFirst), _STD move(_ULast), _STD _Get_unwrapped_n(_STD move(_Output), -_Count));
+            _STD _Seek_wrapped(_Output, _STD move(_UOutput));
             return {_STD move(_First), _STD move(_Output)};
         }
 
@@ -1581,8 +1584,11 @@ namespace ranges {
             requires indirectly_copyable<iterator_t<_Rng>, _It>
         _STATIC_CALL_OPERATOR constexpr copy_backward_result<borrowed_iterator_t<_Rng>, _It> operator()(
             _Rng&& _Range, _It _Output) _CONST_CALL_OPERATOR {
-            auto _ULast = _RANGES _Get_final_iterator_unwrapped(_Range);
-            _Output     = _STD _Copy_backward_unchecked(_Ubegin(_Range), _ULast, _STD move(_Output));
+            auto _ULast       = _RANGES _Get_final_iterator_unwrapped(_Range);
+            const auto _Count = _RANGES _Idl_distance(_Range);
+            auto _UOutput     = _STD _Copy_backward_unchecked(
+                    _Ubegin(_Range), _ULast, _STD _Get_unwrapped_n(_STD move(_Output), -_Count));
+            _STD _Seek_wrapped(_Output, _STD move(_UOutput));
             return {_RANGES _Rewrap_iterator(_Range, _STD move(_ULast)), _STD move(_Output)};
         }
     };

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1538,23 +1538,23 @@ namespace ranges {
         template <input_iterator _It, weakly_incrementable _Out>
             requires indirectly_copyable<_It, _Out>
         _STATIC_CALL_OPERATOR constexpr copy_n_result<_It, _Out> operator()(
-            _It _First, iter_difference_t<_It> _Count, _Out _Result) _CONST_CALL_OPERATOR {
+            _It _First, iter_difference_t<_It> _Count, _Out _Output) _CONST_CALL_OPERATOR {
             auto _UFirst = _STD _Get_unwrapped_n(_STD move(_First), _Count);
             if constexpr (_Iter_copy_cat<decltype(_UFirst), _Out>::_Bitcopy_assignable) {
                 if (!_STD is_constant_evaluated()) {
-                    _Result = _STD _Copy_memmove_n(_UFirst, static_cast<size_t>(_Count), _STD move(_Result));
+                    _Output = _STD _Copy_memmove_n(_UFirst, static_cast<size_t>(_Count), _STD move(_Output));
                     _UFirst += _Count;
                     _STD _Seek_wrapped(_First, _STD move(_UFirst));
-                    return {_STD move(_First), _STD move(_Result)};
+                    return {_STD move(_First), _STD move(_Output)};
                 }
             }
 
-            for (; _Count > 0; ++_UFirst, (void) ++_Result, --_Count) {
-                *_Result = *_UFirst;
+            for (; _Count > 0; ++_UFirst, (void) ++_Output, --_Count) {
+                *_Output = *_UFirst;
             }
 
             _STD _Seek_wrapped(_First, _STD move(_UFirst));
-            return {_STD move(_First), _STD move(_Result)};
+            return {_STD move(_First), _STD move(_Output)};
         }
     };
 
@@ -1568,22 +1568,22 @@ namespace ranges {
         template <bidirectional_iterator _It1, sentinel_for<_It1> _Se1, bidirectional_iterator _It2>
             requires indirectly_copyable<_It1, _It2>
         _STATIC_CALL_OPERATOR constexpr copy_backward_result<_It1, _It2> operator()(
-            _It1 _First, _Se1 _Last, _It2 _Result) _CONST_CALL_OPERATOR {
+            _It1 _First, _Se1 _Last, _It2 _Output) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
             auto _UFirst = _RANGES _Unwrap_iter<_Se1>(_STD move(_First));
             auto _ULast  = _RANGES _Get_final_iterator_unwrapped<_It1>(_UFirst, _STD move(_Last));
             _STD _Seek_wrapped(_First, _ULast);
-            _Result = _STD _Copy_backward_unchecked(_STD move(_UFirst), _STD move(_ULast), _STD move(_Result));
-            return {_STD move(_First), _STD move(_Result)};
+            _Output = _STD _Copy_backward_unchecked(_STD move(_UFirst), _STD move(_ULast), _STD move(_Output));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
         template <bidirectional_range _Rng, bidirectional_iterator _It>
             requires indirectly_copyable<iterator_t<_Rng>, _It>
         _STATIC_CALL_OPERATOR constexpr copy_backward_result<borrowed_iterator_t<_Rng>, _It> operator()(
-            _Rng&& _Range, _It _Result) _CONST_CALL_OPERATOR {
+            _Rng&& _Range, _It _Output) _CONST_CALL_OPERATOR {
             auto _ULast = _RANGES _Get_final_iterator_unwrapped(_Range);
-            _Result     = _STD _Copy_backward_unchecked(_Ubegin(_Range), _ULast, _STD move(_Result));
-            return {_RANGES _Rewrap_iterator(_Range, _STD move(_ULast)), _STD move(_Result)};
+            _Output     = _STD _Copy_backward_unchecked(_Ubegin(_Range), _ULast, _STD move(_Output));
+            return {_RANGES _Rewrap_iterator(_Range, _STD move(_ULast)), _STD move(_Output)};
         }
     };
 
@@ -1630,10 +1630,10 @@ namespace ranges {
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
             requires indirectly_copyable<_It, _Out>
         _STATIC_CALL_OPERATOR constexpr copy_if_result<_It, _Out> operator()(
-            _It _First, _Se _Last, _Out _Result, _Pr _Pred, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
+            _It _First, _Se _Last, _Out _Output, _Pr _Pred, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _Copy_if_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _STD _Pass_fn(_Pred),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Output), _STD _Pass_fn(_Pred),
                 _STD _Pass_fn(_Proj));
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
@@ -1643,10 +1643,10 @@ namespace ranges {
             indirect_unary_predicate<projected<iterator_t<_Rng>, _Pj>> _Pr>
             requires indirectly_copyable<iterator_t<_Rng>, _Out>
         _STATIC_CALL_OPERATOR constexpr copy_if_result<borrowed_iterator_t<_Rng>, _Out> operator()(
-            _Rng&& _Range, _Out _Result, _Pr _Pred, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
+            _Rng&& _Range, _Out _Output, _Pr _Pred, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             auto _First   = _RANGES begin(_Range);
             auto _UResult = _Copy_if_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
-                _STD move(_Result), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                _STD move(_Output), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }
@@ -1654,7 +1654,7 @@ namespace ranges {
     private:
         template <class _It, class _Se, class _Out, class _Pj, class _Pr>
         _NODISCARD static constexpr copy_if_result<_It, _Out> _Copy_if_unchecked(
-            _It _First, const _Se _Last, _Out _Result, _Pr _Pred, _Pj _Proj) {
+            _It _First, const _Se _Last, _Out _Output, _Pr _Pred, _Pj _Proj) {
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It>);
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se, _It>);
             _STL_INTERNAL_STATIC_ASSERT(indirect_unary_predicate<_Pr, projected<_It, _Pj>>);
@@ -1662,12 +1662,12 @@ namespace ranges {
 
             for (; _First != _Last; ++_First) {
                 if (_STD invoke(_Pred, _STD invoke(_Proj, *_First))) {
-                    *_Result = *_First;
-                    ++_Result;
+                    *_Output = *_First;
+                    ++_Output;
                 }
             }
 
-            return {_STD move(_First), _STD move(_Result)};
+            return {_STD move(_First), _STD move(_Output)};
         }
     };
 
@@ -1678,20 +1678,20 @@ namespace ranges {
 
     template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
         requires indirectly_movable<_It, _Out>
-    constexpr move_result<_It, _Out> _Move_unchecked(_It _First, _Se _Last, _Out _Result) {
+    constexpr move_result<_It, _Out> _Move_unchecked(_It _First, _Se _Last, _Out _Output) {
         if constexpr (_Iter_move_cat<_It, _Out>::_Bitcopy_assignable) {
             if (!_STD is_constant_evaluated()) {
                 auto _Final = _RANGES next(_First, _STD move(_Last));
-                _Result     = _STD _Copy_memmove(_STD move(_First), _Final, _STD move(_Result));
-                return {_STD move(_Final), _STD move(_Result)};
+                _Output     = _STD _Copy_memmove(_STD move(_First), _Final, _STD move(_Output));
+                return {_STD move(_Final), _STD move(_Output)};
             }
         }
 
-        for (; _First != _Last; ++_First, (void) ++_Result) {
-            *_Result = _RANGES iter_move(_First);
+        for (; _First != _Last; ++_First, (void) ++_Output) {
+            *_Output = _RANGES iter_move(_First);
         }
 
-        return {_STD move(_First), _STD move(_Result)};
+        return {_STD move(_First), _STD move(_Output)};
     }
 
     class _Move_fn {
@@ -1699,10 +1699,10 @@ namespace ranges {
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
             requires indirectly_movable<_It, _Out>
         _STATIC_CALL_OPERATOR constexpr move_result<_It, _Out> operator()(
-            _It _First, _Se _Last, _Out _Result) _CONST_CALL_OPERATOR {
+            _It _First, _Se _Last, _Out _Output) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _RANGES _Move_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result));
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Output));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
@@ -1711,10 +1711,10 @@ namespace ranges {
         template <input_range _Rng, weakly_incrementable _Out>
             requires indirectly_movable<iterator_t<_Rng>, _Out>
         _STATIC_CALL_OPERATOR constexpr move_result<borrowed_iterator_t<_Rng>, _Out> operator()(
-            _Rng&& _Range, _Out _Result) _CONST_CALL_OPERATOR {
+            _Rng&& _Range, _Out _Output) _CONST_CALL_OPERATOR {
             auto _First   = _RANGES begin(_Range);
             auto _UResult = _RANGES _Move_unchecked(
-                _RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD move(_Result));
+                _RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD move(_Output));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
@@ -1729,18 +1729,18 @@ namespace ranges {
     // concept-constrained for strict enforcement as it is used by several algorithms
     template <bidirectional_iterator _It1, bidirectional_iterator _It2>
         requires indirectly_movable<_It1, _It2>
-    constexpr _It2 _Move_backward_common(const _It1 _First, _It1 _Last, _It2 _Result) {
+    constexpr _It2 _Move_backward_common(const _It1 _First, _It1 _Last, _It2 _Output) {
         if constexpr (_Iter_move_cat<_It1, _It2>::_Bitcopy_assignable) {
             if (!_STD is_constant_evaluated()) {
-                return _STD _Copy_backward_memmove(_First, _Last, _Result);
+                return _STD _Copy_backward_memmove(_First, _Last, _Output);
             }
         }
 
         while (_First != _Last) {
-            *--_Result = _RANGES iter_move(--_Last);
+            *--_Output = _RANGES iter_move(--_Last);
         }
 
-        return _Result;
+        return _Output;
     }
 
     class _Move_backward_fn {
@@ -1748,22 +1748,22 @@ namespace ranges {
         template <bidirectional_iterator _It1, sentinel_for<_It1> _Se1, bidirectional_iterator _It2>
             requires indirectly_movable<_It1, _It2>
         _STATIC_CALL_OPERATOR constexpr move_backward_result<_It1, _It2> operator()(
-            _It1 _First, _Se1 _Last, _It2 _Result) _CONST_CALL_OPERATOR {
+            _It1 _First, _Se1 _Last, _It2 _Output) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
             auto _UFirst = _RANGES _Unwrap_iter<_Se1>(_STD move(_First));
             auto _ULast  = _RANGES _Get_final_iterator_unwrapped<_It1>(_UFirst, _STD move(_Last));
             _STD _Seek_wrapped(_First, _ULast);
-            _Result = _RANGES _Move_backward_common(_STD move(_UFirst), _STD move(_ULast), _STD move(_Result));
-            return {_STD move(_First), _STD move(_Result)};
+            _Output = _RANGES _Move_backward_common(_STD move(_UFirst), _STD move(_ULast), _STD move(_Output));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
         template <bidirectional_range _Rng, bidirectional_iterator _It>
             requires indirectly_movable<iterator_t<_Rng>, _It>
         _STATIC_CALL_OPERATOR constexpr move_backward_result<borrowed_iterator_t<_Rng>, _It> operator()(
-            _Rng&& _Range, _It _Result) _CONST_CALL_OPERATOR {
+            _Rng&& _Range, _It _Output) _CONST_CALL_OPERATOR {
             auto _ULast = _RANGES _Get_final_iterator_unwrapped(_Range);
-            _Result     = _RANGES _Move_backward_common(_Ubegin(_Range), _ULast, _STD move(_Result));
-            return {_RANGES _Rewrap_iterator(_Range, _STD move(_ULast)), _STD move(_Result)};
+            _Output     = _RANGES _Move_backward_common(_Ubegin(_Range), _ULast, _STD move(_Output));
+            return {_RANGES _Rewrap_iterator(_Range, _STD move(_ULast)), _STD move(_Output)};
         }
     };
 
@@ -3794,10 +3794,10 @@ namespace ranges {
             class _Pj = identity>
             requires indirectly_writable<_Out, indirect_result_t<_Fn&, projected<_It, _Pj>>>
         _STATIC_CALL_OPERATOR constexpr unary_transform_result<_It, _Out> operator()(
-            _It _First, _Se _Last, _Out _Result, _Fn _Func, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
+            _It _First, _Se _Last, _Out _Output, _Fn _Func, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _Transform_unary_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _STD _Pass_fn(_Func),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Output), _STD _Pass_fn(_Func),
                 _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
@@ -3807,10 +3807,10 @@ namespace ranges {
         template <input_range _Rng, weakly_incrementable _Out, copy_constructible _Fn, class _Pj = identity>
             requires indirectly_writable<_Out, indirect_result_t<_Fn&, projected<iterator_t<_Rng>, _Pj>>>
         _STATIC_CALL_OPERATOR constexpr unary_transform_result<borrowed_iterator_t<_Rng>, _Out> operator()(
-            _Rng&& _Range, _Out _Result, _Fn _Func, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
+            _Rng&& _Range, _Out _Output, _Fn _Func, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             auto _First   = _RANGES begin(_Range);
             auto _UResult = _Transform_unary_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)),
-                _Uend(_Range), _STD move(_Result), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj));
+                _Uend(_Range), _STD move(_Output), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
@@ -3820,13 +3820,13 @@ namespace ranges {
             weakly_incrementable _Out, copy_constructible _Fn, class _Pj1 = identity, class _Pj2 = identity>
             requires indirectly_writable<_Out, indirect_result_t<_Fn&, projected<_It1, _Pj1>, projected<_It2, _Pj2>>>
         _STATIC_CALL_OPERATOR constexpr binary_transform_result<_It1, _It2, _Out> operator()(_It1 _First1, _Se1 _Last1,
-            _It2 _First2, _Se2 _Last2, _Out _Result, _Fn _Func, _Pj1 _Proj1 = {},
+            _It2 _First2, _Se2 _Last2, _Out _Output, _Fn _Func, _Pj1 _Proj1 = {},
             _Pj2 _Proj2 = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First1, _Last1);
             _STD _Adl_verify_range(_First2, _Last2);
             auto _UResult = _Transform_binary_unchecked(_RANGES _Unwrap_iter<_Se1>(_STD move(_First1)),
                 _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)), _RANGES _Unwrap_iter<_Se2>(_STD move(_First2)),
-                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD move(_Result), _STD _Pass_fn(_Func),
+                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD move(_Output), _STD _Pass_fn(_Func),
                 _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
 
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
@@ -3840,13 +3840,13 @@ namespace ranges {
                 indirect_result_t<_Fn&, projected<iterator_t<_Rng1>, _Pj1>, projected<iterator_t<_Rng2>, _Pj2>>>
         _STATIC_CALL_OPERATOR constexpr binary_transform_result<borrowed_iterator_t<_Rng1>, borrowed_iterator_t<_Rng2>,
             _Out>
-            operator()(_Rng1&& _Range1, _Rng2&& _Range2, _Out _Result, _Fn _Func, _Pj1 _Proj1 = {},
+            operator()(_Rng1&& _Range1, _Rng2&& _Range2, _Out _Output, _Fn _Func, _Pj1 _Proj1 = {},
                 _Pj2 _Proj2 = {}) _CONST_CALL_OPERATOR {
             auto _First1  = _RANGES begin(_Range1);
             auto _First2  = _RANGES begin(_Range2);
             auto _UResult = _Transform_binary_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)),
                 _Uend(_Range1), _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2),
-                _STD move(_Result), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
+                _STD move(_Output), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
 
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
             _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
@@ -3856,22 +3856,22 @@ namespace ranges {
     private:
         template <class _It, class _Se, class _Out, class _Fn, class _Pj>
         _NODISCARD static constexpr unary_transform_result<_It, _Out> _Transform_unary_unchecked(
-            _It _First, const _Se _Last, _Out _Result, _Fn _Func, _Pj _Proj) {
+            _It _First, const _Se _Last, _Out _Output, _Fn _Func, _Pj _Proj) {
             // transform projected [_First, _Last) with _Func
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It>);
             _STL_INTERNAL_STATIC_ASSERT(weakly_incrementable<_Out>);
             _STL_INTERNAL_STATIC_ASSERT(indirectly_writable<_Out, indirect_result_t<_Fn&, projected<_It, _Pj>>>);
 
-            for (; _First != _Last; ++_First, (void) ++_Result) {
-                *_Result = _STD invoke(_Func, _STD invoke(_Proj, *_First));
+            for (; _First != _Last; ++_First, (void) ++_Output) {
+                *_Output = _STD invoke(_Func, _STD invoke(_Proj, *_First));
             }
 
-            return {_STD move(_First), _STD move(_Result)};
+            return {_STD move(_First), _STD move(_Output)};
         }
 
         template <class _It1, class _Se1, class _It2, class _Se2, class _Out, class _Fn, class _Pj1, class _Pj2>
         _NODISCARD static constexpr binary_transform_result<_It1, _It2, _Out> _Transform_binary_unchecked(_It1 _First1,
-            const _Se1 _Last1, _It2 _First2, const _Se2 _Last2, _Out _Result, _Fn _Func, _Pj1 _Proj1, _Pj2 _Proj2) {
+            const _Se1 _Last1, _It2 _First2, const _Se2 _Last2, _Out _Output, _Fn _Func, _Pj1 _Proj1, _Pj2 _Proj2) {
             // transform projected [_First1, _Last1) and projected [_First2, _Last2) with _Func
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It1>);
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It2>);
@@ -3879,11 +3879,11 @@ namespace ranges {
             _STL_INTERNAL_STATIC_ASSERT(
                 indirectly_writable<_Out, indirect_result_t<_Fn&, projected<_It1, _Pj1>, projected<_It2, _Pj2>>>);
 
-            for (; _First1 != _Last1 && _First2 != _Last2; ++_First1, (void) ++_First2, ++_Result) {
-                *_Result = _STD invoke(_Func, _STD invoke(_Proj1, *_First1), _STD invoke(_Proj2, *_First2));
+            for (; _First1 != _Last1 && _First2 != _Last2; ++_First1, (void) ++_First2, ++_Output) {
+                *_Output = _STD invoke(_Func, _STD invoke(_Proj1, *_First1), _STD invoke(_Proj2, *_First2));
             }
 
-            return {_STD move(_First1), _STD move(_First2), _STD move(_Result)};
+            return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
         }
     };
 
@@ -4124,11 +4124,11 @@ namespace ranges {
             class _Pj = identity>
             requires indirectly_copyable<_It, _Out>
                   && indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty1*>
-        _STATIC_CALL_OPERATOR constexpr replace_copy_result<_It, _Out> operator()(_It _First, _Se _Last, _Out _Result,
+        _STATIC_CALL_OPERATOR constexpr replace_copy_result<_It, _Out> operator()(_It _First, _Se _Last, _Out _Output,
             const _Ty1& _Oldval, const _Ty2& _Newval, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _Replace_copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _Oldval, _Newval,
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Output), _Oldval, _Newval,
                 _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
@@ -4139,10 +4139,10 @@ namespace ranges {
             requires indirectly_copyable<iterator_t<_Rng>, _Out>
                   && indirect_binary_predicate<ranges::equal_to, projected<iterator_t<_Rng>, _Pj>, const _Ty1*>
         _STATIC_CALL_OPERATOR constexpr replace_copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(_Rng&& _Range,
-            _Out _Result, const _Ty1& _Oldval, const _Ty2& _Newval, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
+            _Out _Output, const _Ty1& _Oldval, const _Ty2& _Newval, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             auto _First   = _RANGES begin(_Range);
             auto _UResult = _Replace_copy_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
-                _STD move(_Result), _Oldval, _Newval, _STD _Pass_fn(_Proj));
+                _STD move(_Output), _Oldval, _Newval, _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
@@ -4151,27 +4151,27 @@ namespace ranges {
     private:
         template <class _It, class _Se, class _Ty1, class _Ty2, class _Out, class _Pj>
         _NODISCARD static constexpr replace_copy_result<_It, _Out> _Replace_copy_unchecked(
-            _It _First, const _Se _Last, _Out _Result, const _Ty1& _Oldval, const _Ty2& _Newval, _Pj _Proj) {
-            // copy [_First, _Last) to _Result while replacing projected _Oldval with _Newval
+            _It _First, const _Se _Last, _Out _Output, const _Ty1& _Oldval, const _Ty2& _Newval, _Pj _Proj) {
+            // copy [_First, _Last) to _Output while replacing projected _Oldval with _Newval
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It>);
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se, _It>);
             _STL_INTERNAL_STATIC_ASSERT(output_iterator<_Out, const _Ty2&>);
             _STL_INTERNAL_STATIC_ASSERT(indirectly_copyable<_It, _Out>);
             _STL_INTERNAL_STATIC_ASSERT(indirect_binary_predicate<equal_to, projected<_It, _Pj>, const _Ty1*>);
 
-            for (; _First != _Last; ++_First, (void) ++_Result) {
+            for (; _First != _Last; ++_First, (void) ++_Output) {
                 if constexpr (_Can_vectorize_replace_copy<_Out, iter_value_t<_It>, _Ty2>) {
-                    *_Result = _STD invoke(_Proj, *_First) == _Oldval ? _Newval : *_First;
+                    *_Output = _STD invoke(_Proj, *_First) == _Oldval ? _Newval : *_First;
                 } else {
                     if (_STD invoke(_Proj, *_First) == _Oldval) {
-                        *_Result = _Newval;
+                        *_Output = _Newval;
                     } else {
-                        *_Result = *_First;
+                        *_Output = *_First;
                     }
                 }
             }
 
-            return {_STD move(_First), _STD move(_Result)};
+            return {_STD move(_First), _STD move(_Output)};
         }
     };
 
@@ -4226,10 +4226,10 @@ namespace ranges {
             class _Pj = identity, indirect_unary_predicate<projected<_It, _Pj>> _Pr>
             requires indirectly_copyable<_It, _Out>
         _STATIC_CALL_OPERATOR constexpr replace_copy_if_result<_It, _Out> operator()(
-            _It _First, _Se _Last, _Out _Result, _Pr _Pred, const _Ty& _Newval, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
+            _It _First, _Se _Last, _Out _Output, _Pr _Pred, const _Ty& _Newval, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _Replace_copy_if_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _STD _Pass_fn(_Pred), _Newval,
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Output), _STD _Pass_fn(_Pred), _Newval,
                 _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
@@ -4240,10 +4240,10 @@ namespace ranges {
             indirect_unary_predicate<projected<iterator_t<_Rng>, _Pj>> _Pr>
             requires indirectly_copyable<iterator_t<_Rng>, _Out>
         _STATIC_CALL_OPERATOR constexpr replace_copy_if_result<borrowed_iterator_t<_Rng>, _Out> operator()(
-            _Rng&& _Range, _Out _Result, _Pr _Pred, const _Ty& _Newval, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
+            _Rng&& _Range, _Out _Output, _Pr _Pred, const _Ty& _Newval, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             auto _First   = _RANGES begin(_Range);
             auto _UResult = _Replace_copy_if_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)),
-                _Uend(_Range), _STD move(_Result), _STD _Pass_fn(_Pred), _Newval, _STD _Pass_fn(_Proj));
+                _Uend(_Range), _STD move(_Output), _STD _Pass_fn(_Pred), _Newval, _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
@@ -4252,27 +4252,27 @@ namespace ranges {
     private:
         template <class _It, class _Se, class _Ty, class _Out, class _Pj, class _Pr>
         _NODISCARD static constexpr replace_copy_if_result<_It, _Out> _Replace_copy_if_unchecked(
-            _It _First, const _Se _Last, _Out _Result, _Pr _Pred, const _Ty& _Newval, _Pj _Proj) {
-            // copy [_First, _Last) to _Result while replacing _Oldval with _Newval if projected _Oldval fulfills _Pred
+            _It _First, const _Se _Last, _Out _Output, _Pr _Pred, const _Ty& _Newval, _Pj _Proj) {
+            // copy [_First, _Last) to _Output while replacing _Oldval with _Newval if projected _Oldval fulfills _Pred
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It>);
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se, _It>);
             _STL_INTERNAL_STATIC_ASSERT(output_iterator<_Out, const _Ty&>);
             _STL_INTERNAL_STATIC_ASSERT(indirectly_copyable<_It, _Out>);
             _STL_INTERNAL_STATIC_ASSERT(indirect_unary_predicate<_Pr, projected<_It, _Pj>>);
 
-            for (; _First != _Last; ++_First, (void) ++_Result) {
+            for (; _First != _Last; ++_First, (void) ++_Output) {
                 if constexpr (_Can_vectorize_replace_copy<_Out, iter_value_t<_It>, _Ty>) {
-                    *_Result = _STD invoke(_Pred, _STD invoke(_Proj, *_First)) ? _Newval : *_First;
+                    *_Output = _STD invoke(_Pred, _STD invoke(_Proj, *_First)) ? _Newval : *_First;
                 } else {
                     if (_STD invoke(_Pred, _STD invoke(_Proj, *_First))) {
-                        *_Result = _Newval;
+                        *_Output = _Newval;
                     } else {
-                        *_Result = *_First;
+                        *_Output = *_First;
                     }
                 }
             }
 
-            return {_STD move(_First), _STD move(_Result)};
+            return {_STD move(_First), _STD move(_Output)};
         }
     };
 
@@ -4613,36 +4613,36 @@ namespace ranges {
             requires indirectly_copyable<_It, _Out>
                   && indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
         _STATIC_CALL_OPERATOR constexpr remove_copy_result<_It, _Out> operator()(
-            _It _First, _Se _Last, _Out _Result, const _Ty& _Val, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
+            _It _First, _Se _Last, _Out _Output, const _Ty& _Val, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _Remove_copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Get_unwrapped_unverified(_STD move(_Result)), _Val,
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Get_unwrapped_unverified(_STD move(_Output)), _Val,
                 _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
-            return {_STD move(_First), _STD move(_Result)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
         template <input_range _Rng, weakly_incrementable _Out, class _Ty, class _Pj = identity>
             requires indirectly_copyable<iterator_t<_Rng>, _Out>
                   && indirect_binary_predicate<ranges::equal_to, projected<iterator_t<_Rng>, _Pj>, const _Ty*>
         _STATIC_CALL_OPERATOR constexpr remove_copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(
-            _Rng&& _Range, _Out _Result, const _Ty& _Val, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
+            _Rng&& _Range, _Out _Output, const _Ty& _Val, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             auto _First   = _RANGES begin(_Range);
             auto _UResult = _Remove_copy_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
-                _STD _Get_unwrapped_unverified(_STD move(_Result)), _Val, _STD _Pass_fn(_Proj));
+                _STD _Get_unwrapped_unverified(_STD move(_Output)), _Val, _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
-            return {_STD move(_First), _STD move(_Result)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
     private:
         template <class _It, class _Se, class _Out, class _Ty, class _Pj>
         _NODISCARD static constexpr remove_copy_result<_It, _Out> _Remove_copy_unchecked(
-            _It _First, const _Se _Last, _Out _Result, const _Ty& _Val, _Pj _Proj) {
-            // Copy [_First, _Last) to _Result except projected values equal to _Val
+            _It _First, const _Se _Last, _Out _Output, const _Ty& _Val, _Pj _Proj) {
+            // Copy [_First, _Last) to _Output except projected values equal to _Val
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It>);
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se, _It>);
             _STL_INTERNAL_STATIC_ASSERT(weakly_incrementable<_Out>);
@@ -4651,12 +4651,12 @@ namespace ranges {
 
             for (; _First != _Last; ++_First) {
                 if (_STD invoke(_Proj, *_First) != _Val) {
-                    *_Result = *_First;
-                    ++_Result;
+                    *_Output = *_First;
+                    ++_Output;
                 }
             }
 
-            return {_STD move(_First), _STD move(_Result)};
+            return {_STD move(_First), _STD move(_Output)};
         }
     };
 
@@ -4671,37 +4671,37 @@ namespace ranges {
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
             requires indirectly_copyable<_It, _Out>
         _STATIC_CALL_OPERATOR constexpr remove_copy_if_result<_It, _Out> operator()(
-            _It _First, _Se _Last, _Out _Result, _Pr _Pred, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
+            _It _First, _Se _Last, _Out _Output, _Pr _Pred, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _Remove_copy_if_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Get_unwrapped_unverified(_STD move(_Result)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Get_unwrapped_unverified(_STD move(_Output)),
                 _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
-            return {_STD move(_First), _STD move(_Result)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
         template <input_range _Rng, weakly_incrementable _Out, class _Pj = identity,
             indirect_unary_predicate<projected<iterator_t<_Rng>, _Pj>> _Pr>
             requires indirectly_copyable<iterator_t<_Rng>, _Out>
         _STATIC_CALL_OPERATOR constexpr remove_copy_if_result<borrowed_iterator_t<_Rng>, _Out> operator()(
-            _Rng&& _Range, _Out _Result, _Pr _Pred, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
+            _Rng&& _Range, _Out _Output, _Pr _Pred, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             auto _First = _RANGES begin(_Range);
             auto _UResult =
                 _Remove_copy_if_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
-                    _STD _Get_unwrapped_unverified(_STD move(_Result)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                    _STD _Get_unwrapped_unverified(_STD move(_Output)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
-            return {_STD move(_First), _STD move(_Result)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
     private:
         template <class _It, class _Se, class _Out, class _Pr, class _Pj>
         _NODISCARD static constexpr remove_copy_if_result<_It, _Out> _Remove_copy_if_unchecked(
-            _It _First, const _Se _Last, _Out _Result, _Pr _Pred, _Pj _Proj) {
-            // Copy [_First, _Last) to _Result except projected values that satisfy _Pred
+            _It _First, const _Se _Last, _Out _Output, _Pr _Pred, _Pj _Proj) {
+            // Copy [_First, _Last) to _Output except projected values that satisfy _Pred
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It>);
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se, _It>);
             _STL_INTERNAL_STATIC_ASSERT(weakly_incrementable<_Out>);
@@ -4710,12 +4710,12 @@ namespace ranges {
 
             for (; _First != _Last; ++_First) {
                 if (!_STD invoke(_Pred, _STD invoke(_Proj, *_First))) {
-                    *_Result = *_First;
-                    ++_Result;
+                    *_Output = *_First;
+                    ++_Output;
                 }
             }
 
-            return {_STD move(_First), _STD move(_Result)};
+            return {_STD move(_First), _STD move(_Output)};
         }
     };
 
@@ -4944,36 +4944,36 @@ namespace ranges {
             indirect_equivalence_relation<projected<_It, _Pj>> _Pr = ranges::equal_to>
             requires indirectly_copyable<_It, _Out> && _Can_reread_or_store<_It, _Out>
         _STATIC_CALL_OPERATOR constexpr unique_copy_result<_It, _Out> operator()(
-            _It _First, _Se _Last, _Out _Result, _Pr _Pred = {}, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
+            _It _First, _Se _Last, _Out _Output, _Pr _Pred = {}, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _Unique_copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Get_unwrapped_unverified(_STD move(_Result)),
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD _Get_unwrapped_unverified(_STD move(_Output)),
                 _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
-            return {_STD move(_First), _STD move(_Result)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
         template <input_range _Rng, weakly_incrementable _Out, class _Pj = identity,
             indirect_equivalence_relation<projected<iterator_t<_Rng>, _Pj>> _Pr = ranges::equal_to>
             requires indirectly_copyable<iterator_t<_Rng>, _Out> && _Can_reread_or_store<iterator_t<_Rng>, _Out>
         _STATIC_CALL_OPERATOR constexpr unique_copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(
-            _Rng&& _Range, _Out _Result, _Pr _Pred = {}, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
+            _Rng&& _Range, _Out _Output, _Pr _Pred = {}, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             auto _First   = _RANGES begin(_Range);
             auto _UResult = _Unique_copy_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
-                _STD _Get_unwrapped_unverified(_STD move(_Result)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
+                _STD _Get_unwrapped_unverified(_STD move(_Output)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
-            return {_STD move(_First), _STD move(_Result)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
     private:
         template <class _It, class _Se, class _Out, class _Pj, class _Pr>
         _NODISCARD static constexpr unique_copy_result<_It, _Out> _Unique_copy_unchecked(
-            _It _First, const _Se _Last, _Out _Result, _Pr _Pred, _Pj _Proj) {
-            // Copy elements from [_First, _Last) to _Result, compressing adjacent elements whose projections satisfy
+            _It _First, const _Se _Last, _Out _Output, _Pr _Pred, _Pj _Proj) {
+            // Copy elements from [_First, _Last) to _Output, compressing adjacent elements whose projections satisfy
             // _Pred
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It>);
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se, _It>);
@@ -4983,47 +4983,47 @@ namespace ranges {
             _STL_INTERNAL_STATIC_ASSERT(_Can_reread_or_store<_It, _Out>);
 
             if (_First == _Last) {
-                return {_STD move(_First), _STD move(_Result)};
+                return {_STD move(_First), _STD move(_Output)};
             }
 
             if constexpr (_Is_input_with_value_type<_Out, iter_value_t<_It>>) {
-                // Can reread _Result
-                *_Result = *_First;
+                // Can reread _Output
+                *_Output = *_First;
 
                 while (++_First != _Last) {
-                    if (!_STD invoke(_Pred, _STD invoke(_Proj, *_Result), _STD invoke(_Proj, *_First))) {
-                        ++_Result;
-                        *_Result = *_First;
+                    if (!_STD invoke(_Pred, _STD invoke(_Proj, *_Output), _STD invoke(_Proj, *_First))) {
+                        ++_Output;
+                        *_Output = *_First;
                     }
                 }
             } else if constexpr (forward_iterator<_It>) {
                 // Can reread _First
                 auto _Current = _First;
-                *_Result      = *_First;
+                *_Output      = *_First;
 
                 while (++_First != _Last) {
                     if (!_STD invoke(_Pred, _STD invoke(_Proj, *_Current), _STD invoke(_Proj, *_First))) {
                         _Current = _First;
-                        ++_Result;
-                        *_Result = *_First;
+                        ++_Output;
+                        *_Output = *_First;
                     }
                 }
             } else {
-                // Neither _First nor _Result can be reread, construct temporary
+                // Neither _First nor _Output can be reread, construct temporary
                 iter_value_t<_It> _Val(*_First);
 
                 while (++_First != _Last) {
                     if (!_STD invoke(_Pred, _STD invoke(_Proj, _Val), _STD invoke(_Proj, *_First))) {
-                        *_Result = _STD move(_Val);
-                        ++_Result;
+                        *_Output = _STD move(_Val);
+                        ++_Output;
                         _Val = *_First;
                     }
                 }
-                *_Result = _STD move(_Val);
+                *_Output = _STD move(_Val);
             }
-            ++_Result;
+            ++_Output;
 
-            return {_STD move(_First), _STD move(_Result)};
+            return {_STD move(_First), _STD move(_Output)};
         }
     };
 
@@ -5138,32 +5138,32 @@ namespace ranges {
         template <bidirectional_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
             requires indirectly_copyable<_It, _Out>
         _STATIC_CALL_OPERATOR constexpr reverse_copy_result<_It, _Out> operator()(
-            _It _First, _Se _Last, _Out _Result) _CONST_CALL_OPERATOR {
+            _It _First, _Se _Last, _Out _Output) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
             auto _UFirst = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
             auto _ULast  = _RANGES _Get_final_iterator_unwrapped<_It>(_UFirst, _STD move(_Last));
             _STD _Seek_wrapped(_First, _ULast);
-            _Result = _Reverse_copy_common(_STD move(_UFirst), _STD move(_ULast), _STD move(_Result));
-            return {_STD move(_First), _STD move(_Result)};
+            _Output = _Reverse_copy_common(_STD move(_UFirst), _STD move(_ULast), _STD move(_Output));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
         template <bidirectional_range _Rng, weakly_incrementable _Out>
             requires indirectly_copyable<iterator_t<_Rng>, _Out>
         _STATIC_CALL_OPERATOR constexpr reverse_copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(
-            _Rng&& _Range, _Out _Result) _CONST_CALL_OPERATOR {
+            _Rng&& _Range, _Out _Output) _CONST_CALL_OPERATOR {
             if constexpr (common_range<_Rng>) {
-                _Result = _Reverse_copy_common(_Ubegin(_Range), _Uend(_Range), _STD move(_Result));
-                return {_RANGES end(_Range), _STD move(_Result)};
+                _Output = _Reverse_copy_common(_Ubegin(_Range), _Uend(_Range), _STD move(_Output));
+                return {_RANGES end(_Range), _STD move(_Output)};
             } else {
                 auto _ULast = _RANGES _Get_final_iterator_unwrapped(_Range);
-                _Result     = _Reverse_copy_common(_Ubegin(_Range), _ULast, _STD move(_Result));
-                return {_RANGES _Rewrap_iterator(_Range, _STD move(_ULast)), _STD move(_Result)};
+                _Output     = _Reverse_copy_common(_Ubegin(_Range), _ULast, _STD move(_Output));
+                return {_RANGES _Rewrap_iterator(_Range, _STD move(_ULast)), _STD move(_Output)};
             }
         }
 
     private:
         template <class _It, class _Out>
-        _NODISCARD static constexpr _Out _Reverse_copy_common(const _It _First, _It _Last, _Out _Result) {
+        _NODISCARD static constexpr _Out _Reverse_copy_common(const _It _First, _It _Last, _Out _Output) {
             _STL_INTERNAL_STATIC_ASSERT(bidirectional_iterator<_It>);
             _STL_INTERNAL_STATIC_ASSERT(weakly_incrementable<_Out>);
             _STL_INTERNAL_STATIC_ASSERT(indirectly_copyable<_It, _Out>);
@@ -5179,19 +5179,19 @@ namespace ranges {
                 if constexpr (_Allow_vectorization && _Nx <= 8 && (_Nx & (_Nx - 1)) == 0) {
                     if (!_STD is_constant_evaluated()) {
                         _STD _Reverse_copy_vectorized<_Nx>(
-                            _STD to_address(_First), _STD to_address(_Last), _STD to_address(_Result));
-                        _Result += _Last - _First;
-                        return _Result;
+                            _STD to_address(_First), _STD to_address(_Last), _STD to_address(_Output));
+                        _Output += _Last - _First;
+                        return _Output;
                     }
                 }
             }
 #endif // _USE_STD_VECTOR_ALGORITHMS
 
-            for (; _First != _Last; ++_Result) {
-                *_Result = *--_Last;
+            for (; _First != _Last; ++_Output) {
+                *_Output = *--_Last;
             }
 
-            return _Result;
+            return _Output;
         }
     };
 
@@ -5342,12 +5342,12 @@ namespace ranges {
         template <forward_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
             requires indirectly_copyable<_It, _Out>
         _STATIC_CALL_OPERATOR constexpr rotate_copy_result<_It, _Out> operator()(
-            _It _First, _It _Mid, _Se _Last, _Out _Result) _CONST_CALL_OPERATOR {
+            _It _First, _It _Mid, _Se _Last, _Out _Output) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Mid);
             _STD _Adl_verify_range(_Mid, _Last);
             auto _UResult = _Rotate_copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
                 _RANGES _Unwrap_iter<_Se>(_STD move(_Mid)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)),
-                _STD move(_Result));
+                _STD move(_Output));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
@@ -5356,11 +5356,11 @@ namespace ranges {
         template <forward_range _Rng, weakly_incrementable _Out>
             requires indirectly_copyable<iterator_t<_Rng>, _Out>
         _STATIC_CALL_OPERATOR constexpr rotate_copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(
-            _Rng&& _Range, iterator_t<_Rng> _Mid, _Out _Result) _CONST_CALL_OPERATOR {
+            _Rng&& _Range, iterator_t<_Rng> _Mid, _Out _Output) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_RANGES begin(_Range), _Mid);
             _STD _Adl_verify_range(_Mid, _RANGES end(_Range));
             auto _UResult = _Rotate_copy_unchecked(
-                _Ubegin(_Range), _RANGES _Unwrap_range_iter<_Rng>(_STD move(_Mid)), _Uend(_Range), _STD move(_Result));
+                _Ubegin(_Range), _RANGES _Unwrap_range_iter<_Rng>(_STD move(_Mid)), _Uend(_Range), _STD move(_Output));
 
             return {_RANGES _Rewrap_iterator(_Range, _STD move(_UResult.in)), _STD move(_UResult.out)};
         }
@@ -5368,14 +5368,14 @@ namespace ranges {
     private:
         template <class _It, class _Se, class _Out>
         _NODISCARD static constexpr rotate_copy_result<_It, _Out> _Rotate_copy_unchecked(
-            _It _First, _It _Mid, _Se _Last, _Out _Result) {
-            // Copy the content of [_Mid, _Last) and [_First, _Mid) to _Result
+            _It _First, _It _Mid, _Se _Last, _Out _Output) {
+            // Copy the content of [_Mid, _Last) and [_First, _Mid) to _Output
             _STL_INTERNAL_STATIC_ASSERT(forward_iterator<_It>);
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se, _It>);
             _STL_INTERNAL_STATIC_ASSERT(weakly_incrementable<_Out>);
             _STL_INTERNAL_STATIC_ASSERT(indirectly_copyable<_It, _Out>);
 
-            auto _UResult1 = _RANGES _Copy_unchecked(_Mid, _STD move(_Last), _STD move(_Result));
+            auto _UResult1 = _RANGES _Copy_unchecked(_Mid, _STD move(_Last), _STD move(_Output));
             auto _UResult2 = _RANGES _Copy_unchecked(_STD move(_First), _STD move(_Mid), _STD move(_UResult1.out));
             return {_STD move(_UResult1.in), _STD move(_UResult2.out)};
         }
@@ -5547,20 +5547,20 @@ namespace ranges {
             requires (forward_iterator<_It> || random_access_iterator<_Out>)
                   && indirectly_copyable<_It, _Out> && uniform_random_bit_generator<remove_reference_t<_Urng>>
         _STATIC_CALL_OPERATOR _Out operator()(
-            _It _First, _Se _Last, _Out _Result, iter_difference_t<_It> _Count, _Urng&& _Func) _CONST_CALL_OPERATOR {
+            _It _First, _Se _Last, _Out _Output, iter_difference_t<_It> _Count, _Urng&& _Func) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
             if (_Count <= 0) {
-                return _Result;
+                return _Output;
             }
 
             _Rng_from_urng<iter_difference_t<_It>, remove_reference_t<_Urng>> _RngFunc(_Func);
             if constexpr (forward_iterator<_It>) {
                 auto _UFirst   = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
                 auto _Pop_size = _RANGES distance(_UFirst, _RANGES _Unwrap_sent<_It>(_STD move(_Last)));
-                return _Sample_selection_unchecked(_STD move(_UFirst), _Pop_size, _STD move(_Result), _Count, _RngFunc);
+                return _Sample_selection_unchecked(_STD move(_UFirst), _Pop_size, _STD move(_Output), _Count, _RngFunc);
             } else {
                 return _Sample_reservoir_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                    _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result), _Count, _RngFunc);
+                    _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Output), _Count, _RngFunc);
             }
         }
 
@@ -5569,27 +5569,27 @@ namespace ranges {
                   && indirectly_copyable<iterator_t<_Rng>, _Out>
                   && uniform_random_bit_generator<remove_reference_t<_Urng>>
         _STATIC_CALL_OPERATOR _Out operator()(
-            _Rng&& _Range, _Out _Result, range_difference_t<_Rng> _Count, _Urng&& _Func) _CONST_CALL_OPERATOR {
+            _Rng&& _Range, _Out _Output, range_difference_t<_Rng> _Count, _Urng&& _Func) _CONST_CALL_OPERATOR {
             if (_Count <= 0) {
-                return _Result;
+                return _Output;
             }
 
             _Rng_from_urng<range_difference_t<_Rng>, remove_reference_t<_Urng>> _RngFunc(_Func);
             if constexpr (forward_range<_Rng>) {
                 auto _UFirst   = _Ubegin(_Range);
                 auto _Pop_size = _RANGES distance(_UFirst, _Uend(_Range));
-                return _Sample_selection_unchecked(_STD move(_UFirst), _Pop_size, _STD move(_Result), _Count, _RngFunc);
+                return _Sample_selection_unchecked(_STD move(_UFirst), _Pop_size, _STD move(_Output), _Count, _RngFunc);
             } else {
                 return _Sample_reservoir_unchecked(
-                    _Ubegin(_Range), _Uend(_Range), _STD move(_Result), _Count, _RngFunc);
+                    _Ubegin(_Range), _Uend(_Range), _STD move(_Output), _Count, _RngFunc);
             }
         }
 
     private:
         template <class _It, class _Out, class _Rng>
         _NODISCARD static _Out _Sample_selection_unchecked(
-            _It _First, iter_difference_t<_It> _Pop_size, _Out _Result, iter_difference_t<_It> _Count, _Rng& _RngFunc) {
-            // randomly select _Count elements from [_First, _First + _Pop_size) into _Result
+            _It _First, iter_difference_t<_It> _Pop_size, _Out _Output, iter_difference_t<_It> _Count, _Rng& _RngFunc) {
+            // randomly select _Count elements from [_First, _First + _Pop_size) into _Output
             _STL_INTERNAL_STATIC_ASSERT(forward_iterator<_It>);
             _STL_INTERNAL_STATIC_ASSERT(weakly_incrementable<_Out>);
             _STL_INTERNAL_STATIC_ASSERT(indirectly_copyable<_It, _Out>);
@@ -5600,21 +5600,21 @@ namespace ranges {
 
             for (; _Pop_size > 0; ++_First, (void) --_Pop_size) {
                 if (_RngFunc(_Pop_size) < _Count) {
-                    *_Result = *_First;
-                    ++_Result;
+                    *_Output = *_First;
+                    ++_Output;
                     if (--_Count == 0) {
                         break;
                     }
                 }
             }
 
-            return _Result;
+            return _Output;
         }
 
         template <class _It, class _Se, class _Out, class _Rng>
         _NODISCARD static _Out _Sample_reservoir_unchecked(
-            _It _First, const _Se _Last, _Out _Result, const iter_difference_t<_It> _Count, _Rng& _RngFunc) {
-            // randomly select _Count elements from [_First, _Last) into _Result
+            _It _First, const _Se _Last, _Out _Output, const iter_difference_t<_It> _Count, _Rng& _RngFunc) {
+            // randomly select _Count elements from [_First, _Last) into _Output
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It>);
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se, _It>);
             _STL_INTERNAL_STATIC_ASSERT(random_access_iterator<_Out>);
@@ -5623,19 +5623,19 @@ namespace ranges {
             iter_difference_t<_It> _Pop_size{};
             for (; _Pop_size < _Count; ++_Pop_size, (void) ++_First) {
                 if (_First == _Last) {
-                    return _Result + _Pop_size;
+                    return _Output + _Pop_size;
                 }
 
-                *(_Result + _Pop_size) = *_First;
+                *(_Output + _Pop_size) = *_First;
             }
             for (; _First != _Last; ++_First) {
                 const auto _Idx = _RngFunc(++_Pop_size);
                 if (_Idx < _Count) {
-                    *(_Result + _Idx) = *_First;
+                    *(_Output + _Idx) = *_First;
                 }
             }
 
-            return _Result + _Count;
+            return _Output + _Count;
         }
     };
 
@@ -6009,12 +6009,12 @@ namespace ranges {
 
         template <input_iterator _It, weakly_incrementable _Out>
             requires indirectly_movable<_It, _Out>
-        _NODISCARD static constexpr _Out _Move_n_helper(_It _First, iter_difference_t<_It> _Count, _Out _Result) {
-            for (; _Count > 0; ++_First, (void) --_Count, ++_Result) {
-                *_Result = _RANGES iter_move(_First);
+        _NODISCARD static constexpr _Out _Move_n_helper(_It _First, iter_difference_t<_It> _Count, _Out _Output) {
+            for (; _Count > 0; ++_First, (void) --_Count, ++_Output) {
+                *_Output = _RANGES iter_move(_First);
             }
 
-            return _Result;
+            return _Output;
         }
 
         template <class _It, class _Se, class _SizeTy>
@@ -7421,13 +7421,13 @@ namespace ranges {
             weakly_incrementable _Out, class _Pr = ranges::less, class _Pj1 = identity, class _Pj2 = identity>
             requires mergeable<_It1, _It2, _Out, _Pr, _Pj1, _Pj2>
         _STATIC_CALL_OPERATOR constexpr merge_result<_It1, _It2, _Out> operator()(_It1 _First1, _Se1 _Last1,
-            _It2 _First2, _Se2 _Last2, _Out _Result, _Pr _Pred = {}, _Pj1 _Proj1 = {},
+            _It2 _First2, _Se2 _Last2, _Out _Output, _Pr _Pred = {}, _Pj1 _Proj1 = {},
             _Pj2 _Proj2 = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First1, _Last1);
             _STD _Adl_verify_range(_First2, _Last2);
             auto _UResult = _Merge_unchecked(_RANGES _Unwrap_iter<_Se1>(_STD move(_First1)),
                 _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)), _RANGES _Unwrap_iter<_Se2>(_STD move(_First2)),
-                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD move(_Result), _STD _Pass_fn(_Pred),
+                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD move(_Output), _STD _Pass_fn(_Pred),
                 _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
             _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
@@ -7438,12 +7438,12 @@ namespace ranges {
             class _Pj1 = identity, class _Pj2 = identity>
             requires mergeable<iterator_t<_Rng1>, iterator_t<_Rng2>, _Out, _Pr, _Pj1, _Pj2>
         _STATIC_CALL_OPERATOR constexpr merge_result<borrowed_iterator_t<_Rng1>, borrowed_iterator_t<_Rng2>, _Out>
-            operator()(_Rng1&& _Range1, _Rng2&& _Range2, _Out _Result, _Pr _Pred = {}, _Pj1 _Proj1 = {},
+            operator()(_Rng1&& _Range1, _Rng2&& _Range2, _Out _Output, _Pr _Pred = {}, _Pj1 _Proj1 = {},
                 _Pj2 _Proj2 = {}) _CONST_CALL_OPERATOR {
             auto _First1  = _RANGES begin(_Range1);
             auto _First2  = _RANGES begin(_Range2);
             auto _UResult = _Merge_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1),
-                _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2), _STD move(_Result),
+                _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2), _STD move(_Output),
                 _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
             _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
@@ -7453,7 +7453,7 @@ namespace ranges {
     private:
         template <class _It1, class _Se1, class _It2, class _Se2, class _Out, class _Pr, class _Pj1, class _Pj2>
         _NODISCARD static constexpr merge_result<_It1, _It2, _Out> _Merge_unchecked(_It1 _First1, const _Se1 _Last1,
-            _It2 _First2, const _Se2 _Last2, _Out _Result, _Pr _Pred, _Pj1 _Proj1, _Pj2 _Proj2) {
+            _It2 _First2, const _Se2 _Last2, _Out _Output, _Pr _Pred, _Pj1 _Proj1, _Pj2 _Proj2) {
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It1>);
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se1, _It1>);
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It2>);
@@ -7461,24 +7461,24 @@ namespace ranges {
             _STL_INTERNAL_STATIC_ASSERT(weakly_incrementable<_Out>);
             _STL_INTERNAL_STATIC_ASSERT(mergeable<_It1, _It2, _Out, _Pr, _Pj1, _Pj2>);
 
-            for (;; ++_Result) {
+            for (;; ++_Output) {
                 if (_First1 == _Last1) {
                     auto _Copy_result =
-                        _RANGES _Copy_unchecked(_STD move(_First2), _STD move(_Last2), _STD move(_Result));
+                        _RANGES _Copy_unchecked(_STD move(_First2), _STD move(_Last2), _STD move(_Output));
                     return {_STD move(_First1), _STD move(_Copy_result.in), _STD move(_Copy_result.out)};
                 }
 
                 if (_First2 == _Last2) {
                     auto _Copy_result =
-                        _RANGES _Copy_unchecked(_STD move(_First1), _STD move(_Last1), _STD move(_Result));
+                        _RANGES _Copy_unchecked(_STD move(_First1), _STD move(_Last1), _STD move(_Output));
                     return {_STD move(_Copy_result.in), _STD move(_First2), _STD move(_Copy_result.out)};
                 }
 
                 if (_STD invoke(_Pred, _STD invoke(_Proj2, *_First2), _STD invoke(_Proj1, *_First1))) {
-                    *_Result = *_First2;
+                    *_Output = *_First2;
                     ++_First2;
                 } else {
-                    *_Result = *_First1;
+                    *_Output = *_First1;
                     ++_First1;
                 }
             }
@@ -9508,42 +9508,42 @@ namespace ranges {
             weakly_incrementable _Out, class _Pr = ranges::less, class _Pj1 = identity, class _Pj2 = identity>
             requires mergeable<_It1, _It2, _Out, _Pr, _Pj1, _Pj2>
         _STATIC_CALL_OPERATOR constexpr set_union_result<_It1, _It2, _Out> operator()(_It1 _First1, _Se1 _Last1,
-            _It2 _First2, _Se2 _Last2, _Out _Result, _Pr _Pred = {}, _Pj1 _Proj1 = {},
+            _It2 _First2, _Se2 _Last2, _Out _Output, _Pr _Pred = {}, _Pj1 _Proj1 = {},
             _Pj2 _Proj2 = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First1, _Last1);
             _STD _Adl_verify_range(_First2, _Last2);
             auto _UResult = _Set_union_unchecked(_RANGES _Unwrap_iter<_Se1>(_STD move(_First1)),
                 _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)), _RANGES _Unwrap_iter<_Se2>(_STD move(_First2)),
-                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD _Get_unwrapped_unverified(_STD move(_Result)),
+                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD _Get_unwrapped_unverified(_STD move(_Output)),
                 _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
             _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
-            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
-            return {_STD move(_First1), _STD move(_First2), _STD move(_Result)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
         }
 
         template <input_range _Rng1, input_range _Rng2, weakly_incrementable _Out, class _Pr = ranges::less,
             class _Pj1 = identity, class _Pj2 = identity>
             requires mergeable<iterator_t<_Rng1>, iterator_t<_Rng2>, _Out, _Pr, _Pj1, _Pj2>
         _STATIC_CALL_OPERATOR constexpr set_union_result<borrowed_iterator_t<_Rng1>, borrowed_iterator_t<_Rng2>, _Out>
-            operator()(_Rng1&& _Range1, _Rng2&& _Range2, _Out _Result, _Pr _Pred = {}, _Pj1 _Proj1 = {},
+            operator()(_Rng1&& _Range1, _Rng2&& _Range2, _Out _Output, _Pr _Pred = {}, _Pj1 _Proj1 = {},
                 _Pj2 _Proj2 = {}) _CONST_CALL_OPERATOR {
             auto _First1  = _RANGES begin(_Range1);
             auto _First2  = _RANGES begin(_Range2);
             auto _UResult = _Set_union_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)), _Uend(_Range1),
                 _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2),
-                _STD _Get_unwrapped_unverified(_STD move(_Result)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1),
+                _STD _Get_unwrapped_unverified(_STD move(_Output)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1),
                 _STD _Pass_fn(_Proj2));
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
             _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
-            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
-            return {_STD move(_First1), _STD move(_First2), _STD move(_Result)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
         }
 
     private:
         template <class _It1, class _Se1, class _It2, class _Se2, class _Out, class _Pr, class _Pj1, class _Pj2>
         _NODISCARD static constexpr set_union_result<_It1, _It2, _Out> _Set_union_unchecked(_It1 _First1,
-            const _Se1 _Last1, _It2 _First2, const _Se2 _Last2, _Out _Result, _Pr _Pred, _Pj1 _Proj1, _Pj2 _Proj2) {
+            const _Se1 _Last1, _It2 _First2, const _Se2 _Last2, _Out _Output, _Pr _Pred, _Pj1 _Proj1, _Pj2 _Proj2) {
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It1>);
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se1, _It1>);
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It2>);
@@ -9551,12 +9551,12 @@ namespace ranges {
             _STL_INTERNAL_STATIC_ASSERT(weakly_incrementable<_Out>);
             _STL_INTERNAL_STATIC_ASSERT(mergeable<_It1, _It2, _Out, _Pr, _Pj1, _Pj2>);
 
-            for (; _First1 != _Last1 && _First2 != _Last2; ++_Result) {
+            for (; _First1 != _Last1 && _First2 != _Last2; ++_Output) {
                 if (_STD invoke(_Pred, _STD invoke(_Proj2, *_First2), _STD invoke(_Proj1, *_First1))) {
-                    *_Result = *_First2;
+                    *_Output = *_First2;
                     ++_First2;
                 } else {
-                    *_Result = *_First1;
+                    *_Output = *_First1;
                     if (!_STD invoke(_Pred, _STD invoke(_Proj1, *_First1), _STD invoke(_Proj2, *_First2))) {
                         ++_First2;
                     }
@@ -9564,7 +9564,7 @@ namespace ranges {
                 }
             }
 
-            auto _UResult1 = _RANGES _Copy_unchecked(_STD move(_First1), _STD move(_Last1), _STD move(_Result));
+            auto _UResult1 = _RANGES _Copy_unchecked(_STD move(_First1), _STD move(_Last1), _STD move(_Output));
             auto _UResult2 = _RANGES _Copy_unchecked(_STD move(_First2), _STD move(_Last2), _STD move(_UResult1.out));
             return {_STD move(_UResult1.in), _STD move(_UResult2.in), _STD move(_UResult2.out)};
         }
@@ -9636,18 +9636,18 @@ namespace ranges {
             weakly_incrementable _Out, class _Pr = ranges::less, class _Pj1 = identity, class _Pj2 = identity>
             requires mergeable<_It1, _It2, _Out, _Pr, _Pj1, _Pj2>
         _STATIC_CALL_OPERATOR constexpr set_intersection_result<_It1, _It2, _Out> operator()(_It1 _First1, _Se1 _Last1,
-            _It2 _First2, _Se2 _Last2, _Out _Result, _Pr _Pred = {}, _Pj1 _Proj1 = {},
+            _It2 _First2, _Se2 _Last2, _Out _Output, _Pr _Pred = {}, _Pj1 _Proj1 = {},
             _Pj2 _Proj2 = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First1, _Last1);
             _STD _Adl_verify_range(_First2, _Last2);
             auto _UResult = _Set_intersection_unchecked(_RANGES _Unwrap_iter<_Se1>(_STD move(_First1)),
                 _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)), _RANGES _Unwrap_iter<_Se2>(_STD move(_First2)),
-                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD _Get_unwrapped_unverified(_STD move(_Result)),
+                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD _Get_unwrapped_unverified(_STD move(_Output)),
                 _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
             _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
-            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
-            return {_STD move(_First1), _STD move(_First2), _STD move(_Result)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
         }
 
         template <input_range _Rng1, input_range _Rng2, weakly_incrementable _Out, class _Pr = ranges::less,
@@ -9655,24 +9655,24 @@ namespace ranges {
             requires mergeable<iterator_t<_Rng1>, iterator_t<_Rng2>, _Out, _Pr, _Pj1, _Pj2>
         _STATIC_CALL_OPERATOR constexpr set_intersection_result<borrowed_iterator_t<_Rng1>, borrowed_iterator_t<_Rng2>,
             _Out>
-            operator()(_Rng1&& _Range1, _Rng2&& _Range2, _Out _Result, _Pr _Pred = {}, _Pj1 _Proj1 = {},
+            operator()(_Rng1&& _Range1, _Rng2&& _Range2, _Out _Output, _Pr _Pred = {}, _Pj1 _Proj1 = {},
                 _Pj2 _Proj2 = {}) _CONST_CALL_OPERATOR {
             auto _First1  = _RANGES begin(_Range1);
             auto _First2  = _RANGES begin(_Range2);
             auto _UResult = _Set_intersection_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)),
                 _Uend(_Range1), _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2),
-                _STD _Get_unwrapped_unverified(_STD move(_Result)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1),
+                _STD _Get_unwrapped_unverified(_STD move(_Output)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1),
                 _STD _Pass_fn(_Proj2));
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
             _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
-            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
-            return {_STD move(_First1), _STD move(_First2), _STD move(_Result)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
         }
 
     private:
         template <class _It1, class _Se1, class _It2, class _Se2, class _Out, class _Pr, class _Pj1, class _Pj2>
         _NODISCARD static constexpr set_intersection_result<_It1, _It2, _Out> _Set_intersection_unchecked(_It1 _First1,
-            const _Se1 _Last1, _It2 _First2, const _Se2 _Last2, _Out _Result, _Pr _Pred, _Pj1 _Proj1, _Pj2 _Proj2) {
+            const _Se1 _Last1, _It2 _First2, const _Se2 _Last2, _Out _Output, _Pr _Pred, _Pj1 _Proj1, _Pj2 _Proj2) {
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It1>);
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se1, _It1>);
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It2>);
@@ -9694,14 +9694,14 @@ namespace ranges {
                 } else if (_STD invoke(_Pred, _STD invoke(_Proj2, *_First2), _STD invoke(_Proj1, *_First1))) {
                     ++_First2;
                 } else {
-                    *_Result = *_First1;
-                    ++_Result;
+                    *_Output = *_First1;
+                    ++_Output;
                     ++_First1;
                     ++_First2;
                 }
             }
 
-            return {_STD move(_First1), _STD move(_First2), _STD move(_Result)};
+            return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
         }
     };
 
@@ -9772,38 +9772,38 @@ namespace ranges {
             weakly_incrementable _Out, class _Pr = ranges::less, class _Pj1 = identity, class _Pj2 = identity>
             requires mergeable<_It1, _It2, _Out, _Pr, _Pj1, _Pj2>
         _STATIC_CALL_OPERATOR constexpr set_difference_result<_It1, _Out> operator()(_It1 _First1, _Se1 _Last1,
-            _It2 _First2, _Se2 _Last2, _Out _Result, _Pr _Pred = {}, _Pj1 _Proj1 = {},
+            _It2 _First2, _Se2 _Last2, _Out _Output, _Pr _Pred = {}, _Pj1 _Proj1 = {},
             _Pj2 _Proj2 = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First1, _Last1);
             _STD _Adl_verify_range(_First2, _Last2);
             auto _UResult = _Set_difference_unchecked(_RANGES _Unwrap_iter<_Se1>(_STD move(_First1)),
                 _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)), _RANGES _Unwrap_iter<_Se2>(_STD move(_First2)),
-                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD _Get_unwrapped_unverified(_STD move(_Result)),
+                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD _Get_unwrapped_unverified(_STD move(_Output)),
                 _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in));
-            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
-            return {_STD move(_First1), _STD move(_Result)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First1), _STD move(_Output)};
         }
 
         template <input_range _Rng1, input_range _Rng2, weakly_incrementable _Out, class _Pr = ranges::less,
             class _Pj1 = identity, class _Pj2 = identity>
             requires mergeable<iterator_t<_Rng1>, iterator_t<_Rng2>, _Out, _Pr, _Pj1, _Pj2>
         _STATIC_CALL_OPERATOR constexpr set_difference_result<borrowed_iterator_t<_Rng1>, _Out> operator()(
-            _Rng1&& _Range1, _Rng2&& _Range2, _Out _Result, _Pr _Pred = {}, _Pj1 _Proj1 = {},
+            _Rng1&& _Range1, _Rng2&& _Range2, _Out _Output, _Pr _Pred = {}, _Pj1 _Proj1 = {},
             _Pj2 _Proj2 = {}) _CONST_CALL_OPERATOR {
             auto _First1  = _RANGES begin(_Range1);
             auto _UResult = _Set_difference_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)),
-                _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2), _STD _Get_unwrapped_unverified(_STD move(_Result)),
+                _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2), _STD _Get_unwrapped_unverified(_STD move(_Output)),
                 _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in));
-            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
-            return {_STD move(_First1), _STD move(_Result)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First1), _STD move(_Output)};
         }
 
     private:
         template <class _It1, class _Se1, class _It2, class _Se2, class _Out, class _Pr, class _Pj1, class _Pj2>
         _NODISCARD static constexpr set_difference_result<_It1, _Out> _Set_difference_unchecked(_It1 _First1,
-            const _Se1 _Last1, _It2 _First2, const _Se2 _Last2, _Out _Result, _Pr _Pred, _Pj1 _Proj1, _Pj2 _Proj2) {
+            const _Se1 _Last1, _It2 _First2, const _Se2 _Last2, _Out _Output, _Pr _Pred, _Pj1 _Proj1, _Pj2 _Proj2) {
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It1>);
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se1, _It1>);
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It2>);
@@ -9813,16 +9813,16 @@ namespace ranges {
 
             for (;;) {
                 if (_First1 == _Last1) {
-                    return {_STD move(_First1), _STD move(_Result)};
+                    return {_STD move(_First1), _STD move(_Output)};
                 }
 
                 if (_First2 == _Last2) {
-                    return _RANGES _Copy_unchecked(_STD move(_First1), _STD move(_Last1), _STD move(_Result));
+                    return _RANGES _Copy_unchecked(_STD move(_First1), _STD move(_Last1), _STD move(_Output));
                 }
 
                 if (_STD invoke(_Pred, _STD invoke(_Proj1, *_First1), _STD invoke(_Proj2, *_First2))) {
-                    *_Result = *_First1;
-                    ++_Result;
+                    *_Output = *_First1;
+                    ++_Output;
                     ++_First1;
                 } else {
                     if (!_STD invoke(_Pred, _STD invoke(_Proj2, *_First2), _STD invoke(_Proj1, *_First1))) {
@@ -9916,18 +9916,18 @@ namespace ranges {
             weakly_incrementable _Out, class _Pr = ranges::less, class _Pj1 = identity, class _Pj2 = identity>
             requires mergeable<_It1, _It2, _Out, _Pr, _Pj1, _Pj2>
         _STATIC_CALL_OPERATOR constexpr set_symmetric_difference_result<_It1, _It2, _Out> operator()(_It1 _First1,
-            _Se1 _Last1, _It2 _First2, _Se2 _Last2, _Out _Result, _Pr _Pred = {}, _Pj1 _Proj1 = {},
+            _Se1 _Last1, _It2 _First2, _Se2 _Last2, _Out _Output, _Pr _Pred = {}, _Pj1 _Proj1 = {},
             _Pj2 _Proj2 = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First1, _Last1);
             _STD _Adl_verify_range(_First2, _Last2);
             auto _UResult = _Set_symmetric_difference_unchecked(_RANGES _Unwrap_iter<_Se1>(_STD move(_First1)),
                 _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)), _RANGES _Unwrap_iter<_Se2>(_STD move(_First2)),
-                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD _Get_unwrapped_unverified(_STD move(_Result)),
+                _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD _Get_unwrapped_unverified(_STD move(_Output)),
                 _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
             _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
-            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
-            return {_STD move(_First1), _STD move(_First2), _STD move(_Result)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
         }
 
         template <input_range _Rng1, input_range _Rng2, weakly_incrementable _Out, class _Pr = ranges::less,
@@ -9935,25 +9935,25 @@ namespace ranges {
             requires mergeable<iterator_t<_Rng1>, iterator_t<_Rng2>, _Out, _Pr, _Pj1, _Pj2>
         _STATIC_CALL_OPERATOR constexpr set_symmetric_difference_result<borrowed_iterator_t<_Rng1>,
             borrowed_iterator_t<_Rng2>, _Out>
-            operator()(_Rng1&& _Range1, _Rng2&& _Range2, _Out _Result, _Pr _Pred = {}, _Pj1 _Proj1 = {},
+            operator()(_Rng1&& _Range1, _Rng2&& _Range2, _Out _Output, _Pr _Pred = {}, _Pj1 _Proj1 = {},
                 _Pj2 _Proj2 = {}) _CONST_CALL_OPERATOR {
             auto _First1  = _RANGES begin(_Range1);
             auto _First2  = _RANGES begin(_Range2);
             auto _UResult = _Set_symmetric_difference_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)),
                 _Uend(_Range1), _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2),
-                _STD _Get_unwrapped_unverified(_STD move(_Result)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1),
+                _STD _Get_unwrapped_unverified(_STD move(_Output)), _STD _Pass_fn(_Pred), _STD _Pass_fn(_Proj1),
                 _STD _Pass_fn(_Proj2));
             _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
             _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
-            _STD _Seek_wrapped(_Result, _STD move(_UResult.out));
-            return {_STD move(_First1), _STD move(_First2), _STD move(_Result)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
         }
 
     private:
         template <class _It1, class _Se1, class _It2, class _Se2, class _Out, class _Pr, class _Pj1, class _Pj2>
         _NODISCARD static constexpr set_symmetric_difference_result<_It1, _It2, _Out>
             _Set_symmetric_difference_unchecked(_It1 _First1, const _Se1 _Last1, _It2 _First2, const _Se2 _Last2,
-                _Out _Result, _Pr _Pred, _Pj1 _Proj1, _Pj2 _Proj2) {
+                _Out _Output, _Pr _Pred, _Pj1 _Proj1, _Pj2 _Proj2) {
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It1>);
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se1, _It1>);
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It2>);
@@ -9963,22 +9963,22 @@ namespace ranges {
 
             for (;;) {
                 if (_First1 == _Last1) {
-                    auto _UResult = _RANGES _Copy_unchecked(_STD move(_First2), _STD move(_Last2), _STD move(_Result));
+                    auto _UResult = _RANGES _Copy_unchecked(_STD move(_First2), _STD move(_Last2), _STD move(_Output));
                     return {_STD move(_First1), _STD move(_UResult.in), _STD move(_UResult.out)};
                 }
 
                 if (_First2 == _Last2) {
-                    auto _UResult = _RANGES _Copy_unchecked(_STD move(_First1), _STD move(_Last1), _STD move(_Result));
+                    auto _UResult = _RANGES _Copy_unchecked(_STD move(_First1), _STD move(_Last1), _STD move(_Output));
                     return {_STD move(_UResult.in), _STD move(_First2), _STD move(_UResult.out)};
                 }
 
                 if (_STD invoke(_Pred, _STD invoke(_Proj1, *_First1), _STD invoke(_Proj2, *_First2))) {
-                    *_Result = *_First1;
-                    ++_Result;
+                    *_Output = *_First1;
+                    ++_Output;
                     ++_First1;
                 } else if (_STD invoke(_Pred, _STD invoke(_Proj2, *_First2), _STD invoke(_Proj1, *_First1))) {
-                    *_Result = *_First2;
-                    ++_Result;
+                    *_Output = *_First2;
+                    ++_Output;
                     ++_First2;
                 } else {
                     ++_First1;

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -3788,7 +3788,7 @@ _FwdIt3 transform(_ExPo&& _Exec, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First
 #if _HAS_CXX20
 template <class _Diff1, class _Diff2>
 _NODISCARD constexpr auto _Idl_dist_min([[maybe_unused]] const _Diff1 _Lhs, [[maybe_unused]] const _Diff2 _Rhs) {
-    // returns the minumum of two results from _Idl_distance calls
+    // returns the minimum of two results from _Idl_distance calls
     if constexpr (is_same_v<_Diff1, _Distance_unknown> || is_same_v<_Diff2, _Distance_unknown>) {
         return _Distance_unknown{};
     } else if constexpr (is_same_v<_Diff1, _Distance_unbounded>) {
@@ -3819,55 +3819,34 @@ namespace ranges {
         _STATIC_CALL_OPERATOR constexpr unary_transform_result<_It, _Out> operator()(
             _It _First, _Se _Last, _Out _Output, _Fn _Func, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
-            auto _UFirst = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
-            auto _ULast  = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
+            auto _UFirst      = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
+            auto _ULast       = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
+            const auto _Count = _STD _Idl_distance<_It>(_UFirst, _ULast);
 
-            if constexpr (sized_sentinel_for<_Se, _It>) {
-                const auto _Count = _ULast - _UFirst;
-                auto _UResult     = _Transform_unary_n_unchecked(_STD move(_UFirst), _Count,
-                        _STD _Get_unwrapped_n(_STD move(_Output), _Count), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj));
+            auto _UResult = _Transform_unary_unchecked(_STD move(_UFirst), _STD move(_ULast),
+                _STD _Get_unwrapped_n(_STD move(_Output), _Count), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj));
 
-                _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-                _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
-                return {_STD move(_First), _STD move(_Output)};
-            } else {
-                auto _UResult = _Transform_unary_unchecked(_STD move(_UFirst), _STD move(_ULast),
-                    _STD _Get_unwrapped_unverified(_STD move(_Output)), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj));
-
-                _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-                _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
-                return {_STD move(_First), _STD move(_Output)};
-            }
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
         template <input_range _Rng, weakly_incrementable _Out, copy_constructible _Fn, class _Pj = identity>
             requires indirectly_writable<_Out, indirect_result_t<_Fn&, projected<iterator_t<_Rng>, _Pj>>>
         _STATIC_CALL_OPERATOR constexpr unary_transform_result<borrowed_iterator_t<_Rng>, _Out> operator()(
             _Rng&& _Range, _Out _Output, _Fn _Func, _Pj _Proj = {}) _CONST_CALL_OPERATOR {
-            if constexpr (sized_range<_Rng>) {
-                const auto _Count = _RANGES distance(_Range);
-                auto _First       = _RANGES begin(_Range);
-                auto _UResult =
-                    _Transform_unary_n_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Count,
-                        _STD _Get_unwrapped_n(_STD move(_Output), _Count), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj));
+            const auto _Count = _RANGES _Idl_distance(_Range);
+            auto _First       = _RANGES begin(_Range);
 
-                _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-                _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
-                return {_STD move(_First), _STD move(_Output)};
-            } else {
-                auto _First = _RANGES begin(_Range);
-                auto _UResult =
-                    _Transform_unary_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
-                        _STD _Get_unwrapped_unverified(_STD move(_Output)), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj));
+            auto _UResult =
+                _Transform_unary_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
+                    _STD _Get_unwrapped_n(_STD move(_Output), _Count), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj));
 
-                _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-                _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
-                return {_STD move(_First), _STD move(_Output)};
-            }
+            _STD _Seek_wrapped(_First, _STD move(_UResult.in));
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
-#pragma warning(push)
-#pragma warning(disable : 6287) // Redundant code
         template <input_iterator _It1, sentinel_for<_It1> _Se1, input_iterator _It2, sentinel_for<_It2> _Se2,
             weakly_incrementable _Out, copy_constructible _Fn, class _Pj1 = identity, class _Pj2 = identity>
             requires indirectly_writable<_Out, indirect_result_t<_Fn&, projected<_It1, _Pj1>, projected<_It2, _Pj2>>>
@@ -3877,36 +3856,22 @@ namespace ranges {
             _STD _Adl_verify_range(_First1, _Last1);
             _STD _Adl_verify_range(_First2, _Last2);
 
-            constexpr bool _Min_size_determinable =
-                (sized_sentinel_for<_Se1, _It1> && _Sized_or_unreachable_sentinel_for<_Se2, _It2>)
-                || (sized_sentinel_for<_Se2, _It2> && _Sized_or_unreachable_sentinel_for<_Se1, _It1>);
+            auto _UFirst1      = _RANGES _Unwrap_iter<_Se1>(_STD move(_First1));
+            auto _ULast1       = _RANGES _Unwrap_sent<_It1>(_STD move(_Last1));
+            const auto _Count1 = _STD _Idl_distance<_It1>(_UFirst1, _ULast1);
+            auto _UFirst2      = _RANGES _Unwrap_iter<_Se2>(_STD move(_First2));
+            auto _ULast2       = _RANGES _Unwrap_sent<_It2>(_STD move(_Last2));
+            const auto _Count2 = _STD _Idl_distance<_It2>(_UFirst2, _ULast2);
+            const auto _Count  = _STD _Idl_dist_min(_Count1, _Count2);
 
-            if constexpr (_Min_size_determinable) {
-                auto _UFirst1      = _RANGES _Unwrap_iter<_Se1>(_STD move(_First1));
-                const auto _Count1 = _STD _Idl_distance<_It1>(_UFirst1, _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)));
-                auto _UFirst2      = _RANGES _Unwrap_iter<_Se2>(_STD move(_First2));
-                const auto _Count2 = _STD _Idl_distance<_It2>(_UFirst2, _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)));
-                const auto _Count  = _STD _Idl_dist_min(_Count1, _Count2);
+            auto _UResult = _Transform_binary_unchecked(_STD move(_UFirst1), _STD move(_ULast1), _STD move(_UFirst2),
+                _STD move(_ULast2), _STD _Get_unwrapped_n(_STD move(_Output), _Count), _STD _Pass_fn(_Func),
+                _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
 
-                auto _UResult = _Transform_binary_n_unchecked(_STD move(_UFirst1), _STD move(_UFirst2), _Count,
-                    _STD _Get_unwrapped_n(_STD move(_Output), _Count), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj1),
-                    _STD _Pass_fn(_Proj2));
-
-                _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
-                _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
-                _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
-                return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
-            } else {
-                auto _UResult = _Transform_binary_unchecked(_RANGES _Unwrap_iter<_Se1>(_STD move(_First1)),
-                    _RANGES _Unwrap_sent<_It1>(_STD move(_Last1)), _RANGES _Unwrap_iter<_Se2>(_STD move(_First2)),
-                    _RANGES _Unwrap_sent<_It2>(_STD move(_Last2)), _STD _Get_unwrapped_unverified(_STD move(_Output)),
-                    _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj1), _STD _Pass_fn(_Proj2));
-
-                _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
-                _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
-                _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
-                return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
-            }
+            _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
+            _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
         }
 
         template <input_range _Rng1, input_range _Rng2, weakly_incrementable _Out, copy_constructible _Fn,
@@ -3917,36 +3882,20 @@ namespace ranges {
             _Out>
             operator()(_Rng1&& _Range1, _Rng2&& _Range2, _Out _Output, _Fn _Func, _Pj1 _Proj1 = {},
                 _Pj2 _Proj2 = {}) _CONST_CALL_OPERATOR {
-            constexpr bool _Min_size_determinable = (sized_range<_Rng1> && _Sized_or_infinite_range<_Rng2>)
-                                                 || (sized_range<_Rng2> && _Sized_or_infinite_range<_Rng1>);
-            if constexpr (_Min_size_determinable) {
-                const auto _Count = _STD _Idl_dist_min(_RANGES _Idl_distance(_Range1), _RANGES _Idl_distance(_Range2));
-                auto _First1      = _RANGES begin(_Range1);
-                auto _First2      = _RANGES begin(_Range2);
-                auto _UResult     = _Transform_binary_n_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)),
-                        _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Count,
-                        _STD _Get_unwrapped_n(_STD move(_Output), _Count), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj1),
-                        _STD _Pass_fn(_Proj2));
+            const auto _Count = _STD _Idl_dist_min(_RANGES _Idl_distance(_Range1), _RANGES _Idl_distance(_Range2));
+            auto _First1      = _RANGES begin(_Range1);
+            auto _First2      = _RANGES begin(_Range2);
 
-                _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
-                _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
-                _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
-                return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
-            } else {
-                auto _First1  = _RANGES begin(_Range1);
-                auto _First2  = _RANGES begin(_Range2);
-                auto _UResult = _Transform_binary_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)),
-                    _Uend(_Range1), _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2),
-                    _STD _Get_unwrapped_unverified(_STD move(_Output)), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj1),
-                    _STD _Pass_fn(_Proj2));
+            auto _UResult = _Transform_binary_unchecked(_RANGES _Unwrap_range_iter<_Rng1>(_STD move(_First1)),
+                _Uend(_Range1), _RANGES _Unwrap_range_iter<_Rng2>(_STD move(_First2)), _Uend(_Range2),
+                _STD _Get_unwrapped_n(_STD move(_Output), _Count), _STD _Pass_fn(_Func), _STD _Pass_fn(_Proj1),
+                _STD _Pass_fn(_Proj2));
 
-                _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
-                _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
-                _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
-                return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
-            }
+            _STD _Seek_wrapped(_First1, _STD move(_UResult.in1));
+            _STD _Seek_wrapped(_First2, _STD move(_UResult.in2));
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
         }
-#pragma warning(pop)
 
     private:
         template <class _It, class _Se, class _Out, class _Fn, class _Pj>
@@ -3964,30 +3913,6 @@ namespace ranges {
             return {_STD move(_First), _STD move(_Output)};
         }
 
-        template <class _It, class _Out, class _Fn, class _Pj>
-        _NODISCARD static constexpr unary_transform_result<_It, _Out> _Transform_unary_n_unchecked(
-            _It _First, iter_difference_t<_It> _Count, _Out _Output, _Fn _Func, _Pj _Proj) {
-            // transform projected _First + [0, _Count) with _Func
-            _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It>);
-            _STL_INTERNAL_STATIC_ASSERT(weakly_incrementable<_Out>);
-            _STL_INTERNAL_STATIC_ASSERT(indirectly_writable<_Out, indirect_result_t<_Fn&, projected<_It, _Pj>>>);
-
-            if constexpr (random_access_iterator<_It>
-                          && random_access_iterator<_Out>) { // FIXME: justify this with benchmarks
-                for (iter_difference_t<_It> _Idx = 0; _Idx < _Count; ++_Idx) {
-                    _Output[_Idx] = _STD invoke(_Func, _STD invoke(_Proj, _First[_Idx]));
-                }
-
-                return {_First + _Count, _Output + _Count};
-            } else {
-                for (; _Count > 0; ++_First, (void) ++_Output, --_Count) {
-                    *_Output = _STD invoke(_Func, _STD invoke(_Proj, *_First));
-                }
-
-                return {_STD move(_First), _STD move(_Output)};
-            }
-        }
-
         template <class _It1, class _Se1, class _It2, class _Se2, class _Out, class _Fn, class _Pj1, class _Pj2>
         _NODISCARD static constexpr binary_transform_result<_It1, _It2, _Out> _Transform_binary_unchecked(_It1 _First1,
             const _Se1 _Last1, _It2 _First2, const _Se2 _Last2, _Out _Output, _Fn _Func, _Pj1 _Proj1, _Pj2 _Proj2) {
@@ -4003,34 +3928,6 @@ namespace ranges {
             }
 
             return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
-        }
-
-        template <class _It1, class _It2, class _Diff, class _Out, class _Fn, class _Pj1, class _Pj2>
-        _NODISCARD static constexpr binary_transform_result<_It1, _It2, _Out> _Transform_binary_n_unchecked(
-            _It1 _First1, _It2 _First2, _Diff _Count, _Out _Output, _Fn _Func, _Pj1 _Proj1, _Pj2 _Proj2) {
-            // transform projected _First1 + [0, _Count) and projected _First2 + [0, _Count) with _Func
-            _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It1>);
-            _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It2>);
-            _STL_INTERNAL_STATIC_ASSERT(_Signed_integer_like<_Diff>);
-            _STL_INTERNAL_STATIC_ASSERT(weakly_incrementable<_Out>);
-            _STL_INTERNAL_STATIC_ASSERT(
-                indirectly_writable<_Out, indirect_result_t<_Fn&, projected<_It1, _Pj1>, projected<_It2, _Pj2>>>);
-
-            if constexpr (random_access_iterator<_It1> && random_access_iterator<_It2>
-                          && random_access_iterator<_Out>) { // FIXME: justify this with benchmarks
-                for (_Diff _Idx = 0; _Idx < _Count; ++_Idx) {
-                    _Output[_Idx] =
-                        _STD invoke(_Func, _STD invoke(_Proj1, _First1[_Idx]), _STD invoke(_Proj2, _First2[_Idx]));
-                }
-
-                return {_First1 + _Count, _First2 + _Count, _Output + _Count};
-            } else {
-                for (; _Count > 0; ++_First1, (void) ++_First2, (void) ++_Output, --_Count) {
-                    *_Output = _STD invoke(_Func, _STD invoke(_Proj1, *_First1), _STD invoke(_Proj2, *_First2));
-                }
-
-                return {_STD move(_First1), _STD move(_First2), _STD move(_Output)};
-            }
         }
     };
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -5387,12 +5387,15 @@ namespace ranges {
             _It _First, _It _Mid, _Se _Last, _Out _Output) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Mid);
             _STD _Adl_verify_range(_Mid, _Last);
-            auto _UResult = _Rotate_copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_iter<_Se>(_STD move(_Mid)), _RANGES _Unwrap_sent<_It>(_STD move(_Last)),
-                _STD move(_Output));
+            auto _UFirst      = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
+            auto _ULast       = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
+            const auto _Count = _STD _Idl_distance<_It>(_UFirst, _ULast);
+            auto _UResult     = _Rotate_copy_unchecked(_STD move(_UFirst), _RANGES _Unwrap_iter<_Se>(_STD move(_Mid)),
+                    _STD move(_ULast), _STD _Get_unwrapped_n(_STD move(_Output), _Count));
 
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-            return {_STD move(_First), _STD move(_UResult.out)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
         template <forward_range _Rng, weakly_incrementable _Out>
@@ -5401,10 +5404,11 @@ namespace ranges {
             _Rng&& _Range, iterator_t<_Rng> _Mid, _Out _Output) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_RANGES begin(_Range), _Mid);
             _STD _Adl_verify_range(_Mid, _RANGES end(_Range));
-            auto _UResult = _Rotate_copy_unchecked(
-                _Ubegin(_Range), _RANGES _Unwrap_range_iter<_Rng>(_STD move(_Mid)), _Uend(_Range), _STD move(_Output));
-
-            return {_RANGES _Rewrap_iterator(_Range, _STD move(_UResult.in)), _STD move(_UResult.out)};
+            const auto _Count = _RANGES _Idl_distance(_Range);
+            auto _UResult = _Rotate_copy_unchecked(_Ubegin(_Range), _RANGES _Unwrap_range_iter<_Rng>(_STD move(_Mid)),
+                _Uend(_Range), _STD _Get_unwrapped_n(_STD move(_Output), _Count));
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_RANGES _Rewrap_iterator(_Range, _STD move(_UResult.in)), _STD move(_Output)};
         }
 
     private:

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -645,8 +645,7 @@ namespace ranges {
         template <_No_throw_input_iterator _It>
             requires destructible<iter_value_t<_It>>
         _STATIC_CALL_OPERATOR constexpr _It operator()(
-            _It _First, const iter_difference_t<_It> _Count_raw) _CONST_CALL_OPERATOR noexcept {
-            _Algorithm_int_t<iter_difference_t<_It>> _Count = _Count_raw;
+            _It _First, iter_difference_t<_It> _Count) _CONST_CALL_OPERATOR noexcept {
             if (_Count <= 0) {
                 return _First;
             }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4961,28 +4961,33 @@ namespace ranges {
         return {_STD move(_First), _STD move(_Output)};
     }
 
-    class _Copy_fn {
-    public:
+    struct _Copy_fn {
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
             requires indirectly_copyable<_It, _Out>
         _STATIC_CALL_OPERATOR constexpr copy_result<_It, _Out> operator()(
             _It _First, _Se _Last, _Out _Output) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
-            auto _UResult = _RANGES _Copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Output));
+            auto _UFirst      = _RANGES _Unwrap_iter<_Se>(_STD move(_First));
+            auto _ULast       = _RANGES _Unwrap_sent<_It>(_STD move(_Last));
+            const auto _Count = _STD _Idl_distance<_It>(_UFirst, _ULast);
+            auto _UResult     = _RANGES _Copy_unchecked(
+                    _STD move(_UFirst), _STD move(_ULast), _STD _Get_unwrapped_n(_STD move(_Output), _Count));
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-            return {_STD move(_First), _STD move(_UResult.out)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First), _STD move(_Output)};
         }
 
         template <input_range _Rng, weakly_incrementable _Out>
             requires indirectly_copyable<iterator_t<_Rng>, _Out>
         _STATIC_CALL_OPERATOR constexpr copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(
             _Rng&& _Range, _Out _Output) _CONST_CALL_OPERATOR {
-            auto _First   = _RANGES begin(_Range);
-            auto _UResult = _RANGES _Copy_unchecked(
-                _RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD move(_Output));
+            const auto _Count = _RANGES _Idl_distance(_Range);
+            auto _First       = _RANGES begin(_Range);
+            auto _UResult = _RANGES _Copy_unchecked(_RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range),
+                _STD _Get_unwrapped_n(_STD move(_Output), _Count));
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
-            return {_STD move(_First), _STD move(_UResult.out)};
+            _STD _Seek_wrapped(_Output, _STD move(_UResult.out));
+            return {_STD move(_First), _STD move(_Output)};
         }
     };
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3591,7 +3591,9 @@ namespace ranges {
 
     template <range _Rng>
     _NODISCARD constexpr auto _Idl_distance(_Rng& _Range) {
-        // returns _STD _Idl_distance<iterator_t<_Rng>>(begin(_Range), end(_Range))
+        // Returns the length of _Range if it is finite and can be determined in O(1), or
+        // an indicator that the length is infinite, or
+        // an indicator that the length cannot be determined in O(1).
         if constexpr (sized_range<_Rng>) {
             return _RANGES distance(_Range);
         } else if constexpr (same_as<sentinel_t<_Rng>, unreachable_sentinel_t>) {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1410,7 +1410,7 @@ struct _Distance_unknown {
 };
 
 struct _Distance_unbounded {
-    constexpr _Distance_unbounded operator-() const noexcept {
+    _NODISCARD constexpr _Distance_unbounded operator-() const noexcept {
         return {};
     }
 };
@@ -1557,7 +1557,7 @@ _NODISCARD constexpr auto _Idl_distance(const _Iter& _First, const _Sent& _Last)
         return _Distance_unknown{};
     }
 }
-#else // ^^^ C++20 or later / C++17 or earlier vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 template <class _Checked, class _Iter>
 _NODISCARD constexpr auto _Idl_distance(const _Iter& _First, const _Iter& _Last) {
     _STL_INTERNAL_STATIC_ASSERT(is_same_v<_Unwrapped_t<_Checked>, _Iter>);
@@ -1567,7 +1567,7 @@ _NODISCARD constexpr auto _Idl_distance(const _Iter& _First, const _Iter& _Last)
         return _Distance_unknown{};
     }
 }
-#endif // ^^^ C++17 or earlier ^^^
+#endif // ^^^ !_HAS_CXX20 ^^^
 
 template <class _Elem, bool _Is_enum = is_enum_v<_Elem>>
 struct _Unwrap_enum { // if _Elem is an enum, gets its underlying type; otherwise leaves _Elem unchanged

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4939,26 +4939,26 @@ namespace ranges {
 
     template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
         requires indirectly_copyable<_It, _Out>
-    _NODISCARD constexpr copy_result<_It, _Out> _Copy_unchecked(_It _First, _Se _Last, _Out _Result) {
+    _NODISCARD constexpr copy_result<_It, _Out> _Copy_unchecked(_It _First, _Se _Last, _Out _Output) {
         if constexpr (_Sent_copy_cat<_It, _Se, _Out>::_Bitcopy_assignable) {
             if (!_STD is_constant_evaluated()) {
                 if constexpr (is_same_v<_It, _Se>) {
-                    _Result = _STD _Copy_memmove(_STD move(_First), _Last, _STD move(_Result));
-                    return {_STD move(_Last), _STD move(_Result)};
+                    _Output = _STD _Copy_memmove(_STD move(_First), _Last, _STD move(_Output));
+                    return {_STD move(_Last), _STD move(_Output)};
                 } else {
                     const auto _Count = static_cast<size_t>(_Last - _First);
-                    _Result           = _STD _Copy_memmove_n(_First, _Count, _STD move(_Result));
+                    _Output           = _STD _Copy_memmove_n(_First, _Count, _STD move(_Output));
                     _First += _Count;
-                    return {_STD move(_First), _STD move(_Result)};
+                    return {_STD move(_First), _STD move(_Output)};
                 }
             }
         }
 
-        for (; _First != _Last; ++_First, (void) ++_Result) {
-            *_Result = *_First;
+        for (; _First != _Last; ++_First, (void) ++_Output) {
+            *_Output = *_First;
         }
 
-        return {_STD move(_First), _STD move(_Result)};
+        return {_STD move(_First), _STD move(_Output)};
     }
 
     class _Copy_fn {
@@ -4966,10 +4966,10 @@ namespace ranges {
         template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
             requires indirectly_copyable<_It, _Out>
         _STATIC_CALL_OPERATOR constexpr copy_result<_It, _Out> operator()(
-            _It _First, _Se _Last, _Out _Result) _CONST_CALL_OPERATOR {
+            _It _First, _Se _Last, _Out _Output) _CONST_CALL_OPERATOR {
             _STD _Adl_verify_range(_First, _Last);
             auto _UResult = _RANGES _Copy_unchecked(_RANGES _Unwrap_iter<_Se>(_STD move(_First)),
-                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Result));
+                _RANGES _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Output));
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }
@@ -4977,10 +4977,10 @@ namespace ranges {
         template <input_range _Rng, weakly_incrementable _Out>
             requires indirectly_copyable<iterator_t<_Rng>, _Out>
         _STATIC_CALL_OPERATOR constexpr copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(
-            _Rng&& _Range, _Out _Result) _CONST_CALL_OPERATOR {
+            _Rng&& _Range, _Out _Output) _CONST_CALL_OPERATOR {
             auto _First   = _RANGES begin(_Range);
             auto _UResult = _RANGES _Copy_unchecked(
-                _RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD move(_Result));
+                _RANGES _Unwrap_range_iter<_Rng>(_STD move(_First)), _Uend(_Range), _STD move(_Output));
             _STD _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1409,6 +1409,12 @@ struct _Distance_unknown {
     }
 };
 
+struct _Distance_unbounded {
+    constexpr _Distance_unbounded operator-() const noexcept {
+        return {};
+    }
+};
+
 template <class _Diff>
 constexpr _Diff _Max_possible_v{static_cast<_Make_unsigned_like_t<_Diff>>(-1) >> 1};
 
@@ -1430,7 +1436,7 @@ template <class _Iter, class _Diff>
 _NODISCARD constexpr decltype(auto) _Get_unwrapped_n(_Iter&& _It, const _Diff _Off) {
     if constexpr (is_pointer_v<decay_t<_Iter>>) {
         return _It + 0;
-    } else if constexpr (_Unwrappable_for_offset_v<_Iter> && is_integral_v<_Diff>) {
+    } else if constexpr (_Unwrappable_for_offset_v<_Iter> && _Integer_like<_Diff>) {
         // ask an iterator to assert that the iterator moved _Off positions is valid, and unwrap
         using _IDiff     = _Iter_diff_t<_Remove_cvref_t<_Iter>>;
         using _CDiff     = common_type_t<_Diff, _IDiff>;
@@ -1533,15 +1539,35 @@ using _Enable_if_execution_policy_t = typename remove_reference_t<_ExPo>::_Stand
 
 #endif // _HAS_CXX17
 
+#if _HAS_CXX20
+_EXPORT_STD struct unreachable_sentinel_t;
+
+template <class _Checked, class _Iter, class _Sent>
+_NODISCARD constexpr auto _Idl_distance(const _Iter& _First, const _Sent& _Last) {
+    // Returns the distance between _First and _Last,
+    // an indicator that the distance is infinite, or
+    // an indicator that the distance cannot be determined in O(1).
+    _STL_INTERNAL_STATIC_ASSERT(same_as<_Unwrapped_t<_Checked>, _Iter>);
+
+    if constexpr (sized_sentinel_for<_Sent, _Iter>) {
+        return static_cast<iter_difference_t<_Checked>>(_Last - _First);
+    } else if constexpr (same_as<_Sent, unreachable_sentinel_t>) {
+        return _Distance_unbounded{};
+    } else {
+        return _Distance_unknown{};
+    }
+}
+#else // ^^^ C++20 or later / C++17 or earlier vvv
 template <class _Checked, class _Iter>
 _NODISCARD constexpr auto _Idl_distance(const _Iter& _First, const _Iter& _Last) {
-    // tries to get the distance between _First and _Last if they are random-access iterators
-    if constexpr (_Is_ranges_random_iter_v<_Iter>) {
+    _STL_INTERNAL_STATIC_ASSERT(is_same_v<_Unwrapped_t<_Checked>, _Iter>);
+    if constexpr (_Is_cpp17_random_iter_v<_Iter>) {
         return static_cast<_Iter_diff_t<_Checked>>(_Last - _First);
     } else {
         return _Distance_unknown{};
     }
 }
+#endif // ^^^ C++17 or earlier ^^^
 
 template <class _Elem, bool _Is_enum = is_enum_v<_Elem>>
 struct _Unwrap_enum { // if _Elem is an enum, gets its underlying type; otherwise leaves _Elem unchanged
@@ -3562,6 +3588,18 @@ namespace ranges {
     };
 
     _EXPORT_STD inline constexpr _Distance_fn distance;
+
+    template <range _Rng>
+    _NODISCARD constexpr auto _Idl_distance(_Rng& _Range) {
+        // returns _STD _Idl_distance<iterator_t<_Rng>>(begin(_Range), end(_Range))
+        if constexpr (sized_range<_Rng>) {
+            return _RANGES distance(_Range);
+        } else if constexpr (same_as<sentinel_t<_Rng>, unreachable_sentinel_t>) {
+            return _Distance_unbounded{};
+        } else {
+            return _Distance_unknown{};
+        }
+    }
 
     class _Ssize_fn {
     public:

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -24,10 +24,6 @@ std/time/time.syn/formatter.year_month_weekday.pass.cpp:1 FAIL
 std/time/time.syn/formatter.zoned_time.pass.cpp:0 FAIL
 std/time/time.syn/formatter.zoned_time.pass.cpp:1 FAIL
 
-# LLVM-74756: [libc++][test] overload_compare_iterator doesn't support its claimed iterator_category
-std/utilities/memory/specialized.algorithms/uninitialized.copy/uninitialized_copy.pass.cpp FAIL
-std/utilities/memory/specialized.algorithms/uninitialized.move/uninitialized_move.pass.cpp FAIL
-
 # LLVM-90196: [libc++][format] Formatting range with m range-type is incorrect
 std/utilities/format/format.range/format.range.formatter/format.functions.format.pass.cpp FAIL
 std/utilities/format/format.range/format.range.formatter/format.functions.vformat.pass.cpp FAIL


### PR DESCRIPTION
This completes the last bits of the iterator unwrapping design for Ranges algorithms.

Detailed commit-wise description:
* Expand `_Idl_distance` design for Ranges
  * Add `_Distance_unbounded` to represent the distance between an iterator and `unreachable_sentinel`.
  * `_Idl_distance` takes iterator/sentinel pairs in C++20 mode.
  * Add `_RANGES _Idl_distance(range)`, equivalent to `_STD _Idl_distance` but for `sized_range` instead of `sized_sentinel_for`.
  * Support integer-class counts in `_Get_unwrapped_n`.

* Simplify `ranges::destroy_n`. Now that `_Get_unwrapped_n` supports integer-class counts, we don't need to apply `_Algorithm_int_t` to `_Count`.

* Update operations on `_Idl_distance`s
  * Refactor `_Idl_dist_add`:
    * Use `if constexpr` dispatch instead of overloading.
    * `_Distance_unbounded` plus anything is `_Distance_unbounded`.
  * Implement `_Idl_dist_min` to compute the smaller of two `_Idl_distance`s.

* Rename Range algorithm output iterator parameters from `_Result` to `_Output`. This changes our convention. I think `_Output` is more appropriate than `_Result` for this purpose given that most algorithms produce more results than just the output sequence. This also makes `_Result` unambiguously available to refer to the return value of the algorithm which is consistent with our use of `_UResult` for intermediate unwrapped results.

* Unwrap outputs in `ranges::copy`

* Unwrap outputs in `ranges::copy_backward`

* Unwrap outputs in `ranges::copy_if`

* Unwrap outputs in `ranges::copy_n`

* Unwrap outputs in `ranges::merge`

* Unwrap outputs in `ranges::move`

* Unwrap outputs in `ranges::move_backward`

* Unwrap outputs in `ranges::replace_copy`

* Unwrap outputs in `ranges::replace_copy_if`

* Unwrap outputs in `ranges::reverse_copy`

* Unwrap outputs in `ranges::rotate_copy`

* Unwrap outputs in `ranges::sample`

* Unwrap outputs in `ranges::transform` (The warning suppression is necessary to prevent the static analyzer diagnosing the computation of `_Min_size_determinable` as redundant when `_Rng1` and `_Rng2` are the same type.)

Fixes #893.
