### PR TITLE
Don't use `__restrict__` for CUDA

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -2016,7 +2016,7 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 #define _CONST_CALL_OPERATOR const
 #endif // ^^^ !defined(__cpp_static_call_operator) ^^^
 
-#ifdef __CUDACC__ // TRANSITION, CUDA 12.4 doesn't recognize __restrict
+#ifdef __CUDACC__ // TRANSITION, CUDA 12.4 doesn't recognize MSVC __restrict; CUDA __restrict__ is not usable in C++
 #define _RESTRICT
 #else // ^^^ defined(__CUDACC__) / !defined(__CUDACC__) vvv
 #define _RESTRICT __restrict

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -2017,7 +2017,7 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 #endif // ^^^ !defined(__cpp_static_call_operator) ^^^
 
 #ifdef __CUDACC__ // TRANSITION, CUDA 12.4 doesn't recognize __restrict
-#define _RESTRICT __restrict__
+#define _RESTRICT
 #else // ^^^ defined(__CUDACC__) / !defined(__CUDACC__) vvv
 #define _RESTRICT __restrict
 #endif // ^^^ !defined(__CUDACC__) ^^^


### PR DESCRIPTION
#5079 was a nice try, but it doesn't work. We need to revert this before 17.13 Preview 3 branches for release.

It broke NVIDIA's Cutlass again. @CaseyCarter observed:

> In both the old and new preprocessed repros, our `_RESTRICT`s in the declaration of `_Adjacent_difference_no_overlap` are being expanded to plain `restrict`. If I had to guess, I'd say that CUDA is replacing `__restrict__` with `restrict` under the expectation that `__restrict__` is only used in C mode.

Fixes VSO-2295101 / AB#2295101 again.