### PR TITLE
Implement P0472R3 - Put `monostate` in `<utility>`

### DIFF
--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -1001,6 +1001,16 @@ _NODISCARD constexpr bool operator>=(monostate, monostate) noexcept {
     return true;
 }
 #endif // ^^^ !_HAS_CXX20 ^^^
+
+template <>
+struct hash<monostate> {
+    using _ARGUMENT_TYPE_NAME _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS = monostate;
+    using _RESULT_TYPE_NAME _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS   = size_t;
+
+    _NODISCARD _STATIC_CALL_OPERATOR size_t operator()(monostate) _CONST_CALL_OPERATOR noexcept {
+        return 1729; // Arbitrary value
+    }
+};
 #endif // _HAS_CXX17
 
 #if _HAS_TR1_NAMESPACE

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -973,6 +973,36 @@ _NODISCARD _MSVC_INTRINSIC constexpr _Forward_like_t<_Ty, _Uty> forward_like(_Ut
 }
 #endif // _HAS_CXX23
 
+#if _HAS_CXX17
+_EXPORT_STD struct monostate {};
+
+_EXPORT_STD _NODISCARD constexpr bool operator==(monostate, monostate) noexcept {
+    return true;
+}
+
+#if _HAS_CXX20
+_EXPORT_STD _NODISCARD constexpr strong_ordering operator<=>(monostate, monostate) noexcept {
+    return strong_ordering::equal;
+}
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
+_NODISCARD constexpr bool operator!=(monostate, monostate) noexcept {
+    return false;
+}
+_NODISCARD constexpr bool operator<(monostate, monostate) noexcept {
+    return false;
+}
+_NODISCARD constexpr bool operator>(monostate, monostate) noexcept {
+    return false;
+}
+_NODISCARD constexpr bool operator<=(monostate, monostate) noexcept {
+    return true;
+}
+_NODISCARD constexpr bool operator>=(monostate, monostate) noexcept {
+    return true;
+}
+#endif // ^^^ !_HAS_CXX20 ^^^
+#endif // _HAS_CXX17
+
 #if _HAS_TR1_NAMESPACE
 namespace _DEPRECATE_TR1_NAMESPACE tr1 {
     using _STD get;

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -1647,32 +1647,6 @@ constexpr _Ret visit(_Callable&& _Obj, _Variants&&... _Args) {
 }
 #endif // _HAS_CXX20
 
-_EXPORT_STD _NODISCARD constexpr bool operator==(monostate, monostate) noexcept {
-    return true;
-}
-
-#if _HAS_CXX20
-_EXPORT_STD _NODISCARD constexpr strong_ordering operator<=>(monostate, monostate) noexcept {
-    return strong_ordering::equal;
-}
-#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
-_NODISCARD constexpr bool operator!=(monostate, monostate) noexcept {
-    return false;
-}
-_NODISCARD constexpr bool operator<(monostate, monostate) noexcept {
-    return false;
-}
-_NODISCARD constexpr bool operator>(monostate, monostate) noexcept {
-    return false;
-}
-_NODISCARD constexpr bool operator<=(monostate, monostate) noexcept {
-    return true;
-}
-_NODISCARD constexpr bool operator>=(monostate, monostate) noexcept {
-    return true;
-}
-#endif // ^^^ !_HAS_CXX20 ^^^
-
 _EXPORT_STD template <class... _Types,
     enable_if_t<conjunction_v<is_move_constructible<_Types>..., is_swappable<_Types>...>, int> = 0>
 _CONSTEXPR20 void swap(variant<_Types...>& _Left, variant<_Types...>& _Right) noexcept(noexcept(_Left.swap(_Right))) {

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -1676,16 +1676,6 @@ struct hash<variant<_Types...>> : _Conditionally_enabled_hash<variant<_Types...>
     }
 };
 
-template <>
-struct hash<monostate> {
-    using _ARGUMENT_TYPE_NAME _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS = monostate;
-    using _RESULT_TYPE_NAME _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS   = size_t;
-
-    _NODISCARD _STATIC_CALL_OPERATOR size_t operator()(monostate) _CONST_CALL_OPERATOR noexcept {
-        return 1729; // Arbitrary value
-    }
-};
-
 _STD_END
 
 #undef _STL_STAMP

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -7568,10 +7568,6 @@ struct _CXX17_DEPRECATE_ITERATOR_BASE_CLASS iterator { // base type for iterator
     using reference         = _Reference;
 };
 
-#if _HAS_CXX17
-_EXPORT_STD struct monostate {};
-#endif // _HAS_CXX17
-
 #if _HAS_CXX23
 template <_Integer_like _Int>
 _NODISCARD constexpr bool _Add_overflow(const _Int _Left, const _Int _Right, _Int& _Out) {

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -120,6 +120,7 @@
 // P0426R1 constexpr For char_traits
 // P0433R2 Deduction Guides For The STL
 // P0452R1 Unifying <numeric> Parallel Algorithms
+// P0472R3 Put monostate In <utility>
 // P0504R0 Revisiting in_place_t/in_place_type_t<T>/in_place_index_t<I>
 // P0505R0 constexpr For <chrono> (Again)
 // P0508R0 Clarifying insert_return_type


### PR DESCRIPTION
Move `monostate` (from `<xutility>`) and related definitions (from `<variant>`) to `<utility>`.
`<utility>` is included by both headers, so no code is broken.

resolves #5294 