### PR TITLE
`<ranges>`: Fix regression with `ranges::to` for ADL-only `begin`/`end`

### DIFF
--- a/stl/inc/__msvc_ranges_to.hpp
+++ b/stl/inc/__msvc_ranges_to.hpp
@@ -1122,8 +1122,8 @@ namespace ranges {
                     _Cont.reserve(static_cast<range_size_t<_Container>>(_RANGES size(_Range)));
                 }
 
-                auto _Iter = _RANGES begin(_Range);
-                auto _Sent = _RANGES end(_Range);
+                auto _Iter       = _RANGES begin(_Range);
+                const auto _Sent = _RANGES end(_Range);
                 for (; _Iter != _Sent; ++_Iter) {
                     auto&& _Elem  = *_Iter;
                     using _ElemTy = decltype(_Elem);

--- a/stl/inc/__msvc_ranges_to.hpp
+++ b/stl/inc/__msvc_ranges_to.hpp
@@ -1121,7 +1121,11 @@ namespace ranges {
                 if constexpr (_Sized_and_reservable<_Rng, _Container>) {
                     _Cont.reserve(static_cast<range_size_t<_Container>>(_RANGES size(_Range)));
                 }
-                for (auto&& _Elem : _Range) {
+
+                auto _Iter = _RANGES begin(_Range);
+                auto _Sent = _RANGES end(_Range);
+                for (; _Iter != _Sent; ++_Iter) {
+                    auto&& _Elem  = *_Iter;
                     using _ElemTy = decltype(_Elem);
                     if constexpr (_Can_emplace_back<_Container, _ElemTy>) {
                         _Cont.emplace_back(_STD forward<_ElemTy>(_Elem));

--- a/tests/std/tests/P1206R7_ranges_to_misc/test.cpp
+++ b/tests/std/tests/P1206R7_ranges_to_misc/test.cpp
@@ -336,6 +336,30 @@ constexpr bool test_lwg4016() {
     return true;
 }
 
+struct adl_only_range {
+    static constexpr int numbers[2]{42, 1729};
+
+    void begin() const = delete;
+    void end() const   = delete;
+
+    friend constexpr const int* begin(const adl_only_range&) {
+        return ranges::begin(numbers);
+    }
+    friend constexpr const int* end(const adl_only_range&) {
+        return ranges::end(numbers);
+    }
+};
+
+constexpr bool test_lwg4016_regression() {
+    using vec = restricted_vector<restriction_kind::push_back, int>;
+
+    ranges::contiguous_range auto r = adl_only_range{};
+    auto v                          = r | ranges::to<vec>();
+    assert(ranges::equal(v, adl_only_range::numbers));
+
+    return true;
+}
+
 int main() {
     test_reservable();
     static_assert(test_reservable());
@@ -356,4 +380,7 @@ int main() {
 
     test_lwg4016();
     static_assert(test_lwg4016());
+
+    test_lwg4016_regression();
+    static_assert(test_lwg4016_regression());
 }


### PR DESCRIPTION
In #4539, the `ranges::for_each` call in the resolution of LWG-4016 was "manually inlined" to reduce inclusion dependency. However, the inlining was not always correct, because builtin-in range-`for` may just stop and fail when a deleted member `begin`/`end` function is encountered, while `ranges` CPOs continue to consider ADL-found `begin`/`end`.

As a result, we should still use `ranges::begin`/`ranges::end`.

Fixes #5172.