### PR TITLE
`<regex>`: Fix character range bounds in case-insensitive regexes

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1499,7 +1499,7 @@ public:
     void _Add_char(_Elem _Ch);
     void _Add_class();
     void _Add_char_to_class(_Elem _Ch);
-    void _Add_range(_Elem _Ex0, _Elem _Ex1);
+    void _Add_range2(_Elem, _Elem);
     void _Add_named_class(_Regex_traits_base::char_class_type, bool = false);
     void _Add_equiv(_FwdIt, _FwdIt, _Difft);
     void _Add_coll(_FwdIt, _FwdIt, _Difft);
@@ -2882,19 +2882,12 @@ void _Builder<_FwdIt, _Elem, _RxTraits>::_Add_char_to_class(_Elem _Ch) { // add 
 }
 
 template <class _FwdIt, class _Elem, class _RxTraits>
-void _Builder<_FwdIt, _Elem, _RxTraits>::_Add_range(_Elem _Arg0, _Elem _Arg1) {
+void _Builder<_FwdIt, _Elem, _RxTraits>::_Add_range2(const _Elem _Arg0, const _Elem _Arg1) {
     // add character range to set
-    unsigned int _Ex0;
-    unsigned int _Ex1;
-    if (_Flags & regex_constants::icase) { // change to lowercase range
-        _Ex0 = static_cast<unsigned int>(_Traits.translate_nocase(_Arg0));
-        _Ex1 = static_cast<unsigned int>(_Traits.translate_nocase(_Arg1));
-    } else {
-        _Ex0 = static_cast<typename _RxTraits::_Uelem>(_Arg0);
-        _Ex1 = static_cast<typename _RxTraits::_Uelem>(_Arg1);
-    }
-
+    unsigned int _Ex0                    = static_cast<typename _RxTraits::_Uelem>(_Arg0);
+    const unsigned int _Ex1              = static_cast<typename _RxTraits::_Uelem>(_Arg1);
     _Node_class<_Elem, _RxTraits>* _Node = static_cast<_Node_class<_Elem, _RxTraits>*>(_Current);
+
     for (; _Ex0 <= _Ex1 && _Ex1 < _Get_bmax(); ++_Ex0) { // set a bit
         if (!_Node->_Small) {
             _Node->_Small = new _Bitmap;
@@ -2913,7 +2906,7 @@ void _Builder<_FwdIt, _Elem, _RxTraits>::_Add_range(_Elem _Arg0, _Elem _Arg1) {
             }
 
             _Node->_Ranges->_Insert(static_cast<_Elem>(_Ex0));
-            _Node->_Ranges->_Insert(static_cast<_Elem>(_Ex1));
+            _Node->_Ranges->_Insert(_Arg1);
         }
     }
 }
@@ -4113,16 +4106,22 @@ void _Parser<_FwdIt, _Elem, _RxTraits>::_ClassRanges() { // check for valid clas
                 _Error(regex_constants::error_range); // set precedes or follows dash
             }
 
-            if (_Flags & regex_constants::collate) { // translate ends of range
-                _Val  = _Traits.translate(static_cast<_Elem>(_Val));
+            _Elem _Chr2 = static_cast<_Elem>(_Val);
+
+            // translate ends of range
+            if (_Flags & regex_constants::icase) {
+                _Chr1 = _Traits.translate_nocase(_Chr1);
+                _Chr2 = _Traits.translate_nocase(_Chr2);
+            } else if (_Flags & regex_constants::collate) {
                 _Chr1 = _Traits.translate(_Chr1);
+                _Chr2 = _Traits.translate(_Chr2);
             }
 
-            if (static_cast<typename _RxTraits::_Uelem>(_Val) < static_cast<typename _RxTraits::_Uelem>(_Chr1)) {
+            if (static_cast<typename _RxTraits::_Uelem>(_Chr2) < static_cast<typename _RxTraits::_Uelem>(_Chr1)) {
                 _Error(regex_constants::error_range);
             }
 
-            _Nfa._Add_range(_Chr1, static_cast<_Elem>(_Val));
+            _Nfa._Add_range2(_Chr1, _Chr2);
         } else if (_Ret == _Prs_chr) {
             _Nfa._Add_char_to_class(static_cast<_Elem>(_Val));
         }


### PR DESCRIPTION
This PR deals with three related problems for character ranges in case-insensitive mode:
* `_Builder::_Add_range()` casts the character bounds to `unsigned int`. As a consequence, characters with negative numeric values are not added to the bitmap, but rather to the `_Large` list of characters. This means that these characters are not found during matching. (Note the suspiciously different casts in the else branch for the case-sensitive case.)
* The parser fails to reject some empty ranges in case-insensitive mode such as `[Z-a]` (= `[z-a]`).
* When both the `collate` and `icase` flags are set, there is an unnecessary call to translate the bounds by `_Traits.translate()` first before passing them to `_Traits.translate_nocase()`. The standard says in [\[re.grammar\]/14.1 and 14.2](https://eel.is/c++draft/re.grammar#14) that it is sufficient to call `translate_nocase()` only. (See also `_Builder::_Add_char()`, which already follows the Standard in this regard.)

The PR moves the entire character translation into the parser so that empty ranges can be reliably diagnosed there in case-insensitive mode as well. It also fixes the unsigned cast and removes the unnecessary `translate()` call.

The test deliberately does not use any manual signed/unsigned casts, but leaves all of these casts to `char_traits` to avoid getting the casts similarly wrong in `<regex>` and the test.