### PR TITLE
Toolset update: VS 2022 17.12 Preview 3, Python 3.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.12 Preview 2 or later.
+1. Install Visual Studio 2022 17.12 Preview 3 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.
@@ -160,7 +160,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.12 Preview 2 or later.
+1. Install Visual Studio 2022 17.12 Preview 3 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.29.0 or later, and [Ninja][] 1.12.1 or later.
-    * Make sure [Python][] 3.12 or later is available to CMake.
+    * Make sure [Python][] 3.13 or later is available to CMake.
 2. Open Visual Studio, and choose the "Clone or check out code" option. Enter the URL of this repository,
    `https://github.com/microsoft/STL`.
 3. Open a terminal in the IDE with `` Ctrl + ` `` (by default) or press on "View" in the top bar, and then "Terminal".
@@ -169,7 +169,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.29.0 or later, and [Ninja][] 1.12.1 or later.
-    * Make sure [Python][] 3.12 or later is available to CMake.
+    * Make sure [Python][] 3.13 or later is available to CMake.
 2. Open a command prompt.
 3. Change directories to a location where you'd like a clone of this STL repository.
 4. `git clone https://github.com/microsoft/STL.git --recurse-submodules`
@@ -262,7 +262,7 @@ C:\Users\username\Desktop>dumpbin /DEPENDENTS .\example.exe | findstr msvcp
 # How To Run The Tests With A Native Tools Command Prompt
 
 1. Follow either [How To Build With A Native Tools Command Prompt][] or [How To Build With The Visual Studio IDE][].
-2. Acquire [Python][] 3.12 or newer and have it on the `PATH` (or run it directly using its absolute or relative path).
+2. Acquire [Python][] 3.13 or newer and have it on the `PATH` (or run it directly using its absolute or relative path).
 3. Have LLVM's `bin` directory on the `PATH` (so `clang-cl.exe` is available).
     * We recommend selecting "C++ Clang tools for Windows" in the VS Installer. This will automatically add LLVM to the
     `PATH` of the x86 and x64 Native Tools Command Prompts, and will ensure that you're using a supported version.

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,7 +5,7 @@
 
 variables:
 - name: poolName
-  value: 'StlBuild-2024-09-10T1506-Pool'
+  value: 'StlBuild-2024-10-15T1118-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -43,7 +43,7 @@ foreach ($workload in $VisualStudioWorkloads) {
 $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.4.5/PowerShell-7.4.5-win-x64.msi'
 $PowerShellArgs = @('/quiet', '/norestart')
 
