### PR TITLE
Add `.mailmap` file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This file maps author and committer email addresses to canonical names and email
+# addresses for display in the output of `git log` and `git blame`.
+# Format:
+# Canonical Name <canonical@address.dns> <actual@address.dns>
+
+Amy Wishnousky <amyw@microsoft.com> <stwish@microsoft.com>
+Anju del Moral Gonzalez <delMoralGonzalez.Anju@microsoft.com> <judelmor@microsoft.com>

--- a/.mailmap
+++ b/.mailmap
@@ -4,7 +4,8 @@
 # This file maps author and committer email addresses to canonical names and email
 # addresses for display in the output of `git log` and `git blame`.
 # Format:
-# Canonical Name <canonical@example.com> <actual@example.com>
+# Canonical Name <canonical@example.com> <commit@example.com>
+
 
 Amy Wishnousky <amyw@microsoft.com> <stwish@microsoft.com>
 Anju del Moral Gonzalez <delMoralGonzalez.Anju@microsoft.com> <judelmor@microsoft.com>

--- a/.mailmap
+++ b/.mailmap
@@ -4,7 +4,7 @@
 # This file maps author and committer email addresses to canonical names and email
 # addresses for display in the output of `git log` and `git blame`.
 # Format:
-# Canonical Name <canonical@address.dns> <actual@address.dns>
+# Canonical Name <canonical@example.com> <actual@example.com>
 
 Amy Wishnousky <amyw@microsoft.com> <stwish@microsoft.com>
 Anju del Moral Gonzalez <delMoralGonzalez.Anju@microsoft.com> <judelmor@microsoft.com>


### PR DESCRIPTION
Git will use this file to determine a canonical name and email address for each committer and/or author email address to display in the output of `git log` and `git blame`. This is useful when people change names or emails or if someone wants to map their different accounts to a single canonical set of info.

See https://git-scm.com/docs/gitmailmap for details.
