### PR TITLE
Enforce `assign_range()` mandates for sequence containers

### DIFF
--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -832,6 +832,8 @@ public:
 #if _HAS_CXX23
     template <_Container_compatible_range<_Ty> _Rng>
     void assign_range(_Rng&& _Range) {
+        static_assert(_STD assignable_from<_Ty&, _RANGES range_reference_t<_Rng>>,
+            "Elements must be assignable from the range's reference type. N4993 [sequence.reqmts]/60");
         _Assign_range(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
 #endif // _HAS_CXX23

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -832,8 +832,8 @@ public:
 #if _HAS_CXX23
     template <_Container_compatible_range<_Ty> _Rng>
     void assign_range(_Rng&& _Range) {
-        static_assert(_STD assignable_from<_Ty&, _RANGES range_reference_t<_Rng>>,
-            "Elements must be assignable from the range's reference type. N4993 [sequence.reqmts]/60");
+        static_assert(assignable_from<_Ty&, _RANGES range_reference_t<_Rng>>,
+            "Elements must be assignable from the range's reference type (N4993 [sequence.reqmts]/60).");
         _Assign_range(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
 #endif // _HAS_CXX23

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -967,6 +967,8 @@ public:
 #if _HAS_CXX23
     template <_Container_compatible_range<_Ty> _Rng>
     void assign_range(_Rng&& _Range) {
+        static_assert(_STD assignable_from<_Ty&, _RANGES range_reference_t<_Rng>>,
+            "Elements must be assignable from the range's reference type. N4993 [sequence.reqmts]/60");
         _Assign_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
 #endif // _HAS_CXX23

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -967,8 +967,8 @@ public:
 #if _HAS_CXX23
     template <_Container_compatible_range<_Ty> _Rng>
     void assign_range(_Rng&& _Range) {
-        static_assert(_STD assignable_from<_Ty&, _RANGES range_reference_t<_Rng>>,
-            "Elements must be assignable from the range's reference type. N4993 [sequence.reqmts]/60");
+        static_assert(assignable_from<_Ty&, _RANGES range_reference_t<_Rng>>,
+            "Elements must be assignable from the range's reference type (N4993 [sequence.reqmts]/60).");
         _Assign_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
 #endif // _HAS_CXX23

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -1344,8 +1344,8 @@ public:
 #if _HAS_CXX23
     template <_Container_compatible_range<_Ty> _Rng>
     void assign_range(_Rng&& _Range) {
-        static_assert(_STD assignable_from<_Ty&, _RANGES range_reference_t<_Rng>>,
-            "Elements must be assignable from the range's reference type. N4993 [sequence.reqmts]/60");
+        static_assert(assignable_from<_Ty&, _RANGES range_reference_t<_Rng>>,
+            "Elements must be assignable from the range's reference type (N4993 [sequence.reqmts]/60).");
         _Assign_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
 #endif // _HAS_CXX23

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -1344,6 +1344,8 @@ public:
 #if _HAS_CXX23
     template <_Container_compatible_range<_Ty> _Rng>
     void assign_range(_Rng&& _Range) {
+        static_assert(_STD assignable_from<_Ty&, _RANGES range_reference_t<_Rng>>,
+            "Elements must be assignable from the range's reference type. N4993 [sequence.reqmts]/60");
         _Assign_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
 #endif // _HAS_CXX23

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -1488,8 +1488,8 @@ public:
 #if _HAS_CXX23
     template <_Container_compatible_range<_Ty> _Rng>
     constexpr void assign_range(_Rng&& _Range) {
-        static_assert(_STD assignable_from<_Ty&, _RANGES range_reference_t<_Rng>>,
-            "Elements must be assignable from the range's reference type. N4993 [sequence.reqmts]/60");
+        static_assert(assignable_from<_Ty&, _RANGES range_reference_t<_Rng>>,
+            "Elements must be assignable from the range's reference type (N4993 [sequence.reqmts]/60).");
         if constexpr (_RANGES sized_range<_Rng> || _RANGES forward_range<_Rng>) {
             const auto _Length = _To_unsigned_like(_RANGES distance(_Range));
             const auto _Count  = _Convert_size<size_type>(_Length);
@@ -3331,8 +3331,8 @@ public:
 
     template <_Container_compatible_range<bool> _Rng>
     constexpr void assign_range(_Rng&& _Range) {
-        static_assert(_STD assignable_from<bool&, _RANGES range_reference_t<_Rng>>,
-            "bool& must be assignable from the range's reference type. N4993 [sequence.reqmts]/60");
+        static_assert(assignable_from<bool&, _RANGES range_reference_t<_Rng>>,
+            "Elements must be assignable from the range's reference type (N4993 [sequence.reqmts]/60).");
         clear();
         if constexpr (_RANGES forward_range<_Rng> || _RANGES sized_range<_Rng>) {
             const auto _Length = _To_unsigned_like(_RANGES distance(_Range));

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -1488,6 +1488,8 @@ public:
 #if _HAS_CXX23
     template <_Container_compatible_range<_Ty> _Rng>
     constexpr void assign_range(_Rng&& _Range) {
+        static_assert(_STD assignable_from<_Ty&, _RANGES range_reference_t<_Rng>>,
+            "Elements must be assignable from the range's reference type. N4993 [sequence.reqmts]/60");
         if constexpr (_RANGES sized_range<_Rng> || _RANGES forward_range<_Rng>) {
             const auto _Length = _To_unsigned_like(_RANGES distance(_Range));
             const auto _Count  = _Convert_size<size_type>(_Length);
@@ -3329,6 +3331,8 @@ public:
 
     template <_Container_compatible_range<bool> _Rng>
     constexpr void assign_range(_Rng&& _Range) {
+        static_assert(_STD assignable_from<bool&, _RANGES range_reference_t<_Rng>>,
+            "bool& must be assignable from the range's reference type. N4993 [sequence.reqmts]/60");
         clear();
         if constexpr (_RANGES forward_range<_Rng> || _RANGES sized_range<_Rng>) {
             const auto _Length = _To_unsigned_like(_RANGES distance(_Range));


### PR DESCRIPTION
Resolves #5076 by statically asserting the mandates for the sequence containers `deque`, `forward_list`, `list`, and `vector`.

`basic_string` also defines a function `assign_range()`, but I did not add a static assert to it: `basic_string` includes its own specification of `assign_range()` which does not provide for any *Mandates* ([\[string.assign\]/16](https://eel.is/c++draft/strings#string.assign-16)).  Besides, the standard doesn't list `basic_string` among the sequence containers in [\[sequence.reqmts\]/1](https://eel.is/c++draft/sequence.reqmts#1), so it appears to me that [\[sequence.reqmts\]/60](https://eel.is/c++draft/sequence.reqmts#60) doesn't apply directly to `basic_string`.