### PR TITLE
`<xutility>`: Fix conversion between `basic_const_iterator`s

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2211,6 +2211,9 @@ struct _Basic_const_iterator_category<_Iter> {
 _EXPORT_STD template <input_iterator _Iter>
 class basic_const_iterator : public _Basic_const_iterator_category<_Iter> {
 private:
+    template <input_iterator>
+    friend class basic_const_iterator;
+
     /* [[no_unique_address]] */ _Iter _Current{};
 
     using _Reference        = iter_const_reference_t<_Iter>;

--- a/tests/std/tests/P2278R4_basic_const_iterator/test.cpp
+++ b/tests/std/tests/P2278R4_basic_const_iterator/test.cpp
@@ -380,6 +380,15 @@ constexpr bool all_tests() {
     return true;
 }
 
+// GH-5321 "<xutility>: basic_const_iterator<int *> Cannot Convert to basic_const_iterator<const int *>"
+void test_conversion_instantiation() { // COMPILE-ONLY
+    struct Base {};
+    struct Derived : Base {};
+
+    [[maybe_unused]] basic_const_iterator<const int*> cit1 = basic_const_iterator<const int*>{};
+    [[maybe_unused]] basic_const_iterator<Base*> cit2      = basic_const_iterator<Derived*>{};
+}
+
 int main() {
     static_assert(all_tests());
     all_tests();

--- a/tests/std/tests/P2278R4_basic_const_iterator/test.cpp
+++ b/tests/std/tests/P2278R4_basic_const_iterator/test.cpp
@@ -374,19 +374,36 @@ constexpr void test_p2836r1() {
     }
 }
 
-constexpr bool all_tests() {
-    instantiation_test();
-    test_p2836r1();
-    return true;
-}
-
 // GH-5321 "<xutility>: basic_const_iterator<int *> Cannot Convert to basic_const_iterator<const int *>"
-void test_conversion_instantiation() { // COMPILE-ONLY
+constexpr void test_conversion_instantiation() {
     struct Base {};
     struct Derived : Base {};
 
-    [[maybe_unused]] basic_const_iterator<const int*> cit1 = basic_const_iterator<const int*>{};
-    [[maybe_unused]] basic_const_iterator<Base*> cit2      = basic_const_iterator<Derived*>{};
+    {
+        basic_const_iterator<const int*> cit = basic_const_iterator<int*>{};
+        assert(cit.base() == nullptr);
+    }
+    {
+        int n{};
+        basic_const_iterator<const int*> cit = basic_const_iterator<int*>{&n};
+        assert(cit.base() == &n);
+    }
+    {
+        basic_const_iterator<Base*> cit = basic_const_iterator<Derived*>{};
+        assert(cit.base() == nullptr);
+    }
+    {
+        Derived d{};
+        basic_const_iterator<Base*> cit = basic_const_iterator<Derived*>{&d};
+        assert(cit.base() == static_cast<Base*>(&d));
+    }
+}
+
+constexpr bool all_tests() {
+    instantiation_test();
+    test_p2836r1();
+    test_conversion_instantiation();
+    return true;
 }
 
 int main() {


### PR DESCRIPTION
By befriending `basic_const_iterator` specializations. Fixes #5321.