### PR TITLE
<regex>: Successful negative lookahead assertions do not matche to capture groups

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -3580,7 +3580,11 @@ bool _Matcher<_BidIt, _Elem, _RxTraits, _It>::_Match_pat(_Node_base* _Nx) { // c
                     _Tgt_state = _St;
                     _Failed    = true;
                 } else {
-                    _Tgt_state._Cur = _Ch;
+                    if (_Neg) {
+                        _Tgt_state = _St;
+                    } else {
+                        _Tgt_state._Cur = _Ch;
+                    }
                 }
 
                 break;

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -334,10 +334,7 @@ public:
     template <class _Iter>
     char_class_type lookup_classname(_Iter _First, _Iter _Last, bool _Icase = false) const {
         // map [_First, _Last) to character class mask value
-#define _REGEX_CHAR_CLASS_NAME(n, c)                            \
-    {                                                           \
-        n, L##n, static_cast<unsigned int>(_STD size(n) - 1), c \
-    }
+#define _REGEX_CHAR_CLASS_NAME(n, c) {n, L##n, static_cast<unsigned int>(_STD size(n) - 1), c}
         static constexpr _Cl_names _Names[] = {
             // map class names to numeric constants
             _REGEX_CHAR_CLASS_NAME("alnum", _Ch_alnum),
@@ -3610,7 +3607,6 @@ bool _Matcher<_BidIt, _Elem, _RxTraits, _It>::_Match_pat(_Node_base* _Nx) { // c
                 _Node_end_group* _Node = static_cast<_Node_end_group*>(_Nx);
                 _Node_capture* _Node0  = static_cast<_Node_capture*>(_Node->_Back);
                 if (_Cap || _Node0->_Idx != 0) { // update capture data
-                    _Tgt_state._Grp_valid[_Node0->_Idx] = true;
                     _Tgt_state._Grps[_Node0->_Idx]._End = _Tgt_state._Cur;
                 }
                 break;

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -3572,19 +3572,14 @@ bool _Matcher<_BidIt, _Elem, _RxTraits, _It>::_Match_pat(_Node_base* _Nx) { // c
         case _N_neg_assert:
         case _N_assert:
             { // check assert
-                _It _Ch              = _Tgt_state._Cur;
                 bool _Neg            = _Nx->_Kind == _N_neg_assert;
                 _Bt_state_t<_It> _St = _Tgt_state;
                 if (_Match_pat(static_cast<_Node_assert*>(_Nx)->_Child) == _Neg) {
                     // restore initial state and indicate failure
                     _Tgt_state = _St;
                     _Failed    = true;
-                } else {
-                    if (_Neg) {
-                        _Tgt_state = _St;
-                    } else {
-                        _Tgt_state._Cur = _Ch;
-                    }
+                } else if (!_Neg) {
+                    _Tgt_state._Cur = _St._Cur;
                 }
 
                 break;

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -3611,6 +3611,7 @@ bool _Matcher<_BidIt, _Elem, _RxTraits, _It>::_Match_pat(_Node_base* _Nx) { // c
                 _Node_end_group* _Node = static_cast<_Node_end_group*>(_Nx);
                 _Node_capture* _Node0  = static_cast<_Node_capture*>(_Node->_Back);
                 if (_Cap || _Node0->_Idx != 0) { // update capture data
+                    _Tgt_state._Grp_valid[_Node0->_Idx] = true;
                     _Tgt_state._Grps[_Node0->_Idx]._End = _Tgt_state._Cur;
                 }
                 break;


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
Fixes: #5245 