### PR TITLE
Use `__restrict__` for CUDA

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -2017,7 +2017,7 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 #endif // ^^^ !defined(__cpp_static_call_operator) ^^^
 
 #ifdef __CUDACC__ // TRANSITION, CUDA 12.4 doesn't recognize __restrict
-#define _RESTRICT
+#define _RESTRICT __restrict__
 #else // ^^^ defined(__CUDACC__) / !defined(__CUDACC__) vvv
 #define _RESTRICT __restrict
 #endif // ^^^ !defined(__CUDACC__) ^^^


### PR DESCRIPTION
Followup to #4958 and #5061.

According to [CUDA's documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/#restrict), CUDA recognizes `__restrict__`, so I think we can use that spelling for CUDA.