### PR TITLE
Clarify ASan test running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,16 +412,19 @@ set PATH=C:\STL\out\x64\out\bin\amd64;%PATH%
 ## Running Tests With Address Sanitizer (ASan)
 
 You don't need any extra steps to run with test code and the code in STL headers instrumented with [ASan][].
-The test matrices include both ASan and non-ASan configurations if you don't pass `-Dtags=ASAN` or `-Dnotags=ASAN` to exclude one or the other.
+The test matrices include both ASan and non-ASan configurations if you don't pass `-Dtags=ASAN` or `-Dnotags=ASAN`
+to exclude one or the other.
 
-However, to instrument the separately-compiled code (the DLL, the satellites, the [Import Library][] - everything that's in `/stl/src`), you need to build the STL with ASan. Change the build steps to add `-DSTL_ASAN_BUILD=ON`:
+However, to instrument the separately-compiled code (the DLL, the satellites, the [Import Library][] - everything that's
+in `/stl/src`), you need to build the STL with ASan. Change the build steps to add `-DSTL_ASAN_BUILD=ON`:
 
 ```
 cmake --preset x64 -DSTL_ASAN_BUILD=ON
 cmake --build --preset x64
 ```
 
-ASan-instrumented STL binaries require that the executable be instrumented as well, so you'll have to skip the non-ASan configurations by passing `-Dtags=ASAN` to `stl-lit.py`:
+ASan-instrumented STL binaries require that the executable be instrumented as well, so you'll have to skip the non-ASan
+configurations by passing `-Dtags=ASAN` to `stl-lit.py`:
 
 ```
 python out\x64\tests\utils\stl-lit\stl-lit.py tests\std\tests\VSO_0000000_vector_algorithms -Dtags=ASAN -v

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ cmake --build --preset x64
 ASan-instrumented STL binaries require that the executable be instrumented as well, so you'll have to skip the non-ASan configurations by passing `-Dtags=ASAN` to `stl-lit.py`:
 
 ```
-C:\STL\out\x64> python tests\utils\stl-lit\stl-lit.py ..\..\tests\std\tests\VSO_0000000_vector_algorithms -Dtags=ASAN -v
+python out\x64\tests\utils\stl-lit\stl-lit.py tests\std\tests\VSO_0000000_vector_algorithms -Dtags=ASAN -v
 ```
 
 # Benchmarking

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ set PATH=C:\STL\out\x64\out\bin\amd64;%PATH%
 ## Running Tests With Address Sanitizer (ASan)
 
 You don't need any extra steps to run with test code and the code in STL headers instrumented with [ASan][].
-The test matrices include both ASan and non-ASan configurations.
+The test matrices include both ASan and non-ASan configurations if you don't pass `-Dtags=ASAN` or `-Dnotags=ASAN` to exclude one or the other.
 
 However, to instrument the separately-compiled code (the DLL, the satellites, the [Import Library][] - everything that's in `/stl/src`), you need to build the STL with ASan. Change the build steps to add `-DSTL_ASAN_BUILD=ON`:
 

--- a/README.md
+++ b/README.md
@@ -414,19 +414,17 @@ set PATH=C:\STL\out\x64\out\bin\amd64;%PATH%
 You don't need any extra steps to run with test code and the code in STL headers instrumented with [ASan][].
 The test matrices include both ASan and non-ASan configurations.
 
-However, to instrument the separately-compiled code (the DLL, the satellites, the [Import Library][] - everything that's
-in `/stl/src`), you need to build the STL with ASan. Change the build steps to add `-DSTL_ASAN_BUILD=ON`:
+However, to instrument the separately-compiled code (the DLL, the satellites, the [Import Library][] - everything that's in `/stl/src`), you need to build the STL with ASan. Change the build steps to add `-DSTL_ASAN_BUILD=ON`:
 
 ```
 cmake --preset x64 -DSTL_ASAN_BUILD=ON
 cmake --build --preset x64
 ```
 
-ASan-instrumented STL binaries require that the executable be instrumented as well, so you'll have to skip the non-ASan
-configurations by passing `-Dtags=ASAN` to `stl-lit.py`:
+ASan-instrumented STL binaries require that the executable be instrumented as well, so you'll have to skip the non-ASan configurations by passing `-Dtags=ASAN` to `stl-lit.py`:
 
 ```
-python tests\utils\stl-lit\stl-lit.py ..\..\tests\std\tests\VSO_0000000_vector_algorithms -Dtags=ASAN -v
+C:\STL\out\x64> python tests\utils\stl-lit\stl-lit.py ..\..\tests\std\tests\VSO_0000000_vector_algorithms -Dtags=ASAN -v
 ```
 
 # Benchmarking

--- a/README.md
+++ b/README.md
@@ -426,8 +426,10 @@ cmake --build --preset x64
 ASan-instrumented STL binaries require that the executable be instrumented as well, so you'll have to skip the non-ASan
 configurations by passing `-Dtags=ASAN` to `stl-lit.py`:
 
+(This example assumes that your current directory is `C:\Dev\STL\out\x64`.)
+
 ```
-python out\x64\tests\utils\stl-lit\stl-lit.py tests\std\tests\VSO_0000000_vector_algorithms -Dtags=ASAN -v
+python tests\utils\stl-lit\stl-lit.py ..\..\tests\std\tests\VSO_0000000_vector_algorithms -Dtags=ASAN -v
 ```
 
 # Benchmarking


### PR DESCRIPTION
This is an exceedingly _minor_ contribution, so feel free to disregard it. 

When running the ASan'ized tests, I could have used a reminder that the python test script resides within the `.\out\<arch>` folder. The preceeding `cmake` commands should run in the repo's root, so it's easy to forget changing your directory when running the `python <pathToTestScript>/stl-lit.py` command.

This PR adds a reminder that the call to `stl-lit.py` should be performed from `out\x64\` , to make this clearer.

Please feel free to dismiss this, it's a subjective contribution. Thanks!