### PR TITLE
Guard `__restrict` usage for CUDA

### DIFF
--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -463,7 +463,7 @@ _FwdIt2 transform_inclusive_scan(_ExPo&& _Exec, _FwdIt1 _First, _FwdIt1 _Last, _
 
 template <class _TyDest, class _TySrc, class _BinOp>
 void _Adjacent_difference_no_overlap(
-    _TyDest* const __restrict _Dest, _TySrc* const __restrict _Src, const ptrdiff_t _Count, _BinOp _Func) {
+    _TyDest* const _RESTRICT _Dest, _TySrc* const _RESTRICT _Src, const ptrdiff_t _Count, _BinOp _Func) {
     _Dest[0] = _Src[0];
     for (ptrdiff_t _Ix = 1; _Ix != _Count; ++_Ix) {
 #if _HAS_CXX20

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -2016,5 +2016,11 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 #define _CONST_CALL_OPERATOR const
 #endif // ^^^ !defined(__cpp_static_call_operator) ^^^
 
+#ifdef __CUDACC__ // TRANSITION, CUDA 12.4 doesn't recognize __restrict
+#define _RESTRICT
+#else // ^^^ defined(__CUDACC__) / !defined(__CUDACC__) vvv
+#define _RESTRICT __restrict
+#endif // ^^^ !defined(__CUDACC__) ^^^
+
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _YVALS_CORE_H_


### PR DESCRIPTION
Followup to #4958.

Fixes VSO-2295101 "\[RWC\]\[prod/fe\]\[Regression\] Cutlass failed with error C2146: syntax error: missing `')'` before identifier `'_Dest'`". It appears that CUDA 12.4 doesn't understand `__restrict`, so when it attempts to split code between the device (GPU) and host (MSVC) compilers, it mangles what's sent to MSVC.

Apparently this is only an issue when the template is instantiated, which is why it wasn't found by our CUDA test coverage (that includes all headers and does nothing with them). It was only encountered in our Real World Code test suite where we wisely harnessed NVIDIA's Cutlass project.

I am slightly nervous that bad kitties have grabbed `_RESTRICT` but we're following that form for `_LIKELY` etc. and I don't want to pre-emptively avoid issues when we have all legitimate rights to this identifier.

Fixes AB#2295101.