### PR TITLE
[DO NOT MERGE - INFRA TEST] Meow iter swap

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1699,7 +1699,7 @@ namespace ranges {
         }
 
         for (; _First != _Last; ++_First, (void) ++_Output) {
-            *_Output = _RANGES iter_move(_First);
+            *_Output = _RANGES _Woof_iter_move(_First);
         }
 
         return {_STD move(_First), _STD move(_Output)};
@@ -1754,7 +1754,7 @@ namespace ranges {
         }
 
         while (_First != _Last) {
-            *--_Output = _RANGES iter_move(--_Last);
+            *--_Output = _RANGES _Woof_iter_move(--_Last);
         }
 
         return _Output;
@@ -3701,7 +3701,7 @@ namespace ranges {
 #endif // _USE_STD_VECTOR_ALGORITHMS
 
             for (; _First1 != _Last1 && _First2 != _Last2; ++_First1, (void) ++_First2) {
-                _RANGES iter_swap(_First1, _First2);
+                _RANGES _Meow_iter_swap(_First1, _First2);
             }
 
             return {_STD move(_First1), _STD move(_First2)};
@@ -4615,7 +4615,7 @@ namespace ranges {
 
             while (++_First != _Last) {
                 if (_STD invoke(_Proj, *_First) != _Val) {
-                    *_Next = _RANGES iter_move(_First);
+                    *_Next = _RANGES _Woof_iter_move(_First);
                     ++_Next;
                 }
             }
@@ -4667,7 +4667,7 @@ namespace ranges {
 
             while (++_First != _Last) {
                 if (!_STD invoke(_Pred, _STD invoke(_Proj, *_First))) {
-                    *_Next = _RANGES iter_move(_First);
+                    *_Next = _RANGES _Woof_iter_move(_First);
                     ++_Next;
                 }
             }
@@ -4898,7 +4898,7 @@ namespace ranges {
             while (++_First != _Last) {
                 if (!_STD invoke(_Pred, _STD invoke(_Proj, *_Current), _STD invoke(_Proj, *_First))) {
                     ++_Current;
-                    *_Current = _RANGES iter_move(_First);
+                    *_Current = _RANGES _Woof_iter_move(_First);
                 }
             }
             ++_Current;
@@ -5124,7 +5124,7 @@ namespace ranges {
 #endif // _USE_STD_VECTOR_ALGORITHMS
 
         for (; _First != _Last && _First != --_Last; ++_First) {
-            _RANGES iter_swap(_First, _Last);
+            _RANGES _Meow_iter_swap(_First, _Last);
         }
     }
 
@@ -5290,7 +5290,7 @@ namespace ranges {
         _STL_INTERNAL_CHECK(_Mid != _Last);
 
         do {
-            _RANGES iter_swap(_First, --_Last);
+            _RANGES _Meow_iter_swap(_First, --_Last);
         } while (++_First != _Mid && _Last != _Mid);
 
         return {_STD move(_First), _STD move(_Last)};
@@ -5335,7 +5335,7 @@ namespace ranges {
         } else {
             auto _Next = _Mid;
             do { // rotate the first cycle
-                _RANGES iter_swap(_First, _Next);
+                _RANGES _Meow_iter_swap(_First, _Next);
                 ++_First;
                 ++_Next;
                 if (_First == _Mid) {
@@ -5348,7 +5348,7 @@ namespace ranges {
             while (_Mid != _Last) { // rotate subsequent cycles
                 _Next = _Mid;
                 do {
-                    _RANGES iter_swap(_First, _Next);
+                    _RANGES _Meow_iter_swap(_First, _Next);
                     ++_First;
                     ++_Next;
                     if (_First == _Mid) {
@@ -5811,7 +5811,7 @@ namespace ranges {
                 const _Diff _Off = _Func(_Target_index + 1);
                 _STL_ASSERT(0 <= _Off && _Off <= _Target_index, "random value out of range");
                 if (_Off != _Target_index) { // avoid self-move-assignment
-                    _RANGES iter_swap(_Target, _First + _Off);
+                    _RANGES _Meow_iter_swap(_Target, _First + _Off);
                 }
             }
             return _Target;
@@ -6104,7 +6104,7 @@ namespace ranges {
             requires indirectly_movable<_It, _Out>
         _NODISCARD static constexpr _Out _Move_n_helper(_It _First, iter_difference_t<_It> _Count, _Out _Output) {
             for (; _Count > 0; ++_First, (void) --_Count, ++_Output) {
-                *_Output = _RANGES iter_move(_First);
+                *_Output = _RANGES _Woof_iter_move(_First);
             }
 
             return _Output;
@@ -6202,7 +6202,7 @@ namespace ranges {
                             return {_STD move(_Buf), _STD move(_Trail)};
                         }
 
-                        _RANGES iter_swap(_Mid, _Trail);
+                        _RANGES _Meow_iter_swap(_Mid, _Trail);
                     }
                 }
             }
@@ -6326,7 +6326,7 @@ namespace ranges {
                         }
                     } while (!_STD invoke(_Pred, _STD invoke(_Proj, *_Last)));
 
-                    _RANGES iter_swap(_First, _Last); // out of place, swap and loop
+                    _RANGES _Meow_iter_swap(_First, _Last); // out of place, swap and loop
                 }
 
                 return {_STD move(_First), _STD move(_Saved_last)};
@@ -6344,7 +6344,7 @@ namespace ranges {
                 auto _Next = _First;
                 while (++_Next != _Last) {
                     if (_STD invoke(_Pred, _STD invoke(_Proj, *_Next))) {
-                        _RANGES iter_swap(_First, _Next); // out of place, swap and loop
+                        _RANGES _Meow_iter_swap(_First, _Next); // out of place, swap and loop
                         ++_First;
                     }
                 }
@@ -6649,20 +6649,20 @@ namespace ranges {
             if (_Count - 1 <= _Capacity) { // - 1 since we never need to store *_Last
                 _Uninitialized_backout<iter_value_t<_It>*> _Backout{_Temp_ptr};
                 _It _Next = _First;
-                _Backout._Emplace_back(_RANGES iter_move(_First));
+                _Backout._Emplace_back(_RANGES _Woof_iter_move(_First));
                 while (++_First != _Last) {
                     // test each element, moving into the temporary buffer if it's in the false range, or
                     // assigning backwards if it's in the true range
                     if (_STD invoke(_Pred, _STD invoke(_Proj, *_First))) {
-                        *_Next = _RANGES iter_move(_First);
+                        *_Next = _RANGES _Woof_iter_move(_First);
                         ++_Next;
                     } else {
-                        _Backout._Emplace_back(_RANGES iter_move(_First));
+                        _Backout._Emplace_back(_RANGES _Woof_iter_move(_First));
                     }
                 }
 
                 // move the last true element, *_Last, to the end of the true range
-                *_Next = _RANGES iter_move(_Last);
+                *_Next = _RANGES _Woof_iter_move(_Last);
                 ++_Next;
                 // copy back the false range
                 _RANGES _Move_unchecked(_Backout._First, _Backout._Last, _Next);
@@ -6741,7 +6741,7 @@ namespace ranges {
             }
 
             // move _Hole up to parent
-            *(_First + _Hole) = _RANGES iter_move(_First + _Idx);
+            *(_First + _Hole) = _RANGES _Woof_iter_move(_First + _Idx);
             _Hole             = _Idx;
         }
 
@@ -6788,7 +6788,7 @@ namespace ranges {
             }
 
             --_Last;
-            iter_value_t<_It> _Val(_RANGES iter_move(_Last));
+            iter_value_t<_It> _Val(_RANGES _Woof_iter_move(_Last));
             // NB: if _Proj is a _Ref_fn, this aliases the _Proj1 and _Proj2 parameters of _Push_heap_by_index
             _RANGES _Push_heap_by_index(_STD move(_First), _Count - 1, 0, _STD move(_Val), _Pred, _Proj, _Proj);
         }
@@ -6819,12 +6819,12 @@ namespace ranges {
                 --_Idx;
                 --_Mid;
             }
-            *(_First + _Hole) = _RANGES iter_move(_Mid);
+            *(_First + _Hole) = _RANGES _Woof_iter_move(_Mid);
             _Hole             = _Idx;
         }
 
         if (_Idx == _Max_sequence_non_leaf && _Bottom % 2 == 0) { // only child at bottom, move _Hole down to it
-            *(_First + _Hole) = _RANGES iter_move(_First + (_Bottom - 1));
+            *(_First + _Hole) = _RANGES _Woof_iter_move(_First + (_Bottom - 1));
             _Hole             = _Bottom - 1;
         }
 
@@ -6840,7 +6840,7 @@ namespace ranges {
         _STL_INTERNAL_CHECK(_First != _Last);
         _STL_INTERNAL_CHECK(_First != _Dest);
 
-        *_Dest            = _RANGES iter_move(_First);
+        *_Dest            = _RANGES _Woof_iter_move(_First);
         const auto _Count = _Last - _First;
         _RANGES _Pop_heap_hole_by_index(_STD move(_First), 0, _Count, _STD forward<_Ty>(_Val), _Pred, _Proj1, _Proj2);
     }
@@ -6854,7 +6854,7 @@ namespace ranges {
         }
 
         --_Last;
-        iter_value_t<_It> _Val(_RANGES iter_move(_Last));
+        iter_value_t<_It> _Val(_RANGES _Woof_iter_move(_Last));
         // NB: if _Proj is a _Ref_fn, this aliases the _Proj1 and _Proj2 parameters of _Pop_heap_hole_unchecked
         _RANGES _Pop_heap_hole_unchecked(_STD move(_First), _Last, _Last, _STD move(_Val), _Pred, _Proj, _Proj);
     }
@@ -6900,7 +6900,7 @@ namespace ranges {
         for (_Diff _Hole = _Bottom >> 1; _Hole > 0;) { // shift for codegen
             // reheap top half, bottom to top
             --_Hole;
-            iter_value_t<_It> _Val(_RANGES iter_move(_First + _Hole));
+            iter_value_t<_It> _Val(_RANGES _Woof_iter_move(_First + _Hole));
             // NB: if _Proj is a _Ref_fn, this aliases the _Proj1 and _Proj2 parameters of _Pop_heap_hole_by_index
             _RANGES _Pop_heap_hole_by_index(_First, _Hole, _Bottom, _STD move(_Val), _Pred, _Proj, _Proj);
         }
@@ -7886,7 +7886,7 @@ namespace ranges {
     void _Rotate_one_right(_It _First, _It _Mid, _It _Last) {
         // exchanges the range [_First, _Mid) with [_Mid, _Last)
         _STL_INTERNAL_CHECK(_RANGES next(_Mid) == _Last);
-        iter_value_t<_It> _Temp(_RANGES iter_move(_Mid));
+        iter_value_t<_It> _Temp(_RANGES _Woof_iter_move(_Mid));
         _RANGES _Move_backward_common(_First, _STD move(_Mid), _STD move(_Last));
         *_First = _STD move(_Temp);
     }
@@ -7895,7 +7895,7 @@ namespace ranges {
     void _Rotate_one_left(_It _First, _It _Mid, _It _Last) {
         // exchanges the range [_First, _Mid) with [_Mid, _Last)
         _STL_INTERNAL_CHECK(_RANGES next(_First) == _Mid);
-        iter_value_t<_It> _Temp(_RANGES iter_move(_First));
+        iter_value_t<_It> _Temp(_RANGES _Woof_iter_move(_First));
         auto _Result = _RANGES _Move_unchecked(_STD move(_Mid), _STD move(_Last), _STD move(_First));
         *_Result.out = _STD move(_Temp);
     }
@@ -7915,13 +7915,13 @@ namespace ranges {
         --_Left_last;
 
         // We already know that _Mid points to the lowest element and that there is more than 1 element left.
-        *_First = _RANGES iter_move(_Mid);
+        *_First = _RANGES _Woof_iter_move(_Mid);
         ++_First;
         ++_Mid;
 
         for (;;) {
             if (_STD invoke(_Pred, _STD invoke(_Proj, *_Mid), _STD invoke(_Proj, *_Left_first))) {
-                *_First = _RANGES iter_move(_Mid); // the lowest element is now in position
+                *_First = _RANGES _Woof_iter_move(_Mid); // the lowest element is now in position
                 ++_First;
                 ++_Mid;
                 if (_Mid == _Last) {
@@ -7930,13 +7930,13 @@ namespace ranges {
                     return;
                 }
             } else {
-                *_First = _RANGES iter_move(_Left_first);
+                *_First = _RANGES _Woof_iter_move(_Left_first);
                 ++_First;
                 ++_Left_first;
                 if (_Left_first == _Left_last) {
                     // move the remaining right partition and highest element, since *_Left_first is highest
                     const auto _Final = _RANGES _Move_unchecked(_Mid, _Last, _First);
-                    *_Final.out       = _RANGES iter_move(_Left_first);
+                    *_Final.out       = _RANGES _Woof_iter_move(_Left_first);
                     return;
                 }
             }
@@ -7956,14 +7956,14 @@ namespace ranges {
         _Uninitialized_backout<_Ty*> _Backout{_Right_first, _Right_last};
 
         // We already know that _Mid points to the next highest element and that there is more than 1 element left.
-        *--_Last = _RANGES iter_move(--_Mid);
+        *--_Last = _RANGES _Woof_iter_move(--_Mid);
 
         // We already know that _Backout._Last - 1 is the highest element, so do not compare against it again.
         --_Mid;
         --_Right_last;
         for (;;) {
             if (_STD invoke(_Pred, _STD invoke(_Proj, *_Right_last), _STD invoke(_Proj, *_Mid))) {
-                *--_Last = _RANGES iter_move(_Mid); // the lowest element is now in position
+                *--_Last = _RANGES _Woof_iter_move(_Mid); // the lowest element is now in position
                 if (_First == _Mid) {
                     ++_Right_last; // to make [_Right_first, _Right_last) a half-open range
                     _RANGES _Move_backward_common(_Right_first, _Right_last, _STD move(_Last));
@@ -7971,12 +7971,12 @@ namespace ranges {
                 }
                 --_Mid;
             } else {
-                *--_Last = _RANGES iter_move(_Right_last);
+                *--_Last = _RANGES _Woof_iter_move(_Right_last);
                 --_Right_last;
                 if (_Right_first == _Right_last) { // we can't compare with *_Right_first, but we know it is lowest
                     ++_Mid; // restore half-open range [_First, _Mid)
                     _RANGES _Move_backward_common(_First, _STD move(_Mid), _STD move(_Last));
-                    *_First = _RANGES iter_move(_Right_first);
+                    *_First = _RANGES _Woof_iter_move(_Right_first);
                     return;
                 }
             }
@@ -8379,7 +8379,7 @@ namespace ranges {
         }
 
         for (auto _Mid = _First; ++_Mid != _Last;) { // order next element
-            iter_value_t<_It> _Val(_RANGES iter_move(_Mid));
+            iter_value_t<_It> _Val(_RANGES _Woof_iter_move(_Mid));
             auto _Hole = _Mid;
 
             for (auto _Prev = _Hole;;) {
@@ -8387,7 +8387,7 @@ namespace ranges {
                 if (!_STD invoke(_Pred, _STD invoke(_Proj, _Val), _STD invoke(_Proj, *_Prev))) {
                     break;
                 }
-                *_Hole = _RANGES iter_move(_Prev); // move hole down
+                *_Hole = _RANGES _Woof_iter_move(_Prev); // move hole down
                 if (--_Hole == _First) {
                     break;
                 }
@@ -8403,7 +8403,7 @@ namespace ranges {
     constexpr void _Med3_common(_It _First, _It _Mid, _It _Last, _Pr _Pred, _Pj _Proj) {
         // sort median of three elements to middle
         if (_STD invoke(_Pred, _STD invoke(_Proj, *_Mid), _STD invoke(_Proj, *_First))) {
-            _RANGES iter_swap(_Mid, _First);
+            _RANGES _Meow_iter_swap(_Mid, _First);
         }
 
         if (!_STD invoke(_Pred, _STD invoke(_Proj, *_Last), _STD invoke(_Proj, *_Mid))) {
@@ -8411,10 +8411,10 @@ namespace ranges {
         }
 
         // swap middle and last, then test first again
-        _RANGES iter_swap(_Last, _Mid);
+        _RANGES _Meow_iter_swap(_Last, _Mid);
 
         if (_STD invoke(_Pred, _STD invoke(_Proj, *_Mid), _STD invoke(_Proj, *_First))) {
-            _RANGES iter_swap(_Mid, _First);
+            _RANGES _Meow_iter_swap(_Mid, _First);
         }
     }
 
@@ -8468,7 +8468,7 @@ namespace ranges {
                 } else if (_STD invoke(_Pred, _STD invoke(_Proj, *_Gfirst), _STD invoke(_Proj, *_Pfirst))) {
                     break;
                 } else if (_Plast != _Gfirst) {
-                    _RANGES iter_swap(_Plast, _Gfirst);
+                    _RANGES _Meow_iter_swap(_Plast, _Gfirst);
                     ++_Plast;
                 } else {
                     ++_Plast;
@@ -8482,7 +8482,7 @@ namespace ranges {
                                _Pred, _STD invoke(_Proj, *_Pfirst), _STD invoke(_Proj, *_RANGES prev(_Glast)))) {
                     break;
                 } else if (--_Pfirst != _RANGES prev(_Glast)) {
-                    _RANGES iter_swap(_Pfirst, _RANGES prev(_Glast));
+                    _RANGES _Meow_iter_swap(_Pfirst, _RANGES prev(_Glast));
                 }
             }
 
@@ -8492,21 +8492,21 @@ namespace ranges {
 
             if (_Glast == _First) { // no room at bottom, rotate pivot upward
                 if (_Plast != _Gfirst) {
-                    _RANGES iter_swap(_Pfirst, _Plast);
+                    _RANGES _Meow_iter_swap(_Pfirst, _Plast);
                 }
 
                 ++_Plast;
-                _RANGES iter_swap(_Pfirst, _Gfirst);
+                _RANGES _Meow_iter_swap(_Pfirst, _Gfirst);
                 ++_Pfirst;
                 ++_Gfirst;
             } else if (_Gfirst == _Last) { // no room at top, rotate pivot downward
                 if (--_Glast != --_Pfirst) {
-                    _RANGES iter_swap(_Glast, _Pfirst);
+                    _RANGES _Meow_iter_swap(_Glast, _Pfirst);
                 }
 
-                _RANGES iter_swap(_Pfirst, --_Plast);
+                _RANGES _Meow_iter_swap(_Pfirst, --_Plast);
             } else {
-                _RANGES iter_swap(_Gfirst, --_Glast);
+                _RANGES _Meow_iter_swap(_Gfirst, --_Glast);
                 ++_Gfirst;
             }
         }
@@ -8942,7 +8942,7 @@ namespace ranges {
             _It _Next = _Mid;
             for (;;) {
                 if (_STD invoke(_Pred, _STD invoke(_Proj, *_Next), _STD invoke(_Proj, *_First))) {
-                    _Backout._Emplace_back(_RANGES iter_move(_Next));
+                    _Backout._Emplace_back(_RANGES _Woof_iter_move(_Next));
                     ++_Next;
 
                     if (_Next == _Last) {
@@ -8952,7 +8952,7 @@ namespace ranges {
                         return _Backout._Release();
                     }
                 } else {
-                    _Backout._Emplace_back(_RANGES iter_move(_First));
+                    _Backout._Emplace_back(_RANGES _Woof_iter_move(_First));
                     ++_First;
 
                     if (_First == _Mid) {
@@ -8977,7 +8977,7 @@ namespace ranges {
             _InIt _Next = _Mid;
             for (;;) {
                 if (_STD invoke(_Pred, _STD invoke(_Proj, *_Next), _STD invoke(_Proj, *_First))) {
-                    *_Dest = _RANGES iter_move(_Next);
+                    *_Dest = _RANGES _Woof_iter_move(_Next);
                     ++_Dest;
                     ++_Next;
 
@@ -8985,7 +8985,7 @@ namespace ranges {
                         return _RANGES _Move_unchecked(_STD move(_First), _STD move(_Mid), _STD move(_Dest)).out;
                     }
                 } else {
-                    *_Dest = _RANGES iter_move(_First);
+                    *_Dest = _RANGES _Woof_iter_move(_First);
                     ++_Dest;
                     ++_First;
 
@@ -9134,7 +9134,7 @@ namespace ranges {
             for (auto _Next = _Mid; _Next != _Last; ++_Next) {
                 if (_STD invoke(_Pred, _STD invoke(_Proj, *_Next), _STD invoke(_Proj, *_First))) {
                     // replace top with new largest
-                    iter_value_t<_It> _Val(_RANGES iter_move(_Next));
+                    iter_value_t<_It> _Val(_RANGES _Woof_iter_move(_Next));
                     _RANGES _Pop_heap_hole_unchecked(_First, _Mid, _Next, _STD move(_Val), _Pred, _Proj, _Proj);
                 }
             }
@@ -10613,7 +10613,7 @@ namespace ranges {
                         --_Mid;
                     } while (!_STD invoke(_Pred, _STD invoke(_Proj, *_Next), _STD invoke(_Proj, *_Mid)));
 
-                    _RANGES iter_swap(_Next, _Mid);
+                    _RANGES _Meow_iter_swap(_Next, _Mid);
                     _RANGES _Reverse_common(_STD move(_Next1), _STD move(_Last));
                     return true;
                 }
@@ -10717,7 +10717,7 @@ namespace ranges {
                         --_Mid;
                     } while (!_STD invoke(_Pred, _STD invoke(_Proj, *_Mid), _STD invoke(_Proj, *_Next)));
 
-                    _RANGES iter_swap(_Next, _Mid);
+                    _RANGES _Meow_iter_swap(_Next, _Mid);
                     _RANGES _Reverse_common(_STD move(_Next1), _STD move(_Last));
                     return true;
                 }

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -1042,26 +1042,26 @@ public:
     }
 
     _NODISCARD friend constexpr decltype(auto) iter_move(const common_iterator& _Right)
-        noexcept(noexcept(_RANGES iter_move(_Right._Val._Get_first())))
+        noexcept(noexcept(_RANGES _Woof_iter_move(_Right._Val._Get_first())))
         requires input_iterator<_Iter>
     {
 #if _ITERATOR_DEBUG_LEVEL != 0
         _STL_VERIFY(_Right._Val._Contains == _Variantish_state::_Holds_first,
             "can only iter_move from common_iterator if it holds an iterator");
 #endif // _ITERATOR_DEBUG_LEVEL != 0
-        return _RANGES iter_move(_Right._Val._Get_first());
+        return _RANGES _Woof_iter_move(_Right._Val._Get_first());
     }
 
     template <indirectly_swappable<_Iter> _OIter, class _OSe>
     friend constexpr void iter_swap(const common_iterator& _Left, const common_iterator<_OIter, _OSe>& _Right)
-        noexcept(noexcept(_RANGES iter_swap(_Left._Val._Get_first(), _Right._Get_val()._Get_first()))) {
+        noexcept(noexcept(_RANGES _Meow_iter_swap(_Left._Val._Get_first(), _Right._Get_val()._Get_first()))) {
         auto& _Right_val = _Right._Get_val();
 #if _ITERATOR_DEBUG_LEVEL != 0
         _STL_VERIFY(_Left._Val._Contains == _Variantish_state::_Holds_first
                         && _Right_val._Contains == _Variantish_state::_Holds_first,
             "can only iter_swap common_iterators if both hold iterators");
 #endif // _ITERATOR_DEBUG_LEVEL != 0
-        return _RANGES iter_swap(_Left._Val._Get_first(), _Right_val._Get_first());
+        return _RANGES _Meow_iter_swap(_Left._Val._Get_first(), _Right_val._Get_first());
     }
 
     _NODISCARD constexpr _Variantish<_Iter, _Se>& _Get_val() noexcept {
@@ -1358,16 +1358,16 @@ public:
 
     // [counted.iter.cust]
     _NODISCARD friend constexpr decltype(auto) iter_move(const counted_iterator& _Right)
-        noexcept(noexcept(_RANGES iter_move(_Right._Current)))
+        noexcept(noexcept(_RANGES _Woof_iter_move(_Right._Current)))
         requires input_iterator<_Iter>
     {
-        return _RANGES iter_move(_Right._Current);
+        return _RANGES _Woof_iter_move(_Right._Current);
     }
 
     template <indirectly_swappable<_Iter> _Other>
     friend constexpr void iter_swap(const counted_iterator& _Left, const counted_iterator<_Other>& _Right)
-        noexcept(noexcept(_RANGES iter_swap(_Left._Current, _Right.base()))) {
-        _RANGES iter_swap(_Left._Current, _Right.base());
+        noexcept(noexcept(_RANGES _Meow_iter_swap(_Left._Current, _Right.base()))) {
+        _RANGES _Meow_iter_swap(_Left._Current, _Right.base());
     }
 
 #if _ITERATOR_DEBUG_LEVEL != 0

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -364,7 +364,7 @@ namespace ranges {
                 _Uninitialized_backout _Backout{_STD move(_OFirst)};
 
                 for (; _Count > 0 && _Backout._Last != _OLast; --_Count, (void) ++_IFirst) {
-                    _Backout._Emplace_back(_RANGES iter_move(_IFirst));
+                    _Backout._Emplace_back(_RANGES _Woof_iter_move(_IFirst));
                 }
 
                 _OFirst = _Backout._Release();

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1694,22 +1694,22 @@ namespace ranges {
             }
 
             _NODISCARD friend constexpr range_rvalue_reference_t<_Vw> iter_move(const _Iterator& _It)
-                noexcept(noexcept(_RANGES iter_move(_It._Current))) {
+                noexcept(noexcept(_RANGES _Woof_iter_move(_It._Current))) {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _It._Check_dereference();
 #endif // _ITERATOR_DEBUG_LEVEL != 0
-                return _RANGES iter_move(_It._Current);
+                return _RANGES _Woof_iter_move(_It._Current);
             }
 
             friend constexpr void iter_swap(const _Iterator& _Left, const _Iterator& _Right)
-                noexcept(noexcept(_RANGES iter_swap(_Left._Current, _Right._Current)))
+                noexcept(noexcept(_RANGES _Meow_iter_swap(_Left._Current, _Right._Current)))
                 requires indirectly_swappable<iterator_t<_Vw>>
             {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _Left._Check_dereference();
                 _Right._Check_dereference();
 #endif // _ITERATOR_DEBUG_LEVEL != 0
-                return _RANGES iter_swap(_Left._Current, _Right._Current);
+                return _RANGES _Meow_iter_swap(_Left._Current, _Right._Current);
             }
 
             _NODISCARD constexpr bool _Equal(const sentinel_t<_Vw>& _Last) const
@@ -2890,22 +2890,22 @@ namespace ranges {
             }
 
             _NODISCARD friend constexpr decltype(auto) iter_move(const _Iterator& _It)
-                noexcept(noexcept(_RANGES iter_move(*_It._Inner))) {
+                noexcept(noexcept(_RANGES _Woof_iter_move(*_It._Inner))) {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _It._Check_dereference();
 #endif // _ITERATOR_DEBUG_LEVEL != 0
-                return _RANGES iter_move(*_It._Inner);
+                return _RANGES _Woof_iter_move(*_It._Inner);
             }
 
             friend constexpr void iter_swap(const _Iterator& _Left, const _Iterator& _Right)
-                noexcept(noexcept(_RANGES iter_swap(*_Left._Inner, *_Right._Inner)))
+                noexcept(noexcept(_RANGES _Meow_iter_swap(*_Left._Inner, *_Right._Inner)))
                 requires indirectly_swappable<_InnerIter>
             {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _Left._Check_dereference();
                 _Right._Check_dereference();
 #endif // _ITERATOR_DEBUG_LEVEL != 0
-                _RANGES iter_swap(*_Left._Inner, *_Right._Inner);
+                _RANGES _Meow_iter_swap(*_Left._Inner, *_Right._Inner);
             }
         };
 
@@ -3056,7 +3056,7 @@ namespace ranges {
     template <class _Ref, class _RRef, class _It>
     concept _Concat_indirectly_readable_impl = requires(const _It __i) {
         { *__i } -> convertible_to<_Ref>;
-        { _RANGES iter_move(__i) } -> convertible_to<_RRef>;
+        { _RANGES _Woof_iter_move(__i) } -> convertible_to<_RRef>;
     };
 
     template <class... _Rngs>
@@ -3410,7 +3410,7 @@ namespace ranges {
             _NODISCARD friend constexpr decltype(auto) iter_move(const _Iterator& _It) {
                 using _Rvalue_ref =
                     common_reference_t<iter_rvalue_reference_t<_InnerIter>, iter_rvalue_reference_t<_PatternIter>>;
-                return _It._Visit_inner_it<_Rvalue_ref>(_RANGES iter_move);
+                return _It._Visit_inner_it<_Rvalue_ref>(_RANGES _Woof_iter_move);
             }
 
             friend constexpr void iter_swap(const _Iterator& _Left, const _Iterator& _Right)
@@ -3420,9 +3420,9 @@ namespace ranges {
                 case _Variantish_state::_Holds_first:
                     switch (_Right._Inner_it._Contains) {
                     case _Variantish_state::_Holds_first:
-                        return _RANGES iter_swap(_Left._Inner_it._Get_first(), _Right._Inner_it._Get_first());
+                        return _RANGES _Meow_iter_swap(_Left._Inner_it._Get_first(), _Right._Inner_it._Get_first());
                     case _Variantish_state::_Holds_second:
-                        return _RANGES iter_swap(_Left._Inner_it._Get_first(), _Right._Inner_it._Get_second());
+                        return _RANGES _Meow_iter_swap(_Left._Inner_it._Get_first(), _Right._Inner_it._Get_second());
                     case _Variantish_state::_Nothing:
                         break;
                     }
@@ -3430,9 +3430,9 @@ namespace ranges {
                 case _Variantish_state::_Holds_second:
                     switch (_Right._Inner_it._Contains) {
                     case _Variantish_state::_Holds_first:
-                        return _RANGES iter_swap(_Left._Inner_it._Get_second(), _Right._Inner_it._Get_first());
+                        return _RANGES _Meow_iter_swap(_Left._Inner_it._Get_second(), _Right._Inner_it._Get_first());
                     case _Variantish_state::_Holds_second:
-                        return _RANGES iter_swap(_Left._Inner_it._Get_second(), _Right._Inner_it._Get_second());
+                        return _RANGES _Meow_iter_swap(_Left._Inner_it._Get_second(), _Right._Inner_it._Get_second());
                     case _Variantish_state::_Nothing:
                         break;
                     }
@@ -3915,15 +3915,15 @@ namespace ranges {
             }
 
             _NODISCARD friend constexpr decltype(auto) iter_move(const _Inner_iter& _Iter)
-                noexcept(noexcept(_RANGES iter_move(_Iter._Get_current()))) {
-                return _RANGES iter_move(_Iter._Get_current());
+                noexcept(noexcept(_RANGES _Woof_iter_move(_Iter._Get_current()))) {
+                return _RANGES _Woof_iter_move(_Iter._Get_current());
             }
 
             friend constexpr void iter_swap(const _Inner_iter& _Left, const _Inner_iter& _Right)
-                noexcept(noexcept(_RANGES iter_swap(_Left._Get_current(), _Right._Get_current())))
+                noexcept(noexcept(_RANGES _Meow_iter_swap(_Left._Get_current(), _Right._Get_current())))
                 requires indirectly_swappable<iterator_t<_BaseTy>>
             {
-                _RANGES iter_swap(_Left._Get_current(), _Right._Get_current());
+                _RANGES _Meow_iter_swap(_Left._Get_current(), _Right._Get_current());
             }
         };
 
@@ -5275,10 +5275,10 @@ namespace ranges {
             }
 
             _NODISCARD friend constexpr auto iter_move(const _Iterator& _It)
-                noexcept(noexcept(_RANGES iter_move(_It._Current))
+                noexcept(noexcept(_RANGES _Woof_iter_move(_It._Current))
                          && is_nothrow_move_constructible_v<range_rvalue_reference_t<_Base_t>>) {
                 return tuple<difference_type, range_rvalue_reference_t<_Base_t>>{
-                    _It._Pos, _RANGES iter_move(_It._Current)};
+                    _It._Pos, _RANGES _Woof_iter_move(_It._Current)};
             }
         };
 
@@ -5557,15 +5557,15 @@ namespace ranges {
             }
 
             _NODISCARD friend constexpr range_rvalue_reference_t<_Vw> iter_move(const _Inner_iterator& _It)
-                noexcept(noexcept(_RANGES iter_move(_It._Get_current()))) {
-                return _RANGES iter_move(_It._Get_current());
+                noexcept(noexcept(_RANGES _Woof_iter_move(_It._Get_current()))) {
+                return _RANGES _Woof_iter_move(_It._Get_current());
             }
 
             friend constexpr void iter_swap(const _Inner_iterator& _Left, const _Inner_iterator& _Right)
-                noexcept(noexcept(_RANGES iter_swap(_Left._Get_current(), _Right._Get_current())))
+                noexcept(noexcept(_RANGES _Meow_iter_swap(_Left._Get_current(), _Right._Get_current())))
                 requires indirectly_swappable<iterator_t<_Vw>>
             {
-                _RANGES iter_swap(_Left._Get_current(), _Right._Get_current());
+                _RANGES _Meow_iter_swap(_Left._Get_current(), _Right._Get_current());
             }
         };
 
@@ -6912,15 +6912,15 @@ namespace ranges {
             }
 
             _NODISCARD friend constexpr range_rvalue_reference_t<_Base> iter_move(const _Iterator& _It)
-                noexcept(noexcept(_RANGES iter_move(_It._Current))) {
-                return _RANGES iter_move(_It._Current);
+                noexcept(noexcept(_RANGES _Woof_iter_move(_It._Current))) {
+                return _RANGES _Woof_iter_move(_It._Current);
             }
 
             friend constexpr void iter_swap(const _Iterator& _Left, const _Iterator& _Right)
-                noexcept(noexcept(_RANGES iter_swap(_Left._Current, _Right._Current)))
+                noexcept(noexcept(_RANGES _Meow_iter_swap(_Left._Current, _Right._Current)))
                 requires indirectly_swappable<_Base_iterator>
             {
-                return _RANGES iter_swap(_Left._Current, _Right._Current);
+                return _RANGES _Meow_iter_swap(_Left._Current, _Right._Current);
             }
         };
 
@@ -7341,24 +7341,24 @@ namespace ranges {
             }
 
             _NODISCARD friend constexpr auto iter_move(const _Iterator& _Itr) noexcept(
-                (noexcept(_RANGES iter_move(_STD declval<const iterator_t<_Maybe_const<_IsConst, _ViewTypes>>&>()))
+                (noexcept(_RANGES _Woof_iter_move(_STD declval<const iterator_t<_Maybe_const<_IsConst, _ViewTypes>>&>()))
                     && ...)
                 && (is_nothrow_move_constructible_v<range_rvalue_reference_t<_Maybe_const<_IsConst, _ViewTypes>>>
                     && ...)) {
-                return _Tuple_transform(_RANGES iter_move, _Itr._Current);
+                return _Tuple_transform(_RANGES _Woof_iter_move, _Itr._Current);
             }
 
             friend constexpr void iter_swap(const _Iterator& _Lhs, const _Iterator& _Rhs)
-                noexcept((noexcept(_RANGES iter_swap(_STD declval<iterator_t<_Maybe_const<_IsConst, _ViewTypes>>&>(),
+                noexcept((noexcept(_RANGES _Meow_iter_swap(_STD declval<iterator_t<_Maybe_const<_IsConst, _ViewTypes>>&>(),
                               _STD declval<iterator_t<_Maybe_const<_IsConst, _ViewTypes>>&>()))
                           && ...))
                 requires (indirectly_swappable<iterator_t<_Maybe_const<_IsConst, _ViewTypes>>> && ...)
             {
                 const auto _Swap_every_pair_closure =
                     [&_Lhs, &_Rhs]<size_t... _Indices>(index_sequence<_Indices...>) noexcept(noexcept(
-                        ((_RANGES iter_swap(_STD get<_Indices>(_Lhs._Current), _STD get<_Indices>(_Rhs._Current))),
+                        ((_RANGES _Meow_iter_swap(_STD get<_Indices>(_Lhs._Current), _STD get<_Indices>(_Rhs._Current))),
                             ...))) {
-                        ((_RANGES iter_swap(_STD get<_Indices>(_Lhs._Current), _STD get<_Indices>(_Rhs._Current))),
+                        ((_RANGES _Meow_iter_swap(_STD get<_Indices>(_Lhs._Current), _STD get<_Indices>(_Rhs._Current))),
                             ...);
                     };
 
@@ -8178,17 +8178,17 @@ namespace ranges {
             }
 
             _NODISCARD friend constexpr auto iter_move(const _Iterator& _It)
-                noexcept(noexcept(_RANGES iter_move(_STD declval<const _Base_iterator&>()))
+                noexcept(noexcept(_RANGES _Woof_iter_move(_STD declval<const _Base_iterator&>()))
                          && is_nothrow_move_constructible_v<range_rvalue_reference_t<_Base>>) {
-                return _RANGES _Tuple_transform(_RANGES iter_move, _It._Current);
+                return _RANGES _Tuple_transform(_RANGES _Woof_iter_move, _It._Current);
             }
 
             friend constexpr void iter_swap(const _Iterator& _Left, const _Iterator& _Right)
-                noexcept(noexcept(_RANGES iter_swap(_STD declval<_Base_iterator>(), _STD declval<_Base_iterator>())))
+                noexcept(noexcept(_RANGES _Meow_iter_swap(_STD declval<_Base_iterator>(), _STD declval<_Base_iterator>())))
                 requires indirectly_swappable<_Base_iterator>
             {
                 for (size_t _Ix = 0; _Ix < _Nx; ++_Ix) {
-                    _RANGES iter_swap(_Left._Current[_Ix], _Right._Current[_Ix]);
+                    _RANGES _Meow_iter_swap(_Left._Current[_Ix], _Right._Current[_Ix]);
                 }
             }
         };
@@ -8925,13 +8925,13 @@ namespace ranges {
                 return conjunction_v<
                            is_nothrow_move_constructible<range_rvalue_reference_t<_Maybe_const<_Const, _First>>>,
                            is_nothrow_move_constructible<range_rvalue_reference_t<_Maybe_const<_Const, _Rest>>>...>
-                    && (noexcept(_RANGES iter_move(_STD get<_Indices>(_STD declval<const _Iterator&>()._Current)))
+                    && (noexcept(_RANGES _Woof_iter_move(_STD get<_Indices>(_STD declval<const _Iterator&>()._Current)))
                         && ...);
             }
 
             template <size_t... _Indices>
             _NODISCARD static consteval bool _Is_iter_swap_nothrow(index_sequence<_Indices...>) noexcept {
-                return (noexcept(_RANGES iter_swap(_STD get<_Indices>(_STD declval<const _Iterator&>()._Current),
+                return (noexcept(_RANGES _Meow_iter_swap(_STD get<_Indices>(_STD declval<const _Iterator&>()._Current),
                             _STD get<_Indices>(_STD declval<const _Iterator&>()._Current)))
                         && ...);
             }
@@ -9074,7 +9074,7 @@ namespace ranges {
 
             _NODISCARD friend constexpr auto iter_move(const _Iterator& _It)
                 noexcept(_Is_iter_move_nothrow(make_index_sequence<1 + sizeof...(_Rest)>{})) {
-                return _RANGES _Tuple_transform(_RANGES iter_move, _It._Current);
+                return _RANGES _Tuple_transform(_RANGES _Woof_iter_move, _It._Current);
             }
 
             friend constexpr void iter_swap(const _Iterator& _Left, const _Iterator& _Right)
@@ -9083,7 +9083,7 @@ namespace ranges {
                           && indirectly_swappable<iterator_t<_Maybe_const<_Const, _Rest>>>)
             {
                 [&]<size_t... _Indices>(index_sequence<_Indices...>) {
-                    (_RANGES iter_swap(_STD get<_Indices>(_Left._Current), _STD get<_Indices>(_Right._Current)), ...);
+                    (_RANGES _Meow_iter_swap(_STD get<_Indices>(_Left._Current), _STD get<_Indices>(_Right._Current)), ...);
                 }(make_index_sequence<1 + sizeof...(_Rest)>{});
             }
         };

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1777,7 +1777,7 @@ namespace ranges {
             _Uninitialized_backout _Backout{_STD move(_OFirst)};
 
             for (; _IFirst != _ILast && _Backout._Last != _OLast; ++_IFirst) {
-                _Backout._Emplace_back(_RANGES iter_move(_IFirst));
+                _Backout._Emplace_back(_RANGES _Woof_iter_move(_IFirst));
             }
 
             return {_STD move(_IFirst), _Backout._Release()};

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -850,7 +850,7 @@ namespace ranges {
     } // namespace _Iter_move
 
     inline namespace _Cpos {
-        _EXPORT_STD inline constexpr _Iter_move::_Cpo iter_move;
+        _EXPORT_STD inline constexpr _Iter_move::_Cpo _Woof_iter_move;
     }
 } // namespace ranges
 
@@ -858,9 +858,9 @@ namespace ranges {
 
 _EXPORT_STD template <class _Ty>
     requires _Dereferenceable<_Ty> && requires(_Ty& __t) {
-        { _RANGES iter_move(__t) } -> _Can_reference;
+        { _RANGES _Woof_iter_move(__t) } -> _Can_reference;
     }
-using iter_rvalue_reference_t = decltype(_RANGES iter_move(_STD declval<_Ty&>()));
+using iter_rvalue_reference_t = decltype(_RANGES _Woof_iter_move(_STD declval<_Ty&>()));
 
 template <class _It>
 concept _Indirectly_readable_impl =
@@ -869,7 +869,7 @@ concept _Indirectly_readable_impl =
         typename iter_reference_t<_It>;
         typename iter_rvalue_reference_t<_It>;
         { *__i } -> same_as<iter_reference_t<_It>>;
-        { _RANGES iter_move(__i) } -> same_as<iter_rvalue_reference_t<_It>>;
+        { _RANGES _Woof_iter_move(__i) } -> same_as<iter_rvalue_reference_t<_It>>;
     } && common_reference_with<iter_reference_t<_It>&&, iter_value_t<_It>&>
     && common_reference_with<iter_reference_t<_It>&&, iter_rvalue_reference_t<_It>&&>
     && common_reference_with<iter_rvalue_reference_t<_It>&&, const iter_value_t<_It>&>;
@@ -1122,9 +1122,9 @@ namespace ranges {
 
         template <class _Xty, class _Yty>
         _NODISCARD constexpr iter_value_t<remove_reference_t<_Xty>> _Iter_exchange_move(_Xty&& _XVal, _Yty&& _YVal)
-            noexcept(noexcept(iter_value_t<remove_reference_t<_Xty>>(_RANGES iter_move(_XVal)))) {
-            iter_value_t<remove_reference_t<_Xty>> _Tmp(_RANGES iter_move(_XVal));
-            *_XVal = _RANGES iter_move(_YVal);
+            noexcept(noexcept(iter_value_t<remove_reference_t<_Xty>>(_RANGES _Woof_iter_move(_XVal)))) {
+            iter_value_t<remove_reference_t<_Xty>> _Tmp(_RANGES _Woof_iter_move(_XVal));
+            *_XVal = _RANGES _Woof_iter_move(_YVal);
             return _Tmp;
         }
 
@@ -1173,17 +1173,17 @@ namespace ranges {
     } // namespace _Iter_swap
 
     inline namespace _Cpos {
-        _EXPORT_STD inline constexpr _Iter_swap::_Cpo iter_swap;
+        _EXPORT_STD inline constexpr _Iter_swap::_Cpo _Meow_iter_swap;
     }
 } // namespace ranges
 
 _EXPORT_STD template <class _It1, class _It2 = _It1>
 concept indirectly_swappable =
     indirectly_readable<_It1> && indirectly_readable<_It2> && requires(const _It1 __i1, const _It2 __i2) {
-        _RANGES iter_swap(__i1, __i1);
-        _RANGES iter_swap(__i2, __i2);
-        _RANGES iter_swap(__i1, __i2);
-        _RANGES iter_swap(__i2, __i1);
+        _RANGES _Meow_iter_swap(__i1, __i1);
+        _RANGES _Meow_iter_swap(__i2, __i2);
+        _RANGES _Meow_iter_swap(__i1, __i2);
+        _RANGES _Meow_iter_swap(__i2, __i1);
     };
 
 _EXPORT_STD template <class _It1, class _It2, class _Rel, class _Proj1 = identity, class _Proj2 = identity>
@@ -1813,22 +1813,22 @@ public:
     }
 
 #if _HAS_CXX20
-    _NODISCARD friend constexpr iter_rvalue_reference_t<_BidIt> iter_move(const reverse_iterator& _It)
-        noexcept(is_nothrow_copy_constructible_v<_BidIt> && noexcept(_RANGES iter_move(--_STD declval<_BidIt&>()))) {
+    _NODISCARD friend constexpr iter_rvalue_reference_t<_BidIt> iter_move(const reverse_iterator& _It) noexcept(
+        is_nothrow_copy_constructible_v<_BidIt> && noexcept(_RANGES _Woof_iter_move(--_STD declval<_BidIt&>()))) {
         auto _Tmp = _It.current;
         --_Tmp;
-        return _RANGES iter_move(_Tmp);
+        return _RANGES _Woof_iter_move(_Tmp);
     }
 
     template <indirectly_swappable<_BidIt> _BidIt2>
     friend constexpr void iter_swap(const reverse_iterator& _Left, const reverse_iterator<_BidIt2>& _Right)
         noexcept(is_nothrow_copy_constructible_v<_BidIt> && is_nothrow_copy_constructible_v<_BidIt2>
-                 && noexcept(_RANGES iter_swap(--_STD declval<_BidIt&>(), --_STD declval<_BidIt2&>()))) {
+                 && noexcept(_RANGES _Meow_iter_swap(--_STD declval<_BidIt&>(), --_STD declval<_BidIt2&>()))) {
         auto _LTmp = _Left.current;
         auto _RTmp = _Right.base();
         --_LTmp;
         --_RTmp;
-        _RANGES iter_swap(_LTmp, _RTmp);
+        _RANGES _Meow_iter_swap(_LTmp, _RTmp);
     }
 #endif // _HAS_CXX20
 
@@ -2468,8 +2468,8 @@ public:
     }
 
     _NODISCARD friend constexpr _Rvalue_reference iter_move(const basic_const_iterator& _It)
-        noexcept(noexcept(static_cast<_Rvalue_reference>(_RANGES iter_move(_It._Current)))) {
-        return static_cast<_Rvalue_reference>(_RANGES iter_move(_It._Current));
+        noexcept(noexcept(static_cast<_Rvalue_reference>(_RANGES _Woof_iter_move(_It._Current)))) {
+        return static_cast<_Rvalue_reference>(_RANGES _Woof_iter_move(_It._Current));
     }
 };
 
@@ -4249,8 +4249,8 @@ public:
 
     _NODISCARD _CONSTEXPR17 reference operator*() const
 #if _HAS_CXX20
-        noexcept(noexcept(_RANGES iter_move(_Current))) /* strengthened */ {
-        return _RANGES iter_move(_Current);
+        noexcept(noexcept(_RANGES _Woof_iter_move(_Current))) /* strengthened */ {
+        return _RANGES _Woof_iter_move(_Current);
     }
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
         noexcept(noexcept(static_cast<reference>(*_Current))) /* strengthened */ {
@@ -4331,8 +4331,8 @@ public:
 
     _NODISCARD _CONSTEXPR17 reference operator[](const difference_type _Off) const
 #if _HAS_CXX20
-        noexcept(noexcept(_RANGES iter_move(_Current + _Off))) /* strengthened */ {
-        return _RANGES iter_move(_Current + _Off);
+        noexcept(noexcept(_RANGES _Woof_iter_move(_Current + _Off))) /* strengthened */ {
+        return _RANGES _Woof_iter_move(_Current + _Off);
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
         noexcept(noexcept(_STD move(_Current[_Off]))) /* strengthened */ {
         return _STD move(_Current[_Off]);
@@ -4359,14 +4359,14 @@ public:
     }
 
     _NODISCARD friend constexpr reference iter_move(const move_iterator& _It)
-        noexcept(noexcept(_RANGES iter_move(_It._Current))) {
-        return _RANGES iter_move(_It._Current);
+        noexcept(noexcept(_RANGES _Woof_iter_move(_It._Current))) {
+        return _RANGES _Woof_iter_move(_It._Current);
     }
 
     template <indirectly_swappable<_Iter> _Iter2>
     friend constexpr void iter_swap(const move_iterator& _Left, const move_iterator<_Iter2>& _Right)
-        noexcept(noexcept(_RANGES iter_swap(_Left._Current, _Right.base()))) {
-        _RANGES iter_swap(_Left._Current, _Right.base());
+        noexcept(noexcept(_RANGES _Meow_iter_swap(_Left._Current, _Right.base()))) {
+        _RANGES _Meow_iter_swap(_Left._Current, _Right.base());
     }
 #endif // _HAS_CXX20
 

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -1773,4 +1773,4 @@ template <class R>
 concept CanBool = requires(R&& r) { std::forward<R>(r) ? true : false; };
 
 template <class I>
-concept CanIterSwap = requires(I&& i1, I&& i2) { ranges::iter_swap(std::forward<I>(i1), std::forward<I>(i2)); };
+concept CanIterSwap = requires(I&& i1, I&& i2) { ranges::_Meow_iter_swap(std::forward<I>(i1), std::forward<I>(i2)); };

--- a/tests/std/tests/GH_000140_adl_proof_views/env.lst
+++ b/tests/std/tests/GH_000140_adl_proof_views/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_20_matrix.lst
+RUNALL_INCLUDE ..\usual_20_matrix.lst

--- a/tests/std/tests/LWG4105_ranges_ends_with_and_integer_class/env.lst
+++ b/tests/std/tests/LWG4105_ranges_ends_with_and_integer_class/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_latest_matrix.lst
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P0896R4_common_iterator/env.lst
+++ b/tests/std/tests/P0896R4_common_iterator/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_20_matrix.lst
+RUNALL_INCLUDE ..\usual_20_matrix.lst

--- a/tests/std/tests/P0896R4_common_iterator/test.cpp
+++ b/tests/std/tests/P0896R4_common_iterator/test.cpp
@@ -161,7 +161,7 @@ struct instantiator {
                 if constexpr (input_iterator<Iter>) { // iter_move
                     Cit iter1{Iter{input}};
 
-                    const same_as<iter_value_t<Iter>> auto element1(ranges::iter_move(iter1));
+                    const same_as<iter_value_t<Iter>> auto element1(ranges::_Woof_iter_move(iter1));
                     assert(element1 == P(0, 1));
                 }
 
@@ -169,7 +169,7 @@ struct instantiator {
                     Cit iter1{Iter{input}};
                     Cit iter2{Iter{input + 1}};
 
-                    ranges::iter_swap(iter1, iter2);
+                    ranges::_Meow_iter_swap(iter1, iter2);
                     assert(*iter1 == P(0, 2));
                     assert(*iter2 == P(0, 1));
                 }

--- a/tests/std/tests/P0896R4_common_iterator_death/test.cpp
+++ b/tests/std/tests/P0896R4_common_iterator_death/test.cpp
@@ -123,36 +123,36 @@ void test_case_difference_right_valueless() {
 
 void test_case_iter_move_sentinel() {
     CIT cit{default_sentinel};
-    (void) ranges::iter_move(cit); // can only iter_move from common_iterator if it holds an iterator
+    (void) ranges::_Woof_iter_move(cit); // can only iter_move from common_iterator if it holds an iterator
 }
 
 void test_case_iter_move_valueless() {
     CIT cit{_Variantish_empty_tag{}};
-    (void) ranges::iter_move(cit); // can only iter_move from common_iterator if it holds an iterator
+    (void) ranges::_Woof_iter_move(cit); // can only iter_move from common_iterator if it holds an iterator
 }
 
 void test_case_iter_swap_sentinel_left_sentinel() {
     CIT cit1{default_sentinel};
     CIT cit2{};
-    (void) ranges::iter_swap(cit1, cit2); // can only iter_swap common_iterators if both hold iterators
+    (void) ranges::_Meow_iter_swap(cit1, cit2); // can only iter_swap common_iterators if both hold iterators
 }
 
 void test_case_iter_swap_sentinel_left_valueless() {
     CIT cit1{_Variantish_empty_tag{}};
     CIT cit2{};
-    (void) ranges::iter_swap(cit1, cit2); // can only iter_swap common_iterators if both hold iterators
+    (void) ranges::_Meow_iter_swap(cit1, cit2); // can only iter_swap common_iterators if both hold iterators
 }
 
 void test_case_iter_swap_sentinel_right_sentinel() {
     CIT cit1{};
     CIT cit2{default_sentinel};
-    (void) ranges::iter_swap(cit1, cit2); // can only iter_swap common_iterators if both hold iterators
+    (void) ranges::_Meow_iter_swap(cit1, cit2); // can only iter_swap common_iterators if both hold iterators
 }
 
 void test_case_iter_swap_sentinel_right_valueless() {
     CIT cit1{};
     CIT cit2{_Variantish_empty_tag{}};
-    (void) ranges::iter_swap(cit1, cit2); // can only iter_swap common_iterators if both hold iterators
+    (void) ranges::_Meow_iter_swap(cit1, cit2); // can only iter_swap common_iterators if both hold iterators
 }
 
 int main(int argc, char* argv[]) {

--- a/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
@@ -376,7 +376,7 @@ public:
     explicit input_move_iterator(shared_ptr<int>* ptr) : m_ptr(ptr) {}
 
     reference operator*() const {
-        return ranges::iter_move(m_ptr);
+        return ranges::_Woof_iter_move(m_ptr);
     }
     pointer operator->() const {
         return m_ptr;

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -1028,7 +1028,7 @@ namespace iterator_cust_move_test {
     using std::iter_rvalue_reference_t, std::same_as;
 
     template <class T>
-    concept can_iter_move = requires(T&& t) { ranges::iter_move(std::forward<T>(t)); };
+    concept can_iter_move = requires(T&& t) { ranges::_Woof_iter_move(std::forward<T>(t)); };
     template <class T>
     concept can_iter_rvalue_ref = requires { typename iter_rvalue_reference_t<T>; };
 
@@ -1039,38 +1039,38 @@ namespace iterator_cust_move_test {
             return 3.14;
         }
     };
-    static_assert(same_as<decltype(ranges::iter_move(friend_hook{})), double>);
+    static_assert(same_as<decltype(ranges::_Woof_iter_move(friend_hook{})), double>);
     static_assert(!can_iter_rvalue_ref<friend_hook>);
-    static_assert(ranges::iter_move(friend_hook{}) == 3.14);
-    static_assert(noexcept(ranges::iter_move(friend_hook{})));
+    static_assert(ranges::_Woof_iter_move(friend_hook{}) == 3.14);
+    static_assert(noexcept(ranges::_Woof_iter_move(friend_hook{})));
 
     struct non_member_hook {};
     constexpr bool iter_move(non_member_hook) noexcept {
         return false;
     }
-    static_assert(same_as<decltype(ranges::iter_move(non_member_hook{})), bool>);
+    static_assert(same_as<decltype(ranges::_Woof_iter_move(non_member_hook{})), bool>);
     static_assert(!can_iter_rvalue_ref<non_member_hook>);
-    static_assert(ranges::iter_move(non_member_hook{}) == false);
-    static_assert(noexcept(ranges::iter_move(non_member_hook{})));
+    static_assert(ranges::_Woof_iter_move(non_member_hook{}) == false);
+    static_assert(noexcept(ranges::_Woof_iter_move(non_member_hook{})));
 
     enum class E1 { x };
     constexpr E1 iter_move(E1) noexcept {
         return E1::x;
     }
-    static_assert(same_as<decltype(ranges::iter_move(E1::x)), E1>);
+    static_assert(same_as<decltype(ranges::_Woof_iter_move(E1::x)), E1>);
     static_assert(!can_iter_rvalue_ref<E1>);
-    static_assert(static_cast<int>(ranges::iter_move(E1::x)) == 0);
-    static_assert(noexcept(ranges::iter_move(E1::x)));
+    static_assert(static_cast<int>(ranges::_Woof_iter_move(E1::x)) == 0);
+    static_assert(noexcept(ranges::_Woof_iter_move(E1::x)));
 
     // N4928 [iterator.cust.move]/1.2.1 "if *E is an lvalue, std::move(*E)"
     static constexpr int some_ints[] = {0, 1, 2, 3};
     static_assert(same_as<iter_rvalue_reference_t<int*>, int&&>);
-    static_assert(ranges::iter_move(&some_ints[1]) == 1);
-    static_assert(noexcept(ranges::iter_move(&some_ints[1])));
+    static_assert(ranges::_Woof_iter_move(&some_ints[1]) == 1);
+    static_assert(noexcept(ranges::_Woof_iter_move(&some_ints[1])));
 
     static_assert(same_as<iter_rvalue_reference_t<int const*>, int const&&>);
-    static_assert(ranges::iter_move(static_cast<int const*>(&some_ints[2])) == 2);
-    static_assert(noexcept(ranges::iter_move(static_cast<int const*>(&some_ints[2]))));
+    static_assert(ranges::_Woof_iter_move(static_cast<int const*>(&some_ints[2])) == 2);
+    static_assert(noexcept(ranges::_Woof_iter_move(static_cast<int const*>(&some_ints[2]))));
 
     static_assert(same_as<iter_rvalue_reference_t<int[]>, int&&>);
 #if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1008447
@@ -1080,8 +1080,8 @@ namespace iterator_cust_move_test {
 #endif // ^^^ workaround ^^^
 
     static_assert(same_as<iter_rvalue_reference_t<int[4]>, int&&>);
-    static_assert(ranges::iter_move(some_ints) == 0);
-    static_assert(noexcept(ranges::iter_move(some_ints)));
+    static_assert(ranges::_Woof_iter_move(some_ints) == 0);
+    static_assert(noexcept(ranges::_Woof_iter_move(some_ints)));
 
     constexpr int f(int i) noexcept {
         return i + 1;
@@ -1091,8 +1091,8 @@ namespace iterator_cust_move_test {
 #else // ^^^ no workaround / workaround vvv
     static_assert(same_as<iter_rvalue_reference_t<int (*)(int)>, int (&&)(int)>);
 #endif // ^^^ workaround ^^^
-    static_assert(ranges::iter_move(&f)(42) == 43);
-    static_assert(noexcept(ranges::iter_move(&f)));
+    static_assert(ranges::_Woof_iter_move(&f)(42) == 43);
+    static_assert(noexcept(ranges::_Woof_iter_move(&f)));
 
     struct ref_is_lvalue {
         constexpr int const& operator*() const {
@@ -1100,14 +1100,14 @@ namespace iterator_cust_move_test {
         }
     };
     static_assert(same_as<iter_rvalue_reference_t<ref_is_lvalue>, int const&&>);
-    static_assert(ranges::iter_move(ref_is_lvalue{}) == 1);
+    static_assert(ranges::_Woof_iter_move(ref_is_lvalue{}) == 1);
 
     struct with_bogus_typedefs : ref_is_lvalue {
         using value_type = void;
         using reference  = void;
     };
     static_assert(same_as<iter_rvalue_reference_t<with_bogus_typedefs>, int const&&>); // oblivious to nested types
-    static_assert(ranges::iter_move(with_bogus_typedefs{}) == 1);
+    static_assert(ranges::_Woof_iter_move(with_bogus_typedefs{}) == 1);
 
     // N4928 [iterator.cust.move]/1.2.2 "otherwise, *E."
     struct ref_is_prvalue {
@@ -1121,9 +1121,9 @@ namespace iterator_cust_move_test {
         int&& operator*() const;
     };
     static_assert(same_as<iter_rvalue_reference_t<ref_is_xvalue>, int&&>);
-    static_assert(!noexcept(ranges::iter_move(ref_is_xvalue{})));
+    static_assert(!noexcept(ranges::_Woof_iter_move(ref_is_xvalue{})));
 
-    // N4928 [iterator.cust.move]/1.3 "Otherwise, ranges::iter_move(E) is ill-formed."
+    // N4928 [iterator.cust.move]/1.3 "Otherwise, ranges::_Woof_iter_move(E) is ill-formed."
     static_assert(!can_iter_move<int>);
     static_assert(!can_iter_move<void>);
     static_assert(!can_iter_move<int(int) const>);
@@ -1138,7 +1138,7 @@ namespace iterator_cust_swap_test {
         std::same_as, std::swappable_with;
 
     template <class T, class U>
-    concept can_iter_swap = requires(T&& t, U&& u) { ranges::iter_swap(std::forward<T>(t), std::forward<U>(u)); };
+    concept can_iter_swap = requires(T&& t, U&& u) { ranges::_Meow_iter_swap(std::forward<T>(t), std::forward<U>(u)); };
 
     // N4928 [iterator.cust.swap]/4.1: "(void)iter_swap(E1, E2), if [...] iter_swap(E1, E2) is a
     // well-formed expression with overload resolution performed in a context [...]"
@@ -1157,23 +1157,23 @@ namespace iterator_cust_swap_test {
         }
     };
     static_assert(bullet1<friend_hook>);
-    static_assert(same_as<decltype(ranges::iter_swap(friend_hook{}, friend_hook{})), void>);
-    static_assert((ranges::iter_swap(friend_hook{}, friend_hook{}), true));
-    static_assert(noexcept(ranges::iter_swap(friend_hook{}, friend_hook{})));
+    static_assert(same_as<decltype(ranges::_Meow_iter_swap(friend_hook{}, friend_hook{})), void>);
+    static_assert((ranges::_Meow_iter_swap(friend_hook{}, friend_hook{}), true));
+    static_assert(noexcept(ranges::_Meow_iter_swap(friend_hook{}, friend_hook{})));
 
     struct non_member_hook {};
     constexpr char iter_swap(non_member_hook, non_member_hook) noexcept {
         return 'x';
     }
     static_assert(bullet1<non_member_hook>);
-    static_assert(same_as<decltype(ranges::iter_swap(non_member_hook{}, non_member_hook{})), void>);
-    static_assert((ranges::iter_swap(non_member_hook{}, non_member_hook{}), true));
-    static_assert(noexcept(ranges::iter_swap(non_member_hook{}, non_member_hook{})));
+    static_assert(same_as<decltype(ranges::_Meow_iter_swap(non_member_hook{}, non_member_hook{})), void>);
+    static_assert((ranges::_Meow_iter_swap(non_member_hook{}, non_member_hook{}), true));
+    static_assert(noexcept(ranges::_Meow_iter_swap(non_member_hook{}, non_member_hook{})));
 
     enum class E1 { x };
     constexpr void iter_swap(E1, E1) {}
     static_assert(bullet1<E1>);
-    static_assert((ranges::iter_swap(E1::x, E1::x), true));
+    static_assert((ranges::_Meow_iter_swap(E1::x, E1::x), true));
 
     // N4928 [iterator.cust.swap]/4.2: "Otherwise, if the types of E1 and E2 each model indirectly_readable,
     // and if the reference types of E1 and E2 model swappable_with, then ranges::swap(*E1, *E2)."
@@ -1187,11 +1187,11 @@ namespace iterator_cust_swap_test {
         static_assert(bullet2<int*>);
 
         int i0 = 42, i1 = 13;
-        static_assert(same_as<decltype(ranges::iter_swap(&i0, &i1)), void>);
-        ranges::iter_swap(&i0, &i1);
+        static_assert(same_as<decltype(ranges::_Meow_iter_swap(&i0, &i1)), void>);
+        ranges::_Meow_iter_swap(&i0, &i1);
         assert(i0 == 13);
         assert(i1 == 42);
-        static_assert(noexcept(ranges::iter_swap(&i0, &i1)));
+        static_assert(noexcept(ranges::_Meow_iter_swap(&i0, &i1)));
         return true;
     }
     static_assert(test());
@@ -1221,9 +1221,9 @@ struct std::common_type<iterator_cust_swap_test::swap_proxy_ref<X>, iterator_cus
 
 namespace iterator_cust_swap_test {
     static_assert(bullet2<swap_proxy_readable<0>, swap_proxy_readable<1>>);
-    static_assert(same_as<decltype(ranges::iter_swap(swap_proxy_readable<0>{}, swap_proxy_readable<1>{})), void>);
-    static_assert((ranges::iter_swap(swap_proxy_readable<0>{}, swap_proxy_readable<1>{}), true));
-    static_assert(noexcept(ranges::iter_swap(swap_proxy_readable<0>{}, swap_proxy_readable<1>{})));
+    static_assert(same_as<decltype(ranges::_Meow_iter_swap(swap_proxy_readable<0>{}, swap_proxy_readable<1>{})), void>);
+    static_assert((ranges::_Meow_iter_swap(swap_proxy_readable<0>{}, swap_proxy_readable<1>{}), true));
+    static_assert(noexcept(ranges::_Meow_iter_swap(swap_proxy_readable<0>{}, swap_proxy_readable<1>{})));
 
     // N4928 [iterator.cust.swap]/4.3: "Otherwise, if the types T1 and T2 of E1 and E2 model
     // indirectly_movable_storable<T1, T2> and indirectly_movable_storable<T2, T1>..."
@@ -1246,10 +1246,11 @@ namespace iterator_cust_swap_test {
         friend int&& iter_move(unswap_proxy_readable) noexcept;
     };
     static_assert(bullet3<unswap_proxy_readable<0>, unswap_proxy_readable<1>>);
-    static_assert(same_as<decltype(ranges::iter_swap(unswap_proxy_readable<0>{}, unswap_proxy_readable<1>{})), void>);
-    static_assert(noexcept(ranges::iter_swap(unswap_proxy_readable<0>{}, unswap_proxy_readable<1>{})));
+    static_assert(
+        same_as<decltype(ranges::_Meow_iter_swap(unswap_proxy_readable<0>{}, unswap_proxy_readable<1>{})), void>);
+    static_assert(noexcept(ranges::_Meow_iter_swap(unswap_proxy_readable<0>{}, unswap_proxy_readable<1>{})));
 
-    // N4928 [iterator.cust.swap]/4.4: "Otherwise, ranges::iter_swap(E1, E2) is ill-formed."
+    // N4928 [iterator.cust.swap]/4.4: "Otherwise, ranges::_Meow_iter_swap(E1, E2) is ill-formed."
     template <class T, class U>
     concept bullet4 = !can_iter_swap<T, U>;
 
@@ -1287,16 +1288,17 @@ namespace iterator_cust_swap_test {
                 int i1 = 13;
                 S s0{i0};
                 S s1{i1};
-                ranges::iter_swap(s0, s1);
+                ranges::_Meow_iter_swap(s0, s1);
                 assert(i0 == 13);
                 assert(i1 == 42);
             }
 
             {
-                // Validate iter_swap bullet 3 to defend against regression of GH-1067 "ranges::iter_swap is broken"
+                // Validate iter_swap bullet 3 to defend against regression of GH-1067 "ranges::_Meow_iter_swap is
+                // broken"
                 int i  = 42;
                 long l = 13;
-                ranges::iter_swap(&i, &l);
+                ranges::_Meow_iter_swap(&i, &l);
                 assert(i == 13);
                 assert(l == 42);
             }
@@ -3249,11 +3251,11 @@ namespace reverse_iterator_test {
         // Validate iter_move
         int count = 0;
         reverse_iterator i{proxy_iterator<0>{&count}};
-        assert(ranges::iter_move(i) == 42);
+        assert(ranges::_Woof_iter_move(i) == 42);
         assert(count == 1);
 
         // Validate iter_swap
-        ranges::iter_swap(i, reverse_iterator{proxy_iterator<2>{&count}});
+        ranges::_Meow_iter_swap(i, reverse_iterator{proxy_iterator<2>{&count}});
         assert(count == -1);
 
         // Validate <=>
@@ -3497,7 +3499,7 @@ namespace move_iterator_test {
         // Validate iter_move
         int count = 0;
         move_iterator i{proxy_iterator<0>{&count}};
-        assert(ranges::iter_move(i) == 42);
+        assert(ranges::_Woof_iter_move(i) == 42);
         assert(count == 1);
 
         // Validate that operator* and operator[] call iter_move
@@ -3507,7 +3509,7 @@ namespace move_iterator_test {
         assert(count == 3);
 
         // Validate iter_swap
-        ranges::iter_swap(i, move_iterator{proxy_iterator<2>{&count}});
+        ranges::_Meow_iter_swap(i, move_iterator{proxy_iterator<2>{&count}});
         assert(count == 1);
 
         // Validate <=>

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -84,8 +84,8 @@ static_assert(test_cpo(std::compare_weak_order_fallback));
 static_assert(test_cpo(std::compare_partial_order_fallback));
 
 static_assert(test_cpo(ranges::swap));
-static_assert(test_cpo(ranges::iter_swap));
-static_assert(test_cpo(ranges::iter_move));
+static_assert(test_cpo(ranges::_Meow_iter_swap));
+static_assert(test_cpo(ranges::_Woof_iter_move));
 static_assert(test_cpo(ranges::begin));
 static_assert(test_cpo(ranges::end));
 static_assert(test_cpo(ranges::cbegin));

--- a/tests/std/tests/P0896R4_views_drop/env.lst
+++ b/tests/std/tests/P0896R4_views_drop/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_20_matrix.lst
+RUNALL_INCLUDE ..\usual_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_elements/env.lst
+++ b/tests/std/tests/P0896R4_views_elements/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_20_matrix.lst
+RUNALL_INCLUDE ..\usual_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_filter/env.lst
+++ b/tests/std/tests/P0896R4_views_filter/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_20_matrix.lst
+RUNALL_INCLUDE ..\usual_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_filter_death/env.lst
+++ b/tests/std/tests/P0896R4_views_filter_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_20_matrix.lst
+RUNALL_INCLUDE ..\usual_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_filter_death/test.cpp
+++ b/tests/std/tests/P0896R4_views_filter_death/test.cpp
@@ -131,27 +131,27 @@ void test_operator_equal_incompatible_value_initialized() {
 
 void test_iter_move_value_initialized_iterator() {
     ranges::iterator_t<FV> i{};
-    (void) ranges::iter_move(i); // cannot dereference value-initialized filter_view iterator
+    (void) ranges::_Woof_iter_move(i); // cannot dereference value-initialized filter_view iterator
 }
 
 void test_iter_swap_value_initialized_iterators() {
     ranges::iterator_t<FV> i0{};
     ranges::iterator_t<FV> i1{};
-    (void) ranges::iter_swap(i0, i1); // cannot dereference value-initialized filter_view iterator
+    (void) ranges::_Meow_iter_swap(i0, i1); // cannot dereference value-initialized filter_view iterator
 }
 
 void test_iter_swap_value_initialized_iterator_left() {
     ranges::iterator_t<FV> i0{};
     FV r{some_ints, lambda};
     ranges::iterator_t<FV> i1 = r.begin();
-    (void) ranges::iter_swap(i0, i1); // cannot dereference value-initialized filter_view iterator
+    (void) ranges::_Meow_iter_swap(i0, i1); // cannot dereference value-initialized filter_view iterator
 }
 
 void test_iter_swap_value_initialized_iterator_right() {
     FV r{some_ints, lambda};
     ranges::iterator_t<FV> i0 = r.begin();
     ranges::iterator_t<FV> i1{};
-    (void) ranges::iter_swap(i0, i1); // cannot dereference value-initialized filter_view iterator
+    (void) ranges::_Meow_iter_swap(i0, i1); // cannot dereference value-initialized filter_view iterator
 }
 
 int main(int argc, char* argv[]) {

--- a/tests/std/tests/P0896R4_views_filter_iterator/env.lst
+++ b/tests/std/tests/P0896R4_views_filter_iterator/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_20_matrix.lst
+RUNALL_INCLUDE ..\usual_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_filter_iterator/test.cpp
+++ b/tests/std/tests/P0896R4_views_filter_iterator/test.cpp
@@ -91,18 +91,18 @@ struct iterator_instantiator {
             assert(*i0 == 0);
             static_assert(noexcept(*i0));
 
-            assert(ranges::iter_move(i0) == 0); // NB: moving from int leaves it unchanged
-            static_assert(noexcept(ranges::iter_move(i0)) == noexcept(ranges::iter_move(declval<Iter>())));
+            assert(ranges::_Woof_iter_move(i0) == 0); // NB: moving from int leaves it unchanged
+            static_assert(noexcept(ranges::_Woof_iter_move(i0)) == noexcept(ranges::_Woof_iter_move(declval<Iter>())));
 
             if constexpr (forward_iterator<Iter>) {
                 auto i1 = ranges::next(i0);
-                ranges::iter_swap(i0, i1);
+                ranges::_Meow_iter_swap(i0, i1);
                 assert(mutable_ints[0] == 2);
                 assert(mutable_ints[2] == 0);
-                ranges::iter_swap(i1, i0);
+                ranges::_Meow_iter_swap(i1, i0);
                 assert(mutable_ints[0] == 0);
                 assert(mutable_ints[2] == 2);
-                static_assert(noexcept(ranges::iter_swap(i0, i1)));
+                static_assert(noexcept(ranges::_Meow_iter_swap(i0, i1)));
             }
         }
 

--- a/tests/std/tests/P0896R4_views_join/env.lst
+++ b/tests/std/tests/P0896R4_views_join/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_20_matrix.lst
+RUNALL_INCLUDE ..\usual_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_lazy_split/env.lst
+++ b/tests/std/tests/P0896R4_views_lazy_split/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_20_matrix.lst
+RUNALL_INCLUDE ..\usual_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_split/env.lst
+++ b/tests/std/tests/P0896R4_views_split/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_20_matrix.lst
+RUNALL_INCLUDE ..\usual_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_take/env.lst
+++ b/tests/std/tests/P0896R4_views_take/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_20_matrix.lst
+RUNALL_INCLUDE ..\usual_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_transform/env.lst
+++ b/tests/std/tests/P0896R4_views_transform/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_20_matrix.lst
+RUNALL_INCLUDE ..\usual_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_transform/test.cpp
+++ b/tests/std/tests/P0896R4_views_transform/test.cpp
@@ -618,8 +618,8 @@ struct iterator_instantiator {
             assert(*i0 == add8(mutable_ints[0]));
             static_assert(noexcept(*i0));
 
-            assert(ranges::iter_move(i0) == add8(mutable_ints[0])); // NB: moving from int leaves it unchanged
-            static_assert(noexcept(ranges::iter_move(i0)));
+            assert(ranges::_Woof_iter_move(i0) == add8(mutable_ints[0])); // NB: moving from int leaves it unchanged
+            static_assert(noexcept(ranges::_Woof_iter_move(i0)));
 
             static_assert(!CanIterSwap<decltype(i0)>);
         }
@@ -942,7 +942,7 @@ int main() {
         assert(*i1 == 'h');
         assert(*i2 == 'e');
 
-        ranges::iter_swap(i1, i2);
+        ranges::_Meow_iter_swap(i1, i2);
 
         assert(*i1 == 'e');
         assert(*i2 == 'h');

--- a/tests/std/tests/P0896R4_views_transform_death/test.cpp
+++ b/tests/std/tests/P0896R4_views_transform_death/test.cpp
@@ -285,7 +285,7 @@ void test_operator_minus_incompatible_value_initialized() {
 
 void test_iter_move_value_initialized_iterator() {
     ranges::iterator_t<TV> i{};
-    (void) ranges::iter_move(i); // cannot dereference value-initialized transform_view iterator
+    (void) ranges::_Woof_iter_move(i); // cannot dereference value-initialized transform_view iterator
 }
 
 void test_sentinel_compare_value_initialized() {

--- a/tests/std/tests/P1899R3_views_stride/env.lst
+++ b/tests/std/tests/P1899R3_views_stride/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_latest_matrix.lst
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P2164R9_views_enumerate/env.lst
+++ b/tests/std/tests/P2164R9_views_enumerate/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_latest_matrix.lst
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P2164R9_views_enumerate/test.cpp
+++ b/tests/std/tests/P2164R9_views_enumerate/test.cpp
@@ -427,9 +427,9 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         }
 
         using IterMoveResult = tuple<range_difference_t<const Rng>, range_rvalue_reference_t<const Rng>>;
-        [[maybe_unused]] same_as<IterMoveResult> decltype(auto) moved = ranges::iter_move(i);
-        static_assert(noexcept(ranges::iter_move(i))
-                      == (noexcept(ranges::iter_move(i.base()))
+        [[maybe_unused]] same_as<IterMoveResult> decltype(auto) moved = ranges::_Woof_iter_move(i);
+        static_assert(noexcept(ranges::_Woof_iter_move(i))
+                      == (noexcept(ranges::_Woof_iter_move(i.base()))
                           && is_nothrow_move_constructible_v<range_rvalue_reference_t<const Rng>>) );
 
         [[maybe_unused]] same_as<const iterator_t<V>&> decltype(auto) i_base = as_const(i).base();
@@ -558,9 +558,9 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         }
 
         using IterMoveResult = tuple<range_difference_t<const Rng>, range_rvalue_reference_t<const Rng>>;
-        [[maybe_unused]] same_as<IterMoveResult> decltype(auto) moved = ranges::iter_move(ci);
-        static_assert(noexcept(ranges::iter_move(ci))
-                      == (noexcept(ranges::iter_move(ci.base()))
+        [[maybe_unused]] same_as<IterMoveResult> decltype(auto) moved = ranges::_Woof_iter_move(ci);
+        static_assert(noexcept(ranges::_Woof_iter_move(ci))
+                      == (noexcept(ranges::_Woof_iter_move(ci.base()))
                           && is_nothrow_move_constructible_v<range_rvalue_reference_t<const Rng>>) );
 
         [[maybe_unused]] same_as<const iterator_t<const V>&> decltype(auto) ci_base = as_const(ci).base();

--- a/tests/std/tests/P2165R4_tuple_like_common_reference/env.lst
+++ b/tests/std/tests/P2165R4_tuple_like_common_reference/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_latest_matrix.lst
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P2165R4_tuple_like_relational_operators/env.lst
+++ b/tests/std/tests/P2165R4_tuple_like_relational_operators/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_latest_matrix.lst
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P2278R4_basic_const_iterator/env.lst
+++ b/tests/std/tests/P2278R4_basic_const_iterator/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_latest_matrix.lst
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P2278R4_basic_const_iterator/test.cpp
+++ b/tests/std/tests/P2278R4_basic_const_iterator/test.cpp
@@ -242,9 +242,9 @@ constexpr void test_one(It iter) {
 
     { // Validate basic_const_iterator::iter_move()
         using Expected = common_reference_t<const iter_value_t<It>&&, iter_rvalue_reference_t<It>>;
-        [[maybe_unused]] same_as<Expected> decltype(auto) val = ranges::iter_move(citer);
-        static_assert(
-            noexcept(ranges::iter_move(citer)) == noexcept(static_cast<Expected>(ranges::iter_move(citer.base()))));
+        [[maybe_unused]] same_as<Expected> decltype(auto) val = ranges::_Woof_iter_move(citer);
+        static_assert(noexcept(ranges::_Woof_iter_move(citer))
+                      == noexcept(static_cast<Expected>(ranges::_Woof_iter_move(citer.base()))));
     }
 
     { // Validate basic_const_iterator::base() const&

--- a/tests/std/tests/P2321R2_views_adjacent/env.lst
+++ b/tests/std/tests/P2321R2_views_adjacent/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_latest_matrix.lst
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P2321R2_views_adjacent/test.cpp
+++ b/tests/std/tests/P2321R2_views_adjacent/test.cpp
@@ -500,14 +500,14 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
             same_as<repeated_tuple<iter_rvalue_reference_t<BI>, N>> decltype(auto) rval = iter_move(as_const(i));
             assert(rval == expected[0]);
             static_assert(noexcept(iter_move(i))
-                          == (noexcept(ranges::iter_move(declval<BI>()))
+                          == (noexcept(ranges::_Woof_iter_move(declval<BI>()))
                               && is_nothrow_move_constructible_v<iter_rvalue_reference_t<BI>>) );
         }
 
         if constexpr (indirectly_swappable<BI>) { // Check iter_swap
-            static_assert(is_void_v<decltype(ranges::iter_swap(as_const(i), as_const(i)))>);
-            static_assert(
-                noexcept(iter_swap(i, i)) == noexcept(ranges::iter_swap(declval<const BI&>(), declval<const BI&>())));
+            static_assert(is_void_v<decltype(ranges::_Meow_iter_swap(as_const(i), as_const(i)))>);
+            static_assert(noexcept(iter_swap(i, i))
+                          == noexcept(ranges::_Meow_iter_swap(declval<const BI&>(), declval<const BI&>())));
             // Note: other tests are defined in 'test_iter_swap' function
         }
     }
@@ -729,14 +729,14 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
             same_as<repeated_tuple<iter_rvalue_reference_t<CBI>, N>> decltype(auto) rval = iter_move(as_const(ci));
             assert(rval == expected[0]);
             static_assert(noexcept(iter_move(ci))
-                          == (noexcept(ranges::iter_move(declval<CBI>()))
+                          == (noexcept(ranges::_Woof_iter_move(declval<CBI>()))
                               && is_nothrow_move_constructible_v<iter_rvalue_reference_t<CBI>>) );
         }
 
         if constexpr (indirectly_swappable<CBI>) { // Check iter_swap
-            static_assert(is_void_v<decltype(ranges::iter_swap(as_const(ci), as_const(ci)))>);
+            static_assert(is_void_v<decltype(ranges::_Meow_iter_swap(as_const(ci), as_const(ci)))>);
             static_assert(noexcept(iter_swap(ci, ci))
-                          == noexcept(ranges::iter_swap(declval<const CBI&>(), declval<const CBI&>())));
+                          == noexcept(ranges::_Meow_iter_swap(declval<const CBI&>(), declval<const CBI&>())));
             // Note: other tests are defined in 'test_iter_swap' function
         }
     }
@@ -822,7 +822,7 @@ constexpr void test_iter_swap(Rng& rng) {
         for ([[maybe_unused]] size_t _ : views::iota(0u, N)) {
             iter_swap(as_const(i), as_const(j));
         }
-        ranges::iter_swap(as_const(i), as_const(j));
+        ranges::_Meow_iter_swap(as_const(i), as_const(j));
 
         assert(*i == first);
         assert(*j == second);
@@ -839,7 +839,7 @@ constexpr void test_iter_swap(Rng& rng) {
         for ([[maybe_unused]] size_t _ : views::iota(0u, N)) {
             iter_swap(as_const(i), as_const(j));
         }
-        ranges::iter_swap(as_const(i), as_const(j));
+        ranges::_Meow_iter_swap(as_const(i), as_const(j));
 
         assert(*i == first);
         assert(*j == second);

--- a/tests/std/tests/P2321R2_views_adjacent_transform/env.lst
+++ b/tests/std/tests/P2321R2_views_adjacent_transform/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_latest_matrix.lst
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P2321R2_views_zip/env.lst
+++ b/tests/std/tests/P2321R2_views_zip/env.lst
@@ -5,7 +5,7 @@
 # so the test fails to compile unless /permissive- is set. This issue isn't
 # unique to zip_view; all view types whose iterators define overloads for these
 # functions have this requirement.
-RUNALL_INCLUDE ..\strict_latest_matrix.lst
+RUNALL_INCLUDE ..\usual_latest_matrix.lst
 RUNALL_CROSSLIST
 *	PM_CL="/DTEST_INPUT"
 *	PM_CL="/DTEST_FORWARD"

--- a/tests/std/tests/P2321R2_views_zip/test.cpp
+++ b/tests/std/tests/P2321R2_views_zip/test.cpp
@@ -534,19 +534,20 @@ constexpr bool test_one(TestContainerType& test_container, RangeTypes&&... rngs)
 
             // Validate [ADL::]iter_move()
             if constexpr (is_const) {
-                static_assert(is_same_v<decltype(ranges::iter_move(itr)),
-                    tuple<decltype(ranges::iter_move(declval<ranges::iterator_t<const AllView<RangeTypes>>>()))...>>);
+                static_assert(is_same_v<decltype(ranges::_Woof_iter_move(itr)),
+                    tuple<decltype(ranges::_Woof_iter_move(
+                        declval<ranges::iterator_t<const AllView<RangeTypes>>>()))...>>);
             } else {
-                static_assert(is_same_v<decltype(ranges::iter_move(itr)),
-                    tuple<decltype(ranges::iter_move(declval<ranges::iterator_t<AllView<RangeTypes>>>()))...>>);
+                static_assert(is_same_v<decltype(ranges::_Woof_iter_move(itr)),
+                    tuple<decltype(ranges::_Woof_iter_move(declval<ranges::iterator_t<AllView<RangeTypes>>>()))...>>);
             }
 
             static_assert(
-                noexcept(ranges::iter_move(itr))
-                    == (noexcept(ranges::iter_move(declval<const ranges::iterator_t<LocalRangeTypes>&>())) && ...)
+                noexcept(ranges::_Woof_iter_move(itr))
+                    == (noexcept(ranges::_Woof_iter_move(declval<const ranges::iterator_t<LocalRangeTypes>&>())) && ...)
                 && (is_nothrow_move_constructible_v<ranges::range_rvalue_reference_t<LocalRangeTypes>> && ...));
 
-            assert(do_tuples_reference_same_objects(*itr, ranges::iter_move(itr)));
+            assert(do_tuples_reference_same_objects(*itr, ranges::_Woof_iter_move(itr)));
 
             // Validate [ADL::]iter_swap()
             if constexpr ((indirectly_swappable<ranges::iterator_t<LocalRangeTypes>> && ...)) {
@@ -560,7 +561,7 @@ constexpr bool test_one(TestContainerType& test_container, RangeTypes&&... rngs)
 
                 const typename TestContainerType::element_tuple_type old_itr2_value = *itr2;
 
-                ranges::iter_swap(itr, itr2);
+                ranges::_Meow_iter_swap(itr, itr2);
 
                 assert(*itr == old_itr2_value);
                 assert(*itr2 == old_itr_value);

--- a/tests/std/tests/P2321R2_views_zip_transform/env.lst
+++ b/tests/std/tests/P2321R2_views_zip_transform/env.lst
@@ -5,7 +5,7 @@
 # overload for iter_move which causes an ambiguous symbol error when compiling
 # without /permissive- set. This occurs even though zip_transform_view::_Iterator
 # does not define an ADL overload for iter_move.
-RUNALL_INCLUDE ..\strict_latest_matrix.lst
+RUNALL_INCLUDE ..\usual_latest_matrix.lst
 RUNALL_CROSSLIST
 *	PM_CL="/DTEST_INPUT"
 *	PM_CL="/DTEST_FORWARD"

--- a/tests/std/tests/P2374R4_views_cartesian_product/env.lst
+++ b/tests/std/tests/P2374R4_views_cartesian_product/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_latest_matrix.lst
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P2374R4_views_cartesian_product/test.cpp
+++ b/tests/std/tests/P2374R4_views_cartesian_product/test.cpp
@@ -57,8 +57,9 @@ concept UnsignedIntegerLike = _Integer_like<T> && !_Signed_integer_like<T>;
 
 template <class First, class... Rest>
 constexpr bool is_iter_move_nothrow() {
-    constexpr bool is_inner_iter_move_nothrow = (noexcept(ranges::iter_move(declval<const iterator_t<First>&>())) && ...
-                                                 && noexcept(ranges::iter_move(declval<const iterator_t<Rest>&>())));
+    constexpr bool is_inner_iter_move_nothrow =
+        (noexcept(ranges::_Woof_iter_move(declval<const iterator_t<First>&>())) && ...
+            && noexcept(ranges::_Woof_iter_move(declval<const iterator_t<Rest>&>())));
     constexpr bool are_references_nothrow_movable =
         conjunction_v<is_nothrow_move_constructible<ranges::range_rvalue_reference_t<First>>,
             is_nothrow_move_constructible<ranges::range_rvalue_reference_t<Rest>>...>;
@@ -67,9 +68,10 @@ constexpr bool is_iter_move_nothrow() {
 
 template <class First, class... Rest>
 constexpr bool is_iter_swap_nothrow() {
-    return (noexcept(ranges::iter_swap(declval<const iterator_t<First>&>(), declval<const iterator_t<First>&>()))
-            && ... //
-            && noexcept(ranges::iter_swap(declval<const iterator_t<Rest>&>(), declval<const iterator_t<Rest>&>())));
+    return (
+        noexcept(ranges::_Meow_iter_swap(declval<const iterator_t<First>&>(), declval<const iterator_t<First>&>()))
+        && ... //
+        && noexcept(ranges::_Meow_iter_swap(declval<const iterator_t<Rest>&>(), declval<const iterator_t<Rest>&>())));
 }
 
 template <class Expected, ranges::input_range First, ranges::forward_range... Rest>
@@ -781,7 +783,7 @@ constexpr void test_iter_swap(Rngs&... rngs) {
         assert(*i == second);
         assert(*j == first);
 
-        ranges::iter_swap(i, j);
+        ranges::_Meow_iter_swap(i, j);
         assert(*i == first);
         assert(*j == second);
 
@@ -800,7 +802,7 @@ constexpr void test_iter_swap(Rngs&... rngs) {
         assert(*i == second);
         assert(*j == first);
 
-        ranges::iter_swap(i, j);
+        ranges::_Meow_iter_swap(i, j);
         assert(*i == first);
         assert(*j == second);
 

--- a/tests/std/tests/P2374R4_views_cartesian_product_death/env.lst
+++ b/tests/std/tests/P2374R4_views_cartesian_product_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_latest_matrix.lst
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P2374R4_views_cartesian_product_recommended_practices/env.lst
+++ b/tests/std/tests/P2374R4_views_cartesian_product_recommended_practices/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_latest_matrix.lst
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P2387R3_pipe_support_for_user_defined_range_adaptors/env.lst
+++ b/tests/std/tests/P2387R3_pipe_support_for_user_defined_range_adaptors/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_latest_matrix.lst
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P2441R2_views_join_with/env.lst
+++ b/tests/std/tests/P2441R2_views_join_with/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_latest_matrix.lst
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P2441R2_views_join_with/test.cpp
+++ b/tests/std/tests/P2441R2_views_join_with/test.cpp
@@ -564,7 +564,7 @@ void test_valueless_iterator() {
     } catch (const bad_variant_access&) {
     }
     try {
-        (void) ranges::iter_move(it2);
+        (void) ranges::_Woof_iter_move(it2);
         assert(false);
     } catch (const bad_variant_access&) {
     }

--- a/tests/std/tests/P2442R1_views_chunk/env.lst
+++ b/tests/std/tests/P2442R1_views_chunk/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_latest_matrix.lst
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P2442R1_views_chunk/test.cpp
+++ b/tests/std/tests/P2442R1_views_chunk/test.cpp
@@ -485,13 +485,13 @@ constexpr bool test_input(Rng&& rng, Expected&& expected) {
     { // Check iter_move (other tests are defined in 'test_lwg3851' function)
         same_as<ranges::range_rvalue_reference_t<Rng>> decltype(auto) rval = iter_move(as_const(inner_iter));
         assert(rval == expected[0][0]);
-        static_assert(noexcept(iter_move(inner_iter)) == noexcept(ranges::iter_move(declval<const BI&>())));
+        static_assert(noexcept(iter_move(inner_iter)) == noexcept(ranges::_Woof_iter_move(declval<const BI&>())));
     }
 
     if constexpr (indirectly_swappable<BI>) { // Check iter_swap (other tests are defined in 'test_lwg3851' function)
         static_assert(is_void_v<decltype(iter_swap(as_const(inner_iter), as_const(inner_iter)))>);
         static_assert(noexcept(iter_swap(inner_iter, inner_iter))
-                      == noexcept(ranges::iter_swap(declval<const BI&>(), declval<const BI&>())));
+                      == noexcept(ranges::_Meow_iter_swap(declval<const BI&>(), declval<const BI&>())));
     }
 
     assert(inner_iter != inner_sen);

--- a/tests/std/tests/P2442R1_views_chunk_death/env.lst
+++ b/tests/std/tests/P2442R1_views_chunk_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_latest_matrix.lst
+RUNALL_INCLUDE ..\usual_latest_matrix.lst


### PR DESCRIPTION
Hackvestigation of more permissive ranges. Renames `ranges::iter_swap` and `ranges::iter_move` so the objects don't conflict with friend functions in permissive mode. It seems feasible, but I think we'd be better off stuffing the friend functions into a detail namespace and leaving the CPOs unchanged and usable.