### PR TITLE
Implement LWG-4140 Useless default constructors for bit reference types

### DIFF
--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -109,8 +109,6 @@ public:
         }
 
     private:
-        _CONSTEXPR23 reference() noexcept : _Pbitset(nullptr), _Mypos(0) {}
-
         _CONSTEXPR23 reference(bitset<_Bits>& _Bitset, const size_t _Pos) noexcept : _Pbitset(&_Bitset), _Mypos(_Pos) {}
 
         bitset<_Bits>* _Pbitset;

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -2444,9 +2444,6 @@ private:
     using _Mycont          = typename _Mybase::_Mycont;
     using _Difference_type = typename _Mybase::_Difference_type;
 
-    // TRANSITION, ABI: non-trivial constructor
-    _CONSTEXPR20 _Vb_reference() = default;
-
 public:
     _CONSTEXPR20 _Vb_reference(const _Vb_reference&) = default;
 

--- a/tests/std/tests/Dev10_860410_bitset_ctors/test.cpp
+++ b/tests/std/tests/Dev10_860410_bitset_ctors/test.cpp
@@ -12,6 +12,25 @@ using namespace std;
 
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
 
+// Also test LWG-4140 "Useless default constructors for bit reference types" for bitset<N>::reference.
+namespace lwg_4140 {
+    struct default_constructible_type {};
+
+    void test_default_constructor(default_constructible_type) {}
+    void test_default_constructor(bitset<0>::reference) {}
+    void test_default_constructor(bitset<1>::reference) {}
+    void test_default_constructor(bitset<8>::reference) {}
+    void test_default_constructor(bitset<16>::reference) {}
+    void test_default_constructor(bitset<32>::reference) {}
+    void test_default_constructor(bitset<48>::reference) {}
+    void test_default_constructor(bitset<64>::reference) {}
+    void test_default_constructor(bitset<96>::reference) {}
+
+    void test() { // COMPILE-ONLY
+        test_default_constructor({});
+    }
+} // namespace lwg_4140
+
 const char parsedStr[] = "1000110111110011110111111111111111010111110111100101010100001001"
                          "1111111111111111111111111111111111111111111111111111111111111111"
                          "0111111111111111111111111111111111111111111111111111111111111111"

--- a/tests/std/tests/Dev11_0437519_container_requirements/test.compile.pass.cpp
+++ b/tests/std/tests/Dev11_0437519_container_requirements/test.compile.pass.cpp
@@ -3031,6 +3031,23 @@ void assert_vector_bool_noexcept() {
     assert_vector_bool_noexcept_impl<non_pocma_allocator<bool>>();
 }
 
+// Also test LWG-4140 "Useless default constructors for bit reference types" for vector<bool, Alloc>::reference.
+namespace lwg_4140 {
+    struct default_constructible_type {};
+
+    void test_default_constructor(default_constructible_type) {}
+    void test_default_constructor(std::vector<bool>::reference) {}
+    void test_default_constructor(std::vector<bool, pocma_allocator<bool>>::reference) {}
+    void test_default_constructor(std::vector<bool, non_pocma_allocator<bool>>::reference) {}
+#if _HAS_CXX17
+    void test_default_constructor(std::pmr::vector<bool>::reference) {}
+#endif // _HAS_CXX17
+
+    void test() {
+        test_default_constructor({});
+    }
+} // namespace lwg_4140
+
 template <container_tag Tag>
 void assert_container() {
     check_all_container_requirements<Tag>();


### PR DESCRIPTION
Fixes #5122.