### PR TITLE
Add support for running only edg tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,4 +34,4 @@ get_property(STL_LIT_TEST_DIRS GLOBAL PROPERTY STL_LIT_TEST_DIRS)
 
 add_custom_target(STL-CI COMMAND ${STL_LIT_COMMAND} -Dnotags=ASAN ${STL_LIT_TEST_DIRS} USES_TERMINAL)
 add_custom_target(STL-ASan-CI COMMAND ${STL_LIT_COMMAND} -Dtags=ASAN ${STL_LIT_TEST_DIRS} USES_TERMINAL)
-add_custom_target(STL-only-edg-tests COMMAND ${STL_LIT_COMMAND} -Dnotags=ASAN -Dedg_only=True --xunit-xml-output test-results.xml ${STL_LIT_TEST_DIRS} USES_TERMINAL)
+add_custom_target(test-only-edg COMMAND ${STL_LIT_COMMAND} -Dnotags=ASAN -Dtest-only-edg=True --xunit-xml-output test-results.xml ${STL_LIT_TEST_DIRS} USES_TERMINAL)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,3 +34,4 @@ get_property(STL_LIT_TEST_DIRS GLOBAL PROPERTY STL_LIT_TEST_DIRS)
 
 add_custom_target(STL-CI COMMAND ${STL_LIT_COMMAND} -Dnotags=ASAN ${STL_LIT_TEST_DIRS} USES_TERMINAL)
 add_custom_target(STL-ASan-CI COMMAND ${STL_LIT_COMMAND} -Dtags=ASAN ${STL_LIT_TEST_DIRS} USES_TERMINAL)
+add_custom_target(STL-only-edg-tests COMMAND ${STL_LIT_COMMAND} -Dnotags=ASAN -Dedg_only=True --xunit-xml-output test-results.xml ${STL_LIT_TEST_DIRS} USES_TERMINAL)

--- a/tests/utils/stl/test/params.py
+++ b/tests/utils/stl/test/params.py
@@ -58,9 +58,9 @@ def beNice(prio: str) -> list[ConfigAction]:
 
 def getDefaultParameters(config, litConfig):
     DEFAULT_PARAMETERS = [
-      Parameter(name='edg_only', choices=[True, False], type=bool, default=False,
+      Parameter(name='test-only-edg', choices=[True, False], type=bool, default=False,
                 help="Whether to only run edg tests (those that use the /BE flag).",
-                actions=lambda enabled: [AddFeature(name='edg_only')] if enabled else []),
+                actions=lambda enabled: [AddFeature(name='test-only-edg')] if enabled else []),
       Parameter(name='long_tests', choices=[True, False], type=bool, default=True,
                 help="Whether to run tests that take a long time. This can be useful when running on a slow device.",
                 actions=lambda enabled: [AddFeature(name='long_tests')] if enabled else []),

--- a/tests/utils/stl/test/params.py
+++ b/tests/utils/stl/test/params.py
@@ -58,6 +58,9 @@ def beNice(prio: str) -> list[ConfigAction]:
 
 def getDefaultParameters(config, litConfig):
     DEFAULT_PARAMETERS = [
+      Parameter(name='edg_only', choices=[True, False], type=bool, default=False,
+                help="Whether to only run edg tests (those that use the /BE flag).",
+                actions=lambda enabled: [AddFeature(name='edg_only')] if enabled else []),
       Parameter(name='long_tests', choices=[True, False], type=bool, default=True,
                 help="Whether to run tests that take a long time. This can be useful when running on a slow device.",
                 actions=lambda enabled: [AddFeature(name='long_tests')] if enabled else []),

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -72,7 +72,7 @@ class STLTest(Test):
                           msg)
 
         if 'test-only-edg' in self.config.available_features and 'edg' not in self.requires:
-            return Result(UNSUPPORTED, 'We run only /BE tests with the edg_only flag')
+            return Result(UNSUPPORTED, 'We run only /BE tests with the test-only-edg flag')
 
         if 'edg_drop' in self.config.available_features:
             if 'edg' not in self.requires:

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -71,13 +71,12 @@ class STLTest(Test):
             return Result(UNSUPPORTED, "Test does not require any of the features specified in limit_to_features: %s" %
                           msg)
 
-        if 'edg_only' in self.config.available_features:
-            if not 'edg' in self.requires:
-                return Result(UNSUPPORTED, 'We only run /BE tests with the edg_only flag')
+        if 'edg_only' in self.config.available_features and 'edg' not in self.requires:
+            return Result(UNSUPPORTED, 'We run only /BE tests with the edg_only flag')
 
         if 'edg_drop' in self.config.available_features:
-            if not 'edg' in self.requires:
-                return Result(UNSUPPORTED, 'We only run /BE tests with the edg drop')
+            if 'edg' not in self.requires:
+                return Result(UNSUPPORTED, 'We run only /BE tests with the edg drop')
 
             _, tmpBase = self.getTempPaths()
             self.isenseRspPath = tmpBase + '.isense.rsp'

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -71,6 +71,10 @@ class STLTest(Test):
             return Result(UNSUPPORTED, "Test does not require any of the features specified in limit_to_features: %s" %
                           msg)
 
+        if 'edg_only' in self.config.available_features:
+            if not 'edg' in self.requires:
+                return Result(UNSUPPORTED, 'We only run /BE tests with the edg_only flag')
+
         if 'edg_drop' in self.config.available_features:
             if not 'edg' in self.requires:
                 return Result(UNSUPPORTED, 'We only run /BE tests with the edg drop')

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -71,7 +71,7 @@ class STLTest(Test):
             return Result(UNSUPPORTED, "Test does not require any of the features specified in limit_to_features: %s" %
                           msg)
 
-        if 'edg_only' in self.config.available_features and 'edg' not in self.requires:
+        if 'test-only-edg' in self.config.available_features and 'edg' not in self.requires:
             return Result(UNSUPPORTED, 'We run only /BE tests with the edg_only flag')
 
         if 'edg_drop' in self.config.available_features:


### PR DESCRIPTION
Adding a new target STL-only-edg-tests which will run only edg tests.