### PR TITLE
Toolset update: VS 2022 17.13 Preview 3, Clang 19.1.1

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -229,6 +229,8 @@ InsertNewlineAtEOF: true
 #   AtEndOfFile:     false
 #   AtStartOfBlock:  true
 #   AtStartOfFile:   true
+KeepEmptyLines:
+  AtStartOfFile:   false
 # LambdaBodyIndentation: Signature
 # LineEnding:      DeriveLF
 LineEnding:      CRLF

--- a/.clang-format
+++ b/.clang-format
@@ -1,13 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# https://releases.llvm.org/18.1.8/tools/clang/docs/ClangFormatStyleOptions.html
+# https://releases.llvm.org/19.1.0/tools/clang/docs/ClangFormatStyleOptions.html
 
 # To update this .clang-format file for a new clang-format version:
 # 1. Update the documentation link above.
-# 2. Copy the output of `clang-format -dump-config` into a temporary file.
+# 2. Copy the output of `clang-format -dump-config --style=LLVM` into a temporary file.
 #    a. Comment out all of its lines.
-#    b. Uncomment `BasedOnStyle:  LLVM`.
 # 3. Compare that temporary file to this .clang-format file.
 # 4. Adjust this .clang-format file to record new and updated options.
 #    a. Read the new documentation to understand such changes.
@@ -56,7 +55,29 @@ AlignConsecutiveMacros: Consecutive
 #   Enabled:         false
 #   AcrossEmptyLines: false
 #   AcrossComments:  false
+#   AlignCaseArrows: false
 #   AlignCaseColons: false
+# AlignConsecutiveTableGenBreakingDAGArgColons:
+#   Enabled:         false
+#   AcrossEmptyLines: false
+#   AcrossComments:  false
+#   AlignCompound:   false
+#   AlignFunctionPointers: false
+#   PadOperators:    false
+# AlignConsecutiveTableGenCondOperatorColons:
+#   Enabled:         false
+#   AcrossEmptyLines: false
+#   AcrossComments:  false
+#   AlignCompound:   false
+#   AlignFunctionPointers: false
+#   PadOperators:    false
+# AlignConsecutiveTableGenDefinitionColons:
+#   Enabled:         false
+#   AcrossEmptyLines: false
+#   AcrossComments:  false
+#   AlignCompound:   false
+#   AlignFunctionPointers: false
+#   PadOperators:    false
 # AlignEscapedNewlines: Right
 AlignEscapedNewlines: Left
 # AlignOperands:   Align
@@ -71,6 +92,7 @@ AlignTrailingComments:
 # AllowBreakBeforeNoexceptSpecifier: Never
 AllowBreakBeforeNoexceptSpecifier: OnlyWithParen
 # AllowShortBlocksOnASingleLine: Never
+# AllowShortCaseExpressionOnASingleLine: true
 # AllowShortCaseLabelsOnASingleLine: false
 # AllowShortCompoundRequirementOnASingleLine: true
 # AllowShortEnumsOnASingleLine: true
@@ -80,10 +102,7 @@ AllowShortFunctionsOnASingleLine: Empty
 # AllowShortLambdasOnASingleLine: All
 # AllowShortLoopsOnASingleLine: false
 # AlwaysBreakAfterDefinitionReturnType: None
-# AlwaysBreakAfterReturnType: None
 # AlwaysBreakBeforeMultilineStrings: false
-# AlwaysBreakTemplateDeclarations: MultiLine
-AlwaysBreakTemplateDeclarations: Yes
 # AttributeMacros:
 #   - __capability
 # BinPackArguments: true
@@ -112,6 +131,7 @@ AlwaysBreakTemplateDeclarations: Yes
 # BreakAfterAttributes: Leave
 BreakAfterAttributes: Never
 # BreakAfterJavaFieldAnnotations: false
+# BreakAfterReturnType: None
 # BreakArrays:     true
 # BreakBeforeBinaryOperators: None
 BreakBeforeBinaryOperators: NonAssignment
@@ -120,8 +140,11 @@ BreakBeforeBinaryOperators: NonAssignment
 # BreakBeforeInlineASMColon: OnlyMultiline
 # BreakBeforeTernaryOperators: true
 # BreakConstructorInitializers: BeforeColon
+# BreakFunctionDefinitionParameters: false
 # BreakInheritanceList: BeforeColon
 # BreakStringLiterals: true
+# BreakTemplateDeclarations: MultiLine
+BreakTemplateDeclarations: Yes
 # ColumnLimit:     80
 ColumnLimit:     120
 # CommentPragmas:  '^ IWYU pragma:'
@@ -202,14 +225,17 @@ InsertNewlineAtEOF: true
 #   HexMinDigits:    0
 # JavaScriptQuotes: Leave
 # JavaScriptWrapImports: true
-# KeepEmptyLinesAtTheStartOfBlocks: true
-# KeepEmptyLinesAtEOF: false
+# KeepEmptyLines:
+#   AtEndOfFile:     false
+#   AtStartOfBlock:  true
+#   AtStartOfFile:   true
 # LambdaBodyIndentation: Signature
 # LineEnding:      DeriveLF
 LineEnding:      CRLF
 # NOTE: MacroBlockBegin/MacroBlockEnd don't work with _CATCH_ALL.
 # MacroBlockBegin: ''
 # MacroBlockEnd:   ''
+# MainIncludeChar: Quote
 # MaxEmptyLinesToKeep: 1
 MaxEmptyLinesToKeep: 2
 # NamespaceIndentation: None
@@ -286,6 +312,7 @@ SpaceBeforeParensOptions:
 #   Maximum:         -1
 # SpacesInParens:  Never
 # SpacesInParensOptions:
+#   ExceptDoubleParentheses: false
 #   InCStyleCasts:   false
 #   InConditionalStatements: false
 #   InEmptyParentheses: false
@@ -310,6 +337,7 @@ StatementMacros:
   - _FMT_P2286_END
   - _EXTERN_C_UNLESS_PURE
   - _END_EXTERN_C_UNLESS_PURE
+# TableGenBreakInsideDAGArg: DontBreak
 # TabWidth:        8
 # UseTab:          Never
 # VerilogBreakBetweenInstancePorts: true

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.13 Preview 2 or later.
+1. Install Visual Studio 2022 17.13 Preview 3 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.
@@ -160,7 +160,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.13 Preview 2 or later.
+1. Install Visual Studio 2022 17.13 Preview 3 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,7 +5,7 @@
 
 variables:
 - name: poolName
-  value: 'StlBuild-2024-12-12T1002-Pool'
+  value: 'StlBuild-2025-01-22T1525-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -47,7 +47,7 @@ $PythonUrl = 'https://www.python.org/ftp/python/3.13.1/python-3.13.1-amd64.exe'
 $PythonArgs = @('/quiet', 'InstallAllUsers=1', 'PrependPath=1', 'CompileAll=1', 'Include_doc=0')
 
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/12.4.0/local_installers/cuda_12.4.0_551.61_windows.exe'
-$CudaArgs = @('-s')
+$CudaArgs = @('-s', '-n', 'nvcc_12.4')
 
 <#
 .SYNOPSIS

