### PR TITLE
Implement LWG-3956 `chrono::parse` uses `from_stream` as a customization point

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -4608,6 +4608,22 @@ namespace chrono {
         return _Istr;
     }
 
+    namespace _From_stream_adl_only {
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1681199
+        void from_stream() = delete; // Block unqualified name lookup
+#else // ^^^ no workaround / workaround vvv
+        void from_stream();
+#endif // ^^^ workaorund ^^^
+
+        template <class _Parsable, class _CharT, class _Traits, class... _Rest>
+        concept _Can_from_stream = requires(
+            basic_istream<_CharT, _Traits>& __istr, const _CharT* __s, _Parsable& __parsed, _Rest&&... __rest_args) {
+            from_stream(__istr, +__s, __parsed, _STD forward<_Rest>(__rest_args)...); // intentional ADL
+        }
+    } // namespace _From_stream_adl_only
+
+    using _From_stream_adl_only::_Can_from_stream;
+
     template <class _CharT, class _Traits, class _Alloc, class _Parsable>
     struct _Time_parse_iomanip_c_str {
         _Time_parse_iomanip_c_str(const _CharT* _Fmt_, _Parsable& _Tp_,
@@ -4618,6 +4634,7 @@ namespace chrono {
 
         friend basic_istream<_CharT, _Traits>& operator>>(
             basic_istream<_CharT, _Traits>& _Is, _Time_parse_iomanip_c_str&& _Tpi) {
+            using _From_stream_adl_only::from_stream;
             from_stream(_Is, _Tpi._Fmt, _Tpi._Tp, _Tpi._Abbrev, _Tpi._Offset); // intentional ADL
             return _Is;
         }
@@ -4638,6 +4655,7 @@ namespace chrono {
 
         friend basic_istream<_CharT, _Traits>& operator>>(
             basic_istream<_CharT, _Traits>& _Is, _Time_parse_iomanip&& _Tpi) {
+            using _From_stream_adl_only::from_stream;
             from_stream(_Is, _Tpi._Fmt.c_str(), _Tpi._Tp, _Tpi._Abbrev, _Tpi._Offset); // intentional ADL
             return _Is;
         }
@@ -4646,12 +4664,6 @@ namespace chrono {
         _Parsable& _Tp;
         basic_string<_CharT, _Traits, _Alloc>* _Abbrev;
         minutes* _Offset;
-    };
-
-    template <class _Parsable, class _CharT, class _Traits, class... _Rest>
-    concept _Can_from_stream = requires(
-        basic_istream<_CharT, _Traits>& __istr, const _CharT* __s, _Parsable& __parsed, _Rest&&... __rest_args) {
-        from_stream(__istr, +__s, __parsed, _STD forward<_Rest>(__rest_args)...); // intentional ADL
     };
 
     _EXPORT_STD template <class _CharT, _Can_from_stream<_CharT, char_traits<_CharT>> _Parsable>

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -4613,13 +4613,13 @@ namespace chrono {
         void from_stream() = delete; // Block unqualified name lookup
 #else // ^^^ no workaround / workaround vvv
         void from_stream();
-#endif // ^^^ workaorund ^^^
+#endif // ^^^ workaround ^^^
 
         template <class _Parsable, class _CharT, class _Traits, class... _Rest>
         concept _Can_from_stream = requires(
             basic_istream<_CharT, _Traits>& __istr, const _CharT* __s, _Parsable& __parsed, _Rest&&... __rest_args) {
             from_stream(__istr, +__s, __parsed, _STD forward<_Rest>(__rest_args)...); // intentional ADL
-        }
+        };
     } // namespace _From_stream_adl_only
 
     using _From_stream_adl_only::_Can_from_stream;

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_io/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_io/test.cpp
@@ -6,6 +6,7 @@
 #include <charconv>
 #include <chrono>
 #include <cstdint>
+#include <istream>
 #include <iterator>
 #include <limits>
 #include <locale>


### PR DESCRIPTION
Fixes #5289.