### PR TITLE
Added a missing case for `__std_is_file_not_found()`.

### DIFF
--- a/stl/inc/xfilesystem_abi.h
+++ b/stl/inc/xfilesystem_abi.h
@@ -39,6 +39,7 @@ enum class __std_win_error : unsigned long {
     _Insufficient_buffer       = 122, // #define ERROR_INSUFFICIENT_BUFFER        122L
     _Invalid_name              = 123, // #define ERROR_INVALID_NAME               123L
     _Directory_not_empty       = 145, // #define ERROR_DIR_NOT_EMPTY              145L
+    _Bad_pathname              = 161, // #define ERROR_BAD_PATHNAME               161L
     _Already_exists            = 183, // #define ERROR_ALREADY_EXISTS             183L
     _Filename_exceeds_range    = 206, // #define ERROR_FILENAME_EXCED_RANGE       206L
     _Directory_name_is_invalid = 267, // #define ERROR_DIRECTORY                  267L
@@ -54,6 +55,7 @@ _NODISCARD inline bool __std_is_file_not_found(const __std_win_error _Error) noe
     case __std_win_error::_Path_not_found:
     case __std_win_error::_Error_bad_netpath:
     case __std_win_error::_Invalid_name:
+    case __std_win_error::_Bad_pathname:
     case __std_win_error::_Directory_name_is_invalid: // Windows 11 24H2
     case __std_win_error::_Error_netname_deleted: // Windows 11 24H2
         return true;


### PR DESCRIPTION
I noticed some rather peculiar behavior regarding the Win32 API `GetFileAttributesExW()`. Specifically, I found that upon calling this function with an invalid path (in my case, a remote URI) in two separate applications, both would fail as expected. What is interesting is that - for some inexplicable reason - the error code returned by `GetLastError()` differed between these two applications. Specifically, it was always either one of the following:

  * `ERROR_INVALID_NAME`: The file name, directory name, or volume label syntax is incorrect.

  * `ERROR_BAD_PATHNAME`: The specified path is invalid.

When this occurred, I was making use of the throwing `std::filesystem::exists()` overload. So, you could imagine my surprise when this function threw an exception on one of the applications and returned `false` as expected on the other. I have not spent any real time investigating the cause for this difference in behavior myself. In any case, though, it is clear that the `__std_is_file_not_found()` function should have returned `true` when given an `__std_win_error` value corresponding to either of the two error codes.

This commit thus modifies the `__std_is_file_not_found()` function to take into consideration an additional Win32 error code: `ERROR_BAD_PATHNAME`. Prior to this commit, this value did not have a unique value assigned to it in the `__std_win_error` `enum class`. Thus, a new value by the name of `__std_win_error::_Bad_pathname` was also added in this commit.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
