### PR TITLE
Implement LWG-4124 Cannot format `zoned_time` with resolution coarser than seconds

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5270,7 +5270,7 @@ namespace chrono {
     basic_ostream<_CharT, _Traits>& operator<<(
         basic_ostream<_CharT, _Traits>& _Os, const zoned_time<_Duration, _TimeZonePtr>& _Val) {
         const auto _Info = _Val.get_info();
-        return _Os << _Local_time_format_t<_Duration>{_Val.get_local_time(), &_Info.abbrev};
+        return _Os << _Local_time_format_t<common_type_t<_Duration, seconds>>{_Val.get_local_time(), &_Info.abbrev};
     }
 
     template <class _CharT>
@@ -6113,11 +6113,10 @@ constexpr bool enable_nonlocking_formatter_optimization<_CHRONO _Local_time_form
 
 template <class _Duration, class _TimeZonePtr, _Format_supported_charT _CharT>
 struct formatter<_CHRONO zoned_time<_Duration, _TimeZonePtr>, _CharT>
-    : formatter<_CHRONO _Local_time_format_t<_Duration>, _CharT> {
-
+    : formatter<_CHRONO _Local_time_format_t<common_type_t<_Duration, _CHRONO seconds>>, _CharT> {
     template <class _FormatContext>
     auto format(const _CHRONO zoned_time<_Duration, _TimeZonePtr>& _Val, _FormatContext& _FormatCtx) const {
-        using _Mybase    = formatter<_CHRONO _Local_time_format_t<_Duration>, _CharT>;
+        using _Mybase    = formatter<_CHRONO _Local_time_format_t<common_type_t<_Duration, _CHRONO seconds>>, _CharT>;
         const auto _Info = _Val.get_info();
         return _Mybase::format({_Val.get_local_time(), &_Info.abbrev, &_Info.offset}, _FormatCtx);
     }

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -1020,6 +1020,12 @@ void test_zoned_time_formatter() {
            == STR("04/19/21 2021-04-19, 2021 20 21, Apr April Apr 04, 19 19, Mon Monday 1 1"));
     assert(format(STR("{:%H %I %M %S, %r, %R %T %p}"), zt) == STR("08 08 16 17, 08:16:17 AM, 08:16 08:16:17 AM"));
     assert(format(STR("{:%g %G %U %V %W}"), zt) == STR("21 2021 16 16 16"));
+
+    // LWG-4124 "Cannot format zoned_time with resolution coarser than seconds"
+
+    const zoned_time<minutes> zoned_minutes_epoch{};
+
+    empty_braces_helper(zoned_minutes_epoch, STR("1970-01-01 00:00:00 UTC"));
 }
 
 template <typename CharT>


### PR DESCRIPTION
Fixes #5121.

The default to `%F %T %Z` specification for _`locale-time-format-t`_ seems already implemented and tested when chronat was initially implemented.