### PR TITLE
Globally suppress C5278

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -810,6 +810,7 @@
 // warning C5220: a non-static data member with a volatile qualified type no longer implies that compiler generated
 //                copy/move constructors and copy/move assignment operators are not trivial (/Wall)
 // warning C5246: 'member': the initialization of a subobject should be wrapped in braces (/Wall)
+// warning C5278: adding a specialization for 'type trait' has undefined behavior
 // warning C6294: Ill-defined for-loop: initial condition does not satisfy test. Loop body not executed
 
 #ifndef _STL_DISABLED_WARNINGS
@@ -817,7 +818,7 @@
 #define _STL_DISABLED_WARNINGS                        \
     4180 4324 4412 4455 4494 4514 4574 4582 4583 4587 \
     4588 4619 4623 4625 4626 4643 4648 4702 4793 4820 \
-    4868 4988 5026 5027 5045 5220 5246 6294           \
+    4868 4988 5026 5027 5045 5220 5246 5278 6294      \
     _STL_DISABLED_WARNING_C4577                       \
     _STL_DISABLED_WARNING_C4984                       \
     _STL_DISABLED_WARNING_C5053                       \


### PR DESCRIPTION
This is a new warning MSVC is adding to steer users away from attempting to specialize the type traits as forbidden by N4993 [meta.rqmts]/4. Since MSVC implements many of the type traits in the compiler, such specializations are generally ignored to the confusion of users who trigger the UB.

This is a mirror of the STL portion of MSVC-PR-596210.

