### PR TITLE
`bug-report.md`: Add backticks to default title

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: Report a bug in the STL
-title: "<header>: Problem"
+title: "`<header>`: Problem"
 labels: ''
 assignees: ''
 


### PR DESCRIPTION
Approximately every issue has backticks around the header name, surely the template should have em too?