### PR TITLE
`STL.natvis`: Add alternative type name for `time_point`

### DIFF
--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -2240,6 +2240,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   </Type>
 
   <Type Name="std::chrono::time_point&lt;std::chrono::system_clock,std::chrono::duration&lt;__int64,std::ratio&lt;1,10000000&gt; &gt; &gt;">
+    <!-- clang-cl -->
+    <AlternativeType Name="std::chrono::time_point&lt;std::chrono::system_clock,std::chrono::duration&lt;long long,std::ratio&lt;1,10000000&gt; &gt; &gt;" />
+
     <!--
       Same computation as in std::chrono::year_month_day::_Civil_from_days
       and https://howardhinnant.github.io/date_algorithms.html#civil_from_days.


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->

`clang-cl` will produce 
```
std::chrono::time_point<std::chrono::system_clock,std::chrono::duration<long long,std::ratio<1,10000000>>>
```
as the type name for `std::chrono::system_clock::time_point` whereas MSVC will produce 
```
std::chrono::time_point<std::chrono::system_clock,std::chrono::duration<__int64,std::ratio<1,10000000>>>
```
Notice: `long long` vs `__int64` (https://github.com/llvm/llvm-project/issues/134156).

As a workaround, I added the type from `clang-cl` as an `<AlternativeType>`.
