### PR TITLE
Abandon Windows-internal size optimizations for `mutex` and `condition_variable`

### DIFF
--- a/stl/inc/__msvc_threads_core.hpp
+++ b/stl/inc/__msvc_threads_core.hpp
@@ -33,13 +33,12 @@ struct _Stl_critical_section {
 };
 
 struct _Mtx_internal_imp_t {
-#if defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT) // for Windows-internal code
-    static constexpr size_t _Critical_section_size = 2 * sizeof(void*);
-#elif defined(_WIN64) // ordinary 64-bit code
+// TRANSITION, ABI: We should directly store _M_srw_lock above.
+#ifdef _WIN64
     static constexpr size_t _Critical_section_size = 64;
-#else // vvv ordinary 32-bit code vvv
+#else // ^^^ 64-bit / 32-bit vvv
     static constexpr size_t _Critical_section_size = 36;
-#endif // ^^^ ordinary 32-bit code ^^^
+#endif // ^^^ 32-bit ^^^
 
     int _Type{};
     union {
@@ -60,13 +59,12 @@ struct _Stl_condition_variable {
 #pragma warning(push)
 #pragma warning(disable : 26495) // Variable 'meow' is uninitialized. Always initialize a member variable (type.6).
 struct _Cnd_internal_imp_t {
-#if defined(_CRT_WINDOWS) // for Windows-internal code
-    static constexpr size_t _Cnd_internal_imp_size = 2 * sizeof(void*);
-#elif defined(_WIN64) // ordinary 64-bit code
+// TRANSITION, ABI: We should directly store _Win_cv above.
+#ifdef _WIN64
     static constexpr size_t _Cnd_internal_imp_size = 72;
-#else // vvv ordinary 32-bit code vvv
+#else // ^^^ 64-bit / 32-bit vvv
     static constexpr size_t _Cnd_internal_imp_size = 40;
-#endif // ^^^ ordinary 32-bit code ^^^
+#endif // ^^^ 32-bit ^^^
 
     union {
         _Stl_condition_variable _Stl_cv{};


### PR DESCRIPTION
For ages, we've had an "optimization" in the machinery for `mutex` and `condition_variable`, reducing their bloated sizes for Windows-internal builds. This is a relic of when we switched between different implementations for XP, Vista, and Win7; the largest size consumption was for the ConcRT-powered XP implementation. Windows could always assume it was the latest Windows, so it never needed that switching.

Unfortunately, the world is not as simple as we believed it to be. We thought that Windows was built consistently with a macro identifying it as Windows-internal, and that such object files were never mixed with ordinary object files (built with public VS). First, the macro scheme either changed or we didn't fully understand it in the first place (`_CRT_WINDOWS` vs. `UNDOCKED_WINDOWS_UCRT`), and second there's a *lot* of mixing between Windows-internal code and public-VS code via vcpkg and possibly other scenarios. See #4294 and #4301 for previous history here.

As @barcharcraz and @CaseyCarter noted to me, the fact that we can't properly ship a `#pragma detect_mismatch` to verify representation consistency is a severe problem. We keep getting reports from Windows devs who are encountering mismatch scenarios, and while they've been messing with their build settings to get around this, it's a strong indication that we should abandon the attempt.

This PR makes Windows-internal code behave exactly the same as public-VS code has always behaved, getting the unfortunately-bloated sizes. (Due to a long series of cleanups, made possible by dropping XP/Vista support, we now initialize only two pointers of this bloated space, and then we actually use only one, so it isn't as bad as it was before.)

There is no escape hatch for Windows-internal code - we're going to try to rip off the bandage with no escape hatch. (An escape hatch would just lead to more mismatch problems.) If the increased sizes cause performance regressions, that's an indication that they should be directly using Windows synchronization primitives. If there's mismatch caused by picking up this change in a non-simultaneous manner (e.g. updated Windows-internal "LKG" compiler, but using old public VS with the Windows-internal macros), the fix is to pick up the latest toolsets (possibly requiring backports on our side) to consistently get this change.

Note that this **does not affect normal VS users**.

Instead of mentioning the whole history in a comment (which is essentially irrelevant for understanding the state of the code after this change), or even mentioning that the constants could be reduced to `2 * sizeof(void*)` if we could break ABI, I've gone further and noted the change that we actually need to make in vNext - ripping out this entire layer of machinery and using only one pointer. This was essentially implied by the existing TRANSITION comment about unused vptrs, but now we're clearly stating it.