### PR TITLE
Implement LWG-3886 Monad mo' problems (in `optional` and `expected`)

### DIFF
--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -304,7 +304,7 @@ public:
         }
     }
 
-    template <class _Uty = _Ty>
+    template <class _Uty = remove_cv_t<_Ty>>
         requires (!is_same_v<remove_cvref_t<_Uty>, in_place_t> && !is_same_v<remove_cvref_t<_Uty>, expected>
                      && !_Is_specialization_v<remove_cvref_t<_Uty>, unexpected>
                      && (!is_same_v<remove_cv_t<_Ty>, bool>
@@ -469,7 +469,7 @@ public:
                   && _Trivially_move_constructible_assignable_destructible<_Err>
     = default;
 
-    template <class _Uty = _Ty>
+    template <class _Uty = remove_cv_t<_Ty>>
         requires (!is_same_v<remove_cvref_t<_Uty>, expected> && !_Is_specialization_v<remove_cvref_t<_Uty>, unexpected>
                   && is_constructible_v<_Ty, _Uty> && is_assignable_v<_Ty&, _Uty>
                   && (is_nothrow_constructible_v<_Ty, _Uty> || is_nothrow_move_constructible_v<_Ty>
@@ -730,32 +730,38 @@ public:
         return _STD move(_Unexpected);
     }
 
-    template <class _Uty>
-    _NODISCARD constexpr _Ty value_or(_Uty&& _Other) const& noexcept(
-        is_nothrow_copy_constructible_v<_Ty> && is_nothrow_convertible_v<_Uty, _Ty>) /* strengthened */ {
-        static_assert(
-            is_copy_constructible_v<_Ty>, "is_copy_constructible_v<T> must be true. (N4950 [expected.object.obs]/18)");
-        static_assert(
-            is_convertible_v<_Uty, _Ty>, "is_convertible_v<U, T> must be true. (N4950 [expected.object.obs]/18)");
+    template <class _Uty = remove_cv_t<_Ty>>
+    _NODISCARD constexpr remove_cv_t<_Ty> value_or(_Uty&& _Other) const& noexcept(
+        is_nothrow_convertible_v<const _Ty&, remove_cv_t<_Ty>>
+        && is_nothrow_convertible_v<_Uty, remove_cv_t<_Ty>>) /* strengthened */ {
+        static_assert(is_convertible_v<const _Ty&, remove_cv_t<_Ty>>,
+            "is_convertible_v<const T&, remove_cv_t<T>> must be true. "
+            "(N5001 [expected.object.obs]/18 as modified by LWG-3424)");
+        static_assert(is_convertible_v<_Uty, remove_cv_t<_Ty>>,
+            "is_convertible_v<U, remove_cv_t<T>> must be true. "
+            "(N5001 [expected.object.obs]/18 as modified by LWG-3424)");
 
         if (_Has_value) {
             return _Value;
         } else {
-            return static_cast<_Ty>(_STD forward<_Uty>(_Other));
+            return static_cast<remove_cv_t<_Ty>>(_STD forward<_Uty>(_Other));
         }
     }
-    template <class _Uty>
-    _NODISCARD constexpr _Ty value_or(_Uty&& _Other) && noexcept(
-        is_nothrow_move_constructible_v<_Ty> && is_nothrow_convertible_v<_Uty, _Ty>) /* strengthened */ {
-        static_assert(
-            is_move_constructible_v<_Ty>, "is_move_constructible_v<T> must be true. (N4950 [expected.object.obs]/20)");
-        static_assert(
-            is_convertible_v<_Uty, _Ty>, "is_convertible_v<U, T> must be true. (N4950 [expected.object.obs]/20)");
+    template <class _Uty = remove_cv_t<_Ty>>
+    _NODISCARD constexpr remove_cv_t<_Ty> value_or(_Uty&& _Other) && noexcept(
+        is_nothrow_convertible_v<_Ty, remove_cv_t<_Ty>>
+        && is_nothrow_convertible_v<_Uty, remove_cv_t<_Ty>>) /* strengthened */ {
+        static_assert(is_convertible_v<_Ty, remove_cv_t<_Ty>>,
+            "is_convertible_v<T, remove_cv_t<T>> must be true. "
+            "(N5001 [expected.object.obs]/20 as modified by LWG-3424)");
+        static_assert(is_convertible_v<_Uty, remove_cv_t<_Ty>>,
+            "is_convertible_v<U, remove_cv_t<T>> must be true. "
+            "(N5001 [expected.object.obs]/20 as modified by LWG-3424)");
 
         if (_Has_value) {
             return _STD move(_Value);
         } else {
-            return static_cast<_Ty>(_STD forward<_Uty>(_Other));
+            return static_cast<remove_cv_t<_Ty>>(_STD forward<_Uty>(_Other));
         }
     }
 

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -252,7 +252,7 @@ public:
         negation<conjunction<is_same<remove_cv_t<_Ty>, bool>, _Is_specialization<_Remove_cvref_t<_Ty2>, optional>>>,
         is_constructible<_Ty, _Ty2>>>;
 
-    template <class _Ty2 = _Ty, enable_if_t<_AllowDirectConversion<_Ty2>::value, int> = 0>
+    template <class _Ty2 = remove_cv_t<_Ty>, enable_if_t<_AllowDirectConversion<_Ty2>::value, int> = 0>
     constexpr explicit(!is_convertible_v<_Ty2, _Ty>) optional(_Ty2&& _Right)
         noexcept(is_nothrow_constructible_v<_Ty, _Ty2>) // strengthened
         : _Mybase(in_place, _STD forward<_Ty2>(_Right)) {}
@@ -288,10 +288,11 @@ public:
         return *this;
     }
 
-    template <class _Ty2 = _Ty, enable_if_t<conjunction_v<negation<is_same<optional, _Remove_cvref_t<_Ty2>>>,
-                                                negation<conjunction<is_scalar<_Ty>, is_same<_Ty, decay_t<_Ty2>>>>,
-                                                is_constructible<_Ty, _Ty2>, is_assignable<_Ty&, _Ty2>>,
-                                    int> = 0>
+    template <class _Ty2 = remove_cv_t<_Ty>,
+        enable_if_t<conjunction_v<negation<is_same<optional, _Remove_cvref_t<_Ty2>>>,
+                        negation<conjunction<is_scalar<_Ty>, is_same<_Ty, decay_t<_Ty2>>>>, is_constructible<_Ty, _Ty2>,
+                        is_assignable<_Ty&, _Ty2>>,
+            int>         = 0>
     _CONSTEXPR20 optional& operator=(_Ty2&& _Right)
         noexcept(is_nothrow_assignable_v<_Ty&, _Ty2> && is_nothrow_constructible_v<_Ty, _Ty2>) /* strengthened */ {
         this->_Assign(_STD forward<_Ty2>(_Right));
@@ -425,7 +426,7 @@ public:
         return _STD move(this->_Value);
     }
 
-    template <class _Ty2>
+    template <class _Ty2 = remove_cv_t<_Ty>>
     _NODISCARD constexpr remove_cv_t<_Ty> value_or(_Ty2&& _Right) const& {
         static_assert(is_convertible_v<const _Ty&, remove_cv_t<_Ty>>,
             "The const overload of optional<T>::value_or requires const T& to be convertible to remove_cv_t<T> "
@@ -439,7 +440,7 @@ public:
 
         return static_cast<remove_cv_t<_Ty>>(_STD forward<_Ty2>(_Right));
     }
-    template <class _Ty2>
+    template <class _Ty2 = remove_cv_t<_Ty>>
     _NODISCARD constexpr remove_cv_t<_Ty> value_or(_Ty2&& _Right) && {
         static_assert(is_convertible_v<_Ty, remove_cv_t<_Ty>>,
             "The rvalue overload of optional<T>::value_or requires T to be convertible to remove_cv_t<T> "

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -431,8 +431,9 @@ public:
         static_assert(is_convertible_v<const _Ty&, remove_cv_t<_Ty>>,
             "The const overload of optional<T>::value_or requires const T& to be convertible to remove_cv_t<T> "
             "(N4950 [optional.observe]/15 as modified by LWG-3424).");
-        static_assert(is_convertible_v<_Ty2, _Ty>,
-            "optional<T>::value_or(U) requires U to be convertible to T (N4950 [optional.observe]/15).");
+        static_assert(is_convertible_v<_Ty2, remove_cv_t<_Ty>>,
+            "optional<T>::value_or(U) requires U to be convertible to remove_cv_t<T> "
+            "(N4950 [optional.observe]/15 as modified by LWG-3424).");
 
         if (this->_Has_value) {
             return static_cast<const _Ty&>(this->_Value);
@@ -445,8 +446,9 @@ public:
         static_assert(is_convertible_v<_Ty, remove_cv_t<_Ty>>,
             "The rvalue overload of optional<T>::value_or requires T to be convertible to remove_cv_t<T> "
             "(N4950 [optional.observe]/17 as modified by LWG-3424).");
-        static_assert(is_convertible_v<_Ty2, _Ty>,
-            "optional<T>::value_or(U) requires U to be convertible to T (N4950 [optional.observe]/17).");
+        static_assert(is_convertible_v<_Ty2, remove_cv_t<_Ty>>,
+            "optional<T>::value_or(U) requires U to be convertible to remove_cv_t<T> "
+            "(N4950 [optional.observe]/17 as modified by LWG-3424).");
 
         if (this->_Has_value) {
             return static_cast<_Ty&&>(this->_Value);

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -2395,7 +2395,8 @@ constexpr bool test_lwg_3886() {
         assert(ex.value_or({}).qual_ == Qualification::None);
     }
 #if 0 // TRANSITION, LWG-3891
-    assert((expected<const QualDistinction, char>{unexpect} = {QualDistinction{}}).value().qual_ == Qualification::None);
+    assert(
+        (expected<const QualDistinction, char>{unexpect} = {QualDistinction{}}).value().qual_ == Qualification::None);
     {
         expected<const QualDistinction, char> ex{in_place};
         assert((ex = {QualDistinction{}}).value().qual_ == Qualification::None);
@@ -2414,7 +2415,8 @@ void test_lwg_3886_volatile() {
         assert(ex.value_or({}).qual_ == Qualification::None);
     }
 #if 0 // TRANSITION, LWG-3891
-    assert((expected<volatile QualDistinction, char>{unexpect} = {QualDistinction{}}).value().qual_ == Qualification::None);
+    assert((expected<volatile QualDistinction, char>{unexpect} = {QualDistinction{}}).value().qual_
+           == Qualification::None);
     {
         expected<volatile QualDistinction, char> ex{in_place};
         assert((ex = {QualDistinction{}}).value().qual_ == Qualification::None);


### PR DESCRIPTION
Also speculatively implement LWG-3424 for `expected` to avoid `volatile`-qualified return types, and complete the speculative implementation for `optional`.

Some parts of the resolution is not meaningful yet and not tested due to LWG-3891.

Fixes #5119.