### PR TITLE
`<flat_map>`: Restore use of `push_back` in `flat_(multi)map::insert`

### DIFF
--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1847,6 +1847,11 @@ namespace pmr {
     using deque = _STD deque<_Ty, polymorphic_allocator<_Ty>>;
 } // namespace pmr
 #endif // _HAS_CXX17
+
+#if _HAS_CXX23
+template <class _Ty, class _Alloc>
+constexpr bool _Has_guaranteed_push_back<deque<_Ty, _Alloc>> = true;
+#endif // _HAS_CXX23
 _STD_END
 
 #pragma pop_macro("new")

--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -940,8 +940,17 @@ private:
         // Insert the new elements at the end
         for (; _First != _Last; ++_First) {
             value_type _Val = *_First;
-            _Data.keys.insert(_Data.keys.end(), _STD move(_Val.first));
-            _Data.values.insert(_Data.values.end(), _STD move(_Val.second));
+            if constexpr (_Has_guaranteed_push_back<_KeyContainer>) {
+                _Data.keys.push_back(_STD move(_Val.first));
+            } else {
+                _Data.keys.insert(_Data.keys.end(), _STD move(_Val.first));
+            }
+
+            if constexpr (_Has_guaranteed_push_back<_MappedContainer>) {
+                _Data.values.push_back(_STD move(_Val.second));
+            } else {
+                _Data.values.insert(_Data.values.end(), _STD move(_Val.second));
+            }
         }
 
         // Sort the newly inserted elements

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -3998,6 +3998,9 @@ constexpr bool _Is_vector_bool = false;
 template <class _Alloc>
 constexpr bool _Is_vector_bool<vector<bool, _Alloc>> = true;
 
+template <class _Ty, class _Alloc>
+constexpr bool _Has_guaranteed_push_back<vector<_Ty, _Alloc>> = !is_same_v<_Ty, bool>;
+
 template <class _Alloc, class... _Containers>
 concept _Usable_allocator_for = (uses_allocator_v<_Containers, _Alloc> && ...);
 

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2752,6 +2752,9 @@ namespace ranges {
     elements_of(_Rng&&, _Alloc) -> elements_of<_Rng&&, _Alloc>;
 #endif // ^^^ !defined(__cpp_lib_byte) ^^^
 } // namespace ranges
+
+template <class>
+constexpr bool _Has_guaranteed_push_back = false; // N5008 [sequence.reqmts]/104, /108; used by flat_(multi)map::insert.
 #endif // _HAS_CXX23
 
 template <class _Elem, class _UTy>

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -3500,6 +3500,11 @@ namespace pmr {
     _EXPORT_STD using wstring   = basic_string<wchar_t>;
 } // namespace pmr
 #endif // _HAS_CXX17
+
+#if _HAS_CXX23
+template <class _Elem, class _Traits, class _Alloc>
+constexpr bool _Has_guaranteed_push_back<basic_string<_Elem, _Traits, _Alloc>> = true;
+#endif // _HAS_CXX23
 _STD_END
 
 #undef _ASAN_STRING_REMOVE


### PR DESCRIPTION
libc++ tests seem to use some hostile sequence containers whose `push_back` have non-standard semantics for `flat_meow`. Per [[sequence.reqmts]/104](https://eel.is/c++draft/sequence.reqmts#104) and [/108](https://eel.is/c++draft/sequence.reqmts#108), this is unfortunately permitted, because `push_back` with the standard semantics is only required for `basic_string`, `deque`, `inplace_vector`, `list`, and `vector`.

AFAIK, most uses of flat container adaptors will use `vector` as the underlying containers. Also, every standard container adoptable for `flat_meow` has `push_back` with guaranteed semantics. So I think it's worthy enable `push_back` for the most usual uses.

Notes:
- Partial specialization of `_Has_guaranteed_push_back` for `list` is deliberately missing because `list` isn't adoptable for `flat_meow`.
- `inplace_vector` is not implemented yet so the partial specialization for it is missing.