### PR TITLE
`<regex>`: Properly parse dollar anchors in basic and grep mode

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -3947,15 +3947,17 @@ void _Parser<_FwdIt, _Elem, _RxTraits>::_Trans() { // map character to meta-char
                     ++_Next;
                 }
 
-                const bool _Has_escaped_capture_groups = (_L_flags & _L_nex_grp) == 0;
+                // Only the basic and grep grammars set _L_anch_rstr, so _L_alt_pipe and _L_nex_grp must be unset.
+                // Therefore, we don't need to handle "dollar followed by pipe '|' for alternation"
+                // or "dollar followed by non-escaped right parenthesis ')' closing a group" below.
+                _STL_INTERNAL_CHECK((_L_flags & (_L_alt_pipe | _L_nex_grp)) == 0);
 
                 const _Elem _Ch = *_Next;
                 const bool _Is_end_of_alternative =
-                    ((_L_flags & _L_alt_pipe) && _Ch == _Meta_bar) // dollar followed by pipe '|' for alternation
-                    || ((_L_flags & _L_alt_nl) && _Ch == _Meta_nl
+                    ((_L_flags & _L_alt_nl) && _Ch == _Meta_nl
                         && _Disj_count == 0) // dollar followed by newline '\n' for alternation
-                    || (_Escaped == _Has_escaped_capture_groups && _Ch == _Meta_rpar
-                        && _Disj_count != 0); // dollar followed by right parenthesis ')' closing a group
+                    || (_Escaped && _Ch == _Meta_rpar
+                        && _Disj_count != 0); // dollar followed by (escaped) right parenthesis ')' closing a group
 
                 if (!_Is_end_of_alternative) {
                     _Mchar = _Meta_chr;

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1721,7 +1721,7 @@ private:
     // lexing
     [[noreturn]] void _Error(regex_constants::error_type);
 
-    bool _Is_esc() const;
+    bool _Is_esc(_FwdIt) const;
     void _Trans();
     void _Next();
     void _Expect(_Meta_type, regex_constants::error_type);
@@ -3875,8 +3875,7 @@ template <class _FwdIt, class _Elem, class _RxTraits>
 }
 
 template <class _FwdIt, class _Elem, class _RxTraits>
-bool _Parser<_FwdIt, _Elem, _RxTraits>::_Is_esc() const { // assumes _Pat != _End
-    _FwdIt _Ch0 = _Pat;
+bool _Parser<_FwdIt, _Elem, _RxTraits>::_Is_esc(_FwdIt _Ch0) const { // assumes _Ch0 != _End
     return ++_Ch0 != _End
         && ((!(_L_flags & _L_nex_grp) && (*_Ch0 == _Meta_lpar || *_Ch0 == _Meta_rpar))
             || (!(_L_flags & _L_nex_rep) && (*_Ch0 == _Meta_lbr || *_Ch0 == _Meta_rbr)));
@@ -3897,7 +3896,7 @@ void _Parser<_FwdIt, _Elem, _RxTraits>::_Trans() { // map character to meta-char
     }
     switch (_Char) { // handle special cases
     case _Meta_esc:
-        if (_Is_esc()) { // replace escape sequence
+        if (_Is_esc(_Pat)) { // replace escape sequence
             _FwdIt _Ch0 = _Pat;
             _Mchar      = static_cast<_Meta_type>(_Char = *++_Ch0);
         }
@@ -3941,9 +3940,23 @@ void _Parser<_FwdIt, _Elem, _RxTraits>::_Trans() { // map character to meta-char
 
     case _Meta_dlr:
         { // check if $ is special
-            _FwdIt _Ch0 = _Pat;
-            if ((_L_flags & _L_anch_rstr) && ++_Ch0 != _End && *_Ch0 != _Meta_nl) {
-                _Mchar = _Meta_chr;
+            _FwdIt _Next = _Pat;
+            if ((_L_flags & _L_anch_rstr) && ++_Next != _End) {
+                const bool _Escaped = *_Next == _Meta_esc && _Is_esc(_Next);
+                if (_Escaped) {
+                    ++_Next;
+                }
+
+                const _Elem _Ch = *_Next;
+                const bool _Is_end_of_alternative =
+                    ((_L_flags & _L_alt_pipe) && _Ch == _Meta_bar) // dollar followed by pipe |
+                    || ((_L_flags & _L_alt_nl) && _Ch == _Meta_nl && _Disj_count == 0) // dollar followed by pipe \n
+                    || ((_Escaped || (_L_flags & _L_nex_grp)) && _Ch == _Meta_rpar
+                        && _Disj_count != 0); // dollar followed by parenthesis closing a group
+
+                if (!_Is_end_of_alternative) {
+                    _Mchar = _Meta_chr;
+                }
             }
 
             break;
@@ -3972,7 +3985,7 @@ void _Parser<_FwdIt, _Elem, _RxTraits>::_Trans() { // map character to meta-char
 template <class _FwdIt, class _Elem, class _RxTraits>
 void _Parser<_FwdIt, _Elem, _RxTraits>::_Next() { // advance to next input character
     if (_Pat != _End) { // advance
-        if (*_Pat == _Meta_esc && _Is_esc()) {
+        if (*_Pat == _Meta_esc && _Is_esc(_Pat)) {
             ++_Pat;
         }
 

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -3955,7 +3955,7 @@ void _Parser<_FwdIt, _Elem, _RxTraits>::_Trans() { // map character to meta-char
                     || ((_L_flags & _L_alt_nl) && _Ch == _Meta_nl
                         && _Disj_count == 0) // dollar followed by newline '\n' for alternation
                     || (_Escaped == _Has_escaped_capture_groups && _Ch == _Meta_rpar
-                        && _Disj_count != 0); // dollar followed by parenthesis closing a group
+                        && _Disj_count != 0); // dollar followed by right parenthesis ')' closing a group
 
                 if (!_Is_end_of_alternative) {
                     _Mchar = _Meta_chr;

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -3949,8 +3949,9 @@ void _Parser<_FwdIt, _Elem, _RxTraits>::_Trans() { // map character to meta-char
 
                 const _Elem _Ch = *_Next;
                 const bool _Is_end_of_alternative =
-                    ((_L_flags & _L_alt_pipe) && _Ch == _Meta_bar) // dollar followed by pipe |
-                    || ((_L_flags & _L_alt_nl) && _Ch == _Meta_nl && _Disj_count == 0) // dollar followed by pipe \n
+                    ((_L_flags & _L_alt_pipe) && _Ch == _Meta_bar) // dollar followed by pipe '|' for alternation
+                    || ((_L_flags & _L_alt_nl) && _Ch == _Meta_nl
+                        && _Disj_count == 0) // dollar followed by newline '\n' for alternation
                     || ((_Escaped || (_L_flags & _L_nex_grp)) && _Ch == _Meta_rpar
                         && _Disj_count != 0); // dollar followed by parenthesis closing a group
 

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -3947,12 +3947,14 @@ void _Parser<_FwdIt, _Elem, _RxTraits>::_Trans() { // map character to meta-char
                     ++_Next;
                 }
 
+                const bool _Has_escaped_capture_groups = (_L_flags & _L_nex_grp) == 0;
+
                 const _Elem _Ch = *_Next;
                 const bool _Is_end_of_alternative =
                     ((_L_flags & _L_alt_pipe) && _Ch == _Meta_bar) // dollar followed by pipe '|' for alternation
                     || ((_L_flags & _L_alt_nl) && _Ch == _Meta_nl
                         && _Disj_count == 0) // dollar followed by newline '\n' for alternation
-                    || ((_Escaped || (_L_flags & _L_nex_grp)) && _Ch == _Meta_rpar
+                    || (_Escaped == _Has_escaped_capture_groups && _Ch == _Meta_rpar
                         && _Disj_count != 0); // dollar followed by parenthesis closing a group
 
                 if (!_Is_end_of_alternative) {

--- a/tests/std/tests/VSO_0000000_regex_use/test.cpp
+++ b/tests/std/tests/VSO_0000000_regex_use/test.cpp
@@ -1312,7 +1312,6 @@ void test_gh_5362_grep() {
     {
         const test_regex middle_nl(&g_regexTester, "a\na$", grep);
         middle_nl.should_search_match("a\na$", "a");
-        middle_nl.should_search_match("a\na$", "a");
         middle_nl.should_search_match("a\nab", "a");
         middle_nl.should_search_match("a", "a");
         middle_nl.should_search_fail("b");

--- a/tests/std/tests/VSO_0000000_regex_use/test.cpp
+++ b/tests/std/tests/VSO_0000000_regex_use/test.cpp
@@ -1172,9 +1172,9 @@ void test_gh_5253() {
 
 void test_gh_5362_syntax_option(const syntax_option_type basic_or_grep) {
     {
-        const test_regex beginning_anchor(&g_regexTester, "meo[wW]$", basic_or_grep);
-        beginning_anchor.should_search_match("kitten_meow", "meow");
-        beginning_anchor.should_search_fail("homeowner");
+        const test_regex ending_anchor(&g_regexTester, "meo[wW]$", basic_or_grep);
+        ending_anchor.should_search_match("kitten_meow", "meow");
+        ending_anchor.should_search_fail("homeowner");
     }
     {
         const test_regex middle_anchor(&g_regexTester, "me$o[wW]", basic_or_grep);
@@ -1183,16 +1183,16 @@ void test_gh_5362_syntax_option(const syntax_option_type basic_or_grep) {
         middle_anchor.should_search_match("home$owner", "me$ow");
     }
     {
-        const test_regex double_carets(&g_regexTester, "meo[wW]$$", basic_or_grep);
-        double_carets.should_search_fail("kitten_meow");
-        double_carets.should_search_fail("homeowner");
-        double_carets.should_search_match("kitten_meow$", "meow$");
-        double_carets.should_search_fail("kitten_meow$$");
-        double_carets.should_search_fail("homeow$ner");
-        double_carets.should_search_fail("homeow$$ner");
+        const test_regex double_dollars(&g_regexTester, "meo[wW]$$", basic_or_grep);
+        double_dollars.should_search_fail("kitten_meow");
+        double_dollars.should_search_fail("homeowner");
+        double_dollars.should_search_match("kitten_meow$", "meow$");
+        double_dollars.should_search_fail("kitten_meow$$");
+        double_dollars.should_search_fail("homeow$ner");
+        double_dollars.should_search_fail("homeow$$ner");
     }
 
-    g_regexTester.should_not_match("me^ow", R"(\(me$\)o[wW])", basic_or_grep);
+    g_regexTester.should_not_match("me$ow", R"(\(me$\)o[wW])", basic_or_grep);
     g_regexTester.should_not_match("meow", R"(\(me$\)o[wW])", basic_or_grep);
 
     {
@@ -1212,7 +1212,7 @@ void test_gh_5362_syntax_option(const syntax_option_type basic_or_grep) {
     {
         const test_regex firstgroup_anchor(&g_regexTester, R"(\(meo[wW]$\)\(.*\))", basic_or_grep);
         firstgroup_anchor.should_search_match("kitten_meow", "meow");
-        firstgroup_anchor.should_search_fail("^kitten_meow$");
+        firstgroup_anchor.should_search_fail("kitten_meow$");
         firstgroup_anchor.should_search_fail("homeowner");
         firstgroup_anchor.should_search_fail("homeow$ner");
     }
@@ -1226,13 +1226,13 @@ void test_gh_5362_syntax_option(const syntax_option_type basic_or_grep) {
         nested_anchor.should_search_fail("homeow$$ner");
     }
     {
-        const test_regex double_carets(&g_regexTester, R"(\(meo[wW]$$\).*)", basic_or_grep);
-        double_carets.should_search_fail("kitten_meow");
-        double_carets.should_search_match("kitten_meow$", "meow$");
-        double_carets.should_search_fail("kitten_meow$$");
-        double_carets.should_search_fail("homeowner");
-        double_carets.should_search_fail("homeow$ner");
-        double_carets.should_search_fail("homeow$$ner");
+        const test_regex double_dollars(&g_regexTester, R"(\(meo[wW]$$\).*)", basic_or_grep);
+        double_dollars.should_search_fail("kitten_meow");
+        double_dollars.should_search_match("kitten_meow$", "meow$");
+        double_dollars.should_search_fail("kitten_meow$$");
+        double_dollars.should_search_fail("homeowner");
+        double_dollars.should_search_fail("homeow$ner");
+        double_dollars.should_search_fail("homeow$$ner");
     }
 
     // Validate that there is no special behavior near bars,
@@ -1297,7 +1297,7 @@ void test_gh_5362_basic() {
         middle_nl_with_dollar.should_search_fail("b");
     }
     {
-        const test_regex group_middle_nl_with_dollar(&g_regexTester, "^\\(a$\nb\\)$", basic);
+        const test_regex group_middle_nl_with_dollar(&g_regexTester, "\\(a$\nb\\)$", basic);
         group_middle_nl_with_dollar.should_search_match("a$\nb", "a$\nb");
         group_middle_nl_with_dollar.should_search_fail("a\nb");
         group_middle_nl_with_dollar.should_search_fail("a$\nb$");


### PR DESCRIPTION
This PR provides the symmetric change to #5165 for the dollar sign in basic and grep mode. Similar to the handling of the caret anchor, this PR recognizes a dollar sign as an anchor in a basic regular expression if it is at the end of an alternative. It does so by doing a bit of lookahead.

Drive-by: Remove a duplicated test that was accidentally added in #5165.