### PR TITLE
Search for first duplicate in vectorized `unique`

### DIFF
--- a/benchmarks/src/unique.cpp
+++ b/benchmarks/src/unique.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <benchmark/benchmark.h>
 #include <cstdint>
+#include <numeric>
 #include <random>
 #include <type_traits>
 #include <vector>
@@ -19,7 +20,9 @@ void u(benchmark::State& state) {
     std::binomial_distribution<TD> dis(5);
 
     std::vector<T, not_highly_aligned_allocator<T>> src(2552);
-    std::generate(src.begin(), src.end(), [&] { return static_cast<T>(dis(gen)); });
+    std::iota(src.begin(), src.begin() + 390, T{0});
+    std::iota(src.end() - 390, src.end(), T{0});
+    std::generate(src.begin() + 390, src.end() - 390, [&] { return static_cast<T>(dis(gen)); });
 
     std::vector<T, not_highly_aligned_allocator<T>> v;
     v.reserve(src.size());

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -5476,6 +5476,8 @@ void* __stdcall __std_remove_8(void* _First, void* const _Last, const uint64_t _
 }
 
 void* __stdcall __std_unique_1(void* _First, void* _Last) noexcept {
+    _First = const_cast<void*>(__std_adjacent_find_1(_First, _Last));
+
     if (_First == _Last) {
         return _First;
     }
@@ -5496,6 +5498,8 @@ void* __stdcall __std_unique_1(void* _First, void* _Last) noexcept {
 }
 
 void* __stdcall __std_unique_2(void* _First, void* _Last) noexcept {
+    _First = const_cast<void*>(__std_adjacent_find_2(_First, _Last));
+
     if (_First == _Last) {
         return _First;
     }
@@ -5516,6 +5520,8 @@ void* __stdcall __std_unique_2(void* _First, void* _Last) noexcept {
 }
 
 void* __stdcall __std_unique_4(void* _First, void* _Last) noexcept {
+    _First = const_cast<void*>(__std_adjacent_find_4(_First, _Last));
+
     if (_First == _Last) {
         return _First;
     }
@@ -5543,6 +5549,8 @@ void* __stdcall __std_unique_4(void* _First, void* _Last) noexcept {
 }
 
 void* __stdcall __std_unique_8(void* _First, void* _Last) noexcept {
+    _First = const_cast<void*>(__std_adjacent_find_8(_First, _Last));
+
     if (_First == _Last) {
         return _First;
     }

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -5187,8 +5187,6 @@ namespace {
             // It is not possible to leave them untouched while keeping this optimization efficient.
             // This should not be a problem though, as they should be either overwritten by the next step,
             // or left in the removed range.
-            // 'remove' does not require any specific values,
-            // 'unique' needs the last element value to be preserved, as it will be loaded again.
             for (; _Nx != _Size_h / _Ew; ++_Nx) {
                 // Inner loop needed for cases where the shuffle mask operates on element parts rather than whole
                 // elements; for whole elements there would be one iteration.


### PR DESCRIPTION
# 🔍 Missing piece

Vectorized `remove` has carefully considered `find` before actual removal loop. But the similar `adjacent_find` was missed in `unique`.

The effect is at least performance. Find is faster as vectorization, and it also avoids extra writes. I doubt about whether they have correctness impact though.

I've added the missing piece in separately compiled code. This is not the same as in `remove`, where it is in the header. But `unique` has in-place search for duplicates in scalar part that is tightly coupled with the rest of it, so I thought it is better to avoid disrupting that.

# 🏁 Benchmark

The modified benchmark adds two regions without duplicates: at the beginning and at the end of the range. The beginning one is avoidable with `adjacent_find`.

I've ran the modified benchmark for the `main` before #5092, to have the updated non-vectorized baseline to compare against

# ⏱️ Benchmark results

Benchmark                            |   Before vectorization   |  Before PR   | After PR 
-------------------------------------|--------------------------|--------------|----------
u<alg_type::std_fn, std::uint8_t>    |    1181 ns               |     540 ns   |  217 ns  
u<alg_type::std_fn, std::uint16_t>   |    1075 ns               |     649 ns   |  208 ns  
u<alg_type::std_fn, std::uint32_t>   |    1204 ns               |     775 ns   |  285 ns  
u<alg_type::std_fn, std::uint64_t>   |    1110 ns               |    1482 ns   |  551 ns  
u<alg_type::rng, std::uint8_t>       |    1233 ns               |     540 ns   |  221 ns  
u<alg_type::rng, std::uint16_t>      |    1059 ns               |     653 ns   |  207 ns  
u<alg_type::rng, std::uint32_t>      |    1298 ns               |     785 ns   |  285 ns  
u<alg_type::rng, std::uint64_t>      |    1216 ns               |    1490 ns   |  629 ns  

# 💡  Results interpretation

The effect is way more than expected. in particular, the "Before PR" column has shown that vectorization performance has severely degraded after adding already-unique ranges parts to the input.

Apparently it is due to reading just written output. Before the first removed element we read back last element previously written along with newly read elements. The mix of cache data and store buffer data causes the CPU to stall until the store buffer entry reaches the cache. So when we skip to the first non-unique, it is no longer a problem. 