### PR TITLE
Add XOR swap and XCHG assembly optimization for integral types

### DIFF
--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -136,6 +136,29 @@ template <class _Ty, int _Enabled /* = 0 */>
 #endif // ^^^ !_HAS_CXX17 ^^^
 _CONSTEXPR20 void swap(_Ty& _Left, _Ty& _Right)
     noexcept(is_nothrow_move_constructible_v<_Ty> && is_nothrow_move_assignable_v<_Ty>) {
+    if (_STD addressof(_Left) == _STD addressof(_Right)) {
+        return; // Handle self-swap as a no-op; see LWG-4165
+    }
+
+    if constexpr (_STD is_integral_v<_Ty>) {
+#if defined(_M_IX86)
+        if constexpr (sizeof(_Ty) == 4) {
+            __asm
+                {
+                xchg eax, dword ptr [_Left]
+                xchg eax, dword ptr [_Right]
+                xchg dword ptr [_Left], eax
+                }
+            ;
+            return;
+        }
+#endif
+        _Left ^= _Right;
+        _Right ^= _Left;
+        _Left ^= _Right;
+        return;
+    }
+
     _Ty _Tmp = _STD move(_Left);
     _Left    = _STD move(_Right);
     _Right   = _STD move(_Tmp);


### PR DESCRIPTION
- Add _ENABLE_XOR_SWAP macro with default value of 0
- Implement XOR swap optimization for integral types
- Add x86/x64 assembly XCHG optimization
- Add comprehensive test coverage for swap operations

Tests are initially disabled to allow for review before enabling.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
