### PR TITLE
Toolset update: VS 2022 17.13 Preview 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.13 Preview 3 or later.
+1. Install Visual Studio 2022 17.13 Preview 4 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.
@@ -160,7 +160,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.13 Preview 3 or later.
+1. Install Visual Studio 2022 17.13 Preview 4 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,7 +5,7 @@
 
 variables:
 - name: poolName
-  value: 'StlBuild-2025-01-22T1525-Pool'
+  value: 'StlBuild-2025-01-28T1106-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -40,7 +40,7 @@ foreach ($workload in $VisualStudioWorkloads) {
 }
 
 # https://github.com/PowerShell/PowerShell/releases/latest
-$PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/PowerShell-7.4.6-win-x64.msi'
+$PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/PowerShell-7.5.0-win-x64.msi'
 $PowerShellArgs = @('/quiet', '/norestart')
 
 $PythonUrl = 'https://www.python.org/ftp/python/3.13.1/python-3.13.1-amd64.exe'

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -327,32 +327,6 @@ struct is_convertible : bool_constant<__is_convertible_to(_From, _To)> {
 _EXPORT_STD template <class _From, class _To>
 constexpr bool is_convertible_v = __is_convertible_to(_From, _To);
 
-#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, DevCom-1627396
-template <class _Ty>
-struct is_convertible<_Ty&, volatile _Ty&> : true_type {};
-
-template <class _Ty>
-struct is_convertible<volatile _Ty&, volatile _Ty&> : true_type {};
-
-template <class _Ty>
-struct is_convertible<_Ty&, const volatile _Ty&> : true_type {};
-
-template <class _Ty>
-struct is_convertible<volatile _Ty&, const volatile _Ty&> : true_type {};
-
-template <class _Ty>
-constexpr bool is_convertible_v<_Ty&, volatile _Ty&> = true;
-
-template <class _Ty>
-constexpr bool is_convertible_v<volatile _Ty&, volatile _Ty&> = true;
-
-template <class _Ty>
-constexpr bool is_convertible_v<_Ty&, const volatile _Ty&> = true;
-
-template <class _Ty>
-constexpr bool is_convertible_v<volatile _Ty&, const volatile _Ty&> = true;
-#endif // ^^^ workaround ^^^
-
 _EXPORT_STD template <class _Ty>
 struct is_enum : bool_constant<__is_enum(_Ty)> {}; // determine whether _Ty is an enumerated type
 
@@ -2205,13 +2179,7 @@ struct _Is_trivially_swappable : bool_constant<_Is_trivially_swappable_v<_Ty>> {
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _From, class _To>
-concept convertible_to =
-#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, DevCom-1627396
-    is_convertible_v<_From, _To>
-#else // ^^^ workaround / no workaround vvv
-    __is_convertible_to(_From, _To)
-#endif // ^^^ no workaround ^^^
-    && requires { static_cast<_To>(_STD declval<_From>()); };
+concept convertible_to = __is_convertible_to(_From, _To) && requires { static_cast<_To>(_STD declval<_From>()); };
 
 template <class _RefWrap, class _Ty, class _RefWrapQ, class _TyQ>
 concept _Ref_wrap_common_reference_exists_with = _Is_specialization_v<_RefWrap, reference_wrapper> && requires {

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -513,10 +513,8 @@ namespace test_convertible_to {
     static_assert(convertible_to<char (&)[], ConvertsFrom<char const*>>);
 
     // volatile array glvalues
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-1627396
     static_assert(convertible_to<int volatile (&)[42], int volatile (&)[42]>);
     static_assert(convertible_to<int volatile (&)[42][13], int volatile (&)[42][13]>);
-#endif // ^^^ no workaround ^^^
     static_assert(convertible_to<int volatile (&&)[42], int volatile (&&)[42]>);
     static_assert(convertible_to<int volatile (&&)[42][13], int volatile (&&)[42][13]>);
 
@@ -696,10 +694,8 @@ namespace test_common_reference_with {
     static_assert(test<SimpleBase, ConvertsFrom<int, SimpleBase>>());
 
     static_assert(test<int volatile&, int volatile&>());
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-1627396
     static_assert(test<int volatile (&)[42], int volatile (&)[42]>());
     static_assert(test<int volatile (&)[42][13], int volatile (&)[42][13]>());
-#endif // ^^^ no workaround ^^^
     static_assert(test<int volatile (&&)[42], int volatile (&&)[42]>());
     static_assert(test<int volatile (&&)[42][13], int volatile (&&)[42][13]>());
 } // namespace test_common_reference_with
@@ -2022,10 +2018,8 @@ namespace test_swappable_with {
 
     static_assert(test<int (&)[2][2], int (&)[2][2]>());
 
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-1627396
     static_assert(test<int volatile (&)[4], int volatile (&)[4]>());
     static_assert(test<int volatile (&)[3][4], int volatile (&)[3][4]>());
-#endif // ^^^ no workaround ^^^
 
     static_assert(test<MovableFriendSwap, MovableFriendSwap>() == is_permissive);
     static_assert(test<MovableFriendSwap&, MovableFriendSwap&>());

--- a/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
@@ -62,9 +62,7 @@ class CustomTestFormat(STLTestFormat):
             # Generate JSON files that record how these headers depend on one another.
             if noisyProgress:
                 print('Scanning dependencies...')
-            cmd = [test.cxx, *test.flags, *test.compileFlags, *clOptions, '/scanDependencies', '.\\',
-                '/shallowScan', # TRANSITION, VSO-2293247 fixed in VS 2022 17.13 Preview 4 (remove /shallowScan)
-                *allHeaders]
+            cmd = [test.cxx, *test.flags, *test.compileFlags, *clOptions, '/scanDependencies', '.\\', *allHeaders]
             yield TestStep(cmd, shared.execDir, shared.env, False)
 
             # The JSON files also record what object files will be produced.


### PR DESCRIPTION
# :scroll: Changelog

- Code cleanups:
  * Removed compiler bug workarounds.
- Infrastructure improvements:
  * Updated dependencies.
    + Updated build compiler to VS 2022 17.13 Preview 4.

# :gear: Commits

* PowerShell 7.5.0.
* New pool.
* VS 2022 17.13 Preview 4.
  + Still not yet required due to the internal toolset being 17.12-based.
* Remove workaround for VSO-2293247.
* Remove workarounds for DevCom-1627396.

[STL-ASan-CI passed.](https://dev.azure.com/vclibs/STL/_build/results?buildId=18204&view=results)