### PR TITLE
`<regex>`: Do not reset matched capture groups in POSIX regexes

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -3622,9 +3622,13 @@ bool _Matcher<_BidIt, _Elem, _RxTraits, _It>::_Match_pat(_Node_base* _Nx) { // c
             { // record current position
                 _Node_capture* _Node                 = static_cast<_Node_capture*>(_Nx);
                 _Tgt_state._Grps[_Node->_Idx]._Begin = _Tgt_state._Cur;
-                // CodeQL [SM02323] Comparing unchanging unsigned int _Node->_Idx to decreasing size_t _Idx is safe.
-                for (size_t _Idx = _Tgt_state._Grp_valid.size(); _Node->_Idx < _Idx;) {
-                    _Tgt_state._Grp_valid[--_Idx] = false;
+                if (!(_Sflags
+                        & (regex_constants::basic | regex_constants::extended | regex_constants::grep
+                            | regex_constants::egrep | regex_constants::awk))) {
+                    // CodeQL [SM02323] Comparing unchanging unsigned int _Node->_Idx to decreasing size_t _Idx is safe.
+                    for (size_t _Idx = _Tgt_state._Grp_valid.size(); _Node->_Idx < _Idx;) {
+                        _Tgt_state._Grp_valid[--_Idx] = false;
+                    }
                 }
 
                 break;

--- a/tests/std/tests/VSO_0000000_regex_use/test.cpp
+++ b/tests/std/tests/VSO_0000000_regex_use/test.cpp
@@ -1171,6 +1171,30 @@ void test_gh_5253() {
     g_regexTester.should_not_match("a", "()*");
 }
 
+void test_gh_5377() {
+    for (syntax_option_type option : {extended, egrep}) {
+        test_regex abcd_regex(&g_regexTester, R"(^((a)|(b)|(c)|(d))+$)", option);
+        abcd_regex.should_search_match_capture_groups(
+            "abcd", "abcd", match_default, {{3, 4}, {0, 1}, {1, 2}, {2, 3}, {3, 4}});
+        abcd_regex.should_search_match_capture_groups(
+            "acbd", "acbd", match_default, {{3, 4}, {0, 1}, {2, 3}, {1, 2}, {3, 4}});
+        abcd_regex.should_search_match_capture_groups(
+            "dcba", "dcba", match_default, {{3, 4}, {3, 4}, {2, 3}, {1, 2}, {0, 1}});
+    }
+
+    for (syntax_option_type option : {basic, grep}) {
+        test_regex abcd_regex(&g_regexTester, R"(^\(\(a\)*\(b\)*\(c\)*\(d\)*\)*$)", option);
+        abcd_regex.should_search_match_capture_groups(
+            "abcd", "abcd", match_default, {{0, 4}, {0, 1}, {1, 2}, {2, 3}, {3, 4}});
+        abcd_regex.should_search_match_capture_groups(
+            "acbd", "acbd", match_default, {{2, 4}, {0, 1}, {2, 3}, {1, 2}, {3, 4}});
+        abcd_regex.should_search_match_capture_groups(
+            "dcba", "dcba", match_default, {{3, 4}, {3, 4}, {2, 3}, {1, 2}, {0, 1}});
+
+        test_regex backref_regex(&g_regexTester, R"(^\(\(a\)\{0,1\}\(\2b\)\{0,1\}\)*)", option);
+        backref_regex.should_search_match_capture_groups("aaababb", "aaabab", match_default, {{4, 6}, {1, 2}, {4, 6}});
+    }
+}
 int main() {
     test_dev10_449367_case_insensitivity_should_work();
     test_dev11_462743_regex_collate_should_not_disable_regex_icase();
@@ -1208,6 +1232,7 @@ int main() {
     test_gh_5192();
     test_gh_5214();
     test_gh_5253();
+    test_gh_5377();
 
     return g_regexTester.result();
 }


### PR DESCRIPTION
Towards #5365. Fixes the behavior for POSIX regexes: [Section 9.3.6](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_03_06) says that backreferences always refer to the last matched string if a capture group/subexpression has been matched more than once, so captures should not be cleared during matching at all.