### PR TITLE
Fix inconsistent use of `normal_distribution` in benchmarks and tests

### DIFF
--- a/benchmarks/src/adjacent_difference.cpp
+++ b/benchmarks/src/adjacent_difference.cpp
@@ -23,7 +23,7 @@ void bm(benchmark::State& state) {
     vector<T> output(size);
 
     if constexpr (is_floating_point_v<T>) {
-        normal_distribution<T> dis(-100.0, 100.0);
+        normal_distribution<T> dis(0, 100000.0);
         ranges::generate(input, [&] { return dis(gen); });
     } else {
         static_assert(is_unsigned_v<T>, "This avoids signed integers to avoid UB; they shouldn't perform differently");

--- a/benchmarks/src/minmax_element.cpp
+++ b/benchmarks/src/minmax_element.cpp
@@ -28,7 +28,7 @@ void bm(benchmark::State& state) {
     mt19937 gen(84710);
 
     if constexpr (is_floating_point_v<T>) {
-        normal_distribution<T> dis(0, 10000.0);
+        normal_distribution<T> dis(0, 100000.0);
         ranges::generate(a, [&] { return dis(gen); });
     } else {
         uniform_int_distribution<conditional_t<sizeof(T) != 1, T, int>> dis(1, 20);

--- a/tests/std/tests/VSO_0000000_vector_algorithms_floats/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms_floats/test.cpp
@@ -26,7 +26,7 @@ void test_min_max_element_floating_with_values(mt19937_64& gen, const vector<T>&
 
 template <class T>
 void test_min_max_element_floating_any(mt19937_64& gen) {
-    normal_distribution<T> dis(-100000.0, 100000.0);
+    normal_distribution<T> dis(0.0, 100000.0);
 
     constexpr auto input_of_input_size = dataCount / 2;
     vector<T> input_of_input(input_of_input_size);

--- a/tests/std/tests/VSO_0000000_vector_algorithms_floats/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms_floats/test.cpp
@@ -26,7 +26,7 @@ void test_min_max_element_floating_with_values(mt19937_64& gen, const vector<T>&
 
 template <class T>
 void test_min_max_element_floating_any(mt19937_64& gen) {
-    normal_distribution<T> dis(0.0, 100000.0);
+    normal_distribution<T> dis(0, 100000.0);
 
     constexpr auto input_of_input_size = dataCount / 2;
     vector<T> input_of_input(input_of_input_size);


### PR DESCRIPTION
There's no reason to be negative biased.