### PR TITLE
Toolset update: VS 2022 17.13 Preview 2, F32as_v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.13 Preview 1 or later.
+1. Install Visual Studio 2022 17.13 Preview 2 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.
@@ -160,7 +160,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.13 Preview 1 or later.
+1. Install Visual Studio 2022 17.13 Preview 2 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -11,16 +11,16 @@ variables:
   value: 'EnableSpotVM -equals false'
   readonly: true
 - name: tmpDir
-  value: 'D:\Temp'
+  value: 'C:\stlTemp'
   readonly: true
 - name: buildOutputLocation
-  value: 'D:\build'
+  value: 'C:\stlBuild'
   readonly: true
 - name: benchmarkBuildOutputLocation
-  value: 'D:\benchmark'
+  value: 'C:\stlBenchmark'
   readonly: true
 - name: validationBuildOutputLocation
-  value: 'D:\validation'
+  value: 'C:\stlValidation'
   readonly: true
 - name: Codeql.SkipTaskAutoInjection
   value: true

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,7 +5,7 @@
 
 variables:
 - name: poolName
-  value: 'StlBuild-2024-11-12T1255-Pool'
+  value: 'StlBuild-2024-12-12T1002-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -14,7 +14,7 @@ $ErrorActionPreference = 'Stop'
 $CurrentDate = Get-Date
 
 $Location = 'eastus2'
-$VMSize = 'Standard_D32ads_v5'
+$VMSize = 'Standard_F32as_v6'
 $ProtoVMName = 'PROTOTYPE'
 $ImagePublisher = 'MicrosoftWindowsServer'
 $ImageOffer = 'WindowsServer'

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -141,6 +141,7 @@ Display-ProgressBar -Status 'Creating prototype VM'
 $VM = New-AzVMConfig `
   -VMName $ProtoVMName `
   -VMSize $VMSize `
+  -DiskControllerType 'NVMe' `
   -Priority 'Regular'
 
 $VM = Set-AzVMOperatingSystem `
@@ -261,6 +262,9 @@ New-AzRoleAssignment `
 Display-ProgressBar -Status 'Creating image definition'
 
 $ImageDefinitionName = $ResourceGroupName + '-ImageDefinition'
