### PR TITLE
Toolset update: VS 2022 17.13 Preview 1, Windows Server 2025

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.29.0)
+cmake_minimum_required(VERSION 3.30.0)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.12 Preview 3 or later.
+1. Install Visual Studio 2022 17.13 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.
@@ -160,7 +160,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.12 Preview 3 or later.
+1. Install Visual Studio 2022 17.13 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
     if you would like to build the ARM target.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.29.0 or later, and [Ninja][] 1.12.1 or later.
+    * Otherwise, install [CMake][] 3.30.0 or later, and [Ninja][] 1.12.1 or later.
     * Make sure [Python][] 3.13 or later is available to CMake.
 2. Open Visual Studio, and choose the "Clone or check out code" option. Enter the URL of this repository,
    `https://github.com/microsoft/STL`.
@@ -168,7 +168,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
     if you would like to build the ARM target.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.29.0 or later, and [Ninja][] 1.12.1 or later.
+    * Otherwise, install [CMake][] 3.30.0 or later, and [Ninja][] 1.12.1 or later.
     * Make sure [Python][] 3.13 or later is available to CMake.
 2. Open a command prompt.
 3. Change directories to a location where you'd like a clone of this STL repository.

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,7 +5,7 @@
 
 variables:
 - name: poolName
-  value: 'StlBuild-2024-10-15T1118-Pool'
+  value: 'StlBuild-2024-11-12T1255-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -18,7 +18,7 @@ $VMSize = 'Standard_D32ads_v5'
 $ProtoVMName = 'PROTOTYPE'
 $ImagePublisher = 'MicrosoftWindowsServer'
 $ImageOffer = 'WindowsServer'
-$ImageSku = '2022-datacenter-g2'
+$ImageSku = '2025-datacenter-g2'
 
 $ProgressActivity = 'Preparing STL CI pool'
 $TotalProgress = 26

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -40,7 +40,7 @@ foreach ($workload in $VisualStudioWorkloads) {
 }
 
 # https://github.com/PowerShell/PowerShell/releases/latest
-$PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.4.5/PowerShell-7.4.5-win-x64.msi'
+$PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/PowerShell-7.4.6-win-x64.msi'
 $PowerShellArgs = @('/quiet', '/norestart')
 
 $PythonUrl = 'https://www.python.org/ftp/python/3.13.0/python-3.13.0-amd64.exe'

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.29.0)
+cmake_minimum_required(VERSION 3.30.0)
 project(msvc_standard_libraries_benchmarks LANGUAGES CXX)
 
 if(DEFINED STL_BINARY_DIR)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.29.0)
+cmake_minimum_required(VERSION 3.30.0)
 project(msvc_standard_libraries_tools LANGUAGES CXX)
 
 add_subdirectory(format)

--- a/tools/format/CMakeLists.txt
+++ b/tools/format/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.29.0)
+cmake_minimum_required(VERSION 3.30.0)
 project(msvc_standard_libraries_format NONE)
 
 find_program(CLANG_FORMAT

--- a/tools/validate/CMakeLists.txt
+++ b/tools/validate/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.29.0)
+cmake_minimum_required(VERSION 3.30.0)
 project(msvc_standard_libraries_validate LANGUAGES CXX)
 
 add_executable(validate-binary validate.cpp)


### PR DESCRIPTION
# :scroll: Changelog
- Infrastructure improvements:
  * Updated dependencies.
    + Updated build compiler to VS 2022 17.13 Preview 1.
    + Updated CMake to 3.30 (now required).
    + Updated the PR/CI system to Windows Server 2025.

# :page_with_curl: Notes
* Updated PowerShell to 7.4.6.
* VS 2022 17.13 is not yet required because the MSVC-internal build is still using 17.12.
* We last updated the OS in #2496, from Win11 21H2 to Windows Server 2022.
* I've updated the [Checklist for Toolset Updates](https://github.com/microsoft/STL/wiki/Checklist-for-Toolset-Updates) for Windows Server 2025.
* [STL-ASan-CI passed.](https://dev.azure.com/vclibs/STL/_build/results?buildId=17870&view=results)