### PR TITLE
Fix [flat.map.modifiers] bugs found by libcxx tests

### DIFF
--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -940,17 +940,8 @@ private:
         // Insert the new elements at the end
         for (; _First != _Last; ++_First) {
             value_type _Val = *_First;
-            if constexpr (requires { _Data.keys.push_back(_STD move(_Val.first)); }) {
-                _Data.keys.push_back(_STD move(_Val.first));
-            } else {
-                _Data.keys.insert(_Data.keys.end(), _STD move(_Val.first));
-            }
-
-            if constexpr (requires { _Data.values.push_back(_STD move(_Val.second)); }) {
-                _Data.values.push_back(_STD move(_Val.second));
-            } else {
-                _Data.values.insert(_Data.values.end(), _STD move(_Val.second));
-            }
+            _Data.keys.insert(_Data.keys.end(), _STD move(_Val.first));
+            _Data.values.insert(_Data.values.end(), _STD move(_Val.second));
         }
 
         // Sort the newly inserted elements
@@ -1451,7 +1442,9 @@ public:
 
     // [flat.multimap.modifiers] Modifiers
     template <class... _ArgTypes>
-    iterator emplace(_ArgTypes&&... _Args) {
+    iterator emplace(_ArgTypes&&... _Args)
+        requires is_constructible_v<value_type, _ArgTypes...>
+    {
         value_type _Val(_STD forward<_ArgTypes>(_Args)...);
         return _Emplace_key_mapped(_STD move(_Val.first), _STD move(_Val.second));
     }

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -232,9 +232,6 @@ std/strings/c.strings/cuchar.compile.pass.cpp FAIL
 
 # P0429R9 <flat_map>
 
-# FIXME! static_assert(!CanEmplace<Map, Emplaceable>);
-std/containers/container.adaptors/flat.multimap/flat.multimap.modifiers/emplace.pass.cpp FAIL
-
 # FIXME! error: no type named 'value_type' in 'std::greater<int>'
 std/containers/container.adaptors/flat.map/flat.map.cons/deduct.pass.cpp FAIL
 std/containers/container.adaptors/flat.multimap/flat.multimap.cons/deduct.pass.cpp FAIL
@@ -252,18 +249,6 @@ std/containers/container.adaptors/flat.multimap/flat.multimap.cons/move_exceptio
 # FIXME! abort() has been called
 std/containers/container.adaptors/flat.map/flat.map.cons/move.pass.cpp FAIL
 std/containers/container.adaptors/flat.multimap/flat.multimap.cons/move.pass.cpp FAIL
-
-# FIXME! Assertion failed: false
-std/containers/container.adaptors/flat.map/flat.map.modifiers/insert_initializer_list.pass.cpp FAIL
-std/containers/container.adaptors/flat.map/flat.map.modifiers/insert_iter_iter.pass.cpp FAIL
-std/containers/container.adaptors/flat.map/flat.map.modifiers/insert_range.pass.cpp FAIL
-std/containers/container.adaptors/flat.map/flat.map.modifiers/insert_sorted_initializer_list.pass.cpp FAIL
-std/containers/container.adaptors/flat.map/flat.map.modifiers/insert_sorted_iter_iter.pass.cpp FAIL
-std/containers/container.adaptors/flat.multimap/flat.multimap.modifiers/insert_initializer_list.pass.cpp FAIL
-std/containers/container.adaptors/flat.multimap/flat.multimap.modifiers/insert_iter_iter.pass.cpp FAIL
-std/containers/container.adaptors/flat.multimap/flat.multimap.modifiers/insert_range.pass.cpp FAIL
-std/containers/container.adaptors/flat.multimap/flat.multimap.modifiers/insert_sorted_initializer_list.pass.cpp FAIL
-std/containers/container.adaptors/flat.multimap/flat.multimap.modifiers/insert_sorted_iter_iter.pass.cpp FAIL
 
 # FIXME! warning C4242: 'initializing': conversion from '_Ty' to '_Ty2', possible loss of data
 std/containers/container.adaptors/flat.map/flat.map.cons/copy_assign.pass.cpp:0 FAIL


### PR DESCRIPTION
* Add missing constraints:
  * `is_constructible_v<pair<key_type, mapped_type>, Args...>` is `true`
* Always call `insert` in `insert`