### PR TITLE
`<regex>`: Make back-references to unmatched capture groups not match anything in POSIX basic regexes

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -3643,6 +3643,9 @@ bool _Matcher<_BidIt, _Elem, _RxTraits, _It>::_Match_pat(_Node_base* _Nx) { // c
 
         case _N_back:
             { // check back reference
+                _STL_INTERNAL_CHECK(
+                    (_Sflags & (regex_constants::extended | regex_constants::egrep | regex_constants::awk))
+                    == 0); // these grammars don't have backreferences
                 _Node_back* _Node = static_cast<_Node_back*>(_Nx);
                 if (_Tgt_state._Grp_valid[_Node->_Idx]) { // check for match
                     _It _Res0 = _Tgt_state._Cur;
@@ -3654,9 +3657,7 @@ bool _Matcher<_BidIt, _Elem, _RxTraits, _It>::_Match_pat(_Node_base* _Nx) { // c
                     } else {
                         _Tgt_state._Cur = _Res0;
                     }
-                } else if (_Sflags
-                           & (regex_constants::basic | regex_constants::extended | regex_constants::grep
-                               | regex_constants::egrep | regex_constants::awk)) {
+                } else if (_Sflags & (regex_constants::basic | regex_constants::grep)) {
                     _Failed = true;
                 }
                 break;

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -3654,6 +3654,10 @@ bool _Matcher<_BidIt, _Elem, _RxTraits, _It>::_Match_pat(_Node_base* _Nx) { // c
                     } else {
                         _Tgt_state._Cur = _Res0;
                     }
+                } else if (_Sflags
+                           & (regex_constants::basic | regex_constants::extended | regex_constants::grep
+                               | regex_constants::egrep | regex_constants::awk)) {
+                    _Failed = true;
                 }
                 break;
             }

--- a/tests/std/tests/VSO_0000000_regex_use/test.cpp
+++ b/tests/std/tests/VSO_0000000_regex_use/test.cpp
@@ -1171,6 +1171,17 @@ void test_gh_5253() {
     g_regexTester.should_not_match("a", "()*");
 }
 
+void test_gh_5374() {
+    // GH-5374: <regex>: Back-references to unmatched capture groups
+    // should not match in POSIX basic regular expressions
+    for (syntax_option_type option : {basic, grep}) {
+        g_regexTester.should_not_match("", R"(\(.\)*\1)", option);
+        g_regexTester.should_match("", R"(\(.*\)\1)", option);
+        g_regexTester.should_not_match("bc", R"(\(a\)*b\1c)", option);
+        g_regexTester.should_match("bc", R"(\(a*\)b\1c)", option);
+    }
+}
+
 int main() {
     test_dev10_449367_case_insensitivity_should_work();
     test_dev11_462743_regex_collate_should_not_disable_regex_icase();
@@ -1208,6 +1219,7 @@ int main() {
     test_gh_5192();
     test_gh_5214();
     test_gh_5253();
+    test_gh_5374();
 
     return g_regexTester.result();
 }

--- a/tests/std/tests/VSO_0000000_regex_use/test.cpp
+++ b/tests/std/tests/VSO_0000000_regex_use/test.cpp
@@ -1180,6 +1180,12 @@ void test_gh_5374() {
         g_regexTester.should_not_match("bc", R"(\(a\)*b\1c)", option);
         g_regexTester.should_match("bc", R"(\(a*\)b\1c)", option);
     }
+
+    // ECMAScript's behavior is different:
+    g_regexTester.should_match("", R"((.)*\1)", ECMAScript);
+    g_regexTester.should_match("", R"((.*)\1)", ECMAScript);
+    g_regexTester.should_match("bc", R"((a)*b\1c)", ECMAScript);
+    g_regexTester.should_match("bc", R"((a*)b\1c)", ECMAScript);
 }
 
 int main() {


### PR DESCRIPTION
Fixes #5374.