### PR TITLE
Vectorize `basic_string::rfind` (the single character overload)

### DIFF
--- a/benchmarks/src/find_and_count.cpp
+++ b/benchmarks/src/find_and_count.cpp
@@ -48,12 +48,12 @@ void bm(benchmark::State& state) {
             benchmark::DoNotOptimize(ranges::find(a.begin(), a.end(), T{'1'}));
         } else if constexpr (Operation == Op::FindUnsized) {
             benchmark::DoNotOptimize(ranges::find(a.begin(), unreachable_sentinel, T{'1'}));
+        } else if constexpr (Operation == Op::Count) {
+            benchmark::DoNotOptimize(ranges::count(a.begin(), a.end(), T{'1'}));
         } else if constexpr (Operation == Op::StringFind) {
             benchmark::DoNotOptimize(a.find(T{'1'}));
         } else if constexpr (Operation == Op::StringRFind) {
             benchmark::DoNotOptimize(a.rfind(T{'1'}));
-        } else if constexpr (Operation == Op::Count) {
-            benchmark::DoNotOptimize(ranges::count(a.begin(), a.end(), T{'1'}));
         }
     }
 }

--- a/benchmarks/src/find_and_count.cpp
+++ b/benchmarks/src/find_and_count.cpp
@@ -26,10 +26,10 @@ void bm(benchmark::State& state) {
     const auto size = static_cast<size_t>(state.range(0));
     const auto pos  = static_cast<size_t>(state.range(1));
 
-    using Containter = conditional_t<Operation == Op::StringFind || Operation == Op::StringRFind,
+    using Container = conditional_t<Operation == Op::StringFind || Operation == Op::StringRFind,
         basic_string<T, char_traits<T>, Alloc<T>>, vector<T, Alloc<T>>>;
 
-    Containter a(size, T{'0'});
+    Container a(size, T{'0'});
 
     if (pos < size) {
         if constexpr (Operation == Op::StringRFind) {

--- a/benchmarks/src/find_and_count.cpp
+++ b/benchmarks/src/find_and_count.cpp
@@ -7,6 +7,8 @@
 #include <cstdint>
 #include <cstdlib>
 #include <ranges>
+#include <string>
+#include <type_traits>
 #include <vector>
 
 #include "skewed_allocator.hpp"

--- a/stl/inc/__msvc_string_view.hpp
+++ b/stl/inc/__msvc_string_view.hpp
@@ -724,7 +724,24 @@ constexpr size_t _Traits_rfind_ch(_In_reads_(_Hay_size) const _Traits_ptr_t<_Tra
         return static_cast<size_t>(-1);
     }
 
-    for (auto _Match_try = _Haystack + (_STD min)(_Start_at, _Hay_size - 1);; --_Match_try) {
+    const size_t _Actual_start_at = (_STD min)(_Start_at, _Hay_size - 1);
+
+#if _USE_STD_VECTOR_ALGORITHMS
+    if constexpr (_Is_implementation_handled_char_traits<_Traits>) {
+        if (!_STD _Is_constant_evaluated()) {
+            const auto _End = _Haystack + _Actual_start_at + 1;
+            const auto _Ptr = _STD _Find_last_vectorized(_Haystack, _End, _Ch);
+
+            if (_Ptr != _End) {
+                return static_cast<size_t>(_Ptr - _Haystack);
+            } else {
+                return static_cast<size_t>(-1);
+            }
+        }
+    }
+#endif // _USE_STD_VECTOR_ALGORITHMS
+
+    for (auto _Match_try = _Haystack + _Actual_start_at;; --_Match_try) {
         if (_Traits::eq(*_Match_try, _Ch)) {
             return static_cast<size_t>(_Match_try - _Haystack); // found a match
         }

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -54,11 +54,6 @@ _Min_max_element_t __stdcall __std_minmax_element_8(const void* _First, const vo
 _Min_max_element_t __stdcall __std_minmax_element_f(const void* _First, const void* _Last, bool _Unused) noexcept;
 _Min_max_element_t __stdcall __std_minmax_element_d(const void* _First, const void* _Last, bool _Unused) noexcept;
 
-const void* __stdcall __std_find_last_trivial_1(const void* _First, const void* _Last, uint8_t _Val) noexcept;
-const void* __stdcall __std_find_last_trivial_2(const void* _First, const void* _Last, uint16_t _Val) noexcept;
-const void* __stdcall __std_find_last_trivial_4(const void* _First, const void* _Last, uint32_t _Val) noexcept;
-const void* __stdcall __std_find_last_trivial_8(const void* _First, const void* _Last, uint64_t _Val) noexcept;
-
 __declspec(noalias) _Min_max_1i __stdcall __std_minmax_1i(const void* _First, const void* _Last) noexcept;
 __declspec(noalias) _Min_max_1u __stdcall __std_minmax_1u(const void* _First, const void* _Last) noexcept;
 __declspec(noalias) _Min_max_2i __stdcall __std_minmax_2i(const void* _First, const void* _Last) noexcept;
@@ -157,33 +152,6 @@ auto _Minmax_vectorized(_Ty* const _First, _Ty* const _Last) noexcept {
         } else {
             return ::__std_minmax_8u(_First, _Last);
         }
-    } else {
-        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
-    }
-}
-
-template <class _Ty, class _TVal>
-_Ty* _Find_last_vectorized(_Ty* const _First, _Ty* const _Last, const _TVal _Val) noexcept {
-    if constexpr (is_pointer_v<_TVal> || is_null_pointer_v<_TVal>) {
-#ifdef _WIN64
-        return const_cast<_Ty*>(
-            static_cast<const _Ty*>(::__std_find_last_trivial_8(_First, _Last, reinterpret_cast<uint64_t>(_Val))));
-#else
-        return const_cast<_Ty*>(
-            static_cast<const _Ty*>(::__std_find_last_trivial_4(_First, _Last, reinterpret_cast<uint32_t>(_Val))));
-#endif
-    } else if constexpr (sizeof(_Ty) == 1) {
-        return const_cast<_Ty*>(
-            static_cast<const _Ty*>(::__std_find_last_trivial_1(_First, _Last, static_cast<uint8_t>(_Val))));
-    } else if constexpr (sizeof(_Ty) == 2) {
-        return const_cast<_Ty*>(
-            static_cast<const _Ty*>(::__std_find_last_trivial_2(_First, _Last, static_cast<uint16_t>(_Val))));
-    } else if constexpr (sizeof(_Ty) == 4) {
-        return const_cast<_Ty*>(
-            static_cast<const _Ty*>(::__std_find_last_trivial_4(_First, _Last, static_cast<uint32_t>(_Val))));
-    } else if constexpr (sizeof(_Ty) == 8) {
-        return const_cast<_Ty*>(
-            static_cast<const _Ty*>(::__std_find_last_trivial_8(_First, _Last, static_cast<uint64_t>(_Val))));
     } else {
         _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
     }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -93,6 +93,11 @@ const void* __stdcall __std_find_trivial_2(const void* _First, const void* _Last
 const void* __stdcall __std_find_trivial_4(const void* _First, const void* _Last, uint32_t _Val) noexcept;
 const void* __stdcall __std_find_trivial_8(const void* _First, const void* _Last, uint64_t _Val) noexcept;
 
+const void* __stdcall __std_find_last_trivial_1(const void* _First, const void* _Last, uint8_t _Val) noexcept;
+const void* __stdcall __std_find_last_trivial_2(const void* _First, const void* _Last, uint16_t _Val) noexcept;
+const void* __stdcall __std_find_last_trivial_4(const void* _First, const void* _Last, uint32_t _Val) noexcept;
+const void* __stdcall __std_find_last_trivial_8(const void* _First, const void* _Last, uint64_t _Val) noexcept;
+
 const void* __stdcall __std_find_first_of_trivial_1(
     const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept;
 const void* __stdcall __std_find_first_of_trivial_2(
@@ -212,6 +217,33 @@ _Ty* _Find_vectorized(_Ty* const _First, _Ty* const _Last, const _TVal _Val) noe
     } else if constexpr (sizeof(_Ty) == 8) {
         return const_cast<_Ty*>(
             static_cast<const _Ty*>(::__std_find_trivial_8(_First, _Last, static_cast<uint64_t>(_Val))));
+    } else {
+        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
+    }
+}
+
+template <class _Ty, class _TVal>
+_Ty* _Find_last_vectorized(_Ty* const _First, _Ty* const _Last, const _TVal _Val) noexcept {
+    if constexpr (is_pointer_v<_TVal> || is_null_pointer_v<_TVal>) {
+#ifdef _WIN64
+        return const_cast<_Ty*>(
+            static_cast<const _Ty*>(::__std_find_last_trivial_8(_First, _Last, reinterpret_cast<uint64_t>(_Val))));
+#else
+        return const_cast<_Ty*>(
+            static_cast<const _Ty*>(::__std_find_last_trivial_4(_First, _Last, reinterpret_cast<uint32_t>(_Val))));
+#endif
+    } else if constexpr (sizeof(_Ty) == 1) {
+        return const_cast<_Ty*>(
+            static_cast<const _Ty*>(::__std_find_last_trivial_1(_First, _Last, static_cast<uint8_t>(_Val))));
+    } else if constexpr (sizeof(_Ty) == 2) {
+        return const_cast<_Ty*>(
+            static_cast<const _Ty*>(::__std_find_last_trivial_2(_First, _Last, static_cast<uint16_t>(_Val))));
+    } else if constexpr (sizeof(_Ty) == 4) {
+        return const_cast<_Ty*>(
+            static_cast<const _Ty*>(::__std_find_last_trivial_4(_First, _Last, static_cast<uint32_t>(_Val))));
+    } else if constexpr (sizeof(_Ty) == 8) {
+        return const_cast<_Ty*>(
+            static_cast<const _Ty*>(::__std_find_last_trivial_8(_First, _Last, static_cast<uint64_t>(_Val))));
     } else {
         _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
     }

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -1156,11 +1156,11 @@ void test_basic_string_dis(mt19937_64& gen, D& dis) {
     for (;;) {
         input_needle.clear();
 
-        test_case_string_rfind_ch(input_haystack, static_cast<T>(dis(gen)));
         test_case_string_find_first_of(input_haystack, input_needle);
         test_case_string_find_last_of(input_haystack, input_needle);
         test_case_string_find_str(input_haystack, input_needle);
         test_case_string_rfind_str(input_haystack, input_needle);
+        test_case_string_rfind_ch(input_haystack, static_cast<T>(dis(gen)));
 
         for (size_t attempts = 0; attempts < needleDataCount; ++attempts) {
             input_needle.push_back(static_cast<T>(dis(gen)));

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -1128,6 +1128,22 @@ void test_case_string_rfind_str(const basic_string<T>& input_haystack, const bas
     assert(expected == actual);
 }
 
+template <class T>
+void test_case_string_rfind_ch(const basic_string<T>& input_haystack, const T value) {
+    ptrdiff_t expected;
+
+    const auto expected_iter = last_known_good_find_last(input_haystack.begin(), input_haystack.end(), value);
+
+    if (expected_iter != input_haystack.end()) {
+        expected = expected_iter - input_haystack.begin();
+    } else {
+        expected = -1;
+    }
+
+    const auto actual = static_cast<ptrdiff_t>(input_haystack.rfind(value));
+    assert(expected == actual);
+}
+
 template <class T, class D>
 void test_basic_string_dis(mt19937_64& gen, D& dis) {
     basic_string<T> input_haystack;
@@ -1140,6 +1156,7 @@ void test_basic_string_dis(mt19937_64& gen, D& dis) {
     for (;;) {
         input_needle.clear();
 
+        test_case_string_rfind_ch(input_haystack, static_cast<T>(dis(gen)));
         test_case_string_find_first_of(input_haystack, input_needle);
         test_case_string_find_last_of(input_haystack, input_needle);
         test_case_string_find_str(input_haystack, input_needle);
@@ -1147,6 +1164,7 @@ void test_basic_string_dis(mt19937_64& gen, D& dis) {
 
         for (size_t attempts = 0; attempts < needleDataCount; ++attempts) {
             input_needle.push_back(static_cast<T>(dis(gen)));
+            test_case_string_rfind_ch(input_haystack, input_needle.back());
             test_case_string_find_first_of(input_haystack, input_needle);
             test_case_string_find_last_of(input_haystack, input_needle);
             test_case_string_find_str(input_haystack, input_needle);

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -1164,7 +1164,6 @@ void test_basic_string_dis(mt19937_64& gen, D& dis) {
 
         for (size_t attempts = 0; attempts < needleDataCount; ++attempts) {
             input_needle.push_back(static_cast<T>(dis(gen)));
-            test_case_string_rfind_ch(input_haystack, input_needle.back());
             test_case_string_find_first_of(input_haystack, input_needle);
             test_case_string_find_last_of(input_haystack, input_needle);
             test_case_string_find_str(input_haystack, input_needle);


### PR DESCRIPTION
Towards #5036 

# ⏱️ Benchmark results

Benchmark                                                                  |    main  |     this | comment
---------------------------------------------------------------------------|----------|----------|-----
`bm<uint8_t, not_highly_aligned_allocator, Op::FindSized>/8021/3056`       | 37.2 ns  |  45.8 ns | random variation
`bm<uint8_t, not_highly_aligned_allocator, Op::FindSized>/63/62`           | 3.86 ns  |  3.30 ns |
`bm<uint8_t, not_highly_aligned_allocator, Op::FindSized>/31/30`           | 6.91 ns  |  8.26 ns |
`bm<uint8_t, not_highly_aligned_allocator, Op::FindSized>/15/14`           | 6.05 ns  |  6.15 ns |
`bm<uint8_t, not_highly_aligned_allocator, Op::FindSized>/7/6`             | 2.76 ns  |  3.05 ns |
`bm<uint8_t, highly_aligned_allocator, Op::FindSized>/8021/3056`           | 44.8 ns  |  46.6 ns |
`bm<uint8_t, highly_aligned_allocator, Op::FindSized>/63/62`               | 3.14 ns  |  3.27 ns |
`bm<uint8_t, highly_aligned_allocator, Op::FindSized>/31/30`               | 7.56 ns  |  7.86 ns |
`bm<uint8_t, highly_aligned_allocator, Op::FindSized>/15/14`               | 5.96 ns  |  6.39 ns |
`bm<uint8_t, highly_aligned_allocator, Op::FindSized>/7/6`                 | 3.04 ns  |  2.85 ns |
`bm<uint8_t, not_highly_aligned_allocator, Op::FindUnsized>/8021/3056`     | 80.5 ns  |  80.5 ns |
`bm<uint8_t, not_highly_aligned_allocator, Op::FindUnsized>/63/62`         | 3.90 ns  |  3.90 ns |
`bm<uint8_t, not_highly_aligned_allocator, Op::FindUnsized>/31/30`         | 3.31 ns  |  3.27 ns |
`bm<uint8_t, not_highly_aligned_allocator, Op::FindUnsized>/15/14`         | 3.04 ns  |  3.14 ns |
`bm<uint8_t, not_highly_aligned_allocator, Op::FindUnsized>/7/6`           | 2.29 ns  |  2.42 ns |
`bm<uint8_t, highly_aligned_allocator, Op::FindUnsized>/8021/3056`         | 77.3 ns  |  69.6 ns | random variation
`bm<uint8_t, highly_aligned_allocator, Op::FindUnsized>/63/62`             | 2.11 ns  |  2.13 ns |
`bm<uint8_t, highly_aligned_allocator, Op::FindUnsized>/31/30`             | 1.53 ns  |  1.54 ns |
`bm<uint8_t, highly_aligned_allocator, Op::FindUnsized>/15/14`             | 1.29 ns  |  1.30 ns |
`bm<uint8_t, highly_aligned_allocator, Op::FindUnsized>/7/6`               | 1.29 ns  |  1.29 ns |
`bm<uint8_t, not_highly_aligned_allocator, Op::Count>/8021/3056`           | 87.7 ns  |  90.4 ns |
`bm<uint8_t, not_highly_aligned_allocator, Op::Count>/63/62`               | 4.50 ns  |  4.52 ns |
`bm<uint8_t, not_highly_aligned_allocator, Op::Count>/31/30`               | 7.49 ns  |  7.98 ns |
`bm<uint8_t, not_highly_aligned_allocator, Op::Count>/15/14`               | 6.20 ns  |  5.20 ns |
`bm<uint8_t, not_highly_aligned_allocator, Op::Count>/7/6`                 | 3.57 ns  |  3.29 ns |
`bm<uint8_t, highly_aligned_allocator, Op::Count>/8021/3056`               | 75.1 ns  |  75.4 ns |
`bm<uint8_t, highly_aligned_allocator, Op::Count>/63/62`                   | 4.48 ns  |  4.49 ns |
`bm<uint8_t, highly_aligned_allocator, Op::Count>/31/30`                   | 7.60 ns  |  7.90 ns |
`bm<uint8_t, highly_aligned_allocator, Op::Count>/15/14`                   | 5.89 ns  |  5.17 ns |
`bm<uint8_t, highly_aligned_allocator, Op::Count>/7/6`                     | 4.01 ns  |  3.31 ns |
`bm<char, not_highly_aligned_allocator, Op::StringFind>/8021/3056`         | 81.0 ns  |  79.8 ns |
`bm<char, not_highly_aligned_allocator, Op::StringFind>/63/62`             | 14.1 ns  |  15.2 ns |
`bm<char, not_highly_aligned_allocator, Op::StringFind>/31/30`             | 13.3 ns  |  12.7 ns |
`bm<char, not_highly_aligned_allocator, Op::StringFind>/15/14`             | 4.95 ns  |  5.03 ns |
`bm<char, not_highly_aligned_allocator, Op::StringFind>/7/6`               | 2.71 ns  |  2.71 ns |
`bm<char, highly_aligned_allocator, Op::StringFind>/8021/3056`             | 71.6 ns  |  70.5 ns |
`bm<char, highly_aligned_allocator, Op::StringFind>/63/62`                 | 13.0 ns  |  12.9 ns |
`bm<char, highly_aligned_allocator, Op::StringFind>/31/30`                 | 12.5 ns  |  12.1 ns |
`bm<char, highly_aligned_allocator, Op::StringFind>/15/14`                 | 4.85 ns  |  4.86 ns |
`bm<char, highly_aligned_allocator, Op::StringFind>/7/6`                   | 2.72 ns  |  2.72 ns |
`bm<char, not_highly_aligned_allocator, Op::StringRFind>/8021/3056`        |  733 ns  |  43.4 ns | vectorized
`bm<char, not_highly_aligned_allocator, Op::StringRFind>/63/62`            | 17.1 ns  |  3.77 ns | vectorized
`bm<char, not_highly_aligned_allocator, Op::StringRFind>/31/30`            | 9.13 ns  |  5.81 ns | vectorized
`bm<char, not_highly_aligned_allocator, Op::StringRFind>/15/14`            | 6.18 ns  |  5.07 ns | vectorized
`bm<char, not_highly_aligned_allocator, Op::StringRFind>/7/6`              | 3.00 ns  |  3.10 ns | vectorized
`bm<char, highly_aligned_allocator, Op::StringRFind>/8021/3056`            |  731 ns  |  45.1 ns | vectorized
`bm<char, highly_aligned_allocator, Op::StringRFind>/63/62`                | 16.7 ns  |  3.78 ns | vectorized
`bm<char, highly_aligned_allocator, Op::StringRFind>/31/30`                | 9.15 ns  |  7.25 ns | vectorized
`bm<char, highly_aligned_allocator, Op::StringRFind>/15/14`                | 6.15 ns  |  6.53 ns | vectorized
`bm<char, highly_aligned_allocator, Op::StringRFind>/7/6`                  | 3.11 ns  |  3.14 ns | vectorized
`bm<uint16_t, not_highly_aligned_allocator, Op::FindSized>/8021/3056`      | 81.5 ns  |  82.5 ns |
`bm<uint16_t, not_highly_aligned_allocator, Op::FindSized>/63/62`          | 3.19 ns  |  3.28 ns |
`bm<uint16_t, not_highly_aligned_allocator, Op::FindSized>/31/30`          | 2.67 ns  |  2.70 ns |
`bm<uint16_t, not_highly_aligned_allocator, Op::FindSized>/15/14`          | 3.05 ns  |  3.09 ns |
`bm<uint16_t, not_highly_aligned_allocator, Op::FindSized>/7/6`            | 2.58 ns  |  2.59 ns |
`bm<uint16_t, not_highly_aligned_allocator, Op::Count>/8021/3056`          |  164 ns  |   164 ns |
`bm<uint16_t, not_highly_aligned_allocator, Op::Count>/63/62`              | 4.71 ns  |  4.72 ns |
`bm<uint16_t, not_highly_aligned_allocator, Op::Count>/31/30`              | 4.48 ns  |  4.49 ns |
`bm<uint16_t, not_highly_aligned_allocator, Op::Count>/15/14`              | 4.69 ns  |  4.69 ns |
`bm<uint16_t, not_highly_aligned_allocator, Op::Count>/7/6`                | 3.52 ns  |  3.54 ns |
`bm<wchar_t, not_highly_aligned_allocator, Op::StringFind>/8021/3056`      |  731 ns  |   734 ns |
`bm<wchar_t, not_highly_aligned_allocator, Op::StringFind>/63/62`          | 17.3 ns  |  17.4 ns |
`bm<wchar_t, not_highly_aligned_allocator, Op::StringFind>/31/30`          | 9.35 ns  |  9.32 ns |
`bm<wchar_t, not_highly_aligned_allocator, Op::StringFind>/15/14`          | 6.69 ns  |  5.86 ns |
`bm<wchar_t, not_highly_aligned_allocator, Op::StringFind>/7/6`            | 2.69 ns  |  2.75 ns |
`bm<wchar_t, not_highly_aligned_allocator, Op::StringRFind>/8021/3056`     |  732 ns  |  82.6 ns | vectorized
`bm<wchar_t, not_highly_aligned_allocator, Op::StringRFind>/63/62`         | 16.7 ns  |  4.01 ns | vectorized
`bm<wchar_t, not_highly_aligned_allocator, Op::StringRFind>/31/30`         | 8.73 ns  |  3.42 ns | vectorized
`bm<wchar_t, not_highly_aligned_allocator, Op::StringRFind>/15/14`         | 4.41 ns  |  3.76 ns | vectorized
`bm<wchar_t, not_highly_aligned_allocator, Op::StringRFind>/7/6`           | 2.47 ns  |  3.05 ns | vectorized
`bm<uint32_t, not_highly_aligned_allocator, Op::FindSized>/8021/3056`      |  154 ns  |   152 ns |
`bm<uint32_t, not_highly_aligned_allocator, Op::FindSized>/63/62`          | 3.99 ns  |  3.97 ns |
`bm<uint32_t, not_highly_aligned_allocator, Op::FindSized>/31/30`          | 2.85 ns  |  3.00 ns |
`bm<uint32_t, not_highly_aligned_allocator, Op::FindSized>/15/14`          | 2.63 ns  |  2.59 ns |
`bm<uint32_t, not_highly_aligned_allocator, Op::FindSized>/7/6`            | 2.56 ns  |  2.38 ns |
`bm<uint32_t, not_highly_aligned_allocator, Op::Count>/8021/3056`          |  324 ns  |   321 ns |
`bm<uint32_t, not_highly_aligned_allocator, Op::Count>/63/62`              | 4.79 ns  |  4.70 ns |
`bm<uint32_t, not_highly_aligned_allocator, Op::Count>/31/30`              | 4.23 ns  |  4.22 ns |
`bm<uint32_t, not_highly_aligned_allocator, Op::Count>/15/14`              | 3.85 ns  |  3.83 ns |
`bm<uint32_t, not_highly_aligned_allocator, Op::Count>/7/6`                | 3.75 ns  |  3.77 ns |
`bm<char32_t, not_highly_aligned_allocator, Op::StringFind>/8021/3056`     |  729 ns  |   733 ns |
`bm<char32_t, not_highly_aligned_allocator, Op::StringFind>/63/62`         | 16.9 ns  |  30.2 ns |
`bm<char32_t, not_highly_aligned_allocator, Op::StringFind>/31/30`         | 9.46 ns  |  15.7 ns |
`bm<char32_t, not_highly_aligned_allocator, Op::StringFind>/15/14`         | 6.76 ns  |  4.46 ns |
`bm<char32_t, not_highly_aligned_allocator, Op::StringFind>/7/6`           | 2.88 ns  |  2.37 ns |
`bm<char32_t, not_highly_aligned_allocator, Op::StringRFind>/8021/3056`    |  731 ns  |   155 ns | vectorized
`bm<char32_t, not_highly_aligned_allocator, Op::StringRFind>/63/62`        | 16.6 ns  |  5.46 ns | vectorized
`bm<char32_t, not_highly_aligned_allocator, Op::StringRFind>/31/30`        | 8.93 ns  |  3.89 ns | vectorized
`bm<char32_t, not_highly_aligned_allocator, Op::StringRFind>/15/14`        | 5.07 ns  |  3.51 ns | vectorized
`bm<char32_t, not_highly_aligned_allocator, Op::StringRFind>/7/6`          | 2.58 ns  |  3.05 ns | vectorized
`bm<uint64_t, not_highly_aligned_allocator, Op::FindSized>/8021/3056`      |  288 ns  |   287 ns |
`bm<uint64_t, not_highly_aligned_allocator, Op::FindSized>/63/62`          | 6.73 ns  |  6.80 ns |
`bm<uint64_t, not_highly_aligned_allocator, Op::FindSized>/31/30`          | 3.97 ns  |  3.99 ns |
`bm<uint64_t, not_highly_aligned_allocator, Op::FindSized>/15/14`          | 2.84 ns  |  2.82 ns |
`bm<uint64_t, not_highly_aligned_allocator, Op::FindSized>/7/6`            | 2.65 ns  |  2.64 ns |
`bm<uint64_t, not_highly_aligned_allocator, Op::Count>/8021/3056`          |  922 ns  |   930 ns |
`bm<uint64_t, not_highly_aligned_allocator, Op::Count>/63/62`              | 6.41 ns  |  9.30 ns |
`bm<uint64_t, not_highly_aligned_allocator, Op::Count>/31/30`              | 4.19 ns  |  4.17 ns |
`bm<uint64_t, not_highly_aligned_allocator, Op::Count>/15/14`              | 3.51 ns  |  3.54 ns |
`bm<uint64_t, not_highly_aligned_allocator, Op::Count>/7/6`                | 3.16 ns  |  3.20 ns |

# 🥇 Results observation

 * The `StringRFind` cases are improved greatly
 * The `StringFind` cases may need improvement
 * Some interesting very good results for `FindUnsized` with aligned allocator

# ♾️ `FindUnsized` results explanation

TL;DR: There's interesting results, but unfortunately not useful.

The `FindUnsized` with `highly_aligned_allocator` shows surprisingly small timings. Apparently there's an optimization in `memchr` similar to the reverted unsized find vectorization, that reads beyond the valid range. 

Looks like it only reads after the valid range, but does not do aligning read before the valid range, so it requires some alignment for the optimization to fully engage. The required alignment is 16 bytes, implying there's SSE inside, but not AVX. Should work well with default `malloc` 16 bytes alignment.

This doesn't seem to work this good for small sized range. `StringFind` currently uses `memchr`, and it doesn't show that good results.

# 🔜 Further steps

I want to question, whether we want to also vectorize `basic_string::find`. Here are some points:
 * For 8-bit elements, `FindSized` is twice faster than `StringFind`. Looks like `memchr` doesn't use AVX. So we can stop calling `memchr` and use our vectorization. The counter point could be that the C runtime should be optimized instead.
 * For 16-bit elements, which are more rare, the results would be more significant. It is because `wmemchr` is slow. But it is expected to improve in a new Windows Kit.
 * For bigger characters, there are no C runtime functions, so the vectorization would gve huge benefit, but they are more rare.