### PR TITLE
Update llvm-project

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -215,6 +215,9 @@ std/language.support/support.limits/support.limits.general/cstdlib.version.compi
 # P2255R2 "Type Traits To Detect References Binding To Temporaries"
 std/language.support/support.limits/support.limits.general/type_traits.version.compile.pass.cpp FAIL
 
+# P2674R1 is_implicit_lifetime
+std/utilities/meta/meta.unary/meta.unary.prop/is_implicit_lifetime.pass.cpp FAIL
+
 
 # *** MISSING COMPILER FEATURES ***
 # P1169R4 static operator()

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -33,8 +33,9 @@ std/utilities/format/format.range/format.range.fmtset/format.functions.vformat.p
 # LLVM-100506: [libc++][test] Precondition violation in rand.dist.uni.real/param_ctor.pass.cpp
 std/numerics/rand/rand.dist/rand.dist.uni/rand.dist.uni.real/param_ctor.pass.cpp FAIL
 
-# LLVM-105966: [libc++][test] Fix is_always_lock_free test
-std/atomics/atomics.lockfree/is_always_lock_free.cpp FAIL
+# LLVM-113608: [libc++][test] Use ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings) for -Wno-psabi
+std/atomics/atomics.lockfree/is_always_lock_free.pass.cpp:0 FAIL
+std/atomics/atomics.lockfree/is_always_lock_free.pass.cpp:1 FAIL
 
 # Non-Standard regex behavior.
 # "It seems likely that the test is still non-conforming due to how libc++ handles the 'w' character class."

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -33,10 +33,6 @@ std/utilities/format/format.range/format.range.fmtset/format.functions.vformat.p
 # LLVM-100506: [libc++][test] Precondition violation in rand.dist.uni.real/param_ctor.pass.cpp
 std/numerics/rand/rand.dist/rand.dist.uni/rand.dist.uni.real/param_ctor.pass.cpp FAIL
 
-# LLVM-113608: [libc++][test] Use ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings) for -Wno-psabi
-std/atomics/atomics.lockfree/is_always_lock_free.pass.cpp:0 FAIL
-std/atomics/atomics.lockfree/is_always_lock_free.pass.cpp:1 FAIL
-
 # LLVM-113609: [libc++][test] Non-rebindable test_alloc in string.capacity/deallocate_size.pass.cpp
 std/strings/basic.string/string.capacity/deallocate_size.pass.cpp FAIL
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -24,10 +24,6 @@ std/time/time.syn/formatter.year_month_weekday.pass.cpp:1 FAIL
 std/time/time.syn/formatter.zoned_time.pass.cpp:0 FAIL
 std/time/time.syn/formatter.zoned_time.pass.cpp:1 FAIL
 
-# LLVM-74756: [libc++][test] overload_compare_iterator doesn't support its claimed iterator_category
-std/utilities/memory/specialized.algorithms/uninitialized.copy/uninitialized_copy.pass.cpp FAIL
-std/utilities/memory/specialized.algorithms/uninitialized.move/uninitialized_move.pass.cpp FAIL
-
 # LLVM-90196: [libc++][format] Formatting range with m range-type is incorrect
 std/utilities/format/format.range/format.range.formatter/format.functions.format.pass.cpp FAIL
 std/utilities/format/format.range/format.range.formatter/format.functions.vformat.pass.cpp FAIL
@@ -36,10 +32,6 @@ std/utilities/format/format.range/format.range.fmtset/format.functions.vformat.p
 
 # LLVM-100506: [libc++][test] Precondition violation in rand.dist.uni.real/param_ctor.pass.cpp
 std/numerics/rand/rand.dist/rand.dist.uni/rand.dist.uni.real/param_ctor.pass.cpp FAIL
-
-# LLVM-105878: [libc++][test] fp_compare.h includes non-portable <__config>
-std/numerics/c.math/cmath.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.midpoint/midpoint.float.pass.cpp FAIL
 
 # LLVM-105966: [libc++][test] Fix is_always_lock_free test
 std/atomics/atomics.lockfree/is_always_lock_free.cpp FAIL
@@ -82,8 +74,6 @@ std/language.support/support.limits/support.limits.general/chrono.version.compil
 
 # Tests expect __cpp_lib_ranges to have the old value 201811L for P0896R4; we define the C++20 value 201911L for P1716R3.
 std/language.support/support.limits/support.limits.general/algorithm.version.compile.pass.cpp FAIL
