### PR TITLE
Implement LWG-4169 `std::atomic<T>`'s default constructor should be constrained

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -580,7 +580,6 @@ template <class _Ty, size_t /* = ... */>
 struct _Atomic_storage {
     // Provides operations common to all specializations of std::atomic, load, store, exchange, and CAS.
     // Locking version used when hardware has no atomic operations for sizeof(_Ty).
-    _STL_INTERNAL_STATIC_ASSERT(!is_rvalue_reference_v<_Ty>);
 
     using _TVal  = remove_reference_t<_Ty>;
     using _Guard = _Atomic_lock_guard<typename _Atomic_storage_types<_Ty>::_Spinlock>;
@@ -714,8 +713,6 @@ public:
 
 template <class _Ty>
 struct _Atomic_storage<_Ty, 1> { // lock-free using 1-byte intrinsics
-    _STL_INTERNAL_STATIC_ASSERT(!is_rvalue_reference_v<_Ty>);
-
     using _TVal = remove_reference_t<_Ty>;
 
     _Atomic_storage() = default;
@@ -817,8 +814,6 @@ struct _Atomic_storage<_Ty, 1> { // lock-free using 1-byte intrinsics
 
 template <class _Ty>
 struct _Atomic_storage<_Ty, 2> { // lock-free using 2-byte intrinsics
-    _STL_INTERNAL_STATIC_ASSERT(!is_rvalue_reference_v<_Ty>);
-
     using _TVal = remove_reference_t<_Ty>;
 
     _Atomic_storage() = default;
@@ -919,8 +914,6 @@ struct _Atomic_storage<_Ty, 2> { // lock-free using 2-byte intrinsics
 
 template <class _Ty>
 struct _Atomic_storage<_Ty, 4> { // lock-free using 4-byte intrinsics
-    _STL_INTERNAL_STATIC_ASSERT(!is_rvalue_reference_v<_Ty>);
-
     using _TVal = remove_reference_t<_Ty>;
 
     _Atomic_storage() = default;
@@ -1021,8 +1014,6 @@ struct _Atomic_storage<_Ty, 4> { // lock-free using 4-byte intrinsics
 
 template <class _Ty>
 struct _Atomic_storage<_Ty, 8> { // lock-free using 8-byte intrinsics
-    _STL_INTERNAL_STATIC_ASSERT(!is_rvalue_reference_v<_Ty>);
-
     using _TVal = remove_reference_t<_Ty>;
 
     _Atomic_storage() = default;
@@ -1143,8 +1134,6 @@ struct _Atomic_storage<_Ty, 8> { // lock-free using 8-byte intrinsics
 #ifdef _WIN64
 template <class _Ty>
 struct _Atomic_storage<_Ty&, 16> { // lock-free using 16-byte intrinsics
-    _STL_INTERNAL_STATIC_ASSERT(!is_rvalue_reference_v<_Ty>);
-
     // TRANSITION, ABI: replace '_Ty&' with '_Ty' in this specialization
     using _TVal = remove_reference_t<_Ty&>;
 

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2804,9 +2804,17 @@ _EXPORT_STD struct atomic_flag { // flag with test-and-set semantics
 #endif // _HAS_CXX20
 
 #if 1 // TRANSITION, ABI
-    atomic<long> _Storage;
+    atomic<long> _Storage
+#if !_HAS_CXX20 && defined(__EDG__)
+        {0L}
+#endif // ^^^ workaround ^^^
+    ;
 #else // ^^^ don't break ABI / break ABI vvv
-    atomic<bool> _Storage;
+    atomic<bool> _Storage
+#if !_HAS_CXX20 && defined(__EDG__)
+        {false}
+#endif // ^^^ workaround ^^^
+    ;
 #endif // ^^^ break ABI ^^^
 };
 

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -580,14 +580,14 @@ template <class _Ty, size_t /* = ... */>
 struct _Atomic_storage {
     // Provides operations common to all specializations of std::atomic, load, store, exchange, and CAS.
     // Locking version used when hardware has no atomic operations for sizeof(_Ty).
+    _STL_INTERNAL_STATIC_ASSERT(!is_rvalue_reference_v<_Ty>);
 
     using _TVal  = remove_reference_t<_Ty>;
     using _Guard = _Atomic_lock_guard<typename _Atomic_storage_types<_Ty>::_Spinlock>;
 
     _Atomic_storage() = default;
 
-    /* implicit */ constexpr _Atomic_storage(conditional_t<is_reference_v<_Ty>, _Ty, const _TVal&> _Value) noexcept
-        : _Storage(_Value) {
+    /* implicit */ constexpr _Atomic_storage(const _Ty& _Value) noexcept : _Storage(_Value) {
         // non-atomically initialize this atomic
     }
 
@@ -714,13 +714,13 @@ public:
 
 template <class _Ty>
 struct _Atomic_storage<_Ty, 1> { // lock-free using 1-byte intrinsics
+    _STL_INTERNAL_STATIC_ASSERT(!is_rvalue_reference_v<_Ty>);
 
     using _TVal = remove_reference_t<_Ty>;
 
     _Atomic_storage() = default;
 
-    /* implicit */ constexpr _Atomic_storage(conditional_t<is_reference_v<_Ty>, _Ty, const _TVal&> _Value) noexcept
-        : _Storage{_Value} {
+    /* implicit */ constexpr _Atomic_storage(const _Ty& _Value) noexcept : _Storage{_Value} {
         // non-atomically initialize this atomic
     }
 
@@ -817,13 +817,13 @@ struct _Atomic_storage<_Ty, 1> { // lock-free using 1-byte intrinsics
 
 template <class _Ty>
 struct _Atomic_storage<_Ty, 2> { // lock-free using 2-byte intrinsics
+    _STL_INTERNAL_STATIC_ASSERT(!is_rvalue_reference_v<_Ty>);
 
     using _TVal = remove_reference_t<_Ty>;
 
     _Atomic_storage() = default;
 
-    /* implicit */ constexpr _Atomic_storage(conditional_t<is_reference_v<_Ty>, _Ty, const _TVal&> _Value) noexcept
-        : _Storage{_Value} {
+    /* implicit */ constexpr _Atomic_storage(const _Ty& _Value) noexcept : _Storage{_Value} {
         // non-atomically initialize this atomic
     }
 
@@ -919,13 +919,13 @@ struct _Atomic_storage<_Ty, 2> { // lock-free using 2-byte intrinsics
 
 template <class _Ty>
 struct _Atomic_storage<_Ty, 4> { // lock-free using 4-byte intrinsics
+    _STL_INTERNAL_STATIC_ASSERT(!is_rvalue_reference_v<_Ty>);
 
     using _TVal = remove_reference_t<_Ty>;
 
     _Atomic_storage() = default;
 
-    /* implicit */ constexpr _Atomic_storage(conditional_t<is_reference_v<_Ty>, _Ty, const _TVal&> _Value) noexcept
-        : _Storage{_Value} {
+    /* implicit */ constexpr _Atomic_storage(const _Ty& _Value) noexcept : _Storage{_Value} {
         // non-atomically initialize this atomic
     }
 
@@ -1021,13 +1021,13 @@ struct _Atomic_storage<_Ty, 4> { // lock-free using 4-byte intrinsics
 
 template <class _Ty>
 struct _Atomic_storage<_Ty, 8> { // lock-free using 8-byte intrinsics
+    _STL_INTERNAL_STATIC_ASSERT(!is_rvalue_reference_v<_Ty>);
 
     using _TVal = remove_reference_t<_Ty>;
 
     _Atomic_storage() = default;
 
-    /* implicit */ constexpr _Atomic_storage(conditional_t<is_reference_v<_Ty>, _Ty, const _TVal&> _Value) noexcept
-        : _Storage{_Value} {
+    /* implicit */ constexpr _Atomic_storage(const _Ty& _Value) noexcept : _Storage{_Value} {
         // non-atomically initialize this atomic
     }
 
@@ -1143,12 +1143,15 @@ struct _Atomic_storage<_Ty, 8> { // lock-free using 8-byte intrinsics
 #ifdef _WIN64
 template <class _Ty>
 struct _Atomic_storage<_Ty&, 16> { // lock-free using 16-byte intrinsics
+    _STL_INTERNAL_STATIC_ASSERT(!is_rvalue_reference_v<_Ty>);
+
     // TRANSITION, ABI: replace '_Ty&' with '_Ty' in this specialization
     using _TVal = remove_reference_t<_Ty&>;
 
     _Atomic_storage() = default;
 
-    /* implicit */ constexpr _Atomic_storage(conditional_t<is_reference_v<_Ty&>, _Ty&, const _TVal&> _Value) noexcept
+    // TRANSITION, ABI: replace _this_ occurrence of '_Ty&' with 'const _Ty&'
+    /* implicit */ constexpr _Atomic_storage(_Ty& _Value) noexcept
         : _Storage{_Value} {} // non-atomically initialize this atomic
 
     void store(const _TVal _Value) noexcept { // store with sequential consistency

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2123,6 +2123,7 @@ public:
 
     using _Base::_Base;
 
+    template <class _Uty = _Ty, enable_if_t<is_default_constructible_v<_Uty>, int> = 0>
     constexpr atomic() noexcept(is_nothrow_default_constructible_v<_Ty>) : _Base() {}
 
     atomic(const atomic&)                     = delete;

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -586,7 +586,7 @@ struct _Atomic_storage {
 
     _Atomic_storage() = default;
 
-    /* implicit */ constexpr _Atomic_storage(conditional_t<is_reference_v<_Ty>, _Ty, const _TVal> _Value) noexcept
+    /* implicit */ constexpr _Atomic_storage(conditional_t<is_reference_v<_Ty>, _Ty, const _TVal&> _Value) noexcept
         : _Storage(_Value) {
         // non-atomically initialize this atomic
     }
@@ -719,7 +719,7 @@ struct _Atomic_storage<_Ty, 1> { // lock-free using 1-byte intrinsics
 
     _Atomic_storage() = default;
 
-    /* implicit */ constexpr _Atomic_storage(conditional_t<is_reference_v<_Ty>, _Ty, const _TVal> _Value) noexcept
+    /* implicit */ constexpr _Atomic_storage(conditional_t<is_reference_v<_Ty>, _Ty, const _TVal&> _Value) noexcept
         : _Storage{_Value} {
         // non-atomically initialize this atomic
     }
@@ -822,7 +822,7 @@ struct _Atomic_storage<_Ty, 2> { // lock-free using 2-byte intrinsics
 
     _Atomic_storage() = default;
 
-    /* implicit */ constexpr _Atomic_storage(conditional_t<is_reference_v<_Ty>, _Ty, const _TVal> _Value) noexcept
+    /* implicit */ constexpr _Atomic_storage(conditional_t<is_reference_v<_Ty>, _Ty, const _TVal&> _Value) noexcept
         : _Storage{_Value} {
         // non-atomically initialize this atomic
     }
@@ -924,7 +924,7 @@ struct _Atomic_storage<_Ty, 4> { // lock-free using 4-byte intrinsics
 
     _Atomic_storage() = default;
 
-    /* implicit */ constexpr _Atomic_storage(conditional_t<is_reference_v<_Ty>, _Ty, const _TVal> _Value) noexcept
+    /* implicit */ constexpr _Atomic_storage(conditional_t<is_reference_v<_Ty>, _Ty, const _TVal&> _Value) noexcept
         : _Storage{_Value} {
         // non-atomically initialize this atomic
     }
@@ -1026,7 +1026,7 @@ struct _Atomic_storage<_Ty, 8> { // lock-free using 8-byte intrinsics
 
     _Atomic_storage() = default;
 
-    /* implicit */ constexpr _Atomic_storage(conditional_t<is_reference_v<_Ty>, _Ty, const _TVal> _Value) noexcept
+    /* implicit */ constexpr _Atomic_storage(conditional_t<is_reference_v<_Ty>, _Ty, const _TVal&> _Value) noexcept
         : _Storage{_Value} {
         // non-atomically initialize this atomic
     }
@@ -1148,7 +1148,7 @@ struct _Atomic_storage<_Ty&, 16> { // lock-free using 16-byte intrinsics
 
     _Atomic_storage() = default;
 
-    /* implicit */ constexpr _Atomic_storage(conditional_t<is_reference_v<_Ty&>, _Ty&, const _TVal> _Value) noexcept
+    /* implicit */ constexpr _Atomic_storage(conditional_t<is_reference_v<_Ty&>, _Ty&, const _TVal&> _Value) noexcept
         : _Storage{_Value} {} // non-atomically initialize this atomic
 
     void store(const _TVal _Value) noexcept { // store with sequential consistency
@@ -2121,10 +2121,10 @@ public:
 
     using value_type = _Ty;
 
-    using _Base::_Base;
-
     template <class _Uty = _Ty, enable_if_t<is_default_constructible_v<_Uty>, int> = 0>
     constexpr atomic() noexcept(is_nothrow_default_constructible_v<_Ty>) : _Base() {}
+
+    /* implicit */ constexpr atomic(const _Ty _Value) noexcept : _Base(_Value) {}
 
     atomic(const atomic&)                     = delete;
     atomic& operator=(const atomic&)          = delete;
@@ -2804,17 +2804,9 @@ _EXPORT_STD struct atomic_flag { // flag with test-and-set semantics
 #endif // _HAS_CXX20
 
 #if 1 // TRANSITION, ABI
-    atomic<long> _Storage
-#if !_HAS_CXX20 && defined(__EDG__)
-        {0L}
-#endif // ^^^ workaround ^^^
-    ;
+    atomic<long> _Storage;
 #else // ^^^ don't break ABI / break ABI vvv
-    atomic<bool> _Storage
-#if !_HAS_CXX20 && defined(__EDG__)
-        {false}
-#endif // ^^^ workaround ^^^
-    ;
+    atomic<bool> _Storage;
 #endif // ^^^ break ABI ^^^
 };
 

--- a/tests/std/tests/Dev11_0863628_atomic_compare_exchange/test.cpp
+++ b/tests/std/tests/Dev11_0863628_atomic_compare_exchange/test.cpp
@@ -12,10 +12,10 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
 #include <limits>
 #include <new>
 #include <type_traits>
-
 
 using namespace std;
 
@@ -437,6 +437,17 @@ STATIC_ASSERT(atomic<Bytes<1>*>::is_always_lock_free);
 STATIC_ASSERT(atomic<void*>::is_always_lock_free);
 STATIC_ASSERT(atomic<int (*)(int)>::is_always_lock_free);
 #endif // _HAS_CXX17
+
+// Also test LWG-4169 std::atomic<T>'s default constructor should be constrained
+// (backported to C++14/17 modes as we backported P0883R2)
+STATIC_ASSERT(is_default_constructible_v<atomic<int>>);
+STATIC_ASSERT(is_default_constructible_v<atomic<bool>>);
+STATIC_ASSERT(is_default_constructible_v<atomic<void*>>);
+STATIC_ASSERT(is_default_constructible_v<atomic<X>>);
+STATIC_ASSERT(is_default_constructible_v<atomic<Y>>);
+STATIC_ASSERT(!is_default_constructible_v<atomic<reference_wrapper<int>>>);
+STATIC_ASSERT(!is_default_constructible_v<atomic<reference_wrapper<const int>>>);
+STATIC_ASSERT(!is_default_constructible_v<atomic<reference_wrapper<int()>>>);
 
 
 // Also test P0418R2 atomic compare_exchange memory_order Requirements


### PR DESCRIPTION
Fixes #5123.

Perhaps this should be backported to old modes as we backported WG21-P0883R2.