### PR TITLE
`<regex>`: Permit escaping of closing brackets in POSIX regexes

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -4348,6 +4348,7 @@ bool _Parser<_FwdIt, _Elem, _RxTraits>::_IsIdentityEscape(bool _In_character_cla
         return true;
     case _Meta_dot:
     case _Meta_lsq:
+    case _Meta_rsq:
     case _Meta_star:
     case _Meta_caret:
     case _Meta_dlr:

--- a/tests/std/tests/GH_005244_regex_escape_sequences/test.cpp
+++ b/tests/std/tests/GH_005244_regex_escape_sequences/test.cpp
@@ -465,6 +465,13 @@ void test_gh_5244_atomescape_posix_common(syntax_option_type option) {
     check_atomescape_identityescape("^", option);
     check_atomescape_identityescape("$", option);
 
+    // Even though [ is special, ] is not,
+    // so the interpretation of the escape sequence \] is undefined
+    // according to the POSIX standard referenced in the C++ standard.
+    // But we treat \] as an identity escape in line with
+    // more recent versions of the POSIX standard.
+    check_atomescape_identityescape("]", option);
+
     // Sections on "BRE Special Characters" and "ERE Special Characters":
     // escaping ordinary characters is undefined -> reject
     g_regexTester.should_throw(R"(\B)", error_escape, option);
@@ -478,9 +485,6 @@ void test_gh_5244_atomescape_posix_common(syntax_option_type option) {
     g_regexTester.should_throw(R"(\W)", error_escape, option);
     g_regexTester.should_throw(R"(\s)", error_escape, option);
     g_regexTester.should_throw(R"(\S)", error_escape, option);
-
-    // while [ is special, ] is not
-    g_regexTester.should_throw(R"(\])", error_escape, option);
 }
 
 void test_gh_5244_atomescape_posix_not_awk(syntax_option_type option) {
@@ -519,8 +523,6 @@ void test_gh_5244_atomescape_basic_or_grep(syntax_option_type option) {
 }
 
 void test_gh_5244_atomescape_extended_egrep_awk(syntax_option_type option) {
-    test_gh_5244_atomescape_posix_common(option);
-
     // check that the parser accepts escaped characters
     // that are only special in extended regexes
     check_atomescape_identityescape("+", option);
@@ -552,6 +554,7 @@ void test_gh_5244_atomescape_extended_or_egrep(syntax_option_type option) {
 
 void test_gh_5244_atomescape_awk() {
     test_gh_5244_atomescape_extended_egrep_awk(awk);
+    test_gh_5244_atomescape_posix_common(awk);
 
     // awk-only escapes
     check_atomescape_controlescape("\a", "a", awk);


### PR DESCRIPTION
Short follow-up to #5380 to support escapes for closing brackets in POSIX regexes in accordance with the most recent POSIX standard version: https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap09.html#tag_09_03_02 for basic and https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap09.html#tag_09_04_02 for extended regexes.

Because of the (expected) test failures caused by this change, I noticed that the tests in `gh_5244_atomescape_posix_common` are called twice for `extended` and `egrep` from `test_gh_5244_atomescape_extended_or_egrep`: Once via `gh_5244_atomescape_posix_not_awk` and once via `gh_5244_atomescape_extended_egrep_awk`. That's once more than necessary, so let's get rid of this double-testing. I opted to remove the call of `gh_5244_atomescape_posix_common` in `gh_5244_atomescape_extended_egrep_awk`, but this means a call has to be added to `gh_5244_atomescape_awk` so that these common POSIX tests are still exercised in awk mode.