-std/language.support/support.limits/support.limits.general/functional.version.compile.pass.cpp FAIL
-std/language.support/support.limits/support.limits.general/iterator.version.compile.pass.cpp FAIL
 
 # Test expects __cpp_lib_print to have the old value 202207L for P2093R14; we define the C++23 value 202406L for P3235R3.
 std/language.support/support.limits/support.limits.general/ostream.version.compile.pass.cpp FAIL
@@ -156,19 +146,6 @@ std/language.support/support.limits/support.limits.general/format.version.compil
 
 # libc++ doesn't implement LWG-3670
 std/ranges/range.factories/range.iota.view/iterator/member_typedefs.compile.pass.cpp FAIL
-
-# libc++ doesn't implement LWG-3870
-std/utilities/memory/specialized.algorithms/specialized.construct/ranges_construct_at.pass.cpp FAIL
-std/utilities/memory/specialized.algorithms/uninitialized.construct.default/ranges_uninitialized_default_construct.pass.cpp FAIL
-std/utilities/memory/specialized.algorithms/uninitialized.construct.default/ranges_uninitialized_default_construct_n.pass.cpp FAIL
-std/utilities/memory/specialized.algorithms/uninitialized.construct.value/ranges_uninitialized_value_construct.pass.cpp FAIL
-std/utilities/memory/specialized.algorithms/uninitialized.construct.value/ranges_uninitialized_value_construct_n.pass.cpp FAIL
-std/utilities/memory/specialized.algorithms/uninitialized.copy/ranges_uninitialized_copy.pass.cpp FAIL
-std/utilities/memory/specialized.algorithms/uninitialized.copy/ranges_uninitialized_copy_n.pass.cpp FAIL
-std/utilities/memory/specialized.algorithms/uninitialized.fill/ranges_uninitialized_fill.pass.cpp FAIL
-std/utilities/memory/specialized.algorithms/uninitialized.fill.n/ranges_uninitialized_fill_n.pass.cpp FAIL
-std/utilities/memory/specialized.algorithms/uninitialized.move/ranges_uninitialized_move.pass.cpp FAIL
-std/utilities/memory/specialized.algorithms/uninitialized.move/ranges_uninitialized_move_n.pass.cpp FAIL
 
 # libc++ doesn't implement LWG-4013
 std/ranges/range.adaptors/range.lazy.split/range.lazy.split.outer.value/ctor.default.pass.cpp FAIL
@@ -253,9 +230,6 @@ std/containers/views/mdspan/mdspan/index_operator.pass.cpp:1 FAIL
 
 
 # *** MISSING LWG ISSUE RESOLUTIONS ***
-# LWG-2192 "Validity and return type of std::abs(0u) is unclear" (resolution is missing in UCRT, DevCom-10331466)
-std/depr/depr.c.headers/stdlib_h.pass.cpp FAIL
-
 # LWG-2503 "multiline option should be added to syntax_option_type"
 std/re/re.const/re.matchflag/match_multiline.pass.cpp FAIL
 std/re/re.const/re.matchflag/match_not_eol.pass.cpp FAIL
@@ -276,11 +250,6 @@ std/thread/thread.condition/notify_all_at_thread_exit_lwg3343.pass.cpp SKIPPED
 
 
 # *** C1XX COMPILER BUGS ***
-# DevCom-409222 VSO-752709 "Constructing rvalue reference from non-reference-related lvalue reference"
-# Reportedly fixed in VS 2019 16.10, test is still failing, need to investigate.
-std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp:0 FAIL
-std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp:1 FAIL
-
 # VSO-1271673 "static analyzer doesn't know about short-circuiting"
 # Note: The :1 (ASan) configuration doesn't run static analysis.
 std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort.pass.cpp:0 FAIL
@@ -747,9 +716,6 @@ std/re/re.alg/re.alg.search/basic.locale.pass.cpp FAIL
 std/re/re.alg/re.alg.search/ecma.locale.pass.cpp FAIL
 std/re/re.alg/re.alg.search/extended.locale.pass.cpp FAIL
 
-# Not analyzed. Error mentions allocator<const T>.
-std/utilities/memory/specialized.algorithms/specialized.construct/construct_at.pass.cpp FAIL
-
 # Not analyzed. Seems to force a sign conversion error?
 std/iterators/iterator.primitives/iterator.operations/advance.pass.cpp SKIPPED
 
