### PR TITLE
`README.md`: consistent assumption about STL location

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,8 +379,8 @@ steps. Let's assume we want to debug a new feature with tests located in `tests\
 
 As always, build the STL from your branch and run the tests:
 ```
-C:\STL\out\x64> ninja
-C:\STL\out\x64> python tests\utils\stl-lit\stl-lit.py -v C:\STL\tests\std\tests\GH_XXXX_meow
+C:\Dev\STL\out\x64> ninja
+C:\Dev\STL\out\x64> python tests\utils\stl-lit\stl-lit.py -v C:\Dev\STL\tests\std\tests\GH_XXXX_meow
 ```
 
 Let's assume one of the tests fails an assert and we want to debug that configuration. `stl-lit` will conveniently print
@@ -390,15 +390,15 @@ provide debug symbols: `/Zi /Fdbark.pdb`.
 You can replace `bark` with any descriptive name you like. Add these before the `"-link"` option in the command line
 and recompile. Example:
 ```
-C:\STL\out\x64>cl "C:\STL\tests\std\tests\GH_XXXX_meow\test.cpp" [... more arguments ...]
-"-FeC:\STL\out\x64\tests\std\tests\GH_XXXX_meow\Output\02\GH_XXXX_meow.exe" /Zi /Fdbark.pdb "-link"
+C:\Dev\STL\out\x64>cl "C:\Dev\STL\tests\std\tests\GH_XXXX_meow\test.cpp" [... more arguments ...]
+"-FeC:\Dev\STL\out\x64\tests\std\tests\GH_XXXX_meow\Output\02\GH_XXXX_meow.exe" /Zi /Fdbark.pdb "-link"
 [... more arguments ...]
 ```
 
 You can now start debugging the test via:
 ```
-devenv "C:\STL\out\x64\tests\std\tests\GH_XXXX_meow\Output\02\GH_XXXX_meow.exe"
-       "C:\STL\tests\std\tests\GH_XXXX_meow\test.cpp"
+devenv "C:\Dev\STL\out\x64\tests\std\tests\GH_XXXX_meow\Output\02\GH_XXXX_meow.exe"
+       "C:\Dev\STL\tests\std\tests\GH_XXXX_meow\test.cpp"
 ```
 
 However, this might not work right away, as Visual Studio may complain about a missing `msvcp140_oss.dll`. The reason
@@ -406,7 +406,7 @@ is that the STL builds those and other DLLs itself and we should under no circum
 If you are testing one of the configurations with dynamic linkage (`/MD` or `/MDd`) the easiest solution is to add the
 build folder to your path:
 ```
-set PATH=C:\STL\out\x64\out\bin\amd64;%PATH%
+set PATH=C:\Dev\STL\out\x64\out\bin\amd64;%PATH%
 ```
 
 ## Running Tests With Address Sanitizer (ASan)


### PR DESCRIPTION
Other sections already assume `C:\Dev\STL`