### PR TITLE
Toolset update: VS 2022 17.14 Preview 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ __pycache__/
 /out/
 /tools/out/
 /CMakeLists.txt.user
-/*.log
+*.log

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.13 Preview 4 or later.
+1. Install Visual Studio 2022 17.14 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.
@@ -160,7 +160,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.13 Preview 4 or later.
+1. Install Visual Studio 2022 17.14 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,7 +5,7 @@
 
 variables:
 - name: poolName
-  value: 'StlBuild-2025-01-28T1106-Pool'
+  value: 'StlBuild-2025-02-15T0137-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -18,7 +18,7 @@ $VMSize = 'Standard_F32as_v6'
 $ProtoVMName = 'PROTOTYPE'
 $ImagePublisher = 'MicrosoftWindowsServer'
 $ImageOffer = 'WindowsServer'
-$ImageSku = '2025-datacenter-g2'
+$ImageSku = '2025-datacenter-azure-edition'
 
 $ProgressActivity = 'Preparing STL CI pool'
 $TotalProgress = 26

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -43,7 +43,7 @@ foreach ($workload in $VisualStudioWorkloads) {
 $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/PowerShell-7.5.0-win-x64.msi'
 $PowerShellArgs = @('/quiet', '/norestart')
 
-$PythonUrl = 'https://www.python.org/ftp/python/3.13.1/python-3.13.1-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.13.2/python-3.13.2-amd64.exe'
 $PythonArgs = @('/quiet', 'InstallAllUsers=1', 'PrependPath=1', 'CompileAll=1', 'Include_doc=0')
 
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/12.4.0/local_installers/cuda_12.4.0_551.61_windows.exe'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -46,8 +46,10 @@ $PowerShellArgs = @('/quiet', '/norestart')
 $PythonUrl = 'https://www.python.org/ftp/python/3.13.2/python-3.13.2-amd64.exe'
 $PythonArgs = @('/quiet', 'InstallAllUsers=1', 'PrependPath=1', 'CompileAll=1', 'Include_doc=0')
 
+# TRANSITION, GH-5282: Install only nvcc and cudart, then manually add CUDA to the PATH (see below).
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/12.4.0/local_installers/cuda_12.4.0_551.61_windows.exe'
-$CudaArgs = @('-s', '-n', 'nvcc_12.4')
+$CudaArgs = @('-s', '-n', 'nvcc_12.4', 'cudart_12.4')
+$CudaPath = 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\bin'
 
 <#
 .SYNOPSIS
@@ -111,6 +113,12 @@ DownloadAndInstall -Name 'Visual Studio' -Url $VisualStudioUrl -Args $VisualStud
 DownloadAndInstall -Name 'CUDA'          -Url $CudaUrl         -Args $CudaArgs
 
 Write-Host 'Setting environment variables...'
+
+# TRANSITION, GH-5282: Manually add CUDA to the PATH.
+# Don't use $Env:PATH here - that's the local path for this running script, captured before we installed anything.
+# The machine path was just updated by the installers above.
+$machinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+[Environment]::SetEnvironmentVariable('Path', "$machinePath;$CudaPath", 'Machine')
 
 # The STL's PR/CI builds are totally unrepresentative of customer usage.
 [Environment]::SetEnvironmentVariable('VSCMD_SKIP_SENDTELEMETRY', '1', 'Machine')

--- a/stl/inc/__msvc_bit_utils.hpp
+++ b/stl/inc/__msvc_bit_utils.hpp
@@ -337,19 +337,19 @@ constexpr decltype(auto) _Select_countr_zero_impl(_Fn _Callback) {
 #if _HAS_TZCNT_BSF_INTRINSICS && _HAS_CXX20
     if (!_STD is_constant_evaluated()) {
 #ifdef __AVX2__
-        return _Callback([](_Ty _Val) _STATIC_CALL_OPERATOR { return _Countr_zero_tzcnt(_Val); });
+        return _Callback([](_Ty _Val) _STATIC_LAMBDA { return _Countr_zero_tzcnt(_Val); });
 #else // ^^^ AVX2 / not AVX2 vvv
         const bool _Definitely_have_tzcnt = __isa_available >= _Stl_isa_available_avx2;
         if (_Definitely_have_tzcnt) {
-            return _Callback([](_Ty _Val) _STATIC_CALL_OPERATOR { return _Countr_zero_tzcnt(_Val); });
+            return _Callback([](_Ty _Val) _STATIC_LAMBDA { return _Countr_zero_tzcnt(_Val); });
         } else {
-            return _Callback([](_Ty _Val) _STATIC_CALL_OPERATOR { return _Countr_zero_bsf(_Val); });
+            return _Callback([](_Ty _Val) _STATIC_LAMBDA { return _Countr_zero_bsf(_Val); });
         }
 #endif // ^^^ not AVX2 ^^^
     }
 #endif // ^^^ _HAS_TZCNT_BSF_INTRINSICS && _HAS_CXX20 ^^^
     // C++17 constexpr gcd() calls this function, so it should be constexpr unless we detect runtime evaluation.
-    return _Callback([](_Ty _Val) _STATIC_CALL_OPERATOR { return _Countr_zero_fallback(_Val); });
+    return _Callback([](_Ty _Val) _STATIC_LAMBDA { return _Countr_zero_fallback(_Val); });
 }
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
@@ -376,13 +376,13 @@ _CONSTEXPR20 decltype(auto) _Select_popcount_impl(_Fn _Callback) {
 #if !_POPCNT_INTRINSICS_ALWAYS_AVAILABLE
         const bool _Definitely_have_popcnt = __isa_available >= _Stl_isa_available_sse42;
         if (!_Definitely_have_popcnt) {
-            return _Callback([](_Ty _Val) _STATIC_CALL_OPERATOR { return _Popcount_fallback(_Val); });
+            return _Callback([](_Ty _Val) _STATIC_LAMBDA { return _Popcount_fallback(_Val); });
         }
 #endif // ^^^ !_POPCNT_INTRINSICS_ALWAYS_AVAILABLE ^^^
-        return _Callback([](_Ty _Val) _STATIC_CALL_OPERATOR { return _Unchecked_popcount(_Val); });
+        return _Callback([](_Ty _Val) _STATIC_LAMBDA { return _Unchecked_popcount(_Val); });
     }
 #endif // ^^^ _HAS_POPCNT_INTRINSICS ^^^
-    return _Callback([](_Ty _Val) _STATIC_CALL_OPERATOR { return _Popcount_fallback(_Val); });
+    return _Callback([](_Ty _Val) _STATIC_LAMBDA { return _Popcount_fallback(_Val); });
 }
 
 #undef _HAS_POPCNT_INTRINSICS

--- a/stl/inc/__msvc_ranges_to.hpp
+++ b/stl/inc/__msvc_ranges_to.hpp
@@ -1145,7 +1145,7 @@ namespace ranges {
                                      "the default-constructed object. (N4981 [range.utility.conv.to]/2.1.5)");
             }
         } else if constexpr (input_range<range_reference_t<_Rng>>) {
-            const auto _Xform = [](auto&& _Elem) _STATIC_CALL_OPERATOR {
+            const auto _Xform = [](auto&& _Elem) _STATIC_LAMBDA {
                 return _RANGES to<range_value_t<_Container>>(_STD forward<decltype(_Elem)>(_Elem));
             };
             return _RANGES to<_Container>(views::transform(ref_view{_Range}, _Xform), _STD forward<_Types>(_Args)...);

--- a/stl/inc/__msvc_ranges_tuple_formatter.hpp
+++ b/stl/inc/__msvc_ranges_tuple_formatter.hpp
@@ -241,7 +241,7 @@ public:
         template <class _Ty>
         explicit handle(_Ty& _Val) noexcept
             : _Ptr(_STD addressof(_Val)), _Format([](basic_format_parse_context<_CharType>& _Parse_ctx,
-                                                      _Context& _Format_ctx, const void* _Ptr) _STATIC_CALL_OPERATOR {
+                                                      _Context& _Format_ctx, const void* _Ptr) _STATIC_LAMBDA {
                   using _Td = remove_const_t<_Ty>;
                   // doesn't drop const-qualifier per an unnumbered LWG issue
                   using _Tq = conditional_t<_Formattable_with<const _Ty, _Context>, const _Ty, _Ty>;

--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -851,7 +851,7 @@ public:
     path& append(const basic_string<_Elem, _Traits, _Alloc>& _Str0) { // append arbitrary source string
         string_type _Str(_Str0.size(), L'\0');
         // convert _Elem and '/' to '\'
-        _STD transform(_Str0.begin(), _Str0.end(), _Str.begin(), [](const _Elem _Ch) _STATIC_CALL_OPERATOR {
+        _STD transform(_Str0.begin(), _Str0.end(), _Str.begin(), [](const _Elem _Ch) _STATIC_LAMBDA {
             auto _Wch = static_cast<wchar_t>(_Ch);
             if (_Wch == _FS_SLASH) {
                 _Wch = _FS_PREF;

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1237,7 +1237,7 @@ _NON_MEMBER_CALL(_FUNCTION_POINTER_DEDUCTION_GUIDE, X1, X2, X3)
 template <class _Fx, class _Call_op, class = void>
 struct _Deduce_from_call_operator : _Is_memfunptr<_Call_op>::_Guide_type {}; // N4958 [func.wrap.func.con]/16.1
 
-#ifdef __cpp_static_call_operator
+#if _HAS_CXX23
 template <class>
 struct _Inspect_static_call_operator {};
 
@@ -1257,7 +1257,7 @@ _NON_MEMBER_CALL(_STATIC_CALL_OPERATOR_GUIDES, , , noexcept)
 template <class _Fx, class _Call_op>
 struct _Deduce_from_call_operator<_Fx, _Call_op, void_t<decltype(_STD declval<_Fx>().operator())>>
     : _Inspect_static_call_operator<_Call_op> {}; // N4958 [func.wrap.func.con]/16.2
-#endif // ^^^ defined(__cpp_static_call_operator) ^^^
+#endif // _HAS_CXX23
 
 template <class _Fx, class = void>
 struct _Deduce_signature {}; // can't deduce signature when &_Fx::operator() is missing, inaccessible, or ambiguous

--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -553,9 +553,9 @@ namespace pmr {
             // find the pool from which to allocate a block with size _Bytes and alignment _Align
             const size_t _Size      = (_STD max)(_Bytes + sizeof(void*), _Align);
             const auto _Log_of_size = static_cast<unsigned char>(_Ceiling_of_log_2(_Size));
-            return {_STD lower_bound(_Pools.begin(), _Pools.end(), _Log_of_size,
-                        [](const _Pool& _Al, const unsigned char _Log)
-                            _STATIC_CALL_OPERATOR { return _Al._Log_of_size < _Log; }),
+            return {
+                _STD lower_bound(_Pools.begin(), _Pools.end(), _Log_of_size,
+                    [](const _Pool& _Al, const unsigned char _Log) _STATIC_LAMBDA { return _Al._Log_of_size < _Log; }),
                 _Log_of_size};
         }
 

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -480,7 +480,7 @@ public:
         : _MyMutexes(_Mtxes...) {} // construct but don't lock
 
     ~scoped_lock() noexcept {
-        _STD apply([](_Mutexes&... _Mtxes) _STATIC_CALL_OPERATOR { (..., (void) _Mtxes.unlock()); }, _MyMutexes);
+        _STD apply([](_Mutexes&... _Mtxes) _STATIC_LAMBDA { (..., (void) _Mtxes.unlock()); }, _MyMutexes);
     }
 
     scoped_lock(const scoped_lock&)            = delete;

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3301,7 +3301,7 @@ namespace ranges {
 
             _NODISCARD constexpr decltype(auto) operator*() const {
                 using _Ref = common_reference_t<iter_reference_t<_InnerIter>, iter_reference_t<_PatternIter>>;
-                return _Visit_inner_it<_Ref>([](auto&& _It) _STATIC_CALL_OPERATOR -> _Ref { return *_It; });
+                return _Visit_inner_it<_Ref>([](auto&& _It) _STATIC_LAMBDA -> _Ref { return *_It; });
             }
 
             constexpr _Iterator& operator++() {
@@ -7189,14 +7189,13 @@ namespace ranges {
                 noexcept((noexcept(*(_STD declval<iterator_t<_Maybe_const<_IsConst, _ViewTypes>>&>()))
                           && ...)) /* strengthened */ {
                 return _Tuple_transform(
-                    [](auto& _Itr) _STATIC_CALL_OPERATOR noexcept(noexcept(*_Itr)) -> decltype(auto) { return *_Itr; },
+                    [](auto& _Itr) _STATIC_LAMBDA noexcept(noexcept(*_Itr)) -> decltype(auto) { return *_Itr; },
                     _Current);
             }
 
