### PR TITLE
Refactor `_Copy_memmove` and `_Copy_memmove_n`

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1539,24 +1539,26 @@ namespace ranges {
             requires indirectly_copyable<_It, _Out>
         _STATIC_CALL_OPERATOR constexpr copy_n_result<_It, _Out> operator()(
             _It _First, iter_difference_t<_It> _Count, _Out _Output) _CONST_CALL_OPERATOR {
-            auto _UFirst  = _STD _Get_unwrapped_n(_STD move(_First), _Count);
-            auto _UOutput = _STD _Get_unwrapped_n(_STD move(_Output), _Count);
-            if constexpr (_Iter_copy_cat<decltype(_UFirst), decltype(_UOutput)>::_Bitcopy_assignable) {
-                if (!_STD is_constant_evaluated()) {
-                    _UOutput = _STD _Copy_memmove_n(_UFirst, static_cast<size_t>(_Count), _STD move(_UOutput));
-                    _UFirst += _Count;
-                    _STD _Seek_wrapped(_First, _STD move(_UFirst));
-                    _STD _Seek_wrapped(_Output, _STD move(_UOutput));
-                    return {_STD move(_First), _STD move(_Output)};
+            if (_Count > 0) {
+                auto _UFirst  = _STD _Get_unwrapped_n(_STD move(_First), _Count);
+                auto _UOutput = _STD _Get_unwrapped_n(_STD move(_Output), _Count);
+                if constexpr (_Iter_copy_cat<decltype(_UFirst), decltype(_UOutput)>::_Bitcopy_assignable) {
+                    if (!_STD is_constant_evaluated()) {
+                        _UOutput = _STD _Copy_memmove_n(_UFirst, static_cast<size_t>(_Count), _STD move(_UOutput));
+                        _UFirst += _Count;
+                        _STD _Seek_wrapped(_First, _STD move(_UFirst));
+                        _STD _Seek_wrapped(_Output, _STD move(_UOutput));
+                        return {_STD move(_First), _STD move(_Output)};
+                    }
                 }
-            }
 
-            for (; _Count > 0; ++_UFirst, (void) ++_UOutput, --_Count) {
-                *_UOutput = *_UFirst;
-            }
+                for (; _Count > 0; ++_UFirst, (void) ++_UOutput, --_Count) {
+                    *_UOutput = *_UFirst;
+                }
 
-            _STD _Seek_wrapped(_First, _STD move(_UFirst));
-            _STD _Seek_wrapped(_Output, _STD move(_UOutput));
+                _STD _Seek_wrapped(_First, _STD move(_UFirst));
+                _STD _Seek_wrapped(_Output, _STD move(_UOutput));
+            }
             return {_STD move(_First), _STD move(_Output)};
         }
     };

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4763,9 +4763,8 @@ template <class _InIt, class _SizeTy, class _OutIt>
 _CONSTEXPR20 _OutIt _Copy_n_unchecked4(_InIt _First, _SizeTy _Count, _OutIt _Dest) {
     // copy _First + [0, _Count) to _Dest + [0, _Count), returning _Dest + _Count
     // note: has callers outside the copy family
-#if _HAS_CXX20
     _STL_INTERNAL_STATIC_ASSERT(_Integer_like<_SizeTy>);
-#endif // _HAS_CXX20
+    _STL_INTERNAL_CHECK(_Count >= 0);
 
     if constexpr (_Iter_copy_cat<_InIt, _OutIt>::_Bitcopy_assignable) {
 #if _HAS_CXX20

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4708,32 +4708,40 @@ _CONSTEXPR20 void _Verify_ranges_do_not_overlap(const _Iter1& _First1, const _Se
 #endif // _ITERATOR_DEBUG_LEVEL != 2 ^^^
 }
 
-template <class _CtgIt, class _OutCtgIt>
-_OutCtgIt _Copy_memmove(_CtgIt _First, _CtgIt _Last, _OutCtgIt _Dest) {
-    auto _FirstPtr              = _STD _To_address(_First);
-    auto _LastPtr               = _STD _To_address(_Last);
-    auto _DestPtr               = _STD _To_address(_Dest);
-    const char* const _First_ch = const_cast<const char*>(reinterpret_cast<const volatile char*>(_FirstPtr));
-    const char* const _Last_ch  = const_cast<const char*>(reinterpret_cast<const volatile char*>(_LastPtr));
-    char* const _Dest_ch        = const_cast<char*>(reinterpret_cast<const volatile char*>(_DestPtr));
-    const auto _Count           = static_cast<size_t>(_Last_ch - _First_ch);
-    _CSTD memmove(_Dest_ch, _First_ch, _Count);
+template <class _OutCtgIt>
+_OutCtgIt _Copy_memmove_tail(
+    const char* const _First_ch, _OutCtgIt const _Dest, const size_t _Byte_count, const size_t _Object_count) {
+    _STL_INTERNAL_CHECK(_Byte_count == _Object_count * sizeof(*_Dest));
+    const auto _DestPtr  = _STD _To_address(_Dest);
+    char* const _Dest_ch = const_cast<char*>(reinterpret_cast<const volatile char*>(_DestPtr));
+    _CSTD memmove(_Dest_ch, _First_ch, _Byte_count);
     if constexpr (is_pointer_v<_OutCtgIt>) {
+        (void) _Object_count;
         // CodeQL [SM02986] This cast is correct: we're bypassing pointer arithmetic for performance.
-        return reinterpret_cast<_OutCtgIt>(_Dest_ch + _Count);
+        return reinterpret_cast<_OutCtgIt>(_Dest_ch + _Byte_count);
     } else {
-        return _Dest + static_cast<_Iter_diff_t<_OutCtgIt>>(_LastPtr - _FirstPtr);
+        return _Dest + static_cast<_Iter_diff_t<_OutCtgIt>>(_Object_count);
     }
 }
 
 template <class _CtgIt, class _OutCtgIt>
-_OutCtgIt _Copy_memmove_n(_CtgIt _First, const size_t _Count, _OutCtgIt _Dest) {
-    const auto _Result = _STD _Copy_memmove(_First, _First + _Count, _Dest);
-    if constexpr (is_pointer_v<_OutCtgIt>) {
-        return _Result;
-    } else { // _Result is unused so the compiler can optimize it away
-        return _Dest + static_cast<_Iter_diff_t<_OutCtgIt>>(_Count);
-    }
+_OutCtgIt _Copy_memmove(_CtgIt _First, _CtgIt _Last, _OutCtgIt _Dest) {
+    _STL_INTERNAL_CHECK(_First <= _Last);
+    const auto _FirstPtr        = _STD _To_address(_First);
+    const auto _LastPtr         = _STD _To_address(_Last);
+    const auto _Object_count    = static_cast<size_t>(_LastPtr - _FirstPtr);
+    const char* const _First_ch = const_cast<const char*>(reinterpret_cast<const volatile char*>(_FirstPtr));
+    const char* const _Last_ch  = const_cast<const char*>(reinterpret_cast<const volatile char*>(_LastPtr));
+    const auto _Byte_count      = static_cast<size_t>(_Last_ch - _First_ch);
+    return _STD _Copy_memmove_tail(_First_ch, _STD move(_Dest), _Byte_count, _Object_count);
+}
+
+template <class _CtgIt, class _OutCtgIt>
+_OutCtgIt _Copy_memmove_n(_CtgIt _First, const size_t _Object_count, _OutCtgIt _Dest) {
+    const auto _FirstPtr        = _STD _To_address(_First);
+    const char* const _First_ch = const_cast<const char*>(reinterpret_cast<const volatile char*>(_FirstPtr));
+    const auto _Byte_count      = _Object_count * sizeof(*_FirstPtr);
+    return _STD _Copy_memmove_tail(_First_ch, _STD move(_Dest), _Byte_count, _Object_count);
 }
 
 template <class _It, bool _RequiresMutable = false>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4712,8 +4712,8 @@ template <class _OutCtgIt>
 _OutCtgIt _Copy_memmove_tail(
     const char* const _First_ch, const _OutCtgIt _Dest, const size_t _Byte_count, const size_t _Object_count) {
     _STL_INTERNAL_CHECK(_Byte_count == _Object_count * sizeof(*_Dest));
-    const auto _DestPtr  = _STD _To_address(_Dest);
-    char* const _Dest_ch = const_cast<char*>(reinterpret_cast<const volatile char*>(_DestPtr));
+    const auto _Dest_ptr = _STD _To_address(_Dest);
+    char* const _Dest_ch = const_cast<char*>(reinterpret_cast<const volatile char*>(_Dest_ptr));
     _CSTD memmove(_Dest_ch, _First_ch, _Byte_count);
     if constexpr (is_pointer_v<_OutCtgIt>) {
         (void) _Object_count;
@@ -4727,20 +4727,20 @@ _OutCtgIt _Copy_memmove_tail(
 template <class _CtgIt, class _OutCtgIt>
 _OutCtgIt _Copy_memmove(_CtgIt _First, _CtgIt _Last, _OutCtgIt _Dest) {
     _STL_INTERNAL_CHECK(_First <= _Last);
-    const auto _FirstPtr        = _STD _To_address(_First);
-    const auto _LastPtr         = _STD _To_address(_Last);
-    const auto _Object_count    = static_cast<size_t>(_LastPtr - _FirstPtr);
-    const char* const _First_ch = const_cast<const char*>(reinterpret_cast<const volatile char*>(_FirstPtr));
-    const char* const _Last_ch  = const_cast<const char*>(reinterpret_cast<const volatile char*>(_LastPtr));
+    const auto _First_ptr       = _STD _To_address(_First);
+    const auto _Last_ptr        = _STD _To_address(_Last);
+    const auto _Object_count    = static_cast<size_t>(_Last_ptr - _First_ptr);
+    const char* const _First_ch = const_cast<const char*>(reinterpret_cast<const volatile char*>(_First_ptr));
+    const char* const _Last_ch  = const_cast<const char*>(reinterpret_cast<const volatile char*>(_Last_ptr));
     const auto _Byte_count      = static_cast<size_t>(_Last_ch - _First_ch);
     return _STD _Copy_memmove_tail(_First_ch, _STD move(_Dest), _Byte_count, _Object_count);
 }
 
 template <class _CtgIt, class _OutCtgIt>
 _OutCtgIt _Copy_memmove_n(_CtgIt _First, const size_t _Object_count, _OutCtgIt _Dest) {
-    const auto _FirstPtr        = _STD _To_address(_First);
-    const char* const _First_ch = const_cast<const char*>(reinterpret_cast<const volatile char*>(_FirstPtr));
-    const auto _Byte_count      = _Object_count * sizeof(*_FirstPtr);
+    const auto _First_ptr       = _STD _To_address(_First);
+    const char* const _First_ch = const_cast<const char*>(reinterpret_cast<const volatile char*>(_First_ptr));
+    const auto _Byte_count      = _Object_count * sizeof(*_First_ptr);
     return _STD _Copy_memmove_tail(_First_ch, _STD move(_Dest), _Byte_count, _Object_count);
 }
 
@@ -5048,18 +5048,18 @@ _FwdIt2 copy_n(_ExPo&&, _FwdIt1 _First, _Diff _Count_raw, _FwdIt2 _Dest) noexcep
 template <class _CtgIt1, class _CtgIt2>
 _CtgIt2 _Copy_backward_memmove(_CtgIt1 _First, _CtgIt1 _Last, _CtgIt2 _Dest) {
     // implement copy_backward-like function as memmove
-    auto _FirstPtr              = _STD _To_address(_First);
-    auto _LastPtr               = _STD _To_address(_Last);
-    auto _DestPtr               = _STD _To_address(_Dest);
-    const char* const _First_ch = const_cast<const char*>(reinterpret_cast<const volatile char*>(_FirstPtr));
-    const char* const _Last_ch  = const_cast<const char*>(reinterpret_cast<const volatile char*>(_LastPtr));
-    char* const _Dest_ch        = const_cast<char*>(reinterpret_cast<const volatile char*>(_DestPtr));
+    auto _First_ptr             = _STD _To_address(_First);
+    auto _Last_ptr              = _STD _To_address(_Last);
+    auto _Dest_ptr              = _STD _To_address(_Dest);
+    const char* const _First_ch = const_cast<const char*>(reinterpret_cast<const volatile char*>(_First_ptr));
+    const char* const _Last_ch  = const_cast<const char*>(reinterpret_cast<const volatile char*>(_Last_ptr));
+    char* const _Dest_ch        = const_cast<char*>(reinterpret_cast<const volatile char*>(_Dest_ptr));
     const auto _Count           = static_cast<size_t>(_Last_ch - _First_ch);
     auto _Result                = _CSTD memmove(_Dest_ch - _Count, _First_ch, _Count);
     if constexpr (is_pointer_v<_CtgIt2>) {
         return static_cast<_CtgIt2>(_Result);
     } else {
-        return _Dest - static_cast<_Iter_diff_t<_CtgIt2>>(_LastPtr - _FirstPtr);
+        return _Dest - static_cast<_Iter_diff_t<_CtgIt2>>(_Last_ptr - _First_ptr);
     }
 }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4713,7 +4713,7 @@ _OutCtgIt _Copy_memmove_tail(
     const char* const _First_ch, const _OutCtgIt _Dest, const size_t _Byte_count, const size_t _Object_count) {
     _STL_INTERNAL_CHECK(_Byte_count == _Object_count * sizeof(*_Dest));
     const auto _Dest_ptr = _STD _To_address(_Dest);
-    char* const _Dest_ch = const_cast<char*>(reinterpret_cast<const volatile char*>(_Dest_ptr));
+    const auto _Dest_ch  = const_cast<char*>(reinterpret_cast<const volatile char*>(_Dest_ptr));
     _CSTD memmove(_Dest_ch, _First_ch, _Byte_count);
     if constexpr (is_pointer_v<_OutCtgIt>) {
         (void) _Object_count;
@@ -4727,20 +4727,20 @@ _OutCtgIt _Copy_memmove_tail(
 template <class _CtgIt, class _OutCtgIt>
 _OutCtgIt _Copy_memmove(_CtgIt _First, _CtgIt _Last, _OutCtgIt _Dest) {
     _STL_INTERNAL_CHECK(_First <= _Last);
-    const auto _First_ptr       = _STD _To_address(_First);
-    const auto _Last_ptr        = _STD _To_address(_Last);
-    const auto _Object_count    = static_cast<size_t>(_Last_ptr - _First_ptr);
-    const char* const _First_ch = const_cast<const char*>(reinterpret_cast<const volatile char*>(_First_ptr));
-    const char* const _Last_ch  = const_cast<const char*>(reinterpret_cast<const volatile char*>(_Last_ptr));
-    const auto _Byte_count      = static_cast<size_t>(_Last_ch - _First_ch);
+    const auto _First_ptr    = _STD _To_address(_First);
+    const auto _Last_ptr     = _STD _To_address(_Last);
+    const auto _Object_count = static_cast<size_t>(_Last_ptr - _First_ptr);
+    const auto _First_ch     = const_cast<const char*>(reinterpret_cast<const volatile char*>(_First_ptr));
+    const auto _Last_ch      = const_cast<const char*>(reinterpret_cast<const volatile char*>(_Last_ptr));
+    const auto _Byte_count   = static_cast<size_t>(_Last_ch - _First_ch);
     return _STD _Copy_memmove_tail(_First_ch, _STD move(_Dest), _Byte_count, _Object_count);
 }
 
 template <class _CtgIt, class _OutCtgIt>
 _OutCtgIt _Copy_memmove_n(_CtgIt _First, const size_t _Object_count, _OutCtgIt _Dest) {
-    const auto _First_ptr       = _STD _To_address(_First);
-    const char* const _First_ch = const_cast<const char*>(reinterpret_cast<const volatile char*>(_First_ptr));
-    const auto _Byte_count      = _Object_count * sizeof(*_First_ptr);
+    const auto _First_ptr  = _STD _To_address(_First);
+    const auto _First_ch   = const_cast<const char*>(reinterpret_cast<const volatile char*>(_First_ptr));
+    const auto _Byte_count = _Object_count * sizeof(*_First_ptr);
     return _STD _Copy_memmove_tail(_First_ch, _STD move(_Dest), _Byte_count, _Object_count);
 }
 
@@ -5048,14 +5048,14 @@ _FwdIt2 copy_n(_ExPo&&, _FwdIt1 _First, _Diff _Count_raw, _FwdIt2 _Dest) noexcep
 template <class _CtgIt1, class _CtgIt2>
 _CtgIt2 _Copy_backward_memmove(_CtgIt1 _First, _CtgIt1 _Last, _CtgIt2 _Dest) {
     // implement copy_backward-like function as memmove
-    auto _First_ptr             = _STD _To_address(_First);
-    auto _Last_ptr              = _STD _To_address(_Last);
-    auto _Dest_ptr              = _STD _To_address(_Dest);
-    const char* const _First_ch = const_cast<const char*>(reinterpret_cast<const volatile char*>(_First_ptr));
-    const char* const _Last_ch  = const_cast<const char*>(reinterpret_cast<const volatile char*>(_Last_ptr));
-    char* const _Dest_ch        = const_cast<char*>(reinterpret_cast<const volatile char*>(_Dest_ptr));
-    const auto _Count           = static_cast<size_t>(_Last_ch - _First_ch);
-    auto _Result                = _CSTD memmove(_Dest_ch - _Count, _First_ch, _Count);
+    const auto _First_ptr = _STD _To_address(_First);
+    const auto _Last_ptr  = _STD _To_address(_Last);
+    const auto _Dest_ptr  = _STD _To_address(_Dest);
+    const auto _First_ch  = const_cast<const char*>(reinterpret_cast<const volatile char*>(_First_ptr));
+    const auto _Last_ch   = const_cast<const char*>(reinterpret_cast<const volatile char*>(_Last_ptr));
+    const auto _Dest_ch   = const_cast<char*>(reinterpret_cast<const volatile char*>(_Dest_ptr));
+    const auto _Count     = static_cast<size_t>(_Last_ch - _First_ch);
+    const auto _Result    = _CSTD memmove(_Dest_ch - _Count, _First_ch, _Count);
     if constexpr (is_pointer_v<_CtgIt2>) {
         return static_cast<_CtgIt2>(_Result);
     } else {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4710,7 +4710,7 @@ _CONSTEXPR20 void _Verify_ranges_do_not_overlap(const _Iter1& _First1, const _Se
 
 template <class _OutCtgIt>
 _OutCtgIt _Copy_memmove_tail(
-    const char* const _First_ch, _OutCtgIt const _Dest, const size_t _Byte_count, const size_t _Object_count) {
+    const char* const _First_ch, const _OutCtgIt _Dest, const size_t _Byte_count, const size_t _Object_count) {
     _STL_INTERNAL_CHECK(_Byte_count == _Object_count * sizeof(*_Dest));
     const auto _DestPtr  = _STD _To_address(_Dest);
     char* const _Dest_ch = const_cast<char*>(reinterpret_cast<const volatile char*>(_DestPtr));

--- a/tests/std/tests/GH_000431_copy_move_family/test.cpp
+++ b/tests/std/tests/GH_000431_copy_move_family/test.cpp
@@ -682,8 +682,8 @@ struct MyIterator { // A contiguous iterator with a weirdly narrow difference ty
 
     auto operator<=>(const MyIterator&) const = default;
 
-    value_type& operator[](difference_type i) const {
-        return ptr[i];
+    value_type& operator[](difference_type n) const {
+        return ptr[n];
     }
 
     MyIterator& operator+=(difference_type n) {

--- a/tests/std/tests/GH_000431_copy_move_family/test.cpp
+++ b/tests/std/tests/GH_000431_copy_move_family/test.cpp
@@ -680,7 +680,6 @@ struct MyIterator { // A contiguous iterator with a weirdly narrow difference ty
         return tmp;
     }
 
-    bool operator==(const MyIterator&) const  = default;
     auto operator<=>(const MyIterator&) const = default;
 
     value_type& operator[](difference_type i) const {

--- a/tests/std/tests/GH_000431_copy_move_family/test.cpp
+++ b/tests/std/tests/GH_000431_copy_move_family/test.cpp
@@ -644,7 +644,7 @@ void test_algorithms(CopyFn copy_fn) {
 
 #if _HAS_CXX20
 struct MyIterator { // A contiguous iterator with a weirdly narrow difference type
-    using iterator_concept = std::contiguous_iterator_tag;
+    using iterator_concept = contiguous_iterator_tag;
     using value_type       = int;
     using difference_type  = short;
 
@@ -708,16 +708,16 @@ struct MyIterator { // A contiguous iterator with a weirdly narrow difference ty
         return i + n;
     }
 };
-static_assert(std::contiguous_iterator<MyIterator>);
+static_assert(contiguous_iterator<MyIterator>);
 
 void test_copy_n_regressions() {
     // _Copy_memmove_n was adding a size_t to an iterator without converting to its difference_type:
     //  warning C4267: 'argument': conversion from 'size_t' to 'MyIterator::difference_type', possible loss of data
-    std::copy_n(MyIterator{}, -42, MyIterator{});
+    copy_n(MyIterator{}, -42, MyIterator{});
 
     // ranges::copy_n wasn't guarding against negative n when calling the memmove optimization
     int x = 42;
-    std::ranges::copy_n(&x, -42, &x);
+    ranges::copy_n(&x, -42, &x);
 }
 #endif // _HAS_CXX20
 

--- a/tests/std/tests/GH_000431_copy_move_family/test.cpp
+++ b/tests/std/tests/GH_000431_copy_move_family/test.cpp
@@ -648,10 +648,10 @@ struct MyIterator { // A contiguous iterator with a weirdly narrow difference ty
     using value_type       = int;
     using difference_type  = short;
 
-    int* ptr = nullptr;
+    value_type* ptr = nullptr;
 
     MyIterator() = default;
-    explicit MyIterator(int* p) : ptr{p} {}
+    explicit MyIterator(value_type* p) : ptr{p} {}
 
     value_type& operator*() const {
         return *ptr;


### PR DESCRIPTION
* BUG: `_Copy_memmove_n` adds a `size_t` directly to an iterator.
* BUG: `ranges::copy_n` converts `n` to `size_t` without verifying it is non-negative.
* There's a redundant recalculation of `n` in our existing implementation of `_Copy_memmove_n` which calls `_Copy_memmove`. Eliminate that redundancy by extracting the commonality into a new function `_Copy_memmove_tail` called by both `_Copy_memmove` and `_Copy_memmove_n`. 
* `_Copy_n_unchecked4` should verify its precondition that `n >= 0`. Drive-by: We can unconditionally `_STL_INTERNAL_STATIC_ASSERT(_Integer_like<_SizeTy>)` since #5015 defined `_Integer_like` in pre-20 modes
