### PR TITLE
Toolset update: VS 2022 17.14 Preview 2, Clang 19.1.5

### DIFF
--- a/.github/workflows/update-status-chart.yml
+++ b/.github/workflows/update-status-chart.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ">=22.2.0"
+          node-version: ">=23.9.0"
       - name: Install Packages
         run: |
           npm ci

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.14 Preview 1 or later.
+1. Install Visual Studio 2022 17.14 Preview 2 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.
@@ -160,7 +160,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.14 Preview 1 or later.
+1. Install Visual Studio 2022 17.14 Preview 2 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.

--- a/azure-devops/checkout-self.yml
+++ b/azure-devops/checkout-self.yml
@@ -11,6 +11,7 @@ steps:
   submodules: false
   fetchDepth: 1
   fetchTags: false
+  retryCountOnTaskFailure: 4
 - script: |
     git clean --quiet -x -d -f -f
   displayName: 'Clean after checkout'

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,7 +5,7 @@
 
 variables:
 - name: poolName
-  value: 'StlBuild-2025-02-15T0137-Pool'
+  value: 'StlBuild-2025-03-11T1203-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -378,41 +378,41 @@ Remove-AzDisk `
 Display-ProgressBar -Status 'Deleting unused network interface'
 
 Remove-AzNetworkInterface `
--ResourceGroupName $ResourceGroupName `
--Name $NicName `
--Force >> $LogFile
+  -ResourceGroupName $ResourceGroupName `
+  -Name $NicName `
+  -Force >> $LogFile
 
 ####################################################################################################
 Display-ProgressBar -Status 'Deleting unused virtual network'
 
 Remove-AzVirtualNetwork `
--ResourceGroupName $ResourceGroupName `
--Name $VirtualNetworkName `
--Force >> $LogFile
+  -ResourceGroupName $ResourceGroupName `
+  -Name $VirtualNetworkName `
+  -Force >> $LogFile
 
 ####################################################################################################
 Display-ProgressBar -Status 'Deleting unused network security group'
 
 Remove-AzNetworkSecurityGroup `
--ResourceGroupName $ResourceGroupName `
--Name $NetworkSecurityGroupName `
--Force >> $LogFile
+  -ResourceGroupName $ResourceGroupName `
+  -Name $NetworkSecurityGroupName `
+  -Force >> $LogFile
 
 ####################################################################################################
 Display-ProgressBar -Status 'Deleting unused NAT gateway'
 
 Remove-AzNatGateway `
--ResourceGroupName $ResourceGroupName `
--Name $NatGatewayName `
--Force >> $LogFile
+  -ResourceGroupName $ResourceGroupName `
+  -Name $NatGatewayName `
+  -Force >> $LogFile
 
 ####################################################################################################
 Display-ProgressBar -Status 'Deleting unused public IP address'
 
 Remove-AzPublicIpAddress `
--ResourceGroupName $ResourceGroupName `
--Name $PublicIpAddressName `
--Force >> $LogFile
+  -ResourceGroupName $ResourceGroupName `
+  -Name $PublicIpAddressName `
+  -Force >> $LogFile
 
 ####################################################################################################
 Write-Progress -Activity $ProgressActivity -Completed

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -111,10 +111,14 @@ $NetworkSecurityGroup = New-AzNetworkSecurityGroup `
   -ResourceGroupName $ResourceGroupName `
   -Location $Location
 
+# TRANSITION, 2025-09-30: "On September 30, 2025, default outbound access for new deployments will be retired."
+# https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/default-outbound-access
+# We're using `-DefaultOutboundAccess $false` to opt-in early.
 $SubnetName = $ResourceGroupName + '-Subnet'
 $Subnet = New-AzVirtualNetworkSubnetConfig `
   -Name $SubnetName `
   -AddressPrefix '10.0.0.0/16' `
