### PR TITLE
VCRuntime fixed default non-throwing `operator new[]` to call throwing `operator new[]`

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -438,8 +438,9 @@ std/input.output/syncstream/syncbuf/syncstream.syncbuf.members/emit.pass.cpp FAI
 # *** VCRUNTIME BUGS ***
 # DevCom-10373274 VSO-1824997 "vcruntime nothrow array operator new falls back on the wrong function"
 # This passes for the :1 (ASan) configuration, surprisingly.
-std/language.support/support.dynamic/new.delete/new.delete.array/new.size_nothrow.replace.indirect.pass.cpp:0 FAIL
-std/language.support/support.dynamic/new.delete/new.delete.array/new.size_nothrow.replace.indirect.pass.cpp:2 FAIL
+# TRANSITION, vs17.14p1
+std/language.support/support.dynamic/new.delete/new.delete.array/new.size_nothrow.replace.indirect.pass.cpp:0 SKIPPED
+std/language.support/support.dynamic/new.delete/new.delete.array/new.size_nothrow.replace.indirect.pass.cpp:2 SKIPPED
 
 
 # *** CRT BUGS ***


### PR DESCRIPTION
Internally, the default non-throwing array `operator new` now correctly delegates to throwing array `operator new`. Let's mark the corresponding libcxx test `SKIPPED` instead of `FAIL` so the test suite passes both internally and externally. We can remove the skip altogether once the VCRuntime change ships in preview.

This mirrors MSVC-PR-601619 which fixes DevCom-10373274 "vcruntime nothrow array operator new falls back on the wrong function".