+$FeatureTrustedLaunch = @{ Name = 'SecurityType'; Value = 'TrustedLaunch'; }
+$FeatureNVMe = @{ Name = 'DiskControllerTypes'; Value = 'SCSI, NVMe'; }
+$ImageDefinitionFeatures = @($FeatureTrustedLaunch, $FeatureNVMe)
 New-AzGalleryImageDefinition `
   -Location $Location `
   -ResourceGroupName $ResourceGroupName `
@@ -271,7 +275,7 @@ New-AzGalleryImageDefinition `
   -Publisher $ImagePublisher `
   -Offer $ImageOffer `
   -Sku $ImageSku `
-  -Feature @(@{ Name = 'SecurityType'; Value = 'TrustedLaunch'; }) `
+  -Feature $ImageDefinitionFeatures `
   -HyperVGeneration 'V2' | Out-Null
 
 ####################################################################################################

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -43,7 +43,7 @@ foreach ($workload in $VisualStudioWorkloads) {
 $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/PowerShell-7.4.6-win-x64.msi'
 $PowerShellArgs = @('/quiet', '/norestart')
 
-$PythonUrl = 'https://www.python.org/ftp/python/3.13.0/python-3.13.0-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.13.1/python-3.13.1-amd64.exe'
 $PythonArgs = @('/quiet', 'InstallAllUsers=1', 'PrependPath=1', 'CompileAll=1', 'Include_doc=0')
 
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/12.4.0/local_installers/cuda_12.4.0_551.61_windows.exe'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -75,7 +75,7 @@ Function DownloadAndInstall {
 
   try {
     Write-Host "Downloading $Name..."
-    $tempPath = 'D:\installerTemp'
+    $tempPath = 'C:\installerTemp'
     mkdir $tempPath -Force | Out-Null
     $fileName = [uri]::new($Url).Segments[-1]
     $installerPath = Join-Path $tempPath $fileName

--- a/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
+++ b/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
@@ -83,9 +83,7 @@ void test_dll() {
     TheFuncProc pFunc = reinterpret_cast<TheFuncProc>(GetProcAddress(hLibrary, "DllTest"));
     assert(pFunc != nullptr);
     pFunc();
-#if defined(_MSVC_INTERNAL_TESTING) || defined(_DLL) || !defined(__SANITIZE_ADDRESS__) // TRANSITION, vs17.13p2
     FreeLibrary(hLibrary);
-#endif // ^^^ no workaround ^^^
 #endif // ^^^ !defined(_M_CEE) ^^^
 }
 

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -2385,10 +2385,8 @@ static_assert(
 static_assert(!is_assignable_v<expected<int, char>&, ambiguating_expected_assignment_source<int, char>>);
 static_assert(!is_assignable_v<expected<void, int>&, ambiguating_expected_assignment_source<void, int>>);
 #endif // ^^^ no workaround ^^^
-#ifndef __EDG__ // TRANSITION, VSO-2188364
 static_assert(!is_assignable_v<expected<move_only, char>&, ambiguating_expected_assignment_source<move_only, char>>);
 static_assert(!is_assignable_v<expected<void, move_only>&, ambiguating_expected_assignment_source<void, move_only>>);
-#endif // ^^^ no workaround ^^^
 
 int main() {
     test_unexpected::test_all();

--- a/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
@@ -62,7 +62,9 @@ class CustomTestFormat(STLTestFormat):
             # Generate JSON files that record how these headers depend on one another.
             if noisyProgress:
                 print('Scanning dependencies...')
-            cmd = [test.cxx, *test.flags, *test.compileFlags, *clOptions, '/scanDependencies', '.\\', *allHeaders]
+            cmd = [test.cxx, *test.flags, *test.compileFlags, *clOptions, '/scanDependencies', '.\\',
+                '/shallowScan', # TRANSITION, VSO-2293247 fixed in VS 2022 17.13 Preview 3 (remove /shallowScan)
+                *allHeaders]
             yield TestStep(cmd, shared.execDir, shared.env, False)
 
             # The JSON files also record what object files will be produced.

--- a/tests/std/tests/P2502R2_generator/test.cpp
+++ b/tests/std/tests/P2502R2_generator/test.cpp
@@ -152,7 +152,7 @@ void test_weird_reference_types() {
         assert(pos == r.end());
     }
 
-#if !(defined(__EDG__) || (defined(__clang__) && defined(_M_IX86))) // TRANSITION, VSO-2254804 and LLVM-56507
+#if !(defined(__clang__) && defined(_M_IX86)) // TRANSITION, LLVM-56507
     { // Test with mutable rvalue reference type
         constexpr size_t segment_size = 16;
         auto woof                     = []() -> generator<vector<int>&&> {
@@ -172,7 +172,7 @@ void test_weird_reference_types() {
 #endif // ^^^ no workaround ^^^
 }
 
-#if !(defined(__EDG__) || (defined(__clang__) && defined(_M_IX86))) // TRANSITION, VSO-2254804 and LLVM-56507
+#if !(defined(__clang__) && defined(_M_IX86)) // TRANSITION, LLVM-56507
 generator<int> iota_repeater(const int hi, const int depth) {
     if (depth > 0) {
         co_yield ranges::elements_of(iota_repeater(hi, depth - 1));
@@ -401,7 +401,7 @@ int main() {
     assert(ranges::equal(co_upto(6), views::iota(0, 6)));
     zip_example();
     test_weird_reference_types();
-#if !(defined(__EDG__) || (defined(__clang__) && defined(_M_IX86))) // TRANSITION, VSO-2254804 and LLVM-56507
+#if !(defined(__clang__) && defined(_M_IX86)) // TRANSITION, LLVM-56507
     recursive_test();
     arbitrary_range_test();
 


### PR DESCRIPTION
# :scroll: Changelog
- Code cleanups:
  * Removed compiler bug workarounds.
- Infrastructure improvements:
  * Updated dependencies.
    + Updated build compiler to VS 2022 17.13 Preview 2.
    + Updated Python to 3.13.1.
    + Updated VMs to compute-optimized [F32as_v6](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/compute-optimized/fasv6-series).

# :gear: Commits
* Remove workarounds for:
  + VSO-2188364 "EDG assertion failed in `conversion_for_direct_reference_binding_possible`".
  + VSO-2254804 "EDG ICE in `cpfe.dll!make_coroutine_result_expression` with C++23 `<generator>` test".
  + VSO-2046190 "\[CI-NIGHTLY\]\[Libs-ASan-amd64\] `src\vctools\crt\github\tests\std\tests\Dev09_056375_locale_cleanup` failed due to ERROR: AddressSanitizer: access-violation on unknown address".
* Add `/shallowScan` to work around VSO-2293247 "`/Zc:preprocessor` does not terminate macro definitions properly".
  + This has been fixed internally, so we don't need to mirror this to the Perl script.
* Python 3.13.1.
* VS 2022 17.13 Preview 2 (not yet required).
* Standard_F32as_v6.
* Use `C:` and rename directories to avoid any possible collisions.
  + This is necessary because this SKU lacks a local/temporary `D:` storage drive.
* Power Word: NVMe
  + This is necessary because this is an NVMe SKU. Passing [`-DiskControllerType 'NVMe'` to `New-AzVMConfig`](https://learn.microsoft.com/en-us/powershell/module/az.compute/new-azvmconfig?view=azps-13.0.0#-diskcontrollertype) might not be strictly necessary, but passing the `DiskControllerTypes` feature to `New-AzGalleryImageDefinition` is absolutely necessary. Otherwise, 1ES Hosted Pools provisioning will completely and mysteriously fail.
  + Figuring this out was fun. [Fasv6](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/compute-optimized/fasv6-series) links to [Supported OS images for remote NVMe](https://learn.microsoft.com/en-us/azure/virtual-machines/enable-nvme-interface) which doesn't mention Server 2025 as supported, but I deduced that it must be. That then links to [FAQ for remote NVMe disks](https://learn.microsoft.com/en-us/azure/virtual-machines/enable-nvme-remote-faqs) which finally has a section "How do I tag an image that supports NVMe for remote disks?" and provides an Azure CLI command that I was able to translate to our Azure PowerShell. Along the way, I encountered [Store and share images in an Azure Compute Gallery](https://learn.microsoft.com/en-us/azure/virtual-machines/shared-image-galleries) which mentions "DiskControllerType" (singular!) as a feature, with arrays (!) of strings as possible values, which is doubly bogus AFAICT, but it led me down the right path.
* Standard_F32as_v6 NVMe pool.

[STL-ASan-CI passed.](https://dev.azure.com/vclibs/STL/_build/results?buildId=18038&view=results)

# :rocket: Speedup vs. :money_mouth_face: Cost

This significantly accelerates the CI. To do proper science, I cleanly compared this toolset update with varying SKUs:

* Our old SKU [`Standard_D32ads_v5`](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dadsv5-series).
  + This is general-purpose (D), 32 logical cores, AMD (a), temporary storage (d), premium storage (s), Zen 3 (v5).
  + Test run: https://dev.azure.com/vclibs/STL/_build/results?buildId=18033&view=results
* This new SKU [`Standard_F32as_v6`](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/compute-optimized/fasv6-series).
  + This is compute-optimized (F), 32 *physical* cores (i.e. no SMT), AMD (a), *no* temporary storage (d absent), premium storage (s), Zen 4 (v6).
  + Test run: https://dev.azure.com/vclibs/STL/_build/results?buildId=18037&view=results

Previously, the x64 shards took an average of 731 seconds (12m 11s). Now they take an average of 507 seconds (8m 27s), which is a 1.442x speedup. Unsurprisingly, this SKU is more expensive per-hour (1.326x), but the speedup means that this is effectively cheaper to run.
