### PR TITLE
Implement LWG-4014 LWG-3809 changes behavior of some existing `std::subtract_with_carry_engine` code

### DIFF
--- a/stl/inc/random
+++ b/stl/inc/random
@@ -827,7 +827,7 @@ public:
 
     void seed(_Seed_t _Value = 0u, bool _Readcy = false) { // set initial values from specified seed value
         linear_congruential_engine<uint_least32_t, 40014U, 0U, 2147483563U> _Lc{
-            static_cast<uint_least32_t>(_Value == 0U ? default_seed : _Value)};
+            _Value == 0U ? default_seed : static_cast<uint_least32_t>(_Value % 2147483563U)};
         _Reset(_Lc, _Readcy);
     }
 

--- a/tests/std/tests/Dev11_0577418_random_seed_0/test.cpp
+++ b/tests/std/tests/Dev11_0577418_random_seed_0/test.cpp
@@ -24,14 +24,14 @@ int main() {
     // Also test VSO-214595 "subtract_with_carry_engine::seed should accept result_type"
     subtract_with_carry_engine<unsigned long long, 64, 10, 24> ull_swc;
     ull_swc.seed(0x12341234'00000000ULL);
-    assert(run_10k(ull_swc) == 0x01316AEA'3646F686ULL); // libstdc++ and libc++ agree (boost 1.60.0 disagrees)
+    assert(run_10k(ull_swc) == 0x01316AEA'3646F686ULL); // libstdc++ 14.2 and libc++ 19.1 agree, Boost 1.86.0 disagrees
 
     assert(minstd_rand0(0) == minstd_rand0()); // N4964 [rand.eng.lcong]/5
     assert(mt19937(0) != mt19937()); // N4964 [rand.eng.mers]/6
     assert(ranlux24_base(0) == ranlux24_base()); // N4964 [rand.eng.sub]/7
 
     assert(run_10k(minstd_rand0(0)) == 1043618065UL); // QED
-    assert(run_10k(mt19937(0)) == 1543171712UL); // Boost 1.52.0 agrees
+    assert(run_10k(mt19937(0)) == 1543171712UL); // Boost 1.86.0 agrees
     assert(run_10k(ranlux24_base(0)) == 7937952UL); // QED
 
     // Also test LWG-3809 Is std::subtract_with_carry_engine<uint16_t> supposed to work?

--- a/tests/std/tests/Dev11_0577418_random_seed_0/test.cpp
+++ b/tests/std/tests/Dev11_0577418_random_seed_0/test.cpp
@@ -24,7 +24,7 @@ int main() {
     // Also test VSO-214595 "subtract_with_carry_engine::seed should accept result_type"
     subtract_with_carry_engine<unsigned long long, 64, 10, 24> ull_swc;
     ull_swc.seed(0x12341234'00000000ULL);
-    assert(run_10k(ull_swc) == 0x1DD6C263'C41EEED0ULL); // value changed by LWG-3809
+    assert(run_10k(ull_swc) == 0x01316AEA'3646F686ULL); // libstdc++ and libc++ agree (boost 1.60.0 disagrees)
 
     assert(minstd_rand0(0) == minstd_rand0()); // N4964 [rand.eng.lcong]/5
     assert(mt19937(0) != mt19937()); // N4964 [rand.eng.mers]/6


### PR DESCRIPTION
Fixes #5133.

The behavior change was indicated by changes in the test file. LWG-4014 restores the old behavior, which can be indicated by reverting of the change in that line in the test file.