### PR TITLE
`STL.natvis`: Simplify visualization for `string_view`

### DIFF
--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -1112,8 +1112,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   <Type Name="std::basic_string_view&lt;*,*&gt;">
     <Intrinsic Name="size" Expression="_Mysize" />
     <Intrinsic Name="data" Expression="_Mydata" />
-    <DisplayString>{_Mydata,[_Mysize]}</DisplayString>
-    <StringView>_Mydata,[_Mysize]</StringView>
+    <DisplayString>{_Mydata,[_Mysize]na}</DisplayString>
+    <StringView>_Mydata,[_Mysize]na</StringView>
     <Expand>
       <Item Name="[size]" ExcludeView="simple">size()</Item>
       <ArrayItems>
@@ -1125,7 +1125,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
   <!-- This is for _ITERATOR_DEBUG_LEVEL == 0 and must have lower priority. -->
   <Type Name="std::_String_view_iterator&lt;*&gt;" Priority="MediumLow">
-    <SmartPointer Usage="Indexable">_Myptr</SmartPointer>
+    <SmartPointer Usage="Indexable">_Myptr,na</SmartPointer>
     <Expand>
       <Item Name="[ptr]">_Myptr</Item>
     </Expand>
@@ -1133,11 +1133,12 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
   <!-- This is for _ITERATOR_DEBUG_LEVEL != 0 and must have higher priority. -->
   <Type Name="std::_String_view_iterator&lt;*&gt;" Priority="Medium">
-    <SmartPointer Usage="Indexable">_Mydata + _Myoff</SmartPointer>
+    <DisplayString>{_Mydata + _Myoff,[_Mysize - _Myoff]na}</DisplayString>
+    <StringView>_Mydata + _Myoff,[_Mysize - _Myoff]na</StringView>
     <Expand>
       <Item Name="[ptr]">_Mydata + _Myoff</Item>
       <Item Name="[offset]">_Myoff</Item>
-      <Item Name="[string_view]">_Mydata,[_Mysize]</Item>
+      <Item Name="[string_view]">_Mydata,[_Mysize]na</Item>
     </Expand>
   </Type>
 


### PR DESCRIPTION
`std::string_view` should be shown similar to `std::string` in debugger for basic view.