### PR TITLE
`STL.natvis`: Simplify visualization for `string`

### DIFF
--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -1005,13 +1005,11 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
    * wchar_t / unsigned short / char16_t = su format
    * char32_t = s32 format
    -->
-  <Type Name="std::basic_string&lt;char,*&gt;">
-    <AlternativeType Name="std::basic_string&lt;char8_t,*&gt;" />
-
+  <Type Name="std::basic_string&lt;*,*&gt;">
     <Intrinsic Name="size" Expression="_Mypair._Myval2._Mysize" />
     <Intrinsic Name="capacity" Expression="_Mypair._Myval2._Myres" />
-    <!-- _BUF_SIZE = 16 / sizeof(char) &lt; 1 ? 1 : 16 / sizeof(char) == 16 -->
-    <Intrinsic Name="bufSize" Expression="16" />
+    <!-- _BUF_SIZE = 16 / sizeof($T1) &lt; 1 ? 1 : 16 / sizeof($T1) -->
+    <Intrinsic Name="bufSize" Expression="16 / sizeof($T1) &lt; 1 ? 1 : 16 / sizeof($T1)" />
     <Intrinsic Name="isShortString" Expression="capacity() &lt; bufSize()" />
     <Intrinsic Name="isLongString" Expression="capacity() &gt;= bufSize()" />
     <DisplayString Condition="isShortString()">{_Mypair._Myval2._Bx._Buf,na}</DisplayString>
@@ -1030,82 +1028,11 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     </Expand>
   </Type>
 
-  <Type Name="std::basic_string&lt;wchar_t,*&gt;">
-    <AlternativeType Name="std::basic_string&lt;unsigned short,*&gt;" />
-    <AlternativeType Name="std::basic_string&lt;char16_t,*&gt;" />
-
-    <Intrinsic Name="size" Expression="_Mypair._Myval2._Mysize" />
-    <Intrinsic Name="capacity" Expression="_Mypair._Myval2._Myres" />
-    <!-- _BUF_SIZE = 16 / sizeof(wchar_t) &lt; 1 ? 1 : 16 / sizeof(wchar_t) == 8 -->
-    <Intrinsic Name="bufSize" Expression="8" />
-    <Intrinsic Name="isShortString" Expression="capacity() &lt; bufSize()" />
-    <Intrinsic Name="isLongString" Expression="capacity() &gt;= bufSize()" />
-    <DisplayString Condition="isShortString()">{_Mypair._Myval2._Bx._Buf,su}</DisplayString>
-    <DisplayString Condition="isLongString()">{_Mypair._Myval2._Bx._Ptr,su}</DisplayString>
-    <StringView Condition="isShortString()">_Mypair._Myval2._Bx._Buf,su</StringView>
-    <StringView Condition="isLongString()">_Mypair._Myval2._Bx._Ptr,su</StringView>
-    <Expand>
-      <Item Name="[size]" ExcludeView="simple">size()</Item>
-      <Item Name="[capacity]" ExcludeView="simple">capacity()</Item>
-      <Item Name="[allocator]" ExcludeView="simple">_Mypair</Item>
-      <ArrayItems>
-        <Size>_Mypair._Myval2._Mysize</Size>
-        <ValuePointer Condition="isShortString()">_Mypair._Myval2._Bx._Buf</ValuePointer>
-        <ValuePointer Condition="isLongString()">_Mypair._Myval2._Bx._Ptr</ValuePointer>
-      </ArrayItems>
-    </Expand>
-  </Type>
-
-  <Type Name="std::basic_string&lt;char32_t,*&gt;">
-    <Intrinsic Name="size" Expression="_Mypair._Myval2._Mysize" />
-    <Intrinsic Name="capacity" Expression="_Mypair._Myval2._Myres" />
-    <!-- _BUF_SIZE = 16 / sizeof(char32_t) &lt; 1 ? 1 : 16 / sizeof(char32_t) == 4 -->
-    <Intrinsic Name="bufSize" Expression="4" />
-    <Intrinsic Name="isShortString" Expression="capacity() &lt; bufSize()" />
-    <Intrinsic Name="isLongString" Expression="capacity() &gt;= bufSize()" />
-    <DisplayString Condition="isShortString()">{_Mypair._Myval2._Bx._Buf,s32}</DisplayString>
-    <DisplayString Condition="isLongString()">{_Mypair._Myval2._Bx._Ptr,s32}</DisplayString>
-    <StringView Condition="isShortString()">_Mypair._Myval2._Bx._Buf,s32</StringView>
-    <StringView Condition="isLongString()">_Mypair._Myval2._Bx._Ptr,s32</StringView>
-    <Expand>
-      <Item Name="[size]" ExcludeView="simple">size()</Item>
-      <Item Name="[capacity]" ExcludeView="simple">capacity()</Item>
-      <Item Name="[allocator]" ExcludeView="simple">_Mypair</Item>
-      <ArrayItems>
-        <Size>_Mypair._Myval2._Mysize</Size>
-        <ValuePointer Condition="isShortString()">_Mypair._Myval2._Bx._Buf</ValuePointer>
-        <ValuePointer Condition="isLongString()">_Mypair._Myval2._Bx._Ptr</ValuePointer>
-      </ArrayItems>
-    </Expand>
-  </Type>
-
-  <Type Name="std::_String_iterator&lt;std::_String_val&lt;std::_Simple_types&lt;char&gt; &gt; &gt;">
-      <AlternativeType Name="std::_String_const_iterator&lt;std::_String_val&lt;std::_Simple_types&lt;char&gt; &gt; &gt;" />
-      <AlternativeType Name="std::_String_iterator&lt;std::_String_val&lt;std::_Simple_types&lt;char8_t&gt; &gt; &gt;" />
-      <AlternativeType Name="std::_String_const_iterator&lt;std::_String_val&lt;std::_Simple_types&lt;char8_t&gt; &gt; &gt;" />
+  <Type Name="std::_String_iterator&lt;std::_String_val&lt;std::_Simple_types&lt;*&gt; &gt; &gt;">
+      <AlternativeType Name="std::_String_const_iterator&lt;std::_String_val&lt;std::_Simple_types&lt;*&gt; &gt; &gt;" />
       <SmartPointer Usage="Indexable">_Ptr,na</SmartPointer>
       <Expand>
           <Item Name="[ptr]">_Ptr</Item>
