### PR TITLE
`<optional>`: Extend compiler bug workaround to MSVC

### DIFF
--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -952,7 +952,7 @@ _NODISCARD constexpr bool operator>=(const _Ty1& _Left, const optional<_Ty2>& _R
 }
 
 #if _HAS_CXX20
-#ifdef __EDG__ // TRANSITION, DevCom-10880933
+#ifndef __clang__ // TRANSITION, DevCom-10880933 (EDG) and VSO-2444237 (MSVC)
 template <class _Ty>
 void _Derived_from_optional_impl(const optional<_Ty>&);
 


### PR DESCRIPTION
#5369 revealed VSO-2444237 "\[RWC\]\[prod/fe\]\[std:c++latest\]\[Regression\] LLVM failed with Assertion failed: `ParseTree::Utility::SigStack::sigStack.size() == 1`".

@xiangfan-ms tracked this down to the introduction of `_Derived_from_optional` and reduced it to a library-free repro. The compiler is having trouble with the lambda's templated function call operator.

To unblock our Real World Code test suite, we should extend the workaround we're currently using for EDG to also cover MSVC.