### PR TITLE
Implement LWG-4084 `std::fixed` ignores `std::uppercase`

### DIFF
--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -1435,7 +1435,7 @@ private:
         ios_base::fmtflags _Ffl = _Flags & ios_base::floatfield;
         if (_Flags & ios_base::uppercase) {
             if (_Ffl == ios_base::fixed) {
-                _Ch = 'f';
+                _Ch = 'F';
             } else if (_Ffl == (ios_base::scientific | ios_base::fixed)) {
                 _Ch = 'A';
             } else if (_Ffl == ios_base::scientific) {

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -265,6 +265,7 @@ tests\LWG3528_make_from_tuple_impl
 tests\LWG3545_pointer_traits_sfinae
 tests\LWG3561_discard_block_engine_counter
 tests\LWG3610_iota_view_size_and_integer_class
+tests\LWG4084_iostream_uppercase_inf_nan
 tests\LWG4105_ranges_ends_with_and_integer_class
 tests\P0009R18_mdspan_default_accessor
 tests\P0009R18_mdspan_extents

--- a/tests/std/tests/LWG4084_iostream_uppercase_inf_nan/env.lst
+++ b/tests/std/tests/LWG4084_iostream_uppercase_inf_nan/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/LWG4084_iostream_uppercase_inf_nan/test.cpp
+++ b/tests/std/tests/LWG4084_iostream_uppercase_inf_nan/test.cpp
@@ -9,12 +9,12 @@
 
 using namespace std;
 
-template <class CharT, size_t NChar, size_t NWChar, enable_if_t<is_same_v<CharT, char>, int> = 0>
-constexpr const auto& choose_literal(const char (&s)[NChar], const wchar_t (&)[NWChar]) noexcept {
+template <class CharT, size_t N, enable_if_t<is_same_v<CharT, char>, int> = 0>
+constexpr const auto& choose_literal(const char (&s)[N], const wchar_t (&)[N]) noexcept {
     return s;
 }
-template <class CharT, size_t NChar, size_t NWChar, enable_if_t<is_same_v<CharT, wchar_t>, int> = 0>
-constexpr const auto& choose_literal(const char (&)[NChar], const wchar_t (&ws)[NWChar]) noexcept {
+template <class CharT, size_t N, enable_if_t<is_same_v<CharT, wchar_t>, int> = 0>
+constexpr const auto& choose_literal(const char (&)[N], const wchar_t (&ws)[N]) noexcept {
     return ws;
 }
 

--- a/tests/std/tests/LWG4084_iostream_uppercase_inf_nan/test.cpp
+++ b/tests/std/tests/LWG4084_iostream_uppercase_inf_nan/test.cpp
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cassert>
+#include <cstddef>
+#include <limits>
+#include <sstream>
+#include <type_traits>
+
+using namespace std;
+
+template <class CharT, size_t NChar, size_t NWChar, enable_if_t<is_same_v<CharT, char>, int> = 0>
+constexpr const auto& choose_literal(const char (&s)[NChar], const wchar_t (&)[NWChar]) noexcept {
+    return s;
+}
+template <class CharT, size_t NChar, size_t NWChar, enable_if_t<is_same_v<CharT, wchar_t>, int> = 0>
+constexpr const auto& choose_literal(const char (&)[NChar], const wchar_t (&ws)[NWChar]) noexcept {
+    return ws;
+}
+
+#define STATICALLY_WIDEN(CharT, S) ::choose_literal<CharT>(S, L##S)
+
+template <class CharT, class F>
+void test() {
+    // LWG-4084 "std::fixed ignores std::uppercase"
+    {
+        auto s = (basic_ostringstream<CharT>{} << fixed << uppercase << numeric_limits<F>::infinity()).str();
+        assert(s == STATICALLY_WIDEN(CharT, "INF"));
+    }
+    {
+        auto s = (basic_ostringstream<CharT>{} << fixed << uppercase << numeric_limits<F>::quiet_NaN()).str();
+        assert(s == STATICALLY_WIDEN(CharT, "NAN"));
+    }
+    // also test other combinations
+    {
+        auto s = (basic_ostringstream<CharT>{} << fixed << numeric_limits<F>::infinity()).str();
+        assert(s == STATICALLY_WIDEN(CharT, "inf"));
+    }
+    {
+        auto s = (basic_ostringstream<CharT>{} << fixed << numeric_limits<F>::quiet_NaN()).str();
+        assert(s == STATICALLY_WIDEN(CharT, "nan"));
+    }
+
+    {
+        auto s = (basic_ostringstream<CharT>{} << uppercase << numeric_limits<F>::infinity()).str();
+        assert(s == STATICALLY_WIDEN(CharT, "INF"));
+    }
+    {
+        auto s = (basic_ostringstream<CharT>{} << uppercase << numeric_limits<F>::quiet_NaN()).str();
+        assert(s == STATICALLY_WIDEN(CharT, "NAN"));
+    }
+    {
+        auto s = (basic_ostringstream<CharT>{} << numeric_limits<F>::infinity()).str();
+        assert(s == STATICALLY_WIDEN(CharT, "inf"));
+    }
+    {
+        auto s = (basic_ostringstream<CharT>{} << numeric_limits<F>::quiet_NaN()).str();
+        assert(s == STATICALLY_WIDEN(CharT, "nan"));
+    }
+
+    {
+        auto s = (basic_ostringstream<CharT>{} << scientific << uppercase << numeric_limits<F>::infinity()).str();
+        assert(s == STATICALLY_WIDEN(CharT, "INF"));
+    }
+    {
+        auto s = (basic_ostringstream<CharT>{} << scientific << uppercase << numeric_limits<F>::quiet_NaN()).str();
+        assert(s == STATICALLY_WIDEN(CharT, "NAN"));
+    }
+    {
+        auto s = (basic_ostringstream<CharT>{} << scientific << numeric_limits<F>::infinity()).str();
+        assert(s == STATICALLY_WIDEN(CharT, "inf"));
+    }
+    {
+        auto s = (basic_ostringstream<CharT>{} << scientific << numeric_limits<F>::quiet_NaN()).str();
+        assert(s == STATICALLY_WIDEN(CharT, "nan"));
+    }
+
+    {
+        auto s = (basic_ostringstream<CharT>{} << hexfloat << uppercase << numeric_limits<F>::infinity()).str();
+        assert(s == STATICALLY_WIDEN(CharT, "INF"));
+    }
+    {
+        auto s = (basic_ostringstream<CharT>{} << hexfloat << uppercase << numeric_limits<F>::quiet_NaN()).str();
+        assert(s == STATICALLY_WIDEN(CharT, "NAN"));
+    }
+    {
+        auto s = (basic_ostringstream<CharT>{} << hexfloat << numeric_limits<F>::infinity()).str();
+        assert(s == STATICALLY_WIDEN(CharT, "inf"));
+    }
+    {
+        auto s = (basic_ostringstream<CharT>{} << hexfloat << numeric_limits<F>::quiet_NaN()).str();
+        assert(s == STATICALLY_WIDEN(CharT, "nan"));
+    }
+}
+
+int main() {
+    test<char, float>();
+    test<char, double>();
+    test<char, long double>();
+
+    test<wchar_t, float>();
+    test<wchar_t, double>();
+    test<wchar_t, long double>();
+}


### PR DESCRIPTION
Fixes #5120.

It seems that the outputting Inf/NaN with `uppercase` was never tested before.