### PR TITLE
Fix [flat.map.access] bugs found by libcxx tests

### DIFF
--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -1119,20 +1119,21 @@ public:
     }
 
     // [flat.map.access] Access
-    _NODISCARD mapped_type& operator[](const key_type& _Key_val)
+    mapped_type& operator[](const key_type& _Key_val)
         requires is_default_constructible_v<mapped_type>
     {
         return this->try_emplace(_Key_val).first->second;
     }
-    _NODISCARD mapped_type& operator[](key_type&& _Key_val)
+    mapped_type& operator[](key_type&& _Key_val)
         requires is_default_constructible_v<mapped_type>
     {
         return this->try_emplace(_STD move(_Key_val)).first->second;
     }
 
     template <class _OtherKey>
-    _NODISCARD mapped_type& operator[](_OtherKey&& _Key_val)
-        requires _Is_transparent_v<key_compare>
+    mapped_type& operator[](_OtherKey&& _Key_val)
+        requires _Is_transparent_v<key_compare> && is_constructible_v<key_type, _OtherKey>
+              && is_default_constructible_v<mapped_type>
     {
         return this->try_emplace(_STD forward<_OtherKey>(_Key_val)).first->second;
     }

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -232,9 +232,6 @@ std/strings/c.strings/cuchar.compile.pass.cpp FAIL
 
 # P0429R9 <flat_map>
 
-# FIXME! static_assert(!CanIndex<TransparentMap, NonConvertibleTransparent<int>>);
-std/containers/container.adaptors/flat.map/flat.map.access/index_transparent.pass.cpp FAIL
-
 # FIXME! static_assert(!CanEmplace<Map, Emplaceable>);
 std/containers/container.adaptors/flat.multimap/flat.multimap.modifiers/emplace.pass.cpp FAIL
 


### PR DESCRIPTION
* Add missing constraints:
  * `is_constructible_v<key_type, K>` is `true`
  * `is_constructible_v<mapped_type, Args...>` is `true`
* Ignore ignoring return value of `operator[]`