### PR TITLE
`<regex>`: Silence CodeQL false positive warning

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -3567,6 +3567,7 @@ bool _Matcher<_BidIt, _Elem, _RxTraits, _It>::_Match_pat(_Node_base* _Nx) { // c
             { // record current position
                 _Node_capture* _Node                 = static_cast<_Node_capture*>(_Nx);
                 _Tgt_state._Grps[_Node->_Idx]._Begin = _Tgt_state._Cur;
+                // CodeQL [SM02323] Comparing unchanging unsigned int _Node->_Idx to decreasing size_t _Idx is safe.
                 for (size_t _Idx = _Tgt_state._Grp_valid.size(); _Node->_Idx < _Idx;) {
                     _Tgt_state._Grp_valid[--_Idx] = false;
                 }


### PR DESCRIPTION
Windows encountered internal OS-50456631 "\[CodeQL:Warning\]: SM02323: cpp/infiniteloop (in packages/\[...\]/regex)", reported to me by @DefaultRyan. According to the [internal doc](https://liquid.microsoft.com/Web/Object/Read/scanningtoolwarnings/Requirements/CodeQL.SM02323#Zguide), this is:

> \[SM02323\] Comparison of narrow type with wide type in loop condition
> Comparisons between types of different widths in a loop condition can cause the loop to fail to terminate.

In this case, the warning is a false positive, and my suppression comment explains why.

Alternatively, we could widen the `unsigned int` to `size_t`, either with a `static_cast` or a named variable, but that'd be unusual enough to still merit a comment, so I chose the less invasive approach.