### PR TITLE
ASan should detect writing to a `basic_string`'s reserved but uninitialized memory

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2419,7 +2419,7 @@ public:
                 _STATIC_CALL_OPERATOR { _Traits::copy(_New_ptr, _Old_ptr, _Old_size + 1); });
 
         // `_Reallocate_grow_by` calls `_ASAN_STRING_CREATE` assuming that the string
-        // has size (initialized memory) equal to it's new capacity (allocated memory).
+        // has size (initialized memory) equal to its new capacity (allocated memory).
         // This is not true for the `reserve` method, so we modify the ASan annotation.
         _ASAN_STRING_MODIFY(*this, _Mypair._Myval2._Mysize, _Old_size);
         _Mypair._Myval2._Mysize = _Old_size;
@@ -2447,7 +2447,7 @@ public:
                     _STATIC_CALL_OPERATOR { _Traits::copy(_New_ptr, _Old_ptr, _Old_size + 1); });
 
             // `_Reallocate_grow_by` calls `_ASAN_STRING_CREATE` assuming that the string
-            // has size (initialized memory) equal to it's new capacity (allocated memory).
+            // has size (initialized memory) equal to its new capacity (allocated memory).
             // This is not true for the `reserve` method, so we modify the ASan annotation.
             _ASAN_STRING_MODIFY(*this, _Mypair._Myval2._Mysize, _Old_size);
             _Mypair._Myval2._Mysize = _Old_size;

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2418,9 +2418,9 @@ public:
             [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size)
                 _STATIC_CALL_OPERATOR { _Traits::copy(_New_ptr, _Old_ptr, _Old_size + 1); });
 
-        // `_Reallocate_grow_by`calls `_ASAN_STRING_CREATE` assuming that the string
+        // `_Reallocate_grow_by` calls `_ASAN_STRING_CREATE` assuming that the string
         // has size (initialized memory) equal to it's new capacity (allocated memory).
-        // This is not true in `reserve`, so we modify the ASan annotation.
+        // This is not true for the `reserve` method, so we modify the ASan annotation.
         _ASAN_STRING_MODIFY(*this, _Mypair._Myval2._Mysize, _Old_size);
         _Mypair._Myval2._Mysize = _Old_size;
     }
@@ -2446,9 +2446,9 @@ public:
                 [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size)
                     _STATIC_CALL_OPERATOR { _Traits::copy(_New_ptr, _Old_ptr, _Old_size + 1); });
 
-            // `_Reallocate_grow_by`calls `_ASAN_STRING_CREATE` assuming that the string
+            // `_Reallocate_grow_by` calls `_ASAN_STRING_CREATE` assuming that the string
             // has size (initialized memory) equal to it's new capacity (allocated memory).
-            // This is not true in `reserve`, so we modify the ASan annotation.
+            // This is not true for the `reserve` method, so we modify the ASan annotation.
             _ASAN_STRING_MODIFY(*this, _Mypair._Myval2._Mysize, _Old_size);
             _Mypair._Myval2._Mysize = _Old_size;
             return;

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2418,6 +2418,10 @@ public:
             [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size)
                 _STATIC_CALL_OPERATOR { _Traits::copy(_New_ptr, _Old_ptr, _Old_size + 1); });
 
+        // `_Reallocate_grow_by`calls `_ASAN_STRING_CREATE` assuming that the string
+        // has size (initialized memory) equal to it's new capacity (allocated memory).
+        // This is not true in `reserve`, so we modify the ASan annotation.
+        _ASAN_STRING_MODIFY(*this, _Mypair._Myval2._Mysize, _Old_size);
         _Mypair._Myval2._Mysize = _Old_size;
     }
 
@@ -2442,6 +2446,10 @@ public:
                 [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size)
                     _STATIC_CALL_OPERATOR { _Traits::copy(_New_ptr, _Old_ptr, _Old_size + 1); });
 
