### PR TITLE
Toolset update: VS 2022 17.13 Preview 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.13 Preview 1 or later.
+1. Install Visual Studio 2022 17.13 Preview 2 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.
@@ -160,7 +160,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.13 Preview 1 or later.
+1. Install Visual Studio 2022 17.13 Preview 2 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,7 +5,7 @@
 
 variables:
 - name: poolName
-  value: 'StlBuild-2024-11-12T1255-Pool'
+  value: 'StlBuild-2024-12-11T1537-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -43,7 +43,7 @@ foreach ($workload in $VisualStudioWorkloads) {
 $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/PowerShell-7.4.6-win-x64.msi'
 $PowerShellArgs = @('/quiet', '/norestart')
 
-$PythonUrl = 'https://www.python.org/ftp/python/3.13.0/python-3.13.0-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.13.1/python-3.13.1-amd64.exe'
 $PythonArgs = @('/quiet', 'InstallAllUsers=1', 'PrependPath=1', 'CompileAll=1', 'Include_doc=0')
 
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/12.4.0/local_installers/cuda_12.4.0_551.61_windows.exe'

--- a/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
+++ b/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
@@ -83,9 +83,7 @@ void test_dll() {
     TheFuncProc pFunc = reinterpret_cast<TheFuncProc>(GetProcAddress(hLibrary, "DllTest"));
     assert(pFunc != nullptr);
     pFunc();
-#if defined(_MSVC_INTERNAL_TESTING) || defined(_DLL) || !defined(__SANITIZE_ADDRESS__) // TRANSITION, vs17.13p2
     FreeLibrary(hLibrary);
-#endif // ^^^ no workaround ^^^
 #endif // ^^^ !defined(_M_CEE) ^^^
 }
 

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -2385,10 +2385,8 @@ static_assert(
 static_assert(!is_assignable_v<expected<int, char>&, ambiguating_expected_assignment_source<int, char>>);
 static_assert(!is_assignable_v<expected<void, int>&, ambiguating_expected_assignment_source<void, int>>);
 #endif // ^^^ no workaround ^^^
-#ifndef __EDG__ // TRANSITION, VSO-2188364
 static_assert(!is_assignable_v<expected<move_only, char>&, ambiguating_expected_assignment_source<move_only, char>>);
 static_assert(!is_assignable_v<expected<void, move_only>&, ambiguating_expected_assignment_source<void, move_only>>);
-#endif // ^^^ no workaround ^^^
 
 int main() {
     test_unexpected::test_all();

--- a/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
@@ -62,7 +62,9 @@ class CustomTestFormat(STLTestFormat):
             # Generate JSON files that record how these headers depend on one another.
             if noisyProgress:
                 print('Scanning dependencies...')
-            cmd = [test.cxx, *test.flags, *test.compileFlags, *clOptions, '/scanDependencies', '.\\', *allHeaders]
+            cmd = [test.cxx, *test.flags, *test.compileFlags, *clOptions, '/scanDependencies', '.\\',
+                '/shallowScan', # TRANSITION, VSO-2293247 fixed in VS 2022 17.13 Preview 3 (remove /shallowScan)
+                *allHeaders]
             yield TestStep(cmd, shared.execDir, shared.env, False)
 
             # The JSON files also record what object files will be produced.

--- a/tests/std/tests/P2502R2_generator/test.cpp
+++ b/tests/std/tests/P2502R2_generator/test.cpp
@@ -152,7 +152,7 @@ void test_weird_reference_types() {
         assert(pos == r.end());
     }
 
-#if !(defined(__EDG__) || (defined(__clang__) && defined(_M_IX86))) // TRANSITION, VSO-2254804 and LLVM-56507
+#if !(defined(__clang__) && defined(_M_IX86)) // TRANSITION, LLVM-56507
     { // Test with mutable rvalue reference type
         constexpr size_t segment_size = 16;
         auto woof                     = []() -> generator<vector<int>&&> {
@@ -172,7 +172,7 @@ void test_weird_reference_types() {
 #endif // ^^^ no workaround ^^^
 }
 
-#if !(defined(__EDG__) || (defined(__clang__) && defined(_M_IX86))) // TRANSITION, VSO-2254804 and LLVM-56507
+#if !(defined(__clang__) && defined(_M_IX86)) // TRANSITION, LLVM-56507
 generator<int> iota_repeater(const int hi, const int depth) {
     if (depth > 0) {
         co_yield ranges::elements_of(iota_repeater(hi, depth - 1));
@@ -401,7 +401,7 @@ int main() {
     assert(ranges::equal(co_upto(6), views::iota(0, 6)));
     zip_example();
     test_weird_reference_types();
-#if !(defined(__EDG__) || (defined(__clang__) && defined(_M_IX86))) // TRANSITION, VSO-2254804 and LLVM-56507
+#if !(defined(__clang__) && defined(_M_IX86)) // TRANSITION, LLVM-56507
     recursive_test();
     arbitrary_range_test();
 


### PR DESCRIPTION
# :scroll: Changelog
- Code cleanups:
  * Removed compiler bug workarounds.
- Infrastructure improvements:
  * Updated dependencies.
    + Updated build compiler to VS 2022 17.13 Preview 2.
    + Updated Python to 3.13.1.

# :gear: Commits
* Remove workarounds for:
  + VSO-2188364 "EDG assertion failed in `conversion_for_direct_reference_binding_possible`".
  + VSO-2254804 "EDG ICE in `cpfe.dll!make_coroutine_result_expression` with C++23 `<generator>` test".
  + VSO-2046190 "\[CI-NIGHTLY\]\[Libs-ASan-amd64\] `src\vctools\crt\github\tests\std\tests\Dev09_056375_locale_cleanup` failed due to ERROR: AddressSanitizer: access-violation on unknown address".
* Add `/shallowScan` to work around VSO-2293247 "`/Zc:preprocessor` does not terminate macro definitions properly".
  + This has been fixed internally, so we don't need to mirror this to the Perl script.
* Python 3.13.1.
* `Standard_D32ads_v5` pool.
* VS 2022 17.13 Preview 2 (not yet required).

[STL-ASan-CI passed.](https://dev.azure.com/vclibs/STL/_build/results?buildId=18036&view=results)