### PR TITLE
`<random>`: Use `_Unsigned128` for `linear_congruential_engine`

### DIFF
--- a/stl/inc/random
+++ b/stl/inc/random
@@ -500,7 +500,7 @@ _NODISCARD _Uint _Next_linear_congruential_value(_Uint _Prev) noexcept {
         const auto _Mul =
             static_cast<unsigned int>(_Prev) * static_cast<unsigned int>(_Ax) + static_cast<unsigned int>(_Cx);
         return static_cast<_Uint>(_Mul % _Mx);
-    } else if constexpr (_Cx <= ULLONG_MAX && static_cast<_Uint>(_Mx - 1) <= (ULLONG_MAX - _Cx) / _Ax) {
+    } else if constexpr (static_cast<_Uint>(_Mx - 1) <= (ULLONG_MAX - _Cx) / _Ax) {
         // unsigned long long is sufficient to store intermediate calculation
         const auto _Mul = static_cast<unsigned long long>(_Prev) * _Ax + _Cx;
         return static_cast<_Uint>(_Mul % _Mx);

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -461,14 +461,6 @@ _NODISCARD _Real _Nrand_impl(_Gen& _Gx) { // build a floating-point value from r
     }
 }
 
-_INLINE_VAR constexpr int _MP_len = 5;
-using _MP_arr                     = uint64_t[_MP_len];
-
-extern "C++" _NODISCARD _CRTIMP2_PURE uint64_t __CLRCALL_PURE_OR_CDECL _MP_Get(_MP_arr) noexcept;
-extern "C++" _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _MP_Add(_MP_arr, uint64_t) noexcept;
-extern "C++" _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _MP_Mul(_MP_arr, uint64_t, uint64_t) noexcept;
-extern "C++" _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _MP_Rem(_MP_arr, uint64_t) noexcept;
-
 template <class _Uint, _Uint _Ax, _Uint _Cx, _Uint _Mx>
 _NODISCARD _Uint _Next_linear_congruential_value(_Uint _Prev) noexcept {
     // Choose intermediate type:
@@ -505,11 +497,8 @@ _NODISCARD _Uint _Next_linear_congruential_value(_Uint _Prev) noexcept {
         const auto _Mul = static_cast<unsigned long long>(_Prev) * _Ax + _Cx;
         return static_cast<_Uint>(_Mul % _Mx);
     } else { // no intermediate integral type fits; fall back to multiprecision
-        _MP_arr _Wx;
-        _MP_Mul(_Wx, _Prev, _Ax);
-        _MP_Add(_Wx, _Cx);
-        _MP_Rem(_Wx, _Mx);
-        return static_cast<_Uint>(_MP_Get(_Wx));
+        const auto _Mul = _Unsigned128{_Prev} * _Ax + _Cx;
+        return static_cast<_Uint>(_Mul % _Mx);
     }
 }
 

--- a/stl/src/multprec.cpp
+++ b/stl/src/multprec.cpp
@@ -3,14 +3,13 @@
 
 // implements multiprecision math for random number generators
 
-#include <limits>
-#include <random>
+#include <yvals.h>
 
 _STD_BEGIN
 constexpr int _MP_len = 5;
-using _MP_arr         = uint64_t[_MP_len];
+using _MP_arr         = unsigned long long[_MP_len];
 
-constexpr int shift                 = _STD numeric_limits<unsigned long long>::digits / 2;
+constexpr int shift                 = 64 / 2;
 constexpr unsigned long long mask   = ~(~0ULL << shift);
 constexpr unsigned long long maxVal = mask + 1;
 

--- a/stl/src/multprec.cpp
+++ b/stl/src/multprec.cpp
@@ -7,11 +7,15 @@
 #include <random>
 
 _STD_BEGIN
+constexpr int _MP_len = 5;
+using _MP_arr         = uint64_t[_MP_len];
+
 constexpr int shift                 = _STD numeric_limits<unsigned long long>::digits / 2;
 constexpr unsigned long long mask   = ~(~0ULL << shift);
 constexpr unsigned long long maxVal = mask + 1;
 
