### PR TITLE
Various cleanups

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -7477,11 +7477,13 @@ _NODISCARD constexpr auto _Idl_dist_add(_Diff1 _Lhs, _Diff2 _Rhs) {
         return ranges::_Distance_unbounded{};
     } else
 #endif // _HAS_CXX20
+    {
         if constexpr (is_same_v<_Diff1, _Distance_unknown> || is_same_v<_Diff2, _Distance_unknown>) {
             return _Distance_unknown{};
         } else {
             return _Lhs + _Rhs;
         }
+    }
 }
 
 _EXPORT_STD template <class _InIt1, class _InIt2, class _OutIt, class _Pr>

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -203,7 +203,7 @@ extern "C" inline void _Atomic_thread_fence(const unsigned int _Order) noexcept 
     if (_Order == _Atomic_memory_order_seq_cst) {
         volatile long _Guard; // Not initialized to avoid an unnecessary operation; the value does not matter
 
-        // _mm_mfence could have been used, but it is not supported on older x86 CPUs and is slower on some recent CPUs.
+        // _mm_mfence could have been used, but it is slower on some CPUs.
         // The memory fence provided by interlocked operations has some exceptions, but this is fine:
         // std::atomic_thread_fence works with respect to other atomics only; it may not be a full fence for all ops.
         (void) _InterlockedIncrement(&_Guard);

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -666,7 +666,7 @@ basic_istream<_Elem, _Tr>& operator>>(basic_istream<_Elem, _Tr>& _Istr, bitset<_
     }
 
     _Istr.setstate(_State);
-    _Right = bitset<_Bits>(_Buf._Buf, _Count); // convert string and store
+    _Right = bitset<_Bits>{_Buf._Buf, _Count}; // convert string and store
     return _Istr;
 }
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -3493,7 +3493,7 @@ namespace chrono {
 
                 return ratio_less_equal_v<_Period1, _Period2>
                     && ratio_greater_equal_v<ratio<_Max_tick, _Period2::num>, ratio_divide<ratio<1>, _Period1>>;
-            } else if (is_floating_point_v<_Rep1>) {
+            } else if constexpr (is_floating_point_v<_Rep1>) {
                 // With the smallest possible _Period1, ratio<1,INTMAX_MAX>, one day has a tick count of
                 // 86,400*INTMAX_MAX ~= 7.97e23. This is representable by float and double, so they can always represent
                 // at least one day. On the other hand, one second with the largest possible _Period1 needs a tick count

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -1849,7 +1849,7 @@ namespace chrono {
             // time zone name. In vNext, this should be a dedicated argument.
             const string _Tz_arg = _Name + static_cast<char>(_Type);
 
-            const auto _Tz_len = _Name.length();
+            const auto _Tz_len = _Name.size();
 
             const auto _Info =
                 _Make_unique_tzdb_info<__std_tzdb_get_sys_info>(_Tz_arg.c_str(), _Tz_len, _Internal_dur.count());

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -3545,7 +3545,7 @@ _NODISCARD _FormatContext::iterator _Tuple_formatter_format(const tuple<formatte
 
     const int _Width = _STD _Measure_display_width<_CharT>(_Tmp_str);
     return _STD _Write_aligned(
-        _Fmt_ctx.out(), _Width, _Format_specs, _Fmt_align::_Left, [&](typename _FormatContext::iterator _Out) {
+        _Fmt_ctx.out(), _Width, _Format_specs, _Fmt_align::_Left, [&](_FormatContext::iterator _Out) {
             return _STD _Fmt_write(_STD move(_Out), basic_string_view<_CharT>{_Tmp_str});
         });
 }

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -2137,7 +2137,7 @@ template <class _Ret, class _CvFD, class _IntSeq, class _CvBoundTuple, class _Un
 concept _Can_call_binder = requires(_CvFD& _Fx, _CvBoundTuple& _Bound_tuple, _UnboundTuple&& _Unbound_tuple) {
     _STD _Call_binder(_Invoker_ret<_Ret>{}, _IntSeq{}, _Fx, _Bound_tuple, _STD move(_Unbound_tuple));
 };
-#else // ^^^ concept available / concept unavailable vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 template <class _Ret, class _CvFD, class _IntSeq, class _CvBoundTuple, class _UnboundTuple, class = void>
 constexpr bool _Can_call_binder = false;
 
@@ -2145,7 +2145,7 @@ template <class _Ret, class _CvFD, class _IntSeq, class _CvBoundTuple, class _Un
 constexpr bool _Can_call_binder<_Ret, _CvFD, _IntSeq, _CvBoundTuple, _UnboundTuple,
     void_t<decltype(_STD _Call_binder(_Invoker_ret<_Ret>{}, _IntSeq{}, _STD declval<_CvFD&>(),
         _STD declval<_CvBoundTuple&>(), _STD declval<_UnboundTuple>()))>> = true;
-#endif // ^^^ concept unavailable ^^^
+#endif // ^^^ !_HAS_CXX20 ^^^
 
 template <class _Ret>
 struct _Forced_result_type { // used by bind<R>()

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -474,14 +474,17 @@ struct _P_arg_type<void> { // type for functions returning void
     using type = int;
 };
 
+template <class _Ret>
+using _P_arg_type_t = typename _P_arg_type<_Ret>::type;
+
 template <class>
 class _Packaged_state;
 
 // class for managing associated asynchronous state for packaged_task
 template <class _Ret, class... _ArgTypes>
-class _Packaged_state<_Ret(_ArgTypes...)> : public _Associated_state<typename _P_arg_type<_Ret>::type> {
+class _Packaged_state<_Ret(_ArgTypes...)> : public _Associated_state<_P_arg_type_t<_Ret>> {
 public:
-    using _Mybase        = _Associated_state<typename _P_arg_type<_Ret>::type>;
+    using _Mybase        = _Associated_state<_P_arg_type_t<_Ret>>;
     using _Mydel         = typename _Mybase::_Mydel;
     using _Function_type = function<_Ret(_ArgTypes...)>; // TRANSITION, ABI, should not use std::function
 
@@ -1197,7 +1200,7 @@ template <class _Ret, class... _ArgTypes>
 class packaged_task<_Ret(_ArgTypes...)> {
     // class that defines an asynchronous provider that returns the result of a call to a function object
 private:
-    using _Ptype              = typename _P_arg_type<_Ret>::type;
+    using _Ptype              = _P_arg_type_t<_Ret>;
     using _MyPromiseType      = _Promise<_Ptype>;
     using _MyStateManagerType = _State_manager<_Ptype>;
     using _MyStateType        = _Packaged_state<_Ret(_ArgTypes...)>;
@@ -1344,7 +1347,7 @@ private:
 };
 
 template <class _Ret, class _Fty>
-_Associated_state<typename _P_arg_type<_Ret>::type>* _Get_associated_state(launch _Psync, _Fty&& _Fnarg) {
+_Associated_state<_P_arg_type_t<_Ret>>* _Get_associated_state(launch _Psync, _Fty&& _Fnarg) {
     // construct associated asynchronous state object for the launch type
     switch (_Psync) { // select launch type
     case launch::deferred:
@@ -1360,7 +1363,7 @@ _NODISCARD_ASYNC future<_Invoke_result_t<decay_t<_Fty>, decay_t<_ArgTypes>...>> 
     launch _Policy, _Fty&& _Fnarg, _ArgTypes&&... _Args) {
     // manages a callable object launched with supplied policy
     using _Ret   = _Invoke_result_t<decay_t<_Fty>, decay_t<_ArgTypes>...>;
-    using _Ptype = typename _P_arg_type<_Ret>::type;
+    using _Ptype = _P_arg_type_t<_Ret>;
     _Promise<_Ptype> _Pr(
         _Get_associated_state<_Ret>(_Policy, _Fake_no_copy_callable_adapter<_Fty, _ArgTypes...>(
                                                  _STD forward<_Fty>(_Fnarg), _STD forward<_ArgTypes>(_Args)...)));

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -402,12 +402,12 @@ bool _Nrand_for_tr1(
 }
 
 template <class _Gen, class = void>
-struct _Has_static_min_max : false_type {};
+constexpr bool _Has_static_min_max = false;
 
 // This checks a requirement of N4981 [rand.req.urng] `concept uniform_random_bit_generator` but doesn't attempt
 // to implement the whole concept - we just need to distinguish Standard machinery from tr1 machinery.
 template <class _Gen>
-struct _Has_static_min_max<_Gen, void_t<decltype(bool_constant<(_Gen::min)() < (_Gen::max)()>::value)>> : true_type {};
+constexpr bool _Has_static_min_max<_Gen, void_t<decltype(bool_constant<(_Gen::min)() < (_Gen::max)()>::value)>> = true;
 
 template <class _Real, class _Gen>
 _NODISCARD _Real _Nrand_impl(_Gen& _Gx) { // build a floating-point value from random sequence
@@ -415,7 +415,7 @@ _NODISCARD _Real _Nrand_impl(_Gen& _Gx) { // build a floating-point value from r
 
     constexpr auto _Digits = static_cast<size_t>(numeric_limits<_Real>::digits);
 
-    if constexpr (_Has_static_min_max<_Gen>::value) {
+    if constexpr (_Has_static_min_max<_Gen>) {
         return _STD generate_canonical<_Real, _Digits>(_Gx);
     } else if constexpr (is_integral_v<typename _Gen::result_type>) {
         // TRANSITION, for integral tr1 machinery only; Standard machinery can call generate_canonical directly
@@ -2301,8 +2301,7 @@ private:
 
     template <class _Engine>
     result_type _Eval(_Engine& _Eng, _Ty _Min, _Ty _Max) const { // compute next value in range [_Min, _Max]
-        conditional_t<_Has_static_min_max<_Engine>::value, _Rng_from_urng_v2<_Uty, _Engine>,
-            _Rng_from_urng<_Uty, _Engine>>
+        conditional_t<_Has_static_min_max<_Engine>, _Rng_from_urng_v2<_Uty, _Engine>, _Rng_from_urng<_Uty, _Engine>>
             _Generator(_Eng);
 
         const _Uty _Umin = _Adjust(static_cast<_Uty>(_Min));

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -402,7 +402,7 @@ bool _Nrand_for_tr1(
 }
 
 template <class _Gen, class = void>
-struct _Has_static_min_max : false_type {};
+struct _Has_static_min_max : false_type {}; // TRANSITION, VSO-2417491: Should be a variable template
 
 // This checks a requirement of N4981 [rand.req.urng] `concept uniform_random_bit_generator` but doesn't attempt
 // to implement the whole concept - we just need to distinguish Standard machinery from tr1 machinery.

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -461,8 +461,6 @@ _NODISCARD _Real _Nrand_impl(_Gen& _Gx) { // build a floating-point value from r
     }
 }
 
-#define _NRAND(eng, resty) (_Nrand_impl<resty>(eng))
-
 _INLINE_VAR constexpr int _MP_len = 5;
 using _MP_arr                     = uint64_t[_MP_len];
 
@@ -2539,7 +2537,7 @@ public:
 private:
     template <class _Engine>
     result_type _Eval(_Engine& _Eng, const param_type& _Par0) const {
-        return _NRAND(_Eng, double) < _Par0._Px;
+        return _Nrand_impl<double>(_Eng) < _Par0._Px;
     }
 
     param_type _Par;
@@ -2706,7 +2704,7 @@ private:
 
         _Ty1 _Val;
         do {
-            _Val = _CSTD log(_NRAND(_Eng, _Ty1)) / _Par0._Log_1_p;
+            _Val = _CSTD log(_Nrand_impl<_Ty1>(_Eng)) / _Par0._Log_1_p;
         } while (_Val >= _Ty1_max);
         return static_cast<_Ty>(_Val);
     }
@@ -2723,7 +2721,7 @@ public:
     _NODISCARD _Ty operator()(_Engine& _Eng) const {
         _Ty1 _Val = 1.0;
         for (_Ty _Res = 0;; ++_Res) { // count repetitions
-            _Val *= _NRAND(_Eng, _Ty1);
+            _Val *= _Nrand_impl<_Ty1>(_Eng);
             if (_Val <= _Gx0) {
                 return _Res;
             }
@@ -2875,7 +2873,7 @@ private:
             _Ty _Res;
             _Ty1 _Yx;
             for (;;) { // generate a tentative value
-                _Yx = static_cast<_Ty1>(_CSTD tan(_Pi_val * _NRAND(_Eng, _Ty1)));
+                _Yx = static_cast<_Ty1>(_CSTD tan(_Pi_val * _Nrand_impl<_Ty1>(_Eng)));
                 const _Ty1 _Mx{_Par0._Sqrt * _Yx + _Par0._Mean};
                 if (0.0 <= _Mx && _Mx < _Ty1_max) {
                     _Res = static_cast<_Ty>(_Mx);
@@ -2883,7 +2881,7 @@ private:
                 }
             }
 
-            if (_NRAND(_Eng, _Ty1)
+            if (_Nrand_impl<_Ty1>(_Eng)
                 <= 0.9 * (1.0 + _Yx * _Yx) * _CSTD exp(_Res * _Par0._Logm - _XLgamma(_Res + 1.0) - _Par0._Gx1)) {
                 return _Res;
             }
@@ -3043,7 +3041,7 @@ private:
         if (_Par0._Tx < 25) { // generate directly
             _Res = 0;
             for (_Ty _Ix = 0; _Ix < _Par0._Tx; ++_Ix) {
-                if (_NRAND(_Eng, _Ty1) < _Par0._Px) {
+                if (_Nrand_impl<_Ty1>(_Eng) < _Par0._Px) {
                     ++_Res;
                 }
             }
@@ -3051,7 +3049,7 @@ private:
             return _Res;
         } else if (_Par0._Mean < 1.0) {
             // Events are rare, use waiting time method (Luc Devroye, Non-Uniform Random Variate Generation, p. 525).
-            const _Ty1 _Rand = _NRAND(_Eng, _Ty1);
+            const _Ty1 _Rand = _Nrand_impl<_Ty1>(_Eng);
 
             // The exit condition is log(1 - _Rand)/t < log(1-p), which is equivalent to _Rand > 1 - (1-p)^t. If
             // we have a cheap upper bound for 1-(1-p)^t, we can exit early without having to call log. We use two
@@ -3066,7 +3064,7 @@ private:
                 _Ty _Denom = _Par0._Tx;
                 _Ty1 _Sum  = _CSTD log(_Ty1{1.0} - _Rand) / _Denom;
                 while (_Sum >= _Par0._Logp1 && --_Denom != 0) {
-                    _Sum += _CSTD log(_Ty1{1.0} - _NRAND(_Eng, _Ty1)) / _Denom;
+                    _Sum += _CSTD log(_Ty1{1.0} - _Nrand_impl<_Ty1>(_Eng)) / _Denom;
                 }
                 _Res = static_cast<_Ty>(_Par0._Tx - _Denom);
             }
@@ -3077,14 +3075,14 @@ private:
             for (;;) { // generate and reject
                 _Ty1 _Yx;
                 for (;;) { // generate a tentative value
-                    _Yx = static_cast<_Ty1>(_CSTD tan(_Pi_val * _NRAND(_Eng, _Ty1)));
+                    _Yx = static_cast<_Ty1>(_CSTD tan(_Pi_val * _Nrand_impl<_Ty1>(_Eng)));
                     const _Ty1 _Mx{_Par0._Sqrt * _Yx + _Par0._Mean};
                     if (0.0 <= _Mx && _Mx < _Ty1_Tx) {
                         _Res = static_cast<_Ty>(_Mx);
                         break;
                     }
                 }
-                if (_NRAND(_Eng, _Ty1)
+                if (_Nrand_impl<_Ty1>(_Eng)
                     <= 1.2 * _Par0._Sqrt * (1.0 + _Yx * _Yx)
                            * _CSTD exp(_Par0._Gx1 - _XLgamma(_Res + 1.0) - _XLgamma(_Par0._Tx - _Res + 1.0)
                                        + _Res * _Par0._Logp + (_Par0._Tx - _Res) * _Par0._Logp1)) {
@@ -3219,7 +3217,7 @@ public:
 private:
     template <class _Engine>
     result_type _Eval(_Engine& _Eng, const param_type& _Par0) const {
-        return _NRAND(_Eng, _Ty) * (_Par0._Max - _Par0._Min) + _Par0._Min;
+        return _Nrand_impl<_Ty>(_Eng) * (_Par0._Max - _Par0._Min) + _Par0._Min;
     }
 
     param_type _Par;
@@ -3432,7 +3430,7 @@ public:
 private:
     template <class _Engine>
     result_type _Eval(_Engine& _Eng, const param_type& _Par0) const {
-        return -_CSTD log(_Ty{1} - _NRAND(_Eng, _Ty)) / _Par0._Lambda;
+        return -_CSTD log(_Ty{1} - _Nrand_impl<_Ty>(_Eng)) / _Par0._Lambda;
     }
 
     param_type _Par;
@@ -3593,8 +3591,8 @@ private:
             _Ty _Vx2;
             _Ty _Sx;
             for (;;) { // reject bad values to avoid generating NaN/Inf on the next calculations
-                _Vx1 = 2 * _NRAND(_Eng, _Ty) - 1;
-                _Vx2 = 2 * _NRAND(_Eng, _Ty) - 1;
+                _Vx1 = 2 * _Nrand_impl<_Ty>(_Eng) - 1;
+                _Vx2 = 2 * _Nrand_impl<_Ty>(_Eng) - 1;
                 _Sx  = _Vx1 * _Vx1 + _Vx2 * _Vx2;
                 if (_Sx < _Ty{1} && _Vx1 != _Ty{0} && _Vx2 != _Ty{0}) {
                     // good values!
@@ -3772,9 +3770,9 @@ private:
         if (_Par0._Alpha < 1) { // small values of alpha
                                 // from Knuth
             for (;;) { // generate and reject
-                _Ux = _NRAND(_Eng, _Ty);
+                _Ux = _Nrand_impl<_Ty>(_Eng);
                 do {
-                    _Vx = _NRAND(_Eng, _Ty);
+                    _Vx = _Nrand_impl<_Ty>(_Eng);
                 } while (_Vx == 0);
 
                 if (_Ux < _Par0._Px) { // small _Ux
@@ -3785,7 +3783,7 @@ private:
                     _Qx = _CSTD pow(_Xx, _Par0._Alpha - 1);
                 }
 
-                if (_NRAND(_Eng, _Ty) < _Qx) {
+                if (_Nrand_impl<_Ty>(_Eng) < _Qx) {
                     return _Par0._Beta * _Xx;
                 }
             }
@@ -3797,10 +3795,10 @@ private:
 
         if (_Par0._Alpha < 20.0 && (_Count = static_cast<int>(_Par0._Alpha)) == _Par0._Alpha) {
             // _Alpha is small integer, compute directly
-            _Yx = _NRAND(_Eng, _Ty);
+            _Yx = _Nrand_impl<_Ty>(_Eng);
             while (--_Count) { // adjust result
                 do {
-                    _Ux = _NRAND(_Eng, _Ty);
+                    _Ux = _Nrand_impl<_Ty>(_Eng);
                 } while (_Ux == 0);
 
                 _Yx *= _Ux;
@@ -3810,12 +3808,12 @@ private:
 
         // no shortcuts
         for (;;) { // generate and reject
-            _Yx = static_cast<_Ty>(_CSTD tan(_Pi_val * _NRAND(_Eng, _Ty)));
+            _Yx = static_cast<_Ty>(_CSTD tan(_Pi_val * _Nrand_impl<_Ty>(_Eng)));
             _Xx = _Par0._Sqrt * _Yx + _Par0._Alpha - 1;
             if (0 < _Xx
-                && _NRAND(_Eng, _Ty) <= (1 + _Yx * _Yx)
-                                            * _CSTD exp((_Par0._Alpha - 1) * _CSTD log(_Xx / (_Par0._Alpha - 1))
-                                                        - _Par0._Sqrt * _Yx)) {
+                && _Nrand_impl<_Ty>(_Eng) <= (1 + _Yx * _Yx)
+                                                 * _CSTD exp((_Par0._Alpha - 1) * _CSTD log(_Xx / (_Par0._Alpha - 1))
+                                                             - _Par0._Sqrt * _Yx)) {
                 return _Par0._Beta * _Xx;
             }
         }
@@ -3952,7 +3950,7 @@ public:
 private:
     template <class _Engine>
     result_type _Eval(_Engine& _Eng, const param_type& _Par0) const { // generate pseudo-random value
-        _Ty _Px = (_Ty{1} - _NRAND(_Eng, _Ty));
+        _Ty _Px = (_Ty{1} - _Nrand_impl<_Ty>(_Eng));
         return _Par0._Bx * _CSTD pow(-_CSTD log(_Px), _Ty{1} / _Par0._Ax);
     }
 
@@ -4086,7 +4084,7 @@ public:
 private:
     template <class _Engine>
     result_type _Eval(_Engine& _Eng, const param_type& _Par0) const { // generate pseudo-random value
-        _Ty _Px = _NRAND(_Eng, _Ty);
+        _Ty _Px = _Nrand_impl<_Ty>(_Eng);
         return _Par0._Ax - _Par0._Bx * _CSTD log(-_CSTD log(_Px));
     }
 
@@ -4474,7 +4472,7 @@ public:
 private:
     template <class _Engine>
     result_type _Eval(_Engine& _Eng, const param_type& _Par0) const { // generate pseudo-random value
-        _Ty Px = _NRAND(_Eng, _Ty);
+        _Ty Px = _Nrand_impl<_Ty>(_Eng);
         return static_cast<_Ty>(_Par0._Ax + _Par0._Bx * _CSTD tan(_Pi_val * (Px - static_cast<_Ty>(0.5))));
     }
 
@@ -4497,8 +4495,8 @@ public:
             _Ty _Px1;
             _Ty _Px2;
             for (;;) { // reject large values
-                _Px1 = _NRAND(_Eng, _Ty);
-                _Px2 = _NRAND(_Eng, _Ty);
+                _Px1 = _Nrand_impl<_Ty>(_Eng);
+                _Px2 = _Nrand_impl<_Ty>(_Eng);
                 _Px1 = _CSTD pow(_Px1, _Ty{1} / _Ax);
                 _Px2 = _CSTD pow(_Px2, _Ty{1} / _Bx);
                 _Wx  = _Px1 + _Px2;
@@ -5146,7 +5144,7 @@ public:
 private:
     template <class _Engine>
     result_type _Eval(_Engine& _Eng, const param_type& _Par0) const {
-        double _Px           = _NRAND(_Eng, double);
+        double _Px           = _Nrand_impl<double>(_Eng);
         const auto _First    = _Par0._Pcdf.begin();
         const auto _Position = _STD lower_bound(_First, _Prev_iter(_Par0._Pcdf.end()), _Px);
         return static_cast<result_type>(_Position - _First);
@@ -5699,7 +5697,6 @@ _STL_RESTORE_DEPRECATED_WARNING
 #endif // _HAS_TR1_NAMESPACE
 _STD_END
 
-#undef _NRAND
 #undef _DISTRIBUTION_CONST
 
 // TRANSITION, GH-183

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -402,12 +402,12 @@ bool _Nrand_for_tr1(
 }
 
 template <class _Gen, class = void>
-constexpr bool _Has_static_min_max = false;
+struct _Has_static_min_max : false_type {};
 
 // This checks a requirement of N4981 [rand.req.urng] `concept uniform_random_bit_generator` but doesn't attempt
 // to implement the whole concept - we just need to distinguish Standard machinery from tr1 machinery.
 template <class _Gen>
-constexpr bool _Has_static_min_max<_Gen, void_t<decltype(bool_constant<(_Gen::min)() < (_Gen::max)()>::value)>> = true;
+struct _Has_static_min_max<_Gen, void_t<decltype(bool_constant<(_Gen::min)() < (_Gen::max)()>::value)>> : true_type {};
 
 template <class _Real, class _Gen>
 _NODISCARD _Real _Nrand_impl(_Gen& _Gx) { // build a floating-point value from random sequence
@@ -415,7 +415,7 @@ _NODISCARD _Real _Nrand_impl(_Gen& _Gx) { // build a floating-point value from r
 
     constexpr auto _Digits = static_cast<size_t>(numeric_limits<_Real>::digits);
 
-    if constexpr (_Has_static_min_max<_Gen>) {
+    if constexpr (_Has_static_min_max<_Gen>::value) {
         return _STD generate_canonical<_Real, _Digits>(_Gx);
     } else if constexpr (is_integral_v<typename _Gen::result_type>) {
         // TRANSITION, for integral tr1 machinery only; Standard machinery can call generate_canonical directly
@@ -2301,7 +2301,8 @@ private:
 
     template <class _Engine>
     result_type _Eval(_Engine& _Eng, _Ty _Min, _Ty _Max) const { // compute next value in range [_Min, _Max]
-        conditional_t<_Has_static_min_max<_Engine>, _Rng_from_urng_v2<_Uty, _Engine>, _Rng_from_urng<_Uty, _Engine>>
+        conditional_t<_Has_static_min_max<_Engine>::value, _Rng_from_urng_v2<_Uty, _Engine>,
+            _Rng_from_urng<_Uty, _Engine>>
             _Generator(_Eng);
 
         const _Uty _Umin = _Adjust(static_cast<_Uty>(_Min));

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -533,7 +533,7 @@ private:
 inline bool _Is_word(unsigned char _UCh) {
     // special casing char to avoid branches for std::regex in this path
     static constexpr bool _Is_word_table[_STD _Max_limit<unsigned char>() + 1] = {
-        //        X0 X1 X2 X3 X4 X5 X6 X7 X8 X9 XA XB XC XD XE XF
+        //       X0 X1 X2 X3 X4 X5 X6 X7 X8 X9 XA XB XC XD XE XF
         /* 0X */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         /* 1X */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         /* 2X */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -899,7 +899,7 @@ struct _Variant_init_overload_set_<index_sequence<_Indices...>, _Types...>
 template <class... _Types>
 using _Variant_init_overload_set = _Variant_init_overload_set_<index_sequence_for<_Types...>, _Types...>;
 
-template <class Enable, class _Ty, class... _Types>
+template <class _Enable, class _Ty, class... _Types>
 struct _Variant_init_helper {}; // failure case (has no member "type")
 
 template <class _Ty, class... _Types>

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -800,7 +800,7 @@ public:
                 _Elem _Percent  = _Fmtfirst[-1];
 
                 if (_Specifier == 'E' || _Specifier == 'O' || _Specifier == 'Q' || _Specifier == '#') {
-                    if (++_Fmtfirst == _Fmtlast) { // no specifier, copy %[E0Q#] as literal elements
+                    if (++_Fmtfirst == _Fmtlast) { // no specifier, copy %[EOQ#] as literal elements
                         *_Dest++ = _Percent;
                         *_Dest++ = _Specifier;
                         break;
@@ -940,7 +940,7 @@ public:
                 _Elem _Percent  = _Fmtfirst[-1];
 
                 if (_Specifier == 'E' || _Specifier == 'O' || _Specifier == 'Q' || _Specifier == '#') {
-                    if (++_Fmtfirst == _Fmtlast) { // no specifier, copy %[E0Q#] as literal elements
+                    if (++_Fmtfirst == _Fmtlast) { // no specifier, copy %[EOQ#] as literal elements
                         *_Dest++ = _Percent;
                         *_Dest++ = _Raw;
                         break;
@@ -1089,7 +1089,7 @@ public:
                 _Elem _Percent  = _Fmtfirst[-1];
 
                 if (_Specifier == 'E' || _Specifier == 'O' || _Specifier == 'Q' || _Specifier == '#') {
-                    if (++_Fmtfirst == _Fmtlast) { // no specifier, copy %[E0Q#] as literal elements
+                    if (++_Fmtfirst == _Fmtlast) { // no specifier, copy %[EOQ#] as literal elements
                         *_Dest++ = _Percent;
                         *_Dest++ = _Raw;
                         break;

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -433,10 +433,10 @@ public:
     using _Unchecked_const_iterator = _Tree_unchecked_const_iterator<_Tree_val>;
     using const_iterator            = _Tree_const_iterator<_Tree_val>;
 
-    template <class _AllocNode>
+    template <class _Alnode>
     struct _NODISCARD _Erase_tree_and_orphan_guard {
         _Tree_val* _Val_ptr;
-        _AllocNode& _Al;
+        _Alnode& _Al;
         _Nodeptr _New_root;
 
         _Erase_tree_and_orphan_guard& operator=(const _Erase_tree_and_orphan_guard&) = delete;

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1001,7 +1001,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 
 // P0298R3 std::byte
 #ifndef _HAS_STD_BYTE
-#define _HAS_STD_BYTE _HAS_CXX17
+#define _HAS_STD_BYTE _HAS_CXX17 // TRANSITION, OS-14273702
 #endif // !defined(_HAS_STD_BYTE)
 
 // P0302R1 Removing Allocator Support In std::function

--- a/stl/src/primitives.hpp
+++ b/stl/src/primitives.hpp
@@ -8,7 +8,7 @@
 
 #include <Windows.h>
 
-inline bool _Primitive_wait_for(const _Cnd_t cond, const _Mtx_t mtx, unsigned int timeout) noexcept {
+inline bool _Primitive_wait_for(const _Cnd_t cond, const _Mtx_t mtx, const unsigned int timeout) noexcept {
     const auto pcv  = reinterpret_cast<PCONDITION_VARIABLE>(&cond->_Stl_cv._Win_cv);
     const auto psrw = reinterpret_cast<PSRWLOCK>(&mtx->_Critical_section._M_srw_lock);
     return SleepConditionVariableSRW(pcv, psrw, timeout, 0) != 0;

--- a/stl/src/print.cpp
+++ b/stl/src/print.cpp
@@ -273,7 +273,7 @@ extern "C" {
     _Allocated_string _Allocated_str{};
     _Transcode_result _Transcoded_str{};
 
-    while (true) {
+    for (;;) {
         _Curr_str_segment = _Get_next_utf8_string_segment(_Remaining_str, _Remaining_str_size);
         _Transcoded_str   = _Transcode_utf8_string(_Allocated_str, _Curr_str_segment);
 

--- a/tests/std/tests/P0088R3_variant_msvc/test.cpp
+++ b/tests/std/tests/P0088R3_variant_msvc/test.cpp
@@ -747,7 +747,7 @@ namespace msvc {
 #define CONSTEXPR20 constexpr
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 #define CONSTEXPR20 inline
-#endif // ^^^ !_HAS_CXX20  ^^^
+#endif // ^^^ !_HAS_CXX20 ^^^
         struct X {
             CONSTEXPR20 ~X() {}
         };

--- a/tests/std/tests/P0092R1_polishing_chrono/test.cpp
+++ b/tests/std/tests/P0092R1_polishing_chrono/test.cpp
@@ -166,7 +166,7 @@ namespace floating_point_conversions {
 // Make sure round() handles cases where taking half the divisor itself
 // truncates.
 using odd_divisor = duration<intmax_t, ratio<1, 7>>;
-inline constexpr odd_divisor operator""_odd(unsigned long long val) {
+constexpr odd_divisor operator""_odd(unsigned long long val) {
     return odd_divisor(val);
 }
 

--- a/tests/std/tests/P0220R1_sample/test.cpp
+++ b/tests/std/tests/P0220R1_sample/test.cpp
@@ -41,7 +41,7 @@ namespace {
         assert(sample(SI{cbegin(source)}, SI{cend(source)}, DI{begin(dest1)}, n, cpy).base() == cbegin(dest1) + result);
         assert(equal(cbegin(dest0), cbegin(dest0) + result, cbegin(dest1), cbegin(dest1) + result));
 
-        if (is_base_of_v<forward_iterator_tag, SourceCategory>) {
+        if constexpr (is_base_of_v<forward_iterator_tag, SourceCategory>) {
             // Verify stability
             assert(is_sorted(cbegin(dest0), cbegin(dest0) + result));
         } else {

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_dates/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_dates/test.cpp
@@ -880,7 +880,7 @@ constexpr void year_month_day_test() {
                 assert(sys_days{ymd_max} == sys2 + days{254});
 
                 const year_month_day ymd_last = y / m / last;
-                sys2 += (ymd_last.day() - 1d);
+                sys2 += ymd_last.day() - 1d;
                 assert(sys_days{ymd_last} == sys2);
                 assert(year_month_day{sys2} == ymd_last);
 

--- a/tests/std/tests/P2502R2_generator/test.cpp
+++ b/tests/std/tests/P2502R2_generator/test.cpp
@@ -107,7 +107,7 @@ void test_one(generator<R, V, A> g0, Ex&& expected) {
 
 // Some simple end-to-end tests, mostly from the Working Draft or P2502R2
 generator<int> ints(int start = 0) {
-    while (true) {
+    for (;;) {
         co_yield start++;
     }
 }

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -107,7 +107,9 @@ template <class FwdIt, class T>
 ptrdiff_t last_known_good_count(FwdIt first, FwdIt last, T v) {
     ptrdiff_t result = 0;
     for (; first != last; ++first) {
-        result += (*first == v);
+        if (*first == v) {
+            ++result;
+        }
     }
     return result;
 }

--- a/tests/utils/stl/util.py
+++ b/tests/utils/stl/util.py
@@ -177,15 +177,3 @@ def killProcessAndChildren(pid):
             psutilProc.kill()
         except psutil.NoSuchProcess:
             pass
-
-
-def executeCommandVerbose(cmd, *args, **kwargs):
-    """
-    Execute a command and print its output on failure.
-    """
-    out, err, exitCode = executeCommand(cmd, *args, **kwargs)
-    if exitCode != 0:
-        report = makeReport(cmd, out, err, exitCode)
-        report += "\n\nFailed!"
-        sys.stderr.write('%s\n' % report)
-    return out, err, exitCode


### PR DESCRIPTION
Low-risk cleanups that I've been accumulating.

# :gear: Commits
* Comment: Fix alignment for `_Is_word_table` in `<regex>`.
* Comment: Drop extra space in `P0088R3_variant_msvc`.
* Uglify `Enable` => `_Enable` in `<variant>`.
* Use `if constexpr` for `is_floating_point_v` in `<chrono>`.
* Use `if constexpr` for `is_base_of_v` in `P0220R1_sample`.
* Comments: `concept available` => `_HAS_CXX20` in `<functional>`.
* Add braces to `_Idl_dist_add` control flow in `<algorithm>`.
* Replace away the `_NRAND` macro in `<random>`.
  + Before #2498 on 2022-02-07, the macro was `#define _NRAND(eng, resty) (_STD generate_canonical<resty, static_cast<size_t>(-1)>(eng))` which avoided significant verbosity, but now it serves no purpose.
  + Replaced `_NRAND\((\w+), (\w+)\)` => `_Nrand_impl<$2>($1)` because surrounding parens were never necessary.
* Add `const` to `unsigned int timeout` in `primitives.hpp`.
* ~~Change `_Has_static_min_max` from `struct` to `constexpr bool` in `<random>`.~~
  + Reverted, reported VSO-2417491 "C1XX `/permissive-` (strict mode) mishandles a variable template detecting `static constexpr` member functions", commented. (This isn't worth maintaining separate "workaround" / "no workaround" paths.)
* Drop unnecessary parens in `P0355R7_calendars_and_time_zones_dates`.
* Avoid unnecessary parens and `+= bool` in `VSO_0000000_vector_algorithms`.
  + Directly adding a `bool` is weird, so we conventionally avoid that.
* Drop unnecessary `typename` in `<format>`.
* Extract an alias template `_P_arg_type_t` in `<future>`.
* `_mm_mfence` is SSE2; update comment after #4741.
* Change unnecessary `inline constexpr` to `constexpr` for a function.
* `while (true)` => `for (;;)`
  + We traditionally used "for ever" to avoid "conditional expression is constant" warnings. While the compiler doesn't warn about `true` anymore, our usage remains consistent. (I don't feel super strongly about this one though.)
* Mark `_HAS_STD_BYTE` as `// TRANSITION, OS-14273702`.
  + Internal OS-14273702 has been active since 2017-10-17, but one can hope.
* `_Name.length()` => `_Name.size()` for `string`.
  + We're very particular about the synonym that we call.
* Fix comments: `%[E0Q#]` => `%[EOQ#]`
* Use braces to construct a temporary `bitset`.
  + When possible, we prefer braces to construct temporaries, since this avoids looking like a function call.
* util.py: `executeCommandVerbose` is dead.
* `_AllocNode` => `_Alnode` for consistency.
  + `_Erase_tree_and_orphan_guard` calls `_Erase_tree_and_orphan`, which already uses this naming convention: https://github.com/microsoft/STL/blob/0d8f517ae3828284fed594741b847db940167a59/stl/inc/xtree#L756-L757
  + As I always say, templates don't have a "type system" (especially without concepts), so naming is super important. This is an example of how avoiding unnecessary name changes between template layers is a good idea.