-      </Expand>
-  </Type>
-
-  <Type Name="std::_String_iterator&lt;std::_String_val&lt;std::_Simple_types&lt;wchar_t&gt; &gt; &gt;">
-      <AlternativeType Name="std::_String_const_iterator&lt;std::_String_val&lt;std::_Simple_types&lt;wchar_t&gt; &gt; &gt;" />
-      <AlternativeType Name="std::_String_iterator&lt;std::_String_val&lt;std::_Simple_types&lt;unsigned short&gt; &gt; &gt;" />
-      <AlternativeType Name="std::_String_const_iterator&lt;std::_String_val&lt;std::_Simple_types&lt;unsigned short&gt; &gt; &gt;" />
-      <AlternativeType Name="std::_String_iterator&lt;std::_String_val&lt;std::_Simple_types&lt;char16_t&gt; &gt; &gt;" />
-      <AlternativeType Name="std::_String_const_iterator&lt;std::_String_val&lt;std::_Simple_types&lt;char16_t&gt; &gt; &gt;" />
-      <SmartPointer Usage="Indexable">_Ptr,su</SmartPointer>
-      <Expand>
-          <Item Name="[ptr]">_Ptr</Item>
-      </Expand>
-  </Type>
-
-  <Type Name="std::_String_iterator&lt;std::_String_val&lt;std::_Simple_types&lt;char32_t&gt; &gt; &gt;">
-    <AlternativeType Name="std::_String_const_iterator&lt;std::_String_val&lt;std::_Simple_types&lt;char32_t&gt; &gt; &gt;" />
-    <SmartPointer Usage="Indexable">_Ptr,s32</SmartPointer>
-      <Expand>
-        <Item Name="[ptr]">_Ptr</Item>
       </Expand>
   </Type>
 

--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -1001,9 +1001,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
    * Notes:
    * Hard coding _BUF_SIZE for clang-cl compatibility; clang-cl as of 7.0.1 does not emit S_CONSTANT to get _BUF_SIZE
    *
-   * char = na format
-   * wchar_t / unsigned short / char16_t = su format
-   * char32_t = s32 format
+   * The `na` format specifier means "no address". For more info, see:
+   * https://learn.microsoft.com/en-us/visualstudio/debugger/format-specifiers-in-cpp?view=vs-2022
    -->
   <Type Name="std::basic_string&lt;*,*&gt;">
     <Intrinsic Name="size" Expression="_Mypair._Myval2._Mysize" />

--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -1027,8 +1027,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     </Expand>
   </Type>
 
-  <Type Name="std::_String_iterator&lt;std::_String_val&lt;std::_Simple_types&lt;*&gt; &gt; &gt;">
-      <AlternativeType Name="std::_String_const_iterator&lt;std::_String_val&lt;std::_Simple_types&lt;*&gt; &gt; &gt;" />
+  <Type Name="std::_String_iterator&lt;*&gt;">
+      <AlternativeType Name="std::_String_const_iterator&lt;*&gt;" />
       <SmartPointer Usage="Indexable">_Ptr,na</SmartPointer>
       <Expand>
           <Item Name="[ptr]">_Ptr</Item>

--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -1004,7 +1004,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
    * The `na` format specifier means "no address". For more info, see:
    * https://learn.microsoft.com/en-us/visualstudio/debugger/format-specifiers-in-cpp?view=vs-2022
    -->
-  <Type Name="std::basic_string&lt;*,*&gt;">
+  <Type Name="std::basic_string&lt;*&gt;">
     <Intrinsic Name="size" Expression="_Mypair._Myval2._Mysize" />
     <Intrinsic Name="capacity" Expression="_Mypair._Myval2._Myres" />
     <!-- _BUF_SIZE = 16 / sizeof($T1) &lt; 1 ? 1 : 16 / sizeof($T1) -->


### PR DESCRIPTION
It appears that debugger visualizer accepts `na` regardless if underlying char type