+  -DefaultOutboundAccess $false `
   -NetworkSecurityGroup $NetworkSecurityGroup
 
 $VirtualNetworkName = $ResourceGroupName + '-Network'

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -221,7 +221,6 @@ New-AzVm `
   -Location $Location `
   -VM $VM >> $LogFile
 
-
 ####################################################################################################
 Display-ProgressBar -Status 'Getting prototype VM OS disk name'
 

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -46,10 +46,8 @@ $PowerShellArgs = @('/quiet', '/norestart')
 $PythonUrl = 'https://www.python.org/ftp/python/3.13.2/python-3.13.2-amd64.exe'
 $PythonArgs = @('/quiet', 'InstallAllUsers=1', 'PrependPath=1', 'CompileAll=1', 'Include_doc=0')
 
-# TRANSITION, GH-5282: Install only nvcc and cudart, then manually add CUDA to the PATH (see below).
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/12.4.0/local_installers/cuda_12.4.0_551.61_windows.exe'
-$CudaArgs = @('-s', '-n', 'nvcc_12.4', 'cudart_12.4')
-$CudaPath = 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\bin'
+$CudaArgs = @('-s', '-n')
 
 <#
 .SYNOPSIS
@@ -113,12 +111,6 @@ DownloadAndInstall -Name 'Visual Studio' -Url $VisualStudioUrl -Args $VisualStud
 DownloadAndInstall -Name 'CUDA'          -Url $CudaUrl         -Args $CudaArgs
 
 Write-Host 'Setting environment variables...'
-
-# TRANSITION, GH-5282: Manually add CUDA to the PATH.
-# Don't use $Env:PATH here - that's the local path for this running script, captured before we installed anything.
-# The machine path was just updated by the installers above.
-$machinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
-[Environment]::SetEnvironmentVariable('Path', "$machinePath;$CudaPath", 'Machine')
 
 # The STL's PR/CI builds are totally unrepresentative of customer usage.
 [Environment]::SetEnvironmentVariable('VSCMD_SKIP_SENDTELEMETRY', '1', 'Machine')

--- a/stl/inc/__msvc_bit_utils.hpp
+++ b/stl/inc/__msvc_bit_utils.hpp
@@ -51,7 +51,7 @@ _NODISCARD constexpr int _Countl_zero_fallback(_Ty _Val) noexcept {
     return static_cast<int>(_Nx) - static_cast<int>(_Val);
 }
 
-#if !defined(_M_CEE_PURE) && !defined(__CUDACC__) && !defined(__INTEL_COMPILER)
+#if !defined(_M_CEE_PURE) && !defined(__CUDACC__)
 #define _HAS_COUNTL_ZERO_INTRINSICS 1
 #else // ^^^ intrinsics available / intrinsics unavailable vvv
 #define _HAS_COUNTL_ZERO_INTRINSICS 0
@@ -179,7 +179,7 @@ _NODISCARD constexpr int _Popcount_fallback(_Ty _Val) noexcept {
 }
 
 #if ((defined(_M_IX86) && !defined(_M_HYBRID_X86_ARM64)) || (defined(_M_X64) && !defined(_M_ARM64EC))) \
-    && !defined(_M_CEE_PURE) && !defined(__CUDACC__) && !defined(__INTEL_COMPILER)
+    && !defined(_M_CEE_PURE) && !defined(__CUDACC__)
 #define _HAS_TZCNT_BSF_INTRINSICS 1
 #else // ^^^ intrinsics available / intrinsics unavailable vvv
 #define _HAS_TZCNT_BSF_INTRINSICS 0
@@ -273,8 +273,7 @@ _NODISCARD int _Checked_x86_x64_countr_zero(const _Ty _Val) noexcept {
 
 #endif // _HAS_TZCNT_BSF_INTRINSICS
 
-#if (defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM64)) && !defined(_M_CEE_PURE) && !defined(__CUDACC__) \
-    && !defined(__INTEL_COMPILER)
+#if (defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM64)) && !defined(_M_CEE_PURE) && !defined(__CUDACC__)
 #define _HAS_POPCNT_INTRINSICS 1
 #if defined(__AVX__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #define _POPCNT_INTRINSICS_ALWAYS_AVAILABLE 1

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -36,8 +36,7 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 
-#if defined(_M_X64) && !defined(_M_ARM64EC) && !defined(_M_CEE_PURE) && !defined(__CUDACC__) \
-    && !defined(__INTEL_COMPILER)
+#if defined(_M_X64) && !defined(_M_ARM64EC) && !defined(_M_CEE_PURE) && !defined(__CUDACC__)
 #define _STL_128_INTRINSICS 1
 #ifdef __clang__ // clang doesn't have _udiv128 / _div128
 #define _STL_128_DIV_INTRINSICS 0

--- a/stl/inc/__msvc_iter_core.hpp
+++ b/stl/inc/__msvc_iter_core.hpp
@@ -283,7 +283,7 @@ struct _Iter_traits_category4<false> {
 
 template <class _It>
 concept _Cpp17_random_delta =
-#if defined(__CUDACC__) && !defined(__clang__) // TRANSITION, CUDA 12.5
+#if defined(__CUDACC__) && !defined(__clang__) // TRANSITION, fixed in CUDA 12.5
     totally_ordered<_It> && requires(_It __i, typename incrementable_traits<_It>::difference_type __n) {
 #else // ^^^ workaround / no workaround vvv
     totally_ordered<_It> && requires(_It __i, incrementable_traits<_It>::difference_type __n) {

--- a/stl/inc/__msvc_ranges_tuple_formatter.hpp
+++ b/stl/inc/__msvc_ranges_tuple_formatter.hpp
@@ -264,7 +264,8 @@ public:
         }
     };
 
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, LLVM-81774 (Clang), VSO-1956558 (EDG)
+#if defined(__clang__) || defined(__EDG__) \
+    || defined(__CUDACC__) // TRANSITION, LLVM-81774 (Clang), VSO-1956558 (EDG), VSO-2411436 (needed by CUDA 12.8.1)
     basic_format_arg() noexcept : _Active_state(_Basic_format_arg_type::_None), _No_state() {}
 #else // ^^^ workaround / no workaround vvv
     basic_format_arg() noexcept = default;

--- a/stl/inc/array
+++ b/stl/inc/array
@@ -230,6 +230,11 @@ private:
         _STL_VERIFY(*this <= _Last, "array iterator range transposed");
     }
 
+    friend constexpr void _Verify_range(
+        const _Array_const_iterator& _First, const _Array_const_iterator& _Last) noexcept {
+        _First._Verify_with(_Last);
+    }
+
     constexpr void _Seek_to(pointer _It) noexcept {
         _Idx = static_cast<size_t>(_It - _Ptr);
     }
@@ -276,15 +281,6 @@ public:
     }
 #endif // !_HAS_CXX20
 };
-
-#if _ITERATOR_DEBUG_LEVEL != 0
-template <class _Ty, size_t _Size>
-constexpr void _Verify_range(
-    const _Array_const_iterator<_Ty, _Size>& _First, const _Array_const_iterator<_Ty, _Size>& _Last) noexcept {
-    // TRANSITION, CUDA
-    _First._Verify_with(_Last);
-}
-#endif // _ITERATOR_DEBUG_LEVEL != 0
 
 #if _HAS_CXX20
 template <class _Ty, size_t _Size>

--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -11,8 +11,7 @@
 #include <cstdlib>
 #include <xtr1common>
 
-#if !defined(__clang__) && !defined(__CUDACC__) && !defined(__INTEL_COMPILER) \
-    && !defined(_M_CEE) // TRANSITION, VSO-1663104
+#if !defined(__clang__) && !defined(__CUDACC__) && !defined(_M_CEE) // TRANSITION, VSO-1663104
 #define _HAS_CMATH_INTRINSICS 1
 #else // ^^^ intrinsics available / intrinsics unavailable vvv
 #define _HAS_CMATH_INTRINSICS 0

--- a/stl/inc/string
+++ b/stl/inc/string
@@ -441,30 +441,22 @@ template <class _Elem, class _Ty>
 _NODISCARD basic_string<_Elem> _Integral_to_string(const _Ty _Val) {
     // convert _Val to string
     static_assert(is_integral_v<_Ty>, "_Ty must be integral");
-    using _UTy = make_unsigned_t<_Ty>;
     _Elem _Buff[21]; // can hold -2^63 and 2^64 - 1, plus NUL
     _Elem* const _Buff_end = _STD end(_Buff);
     _Elem* _RNext          = _Buff_end;
-    const auto _UVal       = static_cast<_UTy>(_Val);
-    if (_Val < 0) {
-        _RNext    = _UIntegral_to_buff(_RNext, 0 - _UVal);
-        *--_RNext = '-';
+
+    if constexpr (is_signed_v<_Ty>) {
+        const auto _UVal = static_cast<make_unsigned_t<_Ty>>(_Val);
+        if (_Val < 0) {
+            _RNext    = _UIntegral_to_buff(_RNext, 0 - _UVal);
+            *--_RNext = '-';
+        } else {
+            _RNext = _UIntegral_to_buff(_RNext, _UVal);
+        }
     } else {
-        _RNext = _UIntegral_to_buff(_RNext, _UVal);
+        _RNext = _UIntegral_to_buff(_RNext, _Val);
     }
 
-    return basic_string<_Elem>(_RNext, _Buff_end);
-}
-
-// TRANSITION, CUDA - warning: pointless comparison of unsigned integer with zero
-template <class _Elem, class _Ty>
-_NODISCARD basic_string<_Elem> _UIntegral_to_string(const _Ty _Val) {
-    // convert _Val to string
-    static_assert(is_integral_v<_Ty>, "_Ty must be integral");
-    static_assert(is_unsigned_v<_Ty>, "_Ty must be unsigned");
-    _Elem _Buff[21]; // can hold 2^64 - 1, plus NUL
-    _Elem* const _Buff_end = _STD end(_Buff);
-    _Elem* const _RNext    = _UIntegral_to_buff(_Buff_end, _Val);
     return basic_string<_Elem>(_RNext, _Buff_end);
 }
 
@@ -473,7 +465,7 @@ _EXPORT_STD _NODISCARD inline string to_string(int _Val) {
 }
 
 _EXPORT_STD _NODISCARD inline string to_string(unsigned int _Val) {
-    return _UIntegral_to_string<char>(_Val);
+    return _Integral_to_string<char>(_Val);
 }
 
 _EXPORT_STD _NODISCARD inline string to_string(long _Val) {
@@ -481,7 +473,7 @@ _EXPORT_STD _NODISCARD inline string to_string(long _Val) {
 }
 
 _EXPORT_STD _NODISCARD inline string to_string(unsigned long _Val) {
-    return _UIntegral_to_string<char>(_Val);
+    return _Integral_to_string<char>(_Val);
 }
 
 _EXPORT_STD _NODISCARD inline string to_string(long long _Val) {
@@ -489,7 +481,7 @@ _EXPORT_STD _NODISCARD inline string to_string(long long _Val) {
 }
 
 _EXPORT_STD _NODISCARD inline string to_string(unsigned long long _Val) {
-    return _UIntegral_to_string<char>(_Val);
+    return _Integral_to_string<char>(_Val);
 }
 
 _EXPORT_STD _NODISCARD inline string to_string(double _Val) {
@@ -512,7 +504,7 @@ _EXPORT_STD _NODISCARD inline wstring to_wstring(int _Val) {
 }
 
 _EXPORT_STD _NODISCARD inline wstring to_wstring(unsigned int _Val) {
-    return _UIntegral_to_string<wchar_t>(_Val);
+    return _Integral_to_string<wchar_t>(_Val);
 }
 
 _EXPORT_STD _NODISCARD inline wstring to_wstring(long _Val) {
@@ -520,7 +512,7 @@ _EXPORT_STD _NODISCARD inline wstring to_wstring(long _Val) {
 }
 
 _EXPORT_STD _NODISCARD inline wstring to_wstring(unsigned long _Val) {
-    return _UIntegral_to_string<wchar_t>(_Val);
+    return _Integral_to_string<wchar_t>(_Val);
 }
 
 _EXPORT_STD _NODISCARD inline wstring to_wstring(long long _Val) {
@@ -528,7 +520,7 @@ _EXPORT_STD _NODISCARD inline wstring to_wstring(long long _Val) {
 }
 
 _EXPORT_STD _NODISCARD inline wstring to_wstring(unsigned long long _Val) {
-    return _UIntegral_to_string<wchar_t>(_Val);
+    return _Integral_to_string<wchar_t>(_Val);
 }
 
 _EXPORT_STD _NODISCARD inline wstring to_wstring(double _Val) {

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -951,8 +951,8 @@ _NODISCARD constexpr bool in_range(const _Ty _Value) noexcept {
 #endif // _HAS_CXX20
 
 #if _HAS_CXX23
-_EXPORT_STD template <class _Ty>
-_NODISCARD _MSVC_INTRINSIC constexpr underlying_type_t<_Ty> to_underlying(_Ty _Value) noexcept {
+_EXPORT_STD template <class _Ty> // TRANSITION, VSO-2253317: should be _MSVC_INTRINSIC
+_NODISCARD constexpr underlying_type_t<_Ty> to_underlying(_Ty _Value) noexcept {
     return static_cast<underlying_type_t<_Ty>>(_Value);
 }
 

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1500,8 +1500,8 @@ struct _Container_proxy_ptr12 : _Basic_container_proxy_ptr12 {
 };
 
 #if _ITERATOR_DEBUG_LEVEL == 0
-_INLINE_VAR constexpr _Fake_allocator _Fake_alloc{};
-#define _GET_PROXY_ALLOCATOR(_Alty, _Al) _Fake_alloc // TRANSITION, VSO-1284799, should be _Fake_allocator{}
+#define _GET_PROXY_ALLOCATOR(_Alty, _Al) \
+    _Fake_allocator {}
 template <class _Alloc>
 using _Container_proxy_ptr = _Fake_proxy_ptr_impl;
 #else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 / _ITERATOR_DEBUG_LEVEL > 0 vvv

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -923,8 +923,8 @@ _EMIT_STL_ERROR(STL1002, "Unexpected compiler version, expected CUDA 12.4 or new
 _EMIT_STL_ERROR(STL1000, "Unexpected compiler version, expected Clang 19.0.0 or newer.");
 #endif // ^^^ old Clang ^^^
 #elif defined(_MSC_VER)
-#if _MSC_VER < 1942 // Coarse-grained, not inspecting _MSC_FULL_VER
-_EMIT_STL_ERROR(STL1001, "Unexpected compiler version, expected MSVC 19.42 or newer.");
+#if _MSC_VER < 1944 // Coarse-grained, not inspecting _MSC_FULL_VER
+_EMIT_STL_ERROR(STL1001, "Unexpected compiler version, expected MSVC 19.44 or newer.");
 #endif // ^^^ old MSVC ^^^
 #else // vvv other compilers vvv
 // not attempting to detect other compilers

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -698,8 +698,6 @@
 
 #ifndef __has_cpp_attribute
 #define _HAS_MSVC_ATTRIBUTE(x) 0
-#elif defined(__CUDACC__) // TRANSITION, CUDA - warning: attribute namespace "msvc" is unrecognized
-#define _HAS_MSVC_ATTRIBUTE(x) 0
 #else
 #define _HAS_MSVC_ATTRIBUTE(x) __has_cpp_attribute(msvc::x)
 #endif

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -526,14 +526,7 @@
 #define _STL_STRINGIZE_(S) #S
 #define _STL_STRINGIZE(S)  _STL_STRINGIZE_(S)
 
-// Note that _STL_PRAGMA is load-bearing;
-// it still needs to exist even once CUDA and ICC support _Pragma.
-#if defined(__CUDACC__) || defined(__INTEL_COMPILER)
-#define _STL_PRAGMA(PRAGMA) __pragma(PRAGMA)
-#else
-#define _STL_PRAGMA(PRAGMA) _Pragma(#PRAGMA)
-#endif
-
+#define _STL_PRAGMA(PRAGMA)          _Pragma(#PRAGMA)
 #define _STL_PRAGMA_MESSAGE(MESSAGE) _STL_PRAGMA(message(MESSAGE))
 #define _EMIT_STL_MESSAGE(MESSAGE)   _STL_PRAGMA_MESSAGE(__FILE__ "(" _STL_STRINGIZE(__LINE__) "): " MESSAGE)
 
@@ -883,26 +876,20 @@
 #define _STL_DISABLE_DEPRECATED_WARNING \
     _Pragma("clang diagnostic push")    \
     _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
-#elif defined(__CUDACC__) || defined(__INTEL_COMPILER)
-#define _STL_DISABLE_DEPRECATED_WARNING \
-    __pragma(warning(push))             \
-    __pragma(warning(disable : 4996)) // was declared deprecated
-#else // vvv MSVC vvv
+#else // ^^^ defined(__clang__) / !defined(__clang__) vvv
 #define _STL_DISABLE_DEPRECATED_WARNING \
     _Pragma("warning(push)")            \
     _Pragma("warning(disable : 4996)") // was declared deprecated
-#endif // ^^^ MSVC ^^^
+#endif // ^^^ !defined(__clang__) ^^^
 #endif // _STL_DISABLE_DEPRECATED_WARNING
 // clang-format on
 
 #ifndef _STL_RESTORE_DEPRECATED_WARNING
 #ifdef __clang__
 #define _STL_RESTORE_DEPRECATED_WARNING _Pragma("clang diagnostic pop")
-#elif defined(__CUDACC__) || defined(__INTEL_COMPILER)
-#define _STL_RESTORE_DEPRECATED_WARNING __pragma(warning(pop))
-#else // vvv MSVC vvv
+#else // ^^^ defined(__clang__) / !defined(__clang__) vvv
 #define _STL_RESTORE_DEPRECATED_WARNING _Pragma("warning(pop)")
-#endif // ^^^ MSVC ^^^
+#endif // ^^^ !defined(__clang__) ^^^
 #endif // !defined(_STL_RESTORE_DEPRECATED_WARNING)
 
 #define _CPPLIB_VER       650

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -2024,10 +2024,6 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 #define _STATIC_CALL_OPERATOR static
 #define _CONST_CALL_OPERATOR
 #define _STATIC_LAMBDA static
-#elif _MSC_VER < 1944 // TRANSITION, internal toolset needs to be updated to VS 2022 17.14 Preview 1
-#define _STATIC_CALL_OPERATOR
-#define _CONST_CALL_OPERATOR const
-#define _STATIC_LAMBDA
 #else // TRANSITION, VSO-2383148, fixed in VS 2022 17.14 Preview 3
 #define _STATIC_CALL_OPERATOR static
 #define _CONST_CALL_OPERATOR

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -602,6 +602,7 @@ std/thread/thread.mutex/thread.lock/thread.lock.shared/thread.lock.shared.cons/m
 std/thread/thread.mutex/thread.lock/thread.lock.shared/thread.lock.shared.cons/mutex_time_point.pass.cpp SKIPPED
 std/thread/thread.mutex/thread.lock/thread.lock.shared/thread.lock.shared.cons/mutex.pass.cpp SKIPPED
 std/thread/thread.mutex/thread.lock/thread.lock.shared/thread.lock.shared.locking/lock.pass.cpp SKIPPED
+std/thread/thread.threads/thread.thread.class/thread.thread.destr/dtor.pass.cpp SKIPPED
 std/thread/thread.threads/thread.thread.this/sleep_until.pass.cpp SKIPPED
 
 # Not analyzed, likely bogus tests. Various assertions, probably POSIX assumptions.

--- a/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
+++ b/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
@@ -1370,8 +1370,6 @@ _CONSTEXPR20 bool test_mem_fn() {
     const int&& r2 = mf_pmd(move(cw));
     assert(&r2 == &cw.m_i);
 
-
-#ifndef _M_CEE // TRANSITION, VSO-1664293
     w.m_i = 1000;
 
     assert(mem_fn(&Widget::nullary)(w) == 1001);
@@ -1395,7 +1393,6 @@ _CONSTEXPR20 bool test_mem_fn() {
     assert(mem_fn(&Widget::unary_lv)(&w, 6) == 1061);
 
     assert(mem_fn(&Widget::unary_rv)(move(w), 7) == 1404);
-#endif // ^^^ no workaround ^^^
 
     return true;
 }

--- a/tests/std/tests/GH_000639_nvcc_include_all/test.compile.pass.cpp
+++ b/tests/std/tests/GH_000639_nvcc_include_all/test.compile.pass.cpp
@@ -4,3 +4,12 @@
 #define _MSVC_TESTING_NVCC
 
 #include <__msvc_all_public_headers.hpp>
+
+using namespace std;
+
+#if _HAS_CXX20
+// Test VSO-2411436 "[Feedback] CUDA (12.8) host code compilation fails with std::format and VS2022"
+void test_VSO_2411436() {
+    (void) format("{}", 1729);
+}
+#endif // _HAS_CXX20

--- a/tests/std/tests/P0019R8_atomic_ref/test.cpp
+++ b/tests/std/tests/P0019R8_atomic_ref/test.cpp
@@ -53,11 +53,7 @@ void test_atomic_ref_constraints_single() { // COMPILE-ONLY
     });
     {
         [[maybe_unused]] auto instantiator = [](const AR& r, TD v, std::memory_order ord) {
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-2343282
             (void) r.operator TD();
-#else // ^^^ no workaround / workaround vvv
-            [[maybe_unused]] TD td = r;
-#endif // ^^^ workaround ^^^
             (void) r.load();
             (void) r.load(ord);
             r.wait(v);

--- a/tests/std/tests/P0466R5_layout_compatibility_and_pointer_interconvertibility_traits/test.cpp
+++ b/tests/std/tests/P0466R5_layout_compatibility_and_pointer_interconvertibility_traits/test.cpp
@@ -199,7 +199,9 @@ constexpr bool test() {
         ASSERT(!is_corresponding_member(&S5::v1, &S6::v2));
         ASSERT(!is_corresponding_member(&S5::v2, &S6::v1));
         ASSERT(!is_corresponding_member(&S5::v3, &S6::v3));
+#ifndef _M_CEE // TRANSITION, VSO-2417635
         ASSERT(!is_corresponding_member<NS, NS>(&NS::v1, &NS::w1));
+#endif // ^^^ no workaround ^^^
         ASSERT(!is_corresponding_member(&S7::f1, &S7::f1));
         ASSERT(!is_corresponding_member(static_cast<int S1::*>(nullptr), static_cast<int S2::*>(nullptr)));
         ASSERT(!is_corresponding_member(&S1::v1, static_cast<int S2::*>(nullptr)));
@@ -234,7 +236,9 @@ constexpr bool test() {
         ASSERT(is_pointer_interconvertible_with_class(&U::v2));
 
         ASSERT(!is_pointer_interconvertible_with_class<NS>(&NS::a));
+#ifndef _M_CEE // TRANSITION, VSO-2417635
         ASSERT(!is_pointer_interconvertible_with_class<NS>(&NS::b));
+#endif // ^^^ no workaround ^^^
         ASSERT(!is_pointer_interconvertible_with_class(&C::f1));
         ASSERT(!is_pointer_interconvertible_with_class(static_cast<int A::*>(nullptr)));
     }

--- a/tests/std/tests/P0466R5_layout_compatibility_and_pointer_interconvertibility_traits/test.cpp
+++ b/tests/std/tests/P0466R5_layout_compatibility_and_pointer_interconvertibility_traits/test.cpp
@@ -199,9 +199,7 @@ constexpr bool test() {
         ASSERT(!is_corresponding_member(&S5::v1, &S6::v2));
         ASSERT(!is_corresponding_member(&S5::v2, &S6::v1));
         ASSERT(!is_corresponding_member(&S5::v3, &S6::v3));
-#ifndef _M_CEE // TRANSITION, VSO-1664293
         ASSERT(!is_corresponding_member<NS, NS>(&NS::v1, &NS::w1));
-#endif // ^^^ no workaround ^^^
         ASSERT(!is_corresponding_member(&S7::f1, &S7::f1));
         ASSERT(!is_corresponding_member(static_cast<int S1::*>(nullptr), static_cast<int S2::*>(nullptr)));
         ASSERT(!is_corresponding_member(&S1::v1, static_cast<int S2::*>(nullptr)));
@@ -236,9 +234,7 @@ constexpr bool test() {
         ASSERT(is_pointer_interconvertible_with_class(&U::v2));
 
         ASSERT(!is_pointer_interconvertible_with_class<NS>(&NS::a));
-#ifndef _M_CEE // TRANSITION, VSO-1664293
         ASSERT(!is_pointer_interconvertible_with_class<NS>(&NS::b));
-#endif // ^^^ no workaround ^^^
         ASSERT(!is_pointer_interconvertible_with_class(&C::f1));
         ASSERT(!is_pointer_interconvertible_with_class(static_cast<int A::*>(nullptr)));
     }

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -561,22 +561,17 @@ constexpr void move_only_test() {
 }
 
 constexpr void output_range_test() {
-#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, VSO-1132704
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
-    {
-        using R = test::range<output_iterator_tag, int, test::Sized::no, test::CanDifference::no, test::Common::no,
-            test::CanCompare::no, test::ProxyRef::yes, test::CanView::yes, test::Copyability::move_only>;
-        int some_writable_ints[] = {0, 1, 2, 3};
-        static_assert(same_as<decltype(views::take(R{some_writable_ints}, 99999)), ranges::take_view<R>>);
+    using R = test::range<output_iterator_tag, int, test::Sized::no, test::CanDifference::no, test::Common::no,
+        test::CanCompare::no, test::ProxyRef::yes, test::CanView::yes, test::Copyability::move_only>;
+    int some_writable_ints[] = {0, 1, 2, 3};
+    static_assert(same_as<decltype(views::take(R{some_writable_ints}, 99999)), ranges::take_view<R>>);
 
-        // How do I implement "Fill up to n elements in {output range} with {value}"?
-        ranges::fill(R{some_writable_ints} | views::take(99999), 42);
-        assert(ranges::equal(some_writable_ints, initializer_list<int>{42, 42, 42, 42}));
+    // How do I implement "Fill up to n elements in {output range} with {value}"?
+    ranges::fill(R{some_writable_ints} | views::take(99999), 42);
+    assert(ranges::equal(some_writable_ints, initializer_list<int>{42, 42, 42, 42}));
 
-        ranges::fill(R{some_writable_ints} | views::take(3), 13);
-        assert(ranges::equal(some_writable_ints, initializer_list<int>{13, 13, 13, 42}));
-    }
+    ranges::fill(R{some_writable_ints} | views::take(3), 13);
+    assert(ranges::equal(some_writable_ints, initializer_list<int>{13, 13, 13, 42}));
 }
 
 void test_DevCom_1397309() {

--- a/tools/format/CMakeLists.txt
+++ b/tools/format/CMakeLists.txt
@@ -18,7 +18,7 @@ execute_process(
 )
 
 if(clang_format_version MATCHES "clang-format version ([0-9]+\.[0-9]+\.[0-9]+)")
-    set(expected_version "19.1.1")
+    set(expected_version "19.1.5")
     if(CMAKE_MATCH_1 VERSION_LESS expected_version)
         message(FATAL_ERROR "Found clang-format: ${CLANG_FORMAT} (\"${CMAKE_MATCH_1}\", older than expected version \"${expected_version}\")")
     elseif(CMAKE_MATCH_1 VERSION_EQUAL expected_version)


### PR DESCRIPTION
Resolves #5074. Resolves #5282. Resolves DevCom-10863472 VSO-2411436.

# :scroll: Changelog
- Fixed bugs:
  * Fixed compiler errors when using `<format>` in a CUDA project, by adding a compiler bug workaround.
- Code cleanups:
  * Removed compiler bug workarounds.
- Infrastructure improvements:
  * Updated dependencies.
    + Updated build compiler to VS 2022 17.14 Preview 2 (now required).
    + Updated Clang to 19.1.5.

# :gear: Commits

* Node.js 23.9.0.
  + Increasing our minimum required Node version for the Status Chart isn't necessary at this time, but I like to keep this updated on a semi-regular basis.
* Require VS 2022 17.14.
  + The MSVC-internal toolset has *finally* been updated, allowing us to require 17.14.
* Remove workaround for CUDA 9.2's lack of `if constexpr`.
  + I added this workaround in #772, merged 2020-05-01. We began using `if constexpr` unconditionally (requiring CUDA 10.1 Update 2) in #1544, merged 2021-01-05. This workaround could have been removed then. At least I noticed this 4 years later! I'm going back to always calling `_Integral_to_string()`, now enhanced with `if constexpr`.
* Remove workaround for VSO-612785 "'expect_error' assertion when testing a constexpr 'hidden friend'".
  + This was fixed for VS by EDG 5.0 on 2018-12-15. In #759 merged on 2020-04-30, I had to preserve the workaround because it was still needed for CUDA 9.2 (released 2018-05). Fortunately I commented it, although very poorly. It's been 5 years and we now require CUDA 12.4 (released 2024-03), so we can remove this workaround.
* Remove workaround for VSO-1132704 "Bogus C3615 when implicitly-constexpr defaulted SMF calls non-trivial SMF in base class".
* Remove workaround for VSO-1284799 "constexpr ICE: binding a reference to a temporary emits Assertion failed: Nerrors > 0".
* Remove workaround for VSO-1664293 "/clr C++20 chk assertion failed: rhs.is_lvalue() in constexpr.cpp" in `Dev11_0535636_functional_overhaul`.
  + Update citation to VSO-2417635 "/clr C++20 chk assertion failed: rhs.is_lvalue() in constexpr.cpp, again" in `P0466R5_layout_compatibility_and_pointer_interconvertibility_traits`.
* Remove workaround for VSO-2343282 "C1XX assertion 'If lookup found RDSymbol before it should find something this time, too' affecting STL atomic_ref test".
* Remove workaround now that the internal toolset supports static call operators.
* Remove workaround for DevCom-10841757 (CUDA's installer hangs for VS 2022 17.13 and later).
  + Goodbye #5282!
  + :white_check_mark: Verified that all 6 configurations of `GH_000639_nvcc_include_all` are passing instead of being skipped.
* Skip a sporadic libcxx failure.
  + Goodbye #5074!
* Work around VSO-2253317 "ICE when calling std::to_underlying()".
  + This is a very obscure bug that I encountered while modernizing the MSVC codebase to C++23. (It involves multiplying a `float` by the result of `to_underlying()`.) As a compiler fix hasn't arrived in a timely manner, temporarily removing our "MSVC intrinsic" annotation is easy.
* create-1es-hosted-pool.ps1: Opt-in early to disable default outbound access, [before it's retired on 2025-09-30](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/default-outbound-access).
  + I verified that this takes effect (i.e. with no other changes, this prevents outbound Internet access, so the script can't download anything and totally fails).
* create-1es-hosted-pool.ps1: Create a NAT gateway.
  + This is the most preferred method for explicit outbound connectivity, [according to Azure docs](https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-outbound-connections#scenarios).
* create-1es-hosted-pool.ps1: Consistently indent wrapped options.
* create-1es-hosted-pool.ps1: Add more progress bar messages.
* New pool.
* VS 2022 17.14 Preview 2.
* Add workaround to fix DevCom-10863472 VSO-2411436 "CUDA (12.8) host code compilation fails with std::format and VS2022".
  + And add test coverage, verified in a VM.
* Remove CUDA workaround for `__has_cpp_attribute(msvc::x)`.
  + This was added by #772, merged 2020-05-01, for CUDA 9.2 (released May 2018). I don't observe this warning with CUDA 12.4 (released March 2024).
* Remove workarounds for CUDA/Intel, always use Standard `_Pragma`.
  + These were added by #1342, merged 2021-05-20, for VSO-1329304 "EDG doesn't understand Standard _Pragma". We immediately fixed that locally and reported it upstream to EDG. In that release, VS 2019 16.10, we had just begun requiring CUDA 10.1 Update 2 (released Aug 2019). We now require CUDA 12.4 (released March 2024), and I observe that it understands Standard `_Pragma` just fine.
  + I've verified that Intel accepts Standard `_Pragma` on Windows, see below.
* Remove all `__INTEL_COMPILER` workarounds.
  + Intel deprecated and removed their old compiler (icc), which we no longer attempt to avoid breaking in any way. (See DevCom-10200300.)
  + Their new compiler (icx) is LLVM-based and doesn't define `__INTEL_COMPILER` anymore, so all of our accumulated workarounds don't affect it and can be removed. Instead, icx uses `__INTEL_LLVM_COMPILER` to specifically distinguish itself. It also identifies itself as a `__clang__`, activating all of our Clang codepaths. For example, it accepts Clang-style diagnostic pragmas. See icx usage example below.
  + We still don't officially support or test icx. However, following our unofficial policy of avoiding *gratuitous* breakage should be easier now. (We were treating it as a Clang without realizing it, and it worked!)
* Clarify comment: "TRANSITION, fixed in CUDA 12.5"
  + Added by #4974.
* Add `retryCountOnTaskFailure: 4` to checkout-self.yml.
  + See: https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/steps-checkout?view=azure-pipelines
  + This matches what we do in checkout-submodule.yml: https://github.com/microsoft/STL/blob/0d8f517ae3828284fed594741b847db940167a59/azure-devops/checkout-submodule.yml#L12-L15
  + Retrying *tests* is an abomination. However, it's fine to retry checkouts, to be resilient to network gremlins.
* Clang 19.1.5.
  + VS performed a minor version update. It doesn't affect clang-format output, or any of our product/test code, but we should still update our expected clang-format version to avoid emitting warnings during CMake configuration.

:white_check_mark: [STL-ASan-CI passed.](https://dev.azure.com/vclibs/STL/_build/results?buildId=18317&view=results)

# :computer: icx Usage Example

```
C:\Temp>type meow.cpp
```
```cpp
#include <cstdio>
#include <vector>