@@ -857,9 +823,6 @@ std/iterators/predef.iterators/move.iterators/move.iter.ops/move.iter.op.comp/op
 # Not analyzed. error C2280: 'std::ranges::lazy_split_view<InputView,ForwardTinyView>::lazy_split_view(const std::ranges::lazy_split_view<InputView,ForwardTinyView> &)': attempting to reference a deleted function
 std/ranges/range.adaptors/range.lazy.split/ctor.copy_move.pass.cpp FAIL
 std/ranges/range.adaptors/range.lazy.split/range.lazy.split.inner/iter_swap.pass.cpp FAIL
-
-# Not analyzed. Checking whether packaged_task is constructible from an allocator and a packaged_task of a different type.
-std/thread/futures/futures.task/futures.task.members/ctor2.compile.pass.cpp FAIL
 
 # Not analyzed.
 # MSVC error C2131: expression did not evaluate to a constant

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -72,7 +72,8 @@ std/numerics/rand/rand.util/rand.util.canonical/generate_canonical.pass.cpp FAIL
 # Test expects __cpp_lib_chrono to have the old value 201611L for P0505R0; we define the C++20 value 201907L for P1466R3.
 std/language.support/support.limits/support.limits.general/chrono.version.compile.pass.cpp FAIL
 
-# Tests expect __cpp_lib_ranges to have the old value 201811L for P0896R4; we define the C++20 value 201911L for P1716R3.
+# Test expects __cpp_lib_freestanding_algorithm to not be defined before C++26; we define it unconditionally.
+# Test expects __cpp_lib_shift to have the C++20 value 201806L for P0769R2; we define the C++23 value 202202L for P2440R1.
 std/language.support/support.limits/support.limits.general/algorithm.version.compile.pass.cpp FAIL
 
 # Test expects __cpp_lib_print to have the old value 202207L for P2093R14; we define the C++23 value 202406L for P3235R3.

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -228,10 +228,6 @@ std/thread/futures/futures.task/futures.task.members/ctad.static.compile.pass.cp
 std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/ctad.static.compile.pass.cpp:0 FAIL
 std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/ctad.static.compile.pass.cpp:1 FAIL
 
-# P2128R6 Multidimensional Subscript Operator
-std/containers/views/mdspan/mdspan/index_operator.pass.cpp:0 FAIL
-std/containers/views/mdspan/mdspan/index_operator.pass.cpp:1 FAIL
-
 
 # *** MISSING LWG ISSUE RESOLUTIONS ***
 # LWG-2503 "multiline option should be added to syntax_option_type"
@@ -802,6 +798,8 @@ std/containers/sequences/vector/vector.cons/construct_size_value.pass.cpp:0 FAIL
 std/containers/sequences/vector/vector.cons/construct_size_value.pass.cpp:1 FAIL
 std/containers/sequences/vector/vector.cons/construct_size_value_alloc.pass.cpp:0 FAIL
 std/containers/sequences/vector/vector.cons/construct_size_value_alloc.pass.cpp:1 FAIL
+std/containers/views/mdspan/mdspan/index_operator.pass.cpp:0 FAIL
+std/containers/views/mdspan/mdspan/index_operator.pass.cpp:1 FAIL
 
 # Not analyzed. Looks like a test bug, assuming that hash<vector<bool>> is constexpr.
 std/containers/sequences/vector.bool/enabled_hash.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -37,6 +37,9 @@ std/numerics/rand/rand.dist/rand.dist.uni/rand.dist.uni.real/param_ctor.pass.cpp
 std/atomics/atomics.lockfree/is_always_lock_free.pass.cpp:0 FAIL
 std/atomics/atomics.lockfree/is_always_lock_free.pass.cpp:1 FAIL
 
+# LLVM-113609: [libc++][test] Non-rebindable test_alloc in string.capacity/deallocate_size.pass.cpp
+std/strings/basic.string/string.capacity/deallocate_size.pass.cpp FAIL
+
 # Non-Standard regex behavior.
 # "It seems likely that the test is still non-conforming due to how libc++ handles the 'w' character class."
 std/re/re.traits/lookup_classname.pass.cpp FAIL

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -32,11 +32,6 @@
 
 #if !defined(_PREFAST_) || !defined(_M_IX86) // TRANSITION, VSO-1639191
 
