### PR TITLE
Win8 baseline: Improve STL Hardening codegen size

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1160,16 +1160,20 @@ namespace ranges {
 
             constexpr _Iterator& operator+=(difference_type _Off) noexcept /* strengthened */ {
 #if _ITERATOR_DEBUG_LEVEL != 0
-                if constexpr (sizeof(difference_type) > sizeof(_Index_type)) {
-                    _STL_VERIFY(static_cast<_Index_type>(_Off) == _Off,
-                        _Off > 0 ? "cannot advance repeat_view iterator past end (integer overflow)"
-                                 : "cannot advance repeat_view iterator before begin (integer overflow)");
-                }
-
                 if (_Off > 0) {
+                    if constexpr (sizeof(difference_type) > sizeof(_Index_type)) {
+                        _STL_VERIFY(static_cast<_Index_type>(_Off) == _Off,
+                            "cannot advance repeat_view iterator past end (integer overflow)");
+                    }
+
                     _STL_VERIFY(_Current <= (numeric_limits<_Index_type>::max)() - static_cast<_Index_type>(_Off),
                         "cannot advance repeat_view iterator past end (integer overflow)");
                 } else {
+                    if constexpr (sizeof(difference_type) > sizeof(_Index_type)) {
+                        _STL_VERIFY(static_cast<_Index_type>(_Off) == _Off,
+                            "cannot advance repeat_view iterator before begin (integer overflow)");
+                    }
+
                     _STL_VERIFY(_Current >= (numeric_limits<_Index_type>::min)() - static_cast<_Index_type>(_Off),
                         "cannot advance repeat_view iterator before begin (integer overflow)");
                 }
@@ -1183,16 +1187,20 @@ namespace ranges {
             }
             constexpr _Iterator& operator-=(difference_type _Off) noexcept /* strengthened */ {
 #if _ITERATOR_DEBUG_LEVEL != 0
-                if constexpr (sizeof(difference_type) > sizeof(_Index_type)) {
-                    _STL_VERIFY(static_cast<_Index_type>(_Off) == _Off,
-                        _Off < 0 ? "cannot advance repeat_view iterator past end (integer overflow)"
-                                 : "cannot advance repeat_view iterator before begin (integer overflow)");
-                }
-
                 if (_Off < 0) {
+                    if constexpr (sizeof(difference_type) > sizeof(_Index_type)) {
+                        _STL_VERIFY(static_cast<_Index_type>(_Off) == _Off,
+                            "cannot advance repeat_view iterator past end (integer overflow)");
+                    }
+
                     _STL_VERIFY(_Current <= (numeric_limits<_Index_type>::max)() + static_cast<_Index_type>(_Off),
                         "cannot advance repeat_view iterator past end (integer overflow)");
                 } else {
+                    if constexpr (sizeof(difference_type) > sizeof(_Index_type)) {
+                        _STL_VERIFY(static_cast<_Index_type>(_Off) == _Off,
+                            "cannot advance repeat_view iterator before begin (integer overflow)");
+                    }
+
                     _STL_VERIFY(_Current >= (numeric_limits<_Index_type>::min)() + static_cast<_Index_type>(_Off),
                         "cannot advance repeat_view iterator before begin (integer overflow)");
                 }

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -242,12 +242,16 @@ _EMIT_STL_ERROR(STL1008, "_STL_CALL_ABORT_INSTEAD_OF_INVALID_PARAMETER has been 
 //     a non-void function, etc.), but it will not attempt to replace undefined behavior with implementation-defined
 //     behavior. (For example, we will not transform `pop_back()` of an empty `vector` to be a no-op.)
 #ifndef _MSVC_STL_DOOM_FUNCTION
-#ifdef _MSVC_STL_USE_ABORT_AS_DOOM_FUNCTION
+#ifdef _MSVC_STL_USE_ABORT_AS_DOOM_FUNCTION // The user wants to use abort():
 #define _MSVC_STL_DOOM_FUNCTION(mesg) _CSTD abort()
-#else // ^^^ defined(_MSVC_STL_USE_ABORT_AS_DOOM_FUNCTION) / !defined(_MSVC_STL_USE_ABORT_AS_DOOM_FUNCTION) vvv
-// TRANSITION, GH-4858: after dropping Win7 support, we can directly call __fastfail(FAST_FAIL_INVALID_ARG).
+#elif defined(__clang__) // Use the Clang intrinsic:
+#define _MSVC_STL_DOOM_FUNCTION(mesg) __builtin_verbose_trap("MSVC STL error", mesg)
+#elif defined(_M_CEE_PURE) // Use the classic function because /clr:pure lacks the MSVC __fastfail intrinsic:
 #define _MSVC_STL_DOOM_FUNCTION(mesg) ::_invoke_watson(nullptr, nullptr, nullptr, 0, 0)
-#endif // ^^^ !defined(_MSVC_STL_USE_ABORT_AS_DOOM_FUNCTION) ^^^
+#else // Use the MSVC __fastfail intrinsic:
+extern "C" __declspec(noreturn) void __fastfail(unsigned int); // declared by <intrin.h>
+#define _MSVC_STL_DOOM_FUNCTION(mesg) __fastfail(5) // __fastfail(FAST_FAIL_INVALID_ARG), value defined by <winnt.h>
+#endif // choose "doom function"
 #endif // ^^^ !defined(_MSVC_STL_DOOM_FUNCTION) ^^^
 
 #define _STL_REPORT_ERROR(mesg) \
@@ -494,7 +498,7 @@ private:
     }              \
     }
 
-#define _RAISE(x) ::_invoke_watson(nullptr, nullptr, nullptr, 0, 0)
+#define _RAISE(x) _MSVC_STL_DOOM_FUNCTION("_RAISE was called with !_HAS_EXCEPTIONS")
 
 #define _RERAISE
 #define _THROW(...) (__VA_ARGS__)._Raise()

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -246,7 +246,7 @@ _EMIT_STL_ERROR(STL1008, "_STL_CALL_ABORT_INSTEAD_OF_INVALID_PARAMETER has been 
 #define _MSVC_STL_DOOM_FUNCTION(mesg) _CSTD abort()
 #elif defined(__clang__) // Use the Clang intrinsic:
 #define _MSVC_STL_DOOM_FUNCTION(mesg) __builtin_verbose_trap("MSVC STL error", mesg)
-#elif defined(_M_CEE_PURE) // Use the classic function because /clr:pure lacks the MSVC __fastfail intrinsic:
+#elif defined(_M_CEE) // TRANSITION, VSO-2457624 (/clr silent bad codegen for __fastfail); /clr:pure lacks __fastfail
 #define _MSVC_STL_DOOM_FUNCTION(mesg) ::_invoke_watson(nullptr, nullptr, nullptr, 0, 0)
 #else // Use the MSVC __fastfail intrinsic:
 extern "C" __declspec(noreturn) void __fastfail(unsigned int); // declared by <intrin.h>


### PR DESCRIPTION
# :world_map: Overview
* Will be merged after #5432.
* Followup to #5274.
* For MSVC, this uses [`__fastfail`](https://learn.microsoft.com/en-us/cpp/intrinsics/fastfail?view=msvc-170):
  + "Support for the native fast fail mechanism began in Windows 8."
  + I am manually declaring the intrinsic because it's currently declared by the large `<intrin.h>`. We generally try to avoid duplicating intrinsic declarations (due to calling convention madness) but in this one case I think it's fine. Because `<yvals.h>` is very central and special, moving the declaration into `<intrin0.h>` might still be overly impactful.
  + I also need to hardcode `FAST_FAIL_INVALID_ARG` because there's no way we can drag in `<winnt.h>`.
* For Clang, this uses [`__builtin_verbose_trap`](https://clang.llvm.org/docs/LanguageExtensions.html#builtin-verbose-trap):
  + This is the same mechanism used by [libc++ Hardening](https://libcxx.llvm.org/Hardening.html#hardening-assertion-failure).
  + It's cool in that it emits a single instruction, but when debugging info is enabled, it records the reason without bloating the codegen itself. Conveniently, we're already passing messages down to this layer.
* With STL Hardening enabled, I measured `v[idx]` on x64 with `/O2`:
  + This reduced codegen size from 56 bytes to 29 bytes by avoiding the `_invoke_watson()` function call.
  + Clang codegen was similarly improved.
* In `<ranges>`, we need to avoid a Clang error: "argument to `__builtin_verbose_trap` must be a pointer to a constant string".
* We need to work around VSO-2457624 "`/clr /std:c++20` silent bad codegen with the `__fastfail` intrinsic".

# :scroll: Changelog
- The STL no longer supports targeting Windows 7 and Server 2008 R2:
  * Improved the performance of STL Hardening by using the MSVC [`__fastfail`](https://learn.microsoft.com/en-us/cpp/intrinsics/fastfail?view=msvc-170) intrinsic that was added in Windows 8, and the Clang [`__builtin_verbose_trap`](https://clang.llvm.org/docs/LanguageExtensions.html#builtin-verbose-trap) intrinsic.