### PR TITLE
`<thread>`: Avoid overflow in `_To_absolute_time()`

### DIFF
--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -169,7 +169,7 @@ _NODISCARD auto _To_absolute_time(const chrono::duration<_Rep, _Period>& _Rel_ti
     const auto _Now                      = chrono::steady_clock::now();
     decltype(_Now + _Rel_time) _Abs_time = _Now; // return common type
     if (_Rel_time > _Zero) {
-        constexpr auto _Forever = (chrono::steady_clock::time_point::max)();
+        constexpr auto _Forever = (decltype(_Abs_time)::max)();
         if (_Abs_time < _Forever - _Rel_time) {
             _Abs_time += _Rel_time;
         } else {


### PR DESCRIPTION
Fixes #5234.

We were carefully forming `decltype(_Now + _Rel_time) _Abs_time`, the common type of the given `_Rel_time` (which could be coarse or fine) and `chrono::steady_clock::now()` (which is nanoseconds).

In this bug scenario, `_Rel_time` and therefore the common type are picoseconds.

The problem was that we weren't careful about our `_Forever` constant. We were using `(chrono::steady_clock::time_point::max)()`, but then converting it to the common type (implicitly in the subtraction `_Forever - _Rel_time`, and in the assignment `_Abs_time = _Forever`). When the common type is finer-grained, this attempts to multiply the stored value, but it's already the maximum, so we overflow.

The fix is to use the common type for `_Forever`. This stores the maximum rep with the proper period of the common type, so we won't attempt to multiply it further. (When `_Rel_time` is coarse, the common type is nanoseconds, so there's no change. When `_Rel_time` is fine, this means that `_Forever` is effectively "earlier", because `INT64_MAX` picoseconds from the epoch happens earlier than `INT64_MAX` nanoseconds. This is exactly what we want, since we're performing our overflow check and clamping with the common type that we're about to return.)