### PR TITLE
Fix floating `minmax` performance

### DIFF
--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2222,7 +2222,7 @@ namespace {
         }
     }
 
-    // TRNSITION, DevCom-10767462
+    // TRANSITION, DevCom-10767462
     template <_Min_max_mode _Mode, class _Traits, bool _Sign>
     auto __std_minmax_impl_wrap(const void* const _First, const void* const _Last) {
         auto _Rx = __std_minmax_impl<_Mode, _Traits, _Sign>(_First, _Last);

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2222,6 +2222,7 @@ namespace {
         }
     }
 
+#ifndef _M_ARM64EC
     // TRANSITION, DevCom-10767462
     template <_Min_max_mode _Mode, class _Traits, bool _Sign>
     auto __std_minmax_impl_wrap(const void* const _First, const void* const _Last) noexcept {
@@ -2229,6 +2230,7 @@ namespace {
         _mm256_zeroupper();
         return _Rx;
     }
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     template <_Min_max_mode _Mode, class _Traits, bool _Sign>
     auto __std_minmax_disp(const void* const _First, const void* const _Last) noexcept {

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2234,7 +2234,7 @@ namespace {
     auto __std_minmax_disp(const void* const _First, const void* const _Last) noexcept {
 #ifndef _M_ARM64EC
         if (_Byte_length(_First, _Last) >= 32 && _Use_avx2()) {
-            if constexpr (_Traits::_Avx::_Is_floating && _Mode == _Min_max_mode::_Mode_both) {
+            if constexpr (_Traits::_Avx::_Is_floating) {
                 return __std_minmax_impl_wrap<_Mode, typename _Traits::_Avx, _Sign>(_First, _Last);
             } else {
                 return __std_minmax_impl<_Mode, typename _Traits::_Avx, _Sign>(_First, _Last);

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2222,11 +2222,23 @@ namespace {
         }
     }
 
+    // TRNSITION, DevCom-10767462
+    template <_Min_max_mode _Mode, class _Traits, bool _Sign>
+    auto __std_minmax_impl_wrap(const void* const _First, const void* const _Last) {
+        auto _Rx = __std_minmax_impl<_Mode, _Traits, _Sign>(_First, _Last);
+        _mm256_zeroupper();
+        return _Rx;
+    }
+
     template <_Min_max_mode _Mode, class _Traits, bool _Sign>
     auto __std_minmax_disp(const void* const _First, const void* const _Last) noexcept {
 #ifndef _M_ARM64EC
         if (_Byte_length(_First, _Last) >= 32 && _Use_avx2()) {
-            return __std_minmax_impl<_Mode, typename _Traits::_Avx, _Sign>(_First, _Last);
+            if constexpr (_Traits::_Avx::_Is_floating && _Mode == _Min_max_mode::_Mode_both) {
+                return __std_minmax_impl_wrap<_Mode, typename _Traits::_Avx, _Sign>(_First, _Last);
+            } else {
+                return __std_minmax_impl<_Mode, typename _Traits::_Avx, _Sign>(_First, _Last);
+            }
         }
 
         if (_Byte_length(_First, _Last) >= 16 && _Use_sse42()) {

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2224,7 +2224,7 @@ namespace {
 
     // TRANSITION, DevCom-10767462
     template <_Min_max_mode _Mode, class _Traits, bool _Sign>
-    auto __std_minmax_impl_wrap(const void* const _First, const void* const _Last) {
+    auto __std_minmax_impl_wrap(const void* const _First, const void* const _Last) noexcept {
         auto _Rx = __std_minmax_impl<_Mode, _Traits, _Sign>(_First, _Last);
         _mm256_zeroupper();
         return _Rx;


### PR DESCRIPTION
Work around DevCom-10767462

Looks fragile (how can we be sure that the compiler won't misplace another `vzeroupper` too?) but seems to work.

Alternative to #5010