### PR TITLE
Mark `expected`, `unexpected`, and ALL exception types as `[[nodiscard]]`

### DIFF
--- a/stl/inc/__msvc_ranges_tuple_formatter.hpp
+++ b/stl/inc/__msvc_ranges_tuple_formatter.hpp
@@ -78,7 +78,7 @@ _NODISCARD constexpr const _CharT* _Choose_literal(const char* const _Str, const
 // It's defined here, so that both headers can use this definition.
 #define _STATICALLY_WIDEN(_CharT, _Literal) (_Choose_literal<_CharT>(_Literal, L##_Literal))
 
-_EXPORT_STD class format_error : public runtime_error {
+_EXPORT_STD class _NODISCARD format_error : public runtime_error {
     using runtime_error::runtime_error;
 };
 

--- a/stl/inc/any
+++ b/stl/inc/any
@@ -28,7 +28,7 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 
-_EXPORT_STD class bad_any_cast : public bad_cast { // thrown by failed any_cast
+_EXPORT_STD class _NODISCARD bad_any_cast : public bad_cast { // thrown by failed any_cast
 public:
     _NODISCARD const char* __CLR_OR_THIS_CALL what() const noexcept override {
         return "Bad any_cast";

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -1720,7 +1720,7 @@ namespace chrono {
         sys_info second;
     };
 
-    _EXPORT_STD class nonexistent_local_time : public runtime_error {
+    _EXPORT_STD class _NODISCARD nonexistent_local_time : public runtime_error {
     public:
         template <class _Duration>
         nonexistent_local_time(const local_time<_Duration>& _Tp, const local_info& _Info)
@@ -1736,7 +1736,7 @@ namespace chrono {
         _THROW(nonexistent_local_time{_Tp, _Info});
     }
 
-    _EXPORT_STD class ambiguous_local_time : public runtime_error {
+    _EXPORT_STD class _NODISCARD ambiguous_local_time : public runtime_error {
     public:
         template <class _Duration>
         ambiguous_local_time(const local_time<_Duration>& _Tp, const local_info& _Info)

--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -69,7 +69,7 @@ _STD_END
 #undef stdext
 
 _STDEXT_BEGIN
-class exception;
+class _NODISCARD exception;
 _STDEXT_END
 
 _STD_BEGIN
@@ -83,7 +83,7 @@ extern _CRTIMP2_PURE_IMPORT _Prhand _Raise_handler; // pointer to raise handler
 _STD_END
 
 _STDEXT_BEGIN
-class exception { // base of all library exceptions
+class _NODISCARD exception { // base of all library exceptions
 public:
     static _STD _Prhand _Set_raise_handler(_STD _Prhand _Pnew) { // register a handler for _Raise calls
         const _STD _Prhand _Pold = _STD _Raise_handler;
@@ -123,7 +123,7 @@ protected:
     const char* _Ptr; // the message pointer
 };
 
-class bad_exception : public exception { // base of all bad exceptions
+class _NODISCARD bad_exception : public exception { // base of all bad exceptions
 public:
     __CLR_OR_THIS_CALL bad_exception(const char* _Message = "bad exception") noexcept : exception(_Message) {}
 
@@ -135,9 +135,9 @@ protected:
     }
 };
 
-class bad_array_new_length;
+class _NODISCARD bad_array_new_length;
 
-class bad_alloc : public exception { // base of all bad allocation exceptions
+class _NODISCARD bad_alloc : public exception { // base of all bad allocation exceptions
 public:
     __CLR_OR_THIS_CALL bad_alloc() noexcept
         : exception("bad allocation", 1) {} // construct from message string with no memory allocation
@@ -156,7 +156,7 @@ protected:
     }
 };
 
-class bad_array_new_length : public bad_alloc {
+class _NODISCARD bad_array_new_length : public bad_alloc {
 public:
     bad_array_new_length() noexcept : bad_alloc("bad array new length") {}
 };
@@ -390,8 +390,8 @@ _EXPORT_STD template <class _Ty>
 void rethrow_if_nested(const _Ty&) = delete; // requires /GR option
 #endif // ^^^ !defined(_CPPRTTI) ^^^
 
-_EXPORT_STD class bad_variant_access
-    : public exception { // exception for visit of a valueless variant or get<I> on a variant with index() != I
+_EXPORT_STD class _NODISCARD bad_variant_access : public exception {
+    // exception for visit of a valueless variant or get<I> on a variant with index() != I
 public:
     bad_variant_access() noexcept = default;
 

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -161,7 +161,7 @@ void _Implicitly_construct_in_place_by_binary_op_transform_deref_rhs(
         _Ty([&]() -> _Ty { return _Reduce_op(_STD forward<_LeftTy>(_Left), _Transform_op(*_Iter)); }());
 }
 
-struct _Parallelism_resources_exhausted : exception {
+struct _NODISCARD _Parallelism_resources_exhausted : exception {
     _NODISCARD const char* __CLR_OR_THIS_CALL what() const noexcept override {
         // return pointer to message string
         return "Insufficient resources were available to use additional parallelism.";

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -107,10 +107,10 @@ template <class _Err>
 unexpected(_Err) -> unexpected<_Err>;
 
 _EXPORT_STD template <class _Err>
-class bad_expected_access;
+class _NODISCARD bad_expected_access;
 
 template <>
-class bad_expected_access<void> : public exception {
+class _NODISCARD bad_expected_access<void> : public exception {
 public:
     _NODISCARD const char* __CLR_OR_THIS_CALL what() const noexcept override {
         return "Bad expected access";
@@ -131,7 +131,7 @@ protected:
 };
 
 _EXPORT_STD template <class _Err>
-class bad_expected_access : public bad_expected_access<void> {
+class _NODISCARD bad_expected_access : public bad_expected_access<void> {
 public:
     explicit bad_expected_access(_Err _Unex) noexcept(is_nothrow_move_constructible_v<_Err>) // strengthened
         : _Unexpected(_STD move(_Unex)) {}

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -25,7 +25,7 @@ _STL_DISABLE_CLANG_WARNINGS
 _STD_BEGIN
 
 _EXPORT_STD template <class _Err>
-class unexpected;
+class _NODISCARD unexpected;
 
 template <class _Err>
 struct _Check_unexpected_argument : true_type {
@@ -39,7 +39,7 @@ struct _Check_unexpected_argument : true_type {
 
 // [expected.un.general]
 _EXPORT_STD template <class _Err>
-class unexpected {
+class _NODISCARD unexpected {
     static_assert(_Check_unexpected_argument<_Err>::value);
 
     template <class _Ty, class _Err2>
@@ -205,7 +205,7 @@ concept _Trivially_move_constructible_assignable_destructible =
     && is_trivially_destructible_v<_Type>;
 
 _EXPORT_STD template <class _Ty, class _Err>
-class expected {
+class _NODISCARD expected {
 private:
     static_assert(_Check_expected_argument<_Ty>::value);
     static_assert(_Check_unexpected_argument<_Err>::value);
@@ -1210,7 +1210,7 @@ concept _Expected_unary_move_assignable = is_move_assignable_v<_Err> && is_move_
 
 template <class _Ty, class _Err>
     requires is_void_v<_Ty>
-class expected<_Ty, _Err> {
+class _NODISCARD expected<_Ty, _Err> {
 private:
     static_assert(_Check_unexpected_argument<_Err>::value);
 

--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -1284,7 +1284,7 @@ _NODISCARD path u8path(const basic_string<char, _Traits, _Alloc>& _Str) { // mak
     return path{_Path_cvt<_Char8_t, _Pchar>::_Cvt(_Str_out, _Str.c_str(), _Str.size())};
 }
 
-class filesystem_error : public system_error { // base of all filesystem-error exceptions
+class _NODISCARD filesystem_error : public system_error { // base of all filesystem-error exceptions
 public:
     explicit filesystem_error(
         const string& _Message, error_code _Errcode = make_error_code(errc::operation_not_permitted))

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -1790,7 +1790,7 @@ namespace filesystem {
         return iterator(_Text.cend(), this);
     }
 
-    _EXPORT_STD class filesystem_error : public system_error { // base of all filesystem-error exceptions
+    _EXPORT_STD class _NODISCARD filesystem_error : public system_error { // base of all filesystem-error exceptions
     public:
         filesystem_error(const string& _Message, const error_code _Errcode)
             : system_error(_Errcode, _Message), _What(runtime_error::what()) {}

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -690,7 +690,8 @@ _NODISCARD _CONSTEXPR20 _Not_fn<decay_t<_Callable>> not_fn(_Callable&& _Obj)
 }
 #endif // _HAS_CXX17
 
-_EXPORT_STD class bad_function_call : public exception { // exception thrown when an empty std::function is called
+_EXPORT_STD class _NODISCARD bad_function_call : public exception {
+    // exception thrown when an empty std::function is called
 public:
     bad_function_call() noexcept {}
 

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -113,7 +113,7 @@ _NODISCARD inline const char* _Future_error_map(int _Errcode) noexcept { // conv
     }
 }
 
-_EXPORT_STD class future_error : public logic_error { // future exception
+_EXPORT_STD class _NODISCARD future_error : public logic_error { // future exception
 public:
     explicit future_error(error_code _Errcode) // internal, TRANSITION, will be removed
         : logic_error(""), _Mycode(_Errcode) {}

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1086,7 +1086,8 @@ public:
 };
 #endif // _HAS_AUTO_PTR_ETC
 
-_EXPORT_STD class bad_weak_ptr : public exception { // exception type for invalid use of expired weak_ptr object
+_EXPORT_STD class _NODISCARD bad_weak_ptr : public exception {
+    // exception type for invalid use of expired weak_ptr object
 public:
     bad_weak_ptr() noexcept {}
 

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -35,7 +35,7 @@ _EXPORT_STD struct nullopt_t { // no-value state indicator
 };
 _EXPORT_STD inline constexpr nullopt_t nullopt{nullopt_t::_Tag{}};
 
-_EXPORT_STD class bad_optional_access : public exception {
+_EXPORT_STD class _NODISCARD bad_optional_access : public exception {
 public:
     _NODISCARD const char* __CLR_OR_THIS_CALL what() const noexcept override {
         return "Bad optional access";

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -460,7 +460,7 @@ public:
     }
 };
 
-_EXPORT_STD class regex_error : public runtime_error { // type of all regular expression exceptions
+_EXPORT_STD class _NODISCARD regex_error : public runtime_error { // type of all regular expression exceptions
 public:
     explicit regex_error(regex_constants::error_type _Ex) : runtime_error(_Stringify(_Ex)), _Err(_Ex) {}
 

--- a/stl/inc/stdexcept
+++ b/stl/inc/stdexcept
@@ -17,7 +17,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 _STD_BEGIN
-_EXPORT_STD class logic_error : public exception { // base of all logic-error exceptions
+_EXPORT_STD class _NODISCARD logic_error : public exception { // base of all logic-error exceptions
 public:
     using _Mybase = exception;
 
@@ -33,7 +33,7 @@ protected:
 #endif // !_HAS_EXCEPTIONS
 };
 
-_EXPORT_STD class domain_error : public logic_error { // base of all domain-error exceptions
+_EXPORT_STD class _NODISCARD domain_error : public logic_error { // base of all domain-error exceptions
 public:
     using _Mybase = logic_error;
 
@@ -49,7 +49,7 @@ protected:
 #endif // !_HAS_EXCEPTIONS
 };
 
-_EXPORT_STD class invalid_argument : public logic_error { // base of all invalid-argument exceptions
+_EXPORT_STD class _NODISCARD invalid_argument : public logic_error { // base of all invalid-argument exceptions
 public:
     using _Mybase = logic_error;
 
@@ -65,7 +65,7 @@ protected:
 #endif // !_HAS_EXCEPTIONS
 };
 
-_EXPORT_STD class length_error : public logic_error { // base of all length-error exceptions
+_EXPORT_STD class _NODISCARD length_error : public logic_error { // base of all length-error exceptions
 public:
     using _Mybase = logic_error;
 
@@ -81,7 +81,7 @@ protected:
 #endif // !_HAS_EXCEPTIONS
 };
 
-_EXPORT_STD class out_of_range : public logic_error { // base of all out-of-range exceptions
+_EXPORT_STD class _NODISCARD out_of_range : public logic_error { // base of all out-of-range exceptions
 public:
     using _Mybase = logic_error;
 
@@ -97,7 +97,7 @@ protected:
 #endif // !_HAS_EXCEPTIONS
 };
 
-_EXPORT_STD class runtime_error : public exception { // base of all runtime-error exceptions
+_EXPORT_STD class _NODISCARD runtime_error : public exception { // base of all runtime-error exceptions
 public:
     using _Mybase = exception;
 
@@ -113,7 +113,7 @@ protected:
 #endif // !_HAS_EXCEPTIONS
 };
 
-_EXPORT_STD class overflow_error : public runtime_error { // base of all overflow-error exceptions
+_EXPORT_STD class _NODISCARD overflow_error : public runtime_error { // base of all overflow-error exceptions
 public:
     using _Mybase = runtime_error;
 
@@ -129,7 +129,7 @@ protected:
 #endif // !_HAS_EXCEPTIONS
 };
 
-_EXPORT_STD class underflow_error : public runtime_error { // base of all underflow-error exceptions
+_EXPORT_STD class _NODISCARD underflow_error : public runtime_error { // base of all underflow-error exceptions
 public:
     using _Mybase = runtime_error;
 
@@ -145,7 +145,7 @@ protected:
 #endif // !_HAS_EXCEPTIONS
 };
 
-_EXPORT_STD class range_error : public runtime_error { // base of all range-error exceptions
+_EXPORT_STD class _NODISCARD range_error : public runtime_error { // base of all range-error exceptions
 public:
     using _Mybase = runtime_error;
 

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -458,7 +458,7 @@ struct hash<error_condition> {
     }
 };
 
-class _System_error : public runtime_error { // base of all system-error exceptions
+class _NODISCARD _System_error : public runtime_error { // base of all system-error exceptions
 private:
     static string _Makestr(error_code _Errcode, string _Message) { // compose error message
         if (!_Message.empty()) {
@@ -478,7 +478,7 @@ protected:
     error_code _Mycode; // the stored error code
 };
 
-_EXPORT_STD class system_error : public _System_error { // base of all system-error exceptions
+_EXPORT_STD class _NODISCARD system_error : public _System_error { // base of all system-error exceptions
 private:
     using _Mybase = _System_error;
 

--- a/stl/inc/typeinfo
+++ b/stl/inc/typeinfo
@@ -29,7 +29,7 @@ _STD_BEGIN
 _INLINE_VAR constexpr int _Small_object_num_ptrs = 6 + 16 / sizeof(void*);
 
 #if !_HAS_EXCEPTIONS
-_EXPORT_STD class bad_cast : public exception { // base of all bad cast exceptions
+_EXPORT_STD class _NODISCARD bad_cast : public exception { // base of all bad cast exceptions
 public:
     bad_cast(const char* _Message = "bad cast") noexcept : exception(_Message) {}
 
@@ -41,7 +41,7 @@ protected:
     }
 };
 
-_EXPORT_STD class bad_typeid : public exception { // base of all bad typeid exceptions
+_EXPORT_STD class _NODISCARD bad_typeid : public exception { // base of all bad typeid exceptions
 public:
     bad_typeid(const char* _Message = "bad typeid") noexcept : exception(_Message) {}
 
@@ -53,7 +53,7 @@ protected:
     }
 };
 
-class __non_rtti_object : public bad_typeid { // report a non-RTTI object
+class _NODISCARD __non_rtti_object : public bad_typeid { // report a non-RTTI object
 public:
     __non_rtti_object(const char* _Message) : bad_typeid(_Message) {}
 };

--- a/stl/inc/xiosbase
+++ b/stl/inc/xiosbase
@@ -108,7 +108,7 @@ public:
     using seek_dir  = unsigned int;
 #endif // _HAS_OLD_IOSTREAMS_MEMBERS
 
-    class failure : public system_error { // base of all iostreams exceptions
+    class _NODISCARD failure : public system_error { // base of all iostreams exceptions
     public:
         explicit failure(const string& _Message, const error_code& _Errcode = _STD make_error_code(io_errc::stream))
             : system_error(_Errcode, _Message) {} // construct with message

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -36,6 +36,12 @@ std/numerics/rand/rand.dist/rand.dist.uni/rand.dist.uni.real/param_ctor.pass.cpp
 # LLVM-113609: [libc++][test] Non-rebindable test_alloc in string.capacity/deallocate_size.pass.cpp
 std/strings/basic.string/string.capacity/deallocate_size.pass.cpp FAIL
 
+# LLVM-119174: [libcxx][test] Silence nodiscard warnings for std::expected
+std/utilities/expected/expected.expected/monadic/and_then.pass.cpp FAIL
+std/utilities/expected/expected.expected/monadic/or_else.pass.cpp FAIL
+std/utilities/expected/expected.expected/monadic/transform.pass.cpp FAIL
+std/utilities/expected/expected.expected/monadic/transform_error.pass.cpp FAIL
+
 # Non-Standard regex behavior.
 # "It seems likely that the test is still non-conforming due to how libc++ handles the 'w' character class."
 std/re/re.traits/lookup_classname.pass.cpp FAIL

--- a/tests/std/tests/P2505R5_monadic_functions_for_std_expected/test.cpp
+++ b/tests/std/tests/P2505R5_monadic_functions_for_std_expected/test.cpp
@@ -217,8 +217,6 @@ constexpr void test_impl(Expected&& engaged, Expected&& unengaged) {
             assert(result.value().x == 77);
         }
     }
-
-    engaged.transform([](auto...) { return ""; });
 }
 
 template <IsNothrowConstructible nothrowConstructible, IsNothrowConvertible nothrowConvertible>


### PR DESCRIPTION
A [reddit thread](https://www.reddit.com/r/cpp/comments/1h9u4us/should_stdexpected_be_nodiscard/) has persuaded me to explore marking entire types as `[[nodiscard]]`, which previously we reserved for guard types only.

We're very careful about avoiding `[[nodiscard]]` false positives. Marking an entire type affects all user-defined functions returning that type (as well as all temporary constructions), with no `[[discard]]` antidote available for function declarations. (Individual callsites can always be `(void)` suppressed.) For existing types like C++11 `error_code`, I continue to believe that too much time has passed for it to be reasonable to mark the entire type now.

# :ballot_box_with_check: `<expected>` :no_entry:

However, while explaining our original decision again, I remembered that `<expected>` is actually still new to C++23. I forgot because we shipped it in VS 2022 17.3 (Aug 2022), over two ~~millennia~~ years ago. As it's a new type, and we haven't finalized C++23, we can set policies for this new type without fear of introducing a blizzard of `[[nodiscard]]` warnings in legacy codebases. Early adopters will be writing their first functions returning `std::expected`, so we can keep all of their callsites clean from day one.

I am marking `expected<T, E>`, `expected<void, E>`, and `unexpected<E>`. The idea is that as `expected` is an alternative to exception handling, it should be difficult to unintentionally ignore errors. If a user-defined function has chosen to return the `expected` type, all callers should be inspecting the return value. We are essentially saying that all user-defined functions returning `expected` should be marked `[[nodiscard]]`, and are making that decision for all of them, for all time. (Marking `unexpected` is going to be the least useful because it'll be used the least, but as it contains error information that's intended to construct an `expected`, the same arguments about not dropping it on the floor apply.)

# :grey_exclamation: Exception types

A different rationale applies here. These are legacy types, many going back to C++98, but they are rarely used as values. If a function is returning an exception type by value, it is very likely a "maker" function (crafting a string literal, etc.). Returning an exception by value and then discarding it is highly suspicious, as it looks like it was meant to be thrown. Similarly, constructing a temporary exception and dropping it on the floor is *extremely* likely to be a bug.

The following code previously compiled without warnings (except C4702 "unreachable code", which is noisy and might be silenced). Now it emits a warning, just like a discarded guard temporary:

```
D:\GitHub\STL\out\x64>type meow.cpp
```
```cpp
#include <print>
#include <stdexcept>
using namespace std;

void woof() {
    println("woof() one!");
    runtime_error{"TOO MANY PUPPIES"};
    println("woof() two!");
}

int main() {
    try {
        println("main() before!");
        woof();
        println("main() after!");
    } catch (const runtime_error& e) {
        println("runtime_error: {}", e.what());
    }
}
```
```
D:\GitHub\STL\out\x64>cl /EHsc /nologo /W4 /wd4702 /std:c++latest /MTd /Od meow.cpp
meow.cpp
meow.cpp(7): warning C4834: discarding return value of function with [[nodiscard]] attribute
```

# :white_check_mark: Test updates

* I submitted https://github.com/llvm/llvm-project/pull/119174 upstream. libc++ was clean except for their monadic `expected` tests.
* I dropped an unnecessary call in `P2505R5_monadic_functions_for_std_expected`. This test had already exercised `expected::transform`, and contained a solitary call at the end of the function. It looked like this might have been an editing relic of the original PR when it was introduced, as the existing `expected::transform` coverage is quite sufficient and this last lambda isn't exercising anything new. Rather than `(void)` cast it, or expand it into a thorough test, I'm just dropping it.

# :100: The exception hierarchy

I believe I've audited our entire exception hierarchy, including internal exceptions. If I missed anything in product code, please let me know:

* `exception`
  + `_Parallelism_resources_exhausted`
  + `bad_alloc`
    - `bad_array_new_length`
  + `bad_cast`
    - `bad_any_cast`
  + `bad_exception`
  + `bad_expected_access<void>`
    - `bad_expected_access`
  + `bad_function_call`
  + `bad_optional_access`
  + `bad_typeid`
    - `__non_rtti_object`
  + `bad_variant_access`
  + `bad_weak_ptr`
  + `logic_error`
    - `domain_error`
    - `future_error`
    - `invalid_argument`
    - `length_error`
    - `out_of_range`
  + `runtime_error`
    - `_System_error`
      * `system_error`
        + `ios_base::failure`
        + `std::experimental::filesystem::filesystem_error`
        + `std::filesystem::filesystem_error`
    - `ambiguous_local_time`
    - `format_error`
    - `nonexistent_local_time`
    - `overflow_error`
    - `range_error`
    - `regex_error`
    - `underflow_error`

# :warning: Note to self when mirroring

Internally, I've also marked the following types that are defined in VCRuntime. (I've found and marked all of them, although I still need to build and test those changes, which I'll do while mirroring.)

* `__non_rtti_object`
* `bad_alloc`
* `bad_array_new_length`
* `bad_cast`
* `bad_exception`
* `bad_typeid`
* `exception`
