### PR TITLE
`<any>`: self-assignment check

### DIFF
--- a/stl/inc/any
+++ b/stl/inc/any
@@ -304,7 +304,9 @@ private:
 
     void _Assign(any _That) noexcept { // intentionally pass by value
         reset();
-        _Move_from(_That);
+        if (this != &_That) {
+            _Move_from(_That);
+        }
     }
 
     template <class _Decayed, class... _Types>


### PR DESCRIPTION
Towards #1485.

On self-assignment, including self-move-assignment, `any` resets to empty, then calls `_Move_from` on itself, which treats empty `any` as `_Any_representation::_Trivial` and does self-`memcpy`.

Self-`memcpy` _does seem unacceptably squirrely_.

There are number of ways to fix this issue. We can do `this` check directly in `operator=`s, to avoid any other potential impact. Or we can do the check for empty `any` directly in `_Move_from`, to optimize other empty `any` assignment in addition.

I've arbitrarily chosen to do this in `_Assign`, to keep ruining the `any` that is being self-assigned, do it in just one place, and not do any changes beyond the needed.