### PR TITLE
Remove comments for LWG-3210, LWG-4024, and LWG-4154

### DIFF
--- a/stl/inc/future
+++ b/stl/inc/future
@@ -1210,7 +1210,7 @@ public:
 
     template <class _Fty2, enable_if_t<!is_same_v<_Remove_cvref_t<_Fty2>, packaged_task>, int> = 0>
     explicit packaged_task(_Fty2&& _Fnarg) : _MyPromise(new _MyStateType(_STD forward<_Fty2>(_Fnarg))) {
-        static_assert(_Is_invocable_r<_Ret, decay_t<_Fty2>&, _ArgTypes...>::value, // per LWG-4154
+        static_assert(_Is_invocable_r<_Ret, decay_t<_Fty2>&, _ArgTypes...>::value,
             "The function object must be callable with _ArgTypes... and return _Ret (N4988 [futures.task.members]/3).");
     }
 
@@ -1222,7 +1222,7 @@ public:
     template <class _Fty2, class _Alloc, enable_if_t<!is_same_v<_Remove_cvref_t<_Fty2>, packaged_task>, int> = 0>
     packaged_task(allocator_arg_t, const _Alloc& _Al, _Fty2&& _Fnarg)
         : _MyPromise(_STD _Make_packaged_state<_MyStateType>(_STD forward<_Fty2>(_Fnarg), _Al)) {
-        static_assert(_Is_invocable_r<_Ret, decay_t<_Fty2>&, _ArgTypes...>::value, // per LWG-4154
+        static_assert(_Is_invocable_r<_Ret, decay_t<_Fty2>&, _ArgTypes...>::value,
             "The function object must be callable with _ArgTypes... and return _Ret (N4140 [futures.task.members]/2).");
     }
 #endif // _HAS_FUNCTION_ALLOCATOR_SUPPORT

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -3001,8 +3001,6 @@ template <class _Ty, class _Alloc, class... _Types>
 #endif // ^^^ !_HAS_CXX20 ^^^
 _NODISCARD_SMART_PTR_ALLOC shared_ptr<_Ty> allocate_shared(const _Alloc& _Al, _Types&&... _Args) {
     // make a shared_ptr to non-array object
-    // Note: As of 2019-05-28, this implements the proposed resolution of LWG-3210 (which controls whether
-    // allocator::construct sees T or const T when _Ty is const qualified)
     using _Refoa   = _Ref_count_obj_alloc3<remove_cv_t<_Ty>, _Alloc>;
     using _Alblock = _Rebind_alloc_t<_Alloc, _Refoa>;
     _Alblock _Rebound(_Al);

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -2542,7 +2542,7 @@ private:
     }
 
     void _Destroy() noexcept override { // destroy managed resource
-        _STD _Destroy_in_place(_Storage._Value); // use the default mechanism per LWG-4024
+        _STD _Destroy_in_place(_Storage._Value);
     }
 
     void _Delete_this() noexcept override { // destroy self
@@ -2789,7 +2789,7 @@ private:
     }
 
     void _Destroy() noexcept override { // destroy managed resource
-        _STD _Reverse_destroy_multidimensional_n(_Get_ptr(), _Size); // use the default mechanism per LWG-4024
+        _STD _Reverse_destroy_multidimensional_n(_Get_ptr(), _Size);
     }
 
     void _Delete_this() noexcept override { // destroy self
@@ -2893,7 +2893,7 @@ private:
     void _Destroy() noexcept override { // destroy managed resource
         // not _Storage._Value as _Ty is an array type (not a class type or a scalar type),
         // and thus cannot be used as a pseudo-destructor (N4964 [expr.prim.id.dtor]).
-        _STD _Destroy_in_place(_Storage); // use the default mechanism per LWG-4024
+        _STD _Destroy_in_place(_Storage);
     }
 
     void _Delete_this() noexcept override { // destroy self


### PR DESCRIPTION
These comments referenced proposed resolutions for LWG-3210, LWG-4024, and LWG-4154, which have now been officially accepted as part of the Working Draft (November 2024 meeting). The implementations were already aligned with the standard, so the references are no longer necessary.

This PR simply removes those comments, with no behavioral changes.

Fixes #5127.