-            constexpr _Iterator& operator++() noexcept(
-                noexcept(_Tuple_for_each([](auto& _Itr) _STATIC_CALL_OPERATOR noexcept(noexcept(++_Itr)) { ++_Itr; },
-                    _Current))) /* strengthened */ {
-                _Tuple_for_each([](auto& _Itr) _STATIC_CALL_OPERATOR noexcept(noexcept(++_Itr)) { ++_Itr; }, _Current);
+            constexpr _Iterator& operator++() noexcept(noexcept(_Tuple_for_each(
+                [](auto& _Itr) _STATIC_LAMBDA noexcept(noexcept(++_Itr)) { ++_Itr; }, _Current))) /* strengthened */ {
+                _Tuple_for_each([](auto& _Itr) _STATIC_LAMBDA noexcept(noexcept(++_Itr)) { ++_Itr; }, _Current);
                 return *this;
             }
 
@@ -7215,10 +7214,10 @@ namespace ranges {
             }
 
             constexpr _Iterator& operator--() noexcept(noexcept(_Tuple_for_each(
-                [](auto& _Itr) _STATIC_CALL_OPERATOR noexcept(noexcept(--_Itr)) { --_Itr; }, _Current))) // strengthened
+                [](auto& _Itr) _STATIC_LAMBDA noexcept(noexcept(--_Itr)) { --_Itr; }, _Current))) // strengthened
                 requires _All_bidirectional<_IsConst, _ViewTypes...>
             {
-                _Tuple_for_each([](auto& _Itr) _STATIC_CALL_OPERATOR noexcept(noexcept(--_Itr)) { --_Itr; }, _Current);
+                _Tuple_for_each([](auto& _Itr) _STATIC_LAMBDA noexcept(noexcept(--_Itr)) { --_Itr; }, _Current);
                 return *this;
             }
 
