### PR TITLE
Fix sporadic test failures by avoiding excessive compiler memory consumption

### DIFF
--- a/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
@@ -49,6 +49,8 @@ struct instantiator {
 };
 
 int main() {
+#ifndef _PREFAST_ // TRANSITION, GH-1030
     static_assert((test_in_write<instantiator, int const, int>(), true));
+#endif
     test_in_write<instantiator, int const, int>();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_transform_unary/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_transform_unary/test.cpp
@@ -54,6 +54,8 @@ struct instantiator {
 };
 
 int main() {
+#ifndef _PREFAST_ // TRANSITION, GH-1030
     static_assert((test_in_write<instantiator, const P, int>(), true));
+#endif
     test_in_write<instantiator, const P, int>();
 }

--- a/tests/std/tests/P2321R2_views_adjacent/test.cpp
+++ b/tests/std/tests/P2321R2_views_adjacent/test.cpp
@@ -1016,9 +1016,13 @@ int main() {
         test_one<3>(span<const int>{}, span<tuple<int, int, int>>{});
     }
 
+#ifndef _PREFAST_ // TRANSITION, GH-1030
     static_assert((instantiation_test(), true));
+#endif
     instantiation_test();
 
+#ifndef _PREFAST_ // TRANSITION, GH-1030
     static_assert((instantiation_input_only_test(), true));
+#endif
     instantiation_input_only_test();
 }

--- a/tests/std/tests/P2321R2_views_adjacent_transform/test.cpp
+++ b/tests/std/tests/P2321R2_views_adjacent_transform/test.cpp
@@ -1063,9 +1063,13 @@ int main() {
         static_assert(CanMemberBase<weird_adjacent_transform_view>);
     }
 
+#ifndef _PREFAST_ // TRANSITION, GH-1030
     static_assert((instantiation_test(), true));
+#endif
     instantiation_test();
 
+#ifndef _PREFAST_ // TRANSITION, GH-1030
     static_assert((instantiation_input_only_test(), true));
+#endif
     instantiation_input_only_test();
 }

--- a/tests/std/tests/P2441R2_views_join_with/test.cpp
+++ b/tests/std/tests/P2441R2_views_join_with/test.cpp
@@ -782,7 +782,9 @@ int main() {
         assert(ranges::empty(filtered_and_joined));
     }
 
+#ifndef _PREFAST_ // TRANSITION, GH-1030
     static_assert(instantiation_test());
+#endif
     instantiation_test();
 
     test_valueless_iterator();


### PR DESCRIPTION
Fixes internal VSO-2431296, where `P2321R2_views_adjacent` is sporadically running out of memory for x86-native `/analyze:only` configurations. (Internal builds of the compiler have a bit more debug logic than retail builds, which is why we haven't seen these failures in our GitHub PR/CI system.)

Related:

* #1030
* #3567

Our stressful ranges/views tests, combined with Static Analysis's increased compiler memory consumption, interact poorly with the ***ABSOLUTE ABOMINATION*** of x86-hosted toolsets in the year 2025.

I modified #3567's incantations to find all of the tests that were consuming 3+ GB for x86-native `/analyze:only`, then added our usual workarounds, reducing the peak working set sizes (in bytes) to reasonable levels:

Test                                 |     Before    |        After  |
-------------------------------------|--------------:|--------------:|
`P0896R4_ranges_alg_copy`            | 3,036,147,712 |   657,166,336 |
`P0896R4_ranges_alg_transform_unary` | 3,199,823,872 |   695,132,160 |
`P2321R2_views_adjacent`             | 3,887,595,520 | 1,020,297,216 |
`P2321R2_views_adjacent_transform`   | 3,404,570,624 |   940,150,784 |
`P2441R2_views_join_with`            | 3,391,266,816 |   892,010,496 |

As usual, the workarounds are architecture-independent, since consuming tons of memory isn't great even for properly x64-hosted compilers.

I also checked the plain configurations (original recipe C1XX, not extra crispy `/analyze:only`). There are only a few at 2+ GB for x86-native, and none over 3 GB, so while they're still concerning, they aren't risking OOM:

Test                                                    |      x86-native C1XX |
--------------------------------------------------------|--------------:|
`P2374R4_views_cartesian_product_recommended_practices` | 2,067,791,872 |
`P0896R4_ranges_alg_mismatch`                           | 2,132,271,104 |
`P2321R2_views_adjacent`                                | 2,138,755,072 |
`P2374R4_views_cartesian_product`                       | 2,359,115,776 |

(Note that [`/analyze:only`](https://learn.microsoft.com/en-us/cpp/build/reference/analyze-code-analysis?view=msvc-170) is just a variant of `/analyze` that skips codegen.)