### PR TITLE
Add the ability to opt-out of ASan container annotations on a per-allocator basis

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -483,52 +483,50 @@ private:
         _STL_INTERNAL_CHECK(_Old_last_ != nullptr);
         _STL_INTERNAL_CHECK(_New_last_ != nullptr);
 
+        if constexpr (!_Disable_ASan_container_annotations_for_allocator<allocator_type>) {
 #if _HAS_CXX20
-        if (_STD is_constant_evaluated()) {
-            return;
-        }
+            if (_STD is_constant_evaluated()) {
+                return;
+            }
 #endif // _HAS_CXX20
 
-        if (!_Asan_vector_should_annotate) {
-            return;
-        }
-
-        if constexpr (_Disable_ASan_container_annotations_for_allocator<allocator_type>) {
-            return;
-        }
-
-        const void* const _First    = _STD _Unfancy(_First_);
-        const void* const _End      = _STD _Unfancy(_End_);
-        const void* const _Old_last = _STD _Unfancy(_Old_last_);
-        const void* const _New_last = _STD _Unfancy(_New_last_);
-        if constexpr ((_Container_allocation_minimum_asan_alignment<vector>) >= _Asan_granularity) {
-            // old state:
-            //   [_First, _Old_last) valid
-            //   [_Old_last, _End) poison
-            // new state:
-            //   [_First, _New_last) valid
-            //   [_New_last, asan_aligned_after(_End)) poison
-            _CSTD __sanitizer_annotate_contiguous_container(
-                _First, _STD _Get_asan_aligned_after(_End), _Old_last, _New_last);
-        } else {
-            const auto _Aligned = _STD _Get_asan_aligned_first_end(_First, _End);
-            if (_Aligned._First == _Aligned._End) {
-                // The buffer does not end at least one shadow memory section; nothing to do.
+            if (!_Asan_vector_should_annotate) {
                 return;
             }
 
-            const void* const _Old_fixed = _Aligned._Clamp_to_end(_Old_last);
-            const void* const _New_fixed = _Aligned._Clamp_to_end(_New_last);
+            const void* const _First    = _STD _Unfancy(_First_);
+            const void* const _End      = _STD _Unfancy(_End_);
+            const void* const _Old_last = _STD _Unfancy(_Old_last_);
+            const void* const _New_last = _STD _Unfancy(_New_last_);
+            if constexpr ((_Container_allocation_minimum_asan_alignment<vector>) >= _Asan_granularity) {
+                // old state:
+                //   [_First, _Old_last) valid
+                //   [_Old_last, _End) poison
+                // new state:
+                //   [_First, _New_last) valid
+                //   [_New_last, asan_aligned_after(_End)) poison
+                _CSTD __sanitizer_annotate_contiguous_container(
+                    _First, _STD _Get_asan_aligned_after(_End), _Old_last, _New_last);
+            } else {
+                const auto _Aligned = _STD _Get_asan_aligned_first_end(_First, _End);
+                if (_Aligned._First == _Aligned._End) {
+                    // The buffer does not end at least one shadow memory section; nothing to do.
+                    return;
+                }
 
-            // old state:
-            //   [_Aligned._First, _Old_fixed) valid
-            //   [_Old_fixed, _Aligned._End) poison
-            //   [_Aligned._End, _End) valid
-            // new state:
-            //   [_Aligned._First, _New_fixed) valid
-            //   [_New_fixed, _Aligned._End) poison
-            //   [_Aligned._End, _End) valid
-            _CSTD __sanitizer_annotate_contiguous_container(_Aligned._First, _Aligned._End, _Old_fixed, _New_fixed);
+                const void* const _Old_fixed = _Aligned._Clamp_to_end(_Old_last);
+                const void* const _New_fixed = _Aligned._Clamp_to_end(_New_last);
+
+                // old state:
+                //   [_Aligned._First, _Old_fixed) valid
+                //   [_Old_fixed, _Aligned._End) poison
+                //   [_Aligned._End, _End) valid
+                // new state:
+                //   [_Aligned._First, _New_fixed) valid
+                //   [_New_fixed, _Aligned._End) poison
+                //   [_Aligned._End, _End) valid
+                _CSTD __sanitizer_annotate_contiguous_container(_Aligned._First, _Aligned._End, _Old_fixed, _New_fixed);
+            }
         }
     }
 

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -493,7 +493,7 @@ private:
             return;
         }
 
-        if (!is_ASan_enabled_for_allocator_v<allocator_type>) {
+        if constexpr (!_Is_ASan_enabled_for_allocator<allocator_type>) {
             return;
         }
 

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -493,6 +493,10 @@ private:
             return;
         }
 
+        if (!is_ASan_enabled_for_allocator_v<allocator_type>) {
+            return;
+        }
+
         const void* const _First    = _STD _Unfancy(_First_);
         const void* const _End      = _STD _Unfancy(_End_);
         const void* const _Old_last = _STD _Unfancy(_Old_last_);

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -493,7 +493,7 @@ private:
             return;
         }
 
