### PR TITLE
Update libcxx skips for a new compiler warning

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1381,3 +1381,9 @@ std/containers/sequences/vector/vector.modifiers/assert.push_back.invalidation.p
 # This test is marked as `REQUIRES: has-unix-headers, libcpp-has-abi-bounded-iterators-in-std-array`.
 # Listing these on separate lines would allow magic_comments.txt to recognize it.
 std/containers/sequences/array/assert.iterators.pass.cpp:9 SKIPPED
+
+# These tests emit C5321, which warns when the resolution to core issue 1656 affects a u8 string literal.
+# The conformant behavior is opt-in because it can silently change behavior.
+# : warning C5321: nonstandard extension used: encoding '\x80' as a multi-byte utf-8 character. Use \u instead for cross platform compatibility or '/Zc:u8EscapeEncoding' to disable the extension.
+std/utilities/format/format.functions/escaped_output.unicode.pass.cpp:9 SKIPPED
+std/utilities/format/format.functions/fill.unicode.pass.cpp:9 SKIPPED


### PR DESCRIPTION
Mirrors internal MSVC-PR-610616 "Zc for conformant u8 string encoding of escape sequences".

(I'm refraining from nitpicking the comment too closely because updating it requires rerunning the internal PR checks and that's time-consuming.)

These are phrased as `:9 SKIPPED` which skips them for the MSVC-internal test harness only, as the new warning has not yet shipped. When it does, we'll need to update this to `:0 FAIL` and `:1 FAIL`, or work with upstream LLVM to fix their non-conformant test code.