### PR TITLE
Benchmark: use `not_highly_aligned_allocator` in more places

### DIFF
--- a/benchmarks/src/adjacent_difference.cpp
+++ b/benchmarks/src/adjacent_difference.cpp
@@ -11,6 +11,8 @@
 #include <type_traits>
 #include <vector>
 
+#include "skewed_allocator.hpp"
+
 using namespace std;
 
 template <class T>
@@ -19,8 +21,8 @@ void bm(benchmark::State& state) {
 
     const size_t size = static_cast<size_t>(state.range(0));
 
-    vector<T> input(size);
-    vector<T> output(size);
+    vector<T, not_highly_aligned_allocator<T>> input(size);
+    vector<T, not_highly_aligned_allocator<T>> output(size);
 
     if constexpr (is_floating_point_v<T>) {
         normal_distribution<T> dis(0, 100000.0);

--- a/benchmarks/src/adjacent_find.cpp
+++ b/benchmarks/src/adjacent_find.cpp
@@ -8,6 +8,8 @@
 #include <cstdlib>
 #include <vector>
 
+#include "skewed_allocator.hpp"
+
 using namespace std;
 
 enum class AlgType { Std, Rng };
@@ -17,7 +19,7 @@ void bm(benchmark::State& state) {
     const size_t size = static_cast<size_t>(state.range(0));
     const size_t pos  = static_cast<size_t>(state.range(1));
 
-    vector<T> v(size);
+    vector<T, not_highly_aligned_allocator<T>> v(size);
 
     for (size_t i = 0; i != size; ++i) {
         v[i] = static_cast<T>(i & 3);

--- a/benchmarks/src/iota.cpp
+++ b/benchmarks/src/iota.cpp
@@ -7,6 +7,8 @@
 #include <numeric>
 #include <vector>
 
+#include "skewed_allocator.hpp"
+
 enum class Alg {
     Std,
     Rng,
@@ -16,7 +18,7 @@ template <class T, Alg Algorithm>
 void bm(benchmark::State& state) {
     const auto size = static_cast<std::size_t>(state.range(0));
 
-    std::vector<T> a(size);
+    std::vector<T, not_highly_aligned_allocator<T>> a(size);
 
     for (auto _ : state) {
         if constexpr (Algorithm == Alg::Std) {

--- a/benchmarks/src/minmax_element.cpp
+++ b/benchmarks/src/minmax_element.cpp
@@ -10,6 +10,8 @@
 #include <type_traits>
 #include <vector>
 
+#include "skewed_allocator.hpp"
+
 enum class Op {
     Min,
     Max,
@@ -23,7 +25,7 @@ using namespace std;
 
 template <class T, Op Operation>
 void bm(benchmark::State& state) {
-    vector<T> a(static_cast<size_t>(state.range()));
+    vector<T, not_highly_aligned_allocator<T>> a(static_cast<size_t>(state.range()));
 
     mt19937 gen(84710);
 

--- a/benchmarks/src/mismatch.cpp
+++ b/benchmarks/src/mismatch.cpp
@@ -8,6 +8,8 @@
 #include <ranges>
 #include <vector>
 
+#include "skewed_allocator.hpp"
+
 using namespace std;
 
 constexpr int64_t no_pos = -1;
@@ -19,8 +21,8 @@ enum class op {
 
 template <class T, op Op>
 void bm(benchmark::State& state) {
-    vector<T> a(static_cast<size_t>(state.range(0)), T{'.'});
-    vector<T> b(static_cast<size_t>(state.range(0)), T{'.'});
+    vector<T, not_highly_aligned_allocator<T>> a(static_cast<size_t>(state.range(0)), T{'.'});
+    vector<T, not_highly_aligned_allocator<T>> b(static_cast<size_t>(state.range(0)), T{'.'});
 
     if (state.range(1) != no_pos) {
         b.at(static_cast<size_t>(state.range(1))) = 'x';

--- a/benchmarks/src/remove.cpp
+++ b/benchmarks/src/remove.cpp
@@ -7,13 +7,14 @@
 #include <vector>
 
 #include "lorem.hpp"
+#include "skewed_allocator.hpp"
 
 enum class alg_type { std_fn, rng };
 
 template <alg_type Type, class T>
 void r(benchmark::State& state) {
-    const std::vector<T> src(lorem_ipsum.begin(), lorem_ipsum.end());
-    std::vector<T> v;
+    const std::vector<T, not_highly_aligned_allocator<T>> src(lorem_ipsum.begin(), lorem_ipsum.end());
+    std::vector<T, not_highly_aligned_allocator<T>> v;
     v.reserve(lorem_ipsum.size());
     for (auto _ : state) {
         v = src;
@@ -28,8 +29,8 @@ void r(benchmark::State& state) {
 
 template <alg_type Type, class T>
 void rc(benchmark::State& state) {
-    std::vector<T> src(lorem_ipsum.begin(), lorem_ipsum.end());
-    std::vector<T> v(lorem_ipsum.size());
+    std::vector<T, not_highly_aligned_allocator<T>> src(lorem_ipsum.begin(), lorem_ipsum.end());
+    std::vector<T, not_highly_aligned_allocator<T>> v(lorem_ipsum.size());
     for (auto _ : state) {
         benchmark::DoNotOptimize(src);
         benchmark::DoNotOptimize(v);

--- a/benchmarks/src/replace.cpp
+++ b/benchmarks/src/replace.cpp
@@ -7,36 +7,43 @@
 #include <vector>
 
 #include "lorem.hpp"
+#include "skewed_allocator.hpp"
 
 template <class T>
 void r(benchmark::State& state) {
-    const std::vector<T> a(lorem_ipsum.begin(), lorem_ipsum.end());
-    std::vector<T> b(lorem_ipsum.size());
+    std::vector<T, not_highly_aligned_allocator<T>> a(lorem_ipsum.begin(), lorem_ipsum.end());
+    std::vector<T, not_highly_aligned_allocator<T>> b(lorem_ipsum.size());
 
     for (auto _ : state) {
+        benchmark::DoNotOptimize(a);
         b = a;
         std::replace(std::begin(b), std::end(b), T{'m'}, T{'w'});
+        benchmark::DoNotOptimize(b);
     }
 }
 
 template <class T>
 void rc(benchmark::State& state) {
-    const std::vector<T> a(lorem_ipsum.begin(), lorem_ipsum.end());
-    std::vector<T> b(lorem_ipsum.size());
+    std::vector<T, not_highly_aligned_allocator<T>> a(lorem_ipsum.begin(), lorem_ipsum.end());
+    std::vector<T, not_highly_aligned_allocator<T>> b(lorem_ipsum.size());
 
     for (auto _ : state) {
+        benchmark::DoNotOptimize(a);
         std::replace_copy(std::begin(a), std::end(a), std::begin(b), T{'m'}, T{'w'});
+        benchmark::DoNotOptimize(b);
     }
 }
 
 template <class T>
 void rc_if(benchmark::State& state) {
-    const std::vector<T> a(lorem_ipsum.begin(), lorem_ipsum.end());
-    std::vector<T> b(lorem_ipsum.size());
+    std::vector<T, not_highly_aligned_allocator<T>> a(lorem_ipsum.begin(), lorem_ipsum.end());
+    std::vector<T, not_highly_aligned_allocator<T>> b(lorem_ipsum.size());
 
     for (auto _ : state) {
+        benchmark::DoNotOptimize(a);
         (void) std::replace_copy_if(
             std::begin(a), std::end(a), std::begin(b), [](auto x) { return x <= T{'Z'}; }, T{'X'});
+        benchmark::DoNotOptimize(b);
     }
 }
 

--- a/benchmarks/src/std_copy.cpp
+++ b/benchmarks/src/std_copy.cpp
@@ -8,14 +8,15 @@
 #include <type_traits>
 #include <vector>
 
-#include <udt.hpp>
-#include <utility.hpp>
+#include "skewed_allocator.hpp"
+#include "udt.hpp"
+#include "utility.hpp"
 
 template <typename Contained>
 void handwritten_loop(benchmark::State& state) {
     const size_t r0      = static_cast<size_t>(state.range(0));
-    const auto in_buffer = random_vector<Contained>(r0);
-    std::vector<Contained> out_buffer(r0);
+    const auto in_buffer = random_vector<Contained, not_highly_aligned_allocator>(r0);
+    std::vector<Contained, not_highly_aligned_allocator<Contained>> out_buffer(r0);
     for ([[maybe_unused]] auto _ : state) {
         benchmark::DoNotOptimize(in_buffer.data());
         const Contained* in_ptr           = in_buffer.data();
@@ -32,8 +33,8 @@ void handwritten_loop(benchmark::State& state) {
 template <typename Contained>
 void handwritten_loop_n(benchmark::State& state) {
     const size_t r0      = static_cast<size_t>(state.range(0));
-    const auto in_buffer = random_vector<Contained>(r0);
-    std::vector<Contained> out_buffer(r0);
+    const auto in_buffer = random_vector<Contained, not_highly_aligned_allocator>(r0);
+    std::vector<Contained, not_highly_aligned_allocator<Contained>> out_buffer(r0);
     for ([[maybe_unused]] auto _ : state) {
         benchmark::DoNotOptimize(in_buffer.data());
         const Contained* const in_ptr = in_buffer.data();
@@ -50,8 +51,8 @@ template <typename Contained>
 void memcpy_call(benchmark::State& state) {
     static_assert(std::is_trivially_copyable_v<Contained>, "memcpy must only be called on trivially copyable types");
     const size_t r0      = static_cast<size_t>(state.range(0));
-    const auto in_buffer = random_vector<Contained>(r0);
-    std::vector<Contained> out_buffer(r0);
+    const auto in_buffer = random_vector<Contained, not_highly_aligned_allocator>(r0);
+    std::vector<Contained, not_highly_aligned_allocator<Contained>> out_buffer(r0);
     for ([[maybe_unused]] auto _ : state) {
         benchmark::DoNotOptimize(in_buffer.data());
         memcpy(out_buffer.data(), in_buffer.data(), r0 * sizeof(Contained));
@@ -62,8 +63,8 @@ void memcpy_call(benchmark::State& state) {
 template <typename Contained>
 void std_copy_call(benchmark::State& state) {
     const size_t r0      = static_cast<size_t>(state.range(0));
-    const auto in_buffer = random_vector<Contained>(r0);
-    std::vector<Contained> out_buffer(r0);
+    const auto in_buffer = random_vector<Contained, not_highly_aligned_allocator>(r0);
+    std::vector<Contained, not_highly_aligned_allocator<Contained>> out_buffer(r0);
     for ([[maybe_unused]] auto _ : state) {
         benchmark::DoNotOptimize(in_buffer.data());
         std::copy(in_buffer.begin(), in_buffer.end(), out_buffer.begin());
@@ -74,8 +75,8 @@ void std_copy_call(benchmark::State& state) {
 template <typename Contained>
 void std_copy_n_call(benchmark::State& state) {
     const size_t r0      = static_cast<size_t>(state.range(0));
-    const auto in_buffer = random_vector<Contained>(r0);
-    std::vector<Contained> out_buffer(r0);
+    const auto in_buffer = random_vector<Contained, not_highly_aligned_allocator>(r0);
+    std::vector<Contained, not_highly_aligned_allocator<Contained>> out_buffer(r0);
     for ([[maybe_unused]] auto _ : state) {
         benchmark::DoNotOptimize(in_buffer.data());
         std::copy_n(in_buffer.begin(), r0, out_buffer.begin());


### PR DESCRIPTION
Resolves #5035

To avoid trying both aligned and unaligned allocators, try just unaligned. This makes sure we're checking the worst case, where vectorization would be of less  benefit.

Only change the container for potentially-vectorized algorithm benchmark. For, like, random it does not make sense. Also `vector<bool>` is vectorized, if we consider GPR-based vectorization as still vectorization, but this will not be sensitive to the alignment.

Some vector algorithms that are potentially sensitive to the alignment are in fact sensitive to alignment, some are not or almost not. The ones that are sensitive are simplest searches, or data movement. Consider `adjacent_find` as a good example of the sensitive one, here's how the results became worse:

Benchmark                            |  Before    |  After  
-------------------------------------|------------|------------
bm<AlgType::Std, int8_t>/2525/1142   |   19.9 ns  |   22.1 ns  
bm<AlgType::Std, int16_t>/2525/1142  |   33.2 ns  |   51.5 ns  
bm<AlgType::Std, int32_t>/2525/1142  |   75.5 ns  |   89.1 ns  
bm<AlgType::Std, int64_t>/2525/1142  |    139 ns  |    163 ns  
bm<AlgType::Rng, int8_t>/2525/1142   |   16.7 ns  |   20.1 ns  
bm<AlgType::Rng, int16_t>/2525/1142  |   33.0 ns  |   50.5 ns  
bm<AlgType::Rng, int32_t>/2525/1142  |   76.9 ns  |   89.0 ns  
bm<AlgType::Rng, int64_t>/2525/1142  |    141 ns  |    163 ns  

`adjacent_find` does two AVX loads of the same input data at a time, with aligned allocator just one of the loads is unaligned, with unaligned allocator both of them are unaligned. So it stresses the processor ability to deal with unaligned data.

Skipped also `bitset` benchmarks. They are harder to unalign, since they use some stack containers with deduced types. I'm confident that `bitset` from/to string conversion are examples of algorithm that are not very sensitive to the alignment.

Some of recently added benchmark are not changed in this PR, because they already use not highly aligned allocator.

Also I expected `replace_copy` as one of the sensitive, but auto-vectorization is broken at all in latest Preview 🐛.
Created DevCom-10895463

**Drive-by**: proper optimization barriers in replace family benchmarks.