-#ifndef __clang__ // TRANSITION, LLVM-113633
-#define __SIZEOF_DOUBLE__      8
-#define __SIZEOF_LONG_DOUBLE__ 8
-#endif // ^^^ workaround ^^^
-
 #define _SILENCE_CXX20_VOLATILE_DEPRECATION_WARNING
 #define _LIBCXX_IN_DEVCRT
 #include <msvc_stdlib_force_include.h> // Must precede any other libc++ headers

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -760,7 +760,7 @@ void test_hash_monostate() {
     static_assert(std::is_copy_constructible<H>::value, "");
   }
   {
-    test_hash_enabled_for_type<std::monostate>();
+    test_hash_enabled<std::monostate>();
   }
 }
 
@@ -795,18 +795,18 @@ namespace hash {
 void test_hash_variant_enabled() {
   {
 #ifndef __EDG__ // TRANSITION, DevCom-10107834
-    test_hash_enabled_for_type<std::variant<int> >();
-    test_hash_enabled_for_type<std::variant<int*, long, double, const int> >();
+    test_hash_enabled<std::variant<int> >();
+    test_hash_enabled<std::variant<int*, long, double, const int> >();
 #endif // ^^^ no workaround ^^^
   }
   {
-    test_hash_disabled_for_type<std::variant<int, A>>();
-    test_hash_disabled_for_type<std::variant<const A, void*>>();
+    test_hash_disabled<std::variant<int, A>>();
+    test_hash_disabled<std::variant<const A, void*>>();
   }
   {
 #ifndef __EDG__ // TRANSITION, DevCom-10107834
-    test_hash_enabled_for_type<std::variant<int, B>>();
-    test_hash_enabled_for_type<std::variant<const B, int>>();
+    test_hash_enabled<std::variant<int, B>>();
+    test_hash_enabled<std::variant<const B, int>>();
 #endif // ^^^ no workaround ^^^
   }
 }

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -32,6 +32,11 @@
 
 #if !defined(_PREFAST_) || !defined(_M_IX86) // TRANSITION, VSO-1639191
 
+#ifndef __clang__ // TRANSITION, LLVM-113633
+#define __SIZEOF_DOUBLE__      8
+#define __SIZEOF_LONG_DOUBLE__ 8
+#endif // ^^^ workaround ^^^
+
 #define _SILENCE_CXX20_VOLATILE_DEPRECATION_WARNING
 #define _LIBCXX_IN_DEVCRT
 #include <msvc_stdlib_force_include.h> // Must precede any other libc++ headers

--- a/tests/std/tests/P0088R3_variant_msvc/test.cpp
+++ b/tests/std/tests/P0088R3_variant_msvc/test.cpp
@@ -1,11 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef __clang__ // TRANSITION, LLVM-113633
-#define __SIZEOF_DOUBLE__      8
-#define __SIZEOF_LONG_DOUBLE__ 8
-#endif // ^^^ workaround ^^^
-
 #define _SILENCE_CXX23_ALIGNED_UNION_DEPRECATION_WARNING
 #define _LIBCXX_IN_DEVCRT
 #include <msvc_stdlib_force_include.h> // Must precede any other libc++ headers

--- a/tests/std/tests/P0088R3_variant_msvc/test.cpp
+++ b/tests/std/tests/P0088R3_variant_msvc/test.cpp
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#ifndef __clang__ // TRANSITION, LLVM-113633
+#define __SIZEOF_DOUBLE__      8
+#define __SIZEOF_LONG_DOUBLE__ 8
+#endif // ^^^ workaround ^^^
+
 #define _SILENCE_CXX23_ALIGNED_UNION_DEPRECATION_WARNING
 #define _LIBCXX_IN_DEVCRT
 #include <msvc_stdlib_force_include.h> // Must precede any other libc++ headers

--- a/tests/std/tests/P0220R1_any/test.cpp
+++ b/tests/std/tests/P0220R1_any/test.cpp
@@ -706,7 +706,7 @@ int run_test()
         struct TestConstexpr : public std::any {
           constexpr TestConstexpr() : std::any() {}
         };
-        static TEST_CONSTINIT std::any a;
+        TEST_CONSTINIT static std::any a;
         (void)a;
     }
 #endif // ^^^ no workaround ^^^

--- a/tests/std/tests/P0220R1_any/test.cpp
+++ b/tests/std/tests/P0220R1_any/test.cpp
@@ -26,11 +26,6 @@
 // Yes, this is an awkward hand process; notably the required headers can change without notice. We should investigate
 // running the libc++ tests directly in all of our configurations so we needn't replicate this subset of files.
 
