### PR TITLE
Fix unsafe vector assignment operations during reallocations

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -1332,9 +1332,9 @@ public:
         _Simple_reallocation_guard _Guard{_Al, _Newvec, _Newcapacity};
 
         if constexpr (_Nothrow_construct) {
-            _Uninitialized_fill_n(_Newvec, _Newsize, _Val, _Al);
+            _STD _Uninitialized_fill_n(_Newvec, _Newsize, _Val, _Al);
         } else {
-            _Uninitialized_fill_n(_Newvec, _Newsize, _Val, _Al);
+            _STD _Uninitialized_fill_n(_Newvec, _Newsize, _Val, _Al);
         }
 
         _Guard._New_begin = nullptr;
@@ -1433,9 +1433,9 @@ private:
         _Simple_reallocation_guard _Guard{_Al, _Newvec, _Newcapacity};
 
         if constexpr (_Nothrow_construct) {
-            _Uninitialized_copy_n(_STD move(_First), _Newsize, _Newvec, _Al);
+            _STD _Uninitialized_copy_n(_STD move(_First), _Newsize, _Newvec, _Al);
         } else {
-            _Uninitialized_copy_n(_STD move(_First), _Newsize, _Newvec, _Al);
+            _STD _Uninitialized_copy_n(_STD move(_First), _Newsize, _Newvec, _Al);
         }
 
         _Guard._New_begin = nullptr;

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -1317,6 +1317,30 @@ public:
         return _Make_iterator_offset(_Whereoff);
     }
 
+    _CONSTEXPR20 void _Fill_reallocate(const size_type _Newsize, const _Ty& _Val) {
+        if (_Newsize > max_size()) {
+            _Xlength();
+        }
+
+        auto& _Al              = _Getal();
+        size_type _Newcapacity = _Calculate_growth(_Newsize);
+        const pointer _Newvec  = _Allocate_at_least_helper(_Al, _Newcapacity);
+
+        constexpr bool _Nothrow_construct =
+            conjunction_v<is_nothrow_copy_constructible<_Ty>, _Uses_default_construct<_Alloc, _Ty*, const _Ty&>>;
+
+        _Simple_reallocation_guard _Guard{_Al, _Newvec, _Newcapacity};
+
+        if constexpr (_Nothrow_construct) {
+            _Uninitialized_fill_n(_Newvec, _Newsize, _Val, _Al);
+        } else {
+            _Uninitialized_fill_n(_Newvec, _Newsize, _Val, _Al);
+        }
+
+        _Guard._New_begin = nullptr;
+        _Change_array(_Newvec, _Newsize, _Newcapacity);
+    }
+
     _CONSTEXPR20 void assign(_CRT_GUARDOVERFLOW const size_type _Newsize, const _Ty& _Val) {
         // assign _Newsize * _Val
         auto& _Al         = _Getal();
@@ -1341,15 +1365,7 @@ public:
         _My_data._Orphan_all();
         const auto _Oldcapacity = static_cast<size_type>(_My_data._Myend - _Myfirst);
         if (_Newsize > _Oldcapacity) { // reallocate
-            _Clear_and_reserve_geometric(_Newsize);
-            if constexpr (_Nothrow_construct) {
-                _Mylast = _Uninitialized_fill_n(_Myfirst, _Newsize, _Val, _Al);
-                _ASAN_VECTOR_CREATE;
-            } else {
-                _ASAN_VECTOR_CREATE_GUARD;
-                _Mylast = _Uninitialized_fill_n(_Myfirst, _Newsize, _Val, _Al);
-            }
-
+            _Fill_reallocate(_Newsize, _Val);
             return;
         }
 
@@ -1402,6 +1418,31 @@ private:
     }
 
     template <class _Iter>
