### PR TITLE
`STL.natvis`: Fixed `time_point` visualization of year off-by-one

### DIFF
--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -2252,7 +2252,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <Intrinsic Name="mp"    Expression="(5*doy() + 2)/153"/>
     <Intrinsic Name="day"   Expression="doy() - (153*mp()+2)/5 + 1"/>
     <Intrinsic Name="month" Expression="mp() &lt; 10 ? mp()+3 : mp()-9"/>
-    <Intrinsic Name="year"  Expression="((long long)yoe()) + era() * 400 + (month() &lt; 2)"/>
+    <Intrinsic Name="year"  Expression="((long long)yoe()) + era() * 400 + (month() &lt;= 2)"/>
 
     <DisplayString Condition="_MyDur._MyRep &gt;= 0">
       {year(),d}-{month()/10,d}{month()%10,d}-{day()/10,d}{day()%10,d} {


### PR DESCRIPTION
When the `time_point` is sometime in February, the debugger visualization of the year will be off-by-one.

You can test this with this little snippet:
```
#include <chrono>
#include <iostream>

int main()
{
    using namespace std::chrono;

    constexpr year_month_day ymd = 2025y / 2 / 15;
    constexpr system_clock::time_point tp = sys_days{ ymd };
    std::cout << ymd << " | " << tp << std::endl;
}
```
The console output will be correct:
`2025-02-15 | 2025-02-15 00:00:00.0000000`

But the debugger shows a year of 2024 for `tp`:
<img width="188" alt="Screenshot 2025-04-02 210521" src="https://github.com/user-attachments/assets/0b497707-945f-45b5-817e-87ec627b8e0c" />

As per the [referenced calculation](https://howardhinnant.github.io/date_algorithms.html#civil_from_days) used to construct the debugger visualization, the year should be calculated by this formula:
`const Int y = static_cast<Int>(yoe) + era * 400; ... (y + (m <= 2)`

But the nativs contains this:
`<Intrinsic Name="year"  Expression="((long long)yoe()) + era() * 400 + (month() &lt; 2)"/>`

Missing the `=` sign in the less-than-or-equal 2 check.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