@@ -7439,7 +7438,7 @@ namespace ranges {
             }
         }
 
-        static constexpr auto _Size_closure = [](auto... _Sizes) _STATIC_CALL_OPERATOR noexcept {
+        static constexpr auto _Size_closure = [](auto... _Sizes) _STATIC_LAMBDA noexcept {
             using _Common_unsigned_type = _Make_unsigned_like_t<common_type_t<decltype(_Sizes)...>>;
             return (_RANGES min)({static_cast<_Common_unsigned_type>(_Sizes)...});
         };
@@ -8029,7 +8028,7 @@ namespace ranges {
 
             _NODISCARD constexpr auto operator*() const {
                 return _RANGES _Tuple_transform(
-                    [](auto& _It) _STATIC_CALL_OPERATOR -> decltype(auto) { return *_It; }, _Current);
+                    [](auto& _It) _STATIC_LAMBDA -> decltype(auto) { return *_It; }, _Current);
             }
 
             constexpr _Iterator& operator++() noexcept(noexcept(++_Current.front())) /* strengthened */ {
@@ -8956,7 +8955,7 @@ namespace ranges {
 
             _NODISCARD constexpr auto operator*() const {
                 return _RANGES _Tuple_transform(
-                    [](auto& _It) _STATIC_CALL_OPERATOR -> decltype(auto) { return *_It; }, _Current);
+                    [](auto& _It) _STATIC_LAMBDA -> decltype(auto) { return *_It; }, _Current);
             }
 
             constexpr _Iterator& operator++() {

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1503,7 +1503,7 @@ public:
         return _Reallocate_grow_by(
             _Count,
             [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size, const _Elem* const _Ptr,
-                const size_type _Count) _STATIC_CALL_OPERATOR {
+                const size_type _Count) _STATIC_LAMBDA {
                 _Traits::copy(_New_ptr, _Old_ptr, _Old_size);
                 _Traits::copy(_New_ptr + _Old_size, _Ptr, _Count);
                 _Traits::assign(_New_ptr[_Old_size + _Count], _Elem());
@@ -1530,7 +1530,7 @@ public:
         return _Reallocate_grow_by(
             _Count,
             [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size, const size_type _Count,
-                const _Elem _Ch) _STATIC_CALL_OPERATOR {
+                const _Elem _Ch) _STATIC_LAMBDA {
                 _Traits::copy(_New_ptr, _Old_ptr, _Old_size);
                 _Traits::assign(_New_ptr + _Old_size, _Count, _Ch);
                 _Traits::assign(_New_ptr[_Old_size + _Count], _Elem());
@@ -1608,7 +1608,7 @@ public:
 
         return _Reallocate_for(
             _Count,
-            [](_Elem* const _New_ptr, const size_type _Count, const _Elem* const _Ptr) _STATIC_CALL_OPERATOR {
+            [](_Elem* const _New_ptr, const size_type _Count, const _Elem* const _Ptr) _STATIC_LAMBDA {
                 _Traits::copy(_New_ptr, _Ptr, _Count);
                 _Traits::assign(_New_ptr[_Count], _Elem());
             },
@@ -1632,7 +1632,7 @@ public:
 
         return _Reallocate_for(
             _Count,
-            [](_Elem* const _New_ptr, const size_type _Count, const _Elem _Ch) _STATIC_CALL_OPERATOR {
+            [](_Elem* const _New_ptr, const size_type _Count, const _Elem _Ch) _STATIC_LAMBDA {
                 _Traits::assign(_New_ptr, _Count, _Ch);
                 _Traits::assign(_New_ptr[_Count], _Elem());
             },
@@ -1748,7 +1748,7 @@ public:
         return _Reallocate_grow_by(
             _Count,
             [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size, const size_type _Off,
-                const _Elem* const _Ptr, const size_type _Count) _STATIC_CALL_OPERATOR {
+                const _Elem* const _Ptr, const size_type _Count) _STATIC_LAMBDA {
                 _Traits::copy(_New_ptr, _Old_ptr, _Off);
                 _Traits::copy(_New_ptr + _Off, _Ptr, _Count);
                 _Traits::copy(_New_ptr + _Off + _Count, _Old_ptr + _Off, _Old_size - _Off + 1);
@@ -1779,7 +1779,7 @@ public:
         return _Reallocate_grow_by(
             _Count,
             [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size, const size_type _Off,
-                const size_type _Count, const _Elem _Ch) _STATIC_CALL_OPERATOR {
+                const size_type _Count, const _Elem _Ch) _STATIC_LAMBDA {
                 _Traits::copy(_New_ptr, _Old_ptr, _Off);
                 _Traits::assign(_New_ptr + _Off, _Count, _Ch);
                 _Traits::copy(_New_ptr + _Off + _Count, _Old_ptr + _Off, _Old_size - _Off + 1);
@@ -1991,7 +1991,7 @@ public:
         return _Reallocate_grow_by(
             _Growth,
             [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size, const size_type _Off,
-                const size_type _Nx, const _Elem* const _Ptr, const size_type _Count) _STATIC_CALL_OPERATOR {
+                const size_type _Nx, const _Elem* const _Ptr, const size_type _Count) _STATIC_LAMBDA {
                 _Traits::copy(_New_ptr, _Old_ptr, _Off);
                 _Traits::copy(_New_ptr + _Off, _Ptr, _Count);
                 _Traits::copy(_New_ptr + _Off + _Count, _Old_ptr + _Off + _Nx, _Old_size - _Nx - _Off + 1);
@@ -2031,7 +2031,7 @@ public:
         return _Reallocate_grow_by(
             _Count - _Nx,
             [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size, const size_type _Off,
-                const size_type _Nx, const size_type _Count, const _Elem _Ch) _STATIC_CALL_OPERATOR {
+                const size_type _Nx, const size_type _Count, const _Elem _Ch) _STATIC_LAMBDA {
                 _Traits::copy(_New_ptr, _Old_ptr, _Off);
                 _Traits::assign(_New_ptr + _Off, _Count, _Ch);
                 _Traits::copy(_New_ptr + _Off + _Count, _Old_ptr + _Off + _Nx, _Old_size - _Nx - _Off + 1);
@@ -2281,7 +2281,7 @@ public:
         _Reallocate_grow_by(
             1,
             [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size, const _Elem _Ch)
-                _STATIC_CALL_OPERATOR {
+                _STATIC_LAMBDA {
                     _Traits::copy(_New_ptr, _Old_ptr, _Old_size);
                     _Traits::assign(_New_ptr[_Old_size], _Ch);
                     _Traits::assign(_New_ptr[_Old_size + 1], _Elem());
@@ -2381,7 +2381,7 @@ public:
         if (_Mypair._Myval2._Myres < _New_size) {
             _Reallocate_grow_by(_New_size - _Mypair._Myval2._Mysize,
                 [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size)
-                    _STATIC_CALL_OPERATOR { _Traits::copy(_New_ptr, _Old_ptr, _Old_size + 1); });
+                    _STATIC_LAMBDA { _Traits::copy(_New_ptr, _Old_ptr, _Old_size + 1); });
         } else {
             _ASAN_STRING_MODIFY(*this, _Mypair._Myval2._Mysize, _New_size);
             _Mypair._Myval2._Mysize = _New_size;
@@ -2419,7 +2419,7 @@ public:
         const size_type _Old_size = _Mypair._Myval2._Mysize;
         _Reallocate_grow_by(_Newcap - _Old_size,
             [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size)
-                _STATIC_CALL_OPERATOR { _Traits::copy(_New_ptr, _Old_ptr, _Old_size + 1); });
+                _STATIC_LAMBDA { _Traits::copy(_New_ptr, _Old_ptr, _Old_size + 1); });
 
         // `_Reallocate_grow_by` calls `_ASAN_STRING_CREATE` assuming that the string
         // has size (initialized memory) equal to its new capacity (allocated memory).
@@ -2447,7 +2447,7 @@ public:
             const size_type _Old_size = _Mypair._Myval2._Mysize;
             _Reallocate_grow_by(_Newcap - _Old_size,
                 [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size)
-                    _STATIC_CALL_OPERATOR { _Traits::copy(_New_ptr, _Old_ptr, _Old_size + 1); });
+                    _STATIC_LAMBDA { _Traits::copy(_New_ptr, _Old_ptr, _Old_size + 1); });
 
             // `_Reallocate_grow_by` calls `_ASAN_STRING_CREATE` assuming that the string
             // has size (initialized memory) equal to its new capacity (allocated memory).

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6216,7 +6216,9 @@ namespace ranges {
                         _Count = SIZE_MAX;
                     }
 
-                    // C23 7.32.4.6.9 "The wmemchr generic function"/2 doesn't work with unreachable_sentinel_t.
+                    // C23 7.27.5.2 "The memchr generic function"/2 says "The implementation shall behave as if
+                    // it reads the characters sequentially and stops as soon as a matching character is found."
+                    // C23 7.32.4.6.9 "The wmemchr generic function"/2 lacks such wording, so we don't use wmemchr().
                     _Result = static_cast<_Ptr_t>(_CSTD memchr(_First_ptr, static_cast<unsigned char>(_Val), _Count));
 
                     if constexpr (_Is_sized) {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6218,7 +6218,8 @@ namespace ranges {
 
                     // C23 7.27.5.2 "The memchr generic function"/2 says "The implementation shall behave as if
                     // it reads the characters sequentially and stops as soon as a matching character is found."
-                    // C23 7.32.4.6.9 "The wmemchr generic function"/2 lacks such wording, so we don't use wmemchr().
+                    // C23 7.32.4.6.9 "The wmemchr generic function"/2 lacks such wording,
+                    // so we don't use wmemchr(), avoiding issues with unreachable_sentinel_t.
                     _Result = static_cast<_Ptr_t>(_CSTD memchr(_First_ptr, static_cast<unsigned char>(_Val), _Count));
 
                     if constexpr (_Is_sized) {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6179,12 +6179,12 @@ namespace ranges {
     template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity>
         requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
     _NODISCARD constexpr _It _Find_unchecked(_It _First, const _Se _Last, const _Ty& _Val, _Pj _Proj = {}) {
-        constexpr bool _Elements_are_1_or_2_bytes = sizeof(_Iter_value_t<_It>) <= 2;
-        constexpr bool _Is_sized                  = sized_sentinel_for<_Se, _It>;
+        constexpr bool _Elements_are_1_byte = sizeof(_Iter_value_t<_It>) == 1;
+        constexpr bool _Is_sized            = sized_sentinel_for<_Se, _It>;
 
         if constexpr (_Vector_alg_in_find_is_safe<_It, _Ty>
-                      && (_Elements_are_1_or_2_bytes ? _Is_sized || same_as<_Se, unreachable_sentinel_t>
-                                                     : _Is_sized && _USE_STD_VECTOR_ALGORITHMS)
+                      && (_Elements_are_1_byte ? _Is_sized || same_as<_Se, unreachable_sentinel_t>
+                                               : _Is_sized && _USE_STD_VECTOR_ALGORITHMS)
                       && same_as<_Pj, identity>) {
             if (!_STD is_constant_evaluated()) {
                 if (!_STD _Could_compare_equal_to_value_type<_It>(_Val)) {
@@ -6202,13 +6202,13 @@ namespace ranges {
                 _Ptr_t _Result;
 #if _USE_STD_VECTOR_ALGORITHMS
                 if constexpr (_Is_sized) {
-                    // When _Is_sized && _Elements_are_1_or_2_bytes, prefer this over memchr()/wmemchr() for performance
+                    // When _Is_sized && _Elements_are_1_byte, prefer this over memchr() for performance
                     const auto _Last_ptr = _First_ptr + (_Last - _First);
                     _Result              = _STD _Find_vectorized(_First_ptr, _Last_ptr, _Val);
                 } else
 #endif // ^^^ _USE_STD_VECTOR_ALGORITHMS ^^^
                 {
-                    _STL_INTERNAL_STATIC_ASSERT(_Elements_are_1_or_2_bytes);
+                    _STL_INTERNAL_STATIC_ASSERT(_Elements_are_1_byte);
                     size_t _Count;
                     if constexpr (_Is_sized) {
                         _Count = static_cast<size_t>(_Last - _First);
@@ -6216,14 +6216,8 @@ namespace ranges {
                         _Count = SIZE_MAX;
                     }
 
-                    if constexpr (sizeof(_Iter_value_t<_It>) == 1) {
-                        _Result =
-                            static_cast<_Ptr_t>(_CSTD memchr(_First_ptr, static_cast<unsigned char>(_Val), _Count));
-                    } else {
-                        _STL_INTERNAL_STATIC_ASSERT(sizeof(_Iter_value_t<_It>) == 2);
-                        _Result = reinterpret_cast<_Ptr_t>(const_cast<wchar_t*>(_CSTD wmemchr(
-                            reinterpret_cast<const wchar_t*>(_First_ptr), static_cast<wchar_t>(_Val), _Count)));
-                    }
+                    // C23 7.32.4.6.9 "The wmemchr generic function"/2 doesn't work with unreachable_sentinel_t.
+                    _Result = static_cast<_Ptr_t>(_CSTD memchr(_First_ptr, static_cast<unsigned char>(_Val), _Count));
 
                     if constexpr (_Is_sized) {
                         if (_Result == nullptr) {

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -2018,17 +2018,19 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 #define _STATIC_CALL_OPERATOR
 #define _CONST_CALL_OPERATOR const
 #define _STATIC_LAMBDA
-#else // ^^^ workaround for CUDA / no workaround for CUDA vvv
+#elif defined(__clang__) || defined(__EDG__) // no workaround
 #define _STATIC_CALL_OPERATOR static
 #define _CONST_CALL_OPERATOR
-
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-2383148, static lambdas aren't accepted by /Zc:lambda-
 #define _STATIC_LAMBDA static
-#else // ^^^ no workaround for MSVC / workaround for MSVC vvv
+#elif _MSC_VER < 1944 // TRANSITION, internal toolset needs to be updated to VS 2022 17.14 Preview 1
+#define _STATIC_CALL_OPERATOR
+#define _CONST_CALL_OPERATOR const
 #define _STATIC_LAMBDA
-#endif // ^^^ workaround for MSVC ^^^
-
-#endif // ^^^ no workaround for CUDA ^^^
+#else // TRANSITION, VSO-2383148, fixed in VS 2022 17.14 Preview 3
+#define _STATIC_CALL_OPERATOR static
+#define _CONST_CALL_OPERATOR
+#define _STATIC_LAMBDA
+#endif // ^^^ workaround ^^^
 
 #ifdef __CUDACC__ // TRANSITION, CUDA 12.4 doesn't recognize MSVC __restrict; CUDA __restrict__ is not usable in C++
 #define _RESTRICT

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -802,6 +802,8 @@
 //                copy/move constructors and copy/move assignment operators are not trivial (/Wall)
 // warning C5246: 'member': the initialization of a subobject should be wrapped in braces (/Wall)
 // warning C5278: adding a specialization for 'type trait' has undefined behavior
+// warning C5280: a static operator '()' requires at least '/std:c++23preview'
+// warning C5281: a static lambda requires at least '/std:c++23preview'
 // warning C6294: Ill-defined for-loop: initial condition does not satisfy test. Loop body not executed
 
 #ifndef _STL_DISABLED_WARNINGS
@@ -809,7 +811,8 @@
 #define _STL_DISABLED_WARNINGS                        \
     4180 4324 4412 4455 4494 4514 4574 4582 4583 4587 \
     4588 4619 4623 4625 4626 4643 4648 4702 4793 4820 \
-    4868 4988 5026 5027 5045 5220 5246 5278 6294      \
+    4868 4988 5026 5027 5045 5220 5246 5278 5280 5281 \
+    6294                                              \
     _STL_DISABLED_WARNING_C4577                       \
     _STL_DISABLED_WARNING_C4984                       \
     _STL_DISABLED_WARNING_C5053                       \
@@ -820,6 +823,7 @@
 // warning: constexpr if is a C++17 extension [-Wc++17-extensions]
 // warning: explicit(bool) is a C++20 extension [-Wc++20-extensions]
 // warning: declaring overloaded 'operator()' as 'static' is a C++23 extension [-Wc++23-extensions]
+// warning: static lambdas are a C++23 extension [-Wc++23-extensions]
 // warning: ignoring __declspec(allocator) because the function return type '%s' is not a pointer or reference type
 //     [-Wignored-attributes]
 // warning: '#pragma float_control' is not supported on this target - ignored [-Wignored-pragmas]

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -2014,13 +2014,21 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 #define _STL_INTERNAL_STATIC_ASSERT(...)
 #endif // ^^^ !defined(_ENABLE_STL_INTERNAL_CHECK) ^^^
 
-#ifdef __cpp_static_call_operator
-#define _STATIC_CALL_OPERATOR static
-#define _CONST_CALL_OPERATOR
-#else // ^^^ defined(__cpp_static_call_operator) / !defined(__cpp_static_call_operator) vvv
+#ifdef __CUDACC__ // TRANSITION, CUDA 12.4 doesn't have downlevel support for static call operators
 #define _STATIC_CALL_OPERATOR
 #define _CONST_CALL_OPERATOR const
-#endif // ^^^ !defined(__cpp_static_call_operator) ^^^
+#define _STATIC_LAMBDA
+#else // ^^^ workaround for CUDA / no workaround for CUDA vvv
+#define _STATIC_CALL_OPERATOR static
+#define _CONST_CALL_OPERATOR
+
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-2383148, static lambdas aren't accepted by /Zc:lambda-
+#define _STATIC_LAMBDA static
+#else // ^^^ no workaround for MSVC / workaround for MSVC vvv
+#define _STATIC_LAMBDA
+#endif // ^^^ workaround for MSVC ^^^
+
+#endif // ^^^ no workaround for CUDA ^^^
 
 #ifdef __CUDACC__ // TRANSITION, CUDA 12.4 doesn't recognize MSVC __restrict; CUDA __restrict__ is not usable in C++
 #define _RESTRICT

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -4488,7 +4488,10 @@ const void* __stdcall __std_find_trivial_unsized_1(const void* const _First, con
 
 // TRANSITION, ABI: preserved for binary compatibility
 const void* __stdcall __std_find_trivial_unsized_2(const void* const _First, const uint16_t _Val) noexcept {
-    // C23 7.32.4.6.9 "The wmemchr generic function"/2 lacks such wording, so we don't use wmemchr().
+    // C23 7.27.5.2 "The memchr generic function"/2 says "The implementation shall behave as if
+    // it reads the characters sequentially and stops as soon as a matching character is found."
+    // C23 7.32.4.6.9 "The wmemchr generic function"/2 lacks such wording,
+    // so we don't use wmemchr(), avoiding issues with unreachable_sentinel_t.
     return __std_find_trivial_unsized_impl(_First, _Val);
 }
 

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -4481,12 +4481,15 @@ extern "C" {
 
 // TRANSITION, ABI: preserved for binary compatibility
 const void* __stdcall __std_find_trivial_unsized_1(const void* const _First, const uint8_t _Val) noexcept {
+    // C23 7.27.5.2 "The memchr generic function"/2 says "The implementation shall behave as if
+    // it reads the characters sequentially and stops as soon as a matching character is found."
     return memchr(_First, _Val, SIZE_MAX);
 }
 
 // TRANSITION, ABI: preserved for binary compatibility
 const void* __stdcall __std_find_trivial_unsized_2(const void* const _First, const uint16_t _Val) noexcept {
-    return wmemchr(static_cast<const wchar_t*>(_First), static_cast<wchar_t>(_Val), SIZE_MAX);
+    // C23 7.32.4.6.9 "The wmemchr generic function"/2 lacks such wording, so we don't use wmemchr().
+    return __std_find_trivial_unsized_impl(_First, _Val);
 }
 
 // TRANSITION, ABI: preserved for binary compatibility

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -428,35 +428,6 @@ std/algorithms/alg.modifying.operations/alg.move/move.pass.cpp:1 FAIL
 std/language.support/support.rtti/type.info/type_info.equal.pass.cpp:0 FAIL
 std/language.support/support.rtti/type.info/type_info.equal.pass.cpp:1 FAIL
 
-# DevCom-10808176 VSO-2319111 MSVC doesn't properly destroy a loop variable in constant evaluation
-# Fixed in VS 2022 17.14 Preview 1.
-std/algorithms/alg.nonmodifying/alg.find.last/ranges.find_last.pass.cpp:0 FAIL
-std/algorithms/alg.nonmodifying/alg.find.last/ranges.find_last.pass.cpp:1 FAIL
-std/containers/sequences/vector.bool/construct_iter_iter.pass.cpp:0 FAIL
-std/containers/sequences/vector.bool/construct_iter_iter.pass.cpp:1 FAIL
-std/containers/sequences/vector.bool/construct_iter_iter_alloc.pass.cpp:0 FAIL
-std/containers/sequences/vector.bool/construct_iter_iter_alloc.pass.cpp:1 FAIL
-std/containers/sequences/vector.bool/construct_size.pass.cpp:0 FAIL
-std/containers/sequences/vector.bool/construct_size.pass.cpp:1 FAIL
-std/containers/sequences/vector.bool/construct_size_value.pass.cpp:0 FAIL
-std/containers/sequences/vector.bool/construct_size_value.pass.cpp:1 FAIL
-std/containers/sequences/vector.bool/construct_size_value_alloc.pass.cpp:0 FAIL
-std/containers/sequences/vector.bool/construct_size_value_alloc.pass.cpp:1 FAIL
-std/containers/sequences/vector/reverse_iterators.pass.cpp:0 FAIL
-std/containers/sequences/vector/reverse_iterators.pass.cpp:1 FAIL
-std/containers/sequences/vector/vector.cons/construct_iter_iter.pass.cpp:0 FAIL
-std/containers/sequences/vector/vector.cons/construct_iter_iter.pass.cpp:1 FAIL
-std/containers/sequences/vector/vector.cons/construct_iter_iter_alloc.pass.cpp:0 FAIL
-std/containers/sequences/vector/vector.cons/construct_iter_iter_alloc.pass.cpp:1 FAIL
-std/containers/sequences/vector/vector.cons/construct_size.pass.cpp:0 FAIL
-std/containers/sequences/vector/vector.cons/construct_size.pass.cpp:1 FAIL
-std/containers/sequences/vector/vector.cons/construct_size_value.pass.cpp:0 FAIL
-std/containers/sequences/vector/vector.cons/construct_size_value.pass.cpp:1 FAIL
-std/containers/sequences/vector/vector.cons/construct_size_value_alloc.pass.cpp:0 FAIL
-std/containers/sequences/vector/vector.cons/construct_size_value_alloc.pass.cpp:1 FAIL
-std/containers/views/mdspan/mdspan/index_operator.pass.cpp:0 FAIL
-std/containers/views/mdspan/mdspan/index_operator.pass.cpp:1 FAIL
-
 # VSO-2338829 constexpr error "subtracting pointers to elements of different arrays" in _String_const_iterator::_Verify_offset()
 std/strings/basic.string/string.modifiers/string_erase/iter.pass.cpp:0 FAIL
 std/strings/basic.string/string.modifiers/string_erase/iter.pass.cpp:1 FAIL
@@ -1098,6 +1069,10 @@ std/ranges/range.adaptors/range.join/range.join.iterator/iter.swap.pass.cpp:1 FA
 # Not analyzed. Likely MSVC constexpr bug with negative chars passed to __builtin_memcmp.
 std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/compare.pass.cpp:0 FAIL
 std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/compare.pass.cpp:1 FAIL
+
+# Not analyzed. Likely MSVC constexpr bug, "note: failure was caused by a read of a variable outside its lifetime"
+std/containers/views/mdspan/mdspan/index_operator.pass.cpp:0 FAIL
+std/containers/views/mdspan/mdspan/index_operator.pass.cpp:1 FAIL
 
 # Not analyzed. SKIPPED because this is x86-specific, fatal error C1060: compiler is out of heap space
 std/algorithms/alg.modifying.operations/alg.transform/ranges.transform.binary.iterator.pass.cpp:0 SKIPPED

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -959,10 +959,12 @@ std/containers/sequences/vector/vector.modifiers/destroy_elements.pass.cpp FAIL
 std/containers/sequences/vector/vector.modifiers/insert_range.pass.cpp FAIL
 std/strings/basic.string/string.modifiers/string_replace/replace_with_range.pass.cpp FAIL
 std/utilities/charconv/charconv.to.chars/integral.pass.cpp FAIL
-std/utilities/template.bitset/bitset.members/left_shift_eq.pass.cpp FAIL
-std/utilities/template.bitset/bitset.members/op_and_eq.pass.cpp FAIL
-std/utilities/template.bitset/bitset.members/op_or_eq.pass.cpp FAIL
-std/utilities/template.bitset/bitset.members/right_shift_eq.pass.cpp FAIL
+
+# Not analyzed, failing due to constexpr step limits. SKIPPED because they occasionally pass in certain configurations.
+std/utilities/template.bitset/bitset.members/left_shift_eq.pass.cpp SKIPPED
+std/utilities/template.bitset/bitset.members/op_and_eq.pass.cpp SKIPPED
+std/utilities/template.bitset/bitset.members/op_or_eq.pass.cpp SKIPPED
+std/utilities/template.bitset/bitset.members/right_shift_eq.pass.cpp SKIPPED
 
 # Not analyzed. In debug mode, looks like a proxy object unexpectedly exhausts an 80-byte buffer.
 # In release mode, fails in a later assertion that appears to be testing libc++-specific behavior.

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -324,13 +324,8 @@ std/utilities/meta/meta.unary/meta.unary.prop/is_implicit_lifetime.pass.cpp FAIL
 
 
 # *** MISSING COMPILER FEATURES ***
-# P1169R4 static operator()
-std/ranges/range.adaptors/range.adaptor.object/range_adaptor_closure.pass.cpp:0 FAIL
-std/ranges/range.adaptors/range.adaptor.object/range_adaptor_closure.pass.cpp:1 FAIL
-std/thread/futures/futures.task/futures.task.members/ctad.static.compile.pass.cpp:0 FAIL
-std/thread/futures/futures.task/futures.task.members/ctad.static.compile.pass.cpp:1 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/ctad.static.compile.pass.cpp:0 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/ctad.static.compile.pass.cpp:1 FAIL
+
+# None!
 
 
 # *** MISSING LWG ISSUE RESOLUTIONS ***
@@ -1266,6 +1261,10 @@ std/containers/sequences/vector/vector.capacity/shrink_to_fit_exceptions.pass.cp
 # Not analyzed. Our stdalign.h doesn't define __alignas_is_defined in C++ mode.
 std/depr/depr.c.headers/stdalign_h.compile.pass.cpp:0 FAIL
 std/depr/depr.c.headers/stdalign_h.compile.pass.cpp:1 FAIL
+
+# Not analyzed. Probably an MSVC compiler bug, as it rejects `n | negate | negate` while Clang accepts.
+std/ranges/range.adaptors/range.adaptor.object/range_adaptor_closure.pass.cpp:0 FAIL
+std/ranges/range.adaptors/range.adaptor.object/range_adaptor_closure.pass.cpp:1 FAIL
 
 
 # *** XFAILS WHICH PASS ***

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1356,8 +1356,9 @@ std/containers/sequences/vector/vector.modifiers/assert.push_back.invalidation.p
 # Listing these on separate lines would allow magic_comments.txt to recognize it.
 std/containers/sequences/array/assert.iterators.pass.cpp:9 SKIPPED
 
-# These tests emit C5321, which warns when the resolution to core issue 1656 affects a u8 string literal.
+# These tests emit C5321, which warns when the resolution to CWG-1656 affects a u8 string literal.
 # The conformant behavior is opt-in because it can silently change behavior.
-# : warning C5321: nonstandard extension used: encoding '\x80' as a multi-byte utf-8 character. Use \u instead for cross platform compatibility or '/Zc:u8EscapeEncoding' to disable the extension.
+# warning C5321: nonstandard extension used: encoding '\x80' as a multi-byte utf-8 character. Use \u instead
+# for cross platform compatibility or '/Zc:u8EscapeEncoding' to disable the extension.
 std/utilities/format/format.functions/escaped_output.unicode.pass.cpp:9 SKIPPED
 std/utilities/format/format.functions/fill.unicode.pass.cpp:9 SKIPPED

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -587,11 +587,8 @@ std/input.output/syncstream/syncbuf/syncstream.syncbuf.members/emit.pass.cpp FAI
 
 
 # *** VCRUNTIME BUGS ***
-# DevCom-10373274 VSO-1824997 "vcruntime nothrow array operator new falls back on the wrong function"
-# This passes for the :1 (ASan) configuration, surprisingly.
-# Fixed in VS 2022 17.14 Preview 1.
-std/language.support/support.dynamic/new.delete/new.delete.array/new.size_nothrow.replace.indirect.pass.cpp:0 FAIL
-std/language.support/support.dynamic/new.delete/new.delete.array/new.size_nothrow.replace.indirect.pass.cpp:2 FAIL
+
+# None!
 
 
 # *** CRT BUGS ***

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1308,6 +1308,7 @@ std/language.support/support.exception/propagation/current_exception.pass.cpp:2 
 # to silence warnings, but the MSVC-internal test harness doesn't yet parse ADDITIONAL_COMPILE_FLAGS.
 std/algorithms/alg.modifying.operations/alg.replace/ranges.replace.pass.cpp:9 SKIPPED
 std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp:9 SKIPPED
+std/algorithms/alg.nonmodifying/alg.find.last/ranges.find_last.pass.cpp:9 SKIPPED
 std/algorithms/alg.nonmodifying/alg.find/find.pass.cpp:9 SKIPPED
 std/algorithms/alg.nonmodifying/alg.find/ranges.find.pass.cpp:9 SKIPPED
 std/algorithms/alg.nonmodifying/alg.fold/left_folds.pass.cpp:9 SKIPPED

--- a/tests/std/tests/P1169R4_static_call_operator/test.compile.pass.cpp
+++ b/tests/std/tests/P1169R4_static_call_operator/test.compile.pass.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifdef __cpp_static_call_operator
-
 #include <functional>
 #include <future>
 #include <type_traits>
@@ -51,5 +49,3 @@ void all_tests() {
     test_ctad<function>();
     test_ctad<packaged_task>();
 }
-
-#endif // ^^^ defined(__cpp_static_call_operator) ^^^

--- a/tools/scripts/print_failures.py
+++ b/tools/scripts/print_failures.py
@@ -21,7 +21,10 @@ if __name__ == "__main__":
             for testcase_elem in test_xml.getElementsByTagName("testcase"):
                 for failure_elem in testcase_elem.getElementsByTagName("failure"):
                     print(f"name: {testcase_elem.getAttribute('classname')}")
-                    print(f"output: {failure_elem.firstChild.data}")
+                    if failure_elem.firstChild is None:
+                        print("No output, possibly because this was an XPASS.")
+                    else:
+                        print(f"output: {failure_elem.firstChild.data}")
                     print("==================================================")
         else:
             test_log = json.load(file)


### PR DESCRIPTION
# :scroll: Changelog

- Code cleanups:
  * Removed compiler bug workarounds.
- Infrastructure improvements:
  * Updated dependencies.
    + Updated build compiler to VS 2022 17.14 Preview 1.
    + Updated Google Benchmark to 1.9.1.
    + Updated Python to 3.13.2.

# :gear: Commits

* VS 2022 17.14 Preview 1.
* Remove workaround for DevCom-10373274 "vcruntime nothrow array operator new falls back on the wrong function".
* Remove workaround for DevCom-10808176 "MSVC doesn't properly destroy a loop variable in constant evaluation".
  + However, `mdspan/index_operator.pass.cpp` is still failing due to a likely MSVC constexpr bug, "note: failure was caused by a read of a variable outside its lifetime".

# :phone: `static operator()` Commits

All of MSVC/Clang/EDG now support C++23 WG21-P1169R4 `static operator()`, so let's update the codebase:

* Remove `#ifdef __cpp_static_call_operator` from `P1169R4_static_call_operator`.
  + This uses `usual_latest_matrix.lst`.
* Guard `std::function` CTAD for static call operators with `_HAS_CXX23`.
  + There's a question of whether we should attempt to expand this CTAD downlevel, to match how static call operators are supported downlevel. It would probably work, even for CUDA (which I believe currently lacks support for static call operators, but also doesn't appear to reject the SFINAE syntax here on sight). However, `std::function` CTAD is a "nice to have" feature, and we aren't obligated to support it downlevel. Restricting it to C++23 is less risky, and completely avoids any question of disrupting CUDA (as CUDA 12.4 supports only up to C++20).
* Suppress MSVC Future Technology warnings C5280 and C5281.
  + Clang uses the same warning option with different messages; record both.
* Use static call operators downlevel, except for CUDA.
  + In C++14 mode, as of VS 2022 17.14 Preview 1 and Clang 19.1.1:
    - MSVC does NOT define the feature-test macro, but accepts the code (with a C5280 warning).
    - Clang DOES define the feature-test macro, and accepts the code (with a `-Wc++23-extensions` warning).
    - EDG does NOT define the feature-test macro, but accepts the code silently.
  + For Intel's compiler, which we don't support but which we do avoid gratuitously breaking, my experiments on Compiler Explorer indicate that they have Clang's behavior.
  + CUDA 12.4 was released in March 2024, and I suspect that their EDG version doesn't support this yet.
  + Additionally, split the macro into `_STATIC_LAMBDA` to work around VSO-2383148 "C++23 static lambdas aren't accepted by the old lambda processor". This means that they aren't accepted in C++14/17, without enabling `/permissive-` (strict mode) or `/Zc:lambda` (new processor). This also means that they aren't accepted in C++20/23 when `/Zc:lambda-` (old processor) is used. (Note: C++20/23 with `/permissive` (permissive mode) still uses the new processor, and therefore works.) Because none of this is Standard-mandated (it's a "nice to have" minor performance improvement), we should just avoid static lambdas with MSVC while the bug remains active.
    - This will be fixed in 17.14 Preview 3 by MSVC-PR-611685.
* Enable libcxx tests for MSVC.
  + However, `range_adaptor_closure.pass.cpp `is blocked by a compiler bug affecting ranges.

# :gear: More Commits

* Drop the `wmemchr()` optimization for `unreachable_sentinel_t`.
  + Fixes `GH_002431_byte_range_find_with_unreachable_sentinel`, which regressed either with VS 2022 17.14 Preview 1
  or the newer Win11 SDK 26100 that I had unintentionally installed briefly; I didn't care enough to find out what was the cause. (Our README currently recommends installing the older Win11 SDK 22621 because that's what the MS-internal build currently uses.)
* Google Benchmark 1.9.1.
  + No MS-internal changes needed.
* 2025-datacenter-azure-edition.
  + The extra crispy flavor is said to be more efficient than the original recipe. It doesn't seem to make a difference for us, but it seems ideal to use.
* Python 3.13.2.
* Send `create-1es-hosted-pool.ps1` output to a log file.
  + I'm updating the `.gitignore` to ignore `*.log` anywhere in the tree, not just the root. (We don't have any such files in the repo.)
  + This captures output (via appending to ` >> $LogFile`) that I was previously piping to ` | Out-Null` to reduce script noise. I've had some trouble with sporadic failures and this should make it easier to diagnose in the future.
* Fix the CUDA installation.
  + In #5247, I encountered a CUDA installer hang, #5282. While working around it, I didn't notice that `nvcc` was no longer being added to the path, so the test harness was just skipping that test. And I didn't notice that we need to install `cudart` for headers that it wants to include.
  + I don't know how to get the installer to update the path when installing selected subpackages (I tried the "VS integration" one and it wasn't sufficient, and trying different subsets is extremely time-consuming). I'm just going to manually update the path.
  + I've verified that all 6 configurations of `GH_000639_nvcc_include_all` are now passing instead of being skipped.
* New pool.
* Teach `print_failures.py` to understand XPASS in XML.
  + This is parsing:
    ```xml
    <testcase classname="libc++.std/utilities/template_bitset/bitset_members" name="left_shift_eq.pass.cpp" time="8.86">
        <failure><![CDATA[]]></failure>
    </testcase>
    ```
  + It handles XPASS in JSON just fine.
* Fix STL-ASan-CI failures by upgrading `bitset.members` tests from FAIL to SKIPPED.
  + These tests are stressing `constexpr` step limits. One started passing for ASan, which makes little sense. All of the tests in this directory are similar, so skip 'em.
* Expand `memchr`/`wmemchr` comments, fix `__std_find_trivial_unsized_2`.

:white_check_mark: [STL-ASan-CI passed.](https://dev.azure.com/vclibs/STL/_build/results?buildId=18252&view=results)

# :infinity: Commits Forever

* Work around the MSVC-internal toolset being 17.12 and not supporting static call operators.
* Add an MSVC-internal skip for a test with `ADDITIONAL_COMPILE_FLAGS(cl-style-warnings)`.
  + This test was otherwise re-enabled after VSO-2319111 was fixed.
* Cite CWG-1656 with our usual style, improve wrapping.
  + Thanks @frederick-vs-ja!
* Code review feedback: clarify `memchr`/`wmemchr` comments.
  + Thanks @davidmrdavid!
