### PR TITLE
`<valarray>`: Make `valarray` ADL-proof as required

### DIFF
--- a/stl/inc/valarray
+++ b/stl/inc/valarray
@@ -80,7 +80,7 @@ public:
     }
 
     valarray(const _Ty& _Val, size_t _Count) { // construct with _Count * _Val
-        _Grow(_Count, &_Val);
+        _Grow(_Count, _STD addressof(_Val));
     }
 
     valarray(const _Ty* _Ptr, size_t _Count) { // construct with [_Ptr, _Ptr + _Count)
@@ -162,7 +162,7 @@ public:
 
     void resize(size_t _Newsize, _Ty _Val) { // determine new length, filling with _Val elements
         _Tidy_deallocate();
-        _Grow(_Newsize, &_Val, 0);
+        _Grow(_Newsize, _STD addressof(_Val), 0);
     }
 
     valarray& operator=(const slice_array<_Ty>& _Slicearr); // defined below
@@ -538,7 +538,7 @@ private:
             _Myptr = _Allocate_for_op_delete<_Ty>(_Newsize);
             _Tidy_deallocate_guard<valarray> _Guard{this};
             for (size_t _Idx = 0; _Idx < _Newsize; ++_Idx) {
-                _Construct_in_place(_Myptr[_Idx]);
+                _STD _Construct_in_place(_Myptr[_Idx]);
             }
 
             _Guard._Target = nullptr;
@@ -552,7 +552,7 @@ private:
             _Myptr = _Allocate_for_op_delete<_Ty>(_Newsize);
             _Tidy_deallocate_guard<valarray> _Guard{this};
             for (size_t _Idx = 0; _Idx < _Newsize; ++_Idx, _Ptr += _Inc) {
-                _Construct_in_place(_Myptr[_Idx], *_Ptr);
+                _STD _Construct_in_place(_Myptr[_Idx], *_Ptr);
             }
 
             _Guard._Target = nullptr;
@@ -562,7 +562,7 @@ private:
 
     void _Tidy_deallocate() noexcept {
         if (_Myptr) { // destroy elements
-            _Destroy_range(_Myptr, _Myptr + _Mysize);
+            _STD _Destroy_range(_Myptr, _Myptr + _Mysize);
 #ifdef __cpp_aligned_new
             constexpr bool _Extended_alignment = alignof(_Ty) > __STDCPP_DEFAULT_NEW_ALIGNMENT__;
             if constexpr (_Extended_alignment) {
@@ -2028,7 +2028,7 @@ private:
 template <class _Ty>
 valarray<_Ty>& valarray<_Ty>::operator=(const slice_array<_Ty>& _Slicearr) {
     _Tidy_deallocate();
-    _Grow(_Slicearr.size(), &_Slicearr._Data(_Slicearr.start()), _Slicearr.stride());
+    _Grow(_Slicearr.size(), _STD addressof(_Slicearr._Data(_Slicearr.start())), _Slicearr.stride());
     return *this;
 }
 

--- a/tests/std/tests/GH_000140_adl_proof_construction/test.compile.pass.cpp
+++ b/tests/std/tests/GH_000140_adl_proof_construction/test.compile.pass.cpp
@@ -6,6 +6,7 @@
 #include <future>
 #include <memory>
 #include <type_traits>
+#include <utility>
 #include <valarray>
 #if _HAS_CXX17
 #include <optional>
@@ -80,7 +81,7 @@ template <class Tag>
 struct tagged_identity {
     template <class U>
     constexpr U&& operator()(U&& u) const noexcept {
-        return static_cast<U&&>(u);
+        return std::forward<U>(u);
     }
 };
 
@@ -88,7 +89,7 @@ template <class Tag>
 struct tagged_large_identity {
     template <class U>
     constexpr U&& operator()(U&& u) const noexcept {
-        return static_cast<U&&>(u);
+        return std::forward<U>(u);
     }
 
     alignas(64) unsigned char unused[64]{};
@@ -161,8 +162,8 @@ void test_valarray() {
     auto valarr4 = valarr1;
     valarr4      = valarr1;
 
-    auto valarr5 = static_cast<valarray<validator_class>&&>(valarr2);
-    valarr5      = static_cast<valarray<validator_class>&&>(valarr3);
+    auto valarr5 = std::move(valarr2);
+    valarr5      = std::move(valarr3);
 }
 
 #if _HAS_CXX17

--- a/tests/std/tests/GH_000140_adl_proof_construction/test.compile.pass.cpp
+++ b/tests/std/tests/GH_000140_adl_proof_construction/test.compile.pass.cpp
@@ -6,6 +6,7 @@
 #include <future>
 #include <memory>
 #include <type_traits>
+#include <valarray>
 #if _HAS_CXX17
 #include <optional>
 #endif // _HAS_CXX17
@@ -143,6 +144,25 @@ void test_promise() {
 
     promise<validator&>{};
     promise<validator&>{allocator_arg, adl_proof_allocator<unsigned char>{}};
+}
+
+void test_valarray() {
+    using validator_class = holder<validator>;
+
+    valarray<validator_class> valarr1(42);
+
+    validator_class a[1]{};
+    valarray<validator_class> valarr2(a, 1);
+    valarr2.resize(172, a[0]);
+
+    valarray<validator_class> valarr3(a[0], 1);
+    valarr3 = valarr2[slice{0, 1, 1}];
+
+    auto valarr4 = valarr1;
+    valarr4      = valarr1;
+
+    auto valarr5 = static_cast<valarray<validator_class>&&>(valarr2);
+    valarr5      = static_cast<valarray<validator_class>&&>(valarr3);
 }
 
 #if _HAS_CXX17


### PR DESCRIPTION
Towards #140 and #3100.

IMO it's quite insane to use an ADL-incompatible type with `valarray` (or any numeric utility that expects overloaded operators). However, LWG-3133 relaxed the requirements for "[numeric types](https://en.cppreference.com/w/cpp/named_req/NumericType)" so much that ADL-bombs became acceptable. This PR also arguably implements LWG-3133 (by using `std::addressof` instead of `operator&`).