### PR TITLE
LWG-3899 co_yielding elements of an lvalue generator is unnecessarily inefficient

### DIFF
--- a/stl/inc/generator
+++ b/stl/inc/generator
@@ -286,6 +286,13 @@ namespace _Gen_detail {
             return _Nested_awaitable{_STD move(_Elem.range)};
         }
 
+        template <class _Rty, class _Vty, class _Alloc, class _Unused>
+            requires same_as<_Yield_t<_Reference_t<_Rty, _Vty>>, _Yielded>
+        _NODISCARD auto yield_value(_RANGES elements_of<generator<_Rty, _Vty, _Alloc>&, _Unused> _Elem) noexcept {
+            using _Nested_awaitable = _Nested_awaitable_provider<_Rty, _Vty, _Alloc>::_Awaitable;
+            return _Nested_awaitable{_STD move(_Elem.range)};
+        }
+
         template <_RANGES input_range _Rng, class _Alloc>
             requires convertible_to<_RANGES range_reference_t<_Rng>, _Yielded>
         _NODISCARD auto yield_value(_RANGES elements_of<_Rng, _Alloc> _Elem) {


### PR DESCRIPTION
Resolves #5111 
I decided to look into this issue because I like coroutines and wanted to try contributing something.

It turns out that the implementation is quite straight forward, just adding a `yield_value` overload taking a generator by lvalue reference which is otherwise the exact same as the overload taking a generator by rvalue reference.

Since the LWG paper doesn't state specific numbers and to test the implementation I wrote a short test which I tried with both the current STL (as shipped with VS 17.13.0) and my patched version and in both Debug and Release configurations.

```
#include <generator>
#include <algorithm>
#include <chrono>
#include <print>

constexpr int N = 100000;

std::generator<int> f() {
  co_yield 1;
}

std::generator<int> g_rvalue()
{
  for (int i = 0; i < N; i++) {
    auto f1 = f();
    co_yield std::ranges::elements_of(std::move(f1));
  }
}

std::generator<int> g_lvalue()
{
  for (int i = 0; i < N; i++) {
    auto f1 = f();
    co_yield std::ranges::elements_of(f1);
  }
}

int main()
{
  {
    auto start = std::chrono::high_resolution_clock::now();
    int res = std::ranges::fold_left(g_rvalue(), 0, std::plus<int>());
    auto duration = std::chrono::high_resolution_clock::now() - start;
    std::println("With elements_of(rvalue generator)\nresult: {}, time: {}, per element: {}", res, std::chrono::duration_cast<std::chrono::microseconds>(duration), duration / N);
  }

  {
    auto start = std::chrono::high_resolution_clock::now();
    int res = std::ranges::fold_left(g_lvalue(), 0, std::plus<int>());
    auto duration = std::chrono::high_resolution_clock::now() - start;
    std::println("With elements_of(lvalue generator)\nresult: {}, time: {}, per element: {}", res, std::chrono::duration_cast<std::chrono::microseconds>(duration), duration / N);
  }
}
```
Results on my machine (time per element):
||Debug||Release||
|---|---|---|---|---|
||rvalue|lvalue|rvalue|lvalue|
|current|~870ns|~1700ns|~49ns|91ns|
|patched|~870ns|~870ns|~49ns|~49ns|

The results are bit noisy across multiple runs but show clearly that the general overload of `yield_value` (which is used in the current version) takes almost twice as much time as the generator specialised version (both unoptimised and optimised). This is unsurprising since the general overload wraps the range in an extra generator resulting in two coroutine calls per element. The results also show that the difference disappears in the patched version since the lvalue generator also uses the specialised overload.