### PR TITLE
Update the SPDX-License-Identifier for Ryu-derived sources

### DIFF
--- a/stl/inc/xcharconv_ryu.h
+++ b/stl/inc/xcharconv_ryu.h
@@ -1,7 +1,7 @@
 // xcharconv_ryu.h internal header
 
 // Copyright (c) Microsoft Corporation.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception AND BSL-1.0
 
 
 // Copyright 2018 Ulf Adams

--- a/stl/inc/xcharconv_ryu_tables.h
+++ b/stl/inc/xcharconv_ryu_tables.h
@@ -1,7 +1,7 @@
 // xcharconv_ryu_tables.h internal header
 
 // Copyright (c) Microsoft Corporation.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception AND BSL-1.0
 
 
 // Copyright 2018 Ulf Adams

--- a/stl/src/xcharconv_ryu_tables.cpp
+++ b/stl/src/xcharconv_ryu_tables.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception AND BSL-1.0
 
 
 // Copyright 2018 Ulf Adams

--- a/tests/std/tests/P0067R5_charconv/double_fixed_precision_to_chars_test_cases_1.hpp
+++ b/tests/std/tests/P0067R5_charconv/double_fixed_precision_to_chars_test_cases_1.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception AND BSL-1.0
 
 
 // Copyright 2018 Ulf Adams

--- a/tests/std/tests/P0067R5_charconv/double_fixed_precision_to_chars_test_cases_2.hpp
+++ b/tests/std/tests/P0067R5_charconv/double_fixed_precision_to_chars_test_cases_2.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception AND BSL-1.0
 
 
 // Copyright 2018 Ulf Adams

--- a/tests/std/tests/P0067R5_charconv/double_fixed_precision_to_chars_test_cases_3.hpp
+++ b/tests/std/tests/P0067R5_charconv/double_fixed_precision_to_chars_test_cases_3.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception AND BSL-1.0
 
 
 // Copyright 2018 Ulf Adams

--- a/tests/std/tests/P0067R5_charconv/double_scientific_precision_to_chars_test_cases_1.hpp
+++ b/tests/std/tests/P0067R5_charconv/double_scientific_precision_to_chars_test_cases_1.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception AND BSL-1.0
 
 
 // Copyright 2018 Ulf Adams

--- a/tests/std/tests/P0067R5_charconv/double_scientific_precision_to_chars_test_cases_2.hpp
+++ b/tests/std/tests/P0067R5_charconv/double_scientific_precision_to_chars_test_cases_2.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception AND BSL-1.0
 
 
 // Copyright 2018 Ulf Adams

--- a/tests/std/tests/P0067R5_charconv/double_scientific_precision_to_chars_test_cases_3.hpp
+++ b/tests/std/tests/P0067R5_charconv/double_scientific_precision_to_chars_test_cases_3.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception AND BSL-1.0
 
 
 // Copyright 2018 Ulf Adams

--- a/tests/std/tests/P0067R5_charconv/double_to_chars_test_cases.hpp
+++ b/tests/std/tests/P0067R5_charconv/double_to_chars_test_cases.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception AND BSL-1.0
 
 
 // Copyright 2018 Ulf Adams

--- a/tests/std/tests/P0067R5_charconv/float_fixed_precision_to_chars_test_cases.hpp
+++ b/tests/std/tests/P0067R5_charconv/float_fixed_precision_to_chars_test_cases.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception AND BSL-1.0
 
 
 // Copyright 2018 Ulf Adams

--- a/tests/std/tests/P0067R5_charconv/float_scientific_precision_to_chars_test_cases.hpp
+++ b/tests/std/tests/P0067R5_charconv/float_scientific_precision_to_chars_test_cases.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception AND BSL-1.0
 
 
 // Copyright 2018 Ulf Adams

--- a/tests/std/tests/P0067R5_charconv/float_to_chars_test_cases.hpp
+++ b/tests/std/tests/P0067R5_charconv/float_to_chars_test_cases.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception AND BSL-1.0
 
 
 // Copyright 2018 Ulf Adams


### PR DESCRIPTION
Fixes #5397.

I am neither a lawyer nor a cat, and this is not a licensing change. It is simply clarifying our machine-searchable SPDX-License-Identifier to align with our original intentions.

Most of our source files are available under the Apache License v2.0 with LLVM Exception, chosen to match libc++. Our `<charconv>` implementation was derived from the [ulfjack/ryu](https://github.com/ulfjack/ryu) repo's `ryu/` subdirectory, which is dual-licensed. Quoting that repo's README:

> All code outside of third_party/ is copyrighted by Ulf Adams and contributors, and may be used freely in accordance with the Apache 2.0 license. Alternatively, the files in the ryu/ directory may be used freely in accordance with the Boost 1.0 license.

We chose to use Ryu under the Boost Software License and accordingly copied that banner into our sources. (We're pretty careful about isolating derived code into separate source files, especially in product code.)

The important thing for us about the Boost Software License is how it explicitly doesn't require attribution when shipping compiled software to end users, which is something that the LLVM Exception also addresses. (End users don't even know what a C++ Standard Library is.)

As a result, our files implementing and testing `<charconv>` (although not `<charconv>` itself, as it's the layer above Ryu) contain both our usual `SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception` and the (verbose) Boost Software License, both of which must be complied with (which we believe is pretty easy, due to their aligned natures regarding attribution). At the time, I didn't understand that the SPDX syntax wants to express this with AND; see [SPDX IDs: How to use](https://spdx.dev/learn/handling-license-info/#how).

Again, note the difference: Upstream Ryu is effectively Apache-2.0 OR BSL-1.0 (as it says "Alternatively"). We've chosen the BSL-1.0 option, then added our usual license, so our derived sources are Apache-2.0 WITH LLVM-exception AND BSL-1.0. The OR operator would not be suitable for these derived sources, otherwise further derived code could drop the BSL-1.0.