-$PythonUrl = 'https://www.python.org/ftp/python/3.12.6/python-3.12.6-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.13.0/python-3.13.0-amd64.exe'
 $PythonArgs = @('/quiet', 'InstallAllUsers=1', 'PrependPath=1', 'CompileAll=1', 'Include_doc=0')
 
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/12.4.0/local_installers/cuda_12.4.0_551.61_windows.exe'

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -2209,9 +2209,8 @@ namespace chrono {
             auto [_Icu_version, _Zones, _Links] = _Tzdb_generate_time_zones();
             auto [_Leap_sec, _All_ls_positive]  = _Tzdb_generate_leap_seconds(0);
             auto _Version                       = _Icu_version + "." + _STD to_string(_Leap_sec.size());
-            // TRANSITION, VSO-2228186, should call emplace_front with construction arguments
-            _Tzdb_list.emplace_front(tzdb{
-                _STD move(_Version), _STD move(_Zones), _STD move(_Links), _STD move(_Leap_sec), _All_ls_positive});
+            _Tzdb_list.emplace_front(
+                _STD move(_Version), _STD move(_Zones), _STD move(_Links), _STD move(_Leap_sec), _All_ls_positive);
         }
 
         _NODISCARD const tzdb& front() const noexcept {
@@ -2267,9 +2266,8 @@ namespace chrono {
                 }
 
                 auto _Version = _Tzdb_update_version(_Tzdb.version, _Leap_sec.size());
-                // TRANSITION, VSO-2228186, should call emplace_front with construction arguments
-                _Tzdb_list.emplace_front(tzdb{
-                    _STD move(_Version), _STD move(_Zones), _STD move(_Links), _STD move(_Leap_sec), _All_ls_positive});
+                _Tzdb_list.emplace_front(
+                    _STD move(_Version), _STD move(_Zones), _STD move(_Links), _STD move(_Leap_sec), _All_ls_positive);
             }
             return _Tzdb_list.front();
         }

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -2209,8 +2209,9 @@ namespace chrono {
             auto [_Icu_version, _Zones, _Links] = _Tzdb_generate_time_zones();
             auto [_Leap_sec, _All_ls_positive]  = _Tzdb_generate_leap_seconds(0);
             auto _Version                       = _Icu_version + "." + _STD to_string(_Leap_sec.size());
-            _Tzdb_list.emplace_front(
-                _STD move(_Version), _STD move(_Zones), _STD move(_Links), _STD move(_Leap_sec), _All_ls_positive);
+            // TRANSITION, NVCC (was DevCom-10732572), should call emplace_front with construction arguments
+            _Tzdb_list.emplace_front(tzdb{
+                _STD move(_Version), _STD move(_Zones), _STD move(_Links), _STD move(_Leap_sec), _All_ls_positive});
         }
 
         _NODISCARD const tzdb& front() const noexcept {
@@ -2266,8 +2267,9 @@ namespace chrono {
                 }
 
                 auto _Version = _Tzdb_update_version(_Tzdb.version, _Leap_sec.size());
-                _Tzdb_list.emplace_front(
-                    _STD move(_Version), _STD move(_Zones), _STD move(_Links), _STD move(_Leap_sec), _All_ls_positive);
+                // TRANSITION, NVCC (was DevCom-10732572), should call emplace_front with construction arguments
+                _Tzdb_list.emplace_front(tzdb{
+                    _STD move(_Version), _STD move(_Zones), _STD move(_Links), _STD move(_Leap_sec), _All_ls_positive});
             }
             return _Tzdb_list.front();
         }

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1795,16 +1795,16 @@ template <integral _Integral>
 _NODISCARD constexpr string_view _Get_integral_prefix(const char _Type, const _Integral _Value) noexcept {
     switch (_Type) {
     case 'b':
-        return string_view{"0b", 2}; // TRANSITION, VSO-1775715 (should use UDLs in this function)
+        return "0b"sv;
     case 'B':
-        return string_view{"0B", 2};
+        return "0B"sv;
     case 'x':
-        return string_view{"0x", 2};
+        return "0x"sv;
     case 'X':
-        return string_view{"0X", 2};
+        return "0X"sv;
     case 'o':
         if (_Value != _Integral{0}) {
-            return string_view{"0", 1};
+            return "0"sv;
         }
         return {};
     default:

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -927,8 +927,8 @@ _EMIT_STL_ERROR(STL1002, "Unexpected compiler version, expected CUDA 12.4 or new
 _EMIT_STL_ERROR(STL1000, "Unexpected compiler version, expected Clang 18.0.0 or newer.");
 #endif // ^^^ old Clang ^^^
 #elif defined(_MSC_VER)
-#if _MSC_VER < 1941 // Coarse-grained, not inspecting _MSC_FULL_VER
-_EMIT_STL_ERROR(STL1001, "Unexpected compiler version, expected MSVC 19.41 or newer.");
+#if _MSC_VER < 1942 // Coarse-grained, not inspecting _MSC_FULL_VER
+_EMIT_STL_ERROR(STL1001, "Unexpected compiler version, expected MSVC 19.42 or newer.");
 #endif // ^^^ old MSVC ^^^
 #else // vvv other compilers vvv
 // not attempting to detect other compilers

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ add_subdirectory(tr1)
 # chance to add to the config map and test directory global properties.
 add_subdirectory(utils/stl-lit)
 
-find_package(Python "3.12" REQUIRED COMPONENTS Interpreter)
+find_package(Python "3.13" REQUIRED COMPONENTS Interpreter)
 
 if(NOT DEFINED LIT_FLAGS)
     list(APPEND LIT_FLAGS "-o" "${CMAKE_CURRENT_BINARY_DIR}/test_results.json")

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -861,12 +861,6 @@ std/ranges/range.adaptors/range.lazy.split/range.lazy.split.inner/iter_swap.pass
 # Not analyzed. Checking whether packaged_task is constructible from an allocator and a packaged_task of a different type.
 std/thread/futures/futures.task/futures.task.members/ctor2.compile.pass.cpp FAIL
 
-# Not analyzed. Possible MSVC compiler bug, this is inspecting type trait behavior.
-std/utilities/meta/meta.unary/meta.unary.prop/is_nothrow_copy_assignable.pass.cpp:0 FAIL
-std/utilities/meta/meta.unary/meta.unary.prop/is_nothrow_copy_assignable.pass.cpp:1 FAIL
-std/utilities/meta/meta.unary/meta.unary.prop/is_nothrow_move_assignable.pass.cpp:0 FAIL
-std/utilities/meta/meta.unary/meta.unary.prop/is_nothrow_move_assignable.pass.cpp:1 FAIL
-
 # Not analyzed.
 # MSVC error C2131: expression did not evaluate to a constant
 # MSVC note: failure was caused by a read of an uninitialized symbol

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -224,9 +224,6 @@ std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_strong.pa
 std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_weak.pass.cpp:1 SKIPPED
 std/input.output/syncstream/osyncstream/thread/several_threads.pass.cpp:1 SKIPPED
 
-# VSO-2164191 "[ASan][STL] Interception breaks strtoll"
-std/strings/string.conversions/stoll.pass.cpp:1 FAIL
-
 
 # *** MISSING STL FEATURES ***
 # Missing mbrtoc8 and c8rtomb

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -285,9 +285,7 @@ void test_const_lvalue_get() {
   {
     using V = std::variant<int, const long>;
     constexpr V v(42);
-#if defined(_MSVC_INTERNAL_TESTING) || defined(__clang__) || defined(__EDG__) // TRANSITION, vs17.12p3
     ASSERT_NOT_NOEXCEPT(std::get<0>(v));
-#endif // ^^^ no workaround ^^^
     ASSERT_SAME_TYPE(decltype(std::get<0>(v)), const int &);
     static_assert(std::get<0>(v) == 42, "");
   }
@@ -301,9 +299,7 @@ void test_const_lvalue_get() {
   {
     using V = std::variant<int, const long>;
     constexpr V v(42l);
-#if defined(_MSVC_INTERNAL_TESTING) || defined(__clang__) || defined(__EDG__) // TRANSITION, vs17.12p3
     ASSERT_NOT_NOEXCEPT(std::get<1>(v));
-#endif // ^^^ no workaround ^^^
     ASSERT_SAME_TYPE(decltype(std::get<1>(v)), const long &);
     static_assert(std::get<1>(v) == 42, "");
   }
@@ -451,9 +447,7 @@ void test_const_lvalue_get() {
   {
     using V = std::variant<int, const long>;
     constexpr V v(42);
-#if defined(_MSVC_INTERNAL_TESTING) || defined(__clang__) || defined(__EDG__) // TRANSITION, vs17.12p3
     ASSERT_NOT_NOEXCEPT(std::get<int>(v));
-#endif // ^^^ no workaround ^^^
     ASSERT_SAME_TYPE(decltype(std::get<int>(v)), const int &);
     static_assert(std::get<int>(v) == 42, "");
   }
@@ -467,9 +461,7 @@ void test_const_lvalue_get() {
   {
     using V = std::variant<int, const long>;
     constexpr V v(42l);
-#if defined(_MSVC_INTERNAL_TESTING) || defined(__clang__) || defined(__EDG__) // TRANSITION, vs17.12p3
     ASSERT_NOT_NOEXCEPT(std::get<const long>(v));
-#endif // ^^^ no workaround ^^^
     ASSERT_SAME_TYPE(decltype(std::get<const long>(v)), const long &);
     static_assert(std::get<const long>(v) == 42, "");
   }

--- a/tests/std/tests/P1206R7_ranges_to_mappish/test.cpp
+++ b/tests/std/tests/P1206R7_ranges_to_mappish/test.cpp
@@ -156,13 +156,11 @@ struct mappish_instantiator {
             assert(c5.get_allocator().state == 13);
             assert(ranges::is_permutation(c5, expected, any_pair_eq));
         }
-#if defined(_MSVC_INTERNAL_TESTING) || !defined(__EDG__) // TRANSITION, VS 17.12p3
         {
             std::same_as<T> auto c6 = R{some_pairs} | ranges::to<T>(Alloc{13});
             assert(c6.get_allocator().state == 13);
             assert(ranges::is_permutation(c6, expected, any_pair_eq));
         }
-#endif // ^^^ no workaround ^^^
         {
             std::same_as<T> auto c7 = R{some_pairs} | ranges::to<C>(Alloc{13});
             assert(c7.get_allocator().state == 13);

--- a/tests/std/tests/P1206R7_ranges_to_misc/test.cpp
+++ b/tests/std/tests/P1206R7_ranges_to_misc/test.cpp
@@ -54,7 +54,6 @@ struct reservable {
 };
 
 constexpr bool test_reservable() {
-#if defined(_MSVC_INTERNAL_TESTING) || !defined(__EDG__) // TRANSITION, VS 17.12p3
     int some_ints[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     {
         std::same_as<reservable> auto r = some_ints | ranges::to<reservable>(secret_key);
@@ -62,7 +61,6 @@ constexpr bool test_reservable() {
         assert(r.cap_ == ranges::size(some_ints));
         assert(r.reserved_ == ranges::size(some_ints));
     }
-#endif // ^^^ no workaround ^^^
 
     return true;
 }
@@ -93,14 +91,12 @@ constexpr bool test_common_constructible() {
         assert(c0.last_ == ranges::end(some_ints));
         assert(c0.args_ == 3);
     }
-#if defined(_MSVC_INTERNAL_TESTING) || !defined(__EDG__) // TRANSITION, VS 17.12p3
     {
         std::same_as<common_constructible> auto c1 = some_ints | ranges::to<common_constructible>(secret_key);
         assert(c1.first_ == ranges::begin(some_ints));
         assert(c1.last_ == ranges::end(some_ints));
         assert(c1.args_ == 3);
     }
-#endif // ^^^ no workaround ^^^
 
     // Verify that more than one argument can be passed after the range:
     {
@@ -109,14 +105,12 @@ constexpr bool test_common_constructible() {
         assert(c2.last_ == ranges::end(some_ints));
         assert(c2.args_ == 4);
     }
-#if defined(_MSVC_INTERNAL_TESTING) || !defined(__EDG__) // TRANSITION, VS 17.12p3
     {
         std::same_as<common_constructible> auto c3 = some_ints | ranges::to<common_constructible>(secret_key, 3.14);
         assert(c3.first_ == ranges::begin(some_ints));
         assert(c3.last_ == ranges::end(some_ints));
         assert(c3.args_ == 4);
     }
-#endif // ^^^ no workaround ^^^
 
     return true;
 }
@@ -302,7 +296,6 @@ constexpr void test_lwg4016_per_kind() {
         std::same_as<V> auto vec = std::views::iota(0, 42) | ranges::to<V>();
         assert(ranges::equal(vec, std::views::iota(0, 42)));
     }
-#if defined(_MSVC_INTERNAL_TESTING) || !defined(__EDG__) // TRANSITION, VS 17.12p3
     {
         std::same_as<V> auto vec = std::views::iota(0, 42) | ranges::to<V>(std::allocator<int>{});
         assert(ranges::equal(vec, std::views::iota(0, 42)));
@@ -315,7 +308,6 @@ constexpr void test_lwg4016_per_kind() {
         std::same_as<V> auto vec = std::views::empty<int> | ranges::to<V>(std::size_t{42}, std::allocator<int>{});
         assert(ranges::equal(vec, std::views::repeat(0, 42)));
     }
-#endif // ^^^ no workaround ^^^
     {
         std::same_as<V> auto vec = ranges::to<V>(std::views::iota(0, 42), std::initializer_list<int>{-3, -2, -1});
         assert(ranges::equal(vec, std::views::iota(-3, 42)));

--- a/tests/std/tests/P1206R7_ranges_to_sequence/test.cpp
+++ b/tests/std/tests/P1206R7_ranges_to_sequence/test.cpp
@@ -145,13 +145,11 @@ struct sequence_instantiator {
             assert(c5.get_allocator().state == 13);
             assert(ranges::equal(c5, meow));
         }
-#if defined(_MSVC_INTERNAL_TESTING) || !defined(__EDG__) // TRANSITION, VS 17.12p3
         {
             std::same_as<T> auto c6 = R{meow} | ranges::to<T>(Alloc{13});
             assert(c6.get_allocator().state == 13);
             assert(ranges::equal(c6, meow));
         }
-#endif // ^^^ no workaround ^^^
         {
             std::same_as<T> auto c7 = R{meow} | ranges::to<C>(Alloc{13});
             assert(c7.get_allocator().state == 13);

--- a/tests/std/tests/P1206R7_ranges_to_settish/test.cpp
+++ b/tests/std/tests/P1206R7_ranges_to_settish/test.cpp
@@ -150,13 +150,11 @@ struct settish_instantiator {
             assert(c5.get_allocator().state == 13);
             assert(ranges::is_permutation(c5, expected));
         }
-#if defined(_MSVC_INTERNAL_TESTING) || !defined(__EDG__) // TRANSITION, VS 17.12p3
         {
             std::same_as<T> auto c6 = R{some_ints} | ranges::to<T>(Alloc{13});
             assert(c6.get_allocator().state == 13);
             assert(ranges::is_permutation(c6, expected));
         }
-#endif // ^^^ no workaround ^^^
         {
             std::same_as<T> auto c7 = R{some_ints} | ranges::to<C>(Alloc{13});
             assert(c7.get_allocator().state == 13);

--- a/tests/std/tests/P2136R3_invoke_r/test.cpp
+++ b/tests/std/tests/P2136R3_invoke_r/test.cpp
@@ -48,10 +48,8 @@ constexpr bool test_invoke_r() {
     static_assert(is_same_v<decltype(v2), double>);
     static_assert(is_void_v<decltype(invoke_r<void>(square, 1))>);
 
-#if defined(_MSVC_INTERNAL_TESTING) || defined(__clang__) || defined(__EDG__) // TRANSITION, vs17.12p3
     static_assert(!noexcept(invoke_r<int>(square, 3)));
     static_assert(!noexcept(invoke(square, 3)));
-#endif // ^^^ no workaround ^^^
 
     constexpr bool has_noexcept_in_type =
 #ifdef __cpp_noexcept_function_type


### PR DESCRIPTION
# :scroll: Changelog

- Code cleanups:
  * Removed compiler bug workarounds.
- Infrastructure improvements:
  * Updated dependencies.
    + Updated build compiler to VS 2022 17.12 Preview 3 (now required).
    + Updated Python to 3.13.0 (now required).
