### PR TITLE
Add visualizer for `std::flat_set` and flat-map iterators

### DIFF
--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -2410,4 +2410,20 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     </Expand>
   </Type>
 
+  <Type Name="std::_Pairing_iterator_provider&lt;*&gt;::_Iterator">
+    <DisplayString>({_Key_it}, {_Mapped_it})</DisplayString>
+    <Expand>
+      <Item Name="[key]">_Key_it</Item>
+      <Item Name="[value]">_Mapped_it</Item>
+    </Expand>
+  </Type>
+
+  <Type Name="std::flat_set&lt;*&gt;">
+    <DisplayString>{_Mycont}</DisplayString>
+    <Expand>
+      <Item Name="[comparator]" ExcludeView="simple">_Mycomp</Item>
+      <ExpandedItem>_Mycont</ExpandedItem>
+    </Expand>
+  </Type>
+
 </AutoVisualizer>


### PR DESCRIPTION
This PR adds visualizers for `std::flat_set` and `std::_Pairing_iterator_provider<*>::_Iterator`. In https://github.com/microsoft/STL/pull/4887, I didn't add a visualizer for the iterator of `std::flat_map`.

<details><summary>Example/Preview</summary>

This is a bit larger, but shows a `std::flat_map` in {vector, deque}*{vector, deque} combos, a `std::flat_set` with vector and deque containers, a `std::map` + `std::set` (for comparison), and their iterators.

<details><summary>Code</summary>

```cpp
#include <deque>
#include <flat_map>
#include <flat_set>
#include <map>
#include <set>
#include <string>

template <typename KeyContainer, typename MappedContainer> auto makeFlatMap() {
  std::flat_map<int, std::string, std::less<int>, KeyContainer, MappedContainer>
      map;
  map.emplace(42, "hello world");
  map.emplace(1, "meow");
  map.emplace(2, "hey");
  return map;
}

int main() {
  auto mapVecVec = makeFlatMap<std::vector<int>, std::vector<std::string>>();
  auto mapVecDeque = makeFlatMap<std::vector<int>, std::deque<std::string>>();
  auto mapDeqVec = makeFlatMap<std::deque<int>, std::vector<std::string>>();
  auto mapDeqDeq = makeFlatMap<std::deque<int>, std::deque<std::string>>();
  std::map<int, std::string> map{
      {42, "hello world"},
      {1, "meow"},
      {2, "hey"},
  };

  std::flat_set<std::string> setVector{
      "hello world",
      "meow",
      "hey",
  };
  std::flat_set<std::string, std::less<>, std::deque<std::string>> setDeque{
      "hello world",
      "meow",
      "hey",
  };
  std::set<std::string> set{
      "hello world",
      "meow",
      "hey",
  };

  auto mapVecVecBegin = mapVecVec.begin();
  auto mapVecDeqBegin = mapVecDeque.begin();
  auto mapDeqVecBegin = mapDeqVec.begin();
  auto mapDeqDeqBegin = mapDeqDeq.begin();
  auto mapBegin = map.begin();
  auto setVecBegin = setVector.begin();
  auto setDeqBegin = setDeque.begin();
  auto setBegin = set.begin();

  return 0;
}
```
</details>
<details><summary>Display in VS Code</summary>

![](https://github.com/user-attachments/assets/c6f726a3-277f-45b7-8e70-9bfa9e4408cd)
</details> 
<details><summary>Display in Visual Studio</summary>

![](https://github.com/user-attachments/assets/5e2a07b9-6d6e-4990-8d90-d1f7827f5c26)
</details> 

</details> 

For integer types (like `int` in the example), the flat-map iterator (e.g. `mapVecVecBegin`) looks off compared to the "regular" map iterator (`mapBegin`). This only happens with integer types, though (as seen in the example, where the `std::string` displays fine).
