### PR TITLE
Avoid arithmetic overflow in the constructors of `weekday`

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -473,10 +473,11 @@ namespace chrono {
     private:
         unsigned char _Weekday;
 
-        // courtesy of Howard Hinnant
+        // courtesy of Howard Hinnant (modified to avoid overflow)
         // https://howardhinnant.github.io/date_algorithms.html#weekday_from_days
         _NODISCARD static constexpr unsigned int _Weekday_from_days(int _Tp) noexcept {
-            return static_cast<unsigned int>(_Tp >= -4 ? (_Tp + 4) % 7 : (_Tp + 5) % 7 + 6);
+            const auto _Before_modulo = static_cast<unsigned int>(_Tp) + (_Tp >= 0 ? 4u : 0u);
+            return _Before_modulo % 7u; // for codegen by MSVC on x86/ARM64, see GH-5153
         }
     };
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -476,8 +476,9 @@ namespace chrono {
         // courtesy of Howard Hinnant (modified to avoid overflow)
         // https://howardhinnant.github.io/date_algorithms.html#weekday_from_days
         _NODISCARD static constexpr unsigned int _Weekday_from_days(int _Tp) noexcept {
+            _STL_INTERNAL_STATIC_ASSERT(~0u % 7u == 3u); // offset for `_Tp < 0` needs to change
             const auto _Before_modulo = static_cast<unsigned int>(_Tp) + (_Tp >= 0 ? 4u : 0u);
-            return _Before_modulo % 7u; // for codegen by MSVC on x86/ARM64, see GH-5153
+            return _Before_modulo % 7u; // separate expression for MSVC codegen, see GH-5153
         }
     };
 

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_dates/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_dates/test.cpp
@@ -282,7 +282,7 @@ constexpr void weekday_test() {
     assert(Sunday - Tuesday == days{5});
     assert(Wednesday - Thursday == days{6});
 
-    // GH-5153 "<chrono>: Undefined behaviour in weekday::weekday(const sys_days&)."
+    // GH-5153 "<chrono>: integer overflow in weekday::weekday(sys_days::max())"
     assert(weekday{sys_days::max()} == weekday{sys_days::max() - days{7}});
     assert(weekday{local_days::max()} == weekday{local_days::max() - days{7}});
 }

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_dates/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_dates/test.cpp
@@ -281,6 +281,10 @@ constexpr void weekday_test() {
     assert(Sunday - Monday == days{6});
     assert(Sunday - Tuesday == days{5});
     assert(Wednesday - Thursday == days{6});
+
+    // GH-5153 "<chrono>: Undefined behaviour in weekday::weekday(const sys_days&)."
+    assert(weekday{sys_days::max()} == weekday{sys_days::max() - days{7}});
+    assert(weekday{local_days::max()} == weekday{local_days::max() - days{7}});
 }
 
 constexpr void weekday_indexed_test() {


### PR DESCRIPTION
Fixes #5153.