### PR TITLE
Win8 baseline: Simplify `<filesystem>` API calls

### DIFF
--- a/stl/src/filesys.cpp
+++ b/stl/src/filesys.cpp
@@ -48,17 +48,12 @@ static wchar_t* _Strcpy(wchar_t (&_Dest)[_MAX_FILESYS_NAME], const wchar_t* _Src
 }
 
 static HANDLE _FilesysOpenFile(const wchar_t* _Fname, DWORD _Desired_access, DWORD _Flags) {
-#ifdef _CRT_APP
     CREATEFILE2_EXTENDED_PARAMETERS _Create_file_parameters = {};
     _Create_file_parameters.dwSize                          = sizeof(_Create_file_parameters);
     _Create_file_parameters.dwFileFlags                     = _Flags;
 
     return CreateFile2(_Fname, _Desired_access, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, OPEN_EXISTING,
         &_Create_file_parameters);
-#else // ^^^ defined(_CRT_APP) / !defined(_CRT_APP) vvv
-    return CreateFileW(_Fname, _Desired_access, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr,
-        OPEN_EXISTING, _Flags, nullptr);
-#endif // ^^^ !defined(_CRT_APP) ^^^
 }
 
 _FS_DLL wchar_t* __CLRCALL_PURE_OR_CDECL _Read_dir(

--- a/stl/src/filesys.cpp
+++ b/stl/src/filesys.cpp
@@ -433,7 +433,6 @@ _FS_DLL int __CLRCALL_PURE_OR_CDECL _Unlink(const wchar_t* _Fname) noexcept { //
 
 _FS_DLL int __CLRCALL_PURE_OR_CDECL _Copy_file(const wchar_t* _Fname1, const wchar_t* _Fname2) noexcept {
     // copy _Fname1 to _Fname2
-#if defined(_ONECORE)
     COPYFILE2_EXTENDED_PARAMETERS _Params = {0};
     _Params.dwSize                        = sizeof(COPYFILE2_EXTENDED_PARAMETERS);
     _Params.dwCopyFlags                   = 0;
@@ -445,9 +444,6 @@ _FS_DLL int __CLRCALL_PURE_OR_CDECL _Copy_file(const wchar_t* _Fname1, const wch
 
     // take lower bits to undo HRESULT_FROM_WIN32
     return _Copy_result & 0x0000FFFFU;
-#else // ^^^ defined(_ONECORE) / !defined(_ONECORE) vvv
-    return CopyFileW(_Fname1, _Fname2, 0) ? 0 : GetLastError();
-#endif // ^^^ !defined(_ONECORE) ^^^
 }
 
 _FS_DLL int __CLRCALL_PURE_OR_CDECL _Chmod(const wchar_t* _Fname, perms _Newmode) noexcept {

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -115,31 +115,7 @@ namespace {
             return __std_win_error::_Success;
         }
 
-        __std_win_error _Last_error{GetLastError()};
-
-#ifndef _CRT_APP
-        switch (_Last_error) {
-        case __std_win_error::_Not_supported:
-        case __std_win_error::_Invalid_parameter:
-            break; // try more things
-        default:
-            return _Last_error; // real error, bail to the caller
-        }
-
-        // try GetFileInformationByHandle as a fallback
-        BY_HANDLE_FILE_INFORMATION _Info;
-        if (GetFileInformationByHandle(_Handle, &_Info)) {
-            _Id->VolumeSerialNumber = _Info.dwVolumeSerialNumber;
-            _CSTD memcpy(&_Id->FileId.Identifier[0], &_Info.nFileIndexHigh, 4);
-            _CSTD memcpy(&_Id->FileId.Identifier[4], &_Info.nFileIndexLow, 4);
-            _CSTD memset(&_Id->FileId.Identifier[8], 0, 8);
-            return __std_win_error::_Success;
-        }
-
-        _Last_error = __std_win_error{GetLastError()};
-#endif // !defined(_CRT_APP)
-
-        return _Last_error;
+        return __std_win_error{GetLastError()};
     }
 
     [[nodiscard]] _Success_(return == __std_win_error::_Success) __std_win_error

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -60,7 +60,6 @@ namespace {
 
     [[nodiscard]] __std_fs_copy_file_result __stdcall __vcp_Copyfile(
         const wchar_t* const _Source, const wchar_t* const _Target, const bool _Fail_if_exists) noexcept {
-#if defined(_CRT_APP)
         COPYFILE2_EXTENDED_PARAMETERS _Params{};
         _Params.dwSize      = sizeof(_Params);
         _Params.dwCopyFlags = _Fail_if_exists ? COPY_FILE_FAIL_IF_EXISTS : 0;
@@ -72,13 +71,6 @@ namespace {
 
         // take lower bits to undo HRESULT_FROM_WIN32
         return {false, __std_win_error{_Copy_result & 0x0000FFFFU}};
-#else // ^^^ defined(_CRT_APP) / !defined(_CRT_APP) vvv
-        if (CopyFileW(_Source, _Target, _Fail_if_exists)) {
-            return {true, __std_win_error::_Success};
-        }
-
-        return {false, __std_win_error{GetLastError()}};
-#endif // defined(_CRT_APP)
     }
 
     [[nodiscard]] __std_win_error __stdcall _Create_symlink(
@@ -401,7 +393,7 @@ void __stdcall __std_fs_directory_iterator_close(_In_ const __std_fs_dir_handle 
             }
 
             if (!_Do_copy) {
-                // We only need to test `equivalent()` if we _aren't_ going to `CopyFileW()`,
+                // We only need to test `equivalent()` if we _aren't_ going to `CopyFile2()`,
                 // since that call will fail with an `ERROR_SHARING_VIOLATION` anyways.
                 FILE_ID_INFO _Source_id;
                 _Last_error = _Get_file_id_by_handle(_Source_handle._Get(), &_Source_id);

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -33,7 +33,6 @@ namespace {
 #define __vcrt_CreateSymbolicLinkW CreateSymbolicLinkW
 #endif // ^^^ !defined(_CRT_APP) ^^^
 
-#ifdef _CRT_APP
     HANDLE __stdcall __vcp_CreateFile(const wchar_t* const _File_name, const unsigned long _Desired_access,
         const unsigned long _Share, SECURITY_ATTRIBUTES* const _Security_attributes,
         const unsigned long _Creation_disposition, const unsigned long _Flags_and_attributes,
@@ -46,9 +45,6 @@ namespace {
         _Create_file_parameters.hTemplateFile        = _Template_file;
         return CreateFile2(_File_name, _Desired_access, _Share, _Creation_disposition, &_Create_file_parameters);
     }
-#else // ^^^ defined(_CRT_APP) / !defined(_CRT_APP) vvv
-#define __vcp_CreateFile CreateFileW
-#endif // ^^^ !defined(_CRT_APP) ^^^
 
     [[nodiscard]] __std_win_error __stdcall _Translate_CreateFile_last_error(const HANDLE _Handle) {
         if (_Handle != INVALID_HANDLE_VALUE) {


### PR DESCRIPTION
# :world_map: Overview
* Will be merged after #5432.
* These changes are somewhat daring, hence the isolated PR. Our `<filesystem>` implementation (and older `<experimental/filesystem>`) contains several codepaths of the form "if we're a UWP app, call a modern API, otherwise call a legacy API". This is not only twice as much code to maintain, but we don't have automated test coverage for UWP apps, which greatly increases risk. Now that our baseline OS is Win8, we can send everything through the modern APIs.
* The change I'm the least certain about is in Standard `filesystem.cpp`, where `_Get_file_id_by_handle()` has the unusual pattern of calling modern `GetFileInformationByHandleEx()` and then falling back to legacy `GetFileInformationByHandle()`. See the commit notes below for why I suspect this is unnecessary. This code was moved around by #2718 but the original logic dates back to the initial GitHub commit.
* By front-loading this change at the beginning of the Dev18 Preview 1 cycle, we'll have the most time available to gather and react to feedback (including from our Real World Code test suite). If issues are encountered, we can selectively or entirely revert these changes, and we can add comments explaining why the codepaths are necessary.

# :gear: Commits
* Filesystem: Unconditionally call `CopyFile2` instead of `CopyFileW`.
  + [`CopyFile2`][] is "Windows 8 \[desktop apps | UWP apps\]".
  + [`CopyFileW`][] is "Windows XP \[desktop apps | UWP apps\]".
  + We were inconsistently guarding this with `defined(_ONECORE)` versus `defined(_CRT_APP)`.
* Filesystem: Unconditionally call `CreateFile2` instead of `CreateFileW`.
  + [`CreateFile2`][] is "Windows 8 \[desktop apps | UWP apps\]".
  + [`CreateFileW`][] is "Windows XP \[desktop apps only\]".
* Filesystem: Unconditionally call `GetFileInformationByHandleEx` instead of `GetFileInformationByHandle`.
  + [`GetFileInformationByHandleEx`][] is "Windows Vista \[desktop apps | UWP apps\]".
  + [`GetFileInformationByHandle`][] is "Windows XP \[desktop apps only\]".
  + The documentation around `FileIdInfo`/[`FILE_ID_INFO`][] is confusing. It claims "Minimum supported client: None supported" and "Minimum supported server: Windows Server 2012 \[desktop apps only\]", but in modern `filesystem.cpp` it is our only codepath when `defined(_CRT_APP)`. That suggests that it works on Client and works for UWP apps, so I think it might actually be "Windows 8 \[desktop apps | UWP apps\]". This PR certainly appears to work on my client Windows 11 machine.

[`CopyFile2`]: https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-copyfile2
[`CopyFileW`]: https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-copyfilew
[`CreateFile2`]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfile2
[`CreateFileW`]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
[`GetFileInformationByHandleEx`]: https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getfileinformationbyhandleex
[`GetFileInformationByHandle`]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileinformationbyhandle
[`FILE_ID_INFO`]: https://learn.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-file_id_info

# :scroll: Changelog
- The STL no longer supports targeting Windows 7 and Server 2008 R2:
  * Simplified the `<filesystem>` implementation by unconditionally calling APIs that were added in Windows 8.