[[deprecated]] int square(int x) { return x * x; }

int main() {
#ifdef __INTEL_COMPILER
    std::puts("__INTEL_COMPILER is defined.");
#else
    std::puts("__INTEL_COMPILER is NOT defined!");
#endif

#ifdef __INTEL_LLVM_COMPILER
    std::puts("__INTEL_LLVM_COMPILER is defined.");
#endif

#ifdef __clang__
    std::puts("__clang__ is defined.");
#endif

#ifdef SILENCE_DEPRECATED_WARNING
    _Pragma("clang diagnostic push")
    _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
    return square(0);
    _Pragma("clang diagnostic pop")
#else
    return square(0);
#endif
}
```
```
C:\Temp>icx --version
Intel(R) oneAPI DPC++/C++ Compiler for applications running on Intel(R) 64, Version 2025.0.4 Build 20241205
Copyright (C) 1985-2024 Intel Corporation. All rights reserved.

Intel(R) oneAPI DPC++/C++ Compiler 2025.0.4 (2025.0.4.20241205)
Target: x86_64-pc-windows-msvc
Thread model: posix
InstalledDir: C:\Program Files (x86)\Intel\oneAPI\compiler\2025.0\bin\compiler
Configuration file: C:\Program Files (x86)\Intel\oneAPI\compiler\2025.0\bin\compiler\..\icx.cfg

C:\Temp>icx /EHsc /nologo /W4 /DSILENCE_DEPRECATED_WARNING meow.cpp && meow
__INTEL_COMPILER is NOT defined!
__INTEL_LLVM_COMPILER is defined.
__clang__ is defined.

C:\Temp>icx /EHsc /nologo /W4 meow.cpp
C:\Temp\meow.cpp(27,12): warning: 'square' is deprecated [-Wdeprecated-declarations]
27 |     return square(0);
    |            ^
C:\Temp\meow.cpp(4,3): note: 'square' has been explicitly marked deprecated here
    4 | [[deprecated]] int square(int x) { return x * x; }
    |   ^
1 warning generated.
```