--- a/stl/inc/__msvc_heap_algorithms.hpp
+++ b/stl/inc/__msvc_heap_algorithms.hpp
@@ -23,8 +23,8 @@ _CONSTEXPR20 void _Push_heap_by_index(
     _RanIt _First, _Iter_diff_t<_RanIt> _Hole, _Iter_diff_t<_RanIt> _Top, _Ty&& _Val, _Pr _Pred) {
     // percolate _Hole to _Top or where _Val belongs
     using _Diff = _Iter_diff_t<_RanIt>;
-    for (_Diff _Idx                                                          = (_Hole - 1) >> 1; // shift for codegen
-         _Top < _Hole && _DEBUG_LT_PRED(_Pred, *(_First + _Idx), _Val); _Idx = (_Hole - 1) >> 1) { // shift for codegen
+    for (_Diff _Idx                                                         = (_Hole - 1) >> 1; // shift for codegen
+        _Top < _Hole && _DEBUG_LT_PRED(_Pred, *(_First + _Idx), _Val); _Idx = (_Hole - 1) >> 1) { // shift for codegen
         // move _Hole up to parent
         *(_First + _Hole) = _STD move(*(_First + _Idx));
         _Hole             = _Idx;

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -23,7 +23,8 @@
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 #define _TEMPLATE_CLASS_INTEGRAL(type) template <class type, enable_if_t<is_integral_v<type>, int> = 0>
 #define _ZERO_OR_NO_INIT \
-    {} // Trivial default initialization is not allowed in constexpr functions before C++20.
+    {                    \
+    } // Trivial default initialization is not allowed in constexpr functions before C++20.
 #endif // ^^^ !_HAS_CXX20 ^^^
 
 #pragma pack(push, _CRT_PACKING)

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2817,7 +2817,8 @@ _EXPORT_STD using atomic_unsigned_lock_free = atomic_uintptr_t;
 #endif // _HAS_CXX20
 
 #define ATOMIC_FLAG_INIT \
-    {}
+    {                    \
+    }
 
 _EXPORT_STD struct atomic_flag { // flag with test-and-set semantics
 #if _HAS_CXX20

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -282,9 +282,9 @@ inline constexpr unsigned char _Classify_category<strong_ordering> = _Comparison
 
 _EXPORT_STD template <class... _Types>
 using common_comparison_category_t =
-    conditional_t<(_Classify_category<_Types...> & _Comparison_category_none) != 0, void,
-        conditional_t<(_Classify_category<_Types...> & _Comparison_category_partial) != 0, partial_ordering,
-            conditional_t<(_Classify_category<_Types...> & _Comparison_category_weak) != 0, weak_ordering,
+    conditional_t<((_Classify_category<_Types...> & _Comparison_category_none) != 0), void,
+        conditional_t<((_Classify_category<_Types...> & _Comparison_category_partial) != 0), partial_ordering,
+            conditional_t<((_Classify_category<_Types...> & _Comparison_category_weak) != 0), weak_ordering,
                 strong_ordering>>>;
 
 _EXPORT_STD template <class... _Types>

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1012,7 +1012,7 @@ public:
 
         // deallocate unused blocks, traversing over the circular buffer until the first used block index
         for (auto _Block_idx = _First_unused_block_idx; _Block_idx != _First_used_block_idx;
-             _Block_idx      = static_cast<size_type>((_Block_idx + 1) & _Mask)) {
+            _Block_idx       = static_cast<size_type>((_Block_idx + 1) & _Mask)) {
             auto& _Block_ptr = _Map()[static_cast<_Map_difference_type>(_Block_idx)];
             if (_Block_ptr != nullptr) {
                 _Getal().deallocate(_Block_ptr, _Block_size);

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -677,7 +677,9 @@ public:
 private:
     atomic<size_t> _Bottom{0}; // modified by only owning thread
     atomic<size_t> _Top{0}; // modified by all threads
+    // clang-format off: clang-format 19 doesn't understand _Guarded_by_ and will damage the following code
     _Guarded_by_(_Segment_lock) _Circular_buffer<_Ty>* _Segment { _Circular_buffer<_Ty>::_New_circular_buffer() };
+    // clang-format on
     mutex _Segment_lock{};
 };
 

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -580,7 +580,7 @@ public:
 };
 
 _EXPORT_STD template <class _Rx, class _Ty>
-_NODISCARD _CONSTEXPR20 _Mem_fn<_Rx _Ty::*> mem_fn(_Rx _Ty::*_Pm) noexcept {
+_NODISCARD _CONSTEXPR20 _Mem_fn<_Rx _Ty::*> mem_fn(_Rx _Ty::* _Pm) noexcept {
     return _Mem_fn<_Rx _Ty::*>(_Pm);
 }
 

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -2341,9 +2341,8 @@ _NODISCARD constexpr auto bind_front(_Fx&& _Func, _Types&&... _Args) {
 template <size_t... _Ix, class _Cv_FD, class _Cv_tuple_TiD, class... _Unbound>
 constexpr auto _Call_back_binder(index_sequence<_Ix...>, _Cv_FD&& _Obj, _Cv_tuple_TiD&& _Tpl, _Unbound&&... _Unbargs)
     noexcept(noexcept(_STD invoke(_STD forward<_Cv_FD>(_Obj), _STD forward<_Unbound>(_Unbargs)...,
-        _STD get<_Ix>(_STD forward<_Cv_tuple_TiD>(_Tpl))...)))
-        -> decltype(_STD invoke(_STD forward<_Cv_FD>(_Obj), _STD forward<_Unbound>(_Unbargs)...,
-            _STD get<_Ix>(_STD forward<_Cv_tuple_TiD>(_Tpl))...)) {
+        _STD get<_Ix>(_STD forward<_Cv_tuple_TiD>(_Tpl))...))) -> decltype(_STD invoke(_STD forward<_Cv_FD>(_Obj),
+        _STD forward<_Unbound>(_Unbargs)..., _STD get<_Ix>(_STD forward<_Cv_tuple_TiD>(_Tpl))...)) {
     return _STD invoke(_STD forward<_Cv_FD>(_Obj), _STD forward<_Unbound>(_Unbargs)...,
         _STD get<_Ix>(_STD forward<_Cv_tuple_TiD>(_Tpl))...);
 }

--- a/stl/inc/hash_map
+++ b/stl/inc/hash_map
@@ -59,11 +59,6 @@ namespace stdext {
 
         static constexpr bool _Has_transparent_overloads = false;
 
-#if _HAS_CXX20 && defined(__EDG__) // TRANSITION, DevCom-10678753
-        template <class, class>
-        static constexpr bool _Supports_transparency = false;
-#endif // ^^^ workaround ^^^
-
         _Hmap_traits() = default;
 
         _Hmap_traits(const _Tr& _Traits) noexcept(_STD is_nothrow_copy_constructible_v<_Tr>) : _Tr(_Traits) {}

--- a/stl/inc/hash_set
+++ b/stl/inc/hash_set
@@ -54,11 +54,6 @@ namespace stdext {
 
         static constexpr bool _Has_transparent_overloads = false;
 
-#if _HAS_CXX20 && defined(__EDG__) // TRANSITION, DevCom-10678753
-        template <class, class>
-        static constexpr bool _Supports_transparency = false;
-#endif // ^^^ workaround ^^^
-
         _Hset_traits() = default;
 
         _Hset_traits(const _Tr& _Traits) noexcept(_STD is_nothrow_copy_constructible_v<_Tr>) : _Tr(_Traits) {}

--- a/stl/inc/map
+++ b/stl/inc/map
@@ -387,12 +387,12 @@ map(initializer_list<pair<_Kty, _Ty>>, _Alloc) -> map<_Kty, _Ty, less<_Kty>, _Al
 template <_RANGES input_range _Rng, class _Pr = less<_Range_key_type<_Rng>>,
     _Allocator_for_container _Alloc = allocator<_Range_to_alloc_type<_Rng>>>
     requires (!_Allocator_for_container<_Pr>)
-map(from_range_t, _Rng&&, _Pr = _Pr(),
-    _Alloc = _Alloc()) -> map<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>, _Pr, _Alloc>;
+map(from_range_t, _Rng&&, _Pr = _Pr(), _Alloc = _Alloc())
+    -> map<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>, _Pr, _Alloc>;
 
 template <_RANGES input_range _Rng, _Allocator_for_container _Alloc>
-map(from_range_t, _Rng&&,
-    _Alloc) -> map<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>, less<_Range_key_type<_Rng>>, _Alloc>;
+map(from_range_t, _Rng&&, _Alloc)
+    -> map<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>, less<_Range_key_type<_Rng>>, _Alloc>;
 #endif // _HAS_CXX23
 #endif // _HAS_CXX17
 
@@ -601,8 +601,8 @@ public:
 #if _HAS_CXX17
 template <class _Iter, class _Pr = less<_Guide_key_t<_Iter>>, class _Alloc = allocator<_Guide_pair_t<_Iter>>,
     enable_if_t<conjunction_v<_Is_iterator<_Iter>, negation<_Is_allocator<_Pr>>, _Is_allocator<_Alloc>>, int> = 0>
-multimap(
-    _Iter, _Iter, _Pr = _Pr(), _Alloc = _Alloc()) -> multimap<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>, _Pr, _Alloc>;
+multimap(_Iter, _Iter, _Pr = _Pr(), _Alloc = _Alloc())
+    -> multimap<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>, _Pr, _Alloc>;
 
 template <class _Kty, class _Ty, class _Pr = less<_Kty>, class _Alloc = allocator<pair<const _Kty, _Ty>>,
     enable_if_t<conjunction_v<negation<_Is_allocator<_Pr>>, _Is_allocator<_Alloc>>, int> = 0>
@@ -618,12 +618,12 @@ multimap(initializer_list<pair<_Kty, _Ty>>, _Alloc) -> multimap<_Kty, _Ty, less<
 template <_RANGES input_range _Rng, class _Pr = less<_Range_key_type<_Rng>>,
     _Allocator_for_container _Alloc = allocator<_Range_to_alloc_type<_Rng>>>
     requires (!_Allocator_for_container<_Pr>)
-multimap(from_range_t, _Rng&&, _Pr = _Pr(),
-    _Alloc = _Alloc()) -> multimap<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>, _Pr, _Alloc>;
+multimap(from_range_t, _Rng&&, _Pr = _Pr(), _Alloc = _Alloc())
+    -> multimap<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>, _Pr, _Alloc>;
 
 template <_RANGES input_range _Rng, _Allocator_for_container _Alloc>
-multimap(from_range_t, _Rng&&,
-    _Alloc) -> multimap<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>, less<_Range_key_type<_Rng>>, _Alloc>;
+multimap(from_range_t, _Rng&&, _Alloc)
+    -> multimap<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>, less<_Range_key_type<_Rng>>, _Alloc>;
 #endif // _HAS_CXX23
 #endif // _HAS_CXX17
 

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1463,17 +1463,17 @@ template <class _ElementType, class _OtherIndexType, size_t _Nx>
 mdspan(_ElementType*, const array<_OtherIndexType, _Nx>&) -> mdspan<_ElementType, dextents<size_t, _Nx>>;
 
 template <class _ElementType, class _IndexType, size_t... _ExtentsPack>
-mdspan(_ElementType*,
-    const extents<_IndexType, _ExtentsPack...>&) -> mdspan<_ElementType, extents<_IndexType, _ExtentsPack...>>;
+mdspan(_ElementType*, const extents<_IndexType, _ExtentsPack...>&)
+    -> mdspan<_ElementType, extents<_IndexType, _ExtentsPack...>>;
 
 template <class _ElementType, class _MappingType>
 mdspan(_ElementType*, const _MappingType&)
     -> mdspan<_ElementType, typename _MappingType::extents_type, typename _MappingType::layout_type>;
 
 template <class _MappingType, class _AccessorType>
-mdspan(const typename _AccessorType::data_handle_type&, const _MappingType&,
-    const _AccessorType&) -> mdspan<typename _AccessorType::element_type, typename _MappingType::extents_type,
-                              typename _MappingType::layout_type, _AccessorType>;
+mdspan(const typename _AccessorType::data_handle_type&, const _MappingType&, const _AccessorType&)
+    -> mdspan<typename _AccessorType::element_type, typename _MappingType::extents_type,
+        typename _MappingType::layout_type, _AccessorType>;
 
 _STD_END
 

--- a/stl/inc/queue
+++ b/stl/inc/queue
@@ -174,8 +174,8 @@ template <_Iterator_for_container _InIt, _Allocator_for_container _Alloc = alloc
 queue(_InIt, _InIt, _Alloc = _Alloc()) -> queue<_Iter_value_t<_InIt>, deque<_Iter_value_t<_InIt>, _Alloc>>;
 
 template <_RANGES input_range _Rng, _Allocator_for_container _Alloc = allocator<_RANGES range_value_t<_Rng>>>
-queue(from_range_t, _Rng&&,
-    _Alloc = _Alloc()) -> queue<_RANGES range_value_t<_Rng>, deque<_RANGES range_value_t<_Rng>, _Alloc>>;
+queue(from_range_t, _Rng&&, _Alloc = _Alloc())
+    -> queue<_RANGES range_value_t<_Rng>, deque<_RANGES range_value_t<_Rng>, _Alloc>>;
 #endif // _HAS_CXX23
 
 _EXPORT_STD template <class _Ty, class _Container>
@@ -450,8 +450,8 @@ priority_queue(_Pr, _Container) -> priority_queue<typename _Container::value_typ
 template <class _Iter, class _Pr = less<_Iter_value_t<_Iter>>, class _Container = vector<_Iter_value_t<_Iter>>,
     enable_if_t<conjunction_v<_Is_iterator<_Iter>, negation<_Is_allocator<_Pr>>, negation<_Is_allocator<_Container>>>,
         int> = 0>
-priority_queue(
-    _Iter, _Iter, _Pr = _Pr(), _Container = _Container()) -> priority_queue<_Iter_value_t<_Iter>, _Container, _Pr>;
+priority_queue(_Iter, _Iter, _Pr = _Pr(), _Container = _Container())
+    -> priority_queue<_Iter_value_t<_Iter>, _Container, _Pr>;
 
 template <class _Pr, class _Container, class _Alloc,
     enable_if_t<conjunction_v<negation<_Is_allocator<_Pr>>, negation<_Is_allocator<_Container>>,
@@ -469,23 +469,23 @@ priority_queue(_Iter, _Iter, _Compare, _Alloc) -> priority_queue<_Iter_value_t<_
 
 template <class _Iter, class _Compare, class _Container, class _Alloc,
     enable_if_t<conjunction_v<_Is_iterator<_Iter>, uses_allocator<_Container, _Alloc>>, int> = 0>
-priority_queue(_Iter, _Iter, _Compare, _Container,
-    _Alloc) -> priority_queue<typename _Container::value_type, _Container, _Compare>;
+priority_queue(_Iter, _Iter, _Compare, _Container, _Alloc)
+    -> priority_queue<typename _Container::value_type, _Container, _Compare>;
 
 #if _HAS_CXX23
 template <_RANGES input_range _Rng, class _Pr = less<_RANGES range_value_t<_Rng>>,
     enable_if_t<!_Is_allocator<_Pr>::value, int> = 0>
-priority_queue(from_range_t, _Rng&&,
-    _Pr = _Pr()) -> priority_queue<_RANGES range_value_t<_Rng>, vector<_RANGES range_value_t<_Rng>>, _Pr>;
+priority_queue(from_range_t, _Rng&&, _Pr = _Pr())
+    -> priority_queue<_RANGES range_value_t<_Rng>, vector<_RANGES range_value_t<_Rng>>, _Pr>;
 
 template <_RANGES input_range _Rng, class _Pr, class _Alloc,
     enable_if_t<conjunction_v<negation<_Is_allocator<_Pr>>, _Is_allocator<_Alloc>>, int> = 0>
-priority_queue(from_range_t, _Rng&&, _Pr,
-    _Alloc) -> priority_queue<_RANGES range_value_t<_Rng>, vector<_RANGES range_value_t<_Rng>, _Alloc>, _Pr>;
+priority_queue(from_range_t, _Rng&&, _Pr, _Alloc)
+    -> priority_queue<_RANGES range_value_t<_Rng>, vector<_RANGES range_value_t<_Rng>, _Alloc>, _Pr>;
 
 template <_RANGES input_range _Rng, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
-priority_queue(from_range_t, _Rng&&,
-    _Alloc) -> priority_queue<_RANGES range_value_t<_Rng>, vector<_RANGES range_value_t<_Rng>, _Alloc>>;
+priority_queue(from_range_t, _Rng&&, _Alloc)
+    -> priority_queue<_RANGES range_value_t<_Rng>, vector<_RANGES range_value_t<_Rng>, _Alloc>>;
 #endif // _HAS_CXX23
 #endif // _HAS_CXX17
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -7157,13 +7157,9 @@ namespace ranges {
         private:
             friend zip_view;
 
-#if defined(__clang__) && __clang_major__ <= 18 // TRANSITION, Clang 19 (was thought to be LLVM-61763)
-        public:
-#else // ^^^ workaround / no workaround vvv
             template <class _Func, class... _OtherViews>
                 requires _Zip_transform_constraints<_Func, _OtherViews...>
             friend class zip_transform_view;
-#endif // ^^^ no workaround ^^^
 
             using _My_tuple = tuple<iterator_t<_Maybe_const<_IsConst, _ViewTypes>>...>;
 
@@ -7982,13 +7978,9 @@ namespace ranges {
         private:
             friend adjacent_view;
 
-#if defined(__clang__) && __clang_major__ <= 18 // TRANSITION, Clang 19 (was thought to be LLVM-61763)
-        public:
-#else // ^^^ workaround / no workaround vvv
             template <class _Vw2, class _Fn, size_t _Nx2>
                 requires _Adjacent_transform_constraints<_Vw2, _Fn, _Nx2>
             friend class adjacent_transform_view;
-#endif // ^^^ no workaround ^^^
 
             using _Base          = _Maybe_const<_Const, _Vw>;
             using _Base_iterator = iterator_t<_Base>;

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3989,8 +3989,8 @@ namespace ranges {
     lazy_split_view(_Rng&&, _Pat&&) -> lazy_split_view<views::all_t<_Rng>, views::all_t<_Pat>>;
 
     template <input_range _Rng>
-    lazy_split_view(
-        _Rng&&, range_value_t<_Rng>) -> lazy_split_view<views::all_t<_Rng>, single_view<range_value_t<_Rng>>>;
+    lazy_split_view(_Rng&&, range_value_t<_Rng>)
+        -> lazy_split_view<views::all_t<_Rng>, single_view<range_value_t<_Rng>>>;
 
 #if _HAS_CXX23
     template <class _Rng, class _Pat>

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1025,8 +1025,8 @@ namespace ranges {
     };
 
     template <class _Wi, class _Bo>
-        requires (!_Integer_like<_Wi> || !_Integer_like<_Bo>
-                     || (_Signed_integer_like<_Wi> == _Signed_integer_like<_Bo>) )
+        requires (
+            !_Integer_like<_Wi> || !_Integer_like<_Bo> || (_Signed_integer_like<_Wi> == _Signed_integer_like<_Bo>) )
     iota_view(_Wi, _Bo) -> iota_view<_Wi, _Bo>;
 
     template <class _Wi, class _Bo>

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -334,8 +334,10 @@ public:
     template <class _Iter>
     char_class_type lookup_classname(_Iter _First, _Iter _Last, bool _Icase = false) const {
         // map [_First, _Last) to character class mask value
-#define _REGEX_CHAR_CLASS_NAME(n, c) \
-    { n, L##n, static_cast<unsigned int>(_STD size(n) - 1), c }
+#define _REGEX_CHAR_CLASS_NAME(n, c)                            \
+    {                                                           \
+        n, L##n, static_cast<unsigned int>(_STD size(n) - 1), c \
+    }
         static constexpr _Cl_names _Names[] = {
             // map class names to numeric constants
             _REGEX_CHAR_CLASS_NAME("alnum", _Ch_alnum),

--- a/stl/inc/set
+++ b/stl/inc/set
@@ -415,8 +415,8 @@ template <_RANGES input_range _Rng, class _Pr = less<_RANGES range_value_t<_Rng>
 multiset(from_range_t, _Rng&&, _Pr = _Pr(), _Alloc = _Alloc()) -> multiset<_RANGES range_value_t<_Rng>, _Pr, _Alloc>;
 
 template <_RANGES input_range _Rng, _Allocator_for_container _Alloc>
-multiset(
-    from_range_t, _Rng&&, _Alloc) -> multiset<_RANGES range_value_t<_Rng>, less<_RANGES range_value_t<_Rng>>, _Alloc>;
+multiset(from_range_t, _Rng&&, _Alloc)
+    -> multiset<_RANGES range_value_t<_Rng>, less<_RANGES range_value_t<_Rng>>, _Alloc>;
 #endif // _HAS_CXX23
 #endif // _HAS_CXX17
 

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1912,12 +1912,12 @@ _EXPORT_STD template <class _Base, class _Derived>
 constexpr bool is_pointer_interconvertible_base_of_v = __is_pointer_interconvertible_base_of(_Base, _Derived);
 
 _EXPORT_STD template <class _ClassTy, class _MemberTy>
-_NODISCARD constexpr bool is_pointer_interconvertible_with_class(_MemberTy _ClassTy::*_Pm) noexcept {
+_NODISCARD constexpr bool is_pointer_interconvertible_with_class(_MemberTy _ClassTy::* _Pm) noexcept {
     return __is_pointer_interconvertible_with_class(_ClassTy, _Pm);
 }
 
 _EXPORT_STD template <class _ClassTy1, class _ClassTy2, class _MemberTy1, class _MemberTy2>
-_NODISCARD constexpr bool is_corresponding_member(_MemberTy1 _ClassTy1::*_Pm1, _MemberTy2 _ClassTy2::*_Pm2) noexcept {
+_NODISCARD constexpr bool is_corresponding_member(_MemberTy1 _ClassTy1::* _Pm1, _MemberTy2 _ClassTy2::* _Pm2) noexcept {
     return __is_corresponding_member(_ClassTy1, _ClassTy2, _Pm1, _Pm2);
 }
 #endif // ^^^ no workaround ^^^

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1659,8 +1659,8 @@ struct _Invoker_pmd_pointer {
     static constexpr _Invoker_strategy _Strategy = _Invoker_strategy::_Pmd_pointer;
 
     template <class _Decayed, class _Ty1>
-    static constexpr auto _Call(_Decayed _Pmd, _Ty1&& _Arg1)
-        noexcept(noexcept((*static_cast<_Ty1&&>(_Arg1)).*_Pmd)) -> decltype((*static_cast<_Ty1&&>(_Arg1)).*_Pmd) {
+    static constexpr auto _Call(_Decayed _Pmd, _Ty1&& _Arg1) noexcept(noexcept((*static_cast<_Ty1&&>(_Arg1)).*_Pmd))
+        -> decltype((*static_cast<_Ty1&&>(_Arg1)).*_Pmd) {
         return (*static_cast<_Ty1&&>(_Arg1)).*_Pmd;
     }
 };
@@ -1691,8 +1691,8 @@ template <class _Callable, class _Ty1, class _Removed_cvref>
 struct _Invoker1<_Callable, _Ty1, _Removed_cvref, false, false> : _Invoker_functor {};
 
 _EXPORT_STD template <class _Callable>
-constexpr auto invoke(_Callable&& _Obj)
-    noexcept(noexcept(static_cast<_Callable&&>(_Obj)())) -> decltype(static_cast<_Callable&&>(_Obj)()) {
+constexpr auto invoke(_Callable&& _Obj) noexcept(noexcept(static_cast<_Callable&&>(_Obj)()))
+    -> decltype(static_cast<_Callable&&>(_Obj)()) {
     return static_cast<_Callable&&>(_Obj)();
 }
 

--- a/stl/inc/unordered_map
+++ b/stl/inc/unordered_map
@@ -461,8 +461,8 @@ template <class _Iter, class _Hasher = hash<_Guide_key_t<_Iter>>, class _Keyeq =
     enable_if_t<
         conjunction_v<_Is_iterator<_Iter>, _Is_hasher<_Hasher>, negation<_Is_allocator<_Keyeq>>, _Is_allocator<_Alloc>>,
         int> = 0>
-unordered_map(_Iter, _Iter, _Guide_size_type_t<_Alloc> = 0, _Hasher = _Hasher(), _Keyeq = _Keyeq(),
-    _Alloc = _Alloc()) -> unordered_map<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>, _Hasher, _Keyeq, _Alloc>;
+unordered_map(_Iter, _Iter, _Guide_size_type_t<_Alloc> = 0, _Hasher = _Hasher(), _Keyeq = _Keyeq(), _Alloc = _Alloc())
+    -> unordered_map<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>, _Hasher, _Keyeq, _Alloc>;
 
 template <class _Kty, class _Ty, class _Hasher = hash<_Kty>, class _Keyeq = equal_to<_Kty>,
     class _Alloc = allocator<pair<const _Kty, _Ty>>,
@@ -472,30 +472,29 @@ unordered_map(initializer_list<pair<_Kty, _Ty>>, _Guide_size_type_t<_Alloc> = 0,
 
 template <class _Iter, class _Alloc, enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
 unordered_map(_Iter, _Iter, _Alloc) -> unordered_map<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>,
-                                        hash<_Guide_key_t<_Iter>>, equal_to<_Guide_key_t<_Iter>>, _Alloc>;
+    hash<_Guide_key_t<_Iter>>, equal_to<_Guide_key_t<_Iter>>, _Alloc>;
 
 template <class _Iter, class _Alloc, enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
-unordered_map(_Iter, _Iter, _Guide_size_type_t<_Alloc>,
-    _Alloc) -> unordered_map<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>, hash<_Guide_key_t<_Iter>>,
-                equal_to<_Guide_key_t<_Iter>>, _Alloc>;
+unordered_map(_Iter, _Iter, _Guide_size_type_t<_Alloc>, _Alloc) -> unordered_map<_Guide_key_t<_Iter>,
+    _Guide_val_t<_Iter>, hash<_Guide_key_t<_Iter>>, equal_to<_Guide_key_t<_Iter>>, _Alloc>;
 
 template <class _Iter, class _Hasher, class _Alloc,
     enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_hasher<_Hasher>, _Is_allocator<_Alloc>>, int> = 0>
-unordered_map(_Iter, _Iter, _Guide_size_type_t<_Alloc>, _Hasher,
-    _Alloc) -> unordered_map<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>, _Hasher, equal_to<_Guide_key_t<_Iter>>, _Alloc>;
+unordered_map(_Iter, _Iter, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
+    -> unordered_map<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>, _Hasher, equal_to<_Guide_key_t<_Iter>>, _Alloc>;
 
 template <class _Kty, class _Ty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
-unordered_map(
-    initializer_list<pair<_Kty, _Ty>>, _Alloc) -> unordered_map<_Kty, _Ty, hash<_Kty>, equal_to<_Kty>, _Alloc>;
+unordered_map(initializer_list<pair<_Kty, _Ty>>, _Alloc)
+    -> unordered_map<_Kty, _Ty, hash<_Kty>, equal_to<_Kty>, _Alloc>;
 
 template <class _Kty, class _Ty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
-unordered_map(initializer_list<pair<_Kty, _Ty>>, _Guide_size_type_t<_Alloc>,
-    _Alloc) -> unordered_map<_Kty, _Ty, hash<_Kty>, equal_to<_Kty>, _Alloc>;
+unordered_map(initializer_list<pair<_Kty, _Ty>>, _Guide_size_type_t<_Alloc>, _Alloc)
+    -> unordered_map<_Kty, _Ty, hash<_Kty>, equal_to<_Kty>, _Alloc>;
 
 template <class _Kty, class _Ty, class _Hasher, class _Alloc,
     enable_if_t<conjunction_v<_Is_hasher<_Hasher>, _Is_allocator<_Alloc>>, int> = 0>
-unordered_map(initializer_list<pair<_Kty, _Ty>>, _Guide_size_type_t<_Alloc>, _Hasher,
-    _Alloc) -> unordered_map<_Kty, _Ty, _Hasher, equal_to<_Kty>, _Alloc>;
+unordered_map(initializer_list<pair<_Kty, _Ty>>, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
+    -> unordered_map<_Kty, _Ty, _Hasher, equal_to<_Kty>, _Alloc>;
 
 #if _HAS_CXX23
 template <_RANGES input_range _Rng, _Hasher_for_container _Hasher = hash<_Range_key_type<_Rng>>,
@@ -506,13 +505,12 @@ unordered_map(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc> = 0, _Hasher = _H
     _Alloc = _Alloc()) -> unordered_map<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>, _Hasher, _Keyeq, _Alloc>;
 
 template <_RANGES input_range _Rng, _Allocator_for_container _Alloc>
-unordered_map(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc>,
-    _Alloc) -> unordered_map<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>, hash<_Range_key_type<_Rng>>,
-                equal_to<_Range_key_type<_Rng>>, _Alloc>;
+unordered_map(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc>, _Alloc) -> unordered_map<_Range_key_type<_Rng>,
+    _Range_mapped_type<_Rng>, hash<_Range_key_type<_Rng>>, equal_to<_Range_key_type<_Rng>>, _Alloc>;
 
 template <_RANGES input_range _Rng, _Allocator_for_container _Alloc>
 unordered_map(from_range_t, _Rng&&, _Alloc) -> unordered_map<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>,
-                                                hash<_Range_key_type<_Rng>>, equal_to<_Range_key_type<_Rng>>, _Alloc>;
+    hash<_Range_key_type<_Rng>>, equal_to<_Range_key_type<_Rng>>, _Alloc>;
 
 template <_RANGES input_range _Rng, _Hasher_for_container _Hasher, _Allocator_for_container _Alloc>
 unordered_map(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
@@ -844,12 +842,11 @@ unordered_multimap(initializer_list<pair<_Kty, _Ty>>, _Guide_size_type_t<_Alloc>
 
 template <class _Iter, class _Alloc, enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
 unordered_multimap(_Iter, _Iter, _Alloc) -> unordered_multimap<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>,
-                                             hash<_Guide_key_t<_Iter>>, equal_to<_Guide_key_t<_Iter>>, _Alloc>;
+    hash<_Guide_key_t<_Iter>>, equal_to<_Guide_key_t<_Iter>>, _Alloc>;
 
 template <class _Iter, class _Alloc, enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
-unordered_multimap(_Iter, _Iter, _Guide_size_type_t<_Alloc>,
-    _Alloc) -> unordered_multimap<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>, hash<_Guide_key_t<_Iter>>,
-                equal_to<_Guide_key_t<_Iter>>, _Alloc>;
+unordered_multimap(_Iter, _Iter, _Guide_size_type_t<_Alloc>, _Alloc) -> unordered_multimap<_Guide_key_t<_Iter>,
+    _Guide_val_t<_Iter>, hash<_Guide_key_t<_Iter>>, equal_to<_Guide_key_t<_Iter>>, _Alloc>;
 
 template <class _Iter, class _Hasher, class _Alloc,
     enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_hasher<_Hasher>, _Is_allocator<_Alloc>>, int> = 0>
@@ -857,17 +854,17 @@ unordered_multimap(_Iter, _Iter, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
     -> unordered_multimap<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>, _Hasher, equal_to<_Guide_key_t<_Iter>>, _Alloc>;
 
 template <class _Kty, class _Ty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
-unordered_multimap(
-    initializer_list<pair<_Kty, _Ty>>, _Alloc) -> unordered_multimap<_Kty, _Ty, hash<_Kty>, equal_to<_Kty>, _Alloc>;
+unordered_multimap(initializer_list<pair<_Kty, _Ty>>, _Alloc)
+    -> unordered_multimap<_Kty, _Ty, hash<_Kty>, equal_to<_Kty>, _Alloc>;
 
 template <class _Kty, class _Ty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
-unordered_multimap(initializer_list<pair<_Kty, _Ty>>, _Guide_size_type_t<_Alloc>,
-    _Alloc) -> unordered_multimap<_Kty, _Ty, hash<_Kty>, equal_to<_Kty>, _Alloc>;
+unordered_multimap(initializer_list<pair<_Kty, _Ty>>, _Guide_size_type_t<_Alloc>, _Alloc)
+    -> unordered_multimap<_Kty, _Ty, hash<_Kty>, equal_to<_Kty>, _Alloc>;
 
 template <class _Kty, class _Ty, class _Hasher, class _Alloc,
     enable_if_t<conjunction_v<_Is_hasher<_Hasher>, _Is_allocator<_Alloc>>, int> = 0>
-unordered_multimap(initializer_list<pair<_Kty, _Ty>>, _Guide_size_type_t<_Alloc>, _Hasher,
-    _Alloc) -> unordered_multimap<_Kty, _Ty, _Hasher, equal_to<_Kty>, _Alloc>;
+unordered_multimap(initializer_list<pair<_Kty, _Ty>>, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
+    -> unordered_multimap<_Kty, _Ty, _Hasher, equal_to<_Kty>, _Alloc>;
 
 #if _HAS_CXX23
 template <_RANGES input_range _Rng, _Hasher_for_container _Hasher = hash<_Range_key_type<_Rng>>,
@@ -878,19 +875,18 @@ unordered_multimap(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc> = 0, _Hasher
     _Alloc = _Alloc()) -> unordered_multimap<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>, _Hasher, _Keyeq, _Alloc>;
 
 template <_RANGES input_range _Rng, _Allocator_for_container _Alloc>
-unordered_multimap(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc>,
-    _Alloc) -> unordered_multimap<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>, hash<_Range_key_type<_Rng>>,
-                equal_to<_Range_key_type<_Rng>>, _Alloc>;
+unordered_multimap(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc>, _Alloc)
+    -> unordered_multimap<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>, hash<_Range_key_type<_Rng>>,
+        equal_to<_Range_key_type<_Rng>>, _Alloc>;
 
 template <_RANGES input_range _Rng, _Allocator_for_container _Alloc>
-unordered_multimap(
-    from_range_t, _Rng&&, _Alloc) -> unordered_multimap<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>,
-                                      hash<_Range_key_type<_Rng>>, equal_to<_Range_key_type<_Rng>>, _Alloc>;
+unordered_multimap(from_range_t, _Rng&&, _Alloc) -> unordered_multimap<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>,
+    hash<_Range_key_type<_Rng>>, equal_to<_Range_key_type<_Rng>>, _Alloc>;
 
 template <_RANGES input_range _Rng, _Hasher_for_container _Hasher, _Allocator_for_container _Alloc>
-unordered_multimap(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc>, _Hasher,
-    _Alloc) -> unordered_multimap<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>, _Hasher,
-                equal_to<_Range_key_type<_Rng>>, _Alloc>;
+unordered_multimap(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
+    -> unordered_multimap<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>, _Hasher, equal_to<_Range_key_type<_Rng>>,
+        _Alloc>;
 #endif // _HAS_CXX23
 #endif // _HAS_CXX17
 

--- a/stl/inc/unordered_set
+++ b/stl/inc/unordered_set
@@ -326,8 +326,8 @@ template <class _Iter, class _Hasher = hash<_Iter_value_t<_Iter>>, class _Keyeq 
     enable_if_t<
         conjunction_v<_Is_iterator<_Iter>, _Is_hasher<_Hasher>, negation<_Is_allocator<_Keyeq>>, _Is_allocator<_Alloc>>,
         int> = 0>
-unordered_set(_Iter, _Iter, _Guide_size_type_t<_Alloc> = 0, _Hasher = _Hasher(), _Keyeq = _Keyeq(),
-    _Alloc = _Alloc()) -> unordered_set<_Iter_value_t<_Iter>, _Hasher, _Keyeq, _Alloc>;
+unordered_set(_Iter, _Iter, _Guide_size_type_t<_Alloc> = 0, _Hasher = _Hasher(), _Keyeq = _Keyeq(), _Alloc = _Alloc())
+    -> unordered_set<_Iter_value_t<_Iter>, _Hasher, _Keyeq, _Alloc>;
 
 template <class _Kty, class _Hasher = hash<_Kty>, class _Keyeq = equal_to<_Kty>, class _Alloc = allocator<_Kty>,
     enable_if_t<conjunction_v<_Is_hasher<_Hasher>, negation<_Is_allocator<_Keyeq>>, _Is_allocator<_Alloc>>, int> = 0>
@@ -335,22 +335,22 @@ unordered_set(initializer_list<_Kty>, _Guide_size_type_t<_Alloc> = 0, _Hasher = 
     _Alloc = _Alloc()) -> unordered_set<_Kty, _Hasher, _Keyeq, _Alloc>;
 
 template <class _Iter, class _Alloc, enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
-unordered_set(_Iter, _Iter, _Guide_size_type_t<_Alloc>,
-    _Alloc) -> unordered_set<_Iter_value_t<_Iter>, hash<_Iter_value_t<_Iter>>, equal_to<_Iter_value_t<_Iter>>, _Alloc>;
+unordered_set(_Iter, _Iter, _Guide_size_type_t<_Alloc>, _Alloc)
+    -> unordered_set<_Iter_value_t<_Iter>, hash<_Iter_value_t<_Iter>>, equal_to<_Iter_value_t<_Iter>>, _Alloc>;
 
 template <class _Iter, class _Hasher, class _Alloc,
     enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_hasher<_Hasher>, _Is_allocator<_Alloc>>, int> = 0>
-unordered_set(_Iter, _Iter, _Guide_size_type_t<_Alloc>, _Hasher,
-    _Alloc) -> unordered_set<_Iter_value_t<_Iter>, _Hasher, equal_to<_Iter_value_t<_Iter>>, _Alloc>;
+unordered_set(_Iter, _Iter, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
+    -> unordered_set<_Iter_value_t<_Iter>, _Hasher, equal_to<_Iter_value_t<_Iter>>, _Alloc>;
 
 template <class _Kty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
-unordered_set(initializer_list<_Kty>, _Guide_size_type_t<_Alloc>,
-    _Alloc) -> unordered_set<_Kty, hash<_Kty>, equal_to<_Kty>, _Alloc>;
+unordered_set(initializer_list<_Kty>, _Guide_size_type_t<_Alloc>, _Alloc)
+    -> unordered_set<_Kty, hash<_Kty>, equal_to<_Kty>, _Alloc>;
 
 template <class _Kty, class _Hasher, class _Alloc,
     enable_if_t<conjunction_v<_Is_hasher<_Hasher>, _Is_allocator<_Alloc>>, int> = 0>
-unordered_set(initializer_list<_Kty>, _Guide_size_type_t<_Alloc>, _Hasher,
-    _Alloc) -> unordered_set<_Kty, _Hasher, equal_to<_Kty>, _Alloc>;
+unordered_set(initializer_list<_Kty>, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
+    -> unordered_set<_Kty, _Hasher, equal_to<_Kty>, _Alloc>;
 
 #if _HAS_CXX23
 template <_RANGES input_range _Rng, _Hasher_for_container _Hasher = hash<_RANGES range_value_t<_Rng>>,
@@ -361,18 +361,16 @@ unordered_set(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc> = 0, _Hasher = _H
     _Alloc = _Alloc()) -> unordered_set<_RANGES range_value_t<_Rng>, _Hasher, _Keyeq, _Alloc>;
 
 template <_RANGES input_range _Rng, _Allocator_for_container _Alloc>
-unordered_set(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc>,
-    _Alloc) -> unordered_set<_RANGES range_value_t<_Rng>, hash<_RANGES range_value_t<_Rng>>,
-                equal_to<_RANGES range_value_t<_Rng>>, _Alloc>;
+unordered_set(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc>, _Alloc) -> unordered_set<_RANGES range_value_t<_Rng>,
+    hash<_RANGES range_value_t<_Rng>>, equal_to<_RANGES range_value_t<_Rng>>, _Alloc>;
 
 template <_RANGES input_range _Rng, _Allocator_for_container _Alloc>
-unordered_set(
-    from_range_t, _Rng&&, _Alloc) -> unordered_set<_RANGES range_value_t<_Rng>, hash<_RANGES range_value_t<_Rng>>,
-                                      equal_to<_RANGES range_value_t<_Rng>>, _Alloc>;
+unordered_set(from_range_t, _Rng&&, _Alloc) -> unordered_set<_RANGES range_value_t<_Rng>,
+    hash<_RANGES range_value_t<_Rng>>, equal_to<_RANGES range_value_t<_Rng>>, _Alloc>;
 
 template <_RANGES input_range _Rng, _Hasher_for_container _Hasher, _Allocator_for_container _Alloc>
-unordered_set(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc>, _Hasher,
-    _Alloc) -> unordered_set<_RANGES range_value_t<_Rng>, _Hasher, equal_to<_RANGES range_value_t<_Rng>>, _Alloc>;
+unordered_set(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
+    -> unordered_set<_RANGES range_value_t<_Rng>, _Hasher, equal_to<_RANGES range_value_t<_Rng>>, _Alloc>;
 #endif // _HAS_CXX23
 #endif // _HAS_CXX17
 
@@ -685,17 +683,17 @@ unordered_multiset(_Iter, _Iter, _Guide_size_type_t<_Alloc>, _Alloc)
 
 template <class _Iter, class _Hasher, class _Alloc,
     enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_hasher<_Hasher>, _Is_allocator<_Alloc>>, int> = 0>
-unordered_multiset(_Iter, _Iter, _Guide_size_type_t<_Alloc>, _Hasher,
-    _Alloc) -> unordered_multiset<_Iter_value_t<_Iter>, _Hasher, equal_to<_Iter_value_t<_Iter>>, _Alloc>;
+unordered_multiset(_Iter, _Iter, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
+    -> unordered_multiset<_Iter_value_t<_Iter>, _Hasher, equal_to<_Iter_value_t<_Iter>>, _Alloc>;
 
 template <class _Kty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
-unordered_multiset(initializer_list<_Kty>, _Guide_size_type_t<_Alloc>,
-    _Alloc) -> unordered_multiset<_Kty, hash<_Kty>, equal_to<_Kty>, _Alloc>;
+unordered_multiset(initializer_list<_Kty>, _Guide_size_type_t<_Alloc>, _Alloc)
+    -> unordered_multiset<_Kty, hash<_Kty>, equal_to<_Kty>, _Alloc>;
 
 template <class _Kty, class _Hasher, class _Alloc,
     enable_if_t<conjunction_v<_Is_hasher<_Hasher>, _Is_allocator<_Alloc>>, int> = 0>
-unordered_multiset(initializer_list<_Kty>, _Guide_size_type_t<_Alloc>, _Hasher,
-    _Alloc) -> unordered_multiset<_Kty, _Hasher, equal_to<_Kty>, _Alloc>;
+unordered_multiset(initializer_list<_Kty>, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
+    -> unordered_multiset<_Kty, _Hasher, equal_to<_Kty>, _Alloc>;
 
 #if _HAS_CXX23
 template <_RANGES input_range _Rng, _Hasher_for_container _Hasher = hash<_RANGES range_value_t<_Rng>>,
@@ -706,18 +704,17 @@ unordered_multiset(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc> = 0, _Hasher
     _Alloc = _Alloc()) -> unordered_multiset<_RANGES range_value_t<_Rng>, _Hasher, _Keyeq, _Alloc>;
 
 template <_RANGES input_range _Rng, _Allocator_for_container _Alloc>
-unordered_multiset(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc>,
-    _Alloc) -> unordered_multiset<_RANGES range_value_t<_Rng>, hash<_RANGES range_value_t<_Rng>>,
-                equal_to<_RANGES range_value_t<_Rng>>, _Alloc>;
+unordered_multiset(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc>, _Alloc)
+    -> unordered_multiset<_RANGES range_value_t<_Rng>, hash<_RANGES range_value_t<_Rng>>,
+        equal_to<_RANGES range_value_t<_Rng>>, _Alloc>;
 
 template <_RANGES input_range _Rng, _Allocator_for_container _Alloc>
-unordered_multiset(
-    from_range_t, _Rng&&, _Alloc) -> unordered_multiset<_RANGES range_value_t<_Rng>, hash<_RANGES range_value_t<_Rng>>,
-                                      equal_to<_RANGES range_value_t<_Rng>>, _Alloc>;
+unordered_multiset(from_range_t, _Rng&&, _Alloc) -> unordered_multiset<_RANGES range_value_t<_Rng>,
+    hash<_RANGES range_value_t<_Rng>>, equal_to<_RANGES range_value_t<_Rng>>, _Alloc>;
 
 template <_RANGES input_range _Rng, _Hasher_for_container _Hasher, _Allocator_for_container _Alloc>
-unordered_multiset(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc>, _Hasher,
-    _Alloc) -> unordered_multiset<_RANGES range_value_t<_Rng>, _Hasher, equal_to<_RANGES range_value_t<_Rng>>, _Alloc>;
+unordered_multiset(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
+    -> unordered_multiset<_RANGES range_value_t<_Rng>, _Hasher, equal_to<_RANGES range_value_t<_Rng>>, _Alloc>;
 #endif // _HAS_CXX23
 #endif // _HAS_CXX17
 

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -319,7 +319,7 @@ struct pair { // store a pair of values
                      is_constructible<_Ty2, decltype(_STD get<1>(_STD declval<_Other>()))>>
 #endif // ^^^ no workaround ^^^
     constexpr explicit(!conjunction_v<is_convertible<decltype(_STD get<0>(_STD declval<_Other>())), _Ty1>,
-                       is_convertible<decltype(_STD get<1>(_STD declval<_Other>())), _Ty2>>) pair(_Other&& _Right)
+        is_convertible<decltype(_STD get<1>(_STD declval<_Other>())), _Ty2>>) pair(_Other&& _Right)
         noexcept(is_nothrow_constructible_v<_Ty1, decltype(_STD get<0>(_STD declval<_Other>()))>
                  && is_nothrow_constructible_v<_Ty2, decltype(_STD get<1>(_STD declval<_Other>()))>) // strengthened
         : first(_STD get<0>(_STD forward<_Other>(_Right))), second(_STD get<1>(_STD forward<_Other>(_Right))) {

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -499,17 +499,14 @@ _NODISCARD constexpr decltype(auto) _Variant_raw_get(_Storage&& _Obj) noexcept {
         return _STD _Variant_raw_get<_Idx - 8>(
             static_cast<_Storage&&>(_Obj)._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail);
     } else if constexpr (_Idx < 32) {
-        return _STD _Variant_raw_get<_Idx - 16>(
-            static_cast<_Storage&&>(_Obj)
+        return _STD _Variant_raw_get<_Idx - 16>(static_cast<_Storage&&>(_Obj)
                 ._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail);
     } else if constexpr (_Idx < 64) {
-        return _STD _Variant_raw_get<_Idx - 32>(
-            static_cast<_Storage&&>(_Obj)
+        return _STD _Variant_raw_get<_Idx - 32>(static_cast<_Storage&&>(_Obj)
                 ._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail
                 ._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail);
     } else { // _Idx >= 64
-        return _STD _Variant_raw_get<_Idx - 64>(
-            static_cast<_Storage&&>(_Obj)
+        return _STD _Variant_raw_get<_Idx - 64>(static_cast<_Storage&&>(_Obj)
                 ._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail
                 ._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail
                 ._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -97,11 +97,6 @@ template <class _Kty, class _Hasher, class _Keyeq>
 struct _Uhash_choose_transparency {
     // transparency selector for non-transparent hashed containers
     static constexpr bool _Has_transparent_overloads = false;
-
-#if _HAS_CXX20 && defined(__EDG__) // TRANSITION, DevCom-10678753
-    template <class, class>
-    static constexpr bool _Supports_transparency = false;
-#endif // ^^^ workaround ^^^
 };
 
 #if _HAS_CXX20

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -28,6 +28,7 @@ class _Locbase {}; // TRANSITION, ABI, affects sizeof(locale)
 _EXPORT_STD template <class _Elem>
 class collate;
 
+// clang-format off: clang-format 19 doesn't understand _CRTIMP2_PURE_IMPORT and will poorly format the following code
 extern "C++" struct _CRTIMP2_PURE_IMPORT _Crt_new_delete { // base class for marking allocations as CRT blocks
 #ifdef _DEBUG
     void* __CLRCALL_OR_CDECL operator new(size_t _Size) { // replace operator new
@@ -58,6 +59,7 @@ extern "C++" struct _CRTIMP2_PURE_IMPORT _Crt_new_delete { // base class for mar
     void __CLRCALL_OR_CDECL operator delete(void*, void*) noexcept {} // imitate True Placement Delete
 #endif // _DEBUG
 };
+// clang-format on
 
 _EXPORT_STD extern "C++" class locale : public _Locbase<int>, public _Crt_new_delete {
 public:

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -878,7 +878,7 @@ private:
         const size_t _Offset_digit_end = _Parse_hex ? _Offset_hex_digit_end : _Offset_dec_digit_end;
         if (_Grouping.empty()) {
             for (size_t _Idx; _First != _Last && (_Idx = _STD _Find_elem(_Atoms, *_First)) < _Offset_digit_end;
-                 _Seendigit = true, (void) ++_First) {
+                _Seendigit = true, (void) ++_First) {
                 if (_Significant >= _Max_sig_dig) {
                     ++_Power_of_rep_base; // just scale by 10 or 16
                     if (_Idx > 0) {
@@ -977,7 +977,7 @@ private:
         }
 
         for (size_t _Idx; _First != _Last && (_Idx = _STD _Find_elem(_Atoms, *_First)) < _Offset_digit_end;
-             _Seendigit = true, (void) ++_First) {
+            _Seendigit = true, (void) ++_First) {
             if (_Significant < _Max_sig_dig) { // save a significant fraction digit
                 *_Ptr++ = _Src[_Idx];
                 ++_Significant;
@@ -1018,7 +1018,7 @@ private:
             }
 
             for (size_t _Idx; _First != _Last && (_Idx = _STD _Find_elem(_Atoms, *_First)) < _Offset_dec_digit_end;
-                 _Seendigit = true, (void) ++_First) {
+                _Seendigit = true, (void) ++_First) {
                 if (_Exponent_part < PTRDIFF_MAX / 10
                     || (_Exponent_part == PTRDIFF_MAX / 10
                         && static_cast<ptrdiff_t>(_Idx) <= PTRDIFF_MAX % 10)) { // save a significant exponent digit
@@ -1091,7 +1091,7 @@ private:
 
             char* const _Rev_begin = _Ptr;
             for (ptrdiff_t _Exponent_part_abs = _STD abs(_Exponent_part); _Exponent_part_abs != 0;
-                 _Exponent_part_abs /= 10) {
+                _Exponent_part_abs /= 10) {
                 *_Ptr++ = static_cast<char>('0' + _Exponent_part_abs % 10);
             }
             _STD reverse(_Rev_begin, _Ptr);

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -55,8 +55,8 @@ ios_base::iostate _Getint_v2(_InIt& _First, _InIt& _Last, int _Lo, int _Hi, int&
     }
 
     for (char* const _Pe = &_Ac[_Max_int_dig - 1];
-         _First != _Last && '0' <= (_Ch = _Ctype_fac.narrow(*_First)) && _Ch <= '9' && _Digits_read < _Hi_digits;
-         ++_Digits_read, (void) ++_First) { // copy digits
+        _First != _Last && '0' <= (_Ch = _Ctype_fac.narrow(*_First)) && _Ch <= '9' && _Digits_read < _Hi_digits;
+        ++_Digits_read, (void) ++_First) { // copy digits
         *_Ptr = _Ch;
         if (_Ptr < _Pe) {
             ++_Ptr; // drop trailing digits if already too large

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1663,7 +1663,9 @@ _NoThrowFwdIt _Uninitialized_move_unchecked(_InIt _First, const _InIt _Last, _No
 #if 0 // TRANSITION, _HAS_CXX26
         if (!_STD is_constant_evaluated())
 #endif // _HAS_CXX26
-        { return _STD _Copy_memmove(_First, _Last, _Dest); }
+        {
+            return _STD _Copy_memmove(_First, _Last, _Dest);
+        }
     }
     _Uninitialized_backout<_NoThrowFwdIt> _Backout{_Dest};
     for (; _First != _Last; ++_First) {
@@ -1934,7 +1936,9 @@ _NoThrowFwdIt _Uninitialized_copy_unchecked(_InIt _First, const _InIt _Last, _No
 #if 0 // TRANSITION, _HAS_CXX26
         if (!_STD is_constant_evaluated())
 #endif // _HAS_CXX26
-        { return _STD _Copy_memmove(_First, _Last, _Dest); }
+        {
+            return _STD _Copy_memmove(_First, _Last, _Dest);
+        }
     }
 
     _Uninitialized_backout<_NoThrowFwdIt> _Backout{_Dest};

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -3083,13 +3083,13 @@ private:
 #if _HAS_CXX17
 template <class _Iter, class _Alloc = allocator<_Iter_value_t<_Iter>>,
     enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
-basic_string(
-    _Iter, _Iter, _Alloc = _Alloc()) -> basic_string<_Iter_value_t<_Iter>, char_traits<_Iter_value_t<_Iter>>, _Alloc>;
+basic_string(_Iter, _Iter, _Alloc = _Alloc())
+    -> basic_string<_Iter_value_t<_Iter>, char_traits<_Iter_value_t<_Iter>>, _Alloc>;
 
 template <class _Elem, class _Traits, class _Alloc = allocator<_Elem>,
     enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
-explicit basic_string(
-    basic_string_view<_Elem, _Traits>, const _Alloc& = _Alloc()) -> basic_string<_Elem, _Traits, _Alloc>;
+explicit basic_string(basic_string_view<_Elem, _Traits>, const _Alloc& = _Alloc())
+    -> basic_string<_Elem, _Traits, _Alloc>;
 
 template <class _Elem, class _Traits, class _Alloc = allocator<_Elem>,
     enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
@@ -3098,8 +3098,8 @@ basic_string(basic_string_view<_Elem, _Traits>, _Guide_size_type_t<_Alloc>, _Gui
 
 #if _HAS_CXX23
 template <_RANGES input_range _Rng, _Allocator_for_container _Alloc = allocator<_RANGES range_value_t<_Rng>>>
-basic_string(from_range_t, _Rng&&,
-    _Alloc = _Alloc()) -> basic_string<_RANGES range_value_t<_Rng>, char_traits<_RANGES range_value_t<_Rng>>, _Alloc>;
+basic_string(from_range_t, _Rng&&, _Alloc = _Alloc())
+    -> basic_string<_RANGES range_value_t<_Rng>, char_traits<_RANGES range_value_t<_Rng>>, _Alloc>;
 #endif // _HAS_CXX23
 #endif // _HAS_CXX17
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4123,10 +4123,9 @@ namespace ranges {
     subrange(_It, _Se, _Make_unsigned_like_t<iter_difference_t<_It>>) -> subrange<_It, _Se, subrange_kind::sized>;
 
     template <borrowed_range _Rng>
-    subrange(_Rng&&)
-        -> subrange<iterator_t<_Rng>, sentinel_t<_Rng>,
-            (sized_range<_Rng> || sized_sentinel_for<sentinel_t<_Rng>, iterator_t<_Rng>>) ? subrange_kind::sized
-                                                                                          : subrange_kind::unsized>;
+    subrange(_Rng&&) -> subrange<iterator_t<_Rng>, sentinel_t<_Rng>,
+        (sized_range<_Rng> || sized_sentinel_for<sentinel_t<_Rng>, iterator_t<_Rng>>) ? subrange_kind::sized
+                                                                                      : subrange_kind::unsized>;
 
     template <borrowed_range _Rng>
     subrange(_Rng&&, _Make_unsigned_like_t<range_difference_t<_Rng>>)

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2033,14 +2033,14 @@ _NODISCARD constexpr _Ty* end(_Ty (&_Array)[_Size]) noexcept {
 }
 
 _EXPORT_STD template <class _Container>
-_NODISCARD constexpr auto cbegin(const _Container& _Cont)
-    noexcept(noexcept(_STD begin(_Cont))) -> decltype(_STD begin(_Cont)) {
+_NODISCARD constexpr auto cbegin(const _Container& _Cont) noexcept(noexcept(_STD begin(_Cont)))
+    -> decltype(_STD begin(_Cont)) {
     return _STD begin(_Cont);
 }
 
 _EXPORT_STD template <class _Container>
-_NODISCARD constexpr auto cend(const _Container& _Cont)
-    noexcept(noexcept(_STD end(_Cont))) -> decltype(_STD end(_Cont)) {
+_NODISCARD constexpr auto cend(const _Container& _Cont) noexcept(noexcept(_STD end(_Cont)))
+    -> decltype(_STD end(_Cont)) {
     return _STD end(_Cont);
 }
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -929,8 +929,8 @@ _EMIT_STL_ERROR(STL1002, "Unexpected compiler version, expected CUDA 12.4 or new
 #elif defined(__EDG__)
 // not attempting to detect __EDG_VERSION__ being less than expected
 #elif defined(__clang__)
-#if __clang_major__ < 18
-_EMIT_STL_ERROR(STL1000, "Unexpected compiler version, expected Clang 18.0.0 or newer.");
+#if __clang_major__ < 19
+_EMIT_STL_ERROR(STL1000, "Unexpected compiler version, expected Clang 19.0.0 or newer.");
 #endif // ^^^ old Clang ^^^
 #elif defined(_MSC_VER)
 #if _MSC_VER < 1942 // Coarse-grained, not inspecting _MSC_FULL_VER

--- a/stl/src/excptptr.cpp
+++ b/stl/src/excptptr.cpp
@@ -505,8 +505,10 @@ _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL __ExceptionPtrCurrentException(void* 
         // Alloc memory on stack for exception object. This might cause a stack overflow SEH exception, or another C++
         // exception when copying the C++ exception object. In that case, we just let that become the thrown exception.
 
-#pragma warning(suppress : 6255) //  _alloca indicates failure by raising a stack overflow exception
+#pragma warning(push)
+#pragma warning(disable : 6255) //  _alloca indicates failure by raising a stack overflow exception
         void* _PExceptionBuffer = alloca(_PType->sizeOrOffset);
+#pragma warning(pop)
         _CopyExceptionObject(_PExceptionBuffer, _CppRecord.params.pExceptionObject, _PType
 #if _EH_RELATIVE_TYPEINFO
             ,

--- a/stl/src/locale.cpp
+++ b/stl/src/locale.cpp
@@ -124,8 +124,10 @@ void __CLRCALL_PURE_OR_CDECL locale::_Locimp::_Locimp_Addfac(
         }
     }
     ptrfac->_Incref();
-#pragma warning(suppress : 6001) // PREfast isn't following through _realloc_crt here
+#pragma warning(push)
+#pragma warning(disable : 6001) // PREfast isn't following through _realloc_crt here
     if (_This->_Facetvec[id] != nullptr) {
+#pragma warning(pop)
         delete _This->_Facetvec[id]->_Decref();
     }
 

--- a/stl/src/multprec.cpp
+++ b/stl/src/multprec.cpp
@@ -134,8 +134,10 @@ void __CLRCALL_PURE_OR_CDECL _MP_Rem(
 
         unsigned long long rh = ((u[j + n] << shift) + u[j + n - 1]) % v[n - 1];
         for (;;) {
-#pragma warning(suppress : 6385) // TRANSITION, GH-1008
+#pragma warning(push)
+#pragma warning(disable : 6385) // TRANSITION, GH-1008
             if (qh < maxVal && qh * v[n - 2] <= (rh << shift) + u[j + n - 2]) {
+#pragma warning(pop)
                 break;
             } else { // reduce tentative value and retry
                 --qh;

--- a/stl/src/xstoul.cpp
+++ b/stl/src/xstoul.cpp
@@ -71,7 +71,7 @@ _CRTIMP2_PURE unsigned long __CLRCALL_PURE_OR_CDECL _Stoulx(
 
     x = 0;
     for (s2 = sc, y = 0; (sd = static_cast<const char*>(memchr(&digits[0], tolower(*sc), base))) != nullptr;
-         ++sc) { // accumulate digits
+        ++sc) { // accumulate digits
         y   = x;
         dig = static_cast<char>(sd - digits); // for overflow checking
         x   = x * base + dig;

--- a/stl/src/xstoull.cpp
+++ b/stl/src/xstoull.cpp
@@ -69,7 +69,7 @@ _CRTIMP2_PURE unsigned long long __CLRCALL_PURE_OR_CDECL _Stoullx(
 
     x = 0;
     for (s2 = sc, y = 0, dig = 0; (sd = static_cast<const char*>(memchr(&digits[0], tolower(*sc), base))) != nullptr;
-         ++sc) { // accumulate digits
+        ++sc) { // accumulate digits
         y   = x;
         dig = static_cast<char>(sd - digits); // for overflow checking
         x   = x * base + dig;

--- a/stl/src/xwcsxfrm.cpp
+++ b/stl/src/xwcsxfrm.cpp
@@ -73,9 +73,11 @@ _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Wcsxfrm(_Out_writes_(end1 - string
         auto bbuffer = _malloc_crt_t(unsigned char, n1);
 
         if (bbuffer) {
-#pragma warning(suppress : 6386) // PREfast doesn't understand LCMAP_SORTKEY
+#pragma warning(push)
+#pragma warning(disable : 6386) // PREfast doesn't understand LCMAP_SORTKEY
             size = __crtLCMapStringW(locale_name, LCMAP_SORTKEY, string2, static_cast<int>(n2),
                 reinterpret_cast<wchar_t*>(bbuffer.get()), static_cast<int>(n1));
+#pragma warning(pop)
 
             if (size == 0) {
                 // buffer not big enough, get size required.

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -428,6 +428,35 @@ std/algorithms/alg.modifying.operations/alg.move/move.pass.cpp:1 FAIL
 std/language.support/support.rtti/type.info/type_info.equal.pass.cpp:0 FAIL
 std/language.support/support.rtti/type.info/type_info.equal.pass.cpp:1 FAIL
 
+# DevCom-10808176 VSO-2319111 MSVC doesn't properly destroy a loop variable in constant evaluation
+# Fixed in VS 2022 17.14 Preview 1.
+std/algorithms/alg.nonmodifying/alg.find.last/ranges.find_last.pass.cpp:0 FAIL
+std/algorithms/alg.nonmodifying/alg.find.last/ranges.find_last.pass.cpp:1 FAIL
+std/containers/sequences/vector.bool/construct_iter_iter.pass.cpp:0 FAIL
+std/containers/sequences/vector.bool/construct_iter_iter.pass.cpp:1 FAIL
+std/containers/sequences/vector.bool/construct_iter_iter_alloc.pass.cpp:0 FAIL
+std/containers/sequences/vector.bool/construct_iter_iter_alloc.pass.cpp:1 FAIL
+std/containers/sequences/vector.bool/construct_size.pass.cpp:0 FAIL
+std/containers/sequences/vector.bool/construct_size.pass.cpp:1 FAIL
+std/containers/sequences/vector.bool/construct_size_value.pass.cpp:0 FAIL
+std/containers/sequences/vector.bool/construct_size_value.pass.cpp:1 FAIL
+std/containers/sequences/vector.bool/construct_size_value_alloc.pass.cpp:0 FAIL
+std/containers/sequences/vector.bool/construct_size_value_alloc.pass.cpp:1 FAIL
+std/containers/sequences/vector/reverse_iterators.pass.cpp:0 FAIL
+std/containers/sequences/vector/reverse_iterators.pass.cpp:1 FAIL
+std/containers/sequences/vector/vector.cons/construct_iter_iter.pass.cpp:0 FAIL
+std/containers/sequences/vector/vector.cons/construct_iter_iter.pass.cpp:1 FAIL
+std/containers/sequences/vector/vector.cons/construct_iter_iter_alloc.pass.cpp:0 FAIL
+std/containers/sequences/vector/vector.cons/construct_iter_iter_alloc.pass.cpp:1 FAIL
+std/containers/sequences/vector/vector.cons/construct_size.pass.cpp:0 FAIL
+std/containers/sequences/vector/vector.cons/construct_size.pass.cpp:1 FAIL
+std/containers/sequences/vector/vector.cons/construct_size_value.pass.cpp:0 FAIL
+std/containers/sequences/vector/vector.cons/construct_size_value.pass.cpp:1 FAIL
+std/containers/sequences/vector/vector.cons/construct_size_value_alloc.pass.cpp:0 FAIL
+std/containers/sequences/vector/vector.cons/construct_size_value_alloc.pass.cpp:1 FAIL
+std/containers/views/mdspan/mdspan/index_operator.pass.cpp:0 FAIL
+std/containers/views/mdspan/mdspan/index_operator.pass.cpp:1 FAIL
+
 # VSO-2338829 constexpr error "subtracting pointers to elements of different arrays" in _String_const_iterator::_Verify_offset()
 std/strings/basic.string/string.modifiers/string_erase/iter.pass.cpp:0 FAIL
 std/strings/basic.string/string.modifiers/string_erase/iter.pass.cpp:1 FAIL
@@ -915,35 +944,6 @@ std/algorithms/algorithms.results/min_max_result.pass.cpp:1 FAIL
 
 # Not analyzed.
 std/algorithms/robust_against_proxy_iterators_lifetime_bugs.pass.cpp FAIL
-
-# Not analyzed. Possible MSVC constexpr bug.
-# note: failure was caused by a read of a variable outside its lifetime
-std/algorithms/alg.nonmodifying/alg.find.last/ranges.find_last.pass.cpp:0 FAIL
-std/algorithms/alg.nonmodifying/alg.find.last/ranges.find_last.pass.cpp:1 FAIL
-std/containers/sequences/vector.bool/construct_iter_iter.pass.cpp:0 FAIL
-std/containers/sequences/vector.bool/construct_iter_iter.pass.cpp:1 FAIL
-std/containers/sequences/vector.bool/construct_iter_iter_alloc.pass.cpp:0 FAIL
-std/containers/sequences/vector.bool/construct_iter_iter_alloc.pass.cpp:1 FAIL
-std/containers/sequences/vector.bool/construct_size.pass.cpp:0 FAIL
-std/containers/sequences/vector.bool/construct_size.pass.cpp:1 FAIL
-std/containers/sequences/vector.bool/construct_size_value.pass.cpp:0 FAIL
-std/containers/sequences/vector.bool/construct_size_value.pass.cpp:1 FAIL
-std/containers/sequences/vector.bool/construct_size_value_alloc.pass.cpp:0 FAIL
-std/containers/sequences/vector.bool/construct_size_value_alloc.pass.cpp:1 FAIL
-std/containers/sequences/vector/reverse_iterators.pass.cpp:0 FAIL
-std/containers/sequences/vector/reverse_iterators.pass.cpp:1 FAIL
-std/containers/sequences/vector/vector.cons/construct_iter_iter.pass.cpp:0 FAIL
-std/containers/sequences/vector/vector.cons/construct_iter_iter.pass.cpp:1 FAIL
-std/containers/sequences/vector/vector.cons/construct_iter_iter_alloc.pass.cpp:0 FAIL
-std/containers/sequences/vector/vector.cons/construct_iter_iter_alloc.pass.cpp:1 FAIL
-std/containers/sequences/vector/vector.cons/construct_size.pass.cpp:0 FAIL
-std/containers/sequences/vector/vector.cons/construct_size.pass.cpp:1 FAIL
-std/containers/sequences/vector/vector.cons/construct_size_value.pass.cpp:0 FAIL
-std/containers/sequences/vector/vector.cons/construct_size_value.pass.cpp:1 FAIL
-std/containers/sequences/vector/vector.cons/construct_size_value_alloc.pass.cpp:0 FAIL
-std/containers/sequences/vector/vector.cons/construct_size_value_alloc.pass.cpp:1 FAIL
-std/containers/views/mdspan/mdspan/index_operator.pass.cpp:0 FAIL
-std/containers/views/mdspan/mdspan/index_operator.pass.cpp:1 FAIL
 
 # Not analyzed. Looks like a test bug, assuming that hash<vector<bool>> is constexpr.
 std/containers/sequences/vector.bool/enabled_hash.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -589,6 +589,7 @@ std/input.output/syncstream/syncbuf/syncstream.syncbuf.members/emit.pass.cpp FAI
 # *** VCRUNTIME BUGS ***
 # DevCom-10373274 VSO-1824997 "vcruntime nothrow array operator new falls back on the wrong function"
 # This passes for the :1 (ASan) configuration, surprisingly.
+# Fixed in VS 2022 17.14 Preview 1.
 std/language.support/support.dynamic/new.delete/new.delete.array/new.size_nothrow.replace.indirect.pass.cpp:0 FAIL
 std/language.support/support.dynamic/new.delete/new.delete.array/new.size_nothrow.replace.indirect.pass.cpp:2 FAIL
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -428,6 +428,28 @@ std/algorithms/alg.modifying.operations/alg.move/move.pass.cpp:1 FAIL
 std/language.support/support.rtti/type.info/type_info.equal.pass.cpp:0 FAIL
 std/language.support/support.rtti/type.info/type_info.equal.pass.cpp:1 FAIL
 
+# VSO-2338829 constexpr error "subtracting pointers to elements of different arrays" in _String_const_iterator::_Verify_offset()
+std/strings/basic.string/string.modifiers/string_erase/iter.pass.cpp:0 FAIL
+std/strings/basic.string/string.modifiers/string_erase/iter.pass.cpp:1 FAIL
+std/strings/basic.string/string.modifiers/string_erase/iter_iter.pass.cpp:0 FAIL
+std/strings/basic.string/string.modifiers/string_erase/iter_iter.pass.cpp:1 FAIL
+std/strings/basic.string/string.modifiers/string_insert/iter_iter_iter.pass.cpp:0 FAIL
+std/strings/basic.string/string.modifiers/string_insert/iter_iter_iter.pass.cpp:1 FAIL
+std/strings/basic.string/string.modifiers/string_insert/iter_size_char.pass.cpp:0 FAIL
+std/strings/basic.string/string.modifiers/string_insert/iter_size_char.pass.cpp:1 FAIL
+std/strings/basic.string/string.modifiers/string_replace/iter_iter_iter_iter.pass.cpp:0 FAIL
+std/strings/basic.string/string.modifiers/string_replace/iter_iter_iter_iter.pass.cpp:1 FAIL
+std/strings/basic.string/string.modifiers/string_replace/iter_iter_pointer.pass.cpp:0 FAIL
+std/strings/basic.string/string.modifiers/string_replace/iter_iter_pointer.pass.cpp:1 FAIL
+std/strings/basic.string/string.modifiers/string_replace/iter_iter_pointer_size.pass.cpp:0 FAIL
+std/strings/basic.string/string.modifiers/string_replace/iter_iter_pointer_size.pass.cpp:1 FAIL
+std/strings/basic.string/string.modifiers/string_replace/iter_iter_size_char.pass.cpp:0 FAIL
+std/strings/basic.string/string.modifiers/string_replace/iter_iter_size_char.pass.cpp:1 FAIL
+std/strings/basic.string/string.modifiers/string_replace/iter_iter_string.pass.cpp:0 FAIL
+std/strings/basic.string/string.modifiers/string_replace/iter_iter_string.pass.cpp:1 FAIL
+std/strings/basic.string/string.modifiers/string_replace/iter_iter_string_view.pass.cpp:0 FAIL
+std/strings/basic.string/string.modifiers/string_replace/iter_iter_string_view.pass.cpp:1 FAIL
+
 
 # *** CLANG COMPILER BUGS ***
 # LLVM-46207 Clang's tgmath.h interferes with the UCRT's tgmath.h
@@ -939,28 +961,6 @@ std/ranges/range.adaptors/range.lazy.split/range.lazy.split.inner/iter_swap.pass
 # MSVC note: failure was caused by a read of an uninitialized symbol
 # Clang error: non-type template argument is not a constant expression
 std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_const_move.pass.cpp FAIL
-
-# Not analyzed, probably MSVC constexpr issue(s)
-std/strings/basic.string/string.modifiers/string_erase/iter.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_erase/iter.pass.cpp:1 FAIL
-std/strings/basic.string/string.modifiers/string_erase/iter_iter.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_erase/iter_iter.pass.cpp:1 FAIL
-std/strings/basic.string/string.modifiers/string_insert/iter_iter_iter.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_insert/iter_iter_iter.pass.cpp:1 FAIL
-std/strings/basic.string/string.modifiers/string_insert/iter_size_char.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_insert/iter_size_char.pass.cpp:1 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_iter_iter.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_iter_iter.pass.cpp:1 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_pointer.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_pointer.pass.cpp:1 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_pointer_size.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_pointer_size.pass.cpp:1 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_size_char.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_size_char.pass.cpp:1 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_string.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_string.pass.cpp:1 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_string_view.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_string_view.pass.cpp:1 FAIL
 
 # Not analyzed, possible path length issue. With a repo root of D:\GitHub\STL (13 characters), fails with:
 # "error RC2136 : missing '=' in EXSTYLE=<flags>" followed by "LINK : fatal error LNK1327: failure during running rc.exe"

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -433,11 +433,6 @@ std/language.support/support.rtti/type.info/type_info.equal.pass.cpp:1 FAIL
 # LLVM-46207 Clang's tgmath.h interferes with the UCRT's tgmath.h
 std/depr/depr.c.headers/tgmath_h.pass.cpp:2 FAIL
 
-# LLVM-95311 [clang] __has_unique_object_representations gives inconsistent answer based on instantiation order
-# A libc++ product code workaround (using `remove_all_extents_t`) and test coverage were added by LLVM-95314.
-# Fixed by LLVM-95432 in Clang 19.
-std/utilities/meta/meta.unary/meta.unary.prop/has_unique_object_representations.compile.pass.cpp:2 FAIL
-
 
 # *** CLANG ISSUES, NOT YET ANALYZED ***
 # Not analyzed. Clang apparently defines platform macros differently from C1XX.
@@ -446,10 +441,6 @@ std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp
 # Not analyzed. Possibly C++20 equality operator rewrite issues.
 std/utilities/expected/expected.expected/equality/equality.other_expected.pass.cpp:2 FAIL
 std/utilities/expected/expected.void/equality/equality.other_expected.pass.cpp:2 FAIL
-
-# Not analyzed. __cpp_sized_deallocation isn't being defined by Clang.
-std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array.pass.cpp:2 FAIL
-std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete.pass.cpp:2 FAIL
 
 
 # *** STL BUGS ***
@@ -1355,17 +1346,6 @@ std/ranges/range.adaptors/range.lazy.split/constraints.compile.pass.cpp:9 SKIPPE
 std/ranges/range.utility/range.utility.conv/to.pass.cpp:9 SKIPPED
 std/thread/thread.jthread/assign.move.pass.cpp:9 SKIPPED
 std/utilities/meta/meta.unary/dependent_return_type.compile.pass.cpp:9 SKIPPED
-
-# These tests also need ADDITIONAL_COMPILE_FLAGS to silence warnings, but only for Clang 18.
-# TRANSITION, Clang 19
-std/containers/associative/map/map.modifiers/insert_range.pass.cpp:9 SKIPPED
-std/containers/associative/multimap/multimap.modifiers/insert_range.pass.cpp:9 SKIPPED
-std/containers/associative/multiset/insert_range.pass.cpp:9 SKIPPED
-std/containers/associative/set/insert_range.pass.cpp:9 SKIPPED
-std/containers/unord/unord.map/unord.map.modifiers/insert_range.pass.cpp:9 SKIPPED
-std/containers/unord/unord.multimap/unord.multimap.modifiers/insert_range.pass.cpp:9 SKIPPED
-std/containers/unord/unord.multiset/insert_range.pass.cpp:9 SKIPPED
-std/containers/unord/unord.set/insert_range.pass.cpp:9 SKIPPED
 
 # This test is marked as `XFAIL: msvc`, but the MSVC-internal test harness doesn't yet parse XFAIL.
 std/utilities/function.objects/func.wrap/func.wrap.func/noncopyable_return_type.pass.cpp:9 SKIPPED

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -450,6 +450,20 @@ std/strings/basic.string/string.modifiers/string_replace/iter_iter_string.pass.c
 std/strings/basic.string/string.modifiers/string_replace/iter_iter_string_view.pass.cpp:0 FAIL
 std/strings/basic.string/string.modifiers/string_replace/iter_iter_string_view.pass.cpp:1 FAIL
 
+# VSO-2338880 constexpr error in vector::iterator's _Compat() check when using views::transform
+std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.pass.cpp:0 FAIL
+std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.pass.cpp:1 FAIL
+std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.segmented.pass.cpp:0 FAIL
+std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.segmented.pass.cpp:1 FAIL
+std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_n.segmented.pass.cpp:0 FAIL
+std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_n.segmented.pass.cpp:1 FAIL
+std/algorithms/alg.modifying.operations/alg.copy/ranges.copy.segmented.pass.cpp:0 FAIL
+std/algorithms/alg.modifying.operations/alg.copy/ranges.copy.segmented.pass.cpp:1 FAIL
+std/algorithms/alg.modifying.operations/alg.move/ranges.move_backward.segmented.pass.cpp:0 FAIL
+std/algorithms/alg.modifying.operations/alg.move/ranges.move_backward.segmented.pass.cpp:1 FAIL
+std/algorithms/alg.modifying.operations/alg.move/ranges.move.segmented.pass.cpp:0 FAIL
+std/algorithms/alg.modifying.operations/alg.move/ranges.move.segmented.pass.cpp:1 FAIL
+
 
 # *** CLANG COMPILER BUGS ***
 # LLVM-46207 Clang's tgmath.h interferes with the UCRT's tgmath.h
@@ -1064,20 +1078,6 @@ std/time/time.syn/formatter.hh_mm_ss.pass.cpp:2 FAIL
 std/time/time.syn/formatter.local_time.pass.cpp:2 FAIL
 std/time/time.syn/formatter.sys_time.pass.cpp:2 FAIL
 std/time/time.syn/formatter.zoned_time.pass.cpp:2 FAIL
-
-# Not analyzed. constexpr evaluation fails with "vector iterators incompatible".
-std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.pass.cpp:0 FAIL
-std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.pass.cpp:1 FAIL
-std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.segmented.pass.cpp:0 FAIL
-std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.segmented.pass.cpp:1 FAIL
-std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_n.segmented.pass.cpp:0 FAIL
-std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_n.segmented.pass.cpp:1 FAIL
-std/algorithms/alg.modifying.operations/alg.copy/ranges.copy.segmented.pass.cpp:0 FAIL
-std/algorithms/alg.modifying.operations/alg.copy/ranges.copy.segmented.pass.cpp:1 FAIL
-std/algorithms/alg.modifying.operations/alg.move/ranges.move_backward.segmented.pass.cpp:0 FAIL
-std/algorithms/alg.modifying.operations/alg.move/ranges.move_backward.segmented.pass.cpp:1 FAIL
-std/algorithms/alg.modifying.operations/alg.move/ranges.move.segmented.pass.cpp:0 FAIL
-std/algorithms/alg.modifying.operations/alg.move/ranges.move.segmented.pass.cpp:1 FAIL
 
 # Not analyzed. constexpr evaluation fails with note: failure was caused by out of range index MEOW; allowed range is 0 <= index < 2
 std/ranges/range.adaptors/range.join/adaptor.pass.cpp:0 FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -173,7 +173,7 @@ std/ranges/range.adaptors/range.join/range.join.iterator/arrow.pass.cpp FAIL
 std/language.support/support.limits/support.limits.general/version.version.compile.pass.cpp FAIL
 
 
-# *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***
+# *** INTERACTIONS WITH MSVC THAT UPSTREAM LIKELY WON'T FIX ***
 # These tests set an allocator with a max_size() too small to default construct an unordered container
 # (due to our minimum bucket size).
 std/containers/unord/unord.map/max_size.pass.cpp FAIL
@@ -1338,6 +1338,14 @@ std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp:9 SKIPPED
 std/algorithms/alg.nonmodifying/alg.find/find.pass.cpp:9 SKIPPED
 std/algorithms/alg.nonmodifying/alg.find/ranges.find.pass.cpp:9 SKIPPED
 std/algorithms/alg.nonmodifying/alg.fold/left_folds.pass.cpp:9 SKIPPED
+std/containers/associative/map/map.modifiers/insert_range.pass.cpp:9 SKIPPED
+std/containers/associative/multimap/multimap.modifiers/insert_range.pass.cpp:9 SKIPPED
+std/containers/associative/multiset/insert_range.pass.cpp:9 SKIPPED
+std/containers/associative/set/insert_range.pass.cpp:9 SKIPPED
+std/containers/unord/unord.map/unord.map.modifiers/insert_range.pass.cpp:9 SKIPPED
+std/containers/unord/unord.multimap/unord.multimap.modifiers/insert_range.pass.cpp:9 SKIPPED
+std/containers/unord/unord.multiset/insert_range.pass.cpp:9 SKIPPED
+std/containers/unord/unord.set/insert_range.pass.cpp:9 SKIPPED
 std/depr/depr.c.headers/setjmp_h.compile.pass.cpp:9 SKIPPED
 std/input.output/file.streams/fstreams/ifstream.members/buffered_reads.pass.cpp:9 SKIPPED
 std/input.output/file.streams/fstreams/ofstream.members/buffered_writes.pass.cpp:9 SKIPPED

--- a/tests/std/include/instantiate_algorithms_op_deref.hpp
+++ b/tests/std/include/instantiate_algorithms_op_deref.hpp
@@ -333,7 +333,9 @@ void test_optional() {
         const optional<Evil> oe{Evil()};
         (void) oe.value();
     }
-    { (void) optional<Evil>{Evil()}.value(); }
+    {
+        (void) optional<Evil>{Evil()}.value();
+    }
     {
         using T = const optional<Evil>;
         (void) T{Evil()}.value();

--- a/tests/std/tests/Dev08_563686_ostream/test.cpp
+++ b/tests/std/tests/Dev08_563686_ostream/test.cpp
@@ -49,7 +49,9 @@ int main() {
     _CrtMemCheckpoint(&before);
 
     // Construct and destroy an iostream, which previously leaked.
-    { std::iostream s(nullptr); }
+    {
+        std::iostream s(nullptr);
+    }
 
     // Get memory state after iostream allocation/deallocation
     _CrtMemState after;

--- a/tests/std/tests/Dev09_126254_persistent_aux_allocators/test.cpp
+++ b/tests/std/tests/Dev09_126254_persistent_aux_allocators/test.cpp
@@ -98,10 +98,12 @@ void dump_map() {
     }
 }
 
+#pragma warning(push)
+#pragma warning(disable : 4324) // structure was padded due to alignment specifier
 struct alignas(64) OverAlignedInt {
     int x;
-#pragma warning(suppress : 4324) // structure was padded due to alignment specifier
 };
+#pragma warning(pop)
 
 void test_gh_2362() {
     // GH-2362 suggests to add a debug-only nullptr assertion inside std::allocator<T>::deallocate, checking

--- a/tests/std/tests/Dev09_158457_tr1_mem_fn_calling_conventions/test.cpp
+++ b/tests/std/tests/Dev09_158457_tr1_mem_fn_calling_conventions/test.cpp
@@ -200,7 +200,7 @@ STATIC_ASSERT(is_function_v<decltype(z)>);
 // non-viable.)
 
 template <typename R>
-int use_mem_fn(R Cat::*pmf) {
+int use_mem_fn(R Cat::* pmf) {
     Cat cat;
     return mem_fn(pmf)(cat);
 }

--- a/tests/std/tests/Dev09_173612_tr1_regex_leak/test.cpp
+++ b/tests/std/tests/Dev09_173612_tr1_regex_leak/test.cpp
@@ -157,7 +157,9 @@ void test(const char* s) {
     const int orig_scalars = g_scalars;
     const int orig_arrays  = g_arrays;
 
-    { regex r(s); }
+    {
+        regex r(s);
+    }
 
     if (g_scalars != orig_scalars) {
         printf("test(): %d scalar allocation leak(s)!\n", g_scalars - orig_scalars);

--- a/tests/std/tests/Dev10_491486_floating_point_hash/test.cpp
+++ b/tests/std/tests/Dev10_491486_floating_point_hash/test.cpp
@@ -29,8 +29,10 @@ void test_case() {
     assert(fake_bit_cast<MatchingUInt>(pos0d) == 0);
     const auto neg0d = static_cast<Floating>(0.0 * -1.0);
     assert(fake_bit_cast<MatchingUInt>(neg0d) == topBitSet);
-#pragma warning(suppress : 6326) // potential comparison of a constant with another constant
+#pragma warning(push)
+#pragma warning(disable : 6326) // potential comparison of a constant with another constant
     assert(pos0d == neg0d);
+#pragma warning(pop)
     assert(hash<Floating>()(pos0d) == hash<Floating>()(neg0d));
 
     array<size_t, 15> a{{

--- a/tests/std/tests/Dev10_561430_list_and_tree_leaks/test.cpp
+++ b/tests/std/tests/Dev10_561430_list_and_tree_leaks/test.cpp
@@ -116,9 +116,13 @@ int main() {
     }
 #endif // _HAS_FUNCTION_ALLOCATOR_SUPPORT
 
-    { shared_ptr<int> sp(new int(1729), default_delete<int>(), Mallocator<int>()); }
+    {
+        shared_ptr<int> sp(new int(1729), default_delete<int>(), Mallocator<int>());
+    }
 
-    { shared_ptr<int> sp = allocate_shared<int>(Mallocator<int>(), 1729); }
+    {
+        shared_ptr<int> sp = allocate_shared<int>(Mallocator<int>(), 1729);
+    }
 
 #ifndef _M_CEE_PURE
     {

--- a/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
+++ b/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
@@ -1017,7 +1017,7 @@ void test_reference_wrapper_invocation() {
     pmf = &Thing::product;
     assert(rw_pmf(sp, 3) == 60000);
 
-    int Thing::*pmd = &Thing::m_x;
+    int Thing::* pmd = &Thing::m_x;
     reference_wrapper<int Thing::*> rw_pmd(pmd);
     assert(rw_pmd(*sp) == 1000);
     assert(rw_pmd(sp.get()) == 1000);

--- a/tests/std/tests/Dev11_0617384_empty_std_function/test.cpp
+++ b/tests/std/tests/Dev11_0617384_empty_std_function/test.cpp
@@ -35,7 +35,7 @@ int main() {
 #endif // _HAS_FUNCTION_ALLOCATOR_SUPPORT
 
     int (X::*pmf)(int) = nullptr;
-    int X::*pmd        = nullptr;
+    int X::* pmd       = nullptr;
 
     assert(!function<int(X, int)>(pmf));
     assert(!function<int(X)>(pmd));

--- a/tests/std/tests/Dev11_0836436_get_time/test.cpp
+++ b/tests/std/tests/Dev11_0836436_get_time/test.cpp
@@ -912,7 +912,7 @@ void test_gh_4820() {
 
 void test_gh_4882() {
     // GH-4882 <iomanip>: std::put_time should not crash on invalid/out-of-range tm struct values
-    const auto fieldValidation = [](int tm::*const field, const int value, const string& fmt) {
+    const auto fieldValidation = [](int tm::* const field, const int value, const string& fmt) {
         time_t t = time(nullptr);
         tm currentTime;
         localtime_s(&currentTime, &t);
@@ -939,7 +939,7 @@ void test_gh_4882() {
     };
 
     struct FormatTestData {
-        int tm::*field;
+        int tm::* field;
         int lo;
         int hi;
         string fmt;

--- a/tests/std/tests/GH_001858_iostream_exception/test.cpp
+++ b/tests/std/tests/GH_001858_iostream_exception/test.cpp
@@ -619,15 +619,15 @@ STATIC_ASSERT(
 STATIC_ASSERT(
     !is_nothrow_move_assignable_v<basic_istringstream<char, char_traits<char>, pmr::polymorphic_allocator<char>>>);
 STATIC_ASSERT(!is_nothrow_move_assignable_v<
-              basic_istringstream<wchar_t, char_traits<wchar_t>, pmr::polymorphic_allocator<wchar_t>>>);
+    basic_istringstream<wchar_t, char_traits<wchar_t>, pmr::polymorphic_allocator<wchar_t>>>);
 STATIC_ASSERT(
     !is_nothrow_move_assignable_v<basic_ostringstream<char, char_traits<char>, pmr::polymorphic_allocator<char>>>);
 STATIC_ASSERT(!is_nothrow_move_assignable_v<
-              basic_ostringstream<wchar_t, char_traits<wchar_t>, pmr::polymorphic_allocator<wchar_t>>>);
+    basic_ostringstream<wchar_t, char_traits<wchar_t>, pmr::polymorphic_allocator<wchar_t>>>);
 STATIC_ASSERT(
     !is_nothrow_move_assignable_v<basic_stringstream<char, char_traits<char>, pmr::polymorphic_allocator<char>>>);
 STATIC_ASSERT(!is_nothrow_move_assignable_v<
-              basic_stringstream<wchar_t, char_traits<wchar_t>, pmr::polymorphic_allocator<wchar_t>>>);
+    basic_stringstream<wchar_t, char_traits<wchar_t>, pmr::polymorphic_allocator<wchar_t>>>);
 #endif // _HAS_CXX17
 
 STATIC_ASSERT(is_nothrow_std_swappable<stringbuf>);

--- a/tests/std/tests/GH_002581_common_reference_workaround/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002581_common_reference_workaround/test.compile.pass.cpp
@@ -23,8 +23,8 @@ static_assert(contiguous_iterator<volatile Scoped*>);
 static_assert(contiguous_iterator<const volatile Scoped*>);
 static_assert(contiguous_iterator<Test* volatile*>);
 static_assert(contiguous_iterator<Test* const volatile*>);
-static_assert(contiguous_iterator<int Test::*volatile*>);
-static_assert(contiguous_iterator<int Test::*const volatile*>);
+static_assert(contiguous_iterator<int Test::* volatile*>);
+static_assert(contiguous_iterator<int Test::* const volatile*>);
 
 // Tests for move_iterator specializations
 static_assert(random_access_iterator<move_iterator<volatile int*>>);
@@ -39,5 +39,5 @@ static_assert(random_access_iterator<move_iterator<volatile Scoped*>>);
 static_assert(random_access_iterator<move_iterator<const volatile Scoped*>>);
 static_assert(random_access_iterator<move_iterator<Test* volatile*>>);
 static_assert(random_access_iterator<move_iterator<Test* const volatile*>>);
-static_assert(random_access_iterator<move_iterator<int Test::*volatile*>>);
-static_assert(random_access_iterator<move_iterator<int Test::*const volatile*>>);
+static_assert(random_access_iterator<move_iterator<int Test::* volatile*>>);
+static_assert(random_access_iterator<move_iterator<int Test::* const volatile*>>);

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -204,7 +204,7 @@ constexpr void check_construction_from_other_left_mapping() {
 
     { // Check implicit conversions
         static_assert(!NotImplicitlyConstructibleFrom<layout_left::mapping<extents<int, 3>>,
-                      layout_left::mapping<extents<int, 3>>>);
+            layout_left::mapping<extents<int, 3>>>);
         static_assert(NotImplicitlyConstructibleFrom<layout_left::mapping<extents<int, 3>>,
             layout_left::mapping<extents<long long, 3>>>);
         static_assert(NotImplicitlyConstructibleFrom<layout_left::mapping<extents<int, 3, 3>>,

--- a/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
@@ -203,7 +203,7 @@ constexpr void check_construction_from_other_right_mapping() {
 
     { // Check implicit conversions
         static_assert(!NotImplicitlyConstructibleFrom<layout_right::mapping<extents<int, 3>>,
-                      layout_right::mapping<extents<int, 3>>>);
+            layout_right::mapping<extents<int, 3>>>);
         static_assert(NotImplicitlyConstructibleFrom<layout_right::mapping<extents<int, 3>>,
             layout_right::mapping<extents<long long, 3>>>);
         static_assert(NotImplicitlyConstructibleFrom<layout_right::mapping<extents<int, 3, 3>>,

--- a/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
@@ -353,11 +353,11 @@ constexpr void check_construction_from_other_mappings() {
         static_assert(!is_constructible_v<Mapping, layout_right::mapping<extents<long, 3, 3>>>);
         static_assert(!is_constructible_v<Mapping, layout_stride::mapping<extents<int, 4, 4, 3>>>);
         static_assert(!is_constructible_v<Mapping,
-                      LyingLayout<AlwaysUnique::no, AlwaysStrided::yes>::mapping<extents<long, 4, 4>>>);
+            LyingLayout<AlwaysUnique::no, AlwaysStrided::yes>::mapping<extents<long, 4, 4>>>);
         static_assert(!is_constructible_v<Mapping,
-                      LyingLayout<AlwaysUnique::yes, AlwaysStrided::no>::mapping<extents<long, 4, 4>>>);
+            LyingLayout<AlwaysUnique::yes, AlwaysStrided::no>::mapping<extents<long, 4, 4>>>);
         static_assert(!is_constructible_v<Mapping,
-                      LyingLayout<AlwaysUnique::no, AlwaysStrided::no>::mapping<extents<long, 4, 4>>>);
+            LyingLayout<AlwaysUnique::no, AlwaysStrided::no>::mapping<extents<long, 4, 4>>>);
     }
 
     { // Check construction from layout_left::mapping
@@ -540,13 +540,13 @@ constexpr void check_comparisons() {
         static_assert(!equality_comparable_with<DynamicStrideMapping, layout_right::mapping<extents<int, 2>>>);
         static_assert(!equality_comparable_with<StaticStrideMapping, layout_left::mapping<dextents<int, 1>>>);
         static_assert(!equality_comparable_with<DynamicStrideMapping,
-                      LyingLayout<AlwaysUnique::yes, AlwaysStrided::no>::mapping<dextents<int, 2>>>);
+            LyingLayout<AlwaysUnique::yes, AlwaysStrided::no>::mapping<dextents<int, 2>>>);
         static_assert(!equality_comparable_with<StaticStrideMapping,
-                      LyingLayout<AlwaysUnique::yes, AlwaysStrided::no>::mapping<extents<int, 2, 3>>>);
+            LyingLayout<AlwaysUnique::yes, AlwaysStrided::no>::mapping<extents<int, 2, 3>>>);
         static_assert(!equality_comparable_with<DynamicStrideMapping,
-                      LyingLayout<AlwaysUnique::no, AlwaysStrided::no>::mapping<dextents<int, 2>>>);
+            LyingLayout<AlwaysUnique::no, AlwaysStrided::no>::mapping<dextents<int, 2>>>);
         static_assert(!equality_comparable_with<StaticStrideMapping,
-                      LyingLayout<AlwaysUnique::no, AlwaysStrided::no>::mapping<extents<int, 2, 3>>>);
+            LyingLayout<AlwaysUnique::no, AlwaysStrided::no>::mapping<extents<int, 2, 3>>>);
     }
 
     { // Check correctness: layout_stride::mapping with layout_stride::mapping

--- a/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
@@ -602,9 +602,9 @@ constexpr void check_data_handle_and_span_array_constructors() {
         static_assert(is_nothrow_constructible_v<mdspan<bool, dextents<int, 2>, layout_right, VectorBoolAccessor>,
             vector<bool>::iterator, array<short, 2>>); // strengthened
         static_assert(!is_constructible_v<mdspan<int, dextents<int, 2>, layout_right, TrackingAccessor<int>>, int*,
-                      span<int, 2>>);
+            span<int, 2>>);
         static_assert(!is_constructible_v<mdspan<int, dextents<int, 2>, layout_right, TrackingAccessor<int>>, int*,
-                      array<int, 2>>);
+            array<int, 2>>);
     }
 
     { // Check explicitness
@@ -689,9 +689,9 @@ constexpr void check_data_handle_and_extents_constructor() {
         static_assert(is_nothrow_constructible_v<mdspan<bool, dextents<int, 2>, layout_right, VectorBoolAccessor>,
             vector<bool>::iterator, extents<long, 3, 3>>); // strengthened
         static_assert(!is_constructible_v<mdspan<int, dextents<int, 2>, layout_right, TrackingAccessor<int>>, int*,
-                      dextents<signed char, 2>>);
+            dextents<signed char, 2>>);
         static_assert(!is_constructible_v<mdspan<int, dextents<int, 2>, layout_right, TrackingAccessor<int>>, int*,
-                      extents<unsigned char, 4, 4>>);
+            extents<unsigned char, 4, 4>>);
     }
 
     { // Check effects: 'direct-non-list-initializes ptr_ with std::move(p)'
@@ -722,11 +722,11 @@ constexpr void check_data_handle_and_mapping_constructor() {
         static_assert(is_nothrow_constructible_v<mdspan<int, extents<short, 2, 2>, layout_left>, int* const,
             layout_left::mapping<extents<short, 2, 2>>>); // strengthened
         static_assert(!is_constructible_v<
-                      mdspan<vector<int>, extents<long, 5, 5>, TrackingLayout<>, TrackingAccessor<vector<int>>>,
-                      vector<int>*, TrackingLayout<>::mapping<extents<long, 5, 5>>>);
+            mdspan<vector<int>, extents<long, 5, 5>, TrackingLayout<>, TrackingAccessor<vector<int>>>, vector<int>*,
+            TrackingLayout<>::mapping<extents<long, 5, 5>>>);
         static_assert(!is_constructible_v<
-                      mdspan<deque<int>, extents<signed char, 5, 5, 5>, TrackingLayout<>, TrackingAccessor<deque<int>>>,
-                      deque<int>* const, TrackingLayout<>::mapping<extents<signed char, 5, 5, 5>>>);
+            mdspan<deque<int>, extents<signed char, 5, 5, 5>, TrackingLayout<>, TrackingAccessor<deque<int>>>,
+            deque<int>* const, TrackingLayout<>::mapping<extents<signed char, 5, 5, 5>>>);
     }
 
     { // Check effect: 'direct-non-list-initializes ptr_ with std::move(p)'
@@ -781,7 +781,7 @@ constexpr void check_data_handle_and_mapping_and_accessor_constructor() {
 
         using Mds2 = mdspan<short, extents<int, 3, 3, 3>, TrackingLayout<>>;
         static_assert(!is_nothrow_constructible_v<Mds2, Mds2::data_handle_type, const Mds2::mapping_type&,
-                      const Mds2::accessor_type&>);
+            const Mds2::accessor_type&>);
     }
 }
 
@@ -791,9 +791,9 @@ constexpr void check_construction_from_other_mdspan() {
         static_assert(is_nothrow_constructible_v<mdspan<int, extents<int, 4, 4, 4>, layout_stride>,
             mdspan<int, dextents<long, 3>, layout_right>>); // strengthened
         static_assert(!is_constructible_v<mdspan<float, dextents<long long, 2>, layout_left>,
-                      mdspan<float, extents<signed char, 3, 3>, layout_right>>);
+            mdspan<float, extents<signed char, 3, 3>, layout_right>>);
         static_assert(!is_constructible_v<mdspan<double, dextents<unsigned int, 2>, layout_left>,
-                      mdspan<double, extents<unsigned short, 5, 5, 5>, layout_left>>);
+            mdspan<double, extents<unsigned short, 5, 5, 5>, layout_left>>);
     }
 
     { // Check constraint: 'is_constructible_v<accessor_type, const OtherAccessor&>'
@@ -802,7 +802,7 @@ constexpr void check_construction_from_other_mdspan() {
             is_nothrow_constructible_v<mdspan<const double, Ext, layout_right, default_accessor<const double>>,
                 mdspan<double, Ext, layout_right, default_accessor<double>>>); // strengthened
         static_assert(!is_constructible_v<mdspan<const double, Ext, layout_right, TrivialAccessor<const double>>,
-                      mdspan<double, Ext, layout_right, TrivialAccessor<double>>>);
+            mdspan<double, Ext, layout_right, TrivialAccessor<double>>>);
     }
 
     { // Check explicitness
@@ -810,13 +810,13 @@ constexpr void check_construction_from_other_mdspan() {
         static_assert(NotImplicitlyConstructibleFrom<mdspan<int, extents<int, 4, 4>, layout_left>,
             mdspan<int, dextents<long, 2>, layout_stride>>);
         static_assert(!NotImplicitlyConstructibleFrom<mdspan<int, dextents<long, 2>, layout_stride>,
-                      mdspan<int, extents<int, 4, 4>, layout_left>>);
+            mdspan<int, extents<int, 4, 4>, layout_left>>);
         static_assert(NotImplicitlyConstructibleFrom<
             mdspan<const int, extents<int, 4, 4>, layout_left, AccessorWithCustomOffsetPolicy<const int>>,
             mdspan<int, extents<long, 4, 4>, layout_left, AccessorWithCustomOffsetPolicy<int>>>);
         static_assert(!NotImplicitlyConstructibleFrom<
-                      mdspan<const int, extents<int, 4, 4>, layout_left, default_accessor<const int>>,
-                      mdspan<int, extents<long, 4, 4>, layout_left, default_accessor<int>>>);
+            mdspan<const int, extents<int, 4, 4>, layout_left, default_accessor<const int>>,
+            mdspan<int, extents<long, 4, 4>, layout_left, default_accessor<int>>>);
     }
 
     { // Check effects

--- a/tests/std/tests/P0053R7_cpp_synchronized_buffered_ostream/test.cpp
+++ b/tests/std/tests/P0053R7_cpp_synchronized_buffered_ostream/test.cpp
@@ -348,7 +348,9 @@ void test_osyncstream(string_buffer<typename Alloc::value_type>* buf = nullptr) 
     { // test synchronization
         OSyncStream oss(buf);
         oss << "Last ";
-        { OSyncStream(oss.get_wrapped()) << "First Input!\n"; }
+        {
+            OSyncStream(oss.get_wrapped()) << "First Input!\n";
+        }
         oss << "Input!" << '\n';
     }
     if (buf) {

--- a/tests/std/tests/P0083R3_splicing_maps_and_sets/test.cpp
+++ b/tests/std/tests/P0083R3_splicing_maps_and_sets/test.cpp
@@ -387,7 +387,7 @@ void test_merge_single() {
             }
         }(1);
         auto const pos     = std::as_const(c1).find(key);
-        auto c2            = extended_merge_ctype<C2, Reverse == should_reverse::yes>{{0, 0}, {3, 3}};
+        auto c2            = extended_merge_ctype<C2, (Reverse == should_reverse::yes)>{{0, 0}, {3, 3}};
         allocation_allowed = false;
         assert(c1.get_allocator() == c2.get_allocator());
         if constexpr (Move == should_move::yes) {

--- a/tests/std/tests/P0083R3_splicing_maps_and_sets/test.cpp
+++ b/tests/std/tests/P0083R3_splicing_maps_and_sets/test.cpp
@@ -156,7 +156,9 @@ void test_node_handle(NodeHandle& nh1, NodeHandle& nh2, Validator1 v1, Validator
 #ifndef _M_CEE // TRANSITION, VSO-1664382
 #if _HAS_CXX20
 #pragma warning(suppress : 4640) // C4640 emitted by MSVC because 'NodeHandle' type has non-trivial dtor
-    { static constinit NodeHandle static_handle{}; }
+    {
+        static constinit NodeHandle static_handle{};
+    }
 #endif // ^^^ _HAS_CXX20 ^^^
 #endif // ^^^ no workaround ^^^
 

--- a/tests/std/tests/P0083R3_splicing_maps_and_sets/test.cpp
+++ b/tests/std/tests/P0083R3_splicing_maps_and_sets/test.cpp
@@ -155,10 +155,12 @@ void test_node_handle(NodeHandle& nh1, NodeHandle& nh2, Validator1 v1, Validator
     CHECK_EMPTY(NodeHandle{});
 #ifndef _M_CEE // TRANSITION, VSO-1664382
 #if _HAS_CXX20
-#pragma warning(suppress : 4640) // C4640 emitted by MSVC because 'NodeHandle' type has non-trivial dtor
+#pragma warning(push)
+#pragma warning(disable : 4640) // C4640 emitted by MSVC because 'NodeHandle' type has non-trivial dtor
     {
         static constinit NodeHandle static_handle{};
     }
+#pragma warning(pop)
 #endif // ^^^ _HAS_CXX20 ^^^
 #endif // ^^^ no workaround ^^^
 

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -1267,7 +1267,9 @@ void test_directory_iterator_common_parts(const string_view typeName) {
 
     // DirectoryIterator() noexcept;
     // ~DirectoryIterator();
-    { DirectoryIterator default_ctor; }
+    {
+        DirectoryIterator default_ctor;
+    }
 
     // explicit DirectoryIterator(const path& _Path_arg);
     // DirectoryIterator(const path& _Path_arg, directory_options _Options_arg);

--- a/tests/std/tests/P0220R1_string_view/test.cpp
+++ b/tests/std/tests/P0220R1_string_view/test.cpp
@@ -1284,20 +1284,14 @@ namespace test_lwg_3950 {
     template <class Traits>
     concept characterized_traits = requires { typename Traits::is_characterized; };
 
-#ifdef __clang__ // TRANSITION, LLVM-75404
-#define CONST_PARAM const
-#else // ^^^ workaround / no workaround vvv
-#define CONST_PARAM
-#endif // ^^^ no workaround ^^^
-
     template <class CharT, characterized_traits Traits>
-    constexpr bool operator==(CONST_PARAM basic_string_view<CharT, Traits> x,
-        CONST_PARAM type_identity_t<basic_string_view<CharT, Traits>> y) noexcept {
+    constexpr bool operator==(
+        basic_string_view<CharT, Traits> x, type_identity_t<basic_string_view<CharT, Traits>> y) noexcept {
         return x.size() == y.size() && x.compare(y) == 0;
     }
     template <class CharT, characterized_traits Traits>
-    constexpr get_string_comparison_category_t<Traits> operator<=>(CONST_PARAM basic_string_view<CharT, Traits> x,
-        CONST_PARAM type_identity_t<basic_string_view<CharT, Traits>> y) noexcept {
+    constexpr get_string_comparison_category_t<Traits> operator<=>(
+        basic_string_view<CharT, Traits> x, type_identity_t<basic_string_view<CharT, Traits>> y) noexcept {
         return static_cast<get_string_comparison_category_t<Traits>>(x.compare(y) <=> 0);
     }
 

--- a/tests/std/tests/P0288R9_move_only_function/test.cpp
+++ b/tests/std/tests/P0288R9_move_only_function/test.cpp
@@ -214,16 +214,17 @@ void test_assign() {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wself-move"
 #endif // __clang__
+#pragma warning(push)
+#pragma warning(disable : 26800) // use a moved-from object
     {
         test_function_t f1{small_callable{}};
         test_function_t f2{large_callable{}};
         f1 = move(f1); // deliberate self-move as a test case
-#pragma warning(suppress : 26800) // use a moved-from object
         assert(f1(23, x) == 38);
         f2 = move(f2); // deliberate self-move as a test case
-#pragma warning(suppress : 26800) // use a moved-from object
         assert(f2(23, x) == 39);
     }
+#pragma warning(pop)
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif // __clang__
@@ -294,9 +295,11 @@ void test_empty() {
     assert(nullptr == no_callable);
 
     test_function_t no_callable_moved = move(no_callable);
-#pragma warning(suppress : 26800) // use a moved-from object
+#pragma warning(push)
+#pragma warning(disable : 26800) // use a moved-from object
     assert(!no_callable);
     assert(no_callable == nullptr);
+#pragma warning(pop)
     assert(!no_callable_moved);
     assert(no_callable_moved == nullptr);
 }
@@ -339,9 +342,11 @@ void test_inner() {
     move_only_function<short(long, long)> f1(nullptr);
     move_only_function<int(int, int)> f2 = move(f1);
     assert(!f2);
-#pragma warning(suppress : 26800) // use a moved-from object
+#pragma warning(push)
+#pragma warning(disable : 26800) // use a moved-from object
     f2 = move(f1);
     assert(!f1);
+#pragma warning(pop)
 }
 
 
@@ -498,8 +503,10 @@ static_assert(is_same_v<move_only_function<int(char*) const && noexcept>::result
 
 bool fail_allocations = false;
 
-#pragma warning(suppress : 28251) // Inconsistent annotation for 'new': this instance has no annotations.
+#pragma warning(push)
+#pragma warning(disable : 28251) // Inconsistent annotation for 'new': this instance has no annotations.
 void* operator new(size_t size) {
+#pragma warning(pop)
     if (fail_allocations) {
         throw bad_alloc{};
     }

--- a/tests/std/tests/P0414R2_shared_ptr_for_arrays/test.cpp
+++ b/tests/std/tests/P0414R2_shared_ptr_for_arrays/test.cpp
@@ -236,11 +236,11 @@ void test_shared_ptr_all_copy_ctors() {
         const shared_ptr<const string[4]>&>); // GOOD: known-to-unknown is compatible
 
     STATIC_ASSERT(!is_constructible_v<shared_ptr<const string[4]>,
-                  const shared_ptr<string[]>&>); // BAD: unknown-to-known isn't allowed
+        const shared_ptr<string[]>&>); // BAD: unknown-to-known isn't allowed
     STATIC_ASSERT(
         is_nothrow_constructible_v<shared_ptr<const string[4]>, const shared_ptr<string[4]>&>); // GOOD: adds const
     STATIC_ASSERT(!is_constructible_v<shared_ptr<const string[4]>,
-                  const shared_ptr<const string[]>&>); // BAD: unknown-to-known isn't allowed
+        const shared_ptr<const string[]>&>); // BAD: unknown-to-known isn't allowed
     STATIC_ASSERT(is_nothrow_constructible_v<shared_ptr<const string[4]>,
         const shared_ptr<const string[4]>&>); // GOOD: same (plain, not converting)
 
@@ -297,7 +297,7 @@ void test_shared_ptr_all_move_ctors() {
         !is_constructible_v<shared_ptr<const string[4]>, shared_ptr<string[]>>); // BAD: unknown-to-known isn't allowed
     STATIC_ASSERT(is_nothrow_constructible_v<shared_ptr<const string[4]>, shared_ptr<string[4]>>); // GOOD: adds const
     STATIC_ASSERT(!is_constructible_v<shared_ptr<const string[4]>,
-                  shared_ptr<const string[]>>); // BAD: unknown-to-known isn't allowed
+        shared_ptr<const string[]>>); // BAD: unknown-to-known isn't allowed
     STATIC_ASSERT(is_nothrow_constructible_v<shared_ptr<const string[4]>,
         shared_ptr<const string[4]>>); // GOOD: same (plain, not converting)
 
@@ -351,10 +351,10 @@ void test_shared_ptr_weak_ctor() {
         const weak_ptr<const string[4]>&>); // GOOD: known-to-unknown is compatible
 
     STATIC_ASSERT(!is_constructible_v<shared_ptr<const string[4]>,
-                  const weak_ptr<string[]>&>); // BAD: unknown-to-known isn't allowed
+        const weak_ptr<string[]>&>); // BAD: unknown-to-known isn't allowed
     STATIC_ASSERT(is_constructible_v<shared_ptr<const string[4]>, const weak_ptr<string[4]>&>); // GOOD: adds const
     STATIC_ASSERT(!is_constructible_v<shared_ptr<const string[4]>,
-                  const weak_ptr<const string[]>&>); // BAD: unknown-to-known isn't allowed
+        const weak_ptr<const string[]>&>); // BAD: unknown-to-known isn't allowed
     STATIC_ASSERT(is_constructible_v<shared_ptr<const string[4]>, const weak_ptr<const string[4]>&>); // GOOD: same
 
     impl_shared_ptr_weak_ctor<string[], string[]>();
@@ -406,7 +406,7 @@ void test_shared_ptr_unique_ctor() {
     STATIC_ASSERT(
         !is_constructible_v<shared_ptr<const string[4]>, unique_ptr<string[]>>); // BAD: unknown-to-known isn't allowed
     STATIC_ASSERT(!is_constructible_v<shared_ptr<const string[4]>,
-                  unique_ptr<const string[]>>); // BAD: unknown-to-known isn't allowed
+        unique_ptr<const string[]>>); // BAD: unknown-to-known isn't allowed
 
     impl_shared_ptr_unique_ctor<string[], string[]>();
     impl_shared_ptr_unique_ctor<const string[], string[]>();
@@ -678,11 +678,11 @@ void test_weak_ptr_all_copy_ctors_and_shared_ctor() {
         const weak_ptr<const string[4]>&>); // GOOD: known-to-unknown is compatible
 
     STATIC_ASSERT(!is_constructible_v<weak_ptr<const string[4]>,
-                  const weak_ptr<string[]>&>); // BAD: unknown-to-known isn't allowed
+        const weak_ptr<string[]>&>); // BAD: unknown-to-known isn't allowed
     STATIC_ASSERT(
         is_nothrow_constructible_v<weak_ptr<const string[4]>, const weak_ptr<string[4]>&>); // GOOD: adds const
     STATIC_ASSERT(!is_constructible_v<weak_ptr<const string[4]>,
-                  const weak_ptr<const string[]>&>); // BAD: unknown-to-known isn't allowed
+        const weak_ptr<const string[]>&>); // BAD: unknown-to-known isn't allowed
     STATIC_ASSERT(is_nothrow_constructible_v<weak_ptr<const string[4]>,
         const weak_ptr<const string[4]>&>); // GOOD: same (plain, not converting)
 
@@ -708,11 +708,11 @@ void test_weak_ptr_all_copy_ctors_and_shared_ctor() {
         const shared_ptr<const string[4]>&>); // GOOD: known-to-unknown is compatible
 
     STATIC_ASSERT(!is_constructible_v<weak_ptr<const string[4]>,
-                  const shared_ptr<string[]>&>); // BAD: unknown-to-known isn't allowed
+        const shared_ptr<string[]>&>); // BAD: unknown-to-known isn't allowed
     STATIC_ASSERT(
         is_nothrow_constructible_v<weak_ptr<const string[4]>, const shared_ptr<string[4]>&>); // GOOD: adds const
     STATIC_ASSERT(!is_constructible_v<weak_ptr<const string[4]>,
-                  const shared_ptr<const string[]>&>); // BAD: unknown-to-known isn't allowed
+        const shared_ptr<const string[]>&>); // BAD: unknown-to-known isn't allowed
     STATIC_ASSERT(
         is_nothrow_constructible_v<weak_ptr<const string[4]>, const shared_ptr<const string[4]>&>); // GOOD: same
 
@@ -768,7 +768,7 @@ void test_weak_ptr_all_move_ctors() {
         !is_constructible_v<weak_ptr<const string[4]>, weak_ptr<string[]>>); // BAD: unknown-to-known isn't allowed
     STATIC_ASSERT(is_nothrow_constructible_v<weak_ptr<const string[4]>, weak_ptr<string[4]>>); // GOOD: adds const
     STATIC_ASSERT(!is_constructible_v<weak_ptr<const string[4]>,
-                  weak_ptr<const string[]>>); // BAD: unknown-to-known isn't allowed
+        weak_ptr<const string[]>>); // BAD: unknown-to-known isn't allowed
     STATIC_ASSERT(is_nothrow_constructible_v<weak_ptr<const string[4]>,
         weak_ptr<const string[4]>>); // GOOD: same (plain, not converting)
 

--- a/tests/std/tests/P0433R2_deduction_guides/test.cpp
+++ b/tests/std/tests/P0433R2_deduction_guides/test.cpp
@@ -710,8 +710,7 @@ void test_set_or_multiset() {
 }
 
 template <template <typename K, typename V, typename H = hash<K>, typename P = equal_to<K>,
-    typename A = allocator<pair<const K, V>>>
-    typename UM>
+    typename A = allocator<pair<const K, V>>> typename UM>
 void test_unordered_map_or_unordered_multimap() {
     using Purr          = pair<long, char>;
     using CPurr         = pair<const long, char>;

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -147,7 +147,6 @@ void test_simple_formatting() {
     assert(output_string == STR("true a 0 0 0 s sv 0x0 0x0"));
 
     // Test formatting basic_string(_view) with non-Standard traits_type
-    // TRANSITION, LLVM-54051, DevCom-10255929, should also test class template argument deduction for alias templates
     output_string.clear();
     format_to(move_only_back_inserter{output_string}, STR("{} {} {} {} {} {} {} {} {} {}"), true, charT{'a'}, 0, 0u,
         0.0, STR("s"), alternative_basic_string<charT>{STR("str")}, alternative_basic_string_view<charT>{STR("sv")},

--- a/tests/std/tests/P0674R1_make_shared_for_arrays/test.cpp
+++ b/tests/std/tests/P0674R1_make_shared_for_arrays/test.cpp
@@ -581,7 +581,9 @@ void test_allocate_shared_array_unknown_bounds() {
     assert_construct_destruct_equal();
 
     CustomAlloc<int> a5{};
-    { shared_ptr<int[]> p5 = allocate_shared_assert<int[]>(0, a5, 0u); } // p5 cannot be dereferenced
+    {
+        shared_ptr<int[]> p5 = allocate_shared_assert<int[]>(0, a5, 0u);
+    } // p5 cannot be dereferenced
     assert_construct_destruct_equal();
 
     {

--- a/tests/std/tests/P0896R4_common_iterator/test.cpp
+++ b/tests/std/tests/P0896R4_common_iterator/test.cpp
@@ -330,7 +330,7 @@ void test_lwg_3749() { // COMPILE-ONLY
 
     using large_unbounded_iota = decltype(views::iota(42ull));
     static_assert(!common_iterator_has_iterator_category<ranges::iterator_t<large_unbounded_iota>,
-                  ranges::sentinel_t<large_unbounded_iota>>);
+        ranges::sentinel_t<large_unbounded_iota>>);
 }
 
 // Validate that _Variantish works when fed with a non-trivially-destructible type

--- a/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.compile.pass.cpp
+++ b/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.compile.pass.cpp
@@ -1071,7 +1071,7 @@ namespace special_memory_concepts {
     static_assert(
         _No_throw_sentinel_for<sentinel_archetype<sentinel_status::yes>, iterator_archetype<iterator_status::input>>);
     static_assert(!_No_throw_sentinel_for<iterator_archetype<iterator_status::input>,
-                  iterator_archetype<iterator_status::input>>);
+        iterator_archetype<iterator_status::input>>);
     static_assert(_No_throw_sentinel_for<iterator_archetype<iterator_status::forward>,
         iterator_archetype<iterator_status::forward>>);
 

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -3481,7 +3481,7 @@ namespace move_iterator_test {
     static_assert(
         !has_greater_eq<move_iterator<simple_random_iter<sentinel_base>>, move_sentinel<std::default_sentinel_t>>);
     static_assert(!three_way_comparable<move_iterator<simple_random_iter<sentinel_base>>,
-                  move_sentinel<std::default_sentinel_t>>);
+        move_sentinel<std::default_sentinel_t>>);
 
     // GH-3014 "<ranges>: list-initialization is misused"
     void test_gh_3014() { // COMPILE-ONLY

--- a/tests/std/tests/P0896R4_views_iota/test.cpp
+++ b/tests/std/tests/P0896R4_views_iota/test.cpp
@@ -346,7 +346,7 @@ static_assert(!CanUnaryViewsIota<ranges::iota_view<ranges::iterator_t<ranges::io
 static_assert(!CanUnaryViewsIota<ranges::iota_view<int, int>>);
 static_assert(!CanUnaryViewsIota<ranges::iota_view<const char*, const char*>>);
 static_assert(!CanUnaryViewsIota<ranges::iota_view<ranges::iterator_t<ranges::iota_view<long long>>,
-                  ranges::iterator_t<ranges::iota_view<long long>>>>);
+        ranges::iterator_t<ranges::iota_view<long long>>>>);
 
 int main() {
     // Validate standard signed integer types

--- a/tests/std/tests/P0898R3_concepts/invocable_cc.hpp
+++ b/tests/std/tests/P0898R3_concepts/invocable_cc.hpp
@@ -554,8 +554,8 @@ void NAME() {
         static_assert(test<PMF1PCVR, S&, int, long>());
 
         using PMF0RR  = int (MCALLCONV S::*)()&&;
-        using PMF1RR  = int* (MCALLCONV S::*) (long)&&;
-        using PMF2RR  = int& (MCALLCONV S::*) (long, int)&&;
+        using PMF1RR  = int* (MCALLCONV S::*) (long) &&;
+        using PMF2RR  = int& (MCALLCONV S::*) (long, int) &&;
         using PMF1PRR = int const& (S::*) (int, ...)&&;
         static_assert(test<PMF0RR, S>());
         static_assert(!test<PMF0RR, S&>());

--- a/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
@@ -63,7 +63,7 @@ class CustomTestFormat(STLTestFormat):
             if noisyProgress:
                 print('Scanning dependencies...')
             cmd = [test.cxx, *test.flags, *test.compileFlags, *clOptions, '/scanDependencies', '.\\',
-                '/shallowScan', # TRANSITION, VSO-2293247 fixed in VS 2022 17.13 Preview 3 (remove /shallowScan)
+                '/shallowScan', # TRANSITION, VSO-2293247 fixed in VS 2022 17.13 Preview 4 (remove /shallowScan)
                 *allHeaders]
             yield TestStep(cmd, shared.execDir, shared.env, False)
 

--- a/tests/std/tests/P2165R4_tuple_like_relational_operators/test.compile.pass.cpp
+++ b/tests/std/tests/P2165R4_tuple_like_relational_operators/test.compile.pass.cpp
@@ -59,7 +59,7 @@ constexpr bool test() {
         static_assert(verify_comparisons<tuple<int, int>, pair<int, int>>);
         static_assert(!verify_comparisons<tuple<int, int>, pair<int, Incomparable>>);
         static_assert(!verify_comparisons<tuple<int*, int*>,
-                      subrange<int*, int*>>); // subrange does not model equality_comparable
+            subrange<int*, int*>>); // subrange does not model equality_comparable
 
         static_assert(tuple{1, 2} == array<int, 2>{1, 2});
         static_assert(tuple<int, int>{2, 1} != array<int, 2>{1, 2});

--- a/tests/std/tests/P2278R4_views_as_const/test.cpp
+++ b/tests/std/tests/P2278R4_views_as_const/test.cpp
@@ -342,16 +342,20 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         const same_as<iterator_t<R>> auto i = r.begin();
         if (!is_empty) {
             // (static analyzer doesn't realize that `i == nullptr` implies `is_empty`)
-#pragma warning(suppress : 6011) // Dereferencing NULL pointer 'i'
+#pragma warning(push)
+#pragma warning(disable : 6011) // Dereferencing NULL pointer 'i'
             assert(*i == *begin(expected));
+#pragma warning(pop)
         }
 
         if constexpr (copy_constructible<V>) {
             auto r2                              = r;
             const same_as<iterator_t<R>> auto i2 = r2.begin();
             if (!is_empty) {
-#pragma warning(suppress : 6011) // Dereferencing NULL pointer 'i'
+#pragma warning(push)
+#pragma warning(disable : 6011) // Dereferencing NULL pointer 'i'
                 assert(*i2 == *i);
+#pragma warning(pop)
             }
         }
     }
@@ -361,16 +365,20 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     if constexpr (CanMemberBegin<const R>) {
         const same_as<iterator_t<const R>> auto ci = as_const(r).begin();
         if (!is_empty) {
-#pragma warning(suppress : 6011) // Dereferencing NULL pointer 'i'
+#pragma warning(push)
+#pragma warning(disable : 6011) // Dereferencing NULL pointer 'i'
             assert(*ci == *begin(expected));
+#pragma warning(pop)
         }
 
         if constexpr (copy_constructible<V>) {
             const auto cr2                              = r;
             const same_as<iterator_t<const R>> auto ci2 = cr2.begin();
             if (!is_empty) {
-#pragma warning(suppress : 6011) // Dereferencing NULL pointer 'i'
+#pragma warning(push)
+#pragma warning(disable : 6011) // Dereferencing NULL pointer 'i'
                 assert(*ci2 == *ci);
+#pragma warning(pop)
             }
         }
     }

--- a/tests/std/tests/P2474R2_views_repeat/test.cpp
+++ b/tests/std/tests/P2474R2_views_repeat/test.cpp
@@ -284,10 +284,6 @@ struct forward_tester {
 };
 
 struct tuple_tester {
-#ifdef __EDG__ // TRANSITION, VSO-1898933
-    template <class Arg1, class Arg2>
-    constexpr tuple_tester(Arg1&& arg1, Arg2&& arg2) : y(forward<Arg1>(arg1)), z(forward<Arg2>(arg2)) {}
-#endif // ^^^ workaround ^^^
     forward_tester y;
     forward_tester z;
 };

--- a/tests/std/tests/P2502R2_generator/test.cpp
+++ b/tests/std/tests/P2502R2_generator/test.cpp
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#if defined(__clang__) && defined(_M_IX86) // TRANSITION, LLVM-56507
+int main() {}
+#else // ^^^ workaround / no workaround vvv
+
 #include <algorithm>
 #include <array>
 #include <atomic>
@@ -152,7 +156,6 @@ void test_weird_reference_types() {
         assert(pos == r.end());
     }
 
-#if !(defined(__clang__) && defined(_M_IX86)) // TRANSITION, LLVM-56507
     { // Test with mutable rvalue reference type
         constexpr size_t segment_size = 16;
         auto woof                     = []() -> generator<vector<int>&&> {
@@ -169,10 +172,8 @@ void test_weird_reference_types() {
             assert(vec.size() == segment_size);
         }
     }
-#endif // ^^^ no workaround ^^^
 }
 
-#if !(defined(__clang__) && defined(_M_IX86)) // TRANSITION, LLVM-56507
 generator<int> iota_repeater(const int hi, const int depth) {
     if (depth > 0) {
         co_yield ranges::elements_of(iota_repeater(hi, depth - 1));
@@ -244,7 +245,6 @@ void adl_proof_test() {
     }
     assert(i == 42);
 }
-#endif // ^^^ no workaround ^^^
 #endif // ^^^ no workaround ^^^
 
 // Verify behavior with unerased allocator types
@@ -401,7 +401,6 @@ int main() {
     assert(ranges::equal(co_upto(6), views::iota(0, 6)));
     zip_example();
     test_weird_reference_types();
-#if !(defined(__clang__) && defined(_M_IX86)) // TRANSITION, LLVM-56507
     recursive_test();
     arbitrary_range_test();
 
@@ -409,10 +408,10 @@ int main() {
     // Verify generation of a range of pointers-to-incomplete
     adl_proof_test();
 #endif // ^^^ no workaround ^^^
-#endif // ^^^ no workaround ^^^
 
     // Allocator tests
     static_allocator_test();
     dynamic_allocator_test();
     pmr_generator_test();
 }
+#endif // ^^^ no workaround ^^^

--- a/tests/std/tests/P2502R2_generator_death/test.cpp
+++ b/tests/std/tests/P2502R2_generator_death/test.cpp
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#if defined(__clang__) && defined(_M_IX86) // TRANSITION, LLVM-56507
+int main() {}
+#else // ^^^ workaround / no workaround vvv
+
 #define _CONTAINER_DEBUG_LEVEL 1
 
 #include <generator>
@@ -48,3 +52,4 @@ int main(int argc, char** argv) {
 
     return exec.run(argc, argv);
 }
+#endif // ^^^ no workaround ^^^

--- a/tests/std/tests/P2502R2_generator_iterator/test.cpp
+++ b/tests/std/tests/P2502R2_generator_iterator/test.cpp
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#if defined(__clang__) && defined(_M_IX86) // TRANSITION, LLVM-56507
+int main() {}
+#else // ^^^ workaround / no workaround vvv
+
 #include <cassert>
 #include <concepts>
 #include <cstddef>
@@ -46,14 +50,12 @@ generator<Ref, V, Alloc> generate_one() {
     }
 }
 
-#if !(defined(__clang__) && defined(_M_IX86)) // TRANSITION, LLVM-56507
 template <class Ref, class V, class Alloc>
 generator<Ref, V, Alloc> generate_one_recursively() {
     co_yield ranges::elements_of{generate_zero<Ref, V, Alloc>()};
     co_yield ranges::elements_of{generate_one<Ref, V, Alloc>()};
     co_yield ranges::elements_of{generate_zero<Ref, V, Alloc>()};
 }
-#endif // ^^^ no workaround ^^^
 
 template <class Ref, class V = void, class Alloc = void>
 void test_one() {
@@ -103,7 +105,6 @@ void test_one() {
         }
     }
 
-#if !(defined(__clang__) && defined(_M_IX86)) // TRANSITION, LLVM-56507
     { // Test pre-incrementation
         auto g = generate_one_recursively<Ref, V, Alloc>();
         auto i = g.begin();
@@ -121,7 +122,6 @@ void test_one() {
 
         static_assert(is_void_v<decltype(i++)>);
     }
-#endif // ^^^ no workaround ^^^
 
     { // Test equal operator
         auto g1 = generate_one<Ref, V, Alloc>();
@@ -172,3 +172,4 @@ int main() {
     test_with_type<string>();
     test_with_type<MoveOnly>();
 }
+#endif // ^^^ no workaround ^^^

--- a/tests/std/tests/VSO_0000000_any_calling_conventions/a.cpp
+++ b/tests/std/tests/VSO_0000000_any_calling_conventions/a.cpp
@@ -20,7 +20,9 @@ int __cdecl main() {
         // copy / move / destroy it as well.
         std::any a = f(small_but_nontrivial{});
         std::any b = a;
-        { std::any c = std::move(a); }
+        {
+            std::any c = std::move(a);
+        }
     }
 
     assert(small_but_nontrivial::constructions == small_but_nontrivial::destructions);

--- a/tests/std/tests/VSO_0000000_any_calling_conventions/b.cpp
+++ b/tests/std/tests/VSO_0000000_any_calling_conventions/b.cpp
@@ -8,6 +8,8 @@
 
 std::any __cdecl f(std::any a) {
     std::any b = a;
-    { std::any c = std::move(a); }
+    {
+        std::any c = std::move(a);
+    }
     return small_but_nontrivial{};
 }

--- a/tests/std/tests/VSO_0000000_more_pair_tuple_sfinae/test.cpp
+++ b/tests/std/tests/VSO_0000000_more_pair_tuple_sfinae/test.cpp
@@ -520,7 +520,7 @@ STATIC_ASSERT(!is_constructible_v<tuple<int, int, int>, allocator_arg_t, allocat
 STATIC_ASSERT(
     is_constructible_v<tuple<int, int, int>, allocator_arg_t, allocator<int>, const int&, const int&, const int&>);
 STATIC_ASSERT(!is_constructible_v<tuple<int, int, int>, allocator_arg_t, allocator<int>, const int&, const int&,
-              const int&, const int&>);
+    const int&, const int&>);
 
 STATIC_ASSERT(!is_constructible_v<tuple<int, int, int>, allocator_arg_t, allocator<int>, short, short>);
 STATIC_ASSERT(is_constructible_v<tuple<int, int, int>, allocator_arg_t, allocator<int>, short, short, short>);

--- a/tests/std/tests/VSO_0000000_string_view_idl/test.cpp
+++ b/tests/std/tests/VSO_0000000_string_view_idl/test.cpp
@@ -187,13 +187,17 @@ void test_case_remove_suffix_incompatible() {
 void test_case_Copy_s() {
     string_view sv("text");
     char buffer[2];
-#pragma warning(suppress : 28020) // yay PREfast catches this mistake at compile time!
+#pragma warning(push)
+#pragma warning(disable : 28020) // yay PREfast catches this mistake at compile time!
     sv._Copy_s(buffer, 2, 4); // CRT invalid parameter handler (memcpy_s failed)
+#pragma warning(pop)
 }
 
 void test_case_null_constructor() {
-#pragma warning(suppress : 6387) // yay PREfast catches this mistake at compile time!
+#pragma warning(push)
+#pragma warning(disable : 6387) // yay PREfast catches this mistake at compile time!
     string_view sv(nullptr, 1); // non-zero size null string_view
+#pragma warning(pop)
     (void) sv;
 }
 

--- a/tests/std/tests/VSO_0512710_terminate_current_exception_from_noexcept_function/test.cpp
+++ b/tests/std/tests/VSO_0512710_terminate_current_exception_from_noexcept_function/test.cpp
@@ -29,8 +29,10 @@ using namespace std;
 #pragma clang diagnostic ignored "-Wexceptions"
 #endif // __clang__
 void meow() noexcept {
-#pragma warning(suppress : 4297) // 'meow': function assumed not to throw an exception but does
+#pragma warning(push)
+#pragma warning(disable : 4297) // 'meow': function assumed not to throw an exception but does
     throw runtime_error("Runtime error happened");
+#pragma warning(pop)
 }
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/tests/std/tests/VSO_0512710_terminate_current_exception_from_noexcept_function_2/test.cpp
+++ b/tests/std/tests/VSO_0512710_terminate_current_exception_from_noexcept_function_2/test.cpp
@@ -30,8 +30,10 @@ using namespace std;
 #endif // __clang__
 struct A {
     ~A() noexcept {
-#pragma warning(suppress : 4297) // function assumed not to throw an exception but does
+#pragma warning(push)
+#pragma warning(disable : 4297) // function assumed not to throw an exception but does
         throw runtime_error("Runtime error happened");
+#pragma warning(pop)
     }
 };
 #ifdef __clang__

--- a/tests/std/tests/VSO_0830211_container_debugging_range_checks/test.cpp
+++ b/tests/std/tests/VSO_0830211_container_debugging_range_checks/test.cpp
@@ -163,8 +163,10 @@ struct TestCases {
 
     static void test_case_operator_subscript_out_of_range() {
         ContainerType a{false, true, false, true};
-#pragma warning(suppress : 28020) // Yay sometimes PREfast catches this one at compile time!
+#pragma warning(push)
+#pragma warning(disable : 28020) // Yay sometimes PREfast catches this one at compile time!
         (void) a[Traits::zero_offset + 4];
+#pragma warning(pop)
     }
 
     static void test_case_front_empty() {

--- a/tests/std/tests/VSO_1925201_iter_traits/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_1925201_iter_traits/test.compile.pass.cpp
@@ -42,7 +42,5 @@ static_assert(same_as<void, decltype(next(nil, 42))>);
 static_assert(same_as<void, decltype(prev(nil))>);
 static_assert(same_as<void, decltype(prev(nil, 42))>);
 
-#ifndef __clang__ // TRANSITION, LLVM-75404
 static_assert(same_as<void, decltype(shift_left(nil, nil, 42))>);
 static_assert(same_as<void, decltype(shift_right(nil, nil, 42))>);
-#endif // ^^^ no workaround ^^^

--- a/tests/tr1/include/tfuns.h
+++ b/tests/tr1/include/tfuns.h
@@ -332,8 +332,10 @@ int res[] = { // results
 
 #define RESULT(n, o) (res[n + o] - res[o])
 
-#define CALL0(fobj) \
-    { CHECK_INT(fobj(), 1); }
+#define CALL0(fobj)           \
+    {                         \
+        CHECK_INT(fobj(), 1); \
+    }
 #define CALL1x(fobj, funobj)                   \
     {                                          \
         for (int i = 0; i < 10; ++i) {         \

--- a/tests/tr1/include/tfuns.h
+++ b/tests/tr1/include/tfuns.h
@@ -269,8 +269,8 @@ typedef int (funobj::*cvmf8)(int, int, int, int, int, int, int) const volatile;
 typedef int (funobj::*cvmf9)(int, int, int, int, int, int, int, int) const volatile;
 typedef int (funobj::*cvmf10)(int, int, int, int, int, int, int, int, int) const volatile;
 
-typedef int funobj::*md0;
-typedef int* funobj::*md1;
+typedef int funobj::* md0;
+typedef int* funobj::* md1;
 
 struct sp { // simplistic smart pointer
     sp(funobj& f) : ptr(&f) {}

--- a/tests/tr1/include/typetr.h
+++ b/tests/tr1/include/typetr.h
@@ -169,10 +169,10 @@ union U { // dummy union
     double d;
 };
 
-typedef int B::*pmo;
-typedef const int B::*pmoc;
-typedef volatile int B::*pmov;
-typedef const volatile int B::*pmocv;
+typedef int B::* pmo;
+typedef const int B::* pmoc;
+typedef volatile int B::* pmov;
+typedef const volatile int B::* pmocv;
 typedef void (B::*pmf)();
 typedef void (B::*pmfc)() const;
 typedef void (B::*pmfv)() volatile;

--- a/tests/tr1/tests/memory3/test.cpp
+++ b/tests/tr1/tests/memory3/test.cpp
@@ -355,7 +355,7 @@ void t_allocator_traits() { // test allocator_traits
             Mytraits::deallocate(myal, pch, 1);
         }
 
-        CHECK(Mytraits::max_size(myal) == (STD size_t)(-1));
+        CHECK(Mytraits::max_size(myal) == static_cast<STD size_t>(-1));
         CHECK(Mytraits::select_on_container_copy_construction(myal) == myal);
     }
 
@@ -386,7 +386,7 @@ void t_allocator_traits() { // test allocator_traits
         CHECK_INT(*pch, 'x');
         Mytraits::destroy(myal, pch);
         Mytraits::deallocate(myal, pch, 1);
-        CHECK(Mytraits::max_size(myal) == (STD size_t)(-1));
+        CHECK(Mytraits::max_size(myal) == static_cast<STD size_t>(-1));
         CHECK(Mytraits::select_on_container_copy_construction(myal) == myal);
     }
 }

--- a/tests/tr1/tests/scoped_allocator/test.cpp
+++ b/tests/tr1/tests/scoped_allocator/test.cpp
@@ -151,7 +151,7 @@ void t_minimal() { // test against minimal allocator
     myal.destroy(pch);
     myal.deallocate(pch, 1);
 
-    CHECK(myal.max_size() == (STD size_t)(-1));
+    CHECK(myal.max_size() == static_cast<STD size_t>(-1));
     CHECK(myal.select_on_container_copy_construction() == myal);
 }
 

--- a/tools/format/CMakeLists.txt
+++ b/tools/format/CMakeLists.txt
@@ -18,7 +18,7 @@ execute_process(
 )
 
 if(clang_format_version MATCHES "clang-format version ([0-9]+\.[0-9]+\.[0-9]+)")
-    set(expected_version "18.1.8")
+    set(expected_version "19.1.1")
     if(CMAKE_MATCH_1 VERSION_LESS expected_version)
         message(FATAL_ERROR "Found clang-format: ${CLANG_FORMAT} (\"${CMAKE_MATCH_1}\", older than expected version \"${expected_version}\")")
     elseif(CMAKE_MATCH_1 VERSION_EQUAL expected_version)


### PR DESCRIPTION
Fixes #4710.

# :scroll: Changelog

- Code cleanups:
  * Removed compiler bug workarounds.
- Infrastructure improvements:
  * Updated dependencies.
    + Updated build compiler to VS 2022 17.13 Preview 3.
    + Updated Clang to 19.1.1 (now required).

# :gear: Commits

* For CUDA, add '-n' (no reboot) and limit installed components to 'nvcc_12.4'.
  + This makes the installation significantly faster, and prevents the installer from hanging (which started happening in this toolset update for unknown reasons).
* New pool.
* VS 2022 17.13 Preview 3 (not yet required).
  + We still can't require 17.13 due to the MSVC-internal toolset not having been updated yet.
* Clang 19 (required).
* EDG: Remove workaround for VSO-1898933.
* EDG: Remove workarounds for DevCom-10678753.
* Clang: Expand workarounds for LLVM-56507.
  + This has gotten significantly worse, so I'm skipping the entire tests now. It's limited to Clang x86, so I don't care about the loss of coverage.
* Clang: Remove workarounds for LLVM-75404.
* Clang: Remove workarounds for what was thought to be LLVM-61763.
* Clang: Remove workarounds in libcxx/expected_results.txt.
* C1XX: Reported VSO-2338829.
* C1XX: Reported VSO-2338880.
* C1XX: Record DevCom-10808176 as fixed in 17.14 Preview 1.
* VCRuntime: Record DevCom-10373274 as fixed in 17.14 Preview 1.
* C1XX: Record VSO-2293247 as fixed in 17.13 Preview 4.
  + 17.13 Preview 3 didn't contain any MSVC toolset changes (only EDG and Clang), hence the delay.
* LLVM-54051 was fixed, but this should be a perma-workaround.
  + Testing CTAD for alias templates is something for a compiler test suite. It isn't relevant to how `<format>` works, and the specific way we're constructing temporaries with braces would pose problems if we tried to use CTAD (as we could deduce `basic_string<const char *>` which is bogus).
* Expect clang-format 19.1.1.
* Update .clang-format defaults.
* New option: Drop empty lines at start of file.
  + This doesn't result in any changes now, but will prevent such empty lines from being added in the future.
* Add parens to avoid clang-format inserting icky spaces.
* Suppress clang-format to avoid functional damage and poor formatting.
* Change C casts to `static_cast`s in tr1, to avoid clang-format inserting spaces.
  + We don't usually clean up tr1, but these are tiny and C casts are icky.
* clang-format, no manual changes: Improve CTAD.
* clang-format, no manual changes: Add spaces to pointers to members.
* clang-format, no manual changes: Put braces on separate lines.
* clang-format, no manual changes: Decrease indentation when wrapping (with a tiny bit of rewrapping).
* clang-format, no manual changes: Slightly adjust how multi-line for-loops are indented.
* clang-format, no manual changes: Reasonable rewrapping.
* Change ALL pragma warning suppress to push-disable-pop in test code.
  + Sometimes expanding the scope slightly for clarity. This is because clang-format changed one line into three, breaking the suppress in `P0083R3_splicing_maps_and_sets`.
We already cleaned up the product code to avoid this waste of time, in #3069 on 2022-09-03.
* Restore MSVC-internal skips for ADDITIONAL_COMPILE_FLAGS.
  + These were marked as "These tests also need ADDITIONAL_COMPILE_FLAGS to silence warnings, but only for Clang 18" but this still repros with Clang 19. (They emit `-Wmissing-designated-field-initializers` warnings that are silenced by `ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-missing-field-initializers`.) Restore them, and group them with the other skips.
* Rephrase "CONTEST / C1XX" to "MSVC".
  + "Contest" was an old MSVC-internal test harness that we no longer use, so this was confusing.

STL-ASan-CI [passed](https://dev.azure.com/vclibs/STL/_build/results?buildId=18183&view=results).