-        if constexpr (!_Is_ASan_enabled_for_allocator<allocator_type>) {
+        if constexpr (_Disable_ASan_container_annotations_for_allocator<allocator_type>) {
             return;
         }
 

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -805,7 +805,7 @@ struct _Simple_types { // wraps types from allocators with simple addressing for
 _INLINE_VAR constexpr size_t _Asan_granularity      = 8;
 _INLINE_VAR constexpr size_t _Asan_granularity_mask = _Asan_granularity - 1;
 
-// Represents whether ASan container annotations are enabled a given allocator.
+// Controls whether ASan `container-overflow` errors are reported for this allocator.
 template <class>
 constexpr bool _Disable_ASan_container_annotations_for_allocator = false;
 

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -805,6 +805,17 @@ struct _Simple_types { // wraps types from allocators with simple addressing for
 _INLINE_VAR constexpr size_t _Asan_granularity      = 8;
 _INLINE_VAR constexpr size_t _Asan_granularity_mask = _Asan_granularity - 1;
 
+// Represents whether ASan is enabled for allocator type 'T'.
+// By default, ASan is enabled.
+template<typename T>
+struct is_ASan_enabled_for_allocator {
+    static constexpr bool value = true;
+};
+
+// Convenience helper to determine if ASan is enabled for a given allocator type 'T'
+template <typename T>
+constexpr bool is_ASan_enabled_for_allocator_v = is_ASan_enabled_for_allocator<T>::value;
+
 struct _Asan_aligned_pointers {
     const void* _First;
     const void* _End;

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -807,7 +807,7 @@ _INLINE_VAR constexpr size_t _Asan_granularity_mask = _Asan_granularity - 1;
 
 // Represents whether ASan container annotations are enabled a given allocator.
 template <class>
-constexpr bool _Is_ASan_enabled_for_allocator = true;
+constexpr bool _Disable_ASan_container_annotations_for_allocator = false;
 
 struct _Asan_aligned_pointers {
     const void* _First;

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -805,7 +805,7 @@ struct _Simple_types { // wraps types from allocators with simple addressing for
 _INLINE_VAR constexpr size_t _Asan_granularity      = 8;
 _INLINE_VAR constexpr size_t _Asan_granularity_mask = _Asan_granularity - 1;
 
-// Represents whether ASan container annotations are enabled for allocator type 'T'.
+// Represents whether ASan container annotations are enabled a given allocator.
 template <class>
 constexpr bool _Is_ASan_enabled_for_allocator = true;
 

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -806,15 +806,8 @@ _INLINE_VAR constexpr size_t _Asan_granularity      = 8;
 _INLINE_VAR constexpr size_t _Asan_granularity_mask = _Asan_granularity - 1;
 
 // Represents whether ASan container annotations are enabled for allocator type 'T'.
-// By default, ASan is enabled.
-template<typename T>
-struct is_ASan_enabled_for_allocator {
-    static constexpr bool value = true;
-};
-
-// Convenience helper to determine if ASan is enabled for a given allocator type 'T'
-template <typename T>
-constexpr bool is_ASan_enabled_for_allocator_v = is_ASan_enabled_for_allocator<T>::value;
+template <class>
+constexpr bool _Is_ASan_enabled_for_allocator = true;
 
 struct _Asan_aligned_pointers {
     const void* _First;

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -805,7 +805,7 @@ struct _Simple_types { // wraps types from allocators with simple addressing for
 _INLINE_VAR constexpr size_t _Asan_granularity      = 8;
 _INLINE_VAR constexpr size_t _Asan_granularity_mask = _Asan_granularity - 1;
 
-// Represents whether ASan is enabled for allocator type 'T'.
+// Represents whether ASan container annotations are enabled for allocator type 'T'.
 // By default, ASan is enabled.
 template<typename T>
 struct is_ASan_enabled_for_allocator {

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -622,58 +622,57 @@ private:
 
     static _CONSTEXPR20 void _Apply_annotation(const value_type* const _First, const size_type _Capacity,
         const size_type _Old_size, const size_type _New_size) noexcept {
+        if constexpr (!_Disable_ASan_container_annotations_for_allocator<allocator_type>) {
 #if _HAS_CXX20
-        if (_STD is_constant_evaluated()) {
-            return;
-        }
+            if (_STD is_constant_evaluated()) {
+                return;
+            }
 #endif // _HAS_CXX20
-       // Don't annotate small strings; only annotate on the heap.
-        if (_Capacity <= _Small_string_capacity || !_Asan_string_should_annotate) {
-            return;
+
+            // Don't annotate small strings; only annotate on the heap.
+            if (_Capacity <= _Small_string_capacity || !_Asan_string_should_annotate) {
+                return;
+            }
+
+            // Note that `_Capacity`, `_Old_size`, and `_New_size` do not include the null terminator
+            const void* const _End      = _First + _Capacity + 1;
+            const void* const _Old_last = _First + _Old_size + 1;
+            const void* const _New_last = _First + _New_size + 1;
+
+            constexpr bool _Large_string_always_asan_aligned =
+                (_Container_allocation_minimum_asan_alignment<basic_string>) >= _Asan_granularity;
+
+            // for the non-aligned buffer options, the buffer must always have size >= 9 bytes,
+            // so it will always end at least one shadow memory section.
+
+            _Asan_aligned_pointers _Aligned;
+            if constexpr (_Large_string_always_asan_aligned) {
+                _Aligned = {_First, _STD _Get_asan_aligned_after(_End)};
+            } else {
+                _Aligned = _STD _Get_asan_aligned_first_end(_First, _End);
+            }
+            const void* const _Old_fixed = _Aligned._Clamp_to_end(_Old_last);
+            const void* const _New_fixed = _Aligned._Clamp_to_end(_New_last);
+
+            // --- always aligned case ---
+            // old state:
+            //   [_First, _Old_last) valid
+            //   [_Old_last, asan_aligned_after(_End)) poison
+            // new state:
+            //   [_First, _New_last) valid
+            //   [_New_last, asan_aligned_after(_End)) poison
+
+            // --- sometimes non-aligned case ---
+            // old state:
+            //   [_Aligned._First, _Old_fixed) valid
+            //   [_Old_fixed, _Aligned._End) poison
+            //   [_Aligned._End, _End) valid
+            // new state:
+            //   [_Aligned._First, _New_fixed) valid
+            //   [_New_fixed, _Aligned._End) poison
+            //   [_Aligned._End, _End) valid
+            _CSTD __sanitizer_annotate_contiguous_container(_Aligned._First, _Aligned._End, _Old_fixed, _New_fixed);
         }
-
-        if constexpr (_Disable_ASan_container_annotations_for_allocator<allocator_type>) {
-            return;
-        }
-
-        // Note that `_Capacity`, `_Old_size`, and `_New_size` do not include the null terminator
-        const void* const _End      = _First + _Capacity + 1;
-        const void* const _Old_last = _First + _Old_size + 1;
-        const void* const _New_last = _First + _New_size + 1;
-
-        constexpr bool _Large_string_always_asan_aligned =
-            (_Container_allocation_minimum_asan_alignment<basic_string>) >= _Asan_granularity;
-
-        // for the non-aligned buffer options, the buffer must always have size >= 9 bytes,
-        // so it will always end at least one shadow memory section.
-
-        _Asan_aligned_pointers _Aligned;
-        if constexpr (_Large_string_always_asan_aligned) {
-            _Aligned = {_First, _STD _Get_asan_aligned_after(_End)};
-        } else {
-            _Aligned = _STD _Get_asan_aligned_first_end(_First, _End);
-        }
-        const void* const _Old_fixed = _Aligned._Clamp_to_end(_Old_last);
-        const void* const _New_fixed = _Aligned._Clamp_to_end(_New_last);
-
-        // --- always aligned case ---
-        // old state:
-        //   [_First, _Old_last) valid
-        //   [_Old_last, asan_aligned_after(_End)) poison
-        // new state:
-        //   [_First, _New_last) valid
-        //   [_New_last, asan_aligned_after(_End)) poison
-
-        // --- sometimes non-aligned case ---
-        // old state:
-        //   [_Aligned._First, _Old_fixed) valid
-        //   [_Old_fixed, _Aligned._End) poison
-        //   [_Aligned._End, _End) valid
-        // new state:
-        //   [_Aligned._First, _New_fixed) valid
-        //   [_New_fixed, _Aligned._End) poison
-        //   [_Aligned._End, _End) valid
-        _CSTD __sanitizer_annotate_contiguous_container(_Aligned._First, _Aligned._End, _Old_fixed, _New_fixed);
     }
 
 #define _ASAN_STRING_REMOVE(_Str)                       (_Str)._Remove_annotation()

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -632,6 +632,10 @@ private:
             return;
         }
 
+        if constexpr (!_Is_ASan_enabled_for_allocator<allocator_type>) {
+            return;
+        }
+
         // Note that `_Capacity`, `_Old_size`, and `_New_size` do not include the null terminator
         const void* const _End      = _First + _Capacity + 1;
         const void* const _Old_last = _First + _Old_size + 1;

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -632,7 +632,7 @@ private:
             return;
         }
 
-        if constexpr (!_Is_ASan_enabled_for_allocator<allocator_type>) {
+        if constexpr (_Disable_ASan_container_annotations_for_allocator<allocator_type>) {
             return;
         }
 

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -307,8 +307,10 @@ struct implicit_allocator_no_asan_annotations : implicit_allocator<T, Pocma, Sta
     }
 };
 
-template <typename T>
-constexpr bool _Disable_ASan_container_annotations_for_allocator<implicit_allocator_no_asan_annotations<T>> = true;
+template <class T, class Pocma, class Stateless>
+constexpr bool
+    _Disable_ASan_container_annotations_for_allocator<implicit_allocator_no_asan_annotations<T, Pocma, Stateless>> =
+        true;
 
 template <class Alloc>
 void test_construction() {

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -289,8 +289,7 @@ STATIC_ASSERT(_Container_allocation_minimum_asan_alignment<
                   basic_string<wchar_t, char_traits<wchar_t>, implicit_allocator<wchar_t>>>
               == 2);
 
-// Simple implicit allocator that opts out of ASan containers annotations (via
-// `_Disable_ASan_container_annotations_for_allocator`)
+// Simple allocator that opts out of ASan annotations (via `_Disable_ASan_container_annotations_for_allocator`)
 template <class T, class Pocma = true_type, class Stateless = true_type>
 struct implicit_allocator_no_asan_annotations : implicit_allocator<T, Pocma, Stateless> {
     implicit_allocator_no_asan_annotations() = default;
@@ -1877,15 +1876,15 @@ void run_tests() {
 #endif // ^^^ no workaround ^^^
 }
 
-// Test that writing to un-initialized memory in a string triggers ASan container-overflow checks.
+// Test that writing to un-initialized memory in a string triggers ASan container-overflow error.
 template <class CharType, class Alloc = std::allocator<CharType>>
 void run_asan_container_overflow_death_test() {
 
-    // We'll give the string capacity 100 (all uninitialized memory).
+    // We'll give the string capacity 100 (all un-initialized memory).
     std::basic_string<CharType, std::char_traits<CharType>, Alloc> myString;
     myString.reserve(100);
 
-    // Write to 50th element to trigger ASan container-overflow check.
+    // Write to the 50th element to trigger ASan container-overflow check.
     CharType* myData = &myString[0];
     myData[50]       = CharType{'A'};
 }
@@ -1894,7 +1893,7 @@ void run_asan_container_overflow_death_test() {
 template <class CharType>
 void run_asan_annotations_disablement_test() {
 
-    // Test that ASan annotations are disabled for the `implicit_allocator_no_asan_annotations` allocator,
+    // ASan annotations are disabled for the `implicit_allocator_no_asan_annotations` allocator,
     // which should make the container-overflow 'death test' pass.
     run_asan_container_overflow_death_test<CharType, implicit_allocator_no_asan_annotations<CharType>>();
 }

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -1882,7 +1882,7 @@ void run_asan_disablement_test() {
     myString.reserve(100);
 
     CharType* data = &myString[0]; // Get a mutable pointer to the string's data
-    data[50] = CharType{'A'}; // TODO: this isn't failing in ASAn due to a newly found bug. Merge that bug fix first.
+    data[50] = CharType{'A'}; // TODO: this isn't failing due to bug: https://github.com/microsoft/STL/issues/5251
 
     // TODO: is it possible to add a 'negative' test case here? One where ASan expectedly fails?
 }

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -1876,15 +1876,15 @@ void run_tests() {
 #endif // ^^^ no workaround ^^^
 }
 
-// Test that writing to un-initialized memory in a string triggers ASan container-overflow error.
+// Test that writing to uninitialized memory in a string triggers an ASan container-overflow error. (See GH-5251.)
 template <class CharType, class Alloc = std::allocator<CharType>>
 void run_asan_container_overflow_death_test() {
 
-    // We'll give the string capacity 100 (all un-initialized memory).
+    // We'll give the string capacity 100 (all uninitialized memory, except for the null terminator).
     std::basic_string<CharType, std::char_traits<CharType>, Alloc> myString;
     myString.reserve(100);
 
-    // Write to the 50th element to trigger ASan container-overflow check.
+    // Write to the element at index 50 to trigger an ASan container-overflow check.
     CharType* myData = &myString[0];
     myData[50]       = CharType{'A'};
 }
@@ -1915,7 +1915,7 @@ void run_allocator_matrix() {
 
     // To test ASan annotation disablement, we use an ad-hoc allocator type to avoid disrupting other
     // tests that depend on annotations being enabled. Therefore, unlike the prior tests,
-    // this test is not parametrized by the allocator type.
+    // this test is not parameterized by the allocator type.
     run_asan_annotations_disablement_test<CharType>();
 }
 

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -1952,7 +1952,7 @@ void run_asan_disablement_test() {
     const int alloc_size = 32;
     ArenaAllocator<char> allocator(alloc_size, size);
 
-	std::basic_string<char, std::char_traits<char>, ArenaAllocator<char>> myString(allocator);
+    std::basic_string<char, std::char_traits<char>, ArenaAllocator<char>> myString(allocator);
     myString.reserve(50);
     myString.push_back('A');
 

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -1877,11 +1877,11 @@ void run_tests() {
 }
 
 // Test that writing to uninitialized memory in a string triggers an ASan container-overflow error. (See GH-5251.)
-template <class CharType, class Alloc = std::allocator<CharType>>
+template <class CharType, class Alloc = allocator<CharType>>
 void run_asan_container_overflow_death_test() {
 
     // We'll give the string capacity 100 (all uninitialized memory, except for the null terminator).
-    std::basic_string<CharType, std::char_traits<CharType>, Alloc> myString;
+    basic_string<CharType, char_traits<CharType>, Alloc> myString;
     myString.reserve(100);
 
     // Write to the element at index 50 to trigger an ASan container-overflow check.

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -1983,11 +1983,15 @@ int main(int argc, char* argv[]) {
         test_gh_3955();
     });
 #ifdef __SANITIZE_ADDRESS__
+    exec.add_death_tests({
+        run_asan_container_overflow_death_test<char>,
 #ifdef __cpp_char8_t
-    exec.add_death_tests({run_asan_container_overflow_death_test<char8_t>});
+        run_asan_container_overflow_death_test<char8_t>,
 #endif // __cpp_char8_t
-    exec.add_death_tests({run_asan_container_overflow_death_test<char16_t>,
-        run_asan_container_overflow_death_test<char32_t>, run_asan_container_overflow_death_test<wchar_t>});
+        run_asan_container_overflow_death_test<char16_t>,
+        run_asan_container_overflow_death_test<char32_t>,
+        run_asan_container_overflow_death_test<wchar_t>,
+    });
 #endif // ASan instrumentation enabled
     return exec.run(argc, argv);
 }

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -287,93 +287,25 @@ STATIC_ASSERT(_Container_allocation_minimum_asan_alignment<
                   basic_string<wchar_t, char_traits<wchar_t>, implicit_allocator<wchar_t>>>
               == 2);
 
-// Helper class for `ArenaAllocator`, where data is linearly allocated in a finite buffer.
-class Arena {
-public:
-    Arena(size_t allocation_size, size_t capacity):
-        data(new char[capacity* allocation_size]),
-        allocation_size(allocation_size),
-        capacity(capacity),
-        offset(0) {}
-
-    Arena(const Arena& other):
-        data(other.data),
-        allocation_size(other.allocation_size),
-        capacity(other.capacity),
-        offset(other.offset) {}
-
-    void* allocate(size_t n) {
-        assert(offset + n <= capacity && "Allocation failed: the arena is out of memory. You may call `reset` to free up space.");
-        void* result = data + (offset * allocation_size);
-        offset += n;
-        return result;
-    }
-
-    // Deallocates memory in the arena, and `memset`s it all to zero
-    void reset() noexcept {
-        offset = 0;
-        memset(data, 0, capacity*allocation_size);
-    }
-
-    char* const data;
-    const size_t allocation_size;
-    const size_t capacity;
-    size_t offset;
-};
-
-// FIXME: refactor this class into a helper class.
-// An allocator that allocates memory in a pre-allocated buffer (the arena).
-template <typename T>
-class ArenaAllocator {
-public:
-
-    using value_type = T;
-    Arena* arena;
-
-    ArenaAllocator(size_t alloc_size, size_t capacity) {
-        assert(sizeof(T) <= alloc_size && "Constructor failed: allocation size is too small for target type.");
-        arena = new Arena(alloc_size, capacity);
-    }
-
+// Simple implicit allocator that opts out of ASan annotations (via `_Is_ASan_enabled_for_allocator`)
+template <class T, class Pocma = true_type, class Stateless = true_type>
+struct implicit_allocator_no_asan_annotations : implicit_allocator<T, Pocma, Stateless> {
+    implicit_allocator_no_asan_annotations() = default;
     template <class U>
-    ArenaAllocator(const ArenaAllocator<U>& other) {
-        assert(sizeof(T) <= other.arena->allocation_size && "Constructor failed: allocation size is too small for target type.");
-        arena = other.arena;
-    }
+    constexpr implicit_allocator_no_asan_annotations(const implicit_allocator_no_asan_annotations<U, Pocma, Stateless>&) noexcept {}
 
     T* allocate(size_t n) {
-        void* ptr = arena->allocate(n);
-		return reinterpret_cast<T*>(ptr);
+        T* mem = new T[n + 1];
+        return mem + 1;
     }
 
-    // no-op. Memory is deallocated in the `reset` method
-    void deallocate(value_type*, size_t) noexcept {}
-
-    // Deallocates memory in the arena, and `memset`s it all to zero.
-    // the `memset` would normally trigger an ASan AV,
-    // but we'll have the ArenaAllocator opt out of ASan analysis
-    void reset() noexcept {
-        arena->reset();
-    }
-
-    template <typename U>
-    bool operator==(ArenaAllocator<U> const& other)
-    {
-        return this->arena == other.arena;
-    }
-
-    template<typename U>
-    bool operator!=(ArenaAllocator<U> const other)
-    {
-        return !(this == other);
+    void deallocate(T* p, size_t) noexcept {
+        delete[] (p - 1);
     }
 };
 
-// Opt out of ASan analysis for the ArenaAllocator
-// FIXME: IntelliSense claims '_Is_ASan_enabled_for_allocator is not a templateC/C++(864)',
-//  but it works somehow.
 template <typename T>
-constexpr bool _Is_ASan_enabled_for_allocator<ArenaAllocator<T>> = false;
+constexpr bool _Is_ASan_enabled_for_allocator<implicit_allocator_no_asan_annotations<T>> = false;
 
 template <class Alloc>
 void test_construction() {
@@ -1942,27 +1874,18 @@ void run_tests() {
 }
 
 // Tests that ASan analysis can be disabled for a vector with an arena allocator.
-template <class ChartType>
+template <class CharType>
 void run_asan_disablement_test() {
 
-    // The arena allocator stores integers in 32-bit alignment.
-    // It can hold up to 100 such allocations.
-    // The 32-bit alignment is a bit excessive for `char`s, but it ensures the allocator
-    // can be rebound to allocate larger types as well (up to 32-bit types).
-    const int size = 100;
-    const int alloc_size = 32;
-    ArenaAllocator<ChartType> allocator(alloc_size, size);
+    // We'll give the vector capacity 100
+    std::basic_string<CharType, std::char_traits<CharType>, implicit_allocator_no_asan_annotations<CharType>> myString;
+    myString.reserve(100);
 
-    std::basic_string<ChartType, std::char_traits<ChartType>, ArenaAllocator<ChartType>> myString(allocator);
-    myString.reserve(50);
-
-    // When calling reset, the arena would memset all 100 entries of it's buffer to zero.
-    // If the allocator was naively annotated by ASan, this would trigger an AV, because
-    // the arena is accessing memory not tracked by the vector's ASan annotations.
-
-    // However, the allocator is annotated to opt out of ASan analysis through,
-    // `_Is_ASan_enabled_for_allocator`, so this should not trigger an AV.
-    allocator.reset();
+    // We access position (50) of the string, which is within the capacity of the vector
+    // but uninitialized. This would normally trigger an AV because of ASan annotations.
+    // However, the allocator has opted out of ASan analysis through,
+    // `_Is_ASan_enabled_for_allocator`, so this should succeed.
+    // myString.data()[50] = CharType{'A'}; // TODO< this does not compile. Need to investigate
 
     // TODO: is it possible to add a 'negative' test case here? One where ASan expectedly fails?
 }

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -287,7 +287,7 @@ STATIC_ASSERT(_Container_allocation_minimum_asan_alignment<
                   basic_string<wchar_t, char_traits<wchar_t>, implicit_allocator<wchar_t>>>
               == 2);
 
-// Simple implicit allocator that opts out of ASan annotations (via `_Is_ASan_enabled_for_allocator`)
+// Simple implicit allocator that opts out of ASan annotations (via `_Disable_ASan_container_annotations_for_allocator`)
 template <class T, class Pocma = true_type, class Stateless = true_type>
 struct implicit_allocator_no_asan_annotations : implicit_allocator<T, Pocma, Stateless> {
     implicit_allocator_no_asan_annotations() = default;
@@ -305,7 +305,7 @@ struct implicit_allocator_no_asan_annotations : implicit_allocator<T, Pocma, Sta
 };
 
 template <typename T>
-constexpr bool _Is_ASan_enabled_for_allocator<implicit_allocator_no_asan_annotations<T>> = true;
+constexpr bool _Disable_ASan_container_annotations_for_allocator<implicit_allocator_no_asan_annotations<T>> = true;
 
 template <class Alloc>
 void test_construction() {

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -305,7 +305,7 @@ struct implicit_allocator_no_asan_annotations : implicit_allocator<T, Pocma, Sta
 };
 
 template <typename T>
-constexpr bool _Is_ASan_enabled_for_allocator<implicit_allocator_no_asan_annotations<T>> = false;
+constexpr bool _Is_ASan_enabled_for_allocator<implicit_allocator_no_asan_annotations<T>> = true;
 
 template <class Alloc>
 void test_construction() {
@@ -1877,15 +1877,12 @@ void run_tests() {
 template <class CharType>
 void run_asan_disablement_test() {
 
-    // We'll give the vector capacity 100
+    // We'll give the string capacity 100
     std::basic_string<CharType, std::char_traits<CharType>, implicit_allocator_no_asan_annotations<CharType>> myString;
     myString.reserve(100);
 
-    // We access position (50) of the string, which is within the capacity of the vector
-    // but uninitialized. This would normally trigger an AV because of ASan annotations.
-    // However, the allocator has opted out of ASan analysis through,
-    // `_Is_ASan_enabled_for_allocator`, so this should succeed.
-    // myString.data()[50] = CharType{'A'}; // TODO< this does not compile. Need to investigate
+    CharType* data = &myString[0]; // Get a mutable pointer to the string's data
+    data[50] = CharType{'A'}; // TODO: this isn't failing in ASAn due to a newly found bug. Merge that bug fix first.
 
     // TODO: is it possible to add a 'negative' test case here? One where ASan expectedly fails?
 }

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -1942,6 +1942,7 @@ void run_tests() {
 }
 
 // Tests that ASan analysis can be disabled for a vector with an arena allocator.
+template <class ChartType>
 void run_asan_disablement_test() {
 
     // The arena allocator stores integers in 32-bit alignment.
@@ -1950,11 +1951,10 @@ void run_asan_disablement_test() {
     // can be rebound to allocate larger types as well (up to 32-bit types).
     const int size = 100;
     const int alloc_size = 32;
-    ArenaAllocator<char> allocator(alloc_size, size);
+    ArenaAllocator<ChartType> allocator(alloc_size, size);
 
-    std::basic_string<char, std::char_traits<char>, ArenaAllocator<char>> myString(allocator);
+    std::basic_string<ChartType, std::char_traits<ChartType>, ArenaAllocator<ChartType>> myString(allocator);
     myString.reserve(50);
-    myString.push_back('A');
 
     // When calling reset, the arena would memset all 100 entries of it's buffer to zero.
     // If the allocator was naively annotated by ASan, this would trigger an AV, because
@@ -1981,7 +1981,7 @@ void run_allocator_matrix() {
     run_custom_allocator_matrix<CharType, aligned_allocator>();
     run_custom_allocator_matrix<CharType, explicit_allocator>();
     run_custom_allocator_matrix<CharType, implicit_allocator>();
-    run_asan_disablement_test();
+    run_asan_disablement_test<CharType>();
 }
 
 void test_DevCom_10116361() {

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -323,7 +323,7 @@ public:
 
     template <class U>
     ArenaAllocator(const ArenaAllocator<U>& other) {
-        assert(sizeof(U) <= arena->allocation_size && "Constructor failed: allocation size is too small for target type.");
+        assert(sizeof(T) <= other.arena->allocation_size && "Constructor failed: allocation size is too small for target type.");
         arena = other.arena;
     }
 

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -1090,6 +1090,7 @@ void run_custom_allocator_matrix() {
 }
 
 // Tests that ASan analysis can be disabled for a vector with an arena allocator.
+template <class T>
 void run_asan_disablement_test() {
 
     // The arena allocator stores integers in 32-bit alignment.
@@ -1098,12 +1099,11 @@ void run_asan_disablement_test() {
     // can be rebound to allocate larger types as well (up to 32-bit types).
     const int size = 100;
     const int alloc_size = 32;
-    ArenaAllocator<int> allocator(alloc_size, size);
+    ArenaAllocator<T> allocator(alloc_size, size);
 
-    // We'll give the vector capacity 1, and allocate a single integer (99).
-    std::vector<int, ArenaAllocator<int>> vec(allocator);
+    // We'll give the vector capacity 1
+    std::vector<T, ArenaAllocator<T>> vec(allocator);
     vec.reserve(1);
-    vec.push_back(99);
 
     // When calling reset, the arena would memset all 100 entries of it's buffer to zero.
     // If the allocator was naively annotated by ASan, this would trigger an AV, because
@@ -1122,7 +1122,7 @@ void run_allocator_matrix() {
     run_custom_allocator_matrix<T, aligned_allocator>();
     run_custom_allocator_matrix<T, explicit_allocator>();
     run_custom_allocator_matrix<T, implicit_allocator>();
-    run_asan_disablement_test();
+    run_asan_disablement_test<T>();
 }
 
 int main() {

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -277,7 +277,7 @@ struct implicit_allocator : custom_test_allocator<T, Pocma, Stateless> {
 STATIC_ASSERT(_Container_allocation_minimum_asan_alignment<vector<char, implicit_allocator<char>>> == 1);
 STATIC_ASSERT(_Container_allocation_minimum_asan_alignment<vector<wchar_t, implicit_allocator<wchar_t>>> == 2);
 
-// Simple implicit allocator that opts out of ASan annotations (via `_Disable_ASan_container_annotations_for_allocator`)
+// Simple allocator that opts out of ASan annotations (via `_Disable_ASan_container_annotations_for_allocator`)
 template <class T, class Pocma = true_type, class Stateless = true_type>
 struct implicit_allocator_no_asan_annotations : implicit_allocator<T, Pocma, Stateless> {
     implicit_allocator_no_asan_annotations() = default;
@@ -1026,14 +1026,14 @@ void run_custom_allocator_matrix() {
     run_tests<AllocT<T, false_type, false_type>>();
 }
 
-// Test that writing to un-initialized memory in a string triggers ASan container-overflow checks.
+// Test that writing to un-initialized memory in a string triggers ASan container-overflow error.
 template <class T, class Alloc = std::allocator<T>>
 void run_asan_container_overflow_death_test() {
-    // We'll give the vector capacity 100 (all uninitialized memory).
+    // We'll give the vector capacity 100 (all un0initialized memory).
     std::vector<T, Alloc> vector;
     vector.reserve(100);
 
-    // Write to 50th element to trigger ASan container-overflow check.
+    // Write to the 50th element to trigger ASan container-overflow check.
     vector.data()[50] = T();
 }
 
@@ -1041,7 +1041,7 @@ void run_asan_container_overflow_death_test() {
 template <class T>
 void run_asan_annotations_disablement_test() {
 
-    // Test that ASan annotations are disabled for the `implicit_allocator_no_asan_annotations` allocator,
+    // ASan annotations are disabled for the `implicit_allocator_no_asan_annotations` allocator,
     // which should make the container-overflow 'death test' pass.
     run_asan_container_overflow_death_test<T, implicit_allocator_no_asan_annotations<T>>();
 }

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -274,7 +274,7 @@ struct implicit_allocator : custom_test_allocator<T, Pocma, Stateless> {
 STATIC_ASSERT(_Container_allocation_minimum_asan_alignment<vector<char, implicit_allocator<char>>> == 1);
 STATIC_ASSERT(_Container_allocation_minimum_asan_alignment<vector<wchar_t, implicit_allocator<wchar_t>>> == 2);
 
-// Simple implicit allocator that opts out of ASan annotations (via `_Is_ASan_enabled_for_allocator`)
+// Simple implicit allocator that opts out of ASan annotations (via `_Disable_ASan_container_annotations_for_allocator`)
 template <class T, class Pocma = true_type, class Stateless = true_type>
 struct implicit_allocator_no_asan_annotations : implicit_allocator<T, Pocma, Stateless> {
     implicit_allocator_no_asan_annotations() = default;
@@ -292,7 +292,7 @@ struct implicit_allocator_no_asan_annotations : implicit_allocator<T, Pocma, Sta
 };
 
 template <typename T>
-constexpr bool _Is_ASan_enabled_for_allocator<implicit_allocator_no_asan_annotations<T>> = false;
+constexpr bool _Disable_ASan_container_annotations_for_allocator<implicit_allocator_no_asan_annotations<T>> = true;
 
 template <class Alloc>
 void test_push_pop() {
@@ -1033,7 +1033,7 @@ void run_asan_disablement_test() {
     // We access position (50) of the vector, which is within the capacity of the vector
     // but uninitialized. This would normally trigger an AV because of ASan annotations.
     // However, the allocator has opted out of ASan analysis through,
-    // `_Is_ASan_enabled_for_allocator`, so this should succeed.
+    // `_Disable_ASan_container_annotations_for_allocator`, so this should succeed.
     vec.data()[50] = T();
 
     // TODO: is it possible to add a 'negative' test case here? One where ASan expectedly fails?

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -274,45 +274,93 @@ struct implicit_allocator : custom_test_allocator<T, Pocma, Stateless> {
 STATIC_ASSERT(_Container_allocation_minimum_asan_alignment<vector<char, implicit_allocator<char>>> == 1);
 STATIC_ASSERT(_Container_allocation_minimum_asan_alignment<vector<wchar_t, implicit_allocator<wchar_t>>> == 2);
 
-template <class T>
-class arena_allocator {
-    public:
-    using value_type = T;
+// Helper class for `ArenaAllocator`, where data is linearly allocated in a finite buffer.
+class Arena {
+public:
+    Arena(size_t allocation_size, size_t capacity):
+        data(new char[capacity* allocation_size]),
+        allocation_size(allocation_size),
+        capacity(capacity),
+        offset(0) {}
 
-    arena_allocator() : size_(10000), offset_(0) {
-        data_ = new T[size_];
-    };
-    template <class U>
-    constexpr arena_allocator(const arena_allocator<U>& other) : size_(other.size_), offset_(other.offset_) {
-        data_ = std::copy(other.data_, other.data_ + other.size_, data_);
-    }
+    Arena(const Arena& other):
+        data(other.data),
+        allocation_size(other.allocation_size),
+        capacity(other.capacity),
+        offset(other.offset) {}
 
-    T* allocate(size_t n) {
-        assert(offset_ + n <= size_ && "Arena out of memory");
-        T* result = data_ + offset_;
-        offset_ += n;
+    void* allocate(size_t n) {
+        assert(offset + n <= capacity && "Allocation failed: the arena is out of memory. You may call `reset` to free up space.");
+        void* result = data + (offset * allocation_size);
+        offset += n;
         return result;
     }
 
-    void deallocate(T*, size_t) noexcept {
-        // no-op. Memory is deallocated when the arena is reset.
-    }
-
+    // Deallocates memory in the arena, and `memset`s it all to zero
     void reset() noexcept {
-        // reset arena, set memory to zero
-        // the `memset` would normally trigger an ASan AV,
-        // but we'll have the arena_allocator opt out of ASan analysis
-        offset_ = 0;
-        memset(data_, 0, size_);
+        offset = 0;
+        memset(data, 0, capacity*allocation_size);
     }
 
-    T* data_;
-    size_t size_;
-    size_t offset_;
+    char* const data;
+    const size_t allocation_size;
+    const size_t capacity;
+    size_t offset;
 };
 
+// An allocator that allocates memory in a pre-allocated buffer (the arena).
 template <typename T>
-constexpr bool _Is_ASan_enabled_for_allocator<arena_allocator<T>> = false;
+class ArenaAllocator {
+public:
+
+    using value_type = T;
+    Arena* arena;
+
+    ArenaAllocator(size_t alloc_size, size_t capacity) {
+        assert(sizeof(T) <= alloc_size && "Constructor failed: allocation size is too small for target type.");
+        arena = new Arena(alloc_size, capacity);
+    }
+
+    template <class U>
+    ArenaAllocator(const ArenaAllocator<U>& other) {
+        assert(sizeof(U) <= arena->allocation_size && "Constructor failed: allocation size is too small for target type.");
+        arena = other.arena;
+    }
+
+    T* allocate(size_t n) {
+        void* ptr = arena->allocate(n);
+		return reinterpret_cast<T*>(ptr);
+    }
+
+
+    // no-op. Memory is deallocated in the `reset` method
+    void deallocate(value_type*, size_t) noexcept {}
+
+    // Deallocates memory in the arena, and `memset`s it all to zero.
+    // the `memset` would normally trigger an ASan AV,
+    // but we'll have the ArenaAllocator opt out of ASan analysis
+    void reset() noexcept {
+        arena->reset();
+    }
+
+    template <typename U>
+    bool operator==(ArenaAllocator<U> const& other)
+    {
+        return this->arena == other.arena;
+    }
+
+    template<typename U>
+    bool operator!=(ArenaAllocator<U> const other)
+    {
+        return !(this == other);
+    }
+};
+
+// Opt out of ASan analysis for the ArenaAllocator
+// FIXME: IntelliSense claims '_Is_ASan_enabled_for_allocator is not a templateC/C++(864)',
+//  but it works somehow.
+template <typename T>
+constexpr bool _Is_ASan_enabled_for_allocator<ArenaAllocator<T>> = false;
 
 template <class Alloc>
 void test_push_pop() {
@@ -1042,18 +1090,31 @@ void run_custom_allocator_matrix() {
     run_tests<AllocT<T, false_type, false_type>>();
 }
 
-void run_arena_allocator_test() {
-    // TODO: add test where  an allocator's arena is filled in, then reset,
-    // then continues to be used. ASan should not fire.
-    arena_allocator<int> allocator;
-    std::vector<int, arena_allocator<int>> vec(allocator);
-    //vec.reserve(100);
+// Tests that ASan analysis can be disabled for a vector with an arena allocator.
+void run_asan_disablement_test() {
 
-    // vec.push_back(1);
-    // vec.push_back(2);
-    // vec.push_back(3);
+    // The arena allocator stores integers in 32-bit alignment.
+    // It can hold up to 100 such allocations.
+    // The 32-bit alignment is a bit excessive for `int`s, but it ensures the allocator
+    // can be rebound to allocate larger types as well (up to 32-bit types).
+    const int size = 100;
+    const int alloc_size = 32;
+    ArenaAllocator<int> allocator(alloc_size, size);
 
-    //allocator.reset(); // should not trigger ASan AV
+    // We'll give the vector capacity 1, and allocate a single integer (99).
+    std::vector<int, ArenaAllocator<int>> vec(allocator);
+    vec.reserve(1);
+    vec.push_back(99);
+
+    // When calling reset, the arena would memset all 100 entries of it's buffer to zero.
+    // If the allocator was naively annotated by ASan, this would trigger an AV, because
+    // the arena is accessing memory not tracked by the vector's ASan annotations.
+
+    // However, the allocator is annotated to opt out of ASan analysis through,
+    // `_Is_ASan_enabled_for_allocator`, so this should not trigger an AV.
+    allocator.reset();
+
+    // TODO: is it possible to add a 'negative' test case here? One where ASan expectedly fails?
 }
 
 template <class T>
@@ -1062,7 +1123,7 @@ void run_allocator_matrix() {
     run_custom_allocator_matrix<T, aligned_allocator>();
     run_custom_allocator_matrix<T, explicit_allocator>();
     run_custom_allocator_matrix<T, implicit_allocator>();
-    run_arena_allocator_test();
+    run_asan_disablement_test();
 }
 
 int main() {

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -1029,14 +1029,14 @@ void run_custom_allocator_matrix() {
     run_tests<AllocT<T, false_type, false_type>>();
 }
 
-// Test that writing to un-initialized memory in a string triggers ASan container-overflow error.
+// Test that writing to uninitialized memory in a vector triggers an ASan container-overflow error.
 template <class T, class Alloc = std::allocator<T>>
 void run_asan_container_overflow_death_test() {
-    // We'll give the vector capacity 100 (all un0initialized memory).
+    // We'll give the vector capacity 100 (all uninitialized memory).
     std::vector<T, Alloc> vector;
     vector.reserve(100);
 
-    // Write to the 50th element to trigger ASan container-overflow check.
+    // Write to the element at index 50 to trigger an ASan container-overflow check.
     vector.data()[50] = T();
 }
 
@@ -1058,7 +1058,7 @@ void run_allocator_matrix() {
 
     // To test ASan annotation disablement, we use an ad-hoc allocator type to avoid disrupting other
     // tests that depend on annotations being enabled. Therefore, unlike the prior tests,
-    // this test is not parametrized by the allocator type.
+    // this test is not parameterized by the allocator type.
     run_asan_annotations_disablement_test<T>();
 }
 

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -1033,11 +1033,11 @@ void run_custom_allocator_matrix() {
 template <class T, class Alloc = std::allocator<T>>
 void run_asan_container_overflow_death_test() {
     // We'll give the vector capacity 100 (all uninitialized memory).
-    std::vector<T, Alloc> vector;
-    vector.reserve(100);
+    std::vector<T, Alloc> v;
+    v.reserve(100);
 
     // Write to the element at index 50 to trigger an ASan container-overflow check.
-    vector.data()[50] = T();
+    v.data()[50] = T();
 }
 
 // Test that ASan `container-overflow` checks can be disabled for a custom allocator.

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -1037,7 +1037,7 @@ void run_asan_container_overflow_death_test() {
     v.reserve(100);
 
     // Write to the element at index 50 to trigger an ASan container-overflow check.
-    v.data()[50] = T();
+    v.data()[50] = T{};
 }
 
 // Test that ASan `container-overflow` checks can be disabled for a custom allocator.

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -332,7 +332,6 @@ public:
 		return reinterpret_cast<T*>(ptr);
     }
 
-
     // no-op. Memory is deallocated in the `reset` method
     void deallocate(value_type*, size_t) noexcept {}
 

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -1085,9 +1085,12 @@ int main(int argc, char* argv[]) {
     });
 
 #ifdef __SANITIZE_ADDRESS__
-    exec.add_death_tests({run_asan_container_overflow_death_test<int>, run_asan_container_overflow_death_test<double>,
+    exec.add_death_tests({
+        run_asan_container_overflow_death_test<int>,
+        run_asan_container_overflow_death_test<double>,
         run_asan_container_overflow_death_test<non_trivial_can_throw>,
-        run_asan_container_overflow_death_test<non_trivial_cannot_throw>});
+        run_asan_container_overflow_death_test<non_trivial_cannot_throw>,
+    });
 #endif // ASan instrumentation enabled
 
     return exec.run(argc, argv);

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -56,6 +56,9 @@ struct non_trivial_can_throw {
 
     non_trivial_can_throw& operator=(const non_trivial_can_throw&) {
         ++i;
+        if (i == 0) {
+            throw i;
+        }
         return *this;
     }
 

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -298,8 +298,10 @@ struct implicit_allocator_no_asan_annotations : implicit_allocator<T, Pocma, Sta
     }
 };
 
-template <typename T>
-constexpr bool _Disable_ASan_container_annotations_for_allocator<implicit_allocator_no_asan_annotations<T>> = true;
+template <class T, class Pocma, class Stateless>
+constexpr bool
+    _Disable_ASan_container_annotations_for_allocator<implicit_allocator_no_asan_annotations<T, Pocma, Stateless>> =
+        true;
 
 template <class Alloc>
 void test_push_pop() {

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -1030,10 +1030,10 @@ void run_custom_allocator_matrix() {
 }
 
 // Test that writing to uninitialized memory in a vector triggers an ASan container-overflow error.
-template <class T, class Alloc = std::allocator<T>>
+template <class T, class Alloc = allocator<T>>
 void run_asan_container_overflow_death_test() {
     // We'll give the vector capacity 100 (all uninitialized memory).
-    std::vector<T, Alloc> v;
+    vector<T, Alloc> v;
     v.reserve(100);
 
     // Write to the element at index 50 to trigger an ASan container-overflow check.

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -274,92 +274,25 @@ struct implicit_allocator : custom_test_allocator<T, Pocma, Stateless> {
 STATIC_ASSERT(_Container_allocation_minimum_asan_alignment<vector<char, implicit_allocator<char>>> == 1);
 STATIC_ASSERT(_Container_allocation_minimum_asan_alignment<vector<wchar_t, implicit_allocator<wchar_t>>> == 2);
 
-// Helper class for `ArenaAllocator`, where data is linearly allocated in a finite buffer.
-class Arena {
-public:
-    Arena(size_t allocation_size, size_t capacity):
-        data(new char[capacity* allocation_size]),
-        allocation_size(allocation_size),
-        capacity(capacity),
-        offset(0) {}
-
-    Arena(const Arena& other):
-        data(other.data),
-        allocation_size(other.allocation_size),
-        capacity(other.capacity),
-        offset(other.offset) {}
-
-    void* allocate(size_t n) {
-        assert(offset + n <= capacity && "Allocation failed: the arena is out of memory. You may call `reset` to free up space.");
-        void* result = data + (offset * allocation_size);
-        offset += n;
-        return result;
-    }
-
-    // Deallocates memory in the arena, and `memset`s it all to zero
-    void reset() noexcept {
-        offset = 0;
-        memset(data, 0, capacity*allocation_size);
-    }
-
-    char* const data;
-    const size_t allocation_size;
-    const size_t capacity;
-    size_t offset;
-};
-
-// An allocator that allocates memory in a pre-allocated buffer (the arena).
-template <typename T>
-class ArenaAllocator {
-public:
-
-    using value_type = T;
-    Arena* arena;
-
-    ArenaAllocator(size_t alloc_size, size_t capacity) {
-        assert(sizeof(T) <= alloc_size && "Constructor failed: allocation size is too small for target type.");
-        arena = new Arena(alloc_size, capacity);
-    }
-
+// Simple implicit allocator that opts out of ASan annotations (via `_Is_ASan_enabled_for_allocator`)
+template <class T, class Pocma = true_type, class Stateless = true_type>
+struct implicit_allocator_no_asan_annotations : implicit_allocator<T, Pocma, Stateless> {
+    implicit_allocator_no_asan_annotations() = default;
     template <class U>
-    ArenaAllocator(const ArenaAllocator<U>& other) {
-        assert(sizeof(T) <= other.arena->allocation_size && "Constructor failed: allocation size is too small for target type.");
-        arena = other.arena;
-    }
+    constexpr implicit_allocator_no_asan_annotations(const implicit_allocator_no_asan_annotations<U, Pocma, Stateless>&) noexcept {}
 
     T* allocate(size_t n) {
-        void* ptr = arena->allocate(n);
-		return reinterpret_cast<T*>(ptr);
+        T* mem = new T[n + 1];
+        return mem + 1;
     }
 
-    // no-op. Memory is deallocated in the `reset` method
-    void deallocate(value_type*, size_t) noexcept {}
-
-    // Deallocates memory in the arena, and `memset`s it all to zero.
-    // the `memset` would normally trigger an ASan AV,
-    // but we'll have the ArenaAllocator opt out of ASan analysis
-    void reset() noexcept {
-        arena->reset();
-    }
-
-    template <typename U>
-    bool operator==(ArenaAllocator<U> const& other)
-    {
-        return this->arena == other.arena;
-    }
-
-    template<typename U>
-    bool operator!=(ArenaAllocator<U> const other)
-    {
-        return !(this == other);
+    void deallocate(T* p, size_t) noexcept {
+        delete[] (p - 1);
     }
 };
 
-// Opt out of ASan analysis for the ArenaAllocator
-// FIXME: IntelliSense claims '_Is_ASan_enabled_for_allocator is not a templateC/C++(864)',
-//  but it works somehow.
 template <typename T>
-constexpr bool _Is_ASan_enabled_for_allocator<ArenaAllocator<T>> = false;
+constexpr bool _Is_ASan_enabled_for_allocator<implicit_allocator_no_asan_annotations<T>> = false;
 
 template <class Alloc>
 void test_push_pop() {
@@ -1093,25 +1026,15 @@ void run_custom_allocator_matrix() {
 template <class T>
 void run_asan_disablement_test() {
 
-    // The arena allocator stores integers in 32-bit alignment.
-    // It can hold up to 100 such allocations.
-    // The 32-bit alignment is a bit excessive for `int`s, but it ensures the allocator
-    // can be rebound to allocate larger types as well (up to 32-bit types).
-    const int size = 100;
-    const int alloc_size = 32;
-    ArenaAllocator<T> allocator(alloc_size, size);
+    // We'll give the vector capacity 100
+    std::vector<T, implicit_allocator_no_asan_annotations<T>> vec;
+    vec.reserve(100);
 
-    // We'll give the vector capacity 1
-    std::vector<T, ArenaAllocator<T>> vec(allocator);
-    vec.reserve(1);
-
-    // When calling reset, the arena would memset all 100 entries of it's buffer to zero.
-    // If the allocator was naively annotated by ASan, this would trigger an AV, because
-    // the arena is accessing memory not tracked by the vector's ASan annotations.
-
-    // However, the allocator is annotated to opt out of ASan analysis through,
-    // `_Is_ASan_enabled_for_allocator`, so this should not trigger an AV.
-    allocator.reset();
+    // We access position (50) of the vector, which is within the capacity of the vector
+    // but uninitialized. This would normally trigger an AV because of ASan annotations.
+    // However, the allocator has opted out of ASan analysis through,
+    // `_Is_ASan_enabled_for_allocator`, so this should succeed.
+    vec.data()[50] = T();
 
     // TODO: is it possible to add a 'negative' test case here? One where ASan expectedly fails?
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->

**Context:**

The STL "annotates" the `vector` and `basic_string` containers so that ASan will report `container-overflow` whenever allocated _but un-initialized_ data is accessed.

A simple repro is the [`container overflow`](https://learn.microsoft.com/en-us/cpp/sanitizers/error-container-overflow?view=msvc-170#example-access-reserved-memory-in-a-stdvector) error fired in this sample program (assuming it's `/fsanitize=address`'ed):

```C++
// Compile with: cl /EHsc /fsanitize=address /Zi
#include <vector>

int main() {   
    std::vector<int> v(10);
    v.reserve(20); // we've allocated 20 entries, but only initialized only 10

    // Accessing the 10th entry (0-indexed, naturally) triggers an AV 
    v[10] = 1;

}
```

This is sensible behavior in most cases. 

One case where it does not bode well is when an **arena allocator** is used as the **custom allocator** of the container. Arena allocators often tamper with the entire allocated memory at once (e.g. they commonly deallocate their entire 'arena' at once) which would trigger ASan AVs when the capacity of the container exceeds it's size.

We encountered one such bug in the `msvc` front end.

**This PR:**

This PR introduces the ability for custom allocators to opt-out of `vector` and `basic_string`'s ASan annotations. This is controlled by the newly introduced template variable: `_Disable_ASan_container_annotations_for_allocator<...some allocator type...>`.


**Testing:**
* For the _new_ annotation opt-out feature: a simple test case was added for `basic_string` and `vector` respectively
* For the pre-existing annotation feature: a simple 'death test' test case was added for the aforementioned containers respectively as well. In the case of `basic_string`, this replaces the recently added `test_gh_5251` test (from https://github.com/microsoft/STL/pull/5252) to avoid repetition.