### PR TITLE
Toolset update: VS 2022 17.14 Preview 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ cmake_minimum_required(VERSION 3.30.0)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.44.35109.1")
+    message(FATAL_ERROR "The STL must be built with VS 2022 17.14 Preview 3 or later.")
+endif()
+
 include(CheckCXXSourceCompiles)
 check_cxx_source_compiles([=[
 #include <sdkddkver.h>

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.14 Preview 2 or later.
+1. Install Visual Studio 2022 17.14 Preview 3 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.
@@ -160,7 +160,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.14 Preview 2 or later.
+1. Install Visual Studio 2022 17.14 Preview 3 or later.
     * Select "Windows 11 SDK (10.0.22621.0)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,7 +5,7 @@
 
 variables:
 - name: poolName
-  value: 'StlBuild-2025-03-11T1203-Pool'
+  value: 'StlBuild-2025-04-16T1328-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -43,7 +43,7 @@ foreach ($workload in $VisualStudioWorkloads) {
 $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/PowerShell-7.5.0-win-x64.msi'
 $PowerShellArgs = @('/quiet', '/norestart')
 
-$PythonUrl = 'https://www.python.org/ftp/python/3.13.2/python-3.13.2-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.13.3/python-3.13.3-amd64.exe'
 $PythonArgs = @('/quiet', 'InstallAllUsers=1', 'PrependPath=1', 'CompileAll=1', 'Include_doc=0')
 
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/12.4.0/local_installers/cuda_12.4.0_551.61_windows.exe'

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -402,12 +402,12 @@ bool _Nrand_for_tr1(
 }
 
 template <class _Gen, class = void>
-struct _Has_static_min_max : false_type {}; // TRANSITION, VSO-2417491: Should be a variable template
+constexpr bool _Has_static_min_max = false;
 
 // This checks a requirement of N4981 [rand.req.urng] `concept uniform_random_bit_generator` but doesn't attempt
 // to implement the whole concept - we just need to distinguish Standard machinery from tr1 machinery.
 template <class _Gen>
-struct _Has_static_min_max<_Gen, void_t<decltype(bool_constant<(_Gen::min)() < (_Gen::max)()>::value)>> : true_type {};
+constexpr bool _Has_static_min_max<_Gen, void_t<decltype(bool_constant<(_Gen::min)() < (_Gen::max)()>::value)>> = true;
 
 template <class _Real, class _Gen>
 _NODISCARD _Real _Nrand_impl(_Gen& _Gx) { // build a floating-point value from random sequence
@@ -415,7 +415,7 @@ _NODISCARD _Real _Nrand_impl(_Gen& _Gx) { // build a floating-point value from r
 
     constexpr auto _Digits = static_cast<size_t>(numeric_limits<_Real>::digits);
 
-    if constexpr (_Has_static_min_max<_Gen>::value) {
+    if constexpr (_Has_static_min_max<_Gen>) {
         return _STD generate_canonical<_Real, _Digits>(_Gx);
     } else if constexpr (is_integral_v<typename _Gen::result_type>) {
         // TRANSITION, for integral tr1 machinery only; Standard machinery can call generate_canonical directly
@@ -2308,8 +2308,7 @@ private:
 
     template <class _Engine>
     result_type _Eval(_Engine& _Eng, _Ty _Min, _Ty _Max) const { // compute next value in range [_Min, _Max]
-        conditional_t<_Has_static_min_max<_Engine>::value, _Rng_from_urng_v2<_Uty, _Engine>,
-            _Rng_from_urng<_Uty, _Engine>>
+        conditional_t<_Has_static_min_max<_Engine>, _Rng_from_urng_v2<_Uty, _Engine>, _Rng_from_urng<_Uty, _Engine>>
             _Generator(_Eng);
 
         const _Uty _Umin = _Adjust(static_cast<_Uty>(_Min));

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -816,6 +816,15 @@ std/iterators/iterator.requirements/iterator.assoc.types/readable.traits/indirec
 std/containers/sequences/vector/trivial_relocation.pass.cpp:0 FAIL
 std/containers/sequences/vector/trivial_relocation.pass.cpp:1 FAIL
 
+# These tests emit C5321, which warns when the resolution to CWG-1656 affects a u8 string literal.
+# The conformant behavior is opt-in because it can silently change behavior.
+# warning C5321: nonstandard extension used: encoding '\x80' as a multi-byte utf-8 character. Use \u instead
+# for cross platform compatibility or '/Zc:u8EscapeEncoding' to disable the extension.
+std/utilities/format/format.functions/escaped_output.unicode.pass.cpp:0 FAIL
+std/utilities/format/format.functions/escaped_output.unicode.pass.cpp:1 FAIL
+std/utilities/format/format.functions/fill.unicode.pass.cpp:0 FAIL
+std/utilities/format/format.functions/fill.unicode.pass.cpp:1 FAIL
+
 
 # *** LIKELY STL BUGS ***
 # Not analyzed, likely STL bugs. Various assertions.
@@ -1469,10 +1478,3 @@ std/input.output/string.streams/stringstream/stringstream.members/gcount.pass.cp
 
 # Similarly, this test is marked as `REQUIRES: 32-bit-pointer`.
 std/iterators/iterator.container/ssize.LWG3207.compile.pass.cpp:9 SKIPPED
-
-# These tests emit C5321, which warns when the resolution to CWG-1656 affects a u8 string literal.
-# The conformant behavior is opt-in because it can silently change behavior.
-# warning C5321: nonstandard extension used: encoding '\x80' as a multi-byte utf-8 character. Use \u instead
-# for cross platform compatibility or '/Zc:u8EscapeEncoding' to disable the extension.
-std/utilities/format/format.functions/escaped_output.unicode.pass.cpp:9 SKIPPED
-std/utilities/format/format.functions/fill.unicode.pass.cpp:9 SKIPPED

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1186,10 +1186,6 @@ std/ranges/range.adaptors/range.join/range.join.iterator/star.pass.cpp:1 FAIL
 std/ranges/range.adaptors/range.join/range.join.iterator/iter.swap.pass.cpp:0 FAIL
 std/ranges/range.adaptors/range.join/range.join.iterator/iter.swap.pass.cpp:1 FAIL
 
-# Not analyzed. Likely MSVC constexpr bug with negative chars passed to __builtin_memcmp.
-std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/compare.pass.cpp:0 FAIL
-std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/compare.pass.cpp:1 FAIL
-
 # Not analyzed. Likely MSVC constexpr bug, "note: failure was caused by a read of a variable outside its lifetime"
 std/containers/views/mdspan/mdspan/index_operator.pass.cpp:0 FAIL
 std/containers/views/mdspan/mdspan/index_operator.pass.cpp:1 FAIL

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -794,20 +794,16 @@ struct hash<::hash::B> {
 namespace hash {
 void test_hash_variant_enabled() {
   {
-#ifndef __EDG__ // TRANSITION, DevCom-10107834
     test_hash_enabled<std::variant<int> >();
     test_hash_enabled<std::variant<int*, long, double, const int> >();
-#endif // ^^^ no workaround ^^^
   }
   {
     test_hash_disabled<std::variant<int, A>>();
     test_hash_disabled<std::variant<const A, void*>>();
   }
   {
-#ifndef __EDG__ // TRANSITION, DevCom-10107834
     test_hash_enabled<std::variant<int, B>>();
     test_hash_enabled<std::variant<const B, int>>();
-#endif // ^^^ no workaround ^^^
   }
 }
 

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -861,20 +861,16 @@ int run_test()
         assert(std::hash<optional<T>>{}(opt) == std::hash<T>{}(*opt));
     }
     {
-#ifndef __EDG__ // TRANSITION, DevCom-10107834
       test_hash_enabled<std::optional<int> >();
       test_hash_enabled<std::optional<int*> >();
       test_hash_enabled<std::optional<const int> >();
       test_hash_enabled<std::optional<int* const> >();
-#endif // ^^^ no workaround ^^^
 
       test_hash_disabled<std::optional<A>>();
       test_hash_disabled<std::optional<const A>>();
 
-#ifndef __EDG__ // TRANSITION, DevCom-10107834
       test_hash_enabled<std::optional<B>>();
       test_hash_enabled<std::optional<const B>>();
-#endif // ^^^ no workaround ^^^
     }
 
   return 0;

--- a/tests/std/tests/P0758R1_is_nothrow_convertible/test.compile.pass.cpp
+++ b/tests/std/tests/P0758R1_is_nothrow_convertible/test.compile.pass.cpp
@@ -98,9 +98,7 @@ STATIC_ASSERT(is_nothrow_convertible_v<double, unsigned char>);
 STATIC_ASSERT(is_nothrow_convertible_v<int, bool>);
 STATIC_ASSERT(is_nothrow_convertible_v<bool, int>);
 STATIC_ASSERT(is_nothrow_convertible_v<int, long long>);
-#ifndef __EDG__ // TRANSITION, VSO-892705
 STATIC_ASSERT(is_nothrow_convertible_v<int[], int*>);
-#endif // ^^^ no workaround ^^^
 STATIC_ASSERT(is_nothrow_convertible_v<int[1], int*>);
 STATIC_ASSERT(!is_nothrow_convertible_v<int[], int[]>);
 STATIC_ASSERT(!is_nothrow_convertible_v<int[], int[1]>);

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -1545,7 +1545,7 @@ namespace test_default_initializable {
 #endif // ^^^ no workaround ^^^
 
     // Also test GH-1603 "default_initializable accepts types that are not default-initializable"
-#if defined(__clang__) // TRANSITION, DevCom-1326684 (MSVC) and VSO-1898945 (EDG)
+#ifndef __EDG__ // TRANSITION, VSO-1898945
     static_assert(!default_initializable<AggregatesExplicitDefault>);
 #endif // ^^^ no workaround ^^^
 } // namespace test_default_initializable

--- a/tests/std/tests/P2165R4_tuple_like_relational_operators/test.compile.pass.cpp
+++ b/tests/std/tests/P2165R4_tuple_like_relational_operators/test.compile.pass.cpp
@@ -76,13 +76,8 @@ constexpr bool test() {
         int a    = 0;
         int b    = 1;
         int c[2] = {2, 3};
-#ifdef __EDG__ // TRANSITION, VSO-2283373
-        assert((tuple{&c[0], &c[1]} == subrange{&c[0], &c[1]}));
-        assert((tuple{&c[1], &c[0]} != subrange{&c[0], &c[1]}));
-#else // ^^^ workaround / no workaround vvv
         static_assert(tuple{&c[0], &c[1]} == subrange{&c[0], &c[1]});
         static_assert(tuple{&c[1], &c[0]} != subrange{&c[0], &c[1]});
-#endif // ^^^ no workaround ^^^
         static_assert(is_eq(tuple{&a, &b} <=> pair{&a, &b}));
         static_assert(is_lt(tuple{&c[0], &c[0]} <=> pair{&c[0], &c[1]}));
         static_assert(is_gt(tuple{&c[1], &c[0]} <=> pair{&c[0], &c[1]}));


### PR DESCRIPTION
# :scroll: Changelog
- Code cleanups:
  * Removed compiler bug workarounds.
- Infrastructure improvements:
  * Updated dependencies.
    + Updated build compiler to VS 2022 17.14 Preview 3.
    + Updated Python to 3.13.3.

# :gear: Commits
* Python 3.13.3.
* New pool.
* VS 2022 17.14 Preview 3.
* Remove workarounds for:
  + VSO-2283373 "EDG: Failure to compare pointers to array elements in a constant expression".
  + DevCom-10107834 "EDG, `decltype` can't deduce type".
  + VSO-892705 "EDG reports `__is_convertible_to(int[], int*) == false`".
  + DevCom-1326684 "list-init of aggregate with explicitly-default-constructible member incorrectly accepted".
  + VSO-2417491 "C1XX `/permissive-` (strict mode) mishandles a variable template detecting static constexpr member functions".
  + DevCom-10701277 "`__builtin_memcmp()` yields erroneous results if evaluated at compile time".
    - See #5322.
* Change MSVC-internal skips to "likely bogus tests" failures, now that warning C5321 has shipped.
* Add a compiler version check to CMakeLists.txt.
  + This will detect the common problem of a new contributor using production VS instead of the latest Preview. Because the CMake build is GitHub-only, this check can always be kept up-to-date, unlike the `<yvals_core.h>` check which is both coarse-grained and often held back by the MSVC-internal toolset.

STL-ASan-CI [passed](https://dev.azure.com/vclibs/STL/_build/results?buildId=18515&view=results).