### PR TITLE
`<regex>`: Fix word bounds `\b` and `\B` when applied to the empty string

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -3497,7 +3497,7 @@ bool _Matcher<_BidIt, _Elem, _RxTraits, _It>::_Is_wbound() const {
         }
     } else { // --_Cur is not valid
         if (_Tgt_state._Cur == _End) {
-            return (_Mflags & (regex_constants::match_not_bow | regex_constants::match_not_eow)) == 0;
+            return false;
         } else {
             return (_Mflags & regex_constants::match_not_bow) == 0 && _Is_word(*_Tgt_state._Cur);
         }

--- a/tests/std/tests/VSO_0000000_regex_use/test.cpp
+++ b/tests/std/tests/VSO_0000000_regex_use/test.cpp
@@ -499,7 +499,7 @@ void test_VSO_225160_match_eol_flag() {
 
 void test_VSO_226914_word_boundaries() {
     const test_regex emptyAnchor(&g_regexTester, R"(\b)");
-    emptyAnchor.should_search_match("", "");
+    emptyAnchor.should_search_fail("");
     emptyAnchor.should_search_fail("", match_not_bow);
     emptyAnchor.should_search_fail("", match_not_eow);
     emptyAnchor.should_search_fail("", match_not_bow | match_not_eow);
@@ -1171,6 +1171,12 @@ void test_gh_5253() {
     g_regexTester.should_not_match("a", "()*");
 }
 
+void test_gh_5371() {
+    // GH-5371 <regex>: \b and \B are backwards on empty strings
+    g_regexTester.should_not_match("", "\\b");
+    g_regexTester.should_match("", "\\B");
+}
+
 int main() {
     test_dev10_449367_case_insensitivity_should_work();
     test_dev11_462743_regex_collate_should_not_disable_regex_icase();
@@ -1208,6 +1214,7 @@ int main() {
     test_gh_5192();
     test_gh_5214();
     test_gh_5253();
+    test_gh_5371();
 
     return g_regexTester.result();
 }

--- a/tests/std/tests/VSO_0000000_regex_use/test.cpp
+++ b/tests/std/tests/VSO_0000000_regex_use/test.cpp
@@ -1173,8 +1173,8 @@ void test_gh_5253() {
 
 void test_gh_5371() {
     // GH-5371 <regex>: \b and \B are backwards on empty strings
-    g_regexTester.should_not_match("", "\\b");
-    g_regexTester.should_match("", "\\B");
+    g_regexTester.should_not_match("", R"(\b)");
+    g_regexTester.should_match("", R"(\B)");
 }
 
 int main() {


### PR DESCRIPTION
Fixes #5371.

The [ECMAScript standard](https://262.ecma-international.org/#sec-compileassertion) effectively states that `\b` matches a position `i` in the string iff `IsWordChar(i-1) xor IsWordChar(i)` is true. It also defines that for positions `i = -1` and `i = length(input)`, `IsWordChar(i)` always returns `false`. Thus, `\b` does not match anything in the empty string.

Since `\b` does not match the empty string, the flags `match_not_bow` and `match_not_eow` don't matter in this case.