### PR TITLE
Expand workaround for EDG bug in `P0323R12_expected`

### DIFF
--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -2476,24 +2476,17 @@ static_assert(test_inherited_constructors());
 template <class T, class E>
 struct ambiguating_expected_copy_constructor_caller {
     struct const_lvalue_taker {
-        const_lvalue_taker(const expected<T, E>&) {}
+        const_lvalue_taker(const expected<T, E>&);
     };
 
-    void operator()(expected<T, E>) {}
-    void operator()(const_lvalue_taker) {}
+    void operator()(expected<T, E>);
+    void operator()(const_lvalue_taker);
 };
 
 template <class T, class E>
 struct ambiguating_expected_assignment_source {
-    operator const expected<T, E>&() && {
-        return ex;
-    }
-
-    operator expected<T, E>&&() && {
-        return move(ex);
-    }
-
-    expected<T, E> ex;
+    operator const expected<T, E>&() &&;
+    operator expected<T, E>&&() &&;
 };
 
 struct move_only {
@@ -2512,9 +2505,9 @@ static_assert(
 #ifndef __EDG__ // TRANSITION, VSO-1601179
 static_assert(!is_assignable_v<expected<int, char>&, ambiguating_expected_assignment_source<int, char>>);
 static_assert(!is_assignable_v<expected<void, int>&, ambiguating_expected_assignment_source<void, int>>);
-#endif // ^^^ no workaround ^^^
 static_assert(!is_assignable_v<expected<move_only, char>&, ambiguating_expected_assignment_source<move_only, char>>);
 static_assert(!is_assignable_v<expected<void, move_only>&, ambiguating_expected_assignment_source<void, move_only>>);
+#endif // ^^^ no workaround ^^^
 
 static_assert(test_lwg_3886());
 


### PR DESCRIPTION
The IntelliSense compiler just disabled compatibility with an outdated MSVC overload resolution bug (the `do_ms_quirk` bit in VS-PR-602338), causing an apparent regression in `P0323R12_expected`. These `static_assert`s that were previously passing - but for the wrong reason - [now fail with VS trunk](https://dev.azure.com/devdiv/DevDiv/_build?definitionId=24811&_a=summary&view=runs) (apologies for this Microsoft-internal pipeline link, it's the new `test-edg-only` pipeline I helped the IntelliSense team put together). It looks a lot like VSO-1601179, so let's just expand the existing conditional to cover the new failures.

Drive-by: Don't bother to implement some member functions that aren't ODR-used.
