### PR TITLE
Vectorize `basic_string::find`

### DIFF
--- a/stl/inc/__msvc_string_view.hpp
+++ b/stl/inc/__msvc_string_view.hpp
@@ -660,11 +660,28 @@ template <class _Traits>
 constexpr size_t _Traits_find_ch(_In_reads_(_Hay_size) const _Traits_ptr_t<_Traits> _Haystack, const size_t _Hay_size,
     const size_t _Start_at, const _Traits_ch_t<_Traits> _Ch) noexcept {
     // search [_Haystack, _Haystack + _Hay_size) for _Ch, at/after _Start_at
-    if (_Start_at < _Hay_size) {
-        const auto _Found_at = _Traits::find(_Haystack + _Start_at, _Hay_size - _Start_at, _Ch);
-        if (_Found_at) {
-            return static_cast<size_t>(_Found_at - _Haystack);
+    if (_Start_at >= _Hay_size) {
+        return static_cast<size_t>(-1); // (npos) no room for match
+    }
+
+#if _USE_STD_VECTOR_ALGORITHMS
+    if constexpr (_Is_implementation_handled_char_traits<_Traits>) {
+        if (!_STD _Is_constant_evaluated()) {
+            const auto _End = _Haystack + _Hay_size;
+            const auto _Ptr = _STD _Find_vectorized(_Haystack, _End, _Ch);
+
+            if (_Ptr != _End) {
+                return static_cast<size_t>(_Ptr - _Haystack);
+            } else {
+                return static_cast<size_t>(-1); // (npos) no match
+            }
         }
+    }
+#endif // _USE_STD_VECTOR_ALGORITHMS
+
+    const auto _Found_at = _Traits::find(_Haystack + _Start_at, _Hay_size - _Start_at, _Ch);
+    if (_Found_at) {
+        return static_cast<size_t>(_Found_at - _Haystack);
     }
 
     return static_cast<size_t>(-1); // (npos) no match

--- a/stl/inc/__msvc_string_view.hpp
+++ b/stl/inc/__msvc_string_view.hpp
@@ -668,7 +668,7 @@ constexpr size_t _Traits_find_ch(_In_reads_(_Hay_size) const _Traits_ptr_t<_Trai
     if constexpr (_Is_implementation_handled_char_traits<_Traits>) {
         if (!_STD _Is_constant_evaluated()) {
             const auto _End = _Haystack + _Hay_size;
-            const auto _Ptr = _STD _Find_vectorized(_Haystack, _End, _Ch);
+            const auto _Ptr = _STD _Find_vectorized(_Haystack + _Start_at, _End, _Ch);
 
             if (_Ptr != _End) {
                 return static_cast<size_t>(_Ptr - _Haystack);

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -1091,6 +1091,38 @@ void test_case_string_find_last_of(const basic_string<T>& input_haystack, const 
 }
 
 template <class T>
+void test_case_string_find_ch(const basic_string<T>& input_haystack, const T value) {
+    ptrdiff_t expected;
+
+    const auto expected_iter = last_known_good_find(input_haystack.begin(), input_haystack.end(), value);
+
+    if (expected_iter != input_haystack.end()) {
+        expected = expected_iter - input_haystack.begin();
+    } else {
+        expected = -1;
+    }
+
+    const auto actual = static_cast<ptrdiff_t>(input_haystack.find(value));
+    assert(expected == actual);
+}
+
+template <class T>
+void test_case_string_rfind_ch(const basic_string<T>& input_haystack, const T value) {
+    ptrdiff_t expected;
+
+    const auto expected_iter = last_known_good_find_last(input_haystack.begin(), input_haystack.end(), value);
+
+    if (expected_iter != input_haystack.end()) {
+        expected = expected_iter - input_haystack.begin();
+    } else {
+        expected = -1;
+    }
+
+    const auto actual = static_cast<ptrdiff_t>(input_haystack.rfind(value));
+    assert(expected == actual);
+}
+
+template <class T>
 void test_case_string_find_str(const basic_string<T>& input_haystack, const basic_string<T>& input_needle) {
     ptrdiff_t expected;
     if (input_needle.empty()) {
@@ -1128,22 +1160,6 @@ void test_case_string_rfind_str(const basic_string<T>& input_haystack, const bas
     assert(expected == actual);
 }
 
-template <class T>
-void test_case_string_rfind_ch(const basic_string<T>& input_haystack, const T value) {
-    ptrdiff_t expected;
-
-    const auto expected_iter = last_known_good_find_last(input_haystack.begin(), input_haystack.end(), value);
-
-    if (expected_iter != input_haystack.end()) {
-        expected = expected_iter - input_haystack.begin();
-    } else {
-        expected = -1;
-    }
-
-    const auto actual = static_cast<ptrdiff_t>(input_haystack.rfind(value));
-    assert(expected == actual);
-}
-
 template <class T, class D>
 void test_basic_string_dis(mt19937_64& gen, D& dis) {
     basic_string<T> input_haystack;
@@ -1154,13 +1170,16 @@ void test_basic_string_dis(mt19937_64& gen, D& dis) {
     temp.reserve(needleDataCount);
 
     for (;;) {
+        const auto input_element = static_cast<T>(dis(gen));
+        test_case_string_find_ch(input_haystack, input_element);
+        test_case_string_rfind_ch(input_haystack, input_element);
+
         input_needle.clear();
 
         test_case_string_find_first_of(input_haystack, input_needle);
         test_case_string_find_last_of(input_haystack, input_needle);
         test_case_string_find_str(input_haystack, input_needle);
         test_case_string_rfind_str(input_haystack, input_needle);
-        test_case_string_rfind_ch(input_haystack, static_cast<T>(dis(gen)));
 
         for (size_t attempts = 0; attempts < needleDataCount; ++attempts) {
             input_needle.push_back(static_cast<T>(dis(gen)));


### PR DESCRIPTION
Resolves #5036

**⚠️ Need to decide whether this CRT replacing vectorization is needed ⚠️** 

# 🏁 Race against the runtime!

`basic_string::find` is already vectorized for 8 and 16 bit characters via calling `memchr` and `wmemchr`

`memchr` shows good results for smaller positions, but if the distance from the beginning to the result is long the `memchr` results are noticeably worse. There's strong indication that such a results are due to not using AVX in `memchr`.

`wmemchr` is not fast at all. It was promised to be fast in a new CRT in #4873 though.

For larger characters the vectorization is novel, there's no CRT implementation, but these characters are rare anyway.

# ⏱️ Benchmark results

Benchmark                                                              |      main    |       this    
-----------------------------------------------------------------------|--------------|---------------
bm<char, not_highly_aligned_allocator, Op::StringFind>/8021/3056       |   89.6 ns    |    49.3 ns    
bm<char, not_highly_aligned_allocator, Op::StringFind>/63/62           |   11.3 ns    |    3.70 ns    
bm<char, not_highly_aligned_allocator, Op::StringFind>/31/30           |   9.90 ns    |    8.70 ns    
bm<char, not_highly_aligned_allocator, Op::StringFind>/15/14           |   4.94 ns    |    7.10 ns    
bm<char, not_highly_aligned_allocator, Op::StringFind>/7/6             |   2.83 ns    |    3.49 ns    
bm<char, highly_aligned_allocator, Op::StringFind>/8021/3056           |   78.0 ns    |    48.0 ns    
bm<char, highly_aligned_allocator, Op::StringFind>/63/62               |   12.4 ns    |    4.11 ns    
bm<char, highly_aligned_allocator, Op::StringFind>/31/30               |   10.2 ns    |    7.85 ns    
bm<char, highly_aligned_allocator, Op::StringFind>/15/14               |   5.18 ns    |    7.42 ns    
bm<char, highly_aligned_allocator, Op::StringFind>/7/6                 |   2.76 ns    |    3.42 ns    
bm<wchar_t, not_highly_aligned_allocator, Op::StringFind>/8021/3056    |    754 ns    |    85.3 ns    
bm<wchar_t, not_highly_aligned_allocator, Op::StringFind>/63/62        |   31.1 ns    |    3.84 ns    
bm<wchar_t, not_highly_aligned_allocator, Op::StringFind>/31/30        |   16.2 ns    |    2.92 ns    
bm<wchar_t, not_highly_aligned_allocator, Op::StringFind>/15/14        |   4.65 ns    |    3.66 ns    
bm<wchar_t, not_highly_aligned_allocator, Op::StringFind>/7/6          |   2.45 ns    |    2.93 ns    
bm<char32_t, not_highly_aligned_allocator, Op::StringFind>/8021/3056   |    749 ns    |     159 ns    
bm<char32_t, not_highly_aligned_allocator, Op::StringFind>/63/62       |   18.5 ns    |    5.25 ns    
bm<char32_t, not_highly_aligned_allocator, Op::StringFind>/31/30       |   9.60 ns    |    3.55 ns    
bm<char32_t, not_highly_aligned_allocator, Op::StringFind>/15/14       |   6.42 ns    |    2.91 ns    
bm<char32_t, not_highly_aligned_allocator, Op::StringFind>/7/6         |   2.80 ns    |    2.95 ns    