+            // `_Reallocate_grow_by`calls `_ASAN_STRING_CREATE` assuming that the string
+            // has size (initialized memory) equal to it's new capacity (allocated memory).
+            // This is not true in `reserve`, so we modify the ASan annotation.
+            _ASAN_STRING_MODIFY(*this, _Mypair._Myval2._Mysize, _Old_size);
             _Mypair._Myval2._Mysize = _Old_size;
             return;
         }

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -1922,7 +1922,7 @@ void test_gh_3955() {
 void test_gh_5251() {
     // GH-5251 <string>: ASan annotations do not prevent writing to allocated
     // but uninitialized basic_string memory
-    std::basic_string<char> myString;
+    basic_string<char> myString;
     myString.reserve(100);
     char* data = &myString[0];
     data[50]   = 'A'; // ASan should fire!

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -1922,7 +1922,7 @@ void test_gh_3955() {
 void test_gh_5251() {
     // GH-5251 <string>: ASan annotations do not prevent writing to allocated
     // but uninitialized basic_string memory
-    basic_string<char> myString;
+    string myString;
     myString.reserve(100);
     char* myData = &myString[0];
     myData[50]   = 'A'; // ASan should fire!

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -1917,6 +1917,16 @@ void test_gh_3955() {
     assert(s == t);
 }
 
+void test_gh_5251() {
+    // GH-5251 <string>: ASan annotations do not prevent writing to allocated
+    // but uninitialized basic_string memory
+    std::basic_string<char> myString;
+    myString.reserve(100);
+    char* data = &myString[0];
+    data[50] = 'A';
+    // FIXME: How do I declare this as an expected failure?
+}
+
 int main() {
     run_allocator_matrix<char>();
 #ifdef __cpp_char8_t
@@ -1930,4 +1940,5 @@ int main() {
     test_DevCom_10109507();
     test_gh_3883();
     test_gh_3955();
+    test_gh_5251();
 }

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstring>
+#include <test_death.hpp>
 #include <iterator>
 #include <memory>
 #include <new>
@@ -1924,21 +1925,25 @@ void test_gh_5251() {
     myString.reserve(100);
     char* data = &myString[0];
     data[50] = 'A';
-    // FIXME: How do I declare this as an expected failure?
 }
 
-int main() {
-    run_allocator_matrix<char>();
-#ifdef __cpp_char8_t
-    run_allocator_matrix<char8_t>();
-#endif // __cpp_char8_t
-    run_allocator_matrix<char16_t>();
-    run_allocator_matrix<char32_t>();
-    run_allocator_matrix<wchar_t>();
+int main(int argc, char* argv[]) {
+    std_testing::death_test_executive exec([] {
+        run_allocator_matrix<char>();
+    #ifdef __cpp_char8_t
+        run_allocator_matrix<char8_t>();
+    #endif // __cpp_char8_t
+        run_allocator_matrix<char16_t>();
+        run_allocator_matrix<char32_t>();
+        run_allocator_matrix<wchar_t>();
 
-    test_DevCom_10116361();
-    test_DevCom_10109507();
-    test_gh_3883();
-    test_gh_3955();
-    test_gh_5251();
+        test_DevCom_10116361();
+        test_DevCom_10109507();
+        test_gh_3883();
+        test_gh_3955();
+    });
+#ifdef __SANITIZE_ADDRESS__
+    exec.add_death_tests({test_gh_5251});
+#endif // ASan instrumentation enabled
+    return exec.run(argc, argv);
 }

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -1924,7 +1924,7 @@ void test_gh_5251() {
     std::basic_string<char> myString;
     myString.reserve(100);
     char* data = &myString[0];
-    data[50] = 'A';
+    data[50] = 'A'; // ASan should fire!
 }
 
 int main(int argc, char* argv[]) {

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -15,12 +15,13 @@
 #include <cassert>
 #include <cstddef>
 #include <cstring>
-#include <test_death.hpp>
 #include <iterator>
 #include <memory>
 #include <new>
 #include <sstream>
 #include <string>
+
+#include <test_death.hpp>
 #if _HAS_CXX17
 #include <string_view>
 #endif // _HAS_CXX17
@@ -1924,15 +1925,15 @@ void test_gh_5251() {
     std::basic_string<char> myString;
     myString.reserve(100);
     char* data = &myString[0];
-    data[50] = 'A'; // ASan should fire!
+    data[50]   = 'A'; // ASan should fire!
 }
 
 int main(int argc, char* argv[]) {
     std_testing::death_test_executive exec([] {
         run_allocator_matrix<char>();
-    #ifdef __cpp_char8_t
+#ifdef __cpp_char8_t
         run_allocator_matrix<char8_t>();
-    #endif // __cpp_char8_t
+#endif // __cpp_char8_t
         run_allocator_matrix<char16_t>();
         run_allocator_matrix<char32_t>();
         run_allocator_matrix<wchar_t>();

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -1924,8 +1924,8 @@ void test_gh_5251() {
     // but uninitialized basic_string memory
     basic_string<char> myString;
     myString.reserve(100);
-    char* data = &myString[0];
-    data[50]   = 'A'; // ASan should fire!
+    char* myData = &myString[0];
+    myData[50]   = 'A'; // ASan should fire!
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->

Fixes #5251

**Problem:**

As described in the linked bug, the following program should throw under `/fsanitize=address`:

```C++
#include <vector>
#include <string>

int main()
{
    // This crashes (expectedly)
    //std::vector<int> vec;
    //vec.reserve(100);
    //vec.data()[50] = 1;

    // This does not crash (it should crash, like `vector`)
    std::basic_string<char> myString;
    myString.reserve(100);
    char* data = &myString[0];
    data[50] = 'A';
}
```

But it does not. This PR aims to fix that.

**Approach:**

The issue resides in `xstring`'s [`reserve` implementation](https://github.com/microsoft/STL/blob/9b38fb9ccca90fd8b31fd37d4512b190aeef4fe7/stl/inc/xstring#L2409-L2421), inlined below:

```C++
    constexpr void reserve(_CRT_GUARDOVERFLOW const size_type _Newcap) {
        // [... removed stuff]
        const size_type _Old_size = _Mypair._Myval2._Mysize;
        _Reallocate_grow_by(_Newcap - _Old_size,
            [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size)
                _STATIC_CALL_OPERATOR { _Traits::copy(_New_ptr, _Old_ptr, _Old_size + 1); });

        _Mypair._Myval2._Mysize = _Old_size;
        // [... removed stuff]
```

The call to [`_Reallocate_grow_by`](https://github.com/microsoft/STL/blob/9b38fb9ccca90fd8b31fd37d4512b190aeef4fe7/stl/inc/xstring#L2990-L3022) calls the ASan annotation machinery _under the assumption_ that the `size` (i.e the initialized memory) of the string equals it's capacity (i.e the allocated memory). You can see that in the following selected snippets of `_Reallocate_grow_by`:

```C++
    template <class _Fty, class... _ArgTys>
    _CONSTEXPR20 basic_string& _Reallocate_grow_by(const size_type _Size_increase, _Fty _Fn, _ArgTys... _Args) {
        // reallocate to increase size by _Size_increase elements, new buffer prepared by
        // _Fn(_New_ptr, _Old_ptr, _Old_size, _Args...)
        
        // [... removed stuff]
        const size_type _New_size     = _Old_size + _Size_increase; // << [added: assumes new size is equal to capacity]
        const size_type _Old_capacity = _My_data._Myres;
        size_type _New_capacity       = _Calculate_growth(_New_size);
        auto& _Al                     = _Getal();
        const pointer _New_ptr        = _Allocate_for_capacity(_Al, _New_capacity); // throws

        // [... removed stuff]
        _ASAN_STRING_REMOVE(*this);
        _My_data._Mysize      = _New_size;
        _My_data._Myres       = _New_capacity;
        // [... removed stuff]

        _ASAN_STRING_CREATE(*this); // [added: adjusts ASan with wrong assumption]
        return *this;
    }
```

So the _tactical_ fix is simple: To modify the ASan annotations on `reserve` after the call to `_Reallocate_grow_by`. This PR does just that.

**Investigation notes on `_Reallocate_grow_by`:**

This bug made me suspicious that maybe there were other latent ASan annotations bugs, so I did a quick search over the utilization of `_Reallocate_grow_by` in case there were other cases that seemed wrong. **Spoilers:** I found no such other cases.

Here's the callers of `_Reallocate_grow_by`, which should make it clear that it's implementation is correct in most cases.:

* [`append`](https://github.com/microsoft/STL/blob/9b38fb9ccca90fd8b31fd37d4512b190aeef4fe7/stl/inc/xstring#L1500): the aforementioned assumption makes sense here, under reallocation.
* [`insert`](https://github.com/microsoft/STL/blob/9b38fb9ccca90fd8b31fd37d4512b190aeef4fe7/stl/inc/xstring#L1776): the size = capacity assumption makes sense here, under reallocation, as well.

_The following two cases I'm less certain of, but seem ok too:_
* [`resize_and_overwrite`](https://github.com/microsoft/STL/blob/9b38fb9ccca90fd8b31fd37d4512b190aeef4fe7/stl/inc/xstring#L2379): seems right as I don't see any post-operation size adjustements.
* [`replace`](https://github.com/microsoft/STL/blob/9b38fb9ccca90fd8b31fd37d4512b190aeef4fe7/stl/inc/xstring#L2028): would appreciate a second eye on this one.

And of course, the last one is the known buggy `reserve` case.