+    _CONSTEXPR20 void _Assign_reallocate(_Iter _First, const size_type _Newsize) {
+        if (_Newsize > max_size()) {
+            _Xlength();
+        }
+
+        auto& _Al              = _Getal();
+        size_type _Newcapacity = _Calculate_growth(_Newsize);
+        const pointer _Newvec  = _Allocate_at_least_helper(_Al, _Newcapacity);
+
+        constexpr bool _Nothrow_construct = conjunction_v<is_nothrow_constructible<_Ty, _Iter_ref_t<_Iter>>,
+            _Uses_default_construct<_Alloc, _Ty*, _Iter_ref_t<_Iter>>>;
+
+        _Simple_reallocation_guard _Guard{_Al, _Newvec, _Newcapacity};
+
+        if constexpr (_Nothrow_construct) {
+            _Uninitialized_copy_n(_STD move(_First), _Newsize, _Newvec, _Al);
+        } else {
+            _Uninitialized_copy_n(_STD move(_First), _Newsize, _Newvec, _Al);
+        }
+
+        _Guard._New_begin = nullptr;
+        _Change_array(_Newvec, _Newsize, _Newcapacity);
+    }
+
+    template <class _Iter>
     _CONSTEXPR20 void _Assign_counted_range(_Iter _First, const size_type _Newsize) {
         // assign elements from counted range _First + [0, _Newsize)
         auto& _Al         = _Getal();
@@ -1416,14 +1457,7 @@ private:
         _My_data._Orphan_all();
         const auto _Oldcapacity = static_cast<size_type>(_Myend - _Myfirst);
         if (_Newsize > _Oldcapacity) {
-            _Clear_and_reserve_geometric(_Newsize);
-            if constexpr (_Nothrow_construct) {
-                _Mylast = _STD _Uninitialized_copy_n(_STD move(_First), _Newsize, _Myfirst, _Al);
-                _ASAN_VECTOR_CREATE;
-            } else {
-                _ASAN_VECTOR_CREATE_GUARD;
-                _Mylast = _STD _Uninitialized_copy_n(_STD move(_First), _Newsize, _Myfirst, _Al);
-            }
+            _Assign_reallocate(_STD move(_First), _Newsize);
             return;
         }
 
@@ -1672,37 +1706,6 @@ private:
         }
     }
 #endif // _ITERATOR_DEBUG_LEVEL != 0 && defined(_ENABLE_STL_INTERNAL_CHECK)
