### PR TITLE
Implement LWG-4112 `has-arrow` should require `operator->()` to be `const`-qualified

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -89,7 +89,7 @@ namespace ranges {
                         && same_as<sentinel_t<_Rng>, sentinel_t<const _Rng>>;
 
     template <class _It>
-    concept _Has_arrow = input_iterator<_It> && (is_pointer_v<_It> || _Has_member_arrow<_It&>);
+    concept _Has_arrow = input_iterator<_It> && (is_pointer_v<_It> || _Has_member_arrow<const _It&>);
 
     template <bool _IsWrapped, class _Ty>
     using _Maybe_wrapped = conditional_t<_IsWrapped, _Ty, _Unwrapped_t<_Ty>>;

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -152,6 +152,9 @@ std/ranges/range.factories/range.iota.view/iterator/member_typedefs.compile.pass
 std/ranges/range.adaptors/range.lazy.split/range.lazy.split.outer.value/ctor.default.pass.cpp FAIL
 std/ranges/range.adaptors/range.lazy.split/range.lazy.split.outer.value/ctor.iter.pass.cpp FAIL
 
+# libc++ doesn't implement LWG-4112
+std/ranges/range.adaptors/range.join/range.join.iterator/arrow.pass.cpp FAIL
+
 # If any feature-test macro test is failing, this consolidated test will also fail.
 std/language.support/support.limits/support.limits.general/version.version.compile.pass.cpp FAIL
 

--- a/tests/std/tests/P0896R4_views_filter/test.cpp
+++ b/tests/std/tests/P0896R4_views_filter/test.cpp
@@ -357,37 +357,17 @@ enum class arrow_status : bool { bad, good };
 
 template <arrow_status S>
 struct arrowed_iterator {
-    using value_type      = int;
     using difference_type = ptrdiff_t;
+    using value_type      = int;
 
-    int& operator*() const {
-        return *p_;
-    }
-
+    int& operator*() const;
     int* operator->()
-        requires (S == arrow_status::bad)
-    {
-        return p_;
-    }
+        requires (S == arrow_status::bad);
     int* operator->() const
-        requires (S == arrow_status::good)
-    {
-        return p_;
-    }
-
-    arrowed_iterator& operator++() {
-        ++p_;
-        return *this;
-    }
-    arrowed_iterator operator++(int) {
-        auto old = *this;
-        ++*this;
-        return old;
-    }
-
-    friend bool operator==(arrowed_iterator, arrowed_iterator) = default;
-
-    int* p_;
+        requires (S == arrow_status::good);
+    arrowed_iterator& operator++();
+    arrowed_iterator operator++(int);
+    friend bool operator==(arrowed_iterator, arrowed_iterator);
 };
 
 static_assert(CanArrow<ranges::iterator_t<decltype(ranges::subrange<arrowed_iterator<arrow_status::good>>{} //

--- a/tests/std/tests/P0896R4_views_filter/test.cpp
+++ b/tests/std/tests/P0896R4_views_filter/test.cpp
@@ -348,7 +348,7 @@ using move_only_view = test::range<Category, const int, test::Sized{is_random}, 
     IsCommon, test::CanCompare{derived_from<Category, forward_iterator_tag>},
     test::ProxyRef{!derived_from<Category, contiguous_iterator_tag>}, test::CanView::yes, test::Copyability::move_only>;
 
-// LWG-4112 "possibly-const-range should prefer returning const R&"
+// LWG-4112 "has-arrow should require operator->() to be const-qualified"
 
 template <class T>
 concept CanArrow = requires(T&& t) { forward<T>(t).operator->(); };

--- a/tests/std/tests/P0896R4_views_join/test.cpp
+++ b/tests/std/tests/P0896R4_views_join/test.cpp
@@ -698,37 +698,17 @@ enum class arrow_status : bool { bad, good };
 
 template <arrow_status S>
 struct arrowed_iterator {
-    using value_type      = int;
     using difference_type = ptrdiff_t;
+    using value_type      = int;
 
-    int& operator*() const {
-        return *p_;
-    }
-
+    int& operator*() const;
     int* operator->()
-        requires (S == arrow_status::bad)
-    {
-        return p_;
-    }
+        requires (S == arrow_status::bad);
     int* operator->() const
-        requires (S == arrow_status::good)
-    {
-        return p_;
-    }
-
-    arrowed_iterator& operator++() {
-        ++p_;
-        return *this;
-    }
-    arrowed_iterator operator++(int) {
-        auto old = *this;
-        ++*this;
-        return old;
-    }
-
-    friend bool operator==(arrowed_iterator, arrowed_iterator) = default;
-
-    int* p_;
+        requires (S == arrow_status::good);
+    arrowed_iterator& operator++();
+    arrowed_iterator operator++(int);
+    friend bool operator==(arrowed_iterator, arrowed_iterator);
 };
 
 void test_lwg_4112() { // COMPILE-ONLY

--- a/tests/std/tests/P0896R4_views_join/test.cpp
+++ b/tests/std/tests/P0896R4_views_join/test.cpp
@@ -689,7 +689,7 @@ constexpr bool test_lwg3791() {
     return true;
 }
 
-// LWG-4112 "possibly-const-range should prefer returning const R&"
+// LWG-4112 "has-arrow should require operator->() to be const-qualified"
 
 template <class T>
 concept CanArrow = requires(T&& t) { forward<T>(t).operator->(); };


### PR DESCRIPTION
Fixes #5116. This affects `filter_view` & `join_view`'s iterators.

Skipped libcxx test:
- `std/ranges/range.adaptors/range.join/range.join.iterator/arrow.pass.cpp`