### PR TITLE
Unblock RWC by extending the static call operator workaround

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -2015,8 +2015,8 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 #endif // ^^^ !defined(_ENABLE_STL_INTERNAL_CHECK) ^^^
 
 #if defined(__CUDACC__) || (defined(__clang__) && __clang_major__ < 16)
-// TRANSITION, CUDA 12.4 doesn't have downlevel support for static call operators
-// TRANSITION, VSO-2397560, we don't generally attempt to support old versions of Clang
+// TRANSITION, CUDA 12.4 doesn't have downlevel support for static call operators.
+// TRANSITION, VSO-2397560, temporary workaround for Real World Code relying on ancient Clang versions.
 #define _STATIC_CALL_OPERATOR
 #define _CONST_CALL_OPERATOR const
 #define _STATIC_LAMBDA


### PR DESCRIPTION
Fixes internal VSO-2397560 "\[RWC\]\[prod/fe\]\[Regression\] Taichi build failed with error G444FFF0D: overloaded 'operator()' cannot be a static member function".

We build https://github.com/taichi-dev/taichi in our Real World Code test suite. They're using an older version of Clang/LLVM than we require (I believe it's Clang 14 :scream_cat:, when we now require Clang 19), and they've been [defining our escape hatch macro](https://github.com/taichi-dev/taichi/blob/9f30ff98ecf605a0d93a07360abbfacaaaaeba83/taichi/runtime/llvm/runtime_module/runtime.cpp#L13) to get away with this, but #5284's change to use C++23 WG21-P1169R4 `static operator()` downlevel has broken them.

We need to work around CUDA 12.4's lack of support for static call operators, so we may as well extend this to ancient versions of Clang, but we are not attempting to support paleolithic compilers in general. In the future, when we can upgrade our minimum supported CUDA version to something that understands static call operators, we should entirely remove this workaround - if Taichi hasn't upgraded their Clang dependency by then, we'll have to file an issue and temporarily skip it in RWC.