### PR TITLE
`<xutility>`: Extend vectorization condition for `_Synth_three_way`

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5878,6 +5878,13 @@ struct _Lex_compare_three_way_memcmp_classify_comp<_Elem1, _Elem2, compare_three
 };
 
 template <class _Elem1, class _Elem2>
+struct _Lex_compare_three_way_memcmp_classify_comp<_Elem1, _Elem2, _Synth_three_way> {
+    using _Comp = conditional_t<_Lex_compare_memcmp_classify_elements<_Elem1, _Elem2>
+                                    && three_way_comparable_with<const _Elem1&, const _Elem2&>,
+        _Synth_three_way, void>;
+};
+
+template <class _Elem1, class _Elem2>
 struct _Lex_compare_three_way_memcmp_classify_comp<_Elem1, _Elem2, _Strong_order::_Cpo> {
     using _Comp =
         conditional_t<_Lex_compare_memcmp_classify_elements<_Elem1, _Elem2> && _Can_strong_order<_Elem1, _Elem2>,


### PR DESCRIPTION
When `three_way_comparable_with<const _Elem1&, const _Elem2&>` is satisfied, `_Synth_three_way` behaves same as `compare_three_way`. So we should also consider three-way comparison via `_Synth_three_way` to be vectorizable.

The change is expected to make more comparisons between contiguous containers vectorized.

I _think_ existing test coverages are sufficient.