### PR TITLE
`<random>`: Improve performance of `poisson_distribution` constructor

### DIFF
--- a/stl/inc/random
+++ b/stl/inc/random
@@ -2779,10 +2779,12 @@ public:
             return _Mean;
         }
 
+        static constexpr double _Small_threshold = 12.0;
+
         void _Init(_Ty1 _Mean0) noexcept { // set internal state
             _STL_ASSERT(0.0 < _Mean0, "invalid mean argument for poisson_distribution");
             _Mean = _Mean0;
-            if (_Mean0 < 12.0) {
+            if (_Mean0 < _Small_threshold) {
                 _Small._Init(_Mean0);
                 return;
             }
@@ -2871,7 +2873,7 @@ public:
 private:
     template <class _Engine>
     result_type _Eval(_Engine& _Eng, const param_type& _Par0) const {
-        if (_Par0._Mean < 12.0) {
+        if (_Par0._Mean < param_type::_Small_threshold) {
             return _Par0._Small(_Eng);
         }
 

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -2782,10 +2782,13 @@ public:
         void _Init(_Ty1 _Mean0) noexcept { // set internal state
             _STL_ASSERT(0.0 < _Mean0, "invalid mean argument for poisson_distribution");
             _Mean = _Mean0;
+            if (_Mean0 < 12.0) {
+                _Small._Init(_Mean0);
+                return;
+            }
             _Sqrt = _CSTD sqrt(2.0 * _Mean0);
             _Logm = _CSTD log(_Mean0);
             _Gx1  = _Mean0 * _Logm - _XLgamma(_Mean0 + 1.0);
-            _Small._Init(_Mean0);
         }
 
         _Ty1 _Mean;

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -2740,7 +2740,7 @@ public:
     }
 
 private:
-    _Ty1 _Gx0;
+    _Ty1 _Gx0 = 0.0;
 };
 
 _EXPORT_STD template <class _Ty = int>
@@ -2793,10 +2793,10 @@ public:
             _Gx1  = _Mean0 * _Logm - _XLgamma(_Mean0 + 1.0);
         }
 
-        _Ty1 _Mean;
-        _Ty1 _Sqrt;
-        _Ty1 _Logm;
-        _Ty1 _Gx1;
+        _Ty1 _Mean = 0.0;
+        _Ty1 _Sqrt = 0.0;
+        _Ty1 _Logm = 0.0;
+        _Ty1 _Gx1  = 0.0;
 
         _Small_poisson_distribution<_Ty> _Small;
     };


### PR DESCRIPTION
This patch simplifies the construction of `std::poisson_distribution` by avoiding the computation of members that are not used when the mean is small, and vice versa.

This leaves the unused fields uninitialized, though it is unclear to me if this is acceptable or not.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