-[[nodiscard]] unsigned long long __CLRCALL_PURE_OR_CDECL _MP_Get(
+// TRANSITION, ABI: preserved for binary compatibility
+[[nodiscard]] _CRTIMP2_PURE unsigned long long __CLRCALL_PURE_OR_CDECL _MP_Get(
     _MP_arr u) noexcept { // convert multi-word value to scalar value
     return (u[1] << shift) + u[0];
 }
@@ -32,7 +36,8 @@ static void add(unsigned long long* u, int ulen, unsigned long long* v,
     }
 }
 
-void __CLRCALL_PURE_OR_CDECL _MP_Add(
+// TRANSITION, ABI: preserved for binary compatibility
+_CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _MP_Add(
     _MP_arr u, unsigned long long v0) noexcept { // add scalar value to multi-word value
     unsigned long long v[2];
     v[0] = v0 & mask;
@@ -50,7 +55,8 @@ static void mul(
     }
 }
 
-void __CLRCALL_PURE_OR_CDECL _MP_Mul(
+// TRANSITION, ABI: preserved for binary compatibility
+_CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _MP_Mul(
     _MP_arr w, unsigned long long u0, unsigned long long v0) noexcept { // multiply multi-word value by multi-word value
     constexpr int m = 2;
     constexpr int n = 2;
@@ -106,7 +112,8 @@ static void div(_MP_arr u,
     return ulen;
 }
 
-void __CLRCALL_PURE_OR_CDECL _MP_Rem(
+// TRANSITION, ABI: preserved for binary compatibility
+_CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _MP_Rem(
     _MP_arr u, unsigned long long v0) noexcept { // divide multi-word value by value, leaving remainder in u
     unsigned long long v[2];
     v[0]        = v0 & mask;


### PR DESCRIPTION
I noticed that we had a single remaining usage of separately compiled multiprecision arithmetic machinery. I believe that we can replace this with the modern `_Unsigned128` type, which is far better tested and more widely exercised. As @AlexGuteniev observed, `_Unsigned128` uses intrinsics, so it should also be faster than multprec.cpp. And as a final bonus, it makes this codepath strongly resemble the 32-bit and 64-bit codepaths above.

# :man_scientist: Proof that 128 bits are sufficient
The function comment says: https://github.com/microsoft/STL/blob/b5df16a98934319e2e6864d6036cbe9cd9c74faf/stl/inc/random#L474-L482

The first part, _Cx <= (2^128 - 1), is obviously true.

The next part is (_Mx - 1) <= ((2^128 - 1) - _Cx) / _Ax. This is the hardest to achieve for the largest LHS (caused by the largest _Mx) and the smallest RHS (caused by the largest _Ax and the largest _Cx). So ((2^64 - 1) - 1) <= ((2^128 - 1) - (2^64 - 1)) / (2^64 - 1) is the worst case.

```
C:\Temp>py
Python 3.13.3 (tags/v3.13.3:6280bb5, Apr  8 2025, 14:47:33) [MSC v.1943 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> ((2**64 - 1) - 1)
18446744073709551614
>>> ((2**128 - 1) - (2**64 - 1)) // (2**64 - 1)
18446744073709551616
>>> ((2**64 - 1) - 1) <= ((2**128 - 1) - (2**64 - 1)) // (2**64 - 1)
True
```

# :gear: Commits
* `_Uint _Cx` always satisfies `_Cx <= ULLONG_MAX`.
* Use `_Unsigned128`, preserve multprec.cpp for bincompat.
  + We can drop `_INLINE_VAR` from `_MP_len`, giving it internal linkage within multprec.cpp.
  + We don't need `extern "C++"` on the declarations - that was for modules.
  + We need to add `_CRTIMP2_PURE` to the definitions. I thought we had harmonized all declarations and definitions, but we missed these.
* Reduce multprec.cpp dependencies to slightly improve throughput.
  + We can hardcode `64` instead of including `<limits>` for `numeric_limits<unsigned long long>::digits`.
  + `uint64_t` and `unsigned long long` are synonyms. In fact, this file was already using `unsigned long long` for the definitions, even though the declarations originally said `uint64_t`.
  + We moved the declarations out of `<random>` so we don't need it anymore. All we need is `<yvals.h>`.

# :white_check_mark: Notes
* I verified (with `static_assert(false)`) that this codepath is exercised by our test suites.
* I verified (with `dumpbin /exports`) that this doesn't affect the dllexport surface.