-#ifndef __clang__ // TRANSITION, LLVM-113633
-#define __SIZEOF_DOUBLE__      8
-#define __SIZEOF_LONG_DOUBLE__ 8
-#endif // ^^^ workaround ^^^
-
 #define _LIBCXX_IN_DEVCRT
 #include <msvc_stdlib_force_include.h> // Must precede any other libc++ headers
 #include <stdlib.h>

--- a/tests/std/tests/P0220R1_any/test.cpp
+++ b/tests/std/tests/P0220R1_any/test.cpp
@@ -26,6 +26,11 @@
 // Yes, this is an awkward hand process; notably the required headers can change without notice. We should investigate
 // running the libc++ tests directly in all of our configurations so we needn't replicate this subset of files.
 
+#ifndef __clang__ // TRANSITION, LLVM-113633
+#define __SIZEOF_DOUBLE__      8
+#define __SIZEOF_LONG_DOUBLE__ 8
+#endif // ^^^ workaround ^^^
+
 #define _LIBCXX_IN_DEVCRT
 #include <msvc_stdlib_force_include.h> // Must precede any other libc++ headers
 #include <stdlib.h>

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -28,6 +28,11 @@
 // Yes, this is an awkward hand process; notably the required headers can change without notice. We should investigate
 // running the libc++ tests directly in all of our configurations so we needn't replicate this subset of files.
 
+#ifndef __clang__ // TRANSITION, LLVM-113633
+#define __SIZEOF_DOUBLE__      8
+#define __SIZEOF_LONG_DOUBLE__ 8
+#endif // ^^^ workaround ^^^
+
 #define _LIBCXX_IN_DEVCRT
 #include <msvc_stdlib_force_include.h> // Must precede any other libc++ headers
 #include <stdlib.h>

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -862,18 +862,18 @@ int run_test()
     }
     {
 #ifndef __EDG__ // TRANSITION, DevCom-10107834
-      test_hash_enabled_for_type<std::optional<int> >();
-      test_hash_enabled_for_type<std::optional<int*> >();
-      test_hash_enabled_for_type<std::optional<const int> >();
-      test_hash_enabled_for_type<std::optional<int* const> >();
+      test_hash_enabled<std::optional<int> >();
+      test_hash_enabled<std::optional<int*> >();
+      test_hash_enabled<std::optional<const int> >();
+      test_hash_enabled<std::optional<int* const> >();
 #endif // ^^^ no workaround ^^^
 
-      test_hash_disabled_for_type<std::optional<A>>();
-      test_hash_disabled_for_type<std::optional<const A>>();
+      test_hash_disabled<std::optional<A>>();
+      test_hash_disabled<std::optional<const A>>();
 
 #ifndef __EDG__ // TRANSITION, DevCom-10107834
-      test_hash_enabled_for_type<std::optional<B>>();
-      test_hash_enabled_for_type<std::optional<const B>>();
+      test_hash_enabled<std::optional<B>>();
+      test_hash_enabled<std::optional<const B>>();
 #endif // ^^^ no workaround ^^^
     }
 

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -28,11 +28,6 @@
 // Yes, this is an awkward hand process; notably the required headers can change without notice. We should investigate
 // running the libc++ tests directly in all of our configurations so we needn't replicate this subset of files.
 
-#ifndef __clang__ // TRANSITION, LLVM-113633
-#define __SIZEOF_DOUBLE__      8
-#define __SIZEOF_LONG_DOUBLE__ 8
-#endif // ^^^ workaround ^^^
-
 #define _LIBCXX_IN_DEVCRT
 #include <msvc_stdlib_force_include.h> // Must precede any other libc++ headers
 #include <stdlib.h>


### PR DESCRIPTION
It's been 2 months since #4910, let's do this again.

* Update llvm-project.
* Enable passing tests.
* Update reasons for `algorithm.version.compile.pass.cpp` failing.
* Add [P2674R1](https://wg21.link/P2674R1) `is_implicit_lifetime` to missing STL features.
  + Tracked by #3445.
* MSVC implemented multidim subscripts, but this is blocked by a `constexpr` bug.
* Reported llvm/llvm-project#113609.
* llvm/llvm-project#108296 renamed `test_hash_enabled_for_type` => `test_hash_enabled` and `test_hash_disabled_for_type` => `test_hash_disabled`.
* Apply change from llvm/llvm-project#108956 to `P0220R1_any`.