-
-    _CONSTEXPR20 void _Clear_and_reserve_geometric(const size_type _Newsize) {
-        auto& _Al         = _Getal();
-        auto& _My_data    = _Mypair._Myval2;
-        pointer& _Myfirst = _My_data._Myfirst;
-        pointer& _Mylast  = _My_data._Mylast;
-        pointer& _Myend   = _My_data._Myend;
-
-#if _ITERATOR_DEBUG_LEVEL != 0 && defined(_ENABLE_STL_INTERNAL_CHECK)
-        _STL_INTERNAL_CHECK(_Newsize != 0);
-        _Check_all_orphaned();
-#endif // _ITERATOR_DEBUG_LEVEL != 0 && defined(_ENABLE_STL_INTERNAL_CHECK)
-
-        if (_Newsize > max_size()) {
-            _Xlength();
-        }
-
-        const size_type _Newcapacity = _Calculate_growth(_Newsize);
-
-        if (_Myfirst) { // destroy and deallocate old array
-            _Destroy_range(_Myfirst, _Mylast, _Al);
-            _ASAN_VECTOR_REMOVE;
-            _Al.deallocate(_Myfirst, static_cast<size_type>(_Myend - _Myfirst));
-
-            _Myfirst = nullptr;
-            _Mylast  = nullptr;
-            _Myend   = nullptr;
-        }
-
-        _Buy_raw(_Newcapacity);
-    }
 
 public:
     _CONSTEXPR20 void reserve(_CRT_GUARDOVERFLOW size_type _Newcapacity) {
@@ -2131,15 +2134,7 @@ private:
         _My_data._Orphan_all();
         const auto _Oldcapacity = static_cast<size_type>(_My_data._Myend - _Myfirst);
         if (_Newsize > _Oldcapacity) {
-            _Clear_and_reserve_geometric(_Newsize);
-            if constexpr (_Nothrow_construct) {
-                _Mylast = _Uninitialized_move(_First, _Last, _Myfirst, _Al);
-                _ASAN_VECTOR_CREATE;
-            } else {
-                _ASAN_VECTOR_CREATE_GUARD;
-                _Mylast = _Uninitialized_move(_First, _Last, _Myfirst, _Al);
-            }
-
+            _Assign_reallocate(make_move_iterator(_First), _Newsize);
             return;
         }
 

--- a/tests/std/tests/GH_005106_vector_assign_safety/env.lst
+++ b/tests/std/tests/GH_005106_vector_assign_safety/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/GH_005106_vector_assign_safety/test.cpp
+++ b/tests/std/tests/GH_005106_vector_assign_safety/test.cpp
@@ -1,0 +1,235 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cassert>
+#include <iostream>
+#include <ranges>
+#include <vector>
+
+struct throwing_t {
+    int* throw_after_ = nullptr;
+    throwing_t() {
+        throw 0;
+    }
+
+    throwing_t(int& throw_after_n) : throw_after_(&throw_after_n) {
+        if (throw_after_n == 0) {
+            throw 0;
+        }
+        --throw_after_n;
+    }
+
+    throwing_t(const throwing_t& rhs) : throw_after_(rhs.throw_after_) {
+        if (throw_after_ == nullptr || *throw_after_ == 0) {
+            throw 1;
+        }
+        --*throw_after_;
+    }
+
+    throwing_t& operator=(const throwing_t& rhs) {
+        throw_after_ = rhs.throw_after_;
+        if (throw_after_ == nullptr || *throw_after_ == 0) {
+            throw 1;
+        }
+        --*throw_after_;
+        return *this;
+    }
+
+    friend bool operator==(const throwing_t& lhs, const throwing_t& rhs) {
+        return lhs.throw_after_ == rhs.throw_after_;
+    }
+    friend bool operator!=(const throwing_t& lhs, const throwing_t& rhs) {
+        return lhs.throw_after_ != rhs.throw_after_;
+    }
+};
+
+template <class T, class IterCat>
+struct throwing_iterator {
+    using iterator_category = IterCat;
+    using difference_type   = std::ptrdiff_t;
+    using value_type        = T;
+    using reference         = T&;
+    using pointer           = T*;
+
+    int i_;
+    T v_;
+
+    constexpr throwing_iterator(int i = 0, const T& v = T()) : i_(i), v_(v) {}
+
+    reference operator*() {
+        if (i_ == 1) {
+            throw 1;
+        }
+        return v_;
+    }
+
+    friend bool operator==(const throwing_iterator& lhs, const throwing_iterator& rhs) {
+        return lhs.i_ == rhs.i_;
+    }
+    friend bool operator!=(const throwing_iterator& lhs, const throwing_iterator& rhs) {
+        return lhs.i_ != rhs.i_;
+    }
+
+    throwing_iterator& operator++() {
+        ++i_;
+        return *this;
+    }
+
+    throwing_iterator operator++(int) {
+        auto tmp = *this;
+        ++i_;
+        return tmp;
+    }
+};
+
+template <class T, bool POCMA>
+class toggle_pocma_allocator {
+    template <class, bool>
+    friend class toggle_pocma_allocator;
+
+public:
+    using propagate_on_container_move_assignment = std::integral_constant<bool, POCMA>;
+    using value_type                             = T;
+
+    template <class U>
+    struct rebind {
+        using other = toggle_pocma_allocator<U, POCMA>;
+    };
+
+    constexpr toggle_pocma_allocator(int id) : id_(id) {}
+
+    template <class U>
+    constexpr toggle_pocma_allocator(const toggle_pocma_allocator<U, POCMA>& other) : id_(other.id_) {}
+
+    constexpr T* allocate(std::size_t n) {
+        return std::allocator<T>().allocate(n);
+    }
+
+    constexpr void deallocate(T* p, std::size_t n) {
+        std::allocator<T>().deallocate(p, n);
+    }
+
+    constexpr int id() const {
+        return id_;
+    }
+
+    template <class U>
+    constexpr friend bool operator==(const toggle_pocma_allocator& lhs, const toggle_pocma_allocator<U, POCMA>& rhs) {
+        return lhs.id() == rhs.id();
+    }
+
+    template <class U>
+    constexpr friend bool operator!=(const toggle_pocma_allocator& lhs, const toggle_pocma_allocator<U, POCMA>& rhs) {
+        return !(lhs == rhs);
+    }
+
+private:
+    int id_;
+};
+
+template <class T>
+using pocma_allocator = toggle_pocma_allocator<T, true>;
+template <class T>
+using non_pocma_allocator = toggle_pocma_allocator<T, false>;
+
+
+void test() {
+    {
+        int throw_after = 10;
+        throwing_t t    = throw_after;
+        std::vector<throwing_t> in(6, t);
+        std::vector<throwing_t> v(3, t);
+        try { // Throw in copy-assignment operator from element type during construction
+            v = in;
+        } catch (int) {
+        }
+        assert(v.size() == 3);
+    }
+
+    {
+        int throw_after = 10;
+        throwing_t t    = throw_after;
+        non_pocma_allocator<throwing_t> alloc1(1);
+        non_pocma_allocator<throwing_t> alloc2(2);
+        std::vector<throwing_t, non_pocma_allocator<throwing_t>> in(6, t, alloc1);
+        std::vector<throwing_t, non_pocma_allocator<throwing_t>> v(3, t, alloc2);
+        try { // Throw in move-assignment operator from element type during construction
+            v = std::move(in);
+        } catch (int) {
+        }
+        assert(v.size() == 3);
+    }
+
+    {
+        int throw_after = 10;
+        throwing_t t    = throw_after;
+        std::initializer_list<throwing_t> in{t, t, t, t, t, t};
+        std::vector<throwing_t> v(3, t);
+        try { // Throw in operator=(initializer_list<_Ty>) from element type during construction
+            v = in;
+        } catch (int) {
+        }
+        assert(v.size() == 3);
+    }
+
+    {
+        std::vector<int> v(3);
+        try { // Throw in assign(_Iter, _Iter) from forward iterator during construction
+            v.assign(throwing_iterator<int, std::forward_iterator_tag>(),
+                throwing_iterator<int, std::forward_iterator_tag>(6));
+        } catch (int) {
+        }
+        assert(v.size() == 3);
+    }
+
+    {
+        int throw_after = 10;
+        throwing_t t    = throw_after;
+        std::vector<throwing_t> in(6, t);
+        std::vector<throwing_t> v(3, t);
+        try { // Throw in assign(_Iter, _Iter) from element type during construction
+            v.assign(in.begin(), in.end());
+        } catch (int) {
+        }
+        assert(v.size() == 3);
+    }
+
+    {
+        int throw_after = 10;
+        throwing_t t    = throw_after;
+        std::vector<throwing_t> in(6, t);
+        std::vector<throwing_t> v(3, t);
+        try { // Throw in assign_range(_Rng&&) from element type during construction
+            v.assign_range(in);
+        } catch (int) {
+        }
+        assert(v.size() == 3);
+    }
+
+    {
+        int throw_after = 4;
+        throwing_t t    = throw_after;
+        std::vector<throwing_t> v(3, t);
+        try { // Throw in assign(size_type, const _Ty&) from element type during construction
+            v.assign(6, t);
+        } catch (int) {
+        }
+        assert(v.size() == 3);
+    }
+
+    {
+        int throw_after = 10;
+        throwing_t t    = throw_after;
+        std::initializer_list<throwing_t> in{t, t, t, t, t, t};
+        std::vector<throwing_t> v(3, t);
+        try { // Throw in assign(initializer_list<_Ty>) from element type during construction
+            v.assign(in);
+        } catch (int) {
+        }
+        assert(v.size() == 3);
+    }
+}
+
+int main() {
+    test();
+}


### PR DESCRIPTION
Current implementations of vector assignment operations, including the copy, move, `initializer_list`-assignment operators, as well as all overloads of the `assign` functions and the C++23 `assign_range` function, are unsafe during reallocations triggered by assignments. This unsafety can lead to a broken vector with all elements erased, as reported in issue #5106.

The issue arises because all the assignment functions ultimately execute the following code during reallocations on assignments:

```cpp
_Clear_and_reserve_geometric(_Newsize);
if constexpr (_Nothrow_construct) {
    _Mylast = _Uninitialized_{copy,fill,move}_n(_Myfirst, _Newsize, _Val, _Al);
    _ASAN_VECTOR_CREATE;
} else {
    _ASAN_VECTOR_CREATE_GUARD;
    _Mylast = _Uninitialized_{copy,fill,move}_n(_Myfirst, _Newsize, _Val, _Al);
}
```

This sequence is unsafe because the destruction of the old vector occurs strictly before the construction of the new vector elements. If any exception is raised during the subsequent construction of new elements, the original vector is already cleared and there is no way to recover it. 


This patch fixes #5106 using a copy-and-swap idiom, ensuring that the vector remains intact in the event of exceptions during vector reallocations in assignments. In other words, this patch enhances the copy/initializer_list-assignment operators, the `assign` overloads, and C++23 `assign_range` of `std::vector` to provide strong exception guarantees during vector reallocations. However, it should be noted that in general, these assignment operations cannot always guarantee strong exception safety. 
