### PR TITLE
`<xlocale>`: Deprecate non-Standard `locale::empty()`

### DIFF
--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -400,7 +400,8 @@ public:
 
     static _MRTIMP2_PURE locale __CLRCALL_PURE_OR_CDECL global(const locale&); // current locale
 
-    static _MRTIMP2_PURE locale __CLRCALL_PURE_OR_CDECL empty(); // empty (transparent) locale
+    // TRANSITION, ABI: non-Standard empty() is preserved for binary compatibility
+    _DEPRECATE_LOCALE_EMPTY static _MRTIMP2_PURE locale __CLRCALL_PURE_OR_CDECL empty(); // empty (transparent) locale
 
 private:
     struct _Secret_locale_construct_tag {

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1517,7 +1517,17 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define _CXX20_DEPRECATE_CODECVT_CHAR8_T_FACETS
 #endif // ^^^ warning disabled ^^^
 
-// next warning number: STL4048
+#if !defined(_SILENCE_LOCALE_EMPTY_DEPRECATION_WARNING) && !defined(_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS)
+#define _DEPRECATE_LOCALE_EMPTY                                                                                        \
+    [[deprecated(                                                                                                      \
+        "warning STL4048: locale::empty() is a non-Standard extension and will be removed in the future. A "           \
+        "default-constructed locale can be used instead. You can define _SILENCE_LOCALE_EMPTY_DEPRECATION_WARNING or " \
+        "_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS to suppress this warning.")]]
+#else // ^^^ warning enabled / warning disabled vvv
+#define _DEPRECATE_LOCALE_EMPTY
+#endif // ^^^ warning disabled ^^^
+
+// next warning number: STL4049
 
 // next error number: STL1006
 

--- a/stl/src/locale0.cpp
+++ b/stl/src/locale0.cpp
@@ -9,6 +9,8 @@
 
 #undef _ENFORCE_ONLY_CORE_HEADERS // TRANSITION, <xfacet> should be a core header
 
+#define _SILENCE_LOCALE_EMPTY_DEPRECATION_WARNING
+
 #include <crtdbg.h>
 #include <internal_shared.h>
 #include <xatomic.h>


### PR DESCRIPTION
Towards #5184.

I'm not sure whether it is wanted to expose equivalent functionality under an _Ugly name.