### PR TITLE
`<regex>`: Limit backreference parsing to single digit for basic regular expressions

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1187,8 +1187,6 @@ _NODISCARD bool operator!=(const match_results<_BidIt, _Alloc>& _Left, const mat
 }
 #endif // !_HAS_CXX20
 
-_INLINE_VAR constexpr int _BRE_MAX_BACKREF_DIGITS = 1;
-
 _INLINE_VAR constexpr unsigned int _Bmp_max   = 256U; // must fit in an unsigned int
 _INLINE_VAR constexpr unsigned int _Bmp_shift = 3U;
 _INLINE_VAR constexpr unsigned int _Bmp_chrs  = 1U << _Bmp_shift; // # of bits to be stored in each char
@@ -4333,9 +4331,10 @@ bool _Parser<_FwdIt, _Elem, _RxTraits>::_CharacterEscape() { // check for valid 
 
 template <class _FwdIt, class _Elem, class _RxTraits>
 void _Parser<_FwdIt, _Elem, _RxTraits>::_AtomEscape() { // check for valid atom escape
+    constexpr int _Bre_max_backref_digits = 1;
     if ((_L_flags & _L_bckr)
         && _DecimalDigits2(regex_constants::error_backref,
-            (_L_flags & _L_lim_bckr) ? _BRE_MAX_BACKREF_DIGITS : INT_MAX)) { // check for valid back reference
+            (_L_flags & _L_lim_bckr) ? _Bre_max_backref_digits : INT_MAX)) { // check for valid back reference
         if (_Val == 0) { // handle \0
             if (!(_L_flags & _L_bzr_chr)) {
                 _Error(regex_constants::error_escape);

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -3949,7 +3949,7 @@ int _Parser<_FwdIt, _Elem, _RxTraits>::_Do_digits(
 
 template <class _FwdIt, class _Elem, class _RxTraits>
 bool _Parser<_FwdIt, _Elem, _RxTraits>::_DecimalDigits2(
-    const regex_constants::error_type _Error_type, const int _Count /*= INT_MAX */) { // check for decimal value
+    const regex_constants::error_type _Error_type, const int _Count /* = INT_MAX */) { // check for decimal value
     return _Do_digits(10, _Count, _Error_type) != _Count;
 }
 

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1187,7 +1187,8 @@ _NODISCARD bool operator!=(const match_results<_BidIt, _Alloc>& _Left, const mat
 }
 #endif // !_HAS_CXX20
 
-_INLINE_VAR constexpr unsigned int _BRE_MAX_GRP = 9U;
+_INLINE_VAR constexpr unsigned int _BRE_MAX_GRP   = 9U;
+_INLINE_VAR constexpr int _BRE_MAX_BACKREF_DIGITS = 1;
 
 _INLINE_VAR constexpr unsigned int _Bmp_max   = 256U; // must fit in an unsigned int
 _INLINE_VAR constexpr unsigned int _Bmp_shift = 3U;
@@ -1705,7 +1706,7 @@ private:
 
     // parsing
     int _Do_digits(int _Base, int _Count, regex_constants::error_type _Error_type);
-    bool _DecimalDigits(regex_constants::error_type _Error_type);
+    bool _DecimalDigits2(regex_constants::error_type _Error_type, int _Count = INT_MAX);
     void _HexDigits(int);
     bool _OctalDigits();
     void _Do_ex_class(_Meta_type);
@@ -3950,9 +3951,9 @@ int _Parser<_FwdIt, _Elem, _RxTraits>::_Do_digits(
 }
 
 template <class _FwdIt, class _Elem, class _RxTraits>
-bool _Parser<_FwdIt, _Elem, _RxTraits>::_DecimalDigits(
-    regex_constants::error_type _Error_type) { // check for decimal value
-    return _Do_digits(10, INT_MAX, _Error_type) != INT_MAX;
+bool _Parser<_FwdIt, _Elem, _RxTraits>::_DecimalDigits2(
+    const regex_constants::error_type _Error_type, const int _Count /*= INT_MAX */) { // check for decimal value
+    return _Do_digits(10, _Count, _Error_type) != _Count;
 }
 
 template <class _FwdIt, class _Elem, class _RxTraits>
@@ -4041,7 +4042,7 @@ _Prs_ret _Parser<_FwdIt, _Elem, _RxTraits>::_ClassEscape2() { // check for class
         return _Prs_chr;
     } else if ((_L_flags & _L_esc_wsd) && _CharacterClassEscape(false)) {
         return _Prs_set;
-    } else if (_DecimalDigits(regex_constants::error_escape)) { // check for invalid value
+    } else if (_DecimalDigits2(regex_constants::error_escape)) { // check for invalid value
         if (_Val != 0) {
             _Error(regex_constants::error_escape);
         }
@@ -4333,7 +4334,9 @@ bool _Parser<_FwdIt, _Elem, _RxTraits>::_CharacterEscape() { // check for valid 
 
 template <class _FwdIt, class _Elem, class _RxTraits>
 void _Parser<_FwdIt, _Elem, _RxTraits>::_AtomEscape() { // check for valid atom escape
-    if ((_L_flags & _L_bckr) && _DecimalDigits(regex_constants::error_backref)) { // check for valid back reference
+    if ((_L_flags & _L_bckr)
+        && _DecimalDigits2(regex_constants::error_backref,
+            (_L_flags & _L_lim_bckr) ? _BRE_MAX_BACKREF_DIGITS : INT_MAX)) { // check for valid back reference
         if (_Val == 0) { // handle \0
             if (!(_L_flags & _L_bzr_chr)) {
                 _Error(regex_constants::error_escape);
@@ -4365,7 +4368,7 @@ void _Parser<_FwdIt, _Elem, _RxTraits>::_Quantifier() { // check for quantifier 
             _Max = 1;
         } else if (_Mchar == _Meta_lbr) { // check for valid bracketed value
             _Next();
-            if (!_DecimalDigits(regex_constants::error_badbrace)) {
+            if (!_DecimalDigits2(regex_constants::error_badbrace)) {
                 _Error(regex_constants::error_badbrace);
             }
 
@@ -4375,7 +4378,7 @@ void _Parser<_FwdIt, _Elem, _RxTraits>::_Quantifier() { // check for quantifier 
             } else { // check for decimal constant following comma
                 _Next();
                 if (_Mchar != _Meta_rbr) {
-                    if (!_DecimalDigits(regex_constants::error_badbrace)) {
+                    if (!_DecimalDigits2(regex_constants::error_badbrace)) {
                         _Error(regex_constants::error_badbrace);
                     }
 

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1187,7 +1187,6 @@ _NODISCARD bool operator!=(const match_results<_BidIt, _Alloc>& _Left, const mat
 }
 #endif // !_HAS_CXX20
 
-_INLINE_VAR constexpr unsigned int _BRE_MAX_GRP   = 9U;
 _INLINE_VAR constexpr int _BRE_MAX_BACKREF_DIGITS = 1;
 
 _INLINE_VAR constexpr unsigned int _Bmp_max   = 256U; // must fit in an unsigned int
@@ -4343,8 +4342,7 @@ void _Parser<_FwdIt, _Elem, _RxTraits>::_AtomEscape() { // check for valid atom 
             } else {
                 _Nfa._Add_char(static_cast<_Elem>(_Val));
             }
-        } else if (((_L_flags & _L_lim_bckr) && _BRE_MAX_GRP < static_cast<size_t>(_Val))
-                   || _Grp_idx < static_cast<size_t>(_Val) || _Finished_grps.size() <= static_cast<size_t>(_Val)
+        } else if (_Grp_idx < static_cast<size_t>(_Val) || _Finished_grps.size() <= static_cast<size_t>(_Val)
                    || !_Finished_grps[static_cast<size_t>(_Val)]) {
             _Error(regex_constants::error_backref);
         } else {

--- a/tests/std/tests/VSO_0000000_regex_use/test.cpp
+++ b/tests/std/tests/VSO_0000000_regex_use/test.cpp
@@ -669,6 +669,20 @@ void test_gh_5160() {
     neg_regex.should_search_fail(L"xxxYxx\x2009xxxZxxx"); // U+2009 THIN SPACE
 }
 
+void test_gh_5167() {
+    // GH-5167: Limit backreference parsing to single digit for basic regular expressions
+    g_regexTester.should_match("abab0", R"x(\(ab*\)\10)x", basic);
+    g_regexTester.should_match("abab0", R"x(\(ab*\)\10)x", grep);
+    g_regexTester.should_match("abbcdccdc5abb8", R"x(\(ab*\)\([cd]*\)\25\18)x", basic);
+    g_regexTester.should_match("abbcdccdc5abb8", R"x(\(ab*\)\([cd]*\)\25\18)x", grep);
+    g_regexTester.should_not_match("abbcdccdc5abb8", R"x(\(ab*\)\([cd]*\)\15\28)x", basic);
+    g_regexTester.should_not_match("abbcdccdc5abb8", R"x(\(ab*\)\([cd]*\)\15\28)x", grep);
+    g_regexTester.should_throw(R"x(abc\1d)x", error_backref, basic);
+    g_regexTester.should_throw(R"x(abc\1d)x", error_backref, grep);
+    g_regexTester.should_throw(R"x(abc\10)x", error_backref, basic);
+    g_regexTester.should_throw(R"x(abc\10)x", error_backref, grep);
+}
+
 int main() {
     test_dev10_449367_case_insensitivity_should_work();
     test_dev11_462743_regex_collate_should_not_disable_regex_icase();
@@ -699,6 +713,7 @@ int main() {
     test_gh_4995();
     test_gh_5058();
     test_gh_5160();
+    test_gh_5167();
 
     return g_regexTester.result();
 }

--- a/tests/std/tests/VSO_0000000_regex_use/test.cpp
+++ b/tests/std/tests/VSO_0000000_regex_use/test.cpp
@@ -671,16 +671,16 @@ void test_gh_5160() {
 
 void test_gh_5167() {
     // GH-5167: Limit backreference parsing to single digit for basic regular expressions
-    g_regexTester.should_match("abab0", R"x(\(ab*\)\10)x", basic);
-    g_regexTester.should_match("abab0", R"x(\(ab*\)\10)x", grep);
-    g_regexTester.should_match("abbcdccdc5abb8", R"x(\(ab*\)\([cd]*\)\25\18)x", basic);
-    g_regexTester.should_match("abbcdccdc5abb8", R"x(\(ab*\)\([cd]*\)\25\18)x", grep);
-    g_regexTester.should_not_match("abbcdccdc5abb8", R"x(\(ab*\)\([cd]*\)\15\28)x", basic);
-    g_regexTester.should_not_match("abbcdccdc5abb8", R"x(\(ab*\)\([cd]*\)\15\28)x", grep);
-    g_regexTester.should_throw(R"x(abc\1d)x", error_backref, basic);
-    g_regexTester.should_throw(R"x(abc\1d)x", error_backref, grep);
-    g_regexTester.should_throw(R"x(abc\10)x", error_backref, basic);
-    g_regexTester.should_throw(R"x(abc\10)x", error_backref, grep);
+    g_regexTester.should_match("abab0", R"(\(ab*\)\10)", basic);
+    g_regexTester.should_match("abab0", R"(\(ab*\)\10)", grep);
+    g_regexTester.should_match("abbcdccdc5abb8", R"(\(ab*\)\([cd]*\)\25\18)", basic);
+    g_regexTester.should_match("abbcdccdc5abb8", R"(\(ab*\)\([cd]*\)\25\18)", grep);
+    g_regexTester.should_not_match("abbcdccdc5abb8", R"(\(ab*\)\([cd]*\)\15\28)", basic);
+    g_regexTester.should_not_match("abbcdccdc5abb8", R"(\(ab*\)\([cd]*\)\15\28)", grep);
+    g_regexTester.should_throw(R"(abc\1d)", error_backref, basic);
+    g_regexTester.should_throw(R"(abc\1d)", error_backref, grep);
+    g_regexTester.should_throw(R"(abc\10)", error_backref, basic);
+    g_regexTester.should_throw(R"(abc\10)", error_backref, grep);
 }
 
 int main() {


### PR DESCRIPTION
According to [Sections 9.3.6 and 9.5.1 of the POSIX standard](https://pubs.opengroup.org/onlinepubs/9699919799.2008edition/basedefs/V1_chap09.html#tag_09_03_06), a backreference is a backslash followed by a single digit, so `\1` to `\9`. Thus, `\(a\)\10` is a valid basic regular expression matching the string `aa0`, because `\10` is a backreference to capture group 1 (`\(a\)`) plus the digit 0. However, the regex parser currently rejects this regular expression because it interprets `\10` as a backreference to capture group 10.

After this PR, the parser only reads a single digit in basic regular expression (and grep) mode, so `\10` is parsed correctly as a backreference to capture group 1 plus digit 0.