### PR TITLE
Remove usage of `[[likely]]` and `[[unlikely]]`

### DIFF
--- a/stl/inc/__msvc_ranges_tuple_formatter.hpp
+++ b/stl/inc/__msvc_ranges_tuple_formatter.hpp
@@ -1081,7 +1081,7 @@ public:
         if constexpr (_RANGES contiguous_range<_Range_type>) {
             const auto _Size = _STD _To_unsigned_like(_RANGES distance(_Rx));
 
-            if (!_STD in_range<size_t>(_Size)) [[unlikely]] {
+            if (!_STD in_range<size_t>(_Size)) {
                 _Throw_format_error("Formatted range is too long.");
             }
 

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -87,7 +87,7 @@ ios_base::iostate _Print_noformat_nonunicode(ostream& _Ostr, const string_view _
     _TRY_IO_BEGIN
     const auto _Characters_written       = _Ostr.rdbuf()->sputn(_Str.data(), static_cast<streamsize>(_Str.size()));
     const bool _Was_insertion_successful = static_cast<size_t>(_Characters_written) == _Str.size();
-    if (!_Was_insertion_successful) [[unlikely]] {
+    if (!_Was_insertion_successful) {
         _State |= ios_base::badbit;
     }
     _CATCH_IO_(ios_base, _Ostr)
@@ -105,7 +105,7 @@ ios_base::iostate _Print_newline_only_nonunicode(ostream& _Ostr) {
 
     _TRY_IO_BEGIN
     const bool _Was_insertion_successful = _Ostr.rdbuf()->sputc('\n') == '\n';
-    if (!_Was_insertion_successful) [[unlikely]] {
+    if (!_Was_insertion_successful) {
         _State |= ios_base::badbit;
     }
     _CATCH_IO_(ios_base, _Ostr)
@@ -119,9 +119,9 @@ void _Vprint_nonunicode_impl(
     const ostream::sentry _Ok(_Ostr);
     ios_base::iostate _State = ios_base::goodbit;
 
-    if (!_Ok) [[unlikely]] {
+    if (!_Ok) {
         _State |= ios_base::badbit;
-    } else [[likely]] {
+    } else {
         // This is intentionally kept outside of the try/catch block in _Print_noformat_nonunicode()
         // (see N4950 [ostream.formatted.print]/3.2).
         string _Output_str = _STD vformat(_Ostr.getloc(), _Fmt_str, _Fmt_args);
@@ -178,24 +178,24 @@ ios_base::iostate _Do_on_maybe_unicode_console(
         break;
 
     case __std_win_error::_Not_supported:
-        [[unlikely]] return _State;
+        return _State;
 
     default:
-        [[unlikely]] return ios_base::failbit;
+        return ios_base::failbit;
     }
 #pragma warning(pop)
 
     if (_Is_unicode_console) {
         _TRY_IO_BEGIN
         const bool _Was_flush_successful = _Ostr.rdbuf()->pubsync() != -1;
-        if (!_Was_flush_successful) [[unlikely]] {
+        if (!_Was_flush_successful) {
             _State |= ios_base::badbit;
             return _State;
         }
 
         const __std_win_error _Unicode_console_print_result =
             _Unicode_console_func(_Unicode_console_retrieval_result._Console_handle);
-        if (_Unicode_console_print_result != __std_win_error::_Success) [[unlikely]] {
+        if (_Unicode_console_print_result != __std_win_error::_Success) {
             _State |= ios_base::badbit;
         }
         _CATCH_IO_(ios_base, _Ostr)
@@ -234,9 +234,9 @@ void _Vprint_unicode_impl(
     const ostream::sentry _Ok(_Ostr);
     ios_base::iostate _State = ios_base::goodbit;
 
-    if (!_Ok) [[unlikely]] {
+    if (!_Ok) {
         _State |= ios_base::badbit;
-    } else [[likely]] {
+    } else {
         // This is intentionally kept outside of the try/catch block in _Print_noformat_unicode()
         // (see N4950 [ostream.formatted.print]/3.2).
         string _Output_str = _STD vformat(_Ostr.getloc(), _Fmt_str, _Fmt_args);
@@ -255,9 +255,9 @@ void _Print_noformat(ostream& _Ostr, const string_view _Str) {
     const ostream::sentry _Ok(_Ostr);
     ios_base::iostate _State = ios_base::goodbit;
 
-    if (!_Ok) [[unlikely]] {
+    if (!_Ok) {
         _State |= ios_base::badbit;
-    } else [[likely]] {
+    } else {
         if constexpr (_STD _Is_ordinary_literal_encoding_utf8()) {
             _State |= _STD _Print_noformat_unicode(_Ostr, _Str);
         } else {
@@ -302,9 +302,9 @@ void println(ostream& _Ostr) {
     const ostream::sentry _Ok(_Ostr);
     ios_base::iostate _State = ios_base::goodbit;
 
-    if (!_Ok) [[unlikely]] {
+    if (!_Ok) {
         _State |= ios_base::badbit;
-    } else [[likely]] {
+    } else {
         if constexpr (_STD _Is_ordinary_literal_encoding_utf8()) {
             _State |= _STD _Print_newline_only_unicode(_Ostr);
         } else {

--- a/stl/inc/print
+++ b/stl/inc/print
@@ -61,7 +61,7 @@ private:
 inline void _Print_noformat_nonunicode_nonlocking(FILE* const _Stream, const string_view _Str) {
     const bool _Was_write_successful = _CSTD _fwrite_nolock(_Str.data(), 1, _Str.size(), _Stream) == _Str.size();
 
-    if (!_Was_write_successful) [[unlikely]] {
+    if (!_Was_write_successful) {
         _Throw_system_error(static_cast<errc>(errno));
     }
 }
@@ -99,7 +99,7 @@ inline void _Print_noformat_unicode_to_console_nonlocking(
     const __std_unicode_console_handle _Console_handle, const string_view _Str) {
     const __std_win_error _Console_print_result =
         __std_print_to_unicode_console(_Console_handle, _Str.data(), _Str.size());
-    if (_Console_print_result != __std_win_error::_Success) [[unlikely]] {
+    if (_Console_print_result != __std_win_error::_Success) {
         _STD _Throw_system_error_from_std_win_error(_Console_print_result);
     }
 }
@@ -160,10 +160,10 @@ void _Do_on_maybe_unicode_console(
         break;
 
     case __std_win_error::_Not_supported:
-        [[unlikely]] return;
+        return;
 
     default:
-        [[unlikely]] _STD _Throw_system_error_from_std_win_error(_Unicode_console_retrieval_result._Error);
+        _STD _Throw_system_error_from_std_win_error(_Unicode_console_retrieval_result._Error);
     }
 #pragma warning(pop)
 
@@ -180,7 +180,7 @@ inline void _Vprint_unicode_noformat_impl(FILE* const _Stream, const string_view
         const _Stream_lock_guard _Guard{_Stream};
 
         const bool _Was_flush_successful = _CSTD _fflush_nolock(_Stream) == 0;
-        if (!_Was_flush_successful) [[unlikely]] {
+        if (!_Was_flush_successful) {
             _Throw_system_error(static_cast<errc>(errno));
         }
 
@@ -195,7 +195,7 @@ inline void _Vprint_unicode_noformat_impl(FILE* const _Stream, const string_view
 inline void _Fputc_newline(FILE* const _Stream) {
     const bool _Was_write_successful = _CSTD fputc('\n', _Stream) == '\n';
 
-    if (!_Was_write_successful) [[unlikely]] {
+    if (!_Was_write_successful) {
         _Throw_system_error(static_cast<errc>(errno));
     }
 }
@@ -203,12 +203,12 @@ inline void _Fputc_newline(FILE* const _Stream) {
 inline void _Print_newline_only_unicode(FILE* const _Stream) {
     const auto _Unicode_console = [&](const __std_unicode_console_handle _Console_handle) {
         const bool _Was_flush_successful = _CSTD fflush(_Stream) == 0;
-        if (!_Was_flush_successful) [[unlikely]] {
+        if (!_Was_flush_successful) {
             _Throw_system_error(static_cast<errc>(errno));
         }
 
         const __std_win_error _Console_print_result = __std_print_newline_only_to_unicode_console(_Console_handle);
-        if (_Console_print_result != __std_win_error::_Success) [[unlikely]] {
+        if (_Console_print_result != __std_win_error::_Success) {
             _STD _Throw_system_error_from_std_win_error(_Console_print_result);
         }
     };
@@ -234,7 +234,7 @@ inline void _Vprint_unicode_impl(
         const _Stream_lock_guard _Guard{_Stream};
 
         const bool _Was_flush_successful = _CSTD _fflush_nolock(_Stream) == 0;
-        if (!_Was_flush_successful) [[unlikely]] {
+        if (!_Was_flush_successful) {
             _Throw_system_error(static_cast<errc>(errno));
         }
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -564,20 +564,6 @@
 #define _FALLTHROUGH
 #endif
 
-#ifndef __has_cpp_attribute // vvv no attributes vvv
-#define _LIKELY
-#define _UNLIKELY
-#elif __has_cpp_attribute(likely) >= 201803L && __has_cpp_attribute(unlikely) >= 201803L // ^^^ no attr / C++20 attr vvv
-#define _LIKELY   [[likely]]
-#define _UNLIKELY [[unlikely]]
-#elif defined(__clang__) // ^^^ C++20 attributes / clang attributes and C++17 or C++14 vvv
-#define _LIKELY   [[__likely__]]
-#define _UNLIKELY [[__unlikely__]]
-#else // ^^^ clang attributes and C++17 or C++14 / C1XX attributes and C++17 or C++14 vvv
-#define _LIKELY
-#define _UNLIKELY
-#endif // ^^^ C1XX attributes and C++17 or C++14 ^^^
-
 // _HAS_NODISCARD (in vcruntime.h) controls:
 // [[nodiscard]] attributes on STL functions
 

--- a/stl/src/print.cpp
+++ b/stl/src/print.cpp
@@ -16,24 +16,24 @@ extern "C" {
 
 [[nodiscard]] _Success_(return._Error == __std_win_error::_Success) __std_unicode_console_retrieval_result
     __stdcall __std_get_unicode_console_handle_from_file_stream(_In_ FILE* const _Stream) noexcept {
-    if (_Stream == nullptr) [[unlikely]] {
+    if (_Stream == nullptr) {
         return __std_unicode_console_retrieval_result{._Error = __std_win_error::_Invalid_parameter};
     }
 
     const int _Fd = _fileno(_Stream);
 
-    if (_Fd == -2) [[unlikely]] {
+    if (_Fd == -2) {
         // According to https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fileno?view=msvc-170 ,
         // _fileno() returns -2 if _Stream refers to either stdout or stderr and there is no associated output stream.
         // In that case, there is also no associated console HANDLE. (We haven't observed this happening in practice.)
         return __std_unicode_console_retrieval_result{._Error = __std_win_error::_Not_supported};
-    } else if (_Fd == -1) [[unlikely]] {
+    } else if (_Fd == -1) {
         return __std_unicode_console_retrieval_result{._Error = __std_win_error::_Invalid_parameter};
     }
 
     const HANDLE _Console_handle = reinterpret_cast<HANDLE>(_get_osfhandle(_Fd));
 
-    if (_Console_handle == INVALID_HANDLE_VALUE) [[unlikely]] {
+    if (_Console_handle == INVALID_HANDLE_VALUE) {
         return __std_unicode_console_retrieval_result{._Error = __std_win_error::_Invalid_parameter};
     }
 
@@ -89,7 +89,7 @@ namespace {
 
             ::new (&_Str) _Heap_string(_malloc_crt_t(wchar_t, _Capacity)); // Activate _Str
 
-            if (!_Str) [[unlikely]] {
+            if (!_Str) {
                 _Str_capacity = _Buffer_size;
                 _Buffer[0]    = L'\0'; // Activate _Buffer
                 return false;
@@ -149,7 +149,7 @@ namespace {
         const char* const _Str, const size_t _Str_size) noexcept {
         constexpr size_t _Max_str_segment_size = 8192;
 
-        if (_Str_size <= _Max_str_segment_size) [[likely]] {
+        if (_Str_size <= _Max_str_segment_size) {
             return _Minimal_string_view{_Str, _Str_size};
         }
 
@@ -210,7 +210,7 @@ namespace {
     [[nodiscard]] _Transcode_result _Transcode_utf8_string(
         _Allocated_string& _Dst_str, const _Minimal_string_view _Src_str) noexcept {
         // MultiByteToWideChar() fails if strLength == 0.
-        if (_Src_str._Empty()) [[unlikely]] {
+        if (_Src_str._Empty()) {
             return {};
         }
 
@@ -220,19 +220,19 @@ namespace {
         const int32_t _Num_chars_required =
             MultiByteToWideChar(CP_UTF8, 0, _Src_str._Data(), static_cast<int>(_Src_str._Size()), nullptr, 0);
 
-        if (_Num_chars_required == 0) [[unlikely]] {
+        if (_Num_chars_required == 0) {
             return static_cast<__std_win_error>(GetLastError());
         }
 
         const bool _Has_space = _Dst_str._Grow(static_cast<size_t>(_Num_chars_required));
-        if (!_Has_space) [[unlikely]] {
+        if (!_Has_space) {
             return __std_win_error::_Not_enough_memory;
         }
 
         const int32_t _Conversion_result = MultiByteToWideChar(CP_UTF8, 0, _Src_str._Data(),
             static_cast<int>(_Src_str._Size()), _Dst_str._Data(), static_cast<int>(_Dst_str._Capacity()));
 
-        if (_Conversion_result == 0) [[unlikely]] {
+        if (_Conversion_result == 0) {
             // This shouldn't happen...
             _CSTD abort();
         }
@@ -245,7 +245,7 @@ namespace {
         const BOOL _Write_result =
             WriteConsoleW(_Console_handle, _Wide_str._Data(), static_cast<DWORD>(_Wide_str._Size()), nullptr, nullptr);
 
-        if (!_Write_result) [[unlikely]] {
+        if (!_Write_result) {
             return static_cast<__std_win_error>(GetLastError());
         }
 
@@ -258,7 +258,7 @@ extern "C" {
 [[nodiscard]] _Success_(return == __std_win_error::_Success) __std_win_error
     __stdcall __std_print_to_unicode_console(_In_ const __std_unicode_console_handle _Console_handle,
         _In_reads_(_Str_size) const char* const _Str, _In_ const size_t _Str_size) noexcept {
-    if (_Console_handle == __std_unicode_console_handle::_Invalid || _Str == nullptr) [[unlikely]] {
+    if (_Console_handle == __std_unicode_console_handle::_Invalid || _Str == nullptr) {
         return __std_win_error::_Invalid_parameter;
     }
 
@@ -277,13 +277,13 @@ extern "C" {
         _Curr_str_segment = _Get_next_utf8_string_segment(_Remaining_str, _Remaining_str_size);
         _Transcoded_str   = _Transcode_utf8_string(_Allocated_str, _Curr_str_segment);
 
-        if (!_Transcoded_str._Has_value()) [[unlikely]] {
+        if (!_Transcoded_str._Has_value()) {
             return _Transcoded_str._Error();
         }
 
         const __std_win_error _Write_result = _Write_console(_Actual_console_handle, _Transcoded_str._Value());
 
-        if (_Write_result != __std_win_error::_Success) [[unlikely]] {
+        if (_Write_result != __std_win_error::_Success) {
             return _Write_result;
         }
 
@@ -300,7 +300,7 @@ extern "C" {
 [[nodiscard]] _Success_(return == __std_win_error::_Success) __std_win_error
     __stdcall __std_print_newline_only_to_unicode_console(
         _In_ const __std_unicode_console_handle _Console_handle) noexcept {
-    if (_Console_handle == __std_unicode_console_handle::_Invalid) [[unlikely]] {
+    if (_Console_handle == __std_unicode_console_handle::_Invalid) {
         return __std_win_error::_Invalid_parameter;
     }
 
@@ -308,7 +308,7 @@ extern "C" {
 
     const BOOL _Write_result = WriteConsoleW(_Actual_console_handle, L"\n", 1, nullptr, nullptr);
 
-    if (!_Write_result) [[unlikely]] {
+    if (!_Write_result) {
         return static_cast<__std_win_error>(GetLastError());
     }
 

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -5310,7 +5310,7 @@ namespace {
                 _Size_convert = _Size_bits;
 
                 for (size_t _Ix = _Size_bits; _Ix < _Size_chars; ++_Ix) {
-                    if (const _Elem _Cur = _Src[_Ix]; _Cur != _Elem0 && _Cur != _Elem1) [[unlikely]] {
+                    if (const _Elem _Cur = _Src[_Ix]; _Cur != _Elem0 && _Cur != _Elem1) {
                         return false;
                     }
                 }
@@ -5321,7 +5321,7 @@ namespace {
             for (size_t _Ix = 0; _Ix != _Size_convert; ++_Ix) {
                 const _Elem _Cur = _Src[_Size_convert - _Ix - 1];
 
-                if (_Cur != _Elem0 && _Cur != _Elem1) [[unlikely]] {
+                if (_Cur != _Elem0 && _Cur != _Elem1) {
                     return false;
                 }
 

--- a/tests/std/tests/P2093R14_formatted_output/test.cpp
+++ b/tests/std/tests/P2093R14_formatted_output/test.cpp
@@ -42,13 +42,13 @@ namespace test {
             console_handle =
                 CreateConsoleScreenBuffer(screen_buffer_access, 0, nullptr, CONSOLE_TEXTMODE_BUFFER, nullptr);
 
-            if (console_handle == INVALID_HANDLE_VALUE) [[unlikely]] {
+            if (console_handle == INVALID_HANDLE_VALUE) {
                 return;
             }
 
             const int console_fd = _open_osfhandle(reinterpret_cast<intptr_t>(console_handle), _O_TEXT);
 
-            if (console_fd == -1) [[unlikely]] {
+            if (console_fd == -1) {
                 return;
             }
 
@@ -109,9 +109,9 @@ namespace test {
             // those space characters which appear after the user's text.
             const size_t lastValidChar = output_str.find_last_not_of(' ');
 
-            if (lastValidChar == wstring::npos) [[unlikely]] {
+            if (lastValidChar == wstring::npos) {
                 output_str.clear();
-            } else [[likely]] {
+            } else {
                 output_str = output_str.substr(0, lastValidChar + 1);
             }
 
@@ -120,7 +120,7 @@ namespace test {
 
     private:
         void delete_console() {
-            if (is_console_valid()) [[likely]] {
+            if (is_console_valid()) {
                 // According to the MSDN, we don't call CloseHandle() on handles passed to _open_osfhandle(),
                 // and we don't call _close() on file descriptors passed to _fdopen(). So, our only clean-up
                 // task is to call fclose().


### PR DESCRIPTION
@GabrielDosReis informed me that the optimizer team discourages use of the `[[likely]]` and `[[unlikely]]` attributes, and instead encourages PGO/SPGO. (This aligns with what I've always said, "don't help the compiler".) We've accumulated a fair amount of usage of these attributes, *none* of which was motivated by benchmarking. Let's remove this noise from our codebase. If we ever find places where it actually affects performance (presumably for Clang/LLVM, since C2 pays minimal attention to the attribute), we can decide what to do.

* Remove direct usage of `[[likely]]` and `[[unlikely]]`.
* Remove `_LIKELY_X86_X64`, `_LIKELY_ARM_ARM64`, and clang-format suppression.
* Remove `_LIKELY` and `_UNLIKELY`.
