### PR TITLE
Internally remove workaround in `Dev09_056375_locale_cleanup`

### DIFF
--- a/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
+++ b/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
@@ -83,9 +83,9 @@ void test_dll() {
     TheFuncProc pFunc = reinterpret_cast<TheFuncProc>(GetProcAddress(hLibrary, "DllTest"));
     assert(pFunc != nullptr);
     pFunc();
-#if defined(_DLL) || !defined(__SANITIZE_ADDRESS__) // TRANSITION, VSO-2046190
+#if defined(_MSVC_INTERNAL_TESTING) || defined(_DLL) || !defined(__SANITIZE_ADDRESS__) // TRANSITION, vs17.13p2
     FreeLibrary(hLibrary);
-#endif // defined(_DLL) || !defined(__SANITIZE_ADDRESS__)
+#endif // ^^^ no workaround ^^^
 #endif // ^^^ !defined(_M_CEE) ^^^
 }
 


### PR DESCRIPTION
The `FreeLibrary` call made the ASan runtime do Very Bad Things when statically linking the STL. The ASan bug was fixed by [AddressSanitizer-PR-582781](https://devdiv.visualstudio.com/DevDiv/_git/AddressSanitizer/pullrequest/582781) (merged into `prod/be` by MSVC-PR-585734 on 2024-10-16). Let's enable test coverage internally to prevent regressions until the fix ships in 17.13p2.

Fixes VSO-2046190/AB#2046190.

* [x] STL-ASan-CI run: https://dev.azure.com/vclibs/STL/_build/results?buildId=17912&view=results

(I've done some extra validation with the trunk compiler as well to make sure this won't become a problem when merging.)