### PR TITLE
`vector_algorithms.cpp`: introduce namespaces

### DIFF
--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -3380,7 +3380,175 @@ namespace {
             }
         }
     }
+} // unnamed namespace
 
+extern "C" {
+
+// TRANSITION, ABI: preserved for binary compatibility
+const void* __stdcall __std_find_trivial_unsized_1(const void* const _First, const uint8_t _Val) noexcept {
+    // C23 7.27.5.2 "The memchr generic function"/2 says "The implementation shall behave as if
+    // it reads the characters sequentially and stops as soon as a matching character is found."
+    return memchr(_First, _Val, SIZE_MAX);
+}
+
+// TRANSITION, ABI: preserved for binary compatibility
+const void* __stdcall __std_find_trivial_unsized_2(const void* const _First, const uint16_t _Val) noexcept {
+    // C23 7.27.5.2 "The memchr generic function"/2 says "The implementation shall behave as if
+    // it reads the characters sequentially and stops as soon as a matching character is found."
+    // C23 7.32.4.6.9 "The wmemchr generic function"/2 lacks such wording,
+    // so we don't use wmemchr(), avoiding issues with unreachable_sentinel_t.
+    return __std_find_trivial_unsized_impl(_First, _Val);
+}
+
+// TRANSITION, ABI: preserved for binary compatibility
+const void* __stdcall __std_find_trivial_unsized_4(const void* const _First, const uint32_t _Val) noexcept {
+    return __std_find_trivial_unsized_impl(_First, _Val);
+}
+
+// TRANSITION, ABI: preserved for binary compatibility
+const void* __stdcall __std_find_trivial_unsized_8(const void* const _First, const uint64_t _Val) noexcept {
+    return __std_find_trivial_unsized_impl(_First, _Val);
+}
+
+const void* __stdcall __std_find_trivial_1(
+    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
+    return __std_find_trivial_impl<_Find_traits_1, _Find_one_predicate::_Equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_trivial_2(
+    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
+    return __std_find_trivial_impl<_Find_traits_2, _Find_one_predicate::_Equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_trivial_4(
+    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
+    return __std_find_trivial_impl<_Find_traits_4, _Find_one_predicate::_Equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_trivial_8(
+    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
+    return __std_find_trivial_impl<_Find_traits_8, _Find_one_predicate::_Equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_last_trivial_1(
+    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
+    return __std_find_last_trivial_impl<_Find_traits_1, _Find_one_predicate::_Equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_last_trivial_2(
+    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
+    return __std_find_last_trivial_impl<_Find_traits_2, _Find_one_predicate::_Equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_last_trivial_4(
+    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
+    return __std_find_last_trivial_impl<_Find_traits_4, _Find_one_predicate::_Equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_last_trivial_8(
+    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
+    return __std_find_last_trivial_impl<_Find_traits_8, _Find_one_predicate::_Equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_not_ch_1(
+    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
+    return __std_find_trivial_impl<_Find_traits_1, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_not_ch_2(
+    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
+    return __std_find_trivial_impl<_Find_traits_2, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_not_ch_4(
+    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
+    return __std_find_trivial_impl<_Find_traits_4, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_not_ch_8(
+    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
+    return __std_find_trivial_impl<_Find_traits_8, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
+}
+
+__declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_1(
+    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
+    return __std_find_last_pos<_Find_traits_1, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
+}
+
+__declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_2(
+    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
+    return __std_find_last_pos<_Find_traits_2, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
+}
+
+__declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_4(
+    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
+    return __std_find_last_pos<_Find_traits_4, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
+}
+
+__declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_8(
+    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
+    return __std_find_last_pos<_Find_traits_8, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_adjacent_find_1(const void* const _First, const void* const _Last) noexcept {
+    return __std_adjacent_find_impl<_Find_traits_1, uint8_t>(_First, _Last);
+}
+
+const void* __stdcall __std_adjacent_find_2(const void* const _First, const void* const _Last) noexcept {
+    return __std_adjacent_find_impl<_Find_traits_2, uint16_t>(_First, _Last);
+}
+
+const void* __stdcall __std_adjacent_find_4(const void* const _First, const void* const _Last) noexcept {
+    return __std_adjacent_find_impl<_Find_traits_4, uint32_t>(_First, _Last);
+}
+
+const void* __stdcall __std_adjacent_find_8(const void* const _First, const void* const _Last) noexcept {
+    return __std_adjacent_find_impl<_Find_traits_8, uint64_t>(_First, _Last);
+}
+
+__declspec(noalias) size_t __stdcall __std_count_trivial_1(
+    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
+    return __std_count_trivial_impl<_Count_traits_1>(_First, _Last, _Val);
+}
+
+__declspec(noalias) size_t __stdcall __std_count_trivial_2(
+    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
+    return __std_count_trivial_impl<_Count_traits_2>(_First, _Last, _Val);
+}
+
+__declspec(noalias) size_t __stdcall __std_count_trivial_4(
+    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
+    return __std_count_trivial_impl<_Count_traits_4>(_First, _Last, _Val);
+}
+
+__declspec(noalias) size_t __stdcall __std_count_trivial_8(
+    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
+    return __std_count_trivial_impl<_Count_traits_8>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_search_n_1(
+    const void* const _First, const void* const _Last, const size_t _Count, const uint8_t _Value) noexcept {
+    return __std_search_n_impl<_Find_traits_1>(_First, _Last, _Count, _Value);
+}
+
+const void* __stdcall __std_search_n_2(
+    const void* const _First, const void* const _Last, const size_t _Count, const uint16_t _Value) noexcept {
+    return __std_search_n_impl<_Find_traits_2>(_First, _Last, _Count, _Value);
+}
+
+const void* __stdcall __std_search_n_4(
+    const void* const _First, const void* const _Last, const size_t _Count, const uint32_t _Value) noexcept {
+    return __std_search_n_impl<_Find_traits_4>(_First, _Last, _Count, _Value);
+}
+
+const void* __stdcall __std_search_n_8(
+    const void* const _First, const void* const _Last, const size_t _Count, const uint64_t _Value) noexcept {
+    return __std_search_n_impl<_Find_traits_8>(_First, _Last, _Count, _Value);
+}
+
+} // extern "C"
+
+namespace {
     enum class _Find_meow_of_predicate { _Any_of, _None_of };
 
 #ifndef _M_ARM64EC
@@ -4613,168 +4781,6 @@ namespace {
 } // unnamed namespace
 
 extern "C" {
-
-// TRANSITION, ABI: preserved for binary compatibility
-const void* __stdcall __std_find_trivial_unsized_1(const void* const _First, const uint8_t _Val) noexcept {
-    // C23 7.27.5.2 "The memchr generic function"/2 says "The implementation shall behave as if
-    // it reads the characters sequentially and stops as soon as a matching character is found."
-    return memchr(_First, _Val, SIZE_MAX);
-}
-
-// TRANSITION, ABI: preserved for binary compatibility
-const void* __stdcall __std_find_trivial_unsized_2(const void* const _First, const uint16_t _Val) noexcept {
-    // C23 7.27.5.2 "The memchr generic function"/2 says "The implementation shall behave as if
-    // it reads the characters sequentially and stops as soon as a matching character is found."
-    // C23 7.32.4.6.9 "The wmemchr generic function"/2 lacks such wording,
-    // so we don't use wmemchr(), avoiding issues with unreachable_sentinel_t.
-    return __std_find_trivial_unsized_impl(_First, _Val);
-}
-
-// TRANSITION, ABI: preserved for binary compatibility
-const void* __stdcall __std_find_trivial_unsized_4(const void* const _First, const uint32_t _Val) noexcept {
-    return __std_find_trivial_unsized_impl(_First, _Val);
-}
-
-// TRANSITION, ABI: preserved for binary compatibility
-const void* __stdcall __std_find_trivial_unsized_8(const void* const _First, const uint64_t _Val) noexcept {
-    return __std_find_trivial_unsized_impl(_First, _Val);
-}
-
-const void* __stdcall __std_find_trivial_1(
-    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return __std_find_trivial_impl<_Find_traits_1, _Find_one_predicate::_Equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_trivial_2(
-    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return __std_find_trivial_impl<_Find_traits_2, _Find_one_predicate::_Equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_trivial_4(
-    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return __std_find_trivial_impl<_Find_traits_4, _Find_one_predicate::_Equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_trivial_8(
-    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return __std_find_trivial_impl<_Find_traits_8, _Find_one_predicate::_Equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_last_trivial_1(
-    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return __std_find_last_trivial_impl<_Find_traits_1, _Find_one_predicate::_Equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_last_trivial_2(
-    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return __std_find_last_trivial_impl<_Find_traits_2, _Find_one_predicate::_Equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_last_trivial_4(
-    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return __std_find_last_trivial_impl<_Find_traits_4, _Find_one_predicate::_Equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_last_trivial_8(
-    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return __std_find_last_trivial_impl<_Find_traits_8, _Find_one_predicate::_Equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_not_ch_1(
-    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return __std_find_trivial_impl<_Find_traits_1, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_not_ch_2(
-    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return __std_find_trivial_impl<_Find_traits_2, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_not_ch_4(
-    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return __std_find_trivial_impl<_Find_traits_4, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_not_ch_8(
-    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return __std_find_trivial_impl<_Find_traits_8, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
-}
-
-__declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_1(
-    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return __std_find_last_pos<_Find_traits_1, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
-}
-
-__declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_2(
-    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return __std_find_last_pos<_Find_traits_2, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
-}
-
-__declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_4(
-    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return __std_find_last_pos<_Find_traits_4, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
-}
-
-__declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_8(
-    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return __std_find_last_pos<_Find_traits_8, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_adjacent_find_1(const void* const _First, const void* const _Last) noexcept {
-    return __std_adjacent_find_impl<_Find_traits_1, uint8_t>(_First, _Last);
-}
-
-const void* __stdcall __std_adjacent_find_2(const void* const _First, const void* const _Last) noexcept {
-    return __std_adjacent_find_impl<_Find_traits_2, uint16_t>(_First, _Last);
-}
-
-const void* __stdcall __std_adjacent_find_4(const void* const _First, const void* const _Last) noexcept {
-    return __std_adjacent_find_impl<_Find_traits_4, uint32_t>(_First, _Last);
-}
-
-const void* __stdcall __std_adjacent_find_8(const void* const _First, const void* const _Last) noexcept {
-    return __std_adjacent_find_impl<_Find_traits_8, uint64_t>(_First, _Last);
-}
-
-__declspec(noalias) size_t __stdcall __std_count_trivial_1(
-    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return __std_count_trivial_impl<_Count_traits_1>(_First, _Last, _Val);
-}
-
-__declspec(noalias) size_t __stdcall __std_count_trivial_2(
-    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return __std_count_trivial_impl<_Count_traits_2>(_First, _Last, _Val);
-}
-
-__declspec(noalias) size_t __stdcall __std_count_trivial_4(
-    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return __std_count_trivial_impl<_Count_traits_4>(_First, _Last, _Val);
-}
-
-__declspec(noalias) size_t __stdcall __std_count_trivial_8(
-    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return __std_count_trivial_impl<_Count_traits_8>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_search_n_1(
-    const void* const _First, const void* const _Last, const size_t _Count, const uint8_t _Value) noexcept {
-    return __std_search_n_impl<_Find_traits_1>(_First, _Last, _Count, _Value);
-}
-
-const void* __stdcall __std_search_n_2(
-    const void* const _First, const void* const _Last, const size_t _Count, const uint16_t _Value) noexcept {
-    return __std_search_n_impl<_Find_traits_2>(_First, _Last, _Count, _Value);
-}
-
-const void* __stdcall __std_search_n_4(
-    const void* const _First, const void* const _Last, const size_t _Count, const uint32_t _Value) noexcept {
-    return __std_search_n_impl<_Find_traits_4>(_First, _Last, _Count, _Value);
-}
-
-const void* __stdcall __std_search_n_8(
-    const void* const _First, const void* const _Last, const size_t _Count, const uint64_t _Value) noexcept {
-    return __std_search_n_impl<_Find_traits_8>(_First, _Last, _Count, _Value);
-}
 
 const void* __stdcall __std_find_first_of_trivial_1(
     const void* const _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -4253,14 +4253,16 @@ namespace {
                     return _First1;
                 }
             }
-#endif // !_M_ARM64EC
 
             template <class _Ty>
             struct _Find_first_of_traits;
 
             template <>
-            struct _Find_first_of_traits<uint32_t> : _Find_traits_4 {
-#ifndef _M_ARM64EC
+            struct _Find_first_of_traits<uint32_t> {
+                static __m256i _Cmp_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
+                    return _mm256_cmpeq_epi32(_Lhs, _Rhs);
+                }
+
                 template <size_t _Amount>
                 static __m256i _Spread_avx(__m256i _Val, const size_t _Needle_length_el) noexcept {
                     if constexpr (_Amount == 0) {
@@ -4301,12 +4303,14 @@ namespace {
                         static_assert(false, "Unexpected amount");
                     }
                 }
-#endif // !_M_ARM64EC
             };
 
             template <>
-            struct _Find_first_of_traits<uint64_t> : _Find_traits_8 {
-#ifndef _M_ARM64EC
+            struct _Find_first_of_traits<uint64_t> {
+                static __m256i _Cmp_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
+                    return _mm256_cmpeq_epi64(_Lhs, _Rhs);
+                }
+
                 template <size_t _Amount>
                 static __m256i _Spread_avx(const __m256i _Val, const size_t _Needle_length_el) noexcept {
                     if constexpr (_Amount == 0) {
@@ -4336,10 +4340,8 @@ namespace {
                         static_assert(false, "Unexpected amount");
                     }
                 }
-#endif // !_M_ARM64EC
             };
 
-#ifndef _M_ARM64EC
             template <class _Traits, size_t _Needle_length_el_magnitude>
             __m256i _Shuffle_step(const __m256i _Data1, const __m256i _Data2s0) noexcept {
                 __m256i _Eq = _mm256_setzero_si256();

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -3343,7 +3343,7 @@ const void* __stdcall __std_search_n_8(
 } // extern "C"
 
 namespace {
-    namespace _Count {
+    namespace _Counting {
 #ifdef _M_ARM64EC
         using _Count_traits_8 = void;
         using _Count_traits_4 = void;
@@ -3569,29 +3569,29 @@ namespace {
             }
             return _Result;
         }
-    } // namespace _Count
+    } // namespace _Counting
 } // unnamed namespace
 
 extern "C" {
 
 __declspec(noalias) size_t __stdcall __std_count_trivial_1(
     const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return _Count::_Count_impl<_Count::_Count_traits_1>(_First, _Last, _Val);
+    return _Counting::_Count_impl<_Counting::_Count_traits_1>(_First, _Last, _Val);
 }
 
 __declspec(noalias) size_t __stdcall __std_count_trivial_2(
     const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return _Count::_Count_impl<_Count::_Count_traits_2>(_First, _Last, _Val);
+    return _Counting::_Count_impl<_Counting::_Count_traits_2>(_First, _Last, _Val);
 }
 
 __declspec(noalias) size_t __stdcall __std_count_trivial_4(
     const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return _Count::_Count_impl<_Count::_Count_traits_4>(_First, _Last, _Val);
+    return _Counting::_Count_impl<_Counting::_Count_traits_4>(_First, _Last, _Val);
 }
 
 __declspec(noalias) size_t __stdcall __std_count_trivial_8(
     const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return _Count::_Count_impl<_Count::_Count_traits_8>(_First, _Last, _Val);
+    return _Counting::_Count_impl<_Counting::_Count_traits_8>(_First, _Last, _Val);
 }
 
 } // extern "C"

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -21,7 +21,7 @@ extern "C" long __isa_enabled;
 #ifndef _DEBUG
 #pragma optimize("t", on) // Override /Os with /Ot for this TU
 #endif // !defined(_DEBUG)
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
 namespace {
 #ifndef _M_ARM64EC
@@ -51,7 +51,7 @@ namespace {
         return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(
             reinterpret_cast<const unsigned char*>(_Tail_masks) + (32 - _Count_in_bytes)));
     }
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     size_t _Byte_length(const void* const _First, const void* const _Last) noexcept {
         return static_cast<const unsigned char*>(_Last) - static_cast<const unsigned char*>(_First);
@@ -622,7 +622,7 @@ namespace {
                 return _mm256_maskload_epi32(reinterpret_cast<const int*>(_Src), _Mask);
             }
         };
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
         struct _Traits_1_base {
             static constexpr bool _Is_floating = false;
@@ -639,7 +639,7 @@ namespace {
 #ifndef _M_ARM64EC
             static constexpr bool _Has_portion_max = true;
             static constexpr size_t _Portion_max   = 256;
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
         };
 
 #ifndef _M_ARM64EC
@@ -829,7 +829,7 @@ namespace {
                 return _Mask;
             }
         };
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
         struct _Traits_2_base {
             static constexpr bool _Is_floating = false;
@@ -846,7 +846,7 @@ namespace {
 #ifndef _M_ARM64EC
             static constexpr bool _Has_portion_max = true;
             static constexpr size_t _Portion_max   = 65536;
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
         };
 
 #ifndef _M_ARM64EC
@@ -1032,7 +1032,7 @@ namespace {
                 return _Mask;
             }
         };
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
         struct _Traits_4_base {
             static constexpr bool _Is_floating = false;
@@ -1053,7 +1053,7 @@ namespace {
             static constexpr bool _Has_portion_max = true;
             static constexpr size_t _Portion_max   = 0x1'0000'0000ULL;
 #endif // ^^^ 64-bit ^^^
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
         };
 
 #ifndef _M_ARM64EC
@@ -1231,7 +1231,7 @@ namespace {
                 return _Mask;
             }
         };
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
         struct _Traits_8_base {
             static constexpr bool _Is_floating = false;
@@ -1247,7 +1247,7 @@ namespace {
 
 #ifndef _M_ARM64EC
             static constexpr bool _Has_portion_max = false;
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
         };
 
 #ifndef _M_ARM64EC
@@ -1437,7 +1437,7 @@ namespace {
                 return _Mask;
             }
         };
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
         struct _Traits_f_base {
             static constexpr bool _Is_floating = true;
@@ -1458,7 +1458,7 @@ namespace {
             static constexpr bool _Has_portion_max = true;
             static constexpr size_t _Portion_max   = 0x1'0000'0000ULL;
 #endif // ^^^ 64-bit ^^^
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
         };
 
 #ifndef _M_ARM64EC
@@ -1616,7 +1616,7 @@ namespace {
                 return _mm256_castps_si256(_Mask);
             }
         };
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
         struct _Traits_d_base {
             static constexpr bool _Is_floating = true;
@@ -1632,7 +1632,7 @@ namespace {
 
 #ifndef _M_ARM64EC
             static constexpr bool _Has_portion_max = false;
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
         };
 
 #ifndef _M_ARM64EC
@@ -1787,14 +1787,14 @@ namespace {
                 return _mm256_castpd_si256(_Mask);
             }
         };
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
         struct _Traits_1 {
             using _Scalar = _Traits_scalar<_Traits_1_base>;
 #ifndef _M_ARM64EC
             using _Sse = _Traits_1_sse;
             using _Avx = _Traits_1_avx;
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
         };
 
         struct _Traits_2 {
@@ -1802,7 +1802,7 @@ namespace {
 #ifndef _M_ARM64EC
             using _Sse = _Traits_2_sse;
             using _Avx = _Traits_2_avx;
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
         };
 
         struct _Traits_4 {
@@ -1810,7 +1810,7 @@ namespace {
 #ifndef _M_ARM64EC
             using _Sse = _Traits_4_sse;
             using _Avx = _Traits_4_avx;
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
         };
 
         struct _Traits_8 {
@@ -1818,7 +1818,7 @@ namespace {
 #ifndef _M_ARM64EC
             using _Sse = _Traits_8_sse;
             using _Avx = _Traits_8_avx;
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
         };
 
         struct _Traits_f {
@@ -1826,7 +1826,7 @@ namespace {
 #ifndef _M_ARM64EC
             using _Sse = _Traits_f_sse;
             using _Avx = _Traits_f_avx;
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
         };
 
         struct _Traits_d {
@@ -1834,7 +1834,7 @@ namespace {
 #ifndef _M_ARM64EC
             using _Sse = _Traits_d_sse;
             using _Avx = _Traits_d_avx;
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
         };
 
         template <_Min_max_mode _Mode, class _Traits>
@@ -5039,7 +5039,7 @@ namespace {
 
                 return _Last1;
             } else
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
             {
                 const size_t _Max_pos = _Size_bytes_1 - _Size_bytes_2 + sizeof(_Ty);
 
@@ -5288,7 +5288,7 @@ namespace {
                     return _Last1;
                 }
             } else
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
             {
                 auto _Ptr1       = static_cast<const _Ty*>(_Last1) - _Count2;
                 const auto _Ptr2 = static_cast<const _Ty*>(_First2);
@@ -5458,7 +5458,7 @@ namespace {
 
                 _Result /= sizeof(_Ty);
             }
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
             const auto _First1_el = static_cast<const _Ty*>(_First1);
             const auto _First2_el = static_cast<const _Ty*>(_First2);
 
@@ -5523,7 +5523,7 @@ __declspec(noalias) void __stdcall __std_replace_4(
 
         _mm256_zeroupper(); // TRANSITION, DevCom-10331414
     } else
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
     {
         for (auto _Cur = reinterpret_cast<uint32_t*>(_First); _Cur != _Last; ++_Cur) {
             if (*_Cur == _Old_val) {
@@ -5566,7 +5566,7 @@ __declspec(noalias) void __stdcall __std_replace_8(
 
         _mm256_zeroupper(); // TRANSITION, DevCom-10331414
     } else
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
     {
         for (auto _Cur = reinterpret_cast<uint64_t*>(_First); _Cur != _Last; ++_Cur) {
             if (*_Cur == _Old_val) {
@@ -5949,7 +5949,7 @@ namespace {
             return _Out;
         }
 
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
     } // namespace _Removing
 } // unnamed namespace
 
@@ -5965,7 +5965,7 @@ void* __stdcall __std_remove_1(void* _First, void* const _Last, const uint8_t _V
         _Out   = _Removing::_Remove_impl<_Removing::_Sse_1>(_First, _Stop, _Val);
         _First = _Stop;
     }
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     return _Removing::_Remove_fallback(_First, _Last, _Out, _Val);
 }
@@ -5980,7 +5980,7 @@ void* __stdcall __std_remove_2(void* _First, void* const _Last, const uint16_t _
         _Out   = _Removing::_Remove_impl<_Removing::_Sse_2>(_First, _Stop, _Val);
         _First = _Stop;
     }
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     return _Removing::_Remove_fallback(_First, _Last, _Out, _Val);
 }
@@ -6002,7 +6002,7 @@ void* __stdcall __std_remove_4(void* _First, void* const _Last, const uint32_t _
         _Out   = _Removing::_Remove_impl<_Removing::_Sse_4>(_First, _Stop, _Val);
         _First = _Stop;
     }
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     return _Removing::_Remove_fallback(_First, _Last, _Out, _Val);
 }
@@ -6024,7 +6024,7 @@ void* __stdcall __std_remove_8(void* _First, void* const _Last, const uint64_t _
         _Out   = _Removing::_Remove_impl<_Removing::_Sse_8>(_First, _Stop, _Val);
         _First = _Stop;
     }
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     return _Removing::_Remove_fallback(_First, _Last, _Out, _Val);
 }
@@ -6038,7 +6038,7 @@ void* __stdcall __std_remove_copy_1(
         _Out   = _Removing::_Remove_copy_impl<_Removing::_Sse_1>(_First, _Stop, _Out, _Val);
         _First = _Stop;
     }
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     return _Removing::_Remove_fallback(_First, _Last, _Out, _Val);
 }
@@ -6052,7 +6052,7 @@ void* __stdcall __std_remove_copy_2(
         _Out   = _Removing::_Remove_copy_impl<_Removing::_Sse_2>(_First, _Stop, _Out, _Val);
         _First = _Stop;
     }
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     return _Removing::_Remove_fallback(_First, _Last, _Out, _Val);
 }
@@ -6073,7 +6073,7 @@ void* __stdcall __std_remove_copy_4(
         _Out   = _Removing::_Remove_copy_impl<_Removing::_Sse_4>(_First, _Stop, _Out, _Val);
         _First = _Stop;
     }
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     return _Removing::_Remove_fallback(_First, _Last, _Out, _Val);
 }
@@ -6094,7 +6094,7 @@ void* __stdcall __std_remove_copy_8(
         _Out   = _Removing::_Remove_copy_impl<_Removing::_Sse_8>(_First, _Stop, _Out, _Val);
         _First = _Stop;
     }
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     return _Removing::_Remove_fallback(_First, _Last, _Out, _Val);
 }
@@ -6116,7 +6116,7 @@ void* __stdcall __std_unique_1(void* _First, void* const _Last) noexcept {
         _Dest  = _Removing::_Unique_impl<_Removing::_Sse_1>(_First, _Stop);
         _First = _Stop;
     }
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     return _Removing::_Unique_fallback<uint8_t>(_First, _Last, _Dest);
 }
@@ -6138,7 +6138,7 @@ void* __stdcall __std_unique_2(void* _First, void* const _Last) noexcept {
         _Dest  = _Removing::_Unique_impl<_Removing::_Sse_2>(_First, _Stop);
         _First = _Stop;
     }
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     return _Removing::_Unique_fallback<uint16_t>(_First, _Last, _Dest);
 }
@@ -6167,7 +6167,7 @@ void* __stdcall __std_unique_4(void* _First, void* const _Last) noexcept {
         _Dest  = _Removing::_Unique_impl<_Removing::_Sse_4>(_First, _Stop);
         _First = _Stop;
     }
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     return _Removing::_Unique_fallback<uint32_t>(_First, _Last, _Dest);
 }
@@ -6196,7 +6196,7 @@ void* __stdcall __std_unique_8(void* _First, void* const _Last) noexcept {
         _Dest  = _Removing::_Unique_impl<_Removing::_Sse_8>(_First, _Stop);
         _First = _Stop;
     }
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     return _Removing::_Unique_fallback<uint64_t>(_First, _Last, _Dest);
 }
@@ -6216,7 +6216,7 @@ void* __stdcall __std_unique_copy_1(const void* _First, const void* const _Last,
         _Dest  = _Removing::_Unique_copy_impl<_Removing::_Sse_1>(_First, _Stop, _Dest);
         _First = _Stop;
     }
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     return _Removing::_Unique_fallback<uint8_t>(_First, _Last, _Dest);
 }
@@ -6236,7 +6236,7 @@ void* __stdcall __std_unique_copy_2(const void* _First, const void* const _Last,
         _Dest  = _Removing::_Unique_copy_impl<_Removing::_Sse_2>(_First, _Stop, _Dest);
         _First = _Stop;
     }
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     return _Removing::_Unique_fallback<uint16_t>(_First, _Last, _Dest);
 }
@@ -6263,7 +6263,7 @@ void* __stdcall __std_unique_copy_4(const void* _First, const void* const _Last,
         _Dest  = _Removing::_Unique_copy_impl<_Removing::_Sse_4>(_First, _Stop, _Dest);
         _First = _Stop;
     }
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     return _Removing::_Unique_fallback<uint32_t>(_First, _Last, _Dest);
 }
@@ -6290,7 +6290,7 @@ void* __stdcall __std_unique_copy_8(const void* _First, const void* const _Last,
         _Dest  = _Removing::_Unique_copy_impl<_Removing::_Sse_8>(_First, _Stop, _Dest);
         _First = _Stop;
     }
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     return _Removing::_Unique_fallback<uint64_t>(_First, _Last, _Dest);
 }
@@ -6440,7 +6440,7 @@ namespace {
             } else if (_Use_sse42()) {
                 _Impl<_Sse_traits>(_Dest, _Src, _Size_bits, _Elem0, _Elem1);
             } else
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
             {
                 const auto _Arr = reinterpret_cast<const uint8_t*>(_Src);
                 for (size_t _Ix = 0; _Ix < _Size_bits; ++_Ix) {
@@ -6651,7 +6651,7 @@ namespace {
 
             return true;
         }
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
         template <class _Elem>
         bool _Fallback(void* const _Dest, const _Elem* const _Src, const size_t _Size_bytes, const size_t _Size_bits,
@@ -6695,7 +6695,7 @@ namespace {
             } else if (_Use_sse42()) {
                 return _Impl<_Sse>(_Dest, _Src, _Size_bytes, _Size_bits, _Size_chars, _Elem0, _Elem1);
             } else
-#endif // !defined(_M_ARM64EC)
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
             {
                 return _Fallback(_Dest, _Src, _Size_bytes, _Size_bits, _Size_chars, _Elem0, _Elem1);
             }

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -5448,8 +5448,8 @@ namespace {
                 for (; _Result != _Count_bytes_sse; _Result += 0x10) {
                     const __m128i _Elem1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_First1_ch + _Result));
                     const __m128i _Elem2 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_First2_ch + _Result));
-                    const auto _Bingo =
-                        static_cast<unsigned int>(_mm_movemask_epi8(_Traits::_Cmp_sse(_Elem1, _Elem2))) ^ 0xFFFF;
+                    const __m128i _Cmp   = _Traits::_Cmp_sse(_Elem1, _Elem2);
+                    const auto _Bingo    = static_cast<unsigned int>(_mm_movemask_epi8(_Cmp)) ^ 0xFFFF;
                     if (_Bingo != 0) {
                         unsigned long _Offset;
                         // CodeQL [SM02313] _Offset is always initialized: we just tested `if (_Bingo != 0)`.

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2690,8 +2690,13 @@ const void* __stdcall __std_is_sorted_until_d(
 
 namespace {
     namespace _Find {
+#ifdef _M_ARM64EC
+        using _Find_traits_1 = void;
+        using _Find_traits_2 = void;
+        using _Find_traits_4 = void;
+        using _Find_traits_8 = void;
+#else // ^^^ defined(_M_ARM64EC) / !defined(_M_ARM64EC) vvv
         struct _Find_traits_1 {
-#ifndef _M_ARM64EC
             static __m256i _Set_avx(const uint8_t _Val) noexcept {
                 return _mm256_set1_epi8(_Val);
             }
@@ -2707,11 +2712,9 @@ namespace {
             static __m128i _Cmp_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
                 return _mm_cmpeq_epi8(_Lhs, _Rhs);
             }
-#endif // !_M_ARM64EC
         };
 
         struct _Find_traits_2 {
-#ifndef _M_ARM64EC
             static __m256i _Set_avx(const uint16_t _Val) noexcept {
                 return _mm256_set1_epi16(_Val);
             }
@@ -2727,11 +2730,9 @@ namespace {
             static __m128i _Cmp_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
                 return _mm_cmpeq_epi16(_Lhs, _Rhs);
             }
-#endif // !_M_ARM64EC
         };
 
         struct _Find_traits_4 {
-#ifndef _M_ARM64EC
             static __m256i _Set_avx(const uint32_t _Val) noexcept {
                 return _mm256_set1_epi32(_Val);
             }
@@ -2747,11 +2748,9 @@ namespace {
             static __m128i _Cmp_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
                 return _mm_cmpeq_epi32(_Lhs, _Rhs);
             }
-#endif // !_M_ARM64EC
         };
 
         struct _Find_traits_8 {
-#ifndef _M_ARM64EC
             static __m256i _Set_avx(const uint64_t _Val) noexcept {
                 return _mm256_set1_epi64x(_Val);
             }
@@ -2767,8 +2766,8 @@ namespace {
             static __m128i _Cmp_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
                 return _mm_cmpeq_epi64(_Lhs, _Rhs);
             }
-#endif // !_M_ARM64EC
         };
+#endif // !_M_ARM64EC
 
         // TRANSITION, ABI: used only in functions preserved for binary compatibility
         template <class _Ty>
@@ -3340,8 +3339,13 @@ const void* __stdcall __std_search_n_8(
 
 namespace {
     namespace _Count {
+#ifdef _M_ARM64EC
+        using _Count_traits_8 = void;
+        using _Count_traits_4 = void;
+        using _Count_traits_2 = void;
+        using _Count_traits_1 = void;
+#else // ^^^ defined(_M_ARM64EC) / !defined(_M_ARM64EC) vvv
         struct _Count_traits_8 : _Find::_Find_traits_8 {
-#ifndef _M_ARM64EC
             static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
                 return _mm256_sub_epi64(_Lhs, _Rhs);
             }
@@ -3365,11 +3369,9 @@ namespace {
                 return _mm_cvtsi128_si64(_Val) + _mm_extract_epi64(_Val, 1);
 #endif // ^^^ defined(_M_X64) ^^^
             }
-#endif // !_M_ARM64EC
         };
 
         struct _Count_traits_4 : _Find::_Find_traits_4 {
-#ifndef _M_ARM64EC
             // For AVX2, we use hadd_epi32 three times to combine pairs of 32-bit counters into 32-bit results.
             // Therefore, _Max_count is 0x1FFF'FFFF, which is 0xFFFF'FFF8 when doubled three times; any more would
             // overflow.
@@ -3401,11 +3403,9 @@ namespace {
                 const __m128i _Rx5 = _mm_hadd_epi32(_Rx4, _mm_setzero_si128()); // (0+...+3),0,0,0
                 return static_cast<uint32_t>(_mm_cvtsi128_si32(_Rx5));
             }
-#endif // !_M_ARM64EC
         };
 
         struct _Count_traits_2 : _Find::_Find_traits_2 {
-#ifndef _M_ARM64EC
             // For both AVX2 and SSE4.2, we use hadd_epi16 once to combine pairs of 16-bit counters into 16-bit results.
             // Therefore, _Max_count is 0x7FFF, which is 0xFFFE when doubled; any more would overflow.
 
@@ -3430,11 +3430,9 @@ namespace {
                 const __m128i _Rx3 = _mm_unpacklo_epi16(_Rx2, _mm_setzero_si128());
                 return _Count_traits_4::_Reduce_sse(_Rx3);
             }
-#endif // !_M_ARM64EC
         };
 
         struct _Count_traits_1 : _Find::_Find_traits_1 {
-#ifndef _M_ARM64EC
             // For AVX2, _Max_portion_size below is _Max_count * 32 bytes, and we have 1-byte elements.
             // We're using packed 8-bit counters, and 32 of those fit in 256 bits.
 
@@ -3463,8 +3461,8 @@ namespace {
                 const __m128i _Rx1 = _mm_sad_epu8(_Val, _mm_setzero_si128());
                 return _Count_traits_8::_Reduce_sse(_Rx1);
             }
-#endif // !_M_ARM64EC
         };
+#endif // !_M_ARM64EC
 
         template <class _Traits, class _Ty>
         __declspec(noalias) size_t __stdcall _Count_impl(

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -6300,7 +6300,7 @@ void* __stdcall __std_unique_copy_8(const void* _First, const void* const _Last,
 } // extern "C"
 
 namespace {
-    namespace __std_bitset_to_string {
+    namespace _Bitset_to_string {
 #ifdef _M_ARM64EC
         using _Traits_1_avx = void;
         using _Traits_1_sse = void;
@@ -6450,29 +6450,27 @@ namespace {
                 }
             }
         }
-    } // namespace __std_bitset_to_string
+    } // namespace _Bitset_to_string
 } // unnamed namespace
 
 extern "C" {
 
 __declspec(noalias) void __stdcall __std_bitset_to_string_1(
     char* const _Dest, const void* const _Src, const size_t _Size_bits, const char _Elem0, const char _Elem1) noexcept {
-    using namespace __std_bitset_to_string;
+    using namespace _Bitset_to_string;
     _Dispatch<_Traits_1_avx, _Traits_1_sse>(_Dest, _Src, _Size_bits, _Elem0, _Elem1);
 }
 
 __declspec(noalias) void __stdcall __std_bitset_to_string_2(wchar_t* const _Dest, const void* const _Src,
     const size_t _Size_bits, const wchar_t _Elem0, const wchar_t _Elem1) noexcept {
-    using namespace __std_bitset_to_string;
+    using namespace _Bitset_to_string;
     _Dispatch<_Traits_2_avx, _Traits_2_sse>(_Dest, _Src, _Size_bits, _Elem0, _Elem1);
 }
 
 } // extern "C"
 
 namespace {
-
-    namespace __std_bitset_from_string {
-
+    namespace _Bitset_from_string {
 #ifdef _M_ARM64EC
         using _Traits_1_avx = void;
         using _Traits_1_sse = void;
@@ -6704,9 +6702,7 @@ namespace {
                 return _Fallback(_Dest, _Src, _Size_bytes, _Size_bits, _Size_chars, _Elem0, _Elem1);
             }
         }
-
-    } // namespace __std_bitset_from_string
-
+    } // namespace _Bitset_from_string
 } // unnamed namespace
 
 extern "C" {
@@ -6714,7 +6710,7 @@ extern "C" {
 __declspec(noalias) bool __stdcall __std_bitset_from_string_1(void* const _Dest, const char* const _Src,
     const size_t _Size_bytes, const size_t _Size_bits, const size_t _Size_chars, const char _Elem0,
     const char _Elem1) noexcept {
-    using namespace __std_bitset_from_string;
+    using namespace _Bitset_from_string;
 
     return _Dispatch<_Traits_1_avx, _Traits_1_sse>(_Dest, _Src, _Size_bytes, _Size_bits, _Size_chars, _Elem0, _Elem1);
 }
@@ -6722,7 +6718,7 @@ __declspec(noalias) bool __stdcall __std_bitset_from_string_1(void* const _Dest,
 __declspec(noalias) bool __stdcall __std_bitset_from_string_2(void* const _Dest, const wchar_t* const _Src,
     const size_t _Size_bytes, const size_t _Size_bits, const size_t _Size_chars, const wchar_t _Elem0,
     const wchar_t _Elem1) noexcept {
-    using namespace __std_bitset_from_string;
+    using namespace _Bitset_from_string;
 
     return _Dispatch<_Traits_2_avx, _Traits_2_sse>(_Dest, _Src, _Size_bytes, _Size_bits, _Size_chars, _Elem0, _Elem1);
 }

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -77,6 +77,7 @@ namespace {
 } // unnamed namespace
 
 extern "C" {
+
 __declspec(noalias) void __cdecl __std_swap_ranges_trivially_swappable_noalias(
     void* _First1, void* const _Last1, void* _First2) noexcept {
 #ifndef _M_ARM64EC
@@ -152,6 +153,14 @@ __declspec(noalias) void __cdecl __std_swap_ranges_trivially_swappable_noalias(
         *_First2c         = _Ch;
     }
 }
+
+// TRANSITION, ABI: __std_swap_ranges_trivially_swappable() is preserved for binary compatibility
+void* __cdecl __std_swap_ranges_trivially_swappable(
+    void* const _First1, void* const _Last1, void* const _First2) noexcept {
+    __std_swap_ranges_trivially_swappable_noalias(_First1, _Last1, _First2);
+    return static_cast<char*>(_First2) + (static_cast<char*>(_Last1) - static_cast<char*>(_First1));
+}
+
 } // extern "C"
 
 namespace {
@@ -173,13 +182,6 @@ namespace {
 } // unnamed namespace
 
 extern "C" {
-
-// TRANSITION, ABI: __std_swap_ranges_trivially_swappable() is preserved for binary compatibility
-void* __cdecl __std_swap_ranges_trivially_swappable(
-    void* const _First1, void* const _Last1, void* const _First2) noexcept {
-    __std_swap_ranges_trivially_swappable_noalias(_First1, _Last1, _First2);
-    return static_cast<char*>(_First2) + (static_cast<char*>(_Last1) - static_cast<char*>(_First1));
-}
 
 __declspec(noalias) void __cdecl __std_reverse_trivially_swappable_1(void* _First, void* _Last) noexcept {
 #ifndef _M_ARM64EC

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -142,7 +142,7 @@ __declspec(noalias) void __cdecl __std_swap_ranges_trivially_swappable_noalias(
 #else
 #error Unsupported architecture
 #endif
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     auto _First1c      = static_cast<unsigned char*>(_First1);
     const auto _Last1c = static_cast<unsigned char*>(_Last1);
@@ -226,7 +226,7 @@ __declspec(noalias) void __cdecl __std_reverse_trivially_swappable_1(void* _Firs
             _Advance_bytes(_First, 16);
         } while (_First != _Stop_at);
     }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     _Reversing::_Reverse_tail(static_cast<unsigned char*>(_First), static_cast<unsigned char*>(_Last));
 }
@@ -270,7 +270,7 @@ __declspec(noalias) void __cdecl __std_reverse_trivially_swappable_2(void* _Firs
             _Advance_bytes(_First, 16);
         } while (_First != _Stop_at);
     }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     _Reversing::_Reverse_tail(static_cast<unsigned short*>(_First), static_cast<unsigned short*>(_Last));
 }
@@ -309,7 +309,7 @@ __declspec(noalias) void __cdecl __std_reverse_trivially_swappable_4(void* _Firs
             _Advance_bytes(_First, 16);
         } while (_First != _Stop_at);
     }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     _Reversing::_Reverse_tail(static_cast<unsigned long*>(_First), static_cast<unsigned long*>(_Last));
 }
@@ -347,7 +347,7 @@ __declspec(noalias) void __cdecl __std_reverse_trivially_swappable_8(void* _Firs
             _Advance_bytes(_First, 16);
         } while (_First != _Stop_at);
     }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     _Reversing::_Reverse_tail(static_cast<unsigned long long*>(_First), static_cast<unsigned long long*>(_Last));
 }
@@ -385,7 +385,7 @@ __declspec(noalias) void __cdecl __std_reverse_copy_trivially_copyable_1(
             _Advance_bytes(_Dest, 16);
         } while (_Dest != _Stop_at);
     }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     _Reversing::_Reverse_copy_tail(static_cast<const unsigned char*>(_First), static_cast<const unsigned char*>(_Last),
         static_cast<unsigned char*>(_Dest));
@@ -424,7 +424,7 @@ __declspec(noalias) void __cdecl __std_reverse_copy_trivially_copyable_2(
             _Advance_bytes(_Dest, 16);
         } while (_Dest != _Stop_at);
     }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     _Reversing::_Reverse_copy_tail(static_cast<const unsigned short*>(_First),
         static_cast<const unsigned short*>(_Last), static_cast<unsigned short*>(_Dest));
@@ -459,7 +459,7 @@ __declspec(noalias) void __cdecl __std_reverse_copy_trivially_copyable_4(
             _Advance_bytes(_Dest, 16);
         } while (_Dest != _Stop_at);
     }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     _Reversing::_Reverse_copy_tail(static_cast<const unsigned long*>(_First), static_cast<const unsigned long*>(_Last),
         static_cast<unsigned long*>(_Dest));
@@ -493,7 +493,7 @@ __declspec(noalias) void __cdecl __std_reverse_copy_trivially_copyable_8(
             _Advance_bytes(_Dest, 16);
         } while (_Dest != _Stop_at);
     }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
     _Reversing::_Reverse_copy_tail(static_cast<const unsigned long long*>(_First),
         static_cast<const unsigned long long*>(_Last), static_cast<unsigned long long*>(_Dest));
@@ -2766,7 +2766,7 @@ namespace {
                 return _mm_cmpeq_epi64(_Lhs, _Rhs);
             }
         };
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
         // TRANSITION, ABI: used only in functions preserved for binary compatibility
         template <class _Ty>
@@ -2859,7 +2859,7 @@ namespace {
                     _Advance_bytes(_First, 16);
                 } while (_First != _Stop_at);
             }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
             auto _Ptr = static_cast<const _Ty*>(_First);
             if constexpr (_Pred == _Predicate::_Not_equal) {
                 while (_Ptr != _Last && *_Ptr == _Val) {
@@ -2946,7 +2946,7 @@ namespace {
                     }
                 } while (_Last != _Stop_at);
             }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
             auto _Ptr = static_cast<const _Ty*>(_Last);
             for (;;) {
                 if (_Ptr == _First) {
@@ -3053,7 +3053,7 @@ namespace {
                     _Advance_bytes(_First, 16);
                 } while (_First != _Stop_at);
             }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
             auto _Ptr  = static_cast<const _Ty*>(_First);
             auto _Next = _Ptr + 1;
@@ -3152,7 +3152,7 @@ namespace {
                 _Mid1 = static_cast<const _Ty*>(_First);
                 _Rewind_bytes(_First, _lzcnt_u32(~_Carry));
             }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
             auto _Match_start    = static_cast<const _Ty*>(_First);
             const auto _Last_ptr = static_cast<const _Ty*>(_Last);
 
@@ -3461,7 +3461,7 @@ namespace {
                 return _Count_traits_8::_Reduce_sse(_Rx1);
             }
         };
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
         template <class _Traits, class _Ty>
         __declspec(noalias) size_t __stdcall _Count_impl(
@@ -3554,7 +3554,7 @@ namespace {
                     }
                 }
             }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
             for (auto _Ptr = static_cast<const _Ty*>(_First); _Ptr != _Last; ++_Ptr) {
                 if (*_Ptr == _Val) {
@@ -3708,7 +3708,7 @@ namespace {
                 }
             }
         } // namespace _Bitmap_details
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
         namespace _Bitmap_impl {
 #ifndef _M_ARM64EC
@@ -3958,7 +3958,7 @@ namespace {
 
                 return static_cast<size_t>(-1);
             }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
             using _Scalar_table_t = bool[256];
 
@@ -3994,7 +3994,7 @@ namespace {
                     _Table[*_Ptr] = true;
                 }
             }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
             template <class _Ty, _Predicate _Pred>
             size_t _Impl_first_scalar(
@@ -4469,7 +4469,7 @@ namespace {
                         _First1, _Haystack_length, _First2, _First2, _Last_needle_length_el);
                 }
             }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
             template <class _Ty>
             const void* _Dispatch_ptr(const void* const _First1, const void* const _Last1, const void* const _First2,
@@ -4486,7 +4486,7 @@ namespace {
                             _First1, _Byte_length(_First1, _Last1), _First2, _Byte_length(_First2, _Last2));
                     }
                 }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
                 return _Fallback<_Ty, _Predicate::_Any_of>(_First1, _Last1, _First2, _Last2);
             }
@@ -4555,7 +4555,7 @@ namespace {
                 return _Pos_from_ptr<_Ty>(
                     _Impl_4_8<_Ty>(_First1, _Size_bytes_1, _First2, _Size_bytes_2), _First1, _Last1);
             }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
             template <class _Ty, _Predicate _Pred>
             size_t _Dispatch_pos_fallback(const void* const _First1, const size_t _Count1, const void* const _First2,
@@ -4588,7 +4588,7 @@ namespace {
                         return _Dispatch_pos_avx_4_8<_Ty>(_First1, _Count1, _First2, _Count2);
                     }
                 }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
                 return _Dispatch_pos_fallback<_Ty, _Pred>(_First1, _Count1, _First2, _Count2);
             }
         } // namespace _First_of
@@ -4796,7 +4796,7 @@ namespace {
                     return static_cast<size_t>(_Not_found);
                 }
             }
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
             template <class _Ty, _Predicate _Pred>
             size_t _Dispatch_pos(const void* const _First1, const size_t _Count1, const void* const _First2,
@@ -4821,7 +4821,7 @@ namespace {
 
                     return _Impl<_Ty, _Pred>(_First1, _Count1, _First2, _Count2);
                 } else
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
                 {
                     alignas(32) _Scalar_table_t _Table = {};
                     if (_Build_scalar_table<_Ty>(_First2, _Count2, _Table)) {
@@ -5391,7 +5391,7 @@ namespace {
                 return _mm_cmpeq_epi64(_Lhs, _Rhs);
             }
         };
-#endif // !_M_ARM64EC
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
 
         template <class _Traits, class _Ty>
         __declspec(noalias) size_t __stdcall _Mismatch_impl(

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2690,7 +2690,7 @@ const void* __stdcall __std_is_sorted_until_d(
 } // extern "C"
 
 namespace {
-    namespace _Find {
+    namespace _Finding {
 #ifdef _M_ARM64EC
         using _Find_traits_1 = void;
         using _Find_traits_2 = void;
@@ -3189,7 +3189,7 @@ namespace {
                 }
             }
         }
-    } // namespace _Find
+    } // namespace _Finding
 } // unnamed namespace
 
 extern "C" {
@@ -3207,133 +3207,137 @@ const void* __stdcall __std_find_trivial_unsized_2(const void* const _First, con
     // it reads the characters sequentially and stops as soon as a matching character is found."
     // C23 7.32.4.6.9 "The wmemchr generic function"/2 lacks such wording,
     // so we don't use wmemchr(), avoiding issues with unreachable_sentinel_t.
-    return _Find::_Find_unsized_impl(_First, _Val);
+    return _Finding::_Find_unsized_impl(_First, _Val);
 }
 
 // TRANSITION, ABI: preserved for binary compatibility
 const void* __stdcall __std_find_trivial_unsized_4(const void* const _First, const uint32_t _Val) noexcept {
-    return _Find::_Find_unsized_impl(_First, _Val);
+    return _Finding::_Find_unsized_impl(_First, _Val);
 }
 
 // TRANSITION, ABI: preserved for binary compatibility
 const void* __stdcall __std_find_trivial_unsized_8(const void* const _First, const uint64_t _Val) noexcept {
-    return _Find::_Find_unsized_impl(_First, _Val);
+    return _Finding::_Find_unsized_impl(_First, _Val);
 }
 
 const void* __stdcall __std_find_trivial_1(
     const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return _Find::_Find_impl<_Find::_Find_traits_1, _Find::_Predicate::_Equal>(_First, _Last, _Val);
+    return _Finding::_Find_impl<_Finding::_Find_traits_1, _Finding::_Predicate::_Equal>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_trivial_2(
     const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return _Find::_Find_impl<_Find::_Find_traits_2, _Find::_Predicate::_Equal>(_First, _Last, _Val);
+    return _Finding::_Find_impl<_Finding::_Find_traits_2, _Finding::_Predicate::_Equal>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_trivial_4(
     const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return _Find::_Find_impl<_Find::_Find_traits_4, _Find::_Predicate::_Equal>(_First, _Last, _Val);
+    return _Finding::_Find_impl<_Finding::_Find_traits_4, _Finding::_Predicate::_Equal>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_trivial_8(
     const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return _Find::_Find_impl<_Find::_Find_traits_8, _Find::_Predicate::_Equal>(_First, _Last, _Val);
+    return _Finding::_Find_impl<_Finding::_Find_traits_8, _Finding::_Predicate::_Equal>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_last_trivial_1(
     const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return _Find::_Find_last_impl<_Find::_Find_traits_1, _Find::_Predicate::_Equal>(_First, _Last, _Val);
+    return _Finding::_Find_last_impl<_Finding::_Find_traits_1, _Finding::_Predicate::_Equal>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_last_trivial_2(
     const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return _Find::_Find_last_impl<_Find::_Find_traits_2, _Find::_Predicate::_Equal>(_First, _Last, _Val);
+    return _Finding::_Find_last_impl<_Finding::_Find_traits_2, _Finding::_Predicate::_Equal>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_last_trivial_4(
     const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return _Find::_Find_last_impl<_Find::_Find_traits_4, _Find::_Predicate::_Equal>(_First, _Last, _Val);
+    return _Finding::_Find_last_impl<_Finding::_Find_traits_4, _Finding::_Predicate::_Equal>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_last_trivial_8(
     const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return _Find::_Find_last_impl<_Find::_Find_traits_8, _Find::_Predicate::_Equal>(_First, _Last, _Val);
+    return _Finding::_Find_last_impl<_Finding::_Find_traits_8, _Finding::_Predicate::_Equal>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_not_ch_1(
     const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return _Find::_Find_impl<_Find::_Find_traits_1, _Find::_Predicate::_Not_equal>(_First, _Last, _Val);
+    return _Finding::_Find_impl<_Finding::_Find_traits_1, _Finding::_Predicate::_Not_equal>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_not_ch_2(
     const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return _Find::_Find_impl<_Find::_Find_traits_2, _Find::_Predicate::_Not_equal>(_First, _Last, _Val);
+    return _Finding::_Find_impl<_Finding::_Find_traits_2, _Finding::_Predicate::_Not_equal>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_not_ch_4(
     const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return _Find::_Find_impl<_Find::_Find_traits_4, _Find::_Predicate::_Not_equal>(_First, _Last, _Val);
+    return _Finding::_Find_impl<_Finding::_Find_traits_4, _Finding::_Predicate::_Not_equal>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_not_ch_8(
     const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return _Find::_Find_impl<_Find::_Find_traits_8, _Find::_Predicate::_Not_equal>(_First, _Last, _Val);
+    return _Finding::_Find_impl<_Finding::_Find_traits_8, _Finding::_Predicate::_Not_equal>(_First, _Last, _Val);
 }
 
 __declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_1(
     const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return _Find::_Find_last_pos_impl<_Find::_Find_traits_1, _Find::_Predicate::_Not_equal>(_First, _Last, _Val);
+    return _Finding::_Find_last_pos_impl<_Finding::_Find_traits_1, _Finding::_Predicate::_Not_equal>(
+        _First, _Last, _Val);
 }
 
 __declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_2(
     const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return _Find::_Find_last_pos_impl<_Find::_Find_traits_2, _Find::_Predicate::_Not_equal>(_First, _Last, _Val);
+    return _Finding::_Find_last_pos_impl<_Finding::_Find_traits_2, _Finding::_Predicate::_Not_equal>(
+        _First, _Last, _Val);
 }
 
 __declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_4(
     const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return _Find::_Find_last_pos_impl<_Find::_Find_traits_4, _Find::_Predicate::_Not_equal>(_First, _Last, _Val);
+    return _Finding::_Find_last_pos_impl<_Finding::_Find_traits_4, _Finding::_Predicate::_Not_equal>(
+        _First, _Last, _Val);
 }
 
 __declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_8(
     const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return _Find::_Find_last_pos_impl<_Find::_Find_traits_8, _Find::_Predicate::_Not_equal>(_First, _Last, _Val);
+    return _Finding::_Find_last_pos_impl<_Finding::_Find_traits_8, _Finding::_Predicate::_Not_equal>(
+        _First, _Last, _Val);
 }
 
 const void* __stdcall __std_adjacent_find_1(const void* const _First, const void* const _Last) noexcept {
-    return _Find::_Adjacent_find_impl<_Find::_Find_traits_1, uint8_t>(_First, _Last);
+    return _Finding::_Adjacent_find_impl<_Finding::_Find_traits_1, uint8_t>(_First, _Last);
 }
 
 const void* __stdcall __std_adjacent_find_2(const void* const _First, const void* const _Last) noexcept {
-    return _Find::_Adjacent_find_impl<_Find::_Find_traits_2, uint16_t>(_First, _Last);
+    return _Finding::_Adjacent_find_impl<_Finding::_Find_traits_2, uint16_t>(_First, _Last);
 }
 
 const void* __stdcall __std_adjacent_find_4(const void* const _First, const void* const _Last) noexcept {
-    return _Find::_Adjacent_find_impl<_Find::_Find_traits_4, uint32_t>(_First, _Last);
+    return _Finding::_Adjacent_find_impl<_Finding::_Find_traits_4, uint32_t>(_First, _Last);
 }
 
 const void* __stdcall __std_adjacent_find_8(const void* const _First, const void* const _Last) noexcept {
-    return _Find::_Adjacent_find_impl<_Find::_Find_traits_8, uint64_t>(_First, _Last);
+    return _Finding::_Adjacent_find_impl<_Finding::_Find_traits_8, uint64_t>(_First, _Last);
 }
 
 const void* __stdcall __std_search_n_1(
     const void* const _First, const void* const _Last, const size_t _Count, const uint8_t _Value) noexcept {
-    return _Find::_Search_n_impl<_Find::_Find_traits_1>(_First, _Last, _Count, _Value);
+    return _Finding::_Search_n_impl<_Finding::_Find_traits_1>(_First, _Last, _Count, _Value);
 }
 
 const void* __stdcall __std_search_n_2(
     const void* const _First, const void* const _Last, const size_t _Count, const uint16_t _Value) noexcept {
-    return _Find::_Search_n_impl<_Find::_Find_traits_2>(_First, _Last, _Count, _Value);
+    return _Finding::_Search_n_impl<_Finding::_Find_traits_2>(_First, _Last, _Count, _Value);
 }
 
 const void* __stdcall __std_search_n_4(
     const void* const _First, const void* const _Last, const size_t _Count, const uint32_t _Value) noexcept {
-    return _Find::_Search_n_impl<_Find::_Find_traits_4>(_First, _Last, _Count, _Value);
+    return _Finding::_Search_n_impl<_Finding::_Find_traits_4>(_First, _Last, _Count, _Value);
 }
 
 const void* __stdcall __std_search_n_8(
     const void* const _First, const void* const _Last, const size_t _Count, const uint64_t _Value) noexcept {
-    return _Find::_Search_n_impl<_Find::_Find_traits_8>(_First, _Last, _Count, _Value);
+    return _Finding::_Search_n_impl<_Finding::_Find_traits_8>(_First, _Last, _Count, _Value);
 }
 
 } // extern "C"
@@ -3346,7 +3350,7 @@ namespace {
         using _Count_traits_2 = void;
         using _Count_traits_1 = void;
 #else // ^^^ defined(_M_ARM64EC) / !defined(_M_ARM64EC) vvv
-        struct _Count_traits_8 : _Find::_Find_traits_8 {
+        struct _Count_traits_8 : _Finding::_Find_traits_8 {
             static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
                 return _mm256_sub_epi64(_Lhs, _Rhs);
             }
@@ -3372,7 +3376,7 @@ namespace {
             }
         };
 
-        struct _Count_traits_4 : _Find::_Find_traits_4 {
+        struct _Count_traits_4 : _Finding::_Find_traits_4 {
             // For AVX2, we use hadd_epi32 three times to combine pairs of 32-bit counters into 32-bit results.
             // Therefore, _Max_count is 0x1FFF'FFFF, which is 0xFFFF'FFF8 when doubled three times; any more would
             // overflow.
@@ -3406,7 +3410,7 @@ namespace {
             }
         };
 
-        struct _Count_traits_2 : _Find::_Find_traits_2 {
+        struct _Count_traits_2 : _Finding::_Find_traits_2 {
             // For both AVX2 and SSE4.2, we use hadd_epi16 once to combine pairs of 16-bit counters into 16-bit results.
             // Therefore, _Max_count is 0x7FFF, which is 0xFFFE when doubled; any more would overflow.
 
@@ -3433,7 +3437,7 @@ namespace {
             }
         };
 
-        struct _Count_traits_1 : _Find::_Find_traits_1 {
+        struct _Count_traits_1 : _Finding::_Find_traits_1 {
             // For AVX2, _Max_portion_size below is _Max_count * 32 bytes, and we have 1-byte elements.
             // We're using packed 8-bit counters, and 32 of those fit in 256 bits.
 
@@ -4931,7 +4935,7 @@ namespace {
             }
 
             if (_Count2 == 1) {
-                return _Find::_Find_impl<_Traits, _Find::_Predicate::_Equal>(
+                return _Finding::_Find_impl<_Traits, _Finding::_Predicate::_Equal>(
                     _First1, _Last1, *static_cast<const _Ty*>(_First2));
             }
 
@@ -5081,7 +5085,7 @@ namespace {
             }
 
             if (_Count2 == 1) {
-                return _Find::_Find_last_impl<_Traits, _Find::_Predicate::_Equal>(
+                return _Finding::_Find_last_impl<_Traits, _Finding::_Predicate::_Equal>(
                     _First1, _Last1, *static_cast<const _Ty*>(_First2));
             }
 
@@ -5326,22 +5330,22 @@ extern "C" {
 
 const void* __stdcall __std_search_1(
     const void* const _First1, const void* const _Last1, const void* const _First2, const size_t _Count2) noexcept {
-    return _Find_seq::_Search_impl<_Find::_Find_traits_1, uint8_t>(_First1, _Last1, _First2, _Count2);
+    return _Find_seq::_Search_impl<_Finding::_Find_traits_1, uint8_t>(_First1, _Last1, _First2, _Count2);
 }
 
 const void* __stdcall __std_search_2(
     const void* const _First1, const void* const _Last1, const void* const _First2, const size_t _Count2) noexcept {
-    return _Find_seq::_Search_impl<_Find::_Find_traits_2, uint16_t>(_First1, _Last1, _First2, _Count2);
+    return _Find_seq::_Search_impl<_Finding::_Find_traits_2, uint16_t>(_First1, _Last1, _First2, _Count2);
 }
 
 const void* __stdcall __std_find_end_1(
     const void* const _First1, const void* const _Last1, const void* const _First2, const size_t _Count2) noexcept {
-    return _Find_seq::_Find_end_impl<_Find::_Find_traits_1, uint8_t>(_First1, _Last1, _First2, _Count2);
+    return _Find_seq::_Find_end_impl<_Finding::_Find_traits_1, uint8_t>(_First1, _Last1, _First2, _Count2);
 }
 
 const void* __stdcall __std_find_end_2(
     const void* const _First1, const void* const _Last1, const void* const _First2, const size_t _Count2) noexcept {
-    return _Find_seq::_Find_end_impl<_Find::_Find_traits_2, uint16_t>(_First1, _Last1, _First2, _Count2);
+    return _Find_seq::_Find_end_impl<_Finding::_Find_traits_2, uint16_t>(_First1, _Last1, _First2, _Count2);
 }
 
 } // extern "C"

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -4902,380 +4902,139 @@ __declspec(noalias) size_t __stdcall __std_find_last_not_of_trivial_pos_2(const 
 } // extern "C"
 
 namespace {
-    template <class _Traits, class _Ty>
-    const void* __stdcall __std_search_impl(
-        const void* _First1, const void* const _Last1, const void* const _First2, const size_t _Count2) noexcept {
-        if (_Count2 == 0) {
-            return _First1;
-        }
+    namespace _Find_seq {
+        template <class _Traits, class _Ty>
+        const void* __stdcall _Search_impl(
+            const void* _First1, const void* const _Last1, const void* const _First2, const size_t _Count2) noexcept {
+            if (_Count2 == 0) {
+                return _First1;
+            }
 
-        if (_Count2 == 1) {
-            return __std_find_trivial_impl<_Traits, _Find_one_predicate::_Equal>(
-                _First1, _Last1, *static_cast<const _Ty*>(_First2));
-        }
+            if (_Count2 == 1) {
+                return __std_find_trivial_impl<_Traits, _Find_one_predicate::_Equal>(
+                    _First1, _Last1, *static_cast<const _Ty*>(_First2));
+            }
 
-        const size_t _Size_bytes_1 = _Byte_length(_First1, _Last1);
-        const size_t _Size_bytes_2 = _Count2 * sizeof(_Ty);
+            const size_t _Size_bytes_1 = _Byte_length(_First1, _Last1);
+            const size_t _Size_bytes_2 = _Count2 * sizeof(_Ty);
 
-        if (_Size_bytes_1 < _Size_bytes_2) {
-            return _Last1;
-        }
+            if (_Size_bytes_1 < _Size_bytes_2) {
+                return _Last1;
+            }
 
 #ifndef _M_ARM64EC
-        if (_Use_sse42() && _Size_bytes_1 >= 16) {
-            constexpr int _Op = (sizeof(_Ty) == 1 ? _SIDD_UBYTE_OPS : _SIDD_UWORD_OPS) | _SIDD_CMP_EQUAL_ORDERED;
-            constexpr int _Part_size_el = sizeof(_Ty) == 1 ? 16 : 8;
+            if (_Use_sse42() && _Size_bytes_1 >= 16) {
+                constexpr int _Op = (sizeof(_Ty) == 1 ? _SIDD_UBYTE_OPS : _SIDD_UWORD_OPS) | _SIDD_CMP_EQUAL_ORDERED;
+                constexpr int _Part_size_el = sizeof(_Ty) == 1 ? 16 : 8;
 
-            if (_Size_bytes_2 <= 16) {
-                const int _Size_el_2 = static_cast<int>(_Size_bytes_2 / sizeof(_Ty));
+                if (_Size_bytes_2 <= 16) {
+                    const int _Size_el_2 = static_cast<int>(_Size_bytes_2 / sizeof(_Ty));
 
-                const int _Max_full_match_pos = _Part_size_el - _Size_el_2;
+                    const int _Max_full_match_pos = _Part_size_el - _Size_el_2;
 
-                alignas(16) uint8_t _Tmp2[16];
-                memcpy(_Tmp2, _First2, _Size_bytes_2);
-                const __m128i _Data2 = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp2));
+                    alignas(16) uint8_t _Tmp2[16];
+                    memcpy(_Tmp2, _First2, _Size_bytes_2);
+                    const __m128i _Data2 = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp2));
 
-                const void* _Stop1 = _First1;
-                _Advance_bytes(_Stop1, _Size_bytes_1 - 16);
+                    const void* _Stop1 = _First1;
+                    _Advance_bytes(_Stop1, _Size_bytes_1 - 16);
 
-                do {
-                    const __m128i _Data1 = _mm_loadu_si128(static_cast<const __m128i*>(_First1));
+                    do {
+                        const __m128i _Data1 = _mm_loadu_si128(static_cast<const __m128i*>(_First1));
 
-                    if (!_mm_cmpestrc(_Data2, _Size_el_2, _Data1, _Part_size_el, _Op)) {
-                        _Advance_bytes(_First1, 16); // No matches, next.
-                    } else {
-                        const int _Pos = _mm_cmpestri(_Data2, _Size_el_2, _Data1, _Part_size_el, _Op);
-                        _Advance_bytes(_First1, _Pos * sizeof(_Ty));
-                        if (_Pos <= _Max_full_match_pos) {
-                            // Full match. Return this match.
-                            return _First1;
-                        }
-                        // Partial match. Search again from the match start. Will return it if it is full.
-                    }
-                } while (_First1 <= _Stop1);
-
-                const size_t _Size_bytes_1_tail = _Byte_length(_First1, _Last1);
-                if (_Size_bytes_1_tail != 0) {
-                    const int _Size_el_1_tail = static_cast<int>(_Size_bytes_1_tail / sizeof(_Ty));
-
-                    alignas(16) uint8_t _Tmp1[16];
-                    memcpy(_Tmp1, _First1, _Size_bytes_1_tail);
-                    const __m128i _Data1 = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp1));
-
-                    if (_mm_cmpestrc(_Data2, _Size_el_2, _Data1, _Size_el_1_tail, _Op)) {
-                        const int _Pos = _mm_cmpestri(_Data2, _Size_el_2, _Data1, _Size_el_1_tail, _Op);
-                        _Advance_bytes(_First1, _Pos * sizeof(_Ty));
-                        // Full match because size is less than 16. Return this match.
-                        return _First1;
-                    }
-                }
-            } else {
-                const __m128i _Data2  = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_First2));
-                const size_t _Max_pos = _Size_bytes_1 - _Size_bytes_2;
-
-                const void* _Stop1 = _First1;
-                _Advance_bytes(_Stop1, _Max_pos);
-
-                const void* _Tail2 = _First2;
-                _Advance_bytes(_Tail2, 16);
-
-                do {
-                    const __m128i _Data1 = _mm_loadu_si128(static_cast<const __m128i*>(_First1));
-                    if (!_mm_cmpestrc(_Data2, _Part_size_el, _Data1, _Part_size_el, _Op)) {
-                        _Advance_bytes(_First1, 16); // No matches, next.
-                    } else {
-                        const int _Pos = _mm_cmpestri(_Data2, _Part_size_el, _Data1, _Part_size_el, _Op);
-
-                        bool _Match_1st_16 = true;
-
-                        if (_Pos != 0) {
+                        if (!_mm_cmpestrc(_Data2, _Size_el_2, _Data1, _Part_size_el, _Op)) {
+                            _Advance_bytes(_First1, 16); // No matches, next.
+                        } else {
+                            const int _Pos = _mm_cmpestri(_Data2, _Size_el_2, _Data1, _Part_size_el, _Op);
                             _Advance_bytes(_First1, _Pos * sizeof(_Ty));
-
-                            if (_First1 > _Stop1) {
-                                break; // Oops, doesn't fit
-                            }
-
-                            // Match not from the first byte, check 16 symbols
-                            const __m128i _Match1 = _mm_loadu_si128(static_cast<const __m128i*>(_First1));
-                            const __m128i _Cmp    = _mm_xor_si128(_Data2, _Match1);
-                            if (!_mm_testz_si128(_Cmp, _Cmp)) {
-                                _Match_1st_16 = false;
-                            }
-                        }
-
-                        if (_Match_1st_16) {
-                            const void* _Tail1 = _First1;
-                            _Advance_bytes(_Tail1, 16);
-
-                            if (memcmp(_Tail1, _Tail2, _Size_bytes_2 - 16) == 0) {
+                            if (_Pos <= _Max_full_match_pos) {
+                                // Full match. Return this match.
                                 return _First1;
                             }
+                            // Partial match. Search again from the match start. Will return it if it is full.
                         }
+                    } while (_First1 <= _Stop1);
 
-                        // Start from the next element
-                        _Advance_bytes(_First1, sizeof(_Ty));
-                    }
-                } while (_First1 <= _Stop1);
-            }
+                    const size_t _Size_bytes_1_tail = _Byte_length(_First1, _Last1);
+                    if (_Size_bytes_1_tail != 0) {
+                        const int _Size_el_1_tail = static_cast<int>(_Size_bytes_1_tail / sizeof(_Ty));
 
-            return _Last1;
-        } else
-#endif // !defined(_M_ARM64EC)
-        {
-            const size_t _Max_pos = _Size_bytes_1 - _Size_bytes_2 + sizeof(_Ty);
+                        alignas(16) uint8_t _Tmp1[16];
+                        memcpy(_Tmp1, _First1, _Size_bytes_1_tail);
+                        const __m128i _Data1 = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp1));
 
-            auto _Ptr1         = static_cast<const _Ty*>(_First1);
-            const auto _Ptr2   = static_cast<const _Ty*>(_First2);
-            const void* _Stop1 = _Ptr1;
-            _Advance_bytes(_Stop1, _Max_pos);
-
-            for (; _Ptr1 != _Stop1; ++_Ptr1) {
-                if (*_Ptr1 != *_Ptr2) {
-                    continue;
-                }
-
-                bool _Equal = true;
-
-                for (size_t _Idx = 1; _Idx != _Count2; ++_Idx) {
-                    if (_Ptr1[_Idx] != _Ptr2[_Idx]) {
-                        _Equal = false;
-                        break;
-                    }
-                }
-
-                if (_Equal) {
-                    return _Ptr1;
-                }
-            }
-
-            return _Last1;
-        }
-    }
-
-    template <class _Traits, class _Ty>
-    const void* __stdcall __std_find_end_impl(
-        const void* const _First1, const void* const _Last1, const void* const _First2, const size_t _Count2) noexcept {
-        if (_Count2 == 0) {
-            return _Last1;
-        }
-
-        if (_Count2 == 1) {
-            return __std_find_last_trivial_impl<_Traits, _Find_one_predicate::_Equal>(
-                _First1, _Last1, *static_cast<const _Ty*>(_First2));
-        }
-
-        const size_t _Size_bytes_1 = _Byte_length(_First1, _Last1);
-        const size_t _Size_bytes_2 = _Count2 * sizeof(_Ty);
-
-        if (_Size_bytes_1 < _Size_bytes_2) {
-            return _Last1;
-        }
-
-#ifndef _M_ARM64EC
-        if (_Use_sse42() && _Size_bytes_1 >= 16) {
-            constexpr int _Op = (sizeof(_Ty) == 1 ? _SIDD_UBYTE_OPS : _SIDD_UWORD_OPS) | _SIDD_CMP_EQUAL_ORDERED;
-            constexpr int _Part_size_el = sizeof(_Ty) == 1 ? 16 : 8;
-
-            static constexpr int8_t _Low_part_mask[] = {//
-                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, //
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-
-            if (_Size_bytes_2 <= 16) {
-                const int _Size_el_2                  = static_cast<int>(_Count2);
-                constexpr unsigned int _Whole_mask    = (1 << _Part_size_el) - 1;
-                const unsigned int _Needle_fit_mask   = (1 << (_Part_size_el - _Size_el_2 + 1)) - 1;
-                const unsigned int _Needle_unfit_mask = _Whole_mask ^ _Needle_fit_mask;
-
-                const void* _Stop1 = _First1;
-                _Advance_bytes(_Stop1, _Size_bytes_1 & 0xF);
-
-                alignas(16) uint8_t _Tmp2[16];
-                memcpy(_Tmp2, _First2, _Size_bytes_2);
-                const __m128i _Data2 = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp2));
-
-                const void* _Mid1 = _Last1;
-                _Rewind_bytes(_Mid1, 16);
-
-                const auto _Check_fit = [&_Mid1, _Needle_fit_mask](const unsigned int _Match) noexcept {
-                    const unsigned int _Fit_match = _Match & _Needle_fit_mask;
-                    if (_Fit_match != 0) {
-                        unsigned long _Match_last_pos;
-
-                        // CodeQL [SM02313] Result is always initialized: we just tested that _Fit_match is non-zero.
-                        _BitScanReverse(&_Match_last_pos, _Fit_match);
-
-                        _Advance_bytes(_Mid1, _Match_last_pos * sizeof(_Ty));
-                        return true;
-                    }
-
-                    return false;
-                };
-
-#pragma warning(push)
-#pragma warning(disable : 4324) // structure was padded due to alignment specifier
-                const auto _Check_unfit = [=, &_Mid1](const unsigned int _Match) noexcept {
-                    long _Unfit_match = _Match & _Needle_unfit_mask;
-                    while (_Unfit_match != 0) {
-                        const void* _Tmp1 = _Mid1;
-                        unsigned long _Match_last_pos;
-
-                        // CodeQL [SM02313] Result is always initialized: we just tested that _Unfit_match is non-zero.
-                        _BitScanReverse(&_Match_last_pos, _Unfit_match);
-
-                        _Advance_bytes(_Tmp1, _Match_last_pos * sizeof(_Ty));
-
-                        const __m128i _Match_data = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Tmp1));
-                        const __m128i _Cmp_result = _mm_xor_si128(_Data2, _Match_data);
-                        const __m128i _Data_mask =
-                            _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Low_part_mask + 16 - _Size_bytes_2));
-
-                        if (_mm_testz_si128(_Cmp_result, _Data_mask)) {
-                            _Mid1 = _Tmp1;
-                            return true;
+                        if (_mm_cmpestrc(_Data2, _Size_el_2, _Data1, _Size_el_1_tail, _Op)) {
+                            const int _Pos = _mm_cmpestri(_Data2, _Size_el_2, _Data1, _Size_el_1_tail, _Op);
+                            _Advance_bytes(_First1, _Pos * sizeof(_Ty));
+                            // Full match because size is less than 16. Return this match.
+                            return _First1;
                         }
-
-                        _bittestandreset(&_Unfit_match, _Match_last_pos);
                     }
+                } else {
+                    const __m128i _Data2  = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_First2));
+                    const size_t _Max_pos = _Size_bytes_1 - _Size_bytes_2;
 
-                    return false;
-                };
-#pragma warning(pop)
+                    const void* _Stop1 = _First1;
+                    _Advance_bytes(_Stop1, _Max_pos);
 
-                // TRANSITION, DevCom-10689455, the code below could test with _mm_cmpestrc,
-                // if it has been fused with _mm_cmpestrm.
+                    const void* _Tail2 = _First2;
+                    _Advance_bytes(_Tail2, 16);
 
-                // The very last part, for any match needle should fit, otherwise false match
-                const __m128i _Data1_last          = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Mid1));
-                const auto _Match_last             = _mm_cmpestrm(_Data2, _Size_el_2, _Data1_last, _Part_size_el, _Op);
-                const unsigned int _Match_last_val = _mm_cvtsi128_si32(_Match_last);
-                if (_Check_fit(_Match_last_val)) {
-                    return _Mid1;
-                }
+                    do {
+                        const __m128i _Data1 = _mm_loadu_si128(static_cast<const __m128i*>(_First1));
+                        if (!_mm_cmpestrc(_Data2, _Part_size_el, _Data1, _Part_size_el, _Op)) {
+                            _Advance_bytes(_First1, 16); // No matches, next.
+                        } else {
+                            const int _Pos = _mm_cmpestri(_Data2, _Part_size_el, _Data1, _Part_size_el, _Op);
 
-                // The middle part, fit and unfit needle
-                while (_Mid1 != _Stop1) {
-                    _Rewind_bytes(_Mid1, 16);
-                    const __m128i _Data1          = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Mid1));
-                    const auto _Match             = _mm_cmpestrm(_Data2, _Size_el_2, _Data1, _Part_size_el, _Op);
-                    const unsigned int _Match_val = _mm_cvtsi128_si32(_Match);
-                    if (_Match_val != 0 && (_Check_unfit(_Match_val) || _Check_fit(_Match_val))) {
-                        return _Mid1;
-                    }
-                }
+                            bool _Match_1st_16 = true;
 
-                // The first part, fit and unfit needle, mask out already processed positions
-                if (const size_t _Tail_bytes_1 = _Size_bytes_1 & 0xF; _Tail_bytes_1 != 0) {
-                    _Mid1                         = _First1;
-                    const __m128i _Data1          = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Mid1));
-                    const auto _Match             = _mm_cmpestrm(_Data2, _Size_el_2, _Data1, _Part_size_el, _Op);
-                    const unsigned int _Match_val = _mm_cvtsi128_si32(_Match) & ((1 << _Tail_bytes_1) - 1);
-                    if (_Match_val != 0 && (_Check_unfit(_Match_val) || _Check_fit(_Match_val))) {
-                        return _Mid1;
-                    }
+                            if (_Pos != 0) {
+                                _Advance_bytes(_First1, _Pos * sizeof(_Ty));
+
+                                if (_First1 > _Stop1) {
+                                    break; // Oops, doesn't fit
+                                }
+
+                                // Match not from the first byte, check 16 symbols
+                                const __m128i _Match1 = _mm_loadu_si128(static_cast<const __m128i*>(_First1));
+                                const __m128i _Cmp    = _mm_xor_si128(_Data2, _Match1);
+                                if (!_mm_testz_si128(_Cmp, _Cmp)) {
+                                    _Match_1st_16 = false;
+                                }
+                            }
+
+                            if (_Match_1st_16) {
+                                const void* _Tail1 = _First1;
+                                _Advance_bytes(_Tail1, 16);
+
+                                if (memcmp(_Tail1, _Tail2, _Size_bytes_2 - 16) == 0) {
+                                    return _First1;
+                                }
+                            }
+
+                            // Start from the next element
+                            _Advance_bytes(_First1, sizeof(_Ty));
+                        }
+                    } while (_First1 <= _Stop1);
                 }
 
                 return _Last1;
-            } else {
-                const __m128i _Data2 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_First2));
-
-                const void* _Tail2 = _First2;
-                _Advance_bytes(_Tail2, 16);
-
-                const void* _Mid1 = _Last1;
-                _Rewind_bytes(_Mid1, _Size_bytes_2);
-
-                const size_t _Size_diff_bytes = _Size_bytes_1 - _Size_bytes_2;
-                const void* _Stop1            = _First1;
-                _Advance_bytes(_Stop1, _Size_diff_bytes & 0xF);
-
-#pragma warning(push)
-#pragma warning(disable : 4324) // structure was padded due to alignment specifier
-                const auto _Check = [=, &_Mid1](long _Match) noexcept {
-                    while (_Match != 0) {
-                        const void* _Tmp1 = _Mid1;
-                        unsigned long _Match_last_pos;
-
-                        // CodeQL [SM02313] Result is always initialized: we just tested that _Match is non-zero.
-                        _BitScanReverse(&_Match_last_pos, _Match);
-
-                        bool _Match_1st_16 = true;
-
-                        if (_Match_last_pos != 0) {
-                            _Advance_bytes(_Tmp1, _Match_last_pos * sizeof(_Ty));
-
-                            const __m128i _Match_data = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Tmp1));
-                            const __m128i _Cmp_result = _mm_xor_si128(_Data2, _Match_data);
-
-                            if (!_mm_testz_si128(_Cmp_result, _Cmp_result)) {
-                                _Match_1st_16 = false;
-                            }
-                        }
-
-                        if (_Match_1st_16) {
-                            const void* _Tail1 = _Tmp1;
-                            _Advance_bytes(_Tail1, 16);
-
-                            if (memcmp(_Tail1, _Tail2, _Size_bytes_2 - 16) == 0) {
-                                _Mid1 = _Tmp1;
-                                return true;
-                            }
-                        }
-
-                        _bittestandreset(&_Match, _Match_last_pos);
-                    }
-
-                    return false;
-                };
-#pragma warning(pop)
-                // The very last part, just compare, as true match must start with first symbol
-                const __m128i _Data1_last = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Mid1));
-                const __m128i _Match_last = _mm_xor_si128(_Data2, _Data1_last);
-                if (_mm_testz_si128(_Match_last, _Match_last)) {
-                    // Matched 16 bytes, check the rest
-                    const void* _Tail1 = _Mid1;
-                    _Advance_bytes(_Tail1, 16);
-
-                    if (memcmp(_Tail1, _Tail2, _Size_bytes_2 - 16) == 0) {
-                        return _Mid1;
-                    }
-                }
-
-                // TRANSITION, DevCom-10689455, the code below could test with _mm_cmpestrc,
-                // if it has been fused with _mm_cmpestrm.
-
-                // The main part, match all characters
-                while (_Mid1 != _Stop1) {
-                    _Rewind_bytes(_Mid1, 16);
-
-                    const __m128i _Data1          = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Mid1));
-                    const auto _Match             = _mm_cmpestrm(_Data2, _Part_size_el, _Data1, _Part_size_el, _Op);
-                    const unsigned int _Match_val = _mm_cvtsi128_si32(_Match);
-                    if (_Match_val != 0 && _Check(_Match_val)) {
-                        return _Mid1;
-                    }
-                }
-
-                // The first part, mask out already processed positions
-                if (const size_t _Tail_bytes_1 = _Size_diff_bytes & 0xF; _Tail_bytes_1 != 0) {
-                    _Mid1                         = _First1;
-                    const __m128i _Data1          = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Mid1));
-                    const auto _Match             = _mm_cmpestrm(_Data2, _Part_size_el, _Data1, _Part_size_el, _Op);
-                    const unsigned int _Match_val = _mm_cvtsi128_si32(_Match) & ((1 << _Tail_bytes_1) - 1);
-                    if (_Match_val != 0 && _Check(_Match_val)) {
-                        return _Mid1;
-                    }
-                }
-
-                return _Last1;
-            }
-        } else
+            } else
 #endif // !defined(_M_ARM64EC)
-        {
-            auto _Ptr1       = static_cast<const _Ty*>(_Last1) - _Count2;
-            const auto _Ptr2 = static_cast<const _Ty*>(_First2);
+            {
+                const size_t _Max_pos = _Size_bytes_1 - _Size_bytes_2 + sizeof(_Ty);
 
-            for (;;) {
-                if (*_Ptr1 == *_Ptr2) {
+                auto _Ptr1         = static_cast<const _Ty*>(_First1);
+                const auto _Ptr2   = static_cast<const _Ty*>(_First2);
+                const void* _Stop1 = _Ptr1;
+                _Advance_bytes(_Stop1, _Max_pos);
+
+                for (; _Ptr1 != _Stop1; ++_Ptr1) {
+                    if (*_Ptr1 != *_Ptr2) {
+                        continue;
+                    }
+
                     bool _Equal = true;
 
                     for (size_t _Idx = 1; _Idx != _Count2; ++_Idx) {
@@ -5290,36 +5049,279 @@ namespace {
                     }
                 }
 
-                if (_Ptr1 == _First1) {
-                    return _Last1;
-                }
-
-                --_Ptr1;
+                return _Last1;
             }
         }
-    }
+
+        template <class _Traits, class _Ty>
+        const void* __stdcall _Find_end_impl(const void* const _First1, const void* const _Last1,
+            const void* const _First2, const size_t _Count2) noexcept {
+            if (_Count2 == 0) {
+                return _Last1;
+            }
+
+            if (_Count2 == 1) {
+                return __std_find_last_trivial_impl<_Traits, _Find_one_predicate::_Equal>(
+                    _First1, _Last1, *static_cast<const _Ty*>(_First2));
+            }
+
+            const size_t _Size_bytes_1 = _Byte_length(_First1, _Last1);
+            const size_t _Size_bytes_2 = _Count2 * sizeof(_Ty);
+
+            if (_Size_bytes_1 < _Size_bytes_2) {
+                return _Last1;
+            }
+
+#ifndef _M_ARM64EC
+            if (_Use_sse42() && _Size_bytes_1 >= 16) {
+                constexpr int _Op = (sizeof(_Ty) == 1 ? _SIDD_UBYTE_OPS : _SIDD_UWORD_OPS) | _SIDD_CMP_EQUAL_ORDERED;
+                constexpr int _Part_size_el = sizeof(_Ty) == 1 ? 16 : 8;
+
+                static constexpr int8_t _Low_part_mask[] = {//
+                    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, //
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+                if (_Size_bytes_2 <= 16) {
+                    const int _Size_el_2                  = static_cast<int>(_Count2);
+                    constexpr unsigned int _Whole_mask    = (1 << _Part_size_el) - 1;
+                    const unsigned int _Needle_fit_mask   = (1 << (_Part_size_el - _Size_el_2 + 1)) - 1;
+                    const unsigned int _Needle_unfit_mask = _Whole_mask ^ _Needle_fit_mask;
+
+                    const void* _Stop1 = _First1;
+                    _Advance_bytes(_Stop1, _Size_bytes_1 & 0xF);
+
+                    alignas(16) uint8_t _Tmp2[16];
+                    memcpy(_Tmp2, _First2, _Size_bytes_2);
+                    const __m128i _Data2 = _mm_load_si128(reinterpret_cast<const __m128i*>(_Tmp2));
+
+                    const void* _Mid1 = _Last1;
+                    _Rewind_bytes(_Mid1, 16);
+
+                    const auto _Check_fit = [&_Mid1, _Needle_fit_mask](const unsigned int _Match) noexcept {
+                        const unsigned int _Fit_match = _Match & _Needle_fit_mask;
+                        if (_Fit_match != 0) {
+                            unsigned long _Match_last_pos;
+
+                            // CodeQL [SM02313] Result is always initialized: we just tested that _Fit_match != 0.
+                            _BitScanReverse(&_Match_last_pos, _Fit_match);
+
+                            _Advance_bytes(_Mid1, _Match_last_pos * sizeof(_Ty));
+                            return true;
+                        }
+
+                        return false;
+                    };
+
+#pragma warning(push)
+#pragma warning(disable : 4324) // structure was padded due to alignment specifier
+                    const auto _Check_unfit = [=, &_Mid1](const unsigned int _Match) noexcept {
+                        long _Unfit_match = _Match & _Needle_unfit_mask;
+                        while (_Unfit_match != 0) {
+                            const void* _Tmp1 = _Mid1;
+                            unsigned long _Match_last_pos;
+
+                            // CodeQL [SM02313] Result is always initialized: we just tested that _Unfit_match != 0.
+                            _BitScanReverse(&_Match_last_pos, _Unfit_match);
+
+                            _Advance_bytes(_Tmp1, _Match_last_pos * sizeof(_Ty));
+
+                            const __m128i _Match_data = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Tmp1));
+                            const __m128i _Cmp_result = _mm_xor_si128(_Data2, _Match_data);
+                            const __m128i _Data_mask =
+                                _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Low_part_mask + 16 - _Size_bytes_2));
+
+                            if (_mm_testz_si128(_Cmp_result, _Data_mask)) {
+                                _Mid1 = _Tmp1;
+                                return true;
+                            }
+
+                            _bittestandreset(&_Unfit_match, _Match_last_pos);
+                        }
+
+                        return false;
+                    };
+#pragma warning(pop)
+
+                    // TRANSITION, DevCom-10689455, the code below could test with _mm_cmpestrc,
+                    // if it has been fused with _mm_cmpestrm.
+
+                    // The very last part, for any match needle should fit, otherwise false match
+                    const __m128i _Data1_last = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Mid1));
+                    const auto _Match_last    = _mm_cmpestrm(_Data2, _Size_el_2, _Data1_last, _Part_size_el, _Op);
+                    const unsigned int _Match_last_val = _mm_cvtsi128_si32(_Match_last);
+                    if (_Check_fit(_Match_last_val)) {
+                        return _Mid1;
+                    }
+
+                    // The middle part, fit and unfit needle
+                    while (_Mid1 != _Stop1) {
+                        _Rewind_bytes(_Mid1, 16);
+                        const __m128i _Data1          = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Mid1));
+                        const auto _Match             = _mm_cmpestrm(_Data2, _Size_el_2, _Data1, _Part_size_el, _Op);
+                        const unsigned int _Match_val = _mm_cvtsi128_si32(_Match);
+                        if (_Match_val != 0 && (_Check_unfit(_Match_val) || _Check_fit(_Match_val))) {
+                            return _Mid1;
+                        }
+                    }
+
+                    // The first part, fit and unfit needle, mask out already processed positions
+                    if (const size_t _Tail_bytes_1 = _Size_bytes_1 & 0xF; _Tail_bytes_1 != 0) {
+                        _Mid1                         = _First1;
+                        const __m128i _Data1          = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Mid1));
+                        const auto _Match             = _mm_cmpestrm(_Data2, _Size_el_2, _Data1, _Part_size_el, _Op);
+                        const unsigned int _Match_val = _mm_cvtsi128_si32(_Match) & ((1 << _Tail_bytes_1) - 1);
+                        if (_Match_val != 0 && (_Check_unfit(_Match_val) || _Check_fit(_Match_val))) {
+                            return _Mid1;
+                        }
+                    }
+
+                    return _Last1;
+                } else {
+                    const __m128i _Data2 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_First2));
+
+                    const void* _Tail2 = _First2;
+                    _Advance_bytes(_Tail2, 16);
+
+                    const void* _Mid1 = _Last1;
+                    _Rewind_bytes(_Mid1, _Size_bytes_2);
+
+                    const size_t _Size_diff_bytes = _Size_bytes_1 - _Size_bytes_2;
+                    const void* _Stop1            = _First1;
+                    _Advance_bytes(_Stop1, _Size_diff_bytes & 0xF);
+
+#pragma warning(push)
+#pragma warning(disable : 4324) // structure was padded due to alignment specifier
+                    const auto _Check = [=, &_Mid1](long _Match) noexcept {
+                        while (_Match != 0) {
+                            const void* _Tmp1 = _Mid1;
+                            unsigned long _Match_last_pos;
+
+                            // CodeQL [SM02313] Result is always initialized: we just tested that _Match != 0.
+                            _BitScanReverse(&_Match_last_pos, _Match);
+
+                            bool _Match_1st_16 = true;
+
+                            if (_Match_last_pos != 0) {
+                                _Advance_bytes(_Tmp1, _Match_last_pos * sizeof(_Ty));
+
+                                const __m128i _Match_data = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Tmp1));
+                                const __m128i _Cmp_result = _mm_xor_si128(_Data2, _Match_data);
+
+                                if (!_mm_testz_si128(_Cmp_result, _Cmp_result)) {
+                                    _Match_1st_16 = false;
+                                }
+                            }
+
+                            if (_Match_1st_16) {
+                                const void* _Tail1 = _Tmp1;
+                                _Advance_bytes(_Tail1, 16);
+
+                                if (memcmp(_Tail1, _Tail2, _Size_bytes_2 - 16) == 0) {
+                                    _Mid1 = _Tmp1;
+                                    return true;
+                                }
+                            }
+
+                            _bittestandreset(&_Match, _Match_last_pos);
+                        }
+
+                        return false;
+                    };
+#pragma warning(pop)
+                    // The very last part, just compare, as true match must start with first symbol
+                    const __m128i _Data1_last = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Mid1));
+                    const __m128i _Match_last = _mm_xor_si128(_Data2, _Data1_last);
+                    if (_mm_testz_si128(_Match_last, _Match_last)) {
+                        // Matched 16 bytes, check the rest
+                        const void* _Tail1 = _Mid1;
+                        _Advance_bytes(_Tail1, 16);
+
+                        if (memcmp(_Tail1, _Tail2, _Size_bytes_2 - 16) == 0) {
+                            return _Mid1;
+                        }
+                    }
+
+                    // TRANSITION, DevCom-10689455, the code below could test with _mm_cmpestrc,
+                    // if it has been fused with _mm_cmpestrm.
+
+                    // The main part, match all characters
+                    while (_Mid1 != _Stop1) {
+                        _Rewind_bytes(_Mid1, 16);
+
+                        const __m128i _Data1          = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Mid1));
+                        const auto _Match             = _mm_cmpestrm(_Data2, _Part_size_el, _Data1, _Part_size_el, _Op);
+                        const unsigned int _Match_val = _mm_cvtsi128_si32(_Match);
+                        if (_Match_val != 0 && _Check(_Match_val)) {
+                            return _Mid1;
+                        }
+                    }
+
+                    // The first part, mask out already processed positions
+                    if (const size_t _Tail_bytes_1 = _Size_diff_bytes & 0xF; _Tail_bytes_1 != 0) {
+                        _Mid1                         = _First1;
+                        const __m128i _Data1          = _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Mid1));
+                        const auto _Match             = _mm_cmpestrm(_Data2, _Part_size_el, _Data1, _Part_size_el, _Op);
+                        const unsigned int _Match_val = _mm_cvtsi128_si32(_Match) & ((1 << _Tail_bytes_1) - 1);
+                        if (_Match_val != 0 && _Check(_Match_val)) {
+                            return _Mid1;
+                        }
+                    }
+
+                    return _Last1;
+                }
+            } else
+#endif // !defined(_M_ARM64EC)
+            {
+                auto _Ptr1       = static_cast<const _Ty*>(_Last1) - _Count2;
+                const auto _Ptr2 = static_cast<const _Ty*>(_First2);
+
+                for (;;) {
+                    if (*_Ptr1 == *_Ptr2) {
+                        bool _Equal = true;
+
+                        for (size_t _Idx = 1; _Idx != _Count2; ++_Idx) {
+                            if (_Ptr1[_Idx] != _Ptr2[_Idx]) {
+                                _Equal = false;
+                                break;
+                            }
+                        }
+
+                        if (_Equal) {
+                            return _Ptr1;
+                        }
+                    }
+
+                    if (_Ptr1 == _First1) {
+                        return _Last1;
+                    }
+
+                    --_Ptr1;
+                }
+            }
+        }
+    } // namespace _Find_seq
 } // unnamed namespace
 
 extern "C" {
 
 const void* __stdcall __std_search_1(
     const void* const _First1, const void* const _Last1, const void* const _First2, const size_t _Count2) noexcept {
-    return __std_search_impl<_Find_traits_1, uint8_t>(_First1, _Last1, _First2, _Count2);
+    return _Find_seq::_Search_impl<_Find_traits_1, uint8_t>(_First1, _Last1, _First2, _Count2);
 }
 
 const void* __stdcall __std_search_2(
     const void* const _First1, const void* const _Last1, const void* const _First2, const size_t _Count2) noexcept {
-    return __std_search_impl<_Find_traits_2, uint16_t>(_First1, _Last1, _First2, _Count2);
+    return _Find_seq::_Search_impl<_Find_traits_2, uint16_t>(_First1, _Last1, _First2, _Count2);
 }
 
 const void* __stdcall __std_find_end_1(
     const void* const _First1, const void* const _Last1, const void* const _First2, const size_t _Count2) noexcept {
-    return __std_find_end_impl<_Find_traits_1, uint8_t>(_First1, _Last1, _First2, _Count2);
+    return _Find_seq::_Find_end_impl<_Find_traits_1, uint8_t>(_First1, _Last1, _First2, _Count2);
 }
 
 const void* __stdcall __std_find_end_2(
     const void* const _First1, const void* const _Last1, const void* const _First2, const size_t _Count2) noexcept {
-    return __std_find_end_impl<_Find_traits_2, uint16_t>(_First1, _Last1, _First2, _Count2);
+    return _Find_seq::_Find_end_impl<_Find_traits_2, uint16_t>(_First1, _Last1, _First2, _Count2);
 }
 
 } // extern "C"

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -5351,7 +5351,7 @@ const void* __stdcall __std_find_end_2(
 } // extern "C"
 
 namespace {
-    namespace _Mismatch {
+    namespace _Mismatching {
 #ifdef _M_ARM64EC
         using _Traits_1 = void;
         using _Traits_2 = void;
@@ -5476,29 +5476,29 @@ namespace {
 
             return _Result;
         }
-    } // namespace _Mismatch
+    } // namespace _Mismatching
 } // unnamed namespace
 
 extern "C" {
 
 __declspec(noalias) size_t __stdcall __std_mismatch_1(
     const void* const _First1, const void* const _First2, const size_t _Count) noexcept {
-    return _Mismatch::_Mismatch_impl<_Mismatch::_Traits_1, uint8_t>(_First1, _First2, _Count);
+    return _Mismatching::_Mismatch_impl<_Mismatching::_Traits_1, uint8_t>(_First1, _First2, _Count);
 }
 
 __declspec(noalias) size_t __stdcall __std_mismatch_2(
     const void* const _First1, const void* const _First2, const size_t _Count) noexcept {
-    return _Mismatch::_Mismatch_impl<_Mismatch::_Traits_2, uint16_t>(_First1, _First2, _Count);
+    return _Mismatching::_Mismatch_impl<_Mismatching::_Traits_2, uint16_t>(_First1, _First2, _Count);
 }
 
 __declspec(noalias) size_t __stdcall __std_mismatch_4(
     const void* const _First1, const void* const _First2, const size_t _Count) noexcept {
-    return _Mismatch::_Mismatch_impl<_Mismatch::_Traits_4, uint32_t>(_First1, _First2, _Count);
+    return _Mismatching::_Mismatch_impl<_Mismatching::_Traits_4, uint32_t>(_First1, _First2, _Count);
 }
 
 __declspec(noalias) size_t __stdcall __std_mismatch_8(
     const void* const _First1, const void* const _First2, const size_t _Count) noexcept {
-    return _Mismatch::_Mismatch_impl<_Mismatch::_Traits_8, uint64_t>(_First1, _First2, _Count);
+    return _Mismatching::_Mismatch_impl<_Mismatching::_Traits_8, uint64_t>(_First1, _First2, _Count);
 }
 
 __declspec(noalias) void __stdcall __std_replace_4(

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2315,7 +2315,6 @@ namespace {
             return _Minmax_impl<_Mode, typename _Traits::_Scalar, _Sign>(_First, _Last);
         }
 
-
         template <class _Traits, class _Ty>
         const void* _Is_sorted_until_impl(const void* _First, const void* const _Last, const bool _Greater) noexcept {
             const ptrdiff_t _Left_off  = 0 - static_cast<ptrdiff_t>(_Greater);
@@ -3913,7 +3912,6 @@ namespace {
 
                 return static_cast<size_t>(-1);
             }
-
 
             template <class _Ty, _Predicate _Pred>
             size_t _Impl_last_avx(const void* const _Haystack, size_t _Haystack_length, const void* const _Needle,

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -3038,231 +3038,6 @@ namespace {
         return _Last;
     }
 
-    struct _Count_traits_8 : _Find_traits_8 {
-#ifndef _M_ARM64EC
-        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
-            return _mm256_sub_epi64(_Lhs, _Rhs);
-        }
-
-        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
-            return _mm_sub_epi64(_Lhs, _Rhs);
-        }
-
-        static size_t _Reduce_avx(const __m256i _Val) noexcept {
-            const __m128i _Lo64 = _mm256_extracti128_si256(_Val, 0);
-            const __m128i _Hi64 = _mm256_extracti128_si256(_Val, 1);
-            const __m128i _Rx8  = _mm_add_epi64(_Lo64, _Hi64);
-            return _Reduce_sse(_Rx8);
-        }
-
-        static size_t _Reduce_sse(const __m128i _Val) noexcept {
-#ifdef _M_IX86
-            return static_cast<uint32_t>(_mm_cvtsi128_si32(_Val)) + static_cast<uint32_t>(_mm_extract_epi32(_Val, 2));
-#else // ^^^ defined(_M_IX86) / defined(_M_X64) vvv
-            return _mm_cvtsi128_si64(_Val) + _mm_extract_epi64(_Val, 1);
-#endif // ^^^ defined(_M_X64) ^^^
-        }
-#endif // !_M_ARM64EC
-    };
-
-    struct _Count_traits_4 : _Find_traits_4 {
-#ifndef _M_ARM64EC
-        // For AVX2, we use hadd_epi32 three times to combine pairs of 32-bit counters into 32-bit results.
-        // Therefore, _Max_count is 0x1FFF'FFFF, which is 0xFFFF'FFF8 when doubled three times; any more would overflow.
-
-        // For SSE4.2, we use hadd_epi32 twice. This would allow a larger limit,
-        // but it's simpler to use the smaller limit for both codepaths.
-
-        static constexpr size_t _Max_count = 0x1FFF'FFFF;
-
-        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
-            return _mm256_sub_epi32(_Lhs, _Rhs);
-        }
-
-        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
-            return _mm_sub_epi32(_Lhs, _Rhs);
-        }
-
-        static size_t _Reduce_avx(const __m256i _Val) noexcept {
-            constexpr auto _Shuf = _MM_SHUFFLE(3, 1, 2, 0); // Cross lane, to reduce further on low lane
-            const __m256i _Rx4   = _mm256_hadd_epi32(_Val, _mm256_setzero_si256()); // (0+1),(2+3),0,0 per lane
-            const __m256i _Rx5   = _mm256_permute4x64_epi64(_Rx4, _Shuf); // low lane  (0+1),(2+3),(4+5),(6+7)
-            const __m256i _Rx6   = _mm256_hadd_epi32(_Rx5, _mm256_setzero_si256()); // (0+...+3),(4+...+7),0,0
-            const __m256i _Rx7   = _mm256_hadd_epi32(_Rx6, _mm256_setzero_si256()); // (0+...+7),0,0,0
-            return static_cast<uint32_t>(_mm_cvtsi128_si32(_mm256_castsi256_si128(_Rx7)));
-        }
-
-        static size_t _Reduce_sse(const __m128i _Val) noexcept {
-            const __m128i _Rx4 = _mm_hadd_epi32(_Val, _mm_setzero_si128()); // (0+1),(2+3),0,0
-            const __m128i _Rx5 = _mm_hadd_epi32(_Rx4, _mm_setzero_si128()); // (0+...+3),0,0,0
-            return static_cast<uint32_t>(_mm_cvtsi128_si32(_Rx5));
-        }
-#endif // !_M_ARM64EC
-    };
-
-    struct _Count_traits_2 : _Find_traits_2 {
-#ifndef _M_ARM64EC
-        // For both AVX2 and SSE4.2, we use hadd_epi16 once to combine pairs of 16-bit counters into 16-bit results.
-        // Therefore, _Max_count is 0x7FFF, which is 0xFFFE when doubled; any more would overflow.
-
-        static constexpr size_t _Max_count = 0x7FFF;
-
-        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
-            return _mm256_sub_epi16(_Lhs, _Rhs);
-        }
-
-        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
-            return _mm_sub_epi16(_Lhs, _Rhs);
-        }
-
-        static size_t _Reduce_avx(const __m256i _Val) noexcept {
-            const __m256i _Rx2 = _mm256_hadd_epi16(_Val, _mm256_setzero_si256());
-            const __m256i _Rx3 = _mm256_unpacklo_epi16(_Rx2, _mm256_setzero_si256());
-            return _Count_traits_4::_Reduce_avx(_Rx3);
-        }
-
-        static size_t _Reduce_sse(const __m128i _Val) noexcept {
-            const __m128i _Rx2 = _mm_hadd_epi16(_Val, _mm_setzero_si128());
-            const __m128i _Rx3 = _mm_unpacklo_epi16(_Rx2, _mm_setzero_si128());
-            return _Count_traits_4::_Reduce_sse(_Rx3);
-        }
-#endif // !_M_ARM64EC
-    };
-
-    struct _Count_traits_1 : _Find_traits_1 {
-#ifndef _M_ARM64EC
-        // For AVX2, _Max_portion_size below is _Max_count * 32 bytes, and we have 1-byte elements.
-        // We're using packed 8-bit counters, and 32 of those fit in 256 bits.
-
-        // For SSE4.2, _Max_portion_size below is _Max_count * 16 bytes, and we have 1-byte elements.
-        // We're using packed 8-bit counters, and 16 of those fit in 128 bits.
-
-        // For both codepaths, this is why _Max_count is the maximum unsigned 8-bit integer.
-        // (The reduction steps aren't the limiting factor here.)
-
-        static constexpr size_t _Max_count = 0xFF;
-
-        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
-            return _mm256_sub_epi8(_Lhs, _Rhs);
-        }
-
-        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
-            return _mm_sub_epi8(_Lhs, _Rhs);
-        }
-
-        static size_t _Reduce_avx(const __m256i _Val) noexcept {
-            const __m256i _Rx1 = _mm256_sad_epu8(_Val, _mm256_setzero_si256());
-            return _Count_traits_8::_Reduce_avx(_Rx1);
-        }
-
-        static size_t _Reduce_sse(const __m128i _Val) noexcept {
-            const __m128i _Rx1 = _mm_sad_epu8(_Val, _mm_setzero_si128());
-            return _Count_traits_8::_Reduce_sse(_Rx1);
-        }
-#endif // !_M_ARM64EC
-    };
-
-    template <class _Traits, class _Ty>
-    __declspec(noalias) size_t __stdcall __std_count_trivial_impl(
-        const void* _First, const void* const _Last, const _Ty _Val) noexcept {
-        size_t _Result = 0;
-
-#ifndef _M_ARM64EC
-        const size_t _Size_bytes = _Byte_length(_First, _Last);
-
-        if (size_t _Avx_size = _Size_bytes & ~size_t{0x1F}; _Avx_size != 0 && _Use_avx2()) {
-            const __m256i _Comparand = _Traits::_Set_avx(_Val);
-            const void* _Stop_at     = _First;
-
-            for (;;) {
-                if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
-                    _Advance_bytes(_Stop_at, _Avx_size);
-                } else {
-                    constexpr size_t _Max_portion_size = _Traits::_Max_count * 32;
-                    const size_t _Portion_size         = _Avx_size < _Max_portion_size ? _Avx_size : _Max_portion_size;
-                    _Advance_bytes(_Stop_at, _Portion_size);
-                    _Avx_size -= _Portion_size;
-                }
-
-                __m256i _Count_vector = _mm256_setzero_si256();
-
-                do {
-                    const __m256i _Data = _mm256_loadu_si256(static_cast<const __m256i*>(_First));
-                    const __m256i _Mask = _Traits::_Cmp_avx(_Data, _Comparand);
-                    _Count_vector       = _Traits::_Sub_avx(_Count_vector, _Mask);
-                    _Advance_bytes(_First, 32);
-                } while (_First != _Stop_at);
-
-                _Result += _Traits::_Reduce_avx(_Count_vector);
-
-                if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
-                    break;
-                } else {
-                    if (_Avx_size == 0) {
-                        break;
-                    }
-                }
-            }
-
-            if (const size_t _Avx_tail_size = _Size_bytes & 0x1C; _Avx_tail_size != 0) {
-                const __m256i _Tail_mask = _Avx2_tail_mask_32(_Avx_tail_size);
-                const __m256i _Data      = _mm256_maskload_epi32(static_cast<const int*>(_First), _Tail_mask);
-                const __m256i _Mask      = _mm256_and_si256(_Traits::_Cmp_avx(_Data, _Comparand), _Tail_mask);
-                const int _Bingo         = _mm256_movemask_epi8(_Mask);
-                const size_t _Tail_count = __popcnt(_Bingo); // Assume available with SSE4.2
-                _Result += _Tail_count / sizeof(_Ty);
-                _Advance_bytes(_First, _Avx_tail_size);
-            }
-
-            _mm256_zeroupper(); // TRANSITION, DevCom-10331414
-
-            if constexpr (sizeof(_Ty) >= 4) {
-                return _Result;
-            }
-        } else if (size_t _Sse_size = _Size_bytes & ~size_t{0xF}; _Sse_size != 0 && _Use_sse42()) {
-            const __m128i _Comparand = _Traits::_Set_sse(_Val);
-            const void* _Stop_at     = _First;
-
-            for (;;) {
-                if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
-                    _Advance_bytes(_Stop_at, _Sse_size);
-                } else {
-                    constexpr size_t _Max_portion_size = _Traits::_Max_count * 16;
-                    const size_t _Portion_size         = _Sse_size < _Max_portion_size ? _Sse_size : _Max_portion_size;
-                    _Advance_bytes(_Stop_at, _Portion_size);
-                    _Sse_size -= _Portion_size;
-                }
-
-                __m128i _Count_vector = _mm_setzero_si128();
-
-                do {
-                    const __m128i _Data = _mm_loadu_si128(static_cast<const __m128i*>(_First));
-                    const __m128i _Mask = _Traits::_Cmp_sse(_Data, _Comparand);
-                    _Count_vector       = _Traits::_Sub_sse(_Count_vector, _Mask);
-                    _Advance_bytes(_First, 16);
-                } while (_First != _Stop_at);
-
-                _Result += _Traits::_Reduce_sse(_Count_vector);
-
-                if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
-                    break;
-                } else {
-                    if (_Sse_size == 0) {
-                        break;
-                    }
-                }
-            }
-        }
-#endif // !_M_ARM64EC
-
-        for (auto _Ptr = static_cast<const _Ty*>(_First); _Ptr != _Last; ++_Ptr) {
-            if (*_Ptr == _Val) {
-                ++_Result;
-            }
-        }
-        return _Result;
-    }
-
     template <class _Traits, class _Ty>
     const void* __stdcall __std_search_n_impl(
         const void* _First, const void* const _Last, const size_t _Count, const _Ty _Val) noexcept {
@@ -3506,26 +3281,6 @@ const void* __stdcall __std_adjacent_find_8(const void* const _First, const void
     return __std_adjacent_find_impl<_Find_traits_8, uint64_t>(_First, _Last);
 }
 
-__declspec(noalias) size_t __stdcall __std_count_trivial_1(
-    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return __std_count_trivial_impl<_Count_traits_1>(_First, _Last, _Val);
-}
-
-__declspec(noalias) size_t __stdcall __std_count_trivial_2(
-    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return __std_count_trivial_impl<_Count_traits_2>(_First, _Last, _Val);
-}
-
-__declspec(noalias) size_t __stdcall __std_count_trivial_4(
-    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return __std_count_trivial_impl<_Count_traits_4>(_First, _Last, _Val);
-}
-
-__declspec(noalias) size_t __stdcall __std_count_trivial_8(
-    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return __std_count_trivial_impl<_Count_traits_8>(_First, _Last, _Val);
-}
-
 const void* __stdcall __std_search_n_1(
     const void* const _First, const void* const _Last, const size_t _Count, const uint8_t _Value) noexcept {
     return __std_search_n_impl<_Find_traits_1>(_First, _Last, _Count, _Value);
@@ -3544,6 +3299,257 @@ const void* __stdcall __std_search_n_4(
 const void* __stdcall __std_search_n_8(
     const void* const _First, const void* const _Last, const size_t _Count, const uint64_t _Value) noexcept {
     return __std_search_n_impl<_Find_traits_8>(_First, _Last, _Count, _Value);
+}
+
+} // extern "C"
+
+namespace {
+    struct _Count_traits_8 : _Find_traits_8 {
+#ifndef _M_ARM64EC
+        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
+            return _mm256_sub_epi64(_Lhs, _Rhs);
+        }
+
+        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
+            return _mm_sub_epi64(_Lhs, _Rhs);
+        }
+
+        static size_t _Reduce_avx(const __m256i _Val) noexcept {
+            const __m128i _Lo64 = _mm256_extracti128_si256(_Val, 0);
+            const __m128i _Hi64 = _mm256_extracti128_si256(_Val, 1);
+            const __m128i _Rx8  = _mm_add_epi64(_Lo64, _Hi64);
+            return _Reduce_sse(_Rx8);
+        }
+
+        static size_t _Reduce_sse(const __m128i _Val) noexcept {
+#ifdef _M_IX86
+            return static_cast<uint32_t>(_mm_cvtsi128_si32(_Val)) + static_cast<uint32_t>(_mm_extract_epi32(_Val, 2));
+#else // ^^^ defined(_M_IX86) / defined(_M_X64) vvv
+            return _mm_cvtsi128_si64(_Val) + _mm_extract_epi64(_Val, 1);
+#endif // ^^^ defined(_M_X64) ^^^
+        }
+#endif // !_M_ARM64EC
+    };
+
+    struct _Count_traits_4 : _Find_traits_4 {
+#ifndef _M_ARM64EC
+        // For AVX2, we use hadd_epi32 three times to combine pairs of 32-bit counters into 32-bit results.
+        // Therefore, _Max_count is 0x1FFF'FFFF, which is 0xFFFF'FFF8 when doubled three times; any more would overflow.
+
+        // For SSE4.2, we use hadd_epi32 twice. This would allow a larger limit,
+        // but it's simpler to use the smaller limit for both codepaths.
+
+        static constexpr size_t _Max_count = 0x1FFF'FFFF;
+
+        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
+            return _mm256_sub_epi32(_Lhs, _Rhs);
+        }
+
+        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
+            return _mm_sub_epi32(_Lhs, _Rhs);
+        }
+
+        static size_t _Reduce_avx(const __m256i _Val) noexcept {
+            constexpr auto _Shuf = _MM_SHUFFLE(3, 1, 2, 0); // Cross lane, to reduce further on low lane
+            const __m256i _Rx4   = _mm256_hadd_epi32(_Val, _mm256_setzero_si256()); // (0+1),(2+3),0,0 per lane
+            const __m256i _Rx5   = _mm256_permute4x64_epi64(_Rx4, _Shuf); // low lane  (0+1),(2+3),(4+5),(6+7)
+            const __m256i _Rx6   = _mm256_hadd_epi32(_Rx5, _mm256_setzero_si256()); // (0+...+3),(4+...+7),0,0
+            const __m256i _Rx7   = _mm256_hadd_epi32(_Rx6, _mm256_setzero_si256()); // (0+...+7),0,0,0
+            return static_cast<uint32_t>(_mm_cvtsi128_si32(_mm256_castsi256_si128(_Rx7)));
+        }
+
+        static size_t _Reduce_sse(const __m128i _Val) noexcept {
+            const __m128i _Rx4 = _mm_hadd_epi32(_Val, _mm_setzero_si128()); // (0+1),(2+3),0,0
+            const __m128i _Rx5 = _mm_hadd_epi32(_Rx4, _mm_setzero_si128()); // (0+...+3),0,0,0
+            return static_cast<uint32_t>(_mm_cvtsi128_si32(_Rx5));
+        }
+#endif // !_M_ARM64EC
+    };
+
+    struct _Count_traits_2 : _Find_traits_2 {
+#ifndef _M_ARM64EC
+        // For both AVX2 and SSE4.2, we use hadd_epi16 once to combine pairs of 16-bit counters into 16-bit results.
+        // Therefore, _Max_count is 0x7FFF, which is 0xFFFE when doubled; any more would overflow.
+
+        static constexpr size_t _Max_count = 0x7FFF;
+
+        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
+            return _mm256_sub_epi16(_Lhs, _Rhs);
+        }
+
+        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
+            return _mm_sub_epi16(_Lhs, _Rhs);
+        }
+
+        static size_t _Reduce_avx(const __m256i _Val) noexcept {
+            const __m256i _Rx2 = _mm256_hadd_epi16(_Val, _mm256_setzero_si256());
+            const __m256i _Rx3 = _mm256_unpacklo_epi16(_Rx2, _mm256_setzero_si256());
+            return _Count_traits_4::_Reduce_avx(_Rx3);
+        }
+
+        static size_t _Reduce_sse(const __m128i _Val) noexcept {
+            const __m128i _Rx2 = _mm_hadd_epi16(_Val, _mm_setzero_si128());
+            const __m128i _Rx3 = _mm_unpacklo_epi16(_Rx2, _mm_setzero_si128());
+            return _Count_traits_4::_Reduce_sse(_Rx3);
+        }
+#endif // !_M_ARM64EC
+    };
+
+    struct _Count_traits_1 : _Find_traits_1 {
+#ifndef _M_ARM64EC
+        // For AVX2, _Max_portion_size below is _Max_count * 32 bytes, and we have 1-byte elements.
+        // We're using packed 8-bit counters, and 32 of those fit in 256 bits.
+
+        // For SSE4.2, _Max_portion_size below is _Max_count * 16 bytes, and we have 1-byte elements.
+        // We're using packed 8-bit counters, and 16 of those fit in 128 bits.
+
+        // For both codepaths, this is why _Max_count is the maximum unsigned 8-bit integer.
+        // (The reduction steps aren't the limiting factor here.)
+
+        static constexpr size_t _Max_count = 0xFF;
+
+        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
+            return _mm256_sub_epi8(_Lhs, _Rhs);
+        }
+
+        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
+            return _mm_sub_epi8(_Lhs, _Rhs);
+        }
+
+        static size_t _Reduce_avx(const __m256i _Val) noexcept {
+            const __m256i _Rx1 = _mm256_sad_epu8(_Val, _mm256_setzero_si256());
+            return _Count_traits_8::_Reduce_avx(_Rx1);
+        }
+
+        static size_t _Reduce_sse(const __m128i _Val) noexcept {
+            const __m128i _Rx1 = _mm_sad_epu8(_Val, _mm_setzero_si128());
+            return _Count_traits_8::_Reduce_sse(_Rx1);
+        }
+#endif // !_M_ARM64EC
+    };
+
+    template <class _Traits, class _Ty>
+    __declspec(noalias) size_t __stdcall __std_count_trivial_impl(
+        const void* _First, const void* const _Last, const _Ty _Val) noexcept {
+        size_t _Result = 0;
+
+#ifndef _M_ARM64EC
+        const size_t _Size_bytes = _Byte_length(_First, _Last);
+
+        if (size_t _Avx_size = _Size_bytes & ~size_t{0x1F}; _Avx_size != 0 && _Use_avx2()) {
+            const __m256i _Comparand = _Traits::_Set_avx(_Val);
+            const void* _Stop_at     = _First;
+
+            for (;;) {
+                if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
+                    _Advance_bytes(_Stop_at, _Avx_size);
+                } else {
+                    constexpr size_t _Max_portion_size = _Traits::_Max_count * 32;
+                    const size_t _Portion_size         = _Avx_size < _Max_portion_size ? _Avx_size : _Max_portion_size;
+                    _Advance_bytes(_Stop_at, _Portion_size);
+                    _Avx_size -= _Portion_size;
+                }
+
+                __m256i _Count_vector = _mm256_setzero_si256();
+
+                do {
+                    const __m256i _Data = _mm256_loadu_si256(static_cast<const __m256i*>(_First));
+                    const __m256i _Mask = _Traits::_Cmp_avx(_Data, _Comparand);
+                    _Count_vector       = _Traits::_Sub_avx(_Count_vector, _Mask);
+                    _Advance_bytes(_First, 32);
+                } while (_First != _Stop_at);
+
+                _Result += _Traits::_Reduce_avx(_Count_vector);
+
+                if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
+                    break;
+                } else {
+                    if (_Avx_size == 0) {
+                        break;
+                    }
+                }
+            }
+
+            if (const size_t _Avx_tail_size = _Size_bytes & 0x1C; _Avx_tail_size != 0) {
+                const __m256i _Tail_mask = _Avx2_tail_mask_32(_Avx_tail_size);
+                const __m256i _Data      = _mm256_maskload_epi32(static_cast<const int*>(_First), _Tail_mask);
+                const __m256i _Mask      = _mm256_and_si256(_Traits::_Cmp_avx(_Data, _Comparand), _Tail_mask);
+                const int _Bingo         = _mm256_movemask_epi8(_Mask);
+                const size_t _Tail_count = __popcnt(_Bingo); // Assume available with SSE4.2
+                _Result += _Tail_count / sizeof(_Ty);
+                _Advance_bytes(_First, _Avx_tail_size);
+            }
+
+            _mm256_zeroupper(); // TRANSITION, DevCom-10331414
+
+            if constexpr (sizeof(_Ty) >= 4) {
+                return _Result;
+            }
+        } else if (size_t _Sse_size = _Size_bytes & ~size_t{0xF}; _Sse_size != 0 && _Use_sse42()) {
+            const __m128i _Comparand = _Traits::_Set_sse(_Val);
+            const void* _Stop_at     = _First;
+
+            for (;;) {
+                if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
+                    _Advance_bytes(_Stop_at, _Sse_size);
+                } else {
+                    constexpr size_t _Max_portion_size = _Traits::_Max_count * 16;
+                    const size_t _Portion_size         = _Sse_size < _Max_portion_size ? _Sse_size : _Max_portion_size;
+                    _Advance_bytes(_Stop_at, _Portion_size);
+                    _Sse_size -= _Portion_size;
+                }
+
+                __m128i _Count_vector = _mm_setzero_si128();
+
+                do {
+                    const __m128i _Data = _mm_loadu_si128(static_cast<const __m128i*>(_First));
+                    const __m128i _Mask = _Traits::_Cmp_sse(_Data, _Comparand);
+                    _Count_vector       = _Traits::_Sub_sse(_Count_vector, _Mask);
+                    _Advance_bytes(_First, 16);
+                } while (_First != _Stop_at);
+
+                _Result += _Traits::_Reduce_sse(_Count_vector);
+
+                if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
+                    break;
+                } else {
+                    if (_Sse_size == 0) {
+                        break;
+                    }
+                }
+            }
+        }
+#endif // !_M_ARM64EC
+
+        for (auto _Ptr = static_cast<const _Ty*>(_First); _Ptr != _Last; ++_Ptr) {
+            if (*_Ptr == _Val) {
+                ++_Result;
+            }
+        }
+        return _Result;
+    }
+} // unnamed namespace
+
+extern "C" {
+
+__declspec(noalias) size_t __stdcall __std_count_trivial_1(
+    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
+    return __std_count_trivial_impl<_Count_traits_1>(_First, _Last, _Val);
+}
+
+__declspec(noalias) size_t __stdcall __std_count_trivial_2(
+    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
+    return __std_count_trivial_impl<_Count_traits_2>(_First, _Last, _Val);
+}
+
+__declspec(noalias) size_t __stdcall __std_count_trivial_4(
+    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
+    return __std_count_trivial_impl<_Count_traits_4>(_First, _Last, _Val);
+}
+
+__declspec(noalias) size_t __stdcall __std_count_trivial_8(
+    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
+    return __std_count_trivial_impl<_Count_traits_8>(_First, _Last, _Val);
 }
 
 } // extern "C"

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -21,8 +21,10 @@ extern "C" long __isa_enabled;
 #ifndef _DEBUG
 #pragma optimize("t", on) // Override /Os with /Ot for this TU
 #endif // !defined(_DEBUG)
+#endif // !defined(_M_ARM64EC)
 
 namespace {
+#ifndef _M_ARM64EC
     bool _Use_avx2() noexcept {
         return __isa_enabled & (1 << __ISA_AVAILABLE_AVX2);
     }
@@ -49,25 +51,7 @@ namespace {
         return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(
             reinterpret_cast<const unsigned char*>(_Tail_masks) + (32 - _Count_in_bytes)));
     }
-} // namespace
 #endif // !defined(_M_ARM64EC)
-
-namespace {
-    template <class _BidIt>
-    void _Reverse_tail(_BidIt _First, _BidIt _Last) noexcept {
-        for (; _First != _Last && _First != --_Last; ++_First) {
-            const auto _Temp = *_First;
-            *_First          = *_Last;
-            *_Last           = _Temp;
-        }
-    }
-
-    template <class _BidIt, class _OutIt>
-    void _Reverse_copy_tail(const _BidIt _First, _BidIt _Last, _OutIt _Dest) noexcept {
-        while (_First != _Last) {
-            *_Dest++ = *--_Last;
-        }
-    }
 
     size_t _Byte_length(const void* const _First, const void* const _Last) noexcept {
         return static_cast<const unsigned char*>(_Last) - static_cast<const unsigned char*>(_First);
@@ -168,6 +152,27 @@ __declspec(noalias) void __cdecl __std_swap_ranges_trivially_swappable_noalias(
         *_First2c         = _Ch;
     }
 }
+} // extern "C"
+
+namespace {
+    template <class _BidIt>
+    void _Reverse_tail(_BidIt _First, _BidIt _Last) noexcept {
+        for (; _First != _Last && _First != --_Last; ++_First) {
+            const auto _Temp = *_First;
+            *_First          = *_Last;
+            *_Last           = _Temp;
+        }
+    }
+
+    template <class _BidIt, class _OutIt>
+    void _Reverse_copy_tail(const _BidIt _First, _BidIt _Last, _OutIt _Dest) noexcept {
+        while (_First != _Last) {
+            *_Dest++ = *--_Last;
+        }
+    }
+} // unnamed namespace
+
+extern "C" {
 
 // TRANSITION, ABI: __std_swap_ranges_trivially_swappable() is preserved for binary compatibility
 void* __cdecl __std_swap_ranges_trivially_swappable(

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2874,7 +2874,7 @@ namespace {
         }
 
         template <class _Traits, _Predicate _Pred, class _Ty>
-        const void* __stdcall _Find_last(const void* _First, const void* _Last, const _Ty _Val) noexcept {
+        const void* __stdcall _Find_last_impl(const void* _First, const void* _Last, const _Ty _Val) noexcept {
             const void* const _Real_last = _Last;
 #ifndef _M_ARM64EC
             const size_t _Size_bytes = _Byte_length(_First, _Last);
@@ -2968,7 +2968,7 @@ namespace {
         template <class _Traits, _Predicate _Pred, class _Ty>
         size_t __stdcall _Find_last_pos_impl(
             const void* const _First, const void* const _Last, const _Ty _Val) noexcept {
-            const void* const _Result = _Find_last<_Traits, _Pred>(_First, _Last, _Val);
+            const void* const _Result = _Find_last_impl<_Traits, _Pred>(_First, _Last, _Val);
             if (_Result == _Last) {
                 return static_cast<size_t>(-1);
             } else {
@@ -3240,22 +3240,22 @@ const void* __stdcall __std_find_trivial_8(
 
 const void* __stdcall __std_find_last_trivial_1(
     const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return _Find::_Find_last<_Find::_Find_traits_1, _Find::_Predicate::_Equal>(_First, _Last, _Val);
+    return _Find::_Find_last_impl<_Find::_Find_traits_1, _Find::_Predicate::_Equal>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_last_trivial_2(
     const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return _Find::_Find_last<_Find::_Find_traits_2, _Find::_Predicate::_Equal>(_First, _Last, _Val);
+    return _Find::_Find_last_impl<_Find::_Find_traits_2, _Find::_Predicate::_Equal>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_last_trivial_4(
     const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return _Find::_Find_last<_Find::_Find_traits_4, _Find::_Predicate::_Equal>(_First, _Last, _Val);
+    return _Find::_Find_last_impl<_Find::_Find_traits_4, _Find::_Predicate::_Equal>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_last_trivial_8(
     const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return _Find::_Find_last<_Find::_Find_traits_8, _Find::_Predicate::_Equal>(_First, _Last, _Val);
+    return _Find::_Find_last_impl<_Find::_Find_traits_8, _Find::_Predicate::_Equal>(_First, _Last, _Val);
 }
 
 const void* __stdcall __std_find_not_ch_1(
@@ -5079,7 +5079,7 @@ namespace {
             }
 
             if (_Count2 == 1) {
-                return _Find::_Find_last<_Traits, _Find::_Predicate::_Equal>(
+                return _Find::_Find_last_impl<_Traits, _Find::_Predicate::_Equal>(
                     _First1, _Last1, *static_cast<const _Ty*>(_First2));
             }
 

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -4610,7 +4610,255 @@ namespace {
             }
         }
     } // namespace __std_find_last_of
+} // unnamed namespace
 
+extern "C" {
+
+// TRANSITION, ABI: preserved for binary compatibility
+const void* __stdcall __std_find_trivial_unsized_1(const void* const _First, const uint8_t _Val) noexcept {
+    // C23 7.27.5.2 "The memchr generic function"/2 says "The implementation shall behave as if
+    // it reads the characters sequentially and stops as soon as a matching character is found."
+    return memchr(_First, _Val, SIZE_MAX);
+}
+
+// TRANSITION, ABI: preserved for binary compatibility
+const void* __stdcall __std_find_trivial_unsized_2(const void* const _First, const uint16_t _Val) noexcept {
+    // C23 7.27.5.2 "The memchr generic function"/2 says "The implementation shall behave as if
+    // it reads the characters sequentially and stops as soon as a matching character is found."
+    // C23 7.32.4.6.9 "The wmemchr generic function"/2 lacks such wording,
+    // so we don't use wmemchr(), avoiding issues with unreachable_sentinel_t.
+    return __std_find_trivial_unsized_impl(_First, _Val);
+}
+
+// TRANSITION, ABI: preserved for binary compatibility
+const void* __stdcall __std_find_trivial_unsized_4(const void* const _First, const uint32_t _Val) noexcept {
+    return __std_find_trivial_unsized_impl(_First, _Val);
+}
+
+// TRANSITION, ABI: preserved for binary compatibility
+const void* __stdcall __std_find_trivial_unsized_8(const void* const _First, const uint64_t _Val) noexcept {
+    return __std_find_trivial_unsized_impl(_First, _Val);
+}
+
+const void* __stdcall __std_find_trivial_1(
+    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
+    return __std_find_trivial_impl<_Find_traits_1, _Find_one_predicate::_Equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_trivial_2(
+    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
+    return __std_find_trivial_impl<_Find_traits_2, _Find_one_predicate::_Equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_trivial_4(
+    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
+    return __std_find_trivial_impl<_Find_traits_4, _Find_one_predicate::_Equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_trivial_8(
+    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
+    return __std_find_trivial_impl<_Find_traits_8, _Find_one_predicate::_Equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_last_trivial_1(
+    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
+    return __std_find_last_trivial_impl<_Find_traits_1, _Find_one_predicate::_Equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_last_trivial_2(
+    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
+    return __std_find_last_trivial_impl<_Find_traits_2, _Find_one_predicate::_Equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_last_trivial_4(
+    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
+    return __std_find_last_trivial_impl<_Find_traits_4, _Find_one_predicate::_Equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_last_trivial_8(
+    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
+    return __std_find_last_trivial_impl<_Find_traits_8, _Find_one_predicate::_Equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_not_ch_1(
+    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
+    return __std_find_trivial_impl<_Find_traits_1, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_not_ch_2(
+    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
+    return __std_find_trivial_impl<_Find_traits_2, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_not_ch_4(
+    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
+    return __std_find_trivial_impl<_Find_traits_4, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_find_not_ch_8(
+    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
+    return __std_find_trivial_impl<_Find_traits_8, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
+}
+
+__declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_1(
+    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
+    return __std_find_last_pos<_Find_traits_1, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
+}
+
+__declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_2(
+    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
+    return __std_find_last_pos<_Find_traits_2, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
+}
+
+__declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_4(
+    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
+    return __std_find_last_pos<_Find_traits_4, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
+}
+
+__declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_8(
+    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
+    return __std_find_last_pos<_Find_traits_8, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_adjacent_find_1(const void* const _First, const void* const _Last) noexcept {
+    return __std_adjacent_find_impl<_Find_traits_1, uint8_t>(_First, _Last);
+}
+
+const void* __stdcall __std_adjacent_find_2(const void* const _First, const void* const _Last) noexcept {
+    return __std_adjacent_find_impl<_Find_traits_2, uint16_t>(_First, _Last);
+}
+
+const void* __stdcall __std_adjacent_find_4(const void* const _First, const void* const _Last) noexcept {
+    return __std_adjacent_find_impl<_Find_traits_4, uint32_t>(_First, _Last);
+}
+
+const void* __stdcall __std_adjacent_find_8(const void* const _First, const void* const _Last) noexcept {
+    return __std_adjacent_find_impl<_Find_traits_8, uint64_t>(_First, _Last);
+}
+
+__declspec(noalias) size_t __stdcall __std_count_trivial_1(
+    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
+    return __std_count_trivial_impl<_Count_traits_1>(_First, _Last, _Val);
+}
+
+__declspec(noalias) size_t __stdcall __std_count_trivial_2(
+    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
+    return __std_count_trivial_impl<_Count_traits_2>(_First, _Last, _Val);
+}
+
+__declspec(noalias) size_t __stdcall __std_count_trivial_4(
+    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
+    return __std_count_trivial_impl<_Count_traits_4>(_First, _Last, _Val);
+}
+
+__declspec(noalias) size_t __stdcall __std_count_trivial_8(
+    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
+    return __std_count_trivial_impl<_Count_traits_8>(_First, _Last, _Val);
+}
+
+const void* __stdcall __std_search_n_1(
+    const void* const _First, const void* const _Last, const size_t _Count, const uint8_t _Value) noexcept {
+    return __std_search_n_impl<_Find_traits_1>(_First, _Last, _Count, _Value);
+}
+
+const void* __stdcall __std_search_n_2(
+    const void* const _First, const void* const _Last, const size_t _Count, const uint16_t _Value) noexcept {
+    return __std_search_n_impl<_Find_traits_2>(_First, _Last, _Count, _Value);
+}
+
+const void* __stdcall __std_search_n_4(
+    const void* const _First, const void* const _Last, const size_t _Count, const uint32_t _Value) noexcept {
+    return __std_search_n_impl<_Find_traits_4>(_First, _Last, _Count, _Value);
+}
+
+const void* __stdcall __std_search_n_8(
+    const void* const _First, const void* const _Last, const size_t _Count, const uint64_t _Value) noexcept {
+    return __std_search_n_impl<_Find_traits_8>(_First, _Last, _Count, _Value);
+}
+
+const void* __stdcall __std_find_first_of_trivial_1(
+    const void* const _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
+    return __std_find_first_of::_Dispatch_ptr<uint8_t>(_First1, _Last1, _First2, _Last2);
+}
+
+const void* __stdcall __std_find_first_of_trivial_2(
+    const void* const _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
+    return __std_find_first_of::_Dispatch_ptr<uint16_t>(_First1, _Last1, _First2, _Last2);
+}
+
+const void* __stdcall __std_find_first_of_trivial_4(
+    const void* const _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
+    return __std_find_first_of::_Dispatch_ptr<uint32_t>(_First1, _Last1, _First2, _Last2);
+}
+
+const void* __stdcall __std_find_first_of_trivial_8(
+    const void* const _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
+    return __std_find_first_of::_Dispatch_ptr<uint64_t>(_First1, _Last1, _First2, _Last2);
+}
+
+__declspec(noalias) size_t __stdcall __std_find_first_of_trivial_pos_1(const void* const _Haystack,
+    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
+    return __std_find_first_of::_Dispatch_pos<uint8_t, _Find_meow_of_predicate::_Any_of>(
+        _Haystack, _Haystack_length, _Needle, _Needle_length);
+}
+
+__declspec(noalias) size_t __stdcall __std_find_first_of_trivial_pos_2(const void* const _Haystack,
+    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
+    return __std_find_first_of::_Dispatch_pos<uint16_t, _Find_meow_of_predicate::_Any_of>(
+        _Haystack, _Haystack_length, _Needle, _Needle_length);
+}
+
+__declspec(noalias) size_t __stdcall __std_find_first_of_trivial_pos_4(const void* const _Haystack,
+    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
+    return __std_find_first_of::_Dispatch_pos<uint32_t, _Find_meow_of_predicate::_Any_of>(
+        _Haystack, _Haystack_length, _Needle, _Needle_length);
+}
+
+__declspec(noalias) size_t __stdcall __std_find_first_of_trivial_pos_8(const void* const _Haystack,
+    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
+    return __std_find_first_of::_Dispatch_pos<uint64_t, _Find_meow_of_predicate::_Any_of>(
+        _Haystack, _Haystack_length, _Needle, _Needle_length);
+}
+
+__declspec(noalias) size_t __stdcall __std_find_last_of_trivial_pos_1(const void* const _Haystack,
+    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
+    return __std_find_last_of::_Dispatch_pos<uint8_t, _Find_meow_of_predicate::_Any_of>(
+        _Haystack, _Haystack_length, _Needle, _Needle_length);
+}
+
+__declspec(noalias) size_t __stdcall __std_find_last_of_trivial_pos_2(const void* const _Haystack,
+    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
+    return __std_find_last_of::_Dispatch_pos<uint16_t, _Find_meow_of_predicate::_Any_of>(
+        _Haystack, _Haystack_length, _Needle, _Needle_length);
+}
+
+__declspec(noalias) size_t __stdcall __std_find_first_not_of_trivial_pos_1(const void* const _Haystack,
+    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
+    return __std_find_first_of::_Dispatch_pos<uint8_t, _Find_meow_of_predicate::_None_of>(
+        _Haystack, _Haystack_length, _Needle, _Needle_length);
+}
+
+__declspec(noalias) size_t __stdcall __std_find_first_not_of_trivial_pos_2(const void* const _Haystack,
+    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
+    return __std_find_first_of::_Dispatch_pos<uint16_t, _Find_meow_of_predicate::_None_of>(
+        _Haystack, _Haystack_length, _Needle, _Needle_length);
+}
+
+__declspec(noalias) size_t __stdcall __std_find_last_not_of_trivial_pos_1(const void* const _Haystack,
+    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
+    return __std_find_last_of::_Dispatch_pos<uint8_t, _Find_meow_of_predicate::_None_of>(
+        _Haystack, _Haystack_length, _Needle, _Needle_length);
+}
+
+__declspec(noalias) size_t __stdcall __std_find_last_not_of_trivial_pos_2(const void* const _Haystack,
+    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
+    return __std_find_last_of::_Dispatch_pos<uint16_t, _Find_meow_of_predicate::_None_of>(
+        _Haystack, _Haystack_length, _Needle, _Needle_length);
+}
+
+} // extern "C"
+
+namespace {
     template <class _Traits, class _Ty>
     const void* __stdcall __std_search_impl(
         const void* _First1, const void* const _Last1, const void* const _First2, const size_t _Count2) noexcept {
@@ -5010,248 +5258,6 @@ namespace {
 } // unnamed namespace
 
 extern "C" {
-
-// TRANSITION, ABI: preserved for binary compatibility
-const void* __stdcall __std_find_trivial_unsized_1(const void* const _First, const uint8_t _Val) noexcept {
-    // C23 7.27.5.2 "The memchr generic function"/2 says "The implementation shall behave as if
-    // it reads the characters sequentially and stops as soon as a matching character is found."
-    return memchr(_First, _Val, SIZE_MAX);
-}
-
-// TRANSITION, ABI: preserved for binary compatibility
-const void* __stdcall __std_find_trivial_unsized_2(const void* const _First, const uint16_t _Val) noexcept {
-    // C23 7.27.5.2 "The memchr generic function"/2 says "The implementation shall behave as if
-    // it reads the characters sequentially and stops as soon as a matching character is found."
-    // C23 7.32.4.6.9 "The wmemchr generic function"/2 lacks such wording,
-    // so we don't use wmemchr(), avoiding issues with unreachable_sentinel_t.
-    return __std_find_trivial_unsized_impl(_First, _Val);
-}
-
-// TRANSITION, ABI: preserved for binary compatibility
-const void* __stdcall __std_find_trivial_unsized_4(const void* const _First, const uint32_t _Val) noexcept {
-    return __std_find_trivial_unsized_impl(_First, _Val);
-}
-
-// TRANSITION, ABI: preserved for binary compatibility
-const void* __stdcall __std_find_trivial_unsized_8(const void* const _First, const uint64_t _Val) noexcept {
-    return __std_find_trivial_unsized_impl(_First, _Val);
-}
-
-const void* __stdcall __std_find_trivial_1(
-    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return __std_find_trivial_impl<_Find_traits_1, _Find_one_predicate::_Equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_trivial_2(
-    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return __std_find_trivial_impl<_Find_traits_2, _Find_one_predicate::_Equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_trivial_4(
-    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return __std_find_trivial_impl<_Find_traits_4, _Find_one_predicate::_Equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_trivial_8(
-    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return __std_find_trivial_impl<_Find_traits_8, _Find_one_predicate::_Equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_last_trivial_1(
-    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return __std_find_last_trivial_impl<_Find_traits_1, _Find_one_predicate::_Equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_last_trivial_2(
-    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return __std_find_last_trivial_impl<_Find_traits_2, _Find_one_predicate::_Equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_last_trivial_4(
-    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return __std_find_last_trivial_impl<_Find_traits_4, _Find_one_predicate::_Equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_last_trivial_8(
-    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return __std_find_last_trivial_impl<_Find_traits_8, _Find_one_predicate::_Equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_not_ch_1(
-    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return __std_find_trivial_impl<_Find_traits_1, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_not_ch_2(
-    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return __std_find_trivial_impl<_Find_traits_2, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_not_ch_4(
-    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return __std_find_trivial_impl<_Find_traits_4, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_find_not_ch_8(
-    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return __std_find_trivial_impl<_Find_traits_8, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
-}
-
-__declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_1(
-    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return __std_find_last_pos<_Find_traits_1, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
-}
-
-__declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_2(
-    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return __std_find_last_pos<_Find_traits_2, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
-}
-
-__declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_4(
-    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return __std_find_last_pos<_Find_traits_4, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
-}
-
-__declspec(noalias) size_t __stdcall __std_find_last_not_ch_pos_8(
-    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return __std_find_last_pos<_Find_traits_8, _Find_one_predicate::_Not_equal>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_adjacent_find_1(const void* const _First, const void* const _Last) noexcept {
-    return __std_adjacent_find_impl<_Find_traits_1, uint8_t>(_First, _Last);
-}
-
-const void* __stdcall __std_adjacent_find_2(const void* const _First, const void* const _Last) noexcept {
-    return __std_adjacent_find_impl<_Find_traits_2, uint16_t>(_First, _Last);
-}
-
-const void* __stdcall __std_adjacent_find_4(const void* const _First, const void* const _Last) noexcept {
-    return __std_adjacent_find_impl<_Find_traits_4, uint32_t>(_First, _Last);
-}
-
-const void* __stdcall __std_adjacent_find_8(const void* const _First, const void* const _Last) noexcept {
-    return __std_adjacent_find_impl<_Find_traits_8, uint64_t>(_First, _Last);
-}
-
-__declspec(noalias) size_t __stdcall __std_count_trivial_1(
-    const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return __std_count_trivial_impl<_Count_traits_1>(_First, _Last, _Val);
-}
-
-__declspec(noalias) size_t __stdcall __std_count_trivial_2(
-    const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return __std_count_trivial_impl<_Count_traits_2>(_First, _Last, _Val);
-}
-
-__declspec(noalias) size_t __stdcall __std_count_trivial_4(
-    const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return __std_count_trivial_impl<_Count_traits_4>(_First, _Last, _Val);
-}
-
-__declspec(noalias) size_t __stdcall __std_count_trivial_8(
-    const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return __std_count_trivial_impl<_Count_traits_8>(_First, _Last, _Val);
-}
-
-const void* __stdcall __std_search_n_1(
-    const void* const _First, const void* const _Last, const size_t _Count, const uint8_t _Value) noexcept {
-    return __std_search_n_impl<_Find_traits_1>(_First, _Last, _Count, _Value);
-}
-
-const void* __stdcall __std_search_n_2(
-    const void* const _First, const void* const _Last, const size_t _Count, const uint16_t _Value) noexcept {
-    return __std_search_n_impl<_Find_traits_2>(_First, _Last, _Count, _Value);
-}
-
-const void* __stdcall __std_search_n_4(
-    const void* const _First, const void* const _Last, const size_t _Count, const uint32_t _Value) noexcept {
-    return __std_search_n_impl<_Find_traits_4>(_First, _Last, _Count, _Value);
-}
-
-const void* __stdcall __std_search_n_8(
-    const void* const _First, const void* const _Last, const size_t _Count, const uint64_t _Value) noexcept {
-    return __std_search_n_impl<_Find_traits_8>(_First, _Last, _Count, _Value);
-}
-
-const void* __stdcall __std_find_first_of_trivial_1(
-    const void* const _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
-    return __std_find_first_of::_Dispatch_ptr<uint8_t>(_First1, _Last1, _First2, _Last2);
-}
-
-const void* __stdcall __std_find_first_of_trivial_2(
-    const void* const _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
-    return __std_find_first_of::_Dispatch_ptr<uint16_t>(_First1, _Last1, _First2, _Last2);
-}
-
-const void* __stdcall __std_find_first_of_trivial_4(
-    const void* const _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
-    return __std_find_first_of::_Dispatch_ptr<uint32_t>(_First1, _Last1, _First2, _Last2);
-}
-
-const void* __stdcall __std_find_first_of_trivial_8(
-    const void* const _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
-    return __std_find_first_of::_Dispatch_ptr<uint64_t>(_First1, _Last1, _First2, _Last2);
-}
-
-__declspec(noalias) size_t __stdcall __std_find_first_of_trivial_pos_1(const void* const _Haystack,
-    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
-    return __std_find_first_of::_Dispatch_pos<uint8_t, _Find_meow_of_predicate::_Any_of>(
-        _Haystack, _Haystack_length, _Needle, _Needle_length);
-}
-
-__declspec(noalias) size_t __stdcall __std_find_first_of_trivial_pos_2(const void* const _Haystack,
-    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
-    return __std_find_first_of::_Dispatch_pos<uint16_t, _Find_meow_of_predicate::_Any_of>(
-        _Haystack, _Haystack_length, _Needle, _Needle_length);
-}
-
-__declspec(noalias) size_t __stdcall __std_find_first_of_trivial_pos_4(const void* const _Haystack,
-    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
-    return __std_find_first_of::_Dispatch_pos<uint32_t, _Find_meow_of_predicate::_Any_of>(
-        _Haystack, _Haystack_length, _Needle, _Needle_length);
-}
-
-__declspec(noalias) size_t __stdcall __std_find_first_of_trivial_pos_8(const void* const _Haystack,
-    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
-    return __std_find_first_of::_Dispatch_pos<uint64_t, _Find_meow_of_predicate::_Any_of>(
-        _Haystack, _Haystack_length, _Needle, _Needle_length);
-}
-
-__declspec(noalias) size_t __stdcall __std_find_last_of_trivial_pos_1(const void* const _Haystack,
-    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
-    return __std_find_last_of::_Dispatch_pos<uint8_t, _Find_meow_of_predicate::_Any_of>(
-        _Haystack, _Haystack_length, _Needle, _Needle_length);
-}
-
-__declspec(noalias) size_t __stdcall __std_find_last_of_trivial_pos_2(const void* const _Haystack,
-    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
-    return __std_find_last_of::_Dispatch_pos<uint16_t, _Find_meow_of_predicate::_Any_of>(
-        _Haystack, _Haystack_length, _Needle, _Needle_length);
-}
-
-__declspec(noalias) size_t __stdcall __std_find_first_not_of_trivial_pos_1(const void* const _Haystack,
-    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
-    return __std_find_first_of::_Dispatch_pos<uint8_t, _Find_meow_of_predicate::_None_of>(
-        _Haystack, _Haystack_length, _Needle, _Needle_length);
-}
-
-__declspec(noalias) size_t __stdcall __std_find_first_not_of_trivial_pos_2(const void* const _Haystack,
-    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
-    return __std_find_first_of::_Dispatch_pos<uint16_t, _Find_meow_of_predicate::_None_of>(
-        _Haystack, _Haystack_length, _Needle, _Needle_length);
-}
-
-__declspec(noalias) size_t __stdcall __std_find_last_not_of_trivial_pos_1(const void* const _Haystack,
-    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
-    return __std_find_last_of::_Dispatch_pos<uint8_t, _Find_meow_of_predicate::_None_of>(
-        _Haystack, _Haystack_length, _Needle, _Needle_length);
-}
-
-__declspec(noalias) size_t __stdcall __std_find_last_not_of_trivial_pos_2(const void* const _Haystack,
-    const size_t _Haystack_length, const void* const _Needle, const size_t _Needle_length) noexcept {
-    return __std_find_last_of::_Dispatch_pos<uint16_t, _Find_meow_of_predicate::_None_of>(
-        _Haystack, _Haystack_length, _Needle, _Needle_length);
-}
 
 const void* __stdcall __std_search_1(
     const void* const _First1, const void* const _Last1, const void* const _First2, const size_t _Count2) noexcept {

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -5826,7 +5826,7 @@ namespace {
             }
         };
 
-        constexpr size_t _Remove_copy_buffer_size = 512;
+        constexpr size_t _Copy_buffer_size = 512;
 
         template <class _Traits, class _Ty>
         void* _Remove_impl(void* _First, void* const _Stop, const _Ty _Val) noexcept {
@@ -5845,9 +5845,9 @@ namespace {
 
         template <class _Traits, class _Ty>
         void* _Remove_copy_impl(const void* _First, const void* const _Stop, void* _Out, const _Ty _Val) noexcept {
-            unsigned char _Buffer[_Remove_copy_buffer_size];
+            unsigned char _Buffer[_Copy_buffer_size];
             void* _Buffer_out        = _Buffer;
-            void* const _Buffer_stop = _Buffer + _Remove_copy_buffer_size - _Traits::_Step;
+            void* const _Buffer_stop = _Buffer + _Copy_buffer_size - _Traits::_Step;
 
             const auto _Match = _Traits::_Set(_Val);
 
@@ -5891,9 +5891,9 @@ namespace {
 
         template <class _Traits>
         void* _Unique_copy_impl(const void* _First, const void* const _Stop, void* _Out) noexcept {
-            unsigned char _Buffer[_Remove_copy_buffer_size];
+            unsigned char _Buffer[_Copy_buffer_size];
             void* _Buffer_out        = _Buffer;
-            void* const _Buffer_stop = _Buffer + _Remove_copy_buffer_size - _Traits::_Step;
+            void* const _Buffer_stop = _Buffer + _Copy_buffer_size - _Traits::_Step;
 
             do {
                 const auto _Src      = _Traits::_Load(_First);

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -2115,7 +2115,8 @@ namespace {
         }
 
         template <_Min_max_mode _Mode, class _Traits>
-        auto _Minmax_element_disp(const void* const _First, const void* const _Last, const bool _Sign) noexcept {
+        auto __stdcall _Minmax_element_disp(
+            const void* const _First, const void* const _Last, const bool _Sign) noexcept {
 #ifndef _M_ARM64EC
             if (_Byte_length(_First, _Last) >= 32 && _Use_avx2()) {
                 return _Minmax_element_impl<_Mode, typename _Traits::_Avx>(_First, _Last, _Sign);
@@ -2298,7 +2299,7 @@ namespace {
 #endif // ^^^ !defined(_M_ARM64EC) ^^^
 
         template <_Min_max_mode _Mode, class _Traits, bool _Sign>
-        auto _Minmax_disp(const void* const _First, const void* const _Last) noexcept {
+        auto __stdcall _Minmax_disp(const void* const _First, const void* const _Last) noexcept {
 #ifndef _M_ARM64EC
             if (_Byte_length(_First, _Last) >= 32 && _Use_avx2()) {
                 if constexpr (_Traits::_Avx::_Is_floating) {
@@ -2402,7 +2403,8 @@ namespace {
         }
 
         template <class _Traits, class _Ty>
-        const void* _Is_sorted_until_disp(const void* _First, const void* const _Last, const bool _Greater) noexcept {
+        const void* __stdcall _Is_sorted_until_disp(
+            const void* _First, const void* const _Last, const bool _Greater) noexcept {
             if (_First == _Last) {
                 return _First;
             }
@@ -2770,7 +2772,7 @@ namespace {
 
         // TRANSITION, ABI: used only in functions preserved for binary compatibility
         template <class _Ty>
-        const void* _Find_unsized_impl(const void* const _First, const _Ty _Val) noexcept {
+        const void* __stdcall _Find_unsized_impl(const void* const _First, const _Ty _Val) noexcept {
             auto _Ptr = static_cast<const _Ty*>(_First);
             while (*_Ptr != _Val) {
                 ++_Ptr;
@@ -4472,8 +4474,8 @@ namespace {
 #endif // ^^^ !defined(_M_ARM64EC) ^^^
 
             template <class _Ty>
-            const void* _Dispatch_ptr(const void* const _First1, const void* const _Last1, const void* const _First2,
-                const void* const _Last2) noexcept {
+            const void* __stdcall _Dispatch_ptr(const void* const _First1, const void* const _Last1,
+                const void* const _First2, const void* const _Last2) noexcept {
 #ifndef _M_ARM64EC
                 if constexpr (sizeof(_Ty) <= 2) {
                     if (_Use_sse42()) {
@@ -4574,7 +4576,7 @@ namespace {
             }
 
             template <class _Ty, _Predicate _Pred>
-            size_t _Dispatch_pos(const void* const _First1, const size_t _Count1, const void* const _First2,
+            size_t __stdcall _Dispatch_pos(const void* const _First1, const size_t _Count1, const void* const _First2,
                 const size_t _Count2) noexcept {
 #ifndef _M_ARM64EC
                 if constexpr (sizeof(_Ty) <= 2) {
@@ -4799,7 +4801,7 @@ namespace {
 #endif // ^^^ !defined(_M_ARM64EC) ^^^
 
             template <class _Ty, _Predicate _Pred>
-            size_t _Dispatch_pos(const void* const _First1, const size_t _Count1, const void* const _First2,
+            size_t __stdcall _Dispatch_pos(const void* const _First1, const size_t _Count1, const void* const _First2,
                 const size_t _Count2) noexcept {
                 using namespace _Bitmap_impl;
 

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -164,21 +164,23 @@ void* __cdecl __std_swap_ranges_trivially_swappable(
 } // extern "C"
 
 namespace {
-    template <class _BidIt>
-    void _Reverse_tail(_BidIt _First, _BidIt _Last) noexcept {
-        for (; _First != _Last && _First != --_Last; ++_First) {
-            const auto _Temp = *_First;
-            *_First          = *_Last;
-            *_Last           = _Temp;
+    namespace _Reversing {
+        template <class _BidIt>
+        void _Reverse_tail(_BidIt _First, _BidIt _Last) noexcept {
+            for (; _First != _Last && _First != --_Last; ++_First) {
+                const auto _Temp = *_First;
+                *_First          = *_Last;
+                *_Last           = _Temp;
+            }
         }
-    }
 
-    template <class _BidIt, class _OutIt>
-    void _Reverse_copy_tail(const _BidIt _First, _BidIt _Last, _OutIt _Dest) noexcept {
-        while (_First != _Last) {
-            *_Dest++ = *--_Last;
+        template <class _BidIt, class _OutIt>
+        void _Reverse_copy_tail(const _BidIt _First, _BidIt _Last, _OutIt _Dest) noexcept {
+            while (_First != _Last) {
+                *_Dest++ = *--_Last;
+            }
         }
-    }
+    } // namespace _Reversing
 } // unnamed namespace
 
 extern "C" {
@@ -226,7 +228,7 @@ __declspec(noalias) void __cdecl __std_reverse_trivially_swappable_1(void* _Firs
     }
 #endif // !_M_ARM64EC
 
-    _Reverse_tail(static_cast<unsigned char*>(_First), static_cast<unsigned char*>(_Last));
+    _Reversing::_Reverse_tail(static_cast<unsigned char*>(_First), static_cast<unsigned char*>(_Last));
 }
 
 __declspec(noalias) void __cdecl __std_reverse_trivially_swappable_2(void* _First, void* _Last) noexcept {
@@ -270,7 +272,7 @@ __declspec(noalias) void __cdecl __std_reverse_trivially_swappable_2(void* _Firs
     }
 #endif // !_M_ARM64EC
 
-    _Reverse_tail(static_cast<unsigned short*>(_First), static_cast<unsigned short*>(_Last));
+    _Reversing::_Reverse_tail(static_cast<unsigned short*>(_First), static_cast<unsigned short*>(_Last));
 }
 
 __declspec(noalias) void __cdecl __std_reverse_trivially_swappable_4(void* _First, void* _Last) noexcept {
@@ -309,7 +311,7 @@ __declspec(noalias) void __cdecl __std_reverse_trivially_swappable_4(void* _Firs
     }
 #endif // !_M_ARM64EC
 
-    _Reverse_tail(static_cast<unsigned long*>(_First), static_cast<unsigned long*>(_Last));
+    _Reversing::_Reverse_tail(static_cast<unsigned long*>(_First), static_cast<unsigned long*>(_Last));
 }
 
 __declspec(noalias) void __cdecl __std_reverse_trivially_swappable_8(void* _First, void* _Last) noexcept {
@@ -347,7 +349,7 @@ __declspec(noalias) void __cdecl __std_reverse_trivially_swappable_8(void* _Firs
     }
 #endif // !_M_ARM64EC
 
-    _Reverse_tail(static_cast<unsigned long long*>(_First), static_cast<unsigned long long*>(_Last));
+    _Reversing::_Reverse_tail(static_cast<unsigned long long*>(_First), static_cast<unsigned long long*>(_Last));
 }
 
 __declspec(noalias) void __cdecl __std_reverse_copy_trivially_copyable_1(
@@ -385,7 +387,7 @@ __declspec(noalias) void __cdecl __std_reverse_copy_trivially_copyable_1(
     }
 #endif // !_M_ARM64EC
 
-    _Reverse_copy_tail(static_cast<const unsigned char*>(_First), static_cast<const unsigned char*>(_Last),
+    _Reversing::_Reverse_copy_tail(static_cast<const unsigned char*>(_First), static_cast<const unsigned char*>(_Last),
         static_cast<unsigned char*>(_Dest));
 }
 
@@ -424,8 +426,8 @@ __declspec(noalias) void __cdecl __std_reverse_copy_trivially_copyable_2(
     }
 #endif // !_M_ARM64EC
 
-    _Reverse_copy_tail(static_cast<const unsigned short*>(_First), static_cast<const unsigned short*>(_Last),
-        static_cast<unsigned short*>(_Dest));
+    _Reversing::_Reverse_copy_tail(static_cast<const unsigned short*>(_First),
+        static_cast<const unsigned short*>(_Last), static_cast<unsigned short*>(_Dest));
 }
 
 __declspec(noalias) void __cdecl __std_reverse_copy_trivially_copyable_4(
@@ -459,7 +461,7 @@ __declspec(noalias) void __cdecl __std_reverse_copy_trivially_copyable_4(
     }
 #endif // !_M_ARM64EC
 
-    _Reverse_copy_tail(static_cast<const unsigned long*>(_First), static_cast<const unsigned long*>(_Last),
+    _Reversing::_Reverse_copy_tail(static_cast<const unsigned long*>(_First), static_cast<const unsigned long*>(_Last),
         static_cast<unsigned long*>(_Dest));
 }
 
@@ -493,1854 +495,1847 @@ __declspec(noalias) void __cdecl __std_reverse_copy_trivially_copyable_8(
     }
 #endif // !_M_ARM64EC
 
-    _Reverse_copy_tail(static_cast<const unsigned long long*>(_First), static_cast<const unsigned long long*>(_Last),
-        static_cast<unsigned long long*>(_Dest));
+    _Reversing::_Reverse_copy_tail(static_cast<const unsigned long long*>(_First),
+        static_cast<const unsigned long long*>(_Last), static_cast<unsigned long long*>(_Dest));
 }
 
 } // extern "C"
 
 namespace {
-    template <class _Ty>
-    const void* _Min_tail(const void* const _First, const void* const _Last, const void* _Res, _Ty _Cur) noexcept {
-        for (auto _Ptr = static_cast<const _Ty*>(_First); _Ptr != _Last; ++_Ptr) {
-            if (*_Ptr < _Cur) {
-                _Res = _Ptr;
-                _Cur = *_Ptr;
+    namespace _Sorting {
+        template <class _Ty>
+        const void* _Min_tail(const void* const _First, const void* const _Last, const void* _Res, _Ty _Cur) noexcept {
+            for (auto _Ptr = static_cast<const _Ty*>(_First); _Ptr != _Last; ++_Ptr) {
+                if (*_Ptr < _Cur) {
+                    _Res = _Ptr;
+                    _Cur = *_Ptr;
+                }
             }
+
+            return _Res;
         }
 
-        return _Res;
-    }
-
-    template <class _Ty>
-    const void* _Max_tail(const void* const _First, const void* const _Last, const void* _Res, _Ty _Cur) noexcept {
-        for (auto _Ptr = static_cast<const _Ty*>(_First); _Ptr != _Last; ++_Ptr) {
-            if (_Cur < *_Ptr) {
-                _Res = _Ptr;
-                _Cur = *_Ptr;
+        template <class _Ty>
+        const void* _Max_tail(const void* const _First, const void* const _Last, const void* _Res, _Ty _Cur) noexcept {
+            for (auto _Ptr = static_cast<const _Ty*>(_First); _Ptr != _Last; ++_Ptr) {
+                if (_Cur < *_Ptr) {
+                    _Res = _Ptr;
+                    _Cur = *_Ptr;
+                }
             }
+
+            return _Res;
         }
 
-        return _Res;
-    }
-
-    template <class _Ty>
-    _Min_max_element_t _Both_tail(const void* const _First, const void* const _Last, _Min_max_element_t& _Res,
-        _Ty _Cur_min, _Ty _Cur_max) noexcept {
-        for (auto _Ptr = static_cast<const _Ty*>(_First); _Ptr != _Last; ++_Ptr) {
-            if (*_Ptr < _Cur_min) {
-                _Res._Min = _Ptr;
-                _Cur_min  = *_Ptr;
+        template <class _Ty>
+        _Min_max_element_t _Both_tail(const void* const _First, const void* const _Last, _Min_max_element_t& _Res,
+            _Ty _Cur_min, _Ty _Cur_max) noexcept {
+            for (auto _Ptr = static_cast<const _Ty*>(_First); _Ptr != _Last; ++_Ptr) {
+                if (*_Ptr < _Cur_min) {
+                    _Res._Min = _Ptr;
+                    _Cur_min  = *_Ptr;
+                }
+                // Not else!
+                // * Needed for correctness if start with maximum, as we don't handle specially the first element.
+                // * Promote branchless code generation.
+                if (_Cur_max <= *_Ptr) {
+                    _Res._Max = _Ptr;
+                    _Cur_max  = *_Ptr;
+                }
             }
-            // Not else!
-            // * Needed for correctness if start with maximum, as we don't handle specially the first element.
-            // * Promote branchless code generation.
-            if (_Cur_max <= *_Ptr) {
-                _Res._Max = _Ptr;
-                _Cur_max  = *_Ptr;
+
+            return _Res;
+        }
+
+        enum _Min_max_mode {
+            _Mode_min  = 1 << 0,
+            _Mode_max  = 1 << 1,
+            _Mode_both = _Mode_min | _Mode_max,
+        };
+
+        template <class _Base>
+        struct _Traits_scalar : _Base {
+            static constexpr bool _Vectorized  = false;
+            static constexpr size_t _Tail_mask = 0;
+        };
+
+#ifndef _M_ARM64EC
+        struct _Traits_sse_base {
+            static constexpr bool _Vectorized  = true;
+            static constexpr size_t _Vec_size  = 16;
+            static constexpr size_t _Vec_mask  = 0xF;
+            static constexpr size_t _Tail_mask = 0;
+
+            static __m128i _Zero() noexcept {
+                return _mm_setzero_si128();
             }
-        }
 
-        return _Res;
-    }
+            static __m128i _All_ones() noexcept {
+                return _mm_set1_epi8(static_cast<char>(0xFF));
+            }
 
-    enum _Min_max_mode {
-        _Mode_min  = 1 << 0,
-        _Mode_max  = 1 << 1,
-        _Mode_both = _Mode_min | _Mode_max,
-    };
+            static __m128i _Blend(const __m128i _Px1, const __m128i _Px2, const __m128i _Msk) noexcept {
+                return _mm_blendv_epi8(_Px1, _Px2, _Msk);
+            }
 
-    template <class _Base>
-    struct _Minmax_traits_scalar : _Base {
-        static constexpr bool _Vectorized  = false;
-        static constexpr size_t _Tail_mask = 0;
-    };
+            static unsigned long _Mask(const __m128i _Val) noexcept {
+                return _mm_movemask_epi8(_Val);
+            }
 
-#ifndef _M_ARM64EC
-    struct _Minmax_traits_sse_base {
-        static constexpr bool _Vectorized  = true;
-        static constexpr size_t _Vec_size  = 16;
-        static constexpr size_t _Vec_mask  = 0xF;
-        static constexpr size_t _Tail_mask = 0;
+            static void _Exit_vectorized() noexcept {}
+        };
 
-        static __m128i _Zero() noexcept {
-            return _mm_setzero_si128();
-        }
+        struct _Traits_avx_base {
+            static constexpr bool _Vectorized = true;
+            static constexpr size_t _Vec_size = 32;
+            static constexpr size_t _Vec_mask = 0x1F;
 
-        static __m128i _All_ones() noexcept {
-            return _mm_set1_epi8(static_cast<char>(0xFF));
-        }
+            static __m256i _Zero() noexcept {
+                return _mm256_setzero_si256();
+            }
 
-        static __m128i _Blend(const __m128i _Px1, const __m128i _Px2, const __m128i _Msk) noexcept {
-            return _mm_blendv_epi8(_Px1, _Px2, _Msk);
-        }
+            static __m256i _All_ones() noexcept {
+                return _mm256_set1_epi8(static_cast<char>(0xFF));
+            }
 
-        static unsigned long _Mask(const __m128i _Val) noexcept {
-            return _mm_movemask_epi8(_Val);
-        }
+            static __m256i _Blend(const __m256i _Px1, const __m256i _Px2, const __m256i _Msk) noexcept {
+                return _mm256_blendv_epi8(_Px1, _Px2, _Msk);
+            }
 
-        static void _Exit_vectorized() noexcept {}
-    };
+            static unsigned long _Mask(const __m256i _Val) noexcept {
+                return _mm256_movemask_epi8(_Val);
+            }
 
-    struct _Minmax_traits_avx_base {
-        static constexpr bool _Vectorized = true;
-        static constexpr size_t _Vec_size = 32;
-        static constexpr size_t _Vec_mask = 0x1F;
+            static void _Exit_vectorized() noexcept {
+                _mm256_zeroupper();
+            }
+        };
 
-        static __m256i _Zero() noexcept {
-            return _mm256_setzero_si256();
-        }
+        struct _Traits_avx_i_base : _Traits_avx_base {
+            static constexpr size_t _Tail_mask = 0x1C;
 
-        static __m256i _All_ones() noexcept {
-            return _mm256_set1_epi8(static_cast<char>(0xFF));
-        }
+            static __m256i _Blendval(const __m256i _Px1, const __m256i _Px2, const __m256i _Msk) noexcept {
+                return _mm256_blendv_epi8(_Px1, _Px2, _Msk);
+            }
 
-        static __m256i _Blend(const __m256i _Px1, const __m256i _Px2, const __m256i _Msk) noexcept {
-            return _mm256_blendv_epi8(_Px1, _Px2, _Msk);
-        }
-
-        static unsigned long _Mask(const __m256i _Val) noexcept {
-            return _mm256_movemask_epi8(_Val);
-        }
-
-        static void _Exit_vectorized() noexcept {
-            _mm256_zeroupper();
-        }
-    };
-
-    struct _Minmax_traits_avx_i_base : _Minmax_traits_avx_base {
-        static constexpr size_t _Tail_mask = 0x1C;
-
-        static __m256i _Blendval(const __m256i _Px1, const __m256i _Px2, const __m256i _Msk) noexcept {
-            return _mm256_blendv_epi8(_Px1, _Px2, _Msk);
-        }
-
-        static __m256i _Load_mask(const void* const _Src, const __m256i _Mask) noexcept {
-            return _mm256_maskload_epi32(reinterpret_cast<const int*>(_Src), _Mask);
-        }
-    };
+            static __m256i _Load_mask(const void* const _Src, const __m256i _Mask) noexcept {
+                return _mm256_maskload_epi32(reinterpret_cast<const int*>(_Src), _Mask);
+            }
+        };
 #endif // !defined(_M_ARM64EC)
 
-    struct _Minmax_traits_1_base {
-        static constexpr bool _Is_floating = false;
+        struct _Traits_1_base {
+            static constexpr bool _Is_floating = false;
 
-        using _Signed_t   = int8_t;
-        using _Unsigned_t = uint8_t;
+            using _Signed_t   = int8_t;
+            using _Unsigned_t = uint8_t;
 
-        static constexpr _Signed_t _Init_min_val = static_cast<_Signed_t>(0x7F);
-        static constexpr _Signed_t _Init_max_val = static_cast<_Signed_t>(0x80);
+            static constexpr _Signed_t _Init_min_val = static_cast<_Signed_t>(0x7F);
+            static constexpr _Signed_t _Init_max_val = static_cast<_Signed_t>(0x80);
 
-        using _Minmax_i_t = _Min_max_1i;
-        using _Minmax_u_t = _Min_max_1u;
-
-#ifndef _M_ARM64EC
-        static constexpr bool _Has_portion_max = true;
-        static constexpr size_t _Portion_max   = 256;
-#endif // !defined(_M_ARM64EC)
-    };
+            using _Minmax_i_t = _Min_max_1i;
+            using _Minmax_u_t = _Min_max_1u;
 
 #ifndef _M_ARM64EC
-    struct _Minmax_traits_1_sse : _Minmax_traits_1_base, _Minmax_traits_sse_base {
-        static __m128i _Load(const void* const _Src) noexcept {
-            return _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Src));
-        }
-
-        static __m128i _Sign_correction(const __m128i _Val, const bool _Sign) noexcept {
-            alignas(16) static constexpr _Unsigned_t _Sign_corrections[2][16] = {
-                {0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80}, {}};
-            return _mm_sub_epi8(_Val, _mm_load_si128(reinterpret_cast<const __m128i*>(_Sign_corrections[_Sign])));
-        }
-
-        static __m128i _Inc(const __m128i _Idx) noexcept {
-            return _mm_add_epi8(_Idx, _mm_set1_epi8(1));
-        }
-
-        template <class _Fn>
-        static __m128i _H_func(const __m128i _Cur, const _Fn _Funct) noexcept {
-            const __m128i _Shuf_bytes = _mm_set_epi8(14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1);
-            const __m128i _Shuf_words = _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2);
-
-            __m128i _H_min_val = _Cur;
-            _H_min_val         = _Funct(_H_min_val, _mm_shuffle_epi32(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)));
-            _H_min_val         = _Funct(_H_min_val, _mm_shuffle_epi32(_H_min_val, _MM_SHUFFLE(2, 3, 0, 1)));
-            _H_min_val         = _Funct(_H_min_val, _mm_shuffle_epi8(_H_min_val, _Shuf_words));
-            _H_min_val         = _Funct(_H_min_val, _mm_shuffle_epi8(_H_min_val, _Shuf_bytes));
-            return _H_min_val;
-        }
-
-        static __m128i _H_min(const __m128i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_min_epi8(_Val1, _Val2); });
-        }
-
-        static __m128i _H_max(const __m128i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_max_epi8(_Val1, _Val2); });
-        }
-
-        static __m128i _H_min_u(const __m128i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_min_epu8(_Val1, _Val2); });
-        }
-
-        static __m128i _H_max_u(const __m128i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_max_epu8(_Val1, _Val2); });
-        }
-
-        static _Signed_t _Get_any(const __m128i _Cur) noexcept {
-            return static_cast<_Signed_t>(_mm_cvtsi128_si32(_Cur));
-        }
-
-        static _Unsigned_t _Get_v_pos(const __m128i _Idx, const unsigned long _H_pos) noexcept {
-            return static_cast<_Unsigned_t>(_mm_cvtsi128_si32(_mm_shuffle_epi8(_Idx, _mm_cvtsi32_si128(_H_pos))));
-        }
-
-        static __m128i _Cmp_eq(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_cmpeq_epi8(_First, _Second);
-        }
-
-        static __m128i _Cmp_gt(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_cmpgt_epi8(_First, _Second);
-        }
-
-        static __m128i _Cmp_eq_idx(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_cmpeq_epi8(_First, _Second);
-        }
-
-        static __m128i _Min(const __m128i _First, const __m128i _Second, __m128i = _mm_undefined_si128()) noexcept {
-            return _mm_min_epi8(_First, _Second);
-        }
-
-        static __m128i _Max(const __m128i _First, const __m128i _Second, __m128i = _mm_undefined_si128()) noexcept {
-            return _mm_max_epi8(_First, _Second);
-        }
-
-        static __m128i _Min_u(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_min_epu8(_First, _Second);
-        }
-
-        static __m128i _Max_u(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_max_epu8(_First, _Second);
-        }
-
-        static __m128i _Mask_cast(const __m128i _Mask) noexcept {
-            return _Mask;
-        }
-    };
-
-    struct _Minmax_traits_1_avx : _Minmax_traits_1_base, _Minmax_traits_avx_i_base {
-        static __m256i _Load(const void* const _Src) noexcept {
-            return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(_Src));
-        }
-
-        static __m256i _Sign_correction(const __m256i _Val, const bool _Sign) noexcept {
-            alignas(32) static constexpr _Unsigned_t _Sign_corrections[2][32] = {
-                {0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
-                    0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80},
-                {}};
-            return _mm256_sub_epi8(_Val, _mm256_load_si256(reinterpret_cast<const __m256i*>(_Sign_corrections[_Sign])));
-        }
-
-        static __m256i _Inc(const __m256i _Idx) noexcept {
-            return _mm256_add_epi8(_Idx, _mm256_set1_epi8(1));
-        }
-
-        template <class _Fn>
-        static __m256i _H_func(const __m256i _Cur, const _Fn _Funct) noexcept {
-            const __m128i _Shuf_bytes = _mm_set_epi8(14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1);
-            const __m128i _Shuf_words = _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2);
-
-            __m256i _H_min_val = _Cur;
-            _H_min_val         = _Funct(_H_min_val, _mm256_permute4x64_epi64(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)));
-            _H_min_val         = _Funct(_H_min_val, _mm256_shuffle_epi32(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)));
-            _H_min_val         = _Funct(_H_min_val, _mm256_shuffle_epi32(_H_min_val, _MM_SHUFFLE(2, 3, 0, 1)));
-            _H_min_val = _Funct(_H_min_val, _mm256_shuffle_epi8(_H_min_val, _mm256_broadcastsi128_si256(_Shuf_words)));
-            _H_min_val = _Funct(_H_min_val, _mm256_shuffle_epi8(_H_min_val, _mm256_broadcastsi128_si256(_Shuf_bytes)));
-            return _H_min_val;
-        }
-
-        static __m256i _H_min(const __m256i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_min_epi8(_Val1, _Val2); });
-        }
-
-        static __m256i _H_max(const __m256i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_max_epi8(_Val1, _Val2); });
-        }
-
-        static __m256i _H_min_u(const __m256i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_min_epu8(_Val1, _Val2); });
-        }
-
-        static __m256i _H_max_u(const __m256i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_max_epu8(_Val1, _Val2); });
-        }
-
-        static _Signed_t _Get_any(const __m256i _Cur) noexcept {
-            return static_cast<_Signed_t>(_mm256_cvtsi256_si32(_Cur));
-        }
-
-        static _Unsigned_t _Get_v_pos(const __m256i _Idx, const unsigned long _H_pos) noexcept {
-            const uint32_t _Part = _mm256_cvtsi256_si32(
-                _mm256_permutevar8x32_epi32(_Idx, _mm256_castsi128_si256(_mm_cvtsi32_si128(_H_pos >> 2))));
-            return static_cast<_Unsigned_t>(_Part >> ((_H_pos & 0x3) << 3));
-        }
-
-        static __m256i _Cmp_eq(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_cmpeq_epi8(_First, _Second);
-        }
-
-        static __m256i _Cmp_gt(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_cmpgt_epi8(_First, _Second);
-        }
-
-        static __m256i _Cmp_eq_idx(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_cmpeq_epi8(_First, _Second);
-        }
-
-        static __m256i _Min(const __m256i _First, const __m256i _Second, __m256i = _mm256_undefined_si256()) noexcept {
-            return _mm256_min_epi8(_First, _Second);
-        }
-
-        static __m256i _Max(const __m256i _First, const __m256i _Second, __m256i = _mm256_undefined_si256()) noexcept {
-            return _mm256_max_epi8(_First, _Second);
-        }
-
-        static __m256i _Min_u(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_min_epu8(_First, _Second);
-        }
-
-        static __m256i _Max_u(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_max_epu8(_First, _Second);
-        }
-
-        static __m256i _Mask_cast(const __m256i _Mask) noexcept {
-            return _Mask;
-        }
-    };
+            static constexpr bool _Has_portion_max = true;
+            static constexpr size_t _Portion_max   = 256;
 #endif // !defined(_M_ARM64EC)
-
-    struct _Minmax_traits_2_base {
-        static constexpr bool _Is_floating = false;
-
-        using _Signed_t   = int16_t;
-        using _Unsigned_t = uint16_t;
-
-        static constexpr _Signed_t _Init_min_val = static_cast<_Signed_t>(0x7FFF);
-        static constexpr _Signed_t _Init_max_val = static_cast<_Signed_t>(0x8000);
-
-        using _Minmax_i_t = _Min_max_2i;
-        using _Minmax_u_t = _Min_max_2u;
+        };
 
 #ifndef _M_ARM64EC
-        static constexpr bool _Has_portion_max = true;
-        static constexpr size_t _Portion_max   = 65536;
+        struct _Traits_1_sse : _Traits_1_base, _Traits_sse_base {
+            static __m128i _Load(const void* const _Src) noexcept {
+                return _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Src));
+            }
+
+            static __m128i _Sign_correction(const __m128i _Val, const bool _Sign) noexcept {
+                alignas(16) static constexpr _Unsigned_t _Sign_corrections[2][16] = {
+                    {0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80},
+                    {}};
+                return _mm_sub_epi8(_Val, _mm_load_si128(reinterpret_cast<const __m128i*>(_Sign_corrections[_Sign])));
+            }
+
+            static __m128i _Inc(const __m128i _Idx) noexcept {
+                return _mm_add_epi8(_Idx, _mm_set1_epi8(1));
+            }
+
+            template <class _Fn>
+            static __m128i _H_func(const __m128i _Cur, const _Fn _Funct) noexcept {
+                const __m128i _Shuf_b = _mm_set_epi8(14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1);
+                const __m128i _Shuf_w = _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2);
+
+                __m128i _H_min_val = _Cur;
+                _H_min_val         = _Funct(_H_min_val, _mm_shuffle_epi32(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)));
+                _H_min_val         = _Funct(_H_min_val, _mm_shuffle_epi32(_H_min_val, _MM_SHUFFLE(2, 3, 0, 1)));
+                _H_min_val         = _Funct(_H_min_val, _mm_shuffle_epi8(_H_min_val, _Shuf_w));
+                _H_min_val         = _Funct(_H_min_val, _mm_shuffle_epi8(_H_min_val, _Shuf_b));
+                return _H_min_val;
+            }
+
+            static __m128i _H_min(const __m128i _Cur) noexcept {
+                return _H_func(
+                    _Cur, [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_min_epi8(_Val1, _Val2); });
+            }
+
+            static __m128i _H_max(const __m128i _Cur) noexcept {
+                return _H_func(
+                    _Cur, [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_max_epi8(_Val1, _Val2); });
+            }
+
+            static __m128i _H_min_u(const __m128i _Cur) noexcept {
+                return _H_func(
+                    _Cur, [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_min_epu8(_Val1, _Val2); });
+            }
+
+            static __m128i _H_max_u(const __m128i _Cur) noexcept {
+                return _H_func(
+                    _Cur, [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_max_epu8(_Val1, _Val2); });
+            }
+
+            static _Signed_t _Get_any(const __m128i _Cur) noexcept {
+                return static_cast<_Signed_t>(_mm_cvtsi128_si32(_Cur));
+            }
+
+            static _Unsigned_t _Get_v_pos(const __m128i _Idx, const unsigned long _H_pos) noexcept {
+                return static_cast<_Unsigned_t>(_mm_cvtsi128_si32(_mm_shuffle_epi8(_Idx, _mm_cvtsi32_si128(_H_pos))));
+            }
+
+            static __m128i _Cmp_eq(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_cmpeq_epi8(_First, _Second);
+            }
+
+            static __m128i _Cmp_gt(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_cmpgt_epi8(_First, _Second);
+            }
+
+            static __m128i _Cmp_eq_idx(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_cmpeq_epi8(_First, _Second);
+            }
+
+            static __m128i _Min(const __m128i _First, const __m128i _Second, __m128i = _mm_undefined_si128()) noexcept {
+                return _mm_min_epi8(_First, _Second);
+            }
+
+            static __m128i _Max(const __m128i _First, const __m128i _Second, __m128i = _mm_undefined_si128()) noexcept {
+                return _mm_max_epi8(_First, _Second);
+            }
+
+            static __m128i _Min_u(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_min_epu8(_First, _Second);
+            }
+
+            static __m128i _Max_u(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_max_epu8(_First, _Second);
+            }
+
+            static __m128i _Mask_cast(const __m128i _Mask) noexcept {
+                return _Mask;
+            }
+        };
+
+        struct _Traits_1_avx : _Traits_1_base, _Traits_avx_i_base {
+            static __m256i _Load(const void* const _Src) noexcept {
+                return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(_Src));
+            }
+
+            static __m256i _Sign_correction(const __m256i _Val, const bool _Sign) noexcept {
+                alignas(32) static constexpr _Unsigned_t _Sign_corrections[2][32] = {
+                    {0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+                        0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80},
+                    {}};
+                return _mm256_sub_epi8(
+                    _Val, _mm256_load_si256(reinterpret_cast<const __m256i*>(_Sign_corrections[_Sign])));
+            }
+
+            static __m256i _Inc(const __m256i _Idx) noexcept {
+                return _mm256_add_epi8(_Idx, _mm256_set1_epi8(1));
+            }
+
+            template <class _Fn>
+            static __m256i _H_func(const __m256i _Cur, const _Fn _Funct) noexcept {
+                const __m128i _Shuf_b = _mm_set_epi8(14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1);
+                const __m128i _Shuf_w = _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2);
+
+                __m256i _H_min_val = _Cur;
+                _H_min_val         = _Funct(_H_min_val, _mm256_permute4x64_epi64(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)));
+                _H_min_val         = _Funct(_H_min_val, _mm256_shuffle_epi32(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)));
+                _H_min_val         = _Funct(_H_min_val, _mm256_shuffle_epi32(_H_min_val, _MM_SHUFFLE(2, 3, 0, 1)));
+                _H_min_val = _Funct(_H_min_val, _mm256_shuffle_epi8(_H_min_val, _mm256_broadcastsi128_si256(_Shuf_w)));
+                _H_min_val = _Funct(_H_min_val, _mm256_shuffle_epi8(_H_min_val, _mm256_broadcastsi128_si256(_Shuf_b)));
+                return _H_min_val;
+            }
+
+            static __m256i _H_min(const __m256i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_min_epi8(_Val1, _Val2); });
+            }
+
+            static __m256i _H_max(const __m256i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_max_epi8(_Val1, _Val2); });
+            }
+
+            static __m256i _H_min_u(const __m256i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_min_epu8(_Val1, _Val2); });
+            }
+
+            static __m256i _H_max_u(const __m256i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_max_epu8(_Val1, _Val2); });
+            }
+
+            static _Signed_t _Get_any(const __m256i _Cur) noexcept {
+                return static_cast<_Signed_t>(_mm256_cvtsi256_si32(_Cur));
+            }
+
+            static _Unsigned_t _Get_v_pos(const __m256i _Idx, const unsigned long _H_pos) noexcept {
+                const uint32_t _Part = _mm256_cvtsi256_si32(
+                    _mm256_permutevar8x32_epi32(_Idx, _mm256_castsi128_si256(_mm_cvtsi32_si128(_H_pos >> 2))));
+                return static_cast<_Unsigned_t>(_Part >> ((_H_pos & 0x3) << 3));
+            }
+
+            static __m256i _Cmp_eq(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_cmpeq_epi8(_First, _Second);
+            }
+
+            static __m256i _Cmp_gt(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_cmpgt_epi8(_First, _Second);
+            }
+
+            static __m256i _Cmp_eq_idx(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_cmpeq_epi8(_First, _Second);
+            }
+
+            static __m256i _Min(
+                const __m256i _First, const __m256i _Second, __m256i = _mm256_undefined_si256()) noexcept {
+                return _mm256_min_epi8(_First, _Second);
+            }
+
+            static __m256i _Max(
+                const __m256i _First, const __m256i _Second, __m256i = _mm256_undefined_si256()) noexcept {
+                return _mm256_max_epi8(_First, _Second);
+            }
+
+            static __m256i _Min_u(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_min_epu8(_First, _Second);
+            }
+
+            static __m256i _Max_u(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_max_epu8(_First, _Second);
+            }
+
+            static __m256i _Mask_cast(const __m256i _Mask) noexcept {
+                return _Mask;
+            }
+        };
 #endif // !defined(_M_ARM64EC)
-    };
+
+        struct _Traits_2_base {
+            static constexpr bool _Is_floating = false;
+
+            using _Signed_t   = int16_t;
+            using _Unsigned_t = uint16_t;
+
+            static constexpr _Signed_t _Init_min_val = static_cast<_Signed_t>(0x7FFF);
+            static constexpr _Signed_t _Init_max_val = static_cast<_Signed_t>(0x8000);
+
+            using _Minmax_i_t = _Min_max_2i;
+            using _Minmax_u_t = _Min_max_2u;
 
 #ifndef _M_ARM64EC
-    struct _Minmax_traits_2_sse : _Minmax_traits_2_base, _Minmax_traits_sse_base {
-        static __m128i _Load(const void* const _Src) noexcept {
-            return _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Src));
-        }
+            static constexpr bool _Has_portion_max = true;
+            static constexpr size_t _Portion_max   = 65536;
+#endif // !defined(_M_ARM64EC)
+        };
 
-        static __m128i _Sign_correction(const __m128i _Val, const bool _Sign) noexcept {
-            alignas(16) static constexpr _Unsigned_t _Sign_corrections[2][8] = {
-                0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, {}};
-            return _mm_sub_epi16(_Val, _mm_load_si128(reinterpret_cast<const __m128i*>(_Sign_corrections[_Sign])));
-        }
+#ifndef _M_ARM64EC
+        struct _Traits_2_sse : _Traits_2_base, _Traits_sse_base {
+            static __m128i _Load(const void* const _Src) noexcept {
+                return _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Src));
+            }
 
-        static __m128i _Inc(const __m128i _Idx) noexcept {
-            return _mm_add_epi16(_Idx, _mm_set1_epi16(1));
-        }
+            static __m128i _Sign_correction(const __m128i _Val, const bool _Sign) noexcept {
+                alignas(16) static constexpr _Unsigned_t _Sign_corrections[2][8] = {
+                    0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, {}};
+                return _mm_sub_epi16(_Val, _mm_load_si128(reinterpret_cast<const __m128i*>(_Sign_corrections[_Sign])));
+            }
 
-        template <class _Fn>
-        static __m128i _H_func(const __m128i _Cur, const _Fn _Funct) noexcept {
-            const __m128i _Shuf_words = _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2);
+            static __m128i _Inc(const __m128i _Idx) noexcept {
+                return _mm_add_epi16(_Idx, _mm_set1_epi16(1));
+            }
 
-            __m128i _H_min_val = _Cur;
-            _H_min_val         = _Funct(_H_min_val, _mm_shuffle_epi32(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)));
-            _H_min_val         = _Funct(_H_min_val, _mm_shuffle_epi32(_H_min_val, _MM_SHUFFLE(2, 3, 0, 1)));
-            _H_min_val         = _Funct(_H_min_val, _mm_shuffle_epi8(_H_min_val, _Shuf_words));
-            return _H_min_val;
-        }
+            template <class _Fn>
+            static __m128i _H_func(const __m128i _Cur, const _Fn _Funct) noexcept {
+                const __m128i _Shuf_w = _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2);
 
-        static __m128i _H_min(const __m128i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_min_epi16(_Val1, _Val2); });
-        }
+                __m128i _H_min_val = _Cur;
+                _H_min_val         = _Funct(_H_min_val, _mm_shuffle_epi32(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)));
+                _H_min_val         = _Funct(_H_min_val, _mm_shuffle_epi32(_H_min_val, _MM_SHUFFLE(2, 3, 0, 1)));
+                _H_min_val         = _Funct(_H_min_val, _mm_shuffle_epi8(_H_min_val, _Shuf_w));
+                return _H_min_val;
+            }
 
-        static __m128i _H_max(const __m128i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_max_epi16(_Val1, _Val2); });
-        }
+            static __m128i _H_min(const __m128i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_min_epi16(_Val1, _Val2); });
+            }
 
-        static __m128i _H_min_u(const __m128i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_min_epu16(_Val1, _Val2); });
-        }
+            static __m128i _H_max(const __m128i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_max_epi16(_Val1, _Val2); });
+            }
 
-        static __m128i _H_max_u(const __m128i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_max_epu16(_Val1, _Val2); });
-        }
+            static __m128i _H_min_u(const __m128i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_min_epu16(_Val1, _Val2); });
+            }
 
-        static _Signed_t _Get_any(const __m128i _Cur) noexcept {
-            return static_cast<_Signed_t>(_mm_cvtsi128_si32(_Cur));
-        }
+            static __m128i _H_max_u(const __m128i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_max_epu16(_Val1, _Val2); });
+            }
 
-        static _Unsigned_t _Get_v_pos(const __m128i _Idx, const unsigned long _H_pos) noexcept {
-            static constexpr _Unsigned_t _Shuf[] = {0x0100, 0x0302, 0x0504, 0x0706, 0x0908, 0x0B0A, 0x0D0C, 0x0F0E};
+            static _Signed_t _Get_any(const __m128i _Cur) noexcept {
+                return static_cast<_Signed_t>(_mm_cvtsi128_si32(_Cur));
+            }
 
-            return static_cast<_Unsigned_t>(
-                _mm_cvtsi128_si32(_mm_shuffle_epi8(_Idx, _mm_cvtsi32_si128(_Shuf[_H_pos >> 1]))));
-        }
+            static _Unsigned_t _Get_v_pos(const __m128i _Idx, const unsigned long _H_pos) noexcept {
+                static constexpr _Unsigned_t _Shuf[] = {0x0100, 0x0302, 0x0504, 0x0706, 0x0908, 0x0B0A, 0x0D0C, 0x0F0E};
 
-        static __m128i _Cmp_eq(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_cmpeq_epi16(_First, _Second);
-        }
+                return static_cast<_Unsigned_t>(
+                    _mm_cvtsi128_si32(_mm_shuffle_epi8(_Idx, _mm_cvtsi32_si128(_Shuf[_H_pos >> 1]))));
+            }
 
-        static __m128i _Cmp_gt(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_cmpgt_epi16(_First, _Second);
-        }
+            static __m128i _Cmp_eq(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_cmpeq_epi16(_First, _Second);
+            }
 
-        static __m128i _Cmp_eq_idx(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_cmpeq_epi16(_First, _Second);
-        }
+            static __m128i _Cmp_gt(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_cmpgt_epi16(_First, _Second);
+            }
 
-        static __m128i _Min(const __m128i _First, const __m128i _Second, __m128i = _mm_undefined_si128()) noexcept {
-            return _mm_min_epi16(_First, _Second);
-        }
+            static __m128i _Cmp_eq_idx(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_cmpeq_epi16(_First, _Second);
+            }
 
-        static __m128i _Max(const __m128i _First, const __m128i _Second, __m128i = _mm_undefined_si128()) noexcept {
-            return _mm_max_epi16(_First, _Second);
-        }
+            static __m128i _Min(const __m128i _First, const __m128i _Second, __m128i = _mm_undefined_si128()) noexcept {
+                return _mm_min_epi16(_First, _Second);
+            }
 
-        static __m128i _Min_u(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_min_epu16(_First, _Second);
-        }
+            static __m128i _Max(const __m128i _First, const __m128i _Second, __m128i = _mm_undefined_si128()) noexcept {
+                return _mm_max_epi16(_First, _Second);
+            }
 
-        static __m128i _Max_u(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_max_epu16(_First, _Second);
-        }
+            static __m128i _Min_u(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_min_epu16(_First, _Second);
+            }
 
-        static __m128i _Mask_cast(const __m128i _Mask) noexcept {
-            return _Mask;
-        }
-    };
+            static __m128i _Max_u(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_max_epu16(_First, _Second);
+            }
 
-    struct _Minmax_traits_2_avx : _Minmax_traits_2_base, _Minmax_traits_avx_i_base {
-        static __m256i _Load(const void* const _Src) noexcept {
-            return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(_Src));
-        }
+            static __m128i _Mask_cast(const __m128i _Mask) noexcept {
+                return _Mask;
+            }
+        };
 
-        static __m256i _Sign_correction(const __m256i _Val, const bool _Sign) noexcept {
-            alignas(32) static constexpr _Unsigned_t _Sign_corrections[2][16] = {0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
-                0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, {}};
-            return _mm256_sub_epi16(
-                _Val, _mm256_load_si256(reinterpret_cast<const __m256i*>(_Sign_corrections[_Sign])));
-        }
+        struct _Traits_2_avx : _Traits_2_base, _Traits_avx_i_base {
+            static __m256i _Load(const void* const _Src) noexcept {
+                return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(_Src));
+            }
 
-        static __m256i _Inc(const __m256i _Idx) noexcept {
-            return _mm256_add_epi16(_Idx, _mm256_set1_epi16(1));
-        }
+            static __m256i _Sign_correction(const __m256i _Val, const bool _Sign) noexcept {
+                alignas(32) static constexpr _Unsigned_t _Sign_corrections[2][16] = {0x8000, 0x8000, 0x8000, 0x8000,
+                    0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, 0x8000, {}};
+                return _mm256_sub_epi16(
+                    _Val, _mm256_load_si256(reinterpret_cast<const __m256i*>(_Sign_corrections[_Sign])));
+            }
 
-        template <class _Fn>
-        static __m256i _H_func(const __m256i _Cur, const _Fn _Funct) noexcept {
-            const __m128i _Shuf_words = _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2);
+            static __m256i _Inc(const __m256i _Idx) noexcept {
+                return _mm256_add_epi16(_Idx, _mm256_set1_epi16(1));
+            }
 
-            __m256i _H_min_val = _Cur;
-            _H_min_val         = _Funct(_H_min_val, _mm256_permute4x64_epi64(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)));
-            _H_min_val         = _Funct(_H_min_val, _mm256_shuffle_epi32(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)));
-            _H_min_val         = _Funct(_H_min_val, _mm256_shuffle_epi32(_H_min_val, _MM_SHUFFLE(2, 3, 0, 1)));
-            _H_min_val = _Funct(_H_min_val, _mm256_shuffle_epi8(_H_min_val, _mm256_broadcastsi128_si256(_Shuf_words)));
-            return _H_min_val;
-        }
+            template <class _Fn>
+            static __m256i _H_func(const __m256i _Cur, const _Fn _Funct) noexcept {
+                const __m128i _Shuf_w = _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2);
 
-        static __m256i _H_min(const __m256i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_min_epi16(_Val1, _Val2); });
-        }
+                __m256i _H_min_val = _Cur;
+                _H_min_val         = _Funct(_H_min_val, _mm256_permute4x64_epi64(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)));
+                _H_min_val         = _Funct(_H_min_val, _mm256_shuffle_epi32(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)));
+                _H_min_val         = _Funct(_H_min_val, _mm256_shuffle_epi32(_H_min_val, _MM_SHUFFLE(2, 3, 0, 1)));
+                _H_min_val = _Funct(_H_min_val, _mm256_shuffle_epi8(_H_min_val, _mm256_broadcastsi128_si256(_Shuf_w)));
+                return _H_min_val;
+            }
 
-        static __m256i _H_max(const __m256i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_max_epi16(_Val1, _Val2); });
-        }
+            static __m256i _H_min(const __m256i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_min_epi16(_Val1, _Val2); });
+            }
 
-        static __m256i _H_min_u(const __m256i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_min_epu16(_Val1, _Val2); });
-        }
+            static __m256i _H_max(const __m256i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_max_epi16(_Val1, _Val2); });
+            }
 
-        static __m256i _H_max_u(const __m256i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_max_epu16(_Val1, _Val2); });
-        }
+            static __m256i _H_min_u(const __m256i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_min_epu16(_Val1, _Val2); });
+            }
 
-        static _Signed_t _Get_any(const __m256i _Cur) noexcept {
-            return static_cast<_Signed_t>(_mm256_cvtsi256_si32(_Cur));
-        }
+            static __m256i _H_max_u(const __m256i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_max_epu16(_Val1, _Val2); });
+            }
 
-        static _Unsigned_t _Get_v_pos(const __m256i _Idx, const unsigned long _H_pos) noexcept {
-            const uint32_t _Part = _mm256_cvtsi256_si32(
-                _mm256_permutevar8x32_epi32(_Idx, _mm256_castsi128_si256(_mm_cvtsi32_si128(_H_pos >> 2))));
-            return static_cast<_Unsigned_t>(_Part >> ((_H_pos & 0x2) << 3));
-        }
+            static _Signed_t _Get_any(const __m256i _Cur) noexcept {
+                return static_cast<_Signed_t>(_mm256_cvtsi256_si32(_Cur));
+            }
 
-        static __m256i _Cmp_eq(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_cmpeq_epi16(_First, _Second);
-        }
+            static _Unsigned_t _Get_v_pos(const __m256i _Idx, const unsigned long _H_pos) noexcept {
+                const uint32_t _Part = _mm256_cvtsi256_si32(
+                    _mm256_permutevar8x32_epi32(_Idx, _mm256_castsi128_si256(_mm_cvtsi32_si128(_H_pos >> 2))));
+                return static_cast<_Unsigned_t>(_Part >> ((_H_pos & 0x2) << 3));
+            }
 
-        static __m256i _Cmp_gt(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_cmpgt_epi16(_First, _Second);
-        }
+            static __m256i _Cmp_eq(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_cmpeq_epi16(_First, _Second);
+            }
 
-        static __m256i _Cmp_eq_idx(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_cmpeq_epi16(_First, _Second);
-        }
+            static __m256i _Cmp_gt(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_cmpgt_epi16(_First, _Second);
+            }
 
-        static __m256i _Min(const __m256i _First, const __m256i _Second, __m256i = _mm256_undefined_si256()) noexcept {
-            return _mm256_min_epi16(_First, _Second);
-        }
+            static __m256i _Cmp_eq_idx(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_cmpeq_epi16(_First, _Second);
+            }
 
-        static __m256i _Max(const __m256i _First, const __m256i _Second, __m256i = _mm256_undefined_si256()) noexcept {
-            return _mm256_max_epi16(_First, _Second);
-        }
+            static __m256i _Min(
+                const __m256i _First, const __m256i _Second, __m256i = _mm256_undefined_si256()) noexcept {
+                return _mm256_min_epi16(_First, _Second);
+            }
 
-        static __m256i _Min_u(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_min_epu16(_First, _Second);
-        }
+            static __m256i _Max(
+                const __m256i _First, const __m256i _Second, __m256i = _mm256_undefined_si256()) noexcept {
+                return _mm256_max_epi16(_First, _Second);
+            }
 
-        static __m256i _Max_u(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_max_epu16(_First, _Second);
-        }
+            static __m256i _Min_u(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_min_epu16(_First, _Second);
+            }
 
-        static __m256i _Mask_cast(const __m256i _Mask) noexcept {
-            return _Mask;
-        }
-    };
+            static __m256i _Max_u(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_max_epu16(_First, _Second);
+            }
+
+            static __m256i _Mask_cast(const __m256i _Mask) noexcept {
+                return _Mask;
+            }
+        };
 #endif // !defined(_M_ARM64EC)
 
-    struct _Minmax_traits_4_base {
-        static constexpr bool _Is_floating = false;
+        struct _Traits_4_base {
+            static constexpr bool _Is_floating = false;
 
-        using _Signed_t   = int32_t;
-        using _Unsigned_t = uint32_t;
+            using _Signed_t   = int32_t;
+            using _Unsigned_t = uint32_t;
 
-        using _Minmax_i_t = _Min_max_4i;
-        using _Minmax_u_t = _Min_max_4u;
+            using _Minmax_i_t = _Min_max_4i;
+            using _Minmax_u_t = _Min_max_4u;
 
-        static constexpr _Signed_t _Init_min_val = static_cast<_Signed_t>(0x7FFF'FFFFUL);
-        static constexpr _Signed_t _Init_max_val = static_cast<_Signed_t>(0x8000'0000UL);
+            static constexpr _Signed_t _Init_min_val = static_cast<_Signed_t>(0x7FFF'FFFFUL);
+            static constexpr _Signed_t _Init_max_val = static_cast<_Signed_t>(0x8000'0000UL);
 
 #ifndef _M_ARM64EC
 #ifdef _M_IX86
-        static constexpr bool _Has_portion_max = false;
+            static constexpr bool _Has_portion_max = false;
 #else // ^^^ 32-bit / 64-bit vvv
-        static constexpr bool _Has_portion_max = true;
-        static constexpr size_t _Portion_max   = 0x1'0000'0000ULL;
+            static constexpr bool _Has_portion_max = true;
+            static constexpr size_t _Portion_max   = 0x1'0000'0000ULL;
 #endif // ^^^ 64-bit ^^^
 #endif // !defined(_M_ARM64EC)
-    };
+        };
 
 #ifndef _M_ARM64EC
-    struct _Minmax_traits_4_sse : _Minmax_traits_4_base, _Minmax_traits_sse_base {
-        static __m128i _Load(const void* const _Src) noexcept {
-            return _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Src));
-        }
+        struct _Traits_4_sse : _Traits_4_base, _Traits_sse_base {
+            static __m128i _Load(const void* const _Src) noexcept {
+                return _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Src));
+            }
 
-        static __m128i _Sign_correction(const __m128i _Val, const bool _Sign) noexcept {
-            alignas(16) static constexpr _Unsigned_t _Sign_corrections[2][4] = {
-                0x8000'0000UL, 0x8000'0000UL, 0x8000'0000UL, 0x8000'0000UL, {}};
-            return _mm_sub_epi32(_Val, _mm_load_si128(reinterpret_cast<const __m128i*>(_Sign_corrections[_Sign])));
-        }
+            static __m128i _Sign_correction(const __m128i _Val, const bool _Sign) noexcept {
+                alignas(16) static constexpr _Unsigned_t _Sign_corrections[2][4] = {
+                    0x8000'0000UL, 0x8000'0000UL, 0x8000'0000UL, 0x8000'0000UL, {}};
+                return _mm_sub_epi32(_Val, _mm_load_si128(reinterpret_cast<const __m128i*>(_Sign_corrections[_Sign])));
+            }
 
-        static __m128i _Inc(const __m128i _Idx) noexcept {
-            return _mm_add_epi32(_Idx, _mm_set1_epi32(1));
-        }
+            static __m128i _Inc(const __m128i _Idx) noexcept {
+                return _mm_add_epi32(_Idx, _mm_set1_epi32(1));
+            }
 
-        template <class _Fn>
-        static __m128i _H_func(const __m128i _Cur, const _Fn _Funct) noexcept {
-            __m128i _H_min_val = _Cur;
-            _H_min_val         = _Funct(_H_min_val, _mm_shuffle_epi32(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)));
-            _H_min_val         = _Funct(_H_min_val, _mm_shuffle_epi32(_H_min_val, _MM_SHUFFLE(2, 3, 0, 1)));
-            return _H_min_val;
-        }
+            template <class _Fn>
+            static __m128i _H_func(const __m128i _Cur, const _Fn _Funct) noexcept {
+                __m128i _H_min_val = _Cur;
+                _H_min_val         = _Funct(_H_min_val, _mm_shuffle_epi32(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)));
+                _H_min_val         = _Funct(_H_min_val, _mm_shuffle_epi32(_H_min_val, _MM_SHUFFLE(2, 3, 0, 1)));
+                return _H_min_val;
+            }
 
-        static __m128i _H_min(const __m128i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_min_epi32(_Val1, _Val2); });
-        }
+            static __m128i _H_min(const __m128i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_min_epi32(_Val1, _Val2); });
+            }
 
-        static __m128i _H_max(const __m128i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_max_epi32(_Val1, _Val2); });
-        }
+            static __m128i _H_max(const __m128i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_max_epi32(_Val1, _Val2); });
+            }
 
-        static __m128i _H_min_u(const __m128i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_min_epu32(_Val1, _Val2); });
-        }
+            static __m128i _H_min_u(const __m128i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_min_epu32(_Val1, _Val2); });
+            }
 
-        static __m128i _H_max_u(const __m128i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_max_epu32(_Val1, _Val2); });
-        }
+            static __m128i _H_max_u(const __m128i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m128i _Val1, const __m128i _Val2) noexcept { return _mm_max_epu32(_Val1, _Val2); });
+            }
 
-        static _Signed_t _Get_any(const __m128i _Cur) noexcept {
-            return static_cast<_Signed_t>(_mm_cvtsi128_si32(_Cur));
-        }
+            static _Signed_t _Get_any(const __m128i _Cur) noexcept {
+                return static_cast<_Signed_t>(_mm_cvtsi128_si32(_Cur));
+            }
 
-        static _Unsigned_t _Get_v_pos(const __m128i _Idx, const unsigned long _H_pos) noexcept {
-            _Unsigned_t _Array[4];
-            _mm_storeu_si128(reinterpret_cast<__m128i*>(&_Array), _Idx);
-            return _Array[_H_pos >> 2];
-        }
+            static _Unsigned_t _Get_v_pos(const __m128i _Idx, const unsigned long _H_pos) noexcept {
+                _Unsigned_t _Array[4];
+                _mm_storeu_si128(reinterpret_cast<__m128i*>(&_Array), _Idx);
+                return _Array[_H_pos >> 2];
+            }
 
-        static __m128i _Cmp_eq(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_cmpeq_epi32(_First, _Second);
-        }
+            static __m128i _Cmp_eq(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_cmpeq_epi32(_First, _Second);
+            }
 
-        static __m128i _Cmp_gt(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_cmpgt_epi32(_First, _Second);
-        }
+            static __m128i _Cmp_gt(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_cmpgt_epi32(_First, _Second);
+            }
 
-        static __m128i _Cmp_eq_idx(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_cmpeq_epi32(_First, _Second);
-        }
+            static __m128i _Cmp_eq_idx(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_cmpeq_epi32(_First, _Second);
+            }
 
-        static __m128i _Min(const __m128i _First, const __m128i _Second, __m128i = _mm_undefined_si128()) noexcept {
-            return _mm_min_epi32(_First, _Second);
-        }
+            static __m128i _Min(const __m128i _First, const __m128i _Second, __m128i = _mm_undefined_si128()) noexcept {
+                return _mm_min_epi32(_First, _Second);
+            }
 
-        static __m128i _Max(const __m128i _First, const __m128i _Second, __m128i = _mm_undefined_si128()) noexcept {
-            return _mm_max_epi32(_First, _Second);
-        }
+            static __m128i _Max(const __m128i _First, const __m128i _Second, __m128i = _mm_undefined_si128()) noexcept {
+                return _mm_max_epi32(_First, _Second);
+            }
 
-        static __m128i _Min_u(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_min_epu32(_First, _Second);
-        }
+            static __m128i _Min_u(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_min_epu32(_First, _Second);
+            }
 
-        static __m128i _Max_u(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_max_epu32(_First, _Second);
-        }
+            static __m128i _Max_u(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_max_epu32(_First, _Second);
+            }
 
-        static __m128i _Mask_cast(const __m128i _Mask) noexcept {
-            return _Mask;
-        }
-    };
+            static __m128i _Mask_cast(const __m128i _Mask) noexcept {
+                return _Mask;
+            }
+        };
 
-    struct _Minmax_traits_4_avx : _Minmax_traits_4_base, _Minmax_traits_avx_i_base {
-        static __m256i _Load(const void* const _Src) noexcept {
-            return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(_Src));
-        }
+        struct _Traits_4_avx : _Traits_4_base, _Traits_avx_i_base {
+            static __m256i _Load(const void* const _Src) noexcept {
+                return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(_Src));
+            }
 
-        static __m256i _Sign_correction(const __m256i _Val, const bool _Sign) noexcept {
-            alignas(32) static constexpr _Unsigned_t _Sign_corrections[2][8] = {0x8000'0000UL, 0x8000'0000UL,
-                0x8000'0000UL, 0x8000'0000UL, 0x8000'0000UL, 0x8000'0000UL, 0x8000'0000UL, 0x8000'0000UL, {}};
-            return _mm256_sub_epi32(
-                _Val, _mm256_load_si256(reinterpret_cast<const __m256i*>(_Sign_corrections[_Sign])));
-        }
+            static __m256i _Sign_correction(const __m256i _Val, const bool _Sign) noexcept {
+                alignas(32) static constexpr _Unsigned_t _Sign_corrections[2][8] = {0x8000'0000UL, 0x8000'0000UL,
+                    0x8000'0000UL, 0x8000'0000UL, 0x8000'0000UL, 0x8000'0000UL, 0x8000'0000UL, 0x8000'0000UL, {}};
+                return _mm256_sub_epi32(
+                    _Val, _mm256_load_si256(reinterpret_cast<const __m256i*>(_Sign_corrections[_Sign])));
+            }
 
-        static __m256i _Inc(const __m256i _Idx) noexcept {
-            return _mm256_add_epi32(_Idx, _mm256_set1_epi32(1));
-        }
+            static __m256i _Inc(const __m256i _Idx) noexcept {
+                return _mm256_add_epi32(_Idx, _mm256_set1_epi32(1));
+            }
 
-        template <class _Fn>
-        static __m256i _H_func(const __m256i _Cur, const _Fn _Funct) noexcept {
-            __m256i _H_min_val = _Cur;
-            _H_min_val         = _Funct(_H_min_val, _mm256_permute4x64_epi64(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)));
-            _H_min_val         = _Funct(_H_min_val, _mm256_shuffle_epi32(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)));
-            _H_min_val         = _Funct(_H_min_val, _mm256_shuffle_epi32(_H_min_val, _MM_SHUFFLE(2, 3, 0, 1)));
-            return _H_min_val;
-        }
+            template <class _Fn>
+            static __m256i _H_func(const __m256i _Cur, const _Fn _Funct) noexcept {
+                __m256i _H_min_val = _Cur;
+                _H_min_val         = _Funct(_H_min_val, _mm256_permute4x64_epi64(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)));
+                _H_min_val         = _Funct(_H_min_val, _mm256_shuffle_epi32(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)));
+                _H_min_val         = _Funct(_H_min_val, _mm256_shuffle_epi32(_H_min_val, _MM_SHUFFLE(2, 3, 0, 1)));
+                return _H_min_val;
+            }
 
-        static __m256i _H_min(const __m256i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_min_epi32(_Val1, _Val2); });
-        }
+            static __m256i _H_min(const __m256i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_min_epi32(_Val1, _Val2); });
+            }
 
-        static __m256i _H_max(const __m256i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_max_epi32(_Val1, _Val2); });
-        }
+            static __m256i _H_max(const __m256i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_max_epi32(_Val1, _Val2); });
+            }
 
-        static __m256i _H_min_u(const __m256i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_min_epu32(_Val1, _Val2); });
-        }
+            static __m256i _H_min_u(const __m256i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_min_epu32(_Val1, _Val2); });
+            }
 
-        static __m256i _H_max_u(const __m256i _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_max_epu32(_Val1, _Val2); });
-        }
+            static __m256i _H_max_u(const __m256i _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m256i _Val1, const __m256i _Val2) noexcept { return _mm256_max_epu32(_Val1, _Val2); });
+            }
 
-        static _Signed_t _Get_any(const __m256i _Cur) noexcept {
-            return static_cast<_Signed_t>(_mm256_cvtsi256_si32(_Cur));
-        }
+            static _Signed_t _Get_any(const __m256i _Cur) noexcept {
+                return static_cast<_Signed_t>(_mm256_cvtsi256_si32(_Cur));
+            }
 
-        static _Unsigned_t _Get_v_pos(const __m256i _Idx, const unsigned long _H_pos) noexcept {
-            return _mm256_cvtsi256_si32(
-                _mm256_permutevar8x32_epi32(_Idx, _mm256_castsi128_si256(_mm_cvtsi32_si128(_H_pos >> 2))));
-        }
+            static _Unsigned_t _Get_v_pos(const __m256i _Idx, const unsigned long _H_pos) noexcept {
+                return _mm256_cvtsi256_si32(
+                    _mm256_permutevar8x32_epi32(_Idx, _mm256_castsi128_si256(_mm_cvtsi32_si128(_H_pos >> 2))));
+            }
 
-        static __m256i _Cmp_eq(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_cmpeq_epi32(_First, _Second);
-        }
+            static __m256i _Cmp_eq(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_cmpeq_epi32(_First, _Second);
+            }
 
-        static __m256i _Cmp_gt(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_cmpgt_epi32(_First, _Second);
-        }
+            static __m256i _Cmp_gt(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_cmpgt_epi32(_First, _Second);
+            }
 
-        static __m256i _Cmp_eq_idx(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_cmpeq_epi32(_First, _Second);
-        }
+            static __m256i _Cmp_eq_idx(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_cmpeq_epi32(_First, _Second);
+            }
 
-        static __m256i _Min(const __m256i _First, const __m256i _Second, __m256i = _mm256_undefined_si256()) noexcept {
-            return _mm256_min_epi32(_First, _Second);
-        }
+            static __m256i _Min(
+                const __m256i _First, const __m256i _Second, __m256i = _mm256_undefined_si256()) noexcept {
+                return _mm256_min_epi32(_First, _Second);
+            }
 
-        static __m256i _Max(const __m256i _First, const __m256i _Second, __m256i = _mm256_undefined_si256()) noexcept {
-            return _mm256_max_epi32(_First, _Second);
-        }
+            static __m256i _Max(
+                const __m256i _First, const __m256i _Second, __m256i = _mm256_undefined_si256()) noexcept {
+                return _mm256_max_epi32(_First, _Second);
+            }
 
-        static __m256i _Min_u(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_min_epu32(_First, _Second);
-        }
+            static __m256i _Min_u(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_min_epu32(_First, _Second);
+            }
 
-        static __m256i _Max_u(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_max_epu32(_First, _Second);
-        }
+            static __m256i _Max_u(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_max_epu32(_First, _Second);
+            }
 
-        static __m256i _Mask_cast(const __m256i _Mask) noexcept {
-            return _Mask;
-        }
-    };
+            static __m256i _Mask_cast(const __m256i _Mask) noexcept {
+                return _Mask;
+            }
+        };
 #endif // !defined(_M_ARM64EC)
 
-    struct _Minmax_traits_8_base {
-        static constexpr bool _Is_floating = false;
+        struct _Traits_8_base {
+            static constexpr bool _Is_floating = false;
 
-        using _Signed_t   = int64_t;
-        using _Unsigned_t = uint64_t;
+            using _Signed_t   = int64_t;
+            using _Unsigned_t = uint64_t;
 
-        static constexpr _Signed_t _Init_min_val = static_cast<_Signed_t>(0x7FFF'FFFF'FFFF'FFFFULL);
-        static constexpr _Signed_t _Init_max_val = static_cast<_Signed_t>(0x8000'0000'0000'0000ULL);
+            static constexpr _Signed_t _Init_min_val = static_cast<_Signed_t>(0x7FFF'FFFF'FFFF'FFFFULL);
+            static constexpr _Signed_t _Init_max_val = static_cast<_Signed_t>(0x8000'0000'0000'0000ULL);
 
-        using _Minmax_i_t = _Min_max_8i;
-        using _Minmax_u_t = _Min_max_8u;
+            using _Minmax_i_t = _Min_max_8i;
+            using _Minmax_u_t = _Min_max_8u;
 
 #ifndef _M_ARM64EC
-        static constexpr bool _Has_portion_max = false;
+            static constexpr bool _Has_portion_max = false;
 #endif // !defined(_M_ARM64EC)
-    };
+        };
 
 #ifndef _M_ARM64EC
-    struct _Minmax_traits_8_sse : _Minmax_traits_8_base, _Minmax_traits_sse_base {
-        static __m128i _Load(const void* const _Src) noexcept {
-            return _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Src));
-        }
-
-        static __m128i _Sign_correction(const __m128i _Val, const bool _Sign) noexcept {
-            alignas(16) static constexpr _Unsigned_t _Sign_corrections[2][2] = {
-                0x8000'0000'0000'0000ULL, 0x8000'0000'0000'0000ULL, {}};
-            return _mm_sub_epi64(_Val, _mm_load_si128(reinterpret_cast<const __m128i*>(_Sign_corrections[_Sign])));
-        }
-
-        static __m128i _Inc(const __m128i _Idx) noexcept {
-            return _mm_add_epi64(_Idx, _mm_set1_epi64x(1));
-        }
-
-        template <class _Fn>
-        static __m128i _H_func(const __m128i _Cur, const _Fn _Funct) noexcept {
-            _Signed_t _H_min_a       = _Get_any(_Cur);
-            const _Signed_t _H_min_b = _Get_any(_mm_bsrli_si128(_Cur, 8));
-            if (_Funct(_H_min_b, _H_min_a)) {
-                _H_min_a = _H_min_b;
-            }
-            return _mm_set1_epi64x(_H_min_a);
-        }
-
-        static __m128i _H_min(const __m128i _Cur) noexcept {
-            return _H_func(_Cur, [](const _Signed_t _Lhs, const _Signed_t _Rhs) noexcept { return _Lhs < _Rhs; });
-        }
-
-        static __m128i _H_max(const __m128i _Cur) noexcept {
-            return _H_func(_Cur, [](const _Signed_t _Lhs, const _Signed_t _Rhs) noexcept { return _Lhs > _Rhs; });
-        }
-
-        static __m128i _H_min_u(const __m128i _Cur) noexcept {
-            return _H_func(_Cur, [](const _Unsigned_t _Lhs, const _Unsigned_t _Rhs) noexcept { return _Lhs < _Rhs; });
-        }
-
-        static __m128i _H_max_u(const __m128i _Cur) noexcept {
-            return _H_func(_Cur, [](const _Unsigned_t _Lhs, const _Unsigned_t _Rhs) noexcept { return _Lhs > _Rhs; });
-        }
-
-        static _Signed_t _Get_any(const __m128i _Cur) noexcept {
-            // With optimizations enabled, compiles into register movement, rather than an actual stack spill.
-            // Works around the absence of _mm_cvtsi128_si64 on 32-bit.
-            return static_cast<_Signed_t>(_Get_v_pos(_Cur, 0));
-        }
-
-        static _Unsigned_t _Get_v_pos(const __m128i _Idx, const unsigned long _H_pos) noexcept {
-            _Unsigned_t _Array[2];
-            _mm_storeu_si128(reinterpret_cast<__m128i*>(&_Array), _Idx);
-            return _Array[_H_pos >> 3];
-        }
-
-        static __m128i _Cmp_eq(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_cmpeq_epi64(_First, _Second);
-        }
-
-        static __m128i _Cmp_gt(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_cmpgt_epi64(_First, _Second);
-        }
-
-        static __m128i _Cmp_eq_idx(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_cmpeq_epi64(_First, _Second);
-        }
-
-        static __m128i _Min(const __m128i _First, const __m128i _Second, const __m128i _Mask) noexcept {
-            return _mm_blendv_epi8(_First, _Second, _Mask);
-        }
-
-        static __m128i _Max(const __m128i _First, const __m128i _Second, const __m128i _Mask) noexcept {
-            return _mm_blendv_epi8(_First, _Second, _Mask);
-        }
-
-        static __m128i _Min(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_blendv_epi8(_First, _Second, _Cmp_gt(_First, _Second));
-        }
-
-        static __m128i _Max(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_blendv_epi8(_First, _Second, _Cmp_gt(_Second, _First));
-        }
-
-        static __m128i _Mask_cast(const __m128i _Mask) noexcept {
-            return _Mask;
-        }
-    };
-
-    struct _Minmax_traits_8_avx : _Minmax_traits_8_base, _Minmax_traits_avx_i_base {
-        static __m256i _Load(const void* const _Src) noexcept {
-            return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(_Src));
-        }
-
-        static __m256i _Sign_correction(const __m256i _Val, const bool _Sign) noexcept {
-            alignas(32) static constexpr _Unsigned_t _Sign_corrections[2][4] = {0x8000'0000'0000'0000ULL,
-                0x8000'0000'0000'0000ULL, 0x8000'0000'0000'0000ULL, 0x8000'0000'0000'0000ULL, {}};
-            return _mm256_sub_epi64(
-                _Val, _mm256_load_si256(reinterpret_cast<const __m256i*>(_Sign_corrections[_Sign])));
-        }
-
-        static __m256i _Inc(const __m256i _Idx) noexcept {
-            return _mm256_add_epi64(_Idx, _mm256_set1_epi64x(1));
-        }
-
-        template <class _Fn>
-        static __m256i _H_func(const __m256i _Cur, const _Fn _Funct) noexcept {
-            alignas(32) _Signed_t _Array[4];
-            _mm256_store_si256(reinterpret_cast<__m256i*>(_Array), _Cur);
-
-            _Signed_t _H_min_v = _Array[0];
-
-            if (_Funct(_Array[1], _H_min_v)) {
-                _H_min_v = _Array[1];
+        struct _Traits_8_sse : _Traits_8_base, _Traits_sse_base {
+            static __m128i _Load(const void* const _Src) noexcept {
+                return _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Src));
             }
 
-            if (_Funct(_Array[2], _H_min_v)) {
-                _H_min_v = _Array[2];
+            static __m128i _Sign_correction(const __m128i _Val, const bool _Sign) noexcept {
+                alignas(16) static constexpr _Unsigned_t _Sign_corrections[2][2] = {
+                    0x8000'0000'0000'0000ULL, 0x8000'0000'0000'0000ULL, {}};
+                return _mm_sub_epi64(_Val, _mm_load_si128(reinterpret_cast<const __m128i*>(_Sign_corrections[_Sign])));
             }
 
-            if (_Funct(_Array[3], _H_min_v)) {
-                _H_min_v = _Array[3];
+            static __m128i _Inc(const __m128i _Idx) noexcept {
+                return _mm_add_epi64(_Idx, _mm_set1_epi64x(1));
             }
 
-            return _mm256_set1_epi64x(_H_min_v);
-        }
+            template <class _Fn>
+            static __m128i _H_func(const __m128i _Cur, const _Fn _Funct) noexcept {
+                _Signed_t _H_min_a       = _Get_any(_Cur);
+                const _Signed_t _H_min_b = _Get_any(_mm_bsrli_si128(_Cur, 8));
+                if (_Funct(_H_min_b, _H_min_a)) {
+                    _H_min_a = _H_min_b;
+                }
+                return _mm_set1_epi64x(_H_min_a);
+            }
 
-        static __m256i _H_min(const __m256i _Cur) noexcept {
-            return _H_func(_Cur, [](const _Signed_t _Lhs, const _Signed_t _Rhs) noexcept { return _Lhs < _Rhs; });
-        }
+            static __m128i _H_min(const __m128i _Cur) noexcept {
+                return _H_func(_Cur, [](const _Signed_t _Lhs, const _Signed_t _Rhs) noexcept { return _Lhs < _Rhs; });
+            }
 
-        static __m256i _H_max(const __m256i _Cur) noexcept {
-            return _H_func(_Cur, [](const _Signed_t _Lhs, const _Signed_t _Rhs) noexcept { return _Lhs > _Rhs; });
-        }
+            static __m128i _H_max(const __m128i _Cur) noexcept {
+                return _H_func(_Cur, [](const _Signed_t _Lhs, const _Signed_t _Rhs) noexcept { return _Lhs > _Rhs; });
+            }
 
-        static __m256i _H_min_u(const __m256i _Cur) noexcept {
-            return _H_func(_Cur, [](const _Unsigned_t _Lhs, const _Unsigned_t _Rhs) noexcept { return _Lhs < _Rhs; });
-        }
+            static __m128i _H_min_u(const __m128i _Cur) noexcept {
+                return _H_func(
+                    _Cur, [](const _Unsigned_t _Lhs, const _Unsigned_t _Rhs) noexcept { return _Lhs < _Rhs; });
+            }
 
-        static __m256i _H_max_u(const __m256i _Cur) noexcept {
-            return _H_func(_Cur, [](const _Unsigned_t _Lhs, const _Unsigned_t _Rhs) noexcept { return _Lhs > _Rhs; });
-        }
+            static __m128i _H_max_u(const __m128i _Cur) noexcept {
+                return _H_func(
+                    _Cur, [](const _Unsigned_t _Lhs, const _Unsigned_t _Rhs) noexcept { return _Lhs > _Rhs; });
+            }
 
-        static _Signed_t _Get_any(const __m256i _Cur) noexcept {
-            return _Minmax_traits_8_sse::_Get_any(_mm256_castsi256_si128(_Cur));
-        }
+            static _Signed_t _Get_any(const __m128i _Cur) noexcept {
+                // With optimizations enabled, compiles into register movement, rather than an actual stack spill.
+                // Works around the absence of _mm_cvtsi128_si64 on 32-bit.
+                return static_cast<_Signed_t>(_Get_v_pos(_Cur, 0));
+            }
 
-        static _Unsigned_t _Get_v_pos(const __m256i _Idx, const unsigned long _H_pos) noexcept {
-            _Unsigned_t _Array[4];
-            _mm256_storeu_si256(reinterpret_cast<__m256i*>(&_Array), _Idx);
-            return _Array[_H_pos >> 3];
-        }
+            static _Unsigned_t _Get_v_pos(const __m128i _Idx, const unsigned long _H_pos) noexcept {
+                _Unsigned_t _Array[2];
+                _mm_storeu_si128(reinterpret_cast<__m128i*>(&_Array), _Idx);
+                return _Array[_H_pos >> 3];
+            }
 
-        static __m256i _Cmp_eq(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_cmpeq_epi64(_First, _Second);
-        }
+            static __m128i _Cmp_eq(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_cmpeq_epi64(_First, _Second);
+            }
 
-        static __m256i _Cmp_gt(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_cmpgt_epi64(_First, _Second);
-        }
+            static __m128i _Cmp_gt(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_cmpgt_epi64(_First, _Second);
+            }
 
-        static __m256i _Cmp_eq_idx(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_cmpeq_epi64(_First, _Second);
-        }
+            static __m128i _Cmp_eq_idx(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_cmpeq_epi64(_First, _Second);
+            }
 
-        static __m256i _Min(const __m256i _First, const __m256i _Second, const __m256i _Mask) noexcept {
-            return _mm256_blendv_epi8(_First, _Second, _Mask);
-        }
+            static __m128i _Min(const __m128i _First, const __m128i _Second, const __m128i _Mask) noexcept {
+                return _mm_blendv_epi8(_First, _Second, _Mask);
+            }
 
-        static __m256i _Max(const __m256i _First, const __m256i _Second, const __m256i _Mask) noexcept {
-            return _mm256_blendv_epi8(_First, _Second, _Mask);
-        }
+            static __m128i _Max(const __m128i _First, const __m128i _Second, const __m128i _Mask) noexcept {
+                return _mm_blendv_epi8(_First, _Second, _Mask);
+            }
 
-        static __m256i _Min(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_blendv_epi8(_First, _Second, _Cmp_gt(_First, _Second));
-        }
+            static __m128i _Min(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_blendv_epi8(_First, _Second, _Cmp_gt(_First, _Second));
+            }
 
-        static __m256i _Max(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_blendv_epi8(_First, _Second, _Cmp_gt(_Second, _First));
-        }
+            static __m128i _Max(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_blendv_epi8(_First, _Second, _Cmp_gt(_Second, _First));
+            }
 
-        static __m256i _Mask_cast(const __m256i _Mask) noexcept {
-            return _Mask;
-        }
-    };
+            static __m128i _Mask_cast(const __m128i _Mask) noexcept {
+                return _Mask;
+            }
+        };
+
+        struct _Traits_8_avx : _Traits_8_base, _Traits_avx_i_base {
+            static __m256i _Load(const void* const _Src) noexcept {
+                return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(_Src));
+            }
+
+            static __m256i _Sign_correction(const __m256i _Val, const bool _Sign) noexcept {
+                alignas(32) static constexpr _Unsigned_t _Sign_corrections[2][4] = {0x8000'0000'0000'0000ULL,
+                    0x8000'0000'0000'0000ULL, 0x8000'0000'0000'0000ULL, 0x8000'0000'0000'0000ULL, {}};
+                return _mm256_sub_epi64(
+                    _Val, _mm256_load_si256(reinterpret_cast<const __m256i*>(_Sign_corrections[_Sign])));
+            }
+
+            static __m256i _Inc(const __m256i _Idx) noexcept {
+                return _mm256_add_epi64(_Idx, _mm256_set1_epi64x(1));
+            }
+
+            template <class _Fn>
+            static __m256i _H_func(const __m256i _Cur, const _Fn _Funct) noexcept {
+                alignas(32) _Signed_t _Array[4];
+                _mm256_store_si256(reinterpret_cast<__m256i*>(_Array), _Cur);
+
+                _Signed_t _H_min_v = _Array[0];
+
+                if (_Funct(_Array[1], _H_min_v)) {
+                    _H_min_v = _Array[1];
+                }
+
+                if (_Funct(_Array[2], _H_min_v)) {
+                    _H_min_v = _Array[2];
+                }
+
+                if (_Funct(_Array[3], _H_min_v)) {
+                    _H_min_v = _Array[3];
+                }
+
+                return _mm256_set1_epi64x(_H_min_v);
+            }
+
+            static __m256i _H_min(const __m256i _Cur) noexcept {
+                return _H_func(_Cur, [](const _Signed_t _Lhs, const _Signed_t _Rhs) noexcept { return _Lhs < _Rhs; });
+            }
+
+            static __m256i _H_max(const __m256i _Cur) noexcept {
+                return _H_func(_Cur, [](const _Signed_t _Lhs, const _Signed_t _Rhs) noexcept { return _Lhs > _Rhs; });
+            }
+
+            static __m256i _H_min_u(const __m256i _Cur) noexcept {
+                return _H_func(
+                    _Cur, [](const _Unsigned_t _Lhs, const _Unsigned_t _Rhs) noexcept { return _Lhs < _Rhs; });
+            }
+
+            static __m256i _H_max_u(const __m256i _Cur) noexcept {
+                return _H_func(
+                    _Cur, [](const _Unsigned_t _Lhs, const _Unsigned_t _Rhs) noexcept { return _Lhs > _Rhs; });
+            }
+
+            static _Signed_t _Get_any(const __m256i _Cur) noexcept {
+                return _Traits_8_sse::_Get_any(_mm256_castsi256_si128(_Cur));
+            }
+
+            static _Unsigned_t _Get_v_pos(const __m256i _Idx, const unsigned long _H_pos) noexcept {
+                _Unsigned_t _Array[4];
+                _mm256_storeu_si256(reinterpret_cast<__m256i*>(&_Array), _Idx);
+                return _Array[_H_pos >> 3];
+            }
+
+            static __m256i _Cmp_eq(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_cmpeq_epi64(_First, _Second);
+            }
+
+            static __m256i _Cmp_gt(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_cmpgt_epi64(_First, _Second);
+            }
+
+            static __m256i _Cmp_eq_idx(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_cmpeq_epi64(_First, _Second);
+            }
+
+            static __m256i _Min(const __m256i _First, const __m256i _Second, const __m256i _Mask) noexcept {
+                return _mm256_blendv_epi8(_First, _Second, _Mask);
+            }
+
+            static __m256i _Max(const __m256i _First, const __m256i _Second, const __m256i _Mask) noexcept {
+                return _mm256_blendv_epi8(_First, _Second, _Mask);
+            }
+
+            static __m256i _Min(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_blendv_epi8(_First, _Second, _Cmp_gt(_First, _Second));
+            }
+
+            static __m256i _Max(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_blendv_epi8(_First, _Second, _Cmp_gt(_Second, _First));
+            }
+
+            static __m256i _Mask_cast(const __m256i _Mask) noexcept {
+                return _Mask;
+            }
+        };
 #endif // !defined(_M_ARM64EC)
 
-    struct _Minmax_traits_f_base {
-        static constexpr bool _Is_floating = true;
+        struct _Traits_f_base {
+            static constexpr bool _Is_floating = true;
 
-        using _Signed_t   = float;
-        using _Unsigned_t = void;
+            using _Signed_t   = float;
+            using _Unsigned_t = void;
 
-        static constexpr _Signed_t _Init_min_val = __builtin_huge_valf();
-        static constexpr _Signed_t _Init_max_val = -__builtin_huge_valf();
+            static constexpr _Signed_t _Init_min_val = __builtin_huge_valf();
+            static constexpr _Signed_t _Init_max_val = -__builtin_huge_valf();
 
-        using _Minmax_i_t = _Min_max_f;
-        using _Minmax_u_t = void;
+            using _Minmax_i_t = _Min_max_f;
+            using _Minmax_u_t = void;
 
 #ifndef _M_ARM64EC
 #ifdef _M_IX86
-        static constexpr bool _Has_portion_max = false;
+            static constexpr bool _Has_portion_max = false;
 #else // ^^^ 32-bit / 64-bit vvv
-        static constexpr bool _Has_portion_max = true;
-        static constexpr size_t _Portion_max   = 0x1'0000'0000ULL;
+            static constexpr bool _Has_portion_max = true;
+            static constexpr size_t _Portion_max   = 0x1'0000'0000ULL;
 #endif // ^^^ 64-bit ^^^
 #endif // !defined(_M_ARM64EC)
-    };
+        };
 
 #ifndef _M_ARM64EC
-    struct _Minmax_traits_f_sse : _Minmax_traits_f_base, _Minmax_traits_sse_base {
-        static __m128 _Load(const void* const _Src) noexcept {
-            return _mm_loadu_ps(reinterpret_cast<const float*>(_Src));
-        }
+        struct _Traits_f_sse : _Traits_f_base, _Traits_sse_base {
+            static __m128 _Load(const void* const _Src) noexcept {
+                return _mm_loadu_ps(reinterpret_cast<const float*>(_Src));
+            }
 
-        static __m128 _Sign_correction(const __m128 _Val, bool) noexcept {
-            return _Val;
-        }
+            static __m128 _Sign_correction(const __m128 _Val, bool) noexcept {
+                return _Val;
+            }
 
-        static __m128i _Inc(const __m128i _Idx) noexcept {
-            return _mm_add_epi32(_Idx, _mm_set1_epi32(1));
-        }
+            static __m128i _Inc(const __m128i _Idx) noexcept {
+                return _mm_add_epi32(_Idx, _mm_set1_epi32(1));
+            }
 
-        template <class _Fn>
-        static __m128 _H_func(const __m128 _Cur, const _Fn _Funct) noexcept {
-            __m128 _H_min_val = _Cur;
-            _H_min_val        = _Funct(_mm_shuffle_ps(_H_min_val, _H_min_val, _MM_SHUFFLE(2, 3, 0, 1)), _H_min_val);
-            _H_min_val        = _Funct(_mm_shuffle_ps(_H_min_val, _H_min_val, _MM_SHUFFLE(1, 0, 3, 2)), _H_min_val);
-            return _H_min_val;
-        }
+            template <class _Fn>
+            static __m128 _H_func(const __m128 _Cur, const _Fn _Funct) noexcept {
+                __m128 _H_min_val = _Cur;
+                _H_min_val        = _Funct(_mm_shuffle_ps(_H_min_val, _H_min_val, _MM_SHUFFLE(2, 3, 0, 1)), _H_min_val);
+                _H_min_val        = _Funct(_mm_shuffle_ps(_H_min_val, _H_min_val, _MM_SHUFFLE(1, 0, 3, 2)), _H_min_val);
+                return _H_min_val;
+            }
 
-        static __m128 _H_min(const __m128 _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m128 _Val1, const __m128 _Val2) noexcept { return _mm_min_ps(_Val1, _Val2); });
-        }
+            static __m128 _H_min(const __m128 _Cur) noexcept {
+                return _H_func(
+                    _Cur, [](const __m128 _Val1, const __m128 _Val2) noexcept { return _mm_min_ps(_Val1, _Val2); });
+            }
 
-        static __m128 _H_max(const __m128 _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m128 _Val1, const __m128 _Val2) noexcept { return _mm_max_ps(_Val1, _Val2); });
-        }
+            static __m128 _H_max(const __m128 _Cur) noexcept {
+                return _H_func(
+                    _Cur, [](const __m128 _Val1, const __m128 _Val2) noexcept { return _mm_max_ps(_Val1, _Val2); });
+            }
 
-        static __m128i _H_min_u(const __m128i _Cur) noexcept {
-            return _Minmax_traits_4_sse::_H_min_u(_Cur);
-        }
+            static __m128i _H_min_u(const __m128i _Cur) noexcept {
+                return _Traits_4_sse::_H_min_u(_Cur);
+            }
 
-        static __m128i _H_max_u(const __m128i _Cur) noexcept {
-            return _Minmax_traits_4_sse::_H_max_u(_Cur);
-        }
+            static __m128i _H_max_u(const __m128i _Cur) noexcept {
+                return _Traits_4_sse::_H_max_u(_Cur);
+            }
 
-        static float _Get_any(const __m128 _Cur) noexcept {
-            return _mm_cvtss_f32(_Cur);
-        }
+            static float _Get_any(const __m128 _Cur) noexcept {
+                return _mm_cvtss_f32(_Cur);
+            }
 
-        static uint32_t _Get_v_pos(const __m128i _Idx, const unsigned long _H_pos) noexcept {
-            return _Minmax_traits_4_sse::_Get_v_pos(_Idx, _H_pos);
-        }
+            static uint32_t _Get_v_pos(const __m128i _Idx, const unsigned long _H_pos) noexcept {
+                return _Traits_4_sse::_Get_v_pos(_Idx, _H_pos);
+            }
 
-        static __m128 _Cmp_eq(const __m128 _First, const __m128 _Second) noexcept {
-            return _mm_cmpeq_ps(_First, _Second);
-        }
+            static __m128 _Cmp_eq(const __m128 _First, const __m128 _Second) noexcept {
+                return _mm_cmpeq_ps(_First, _Second);
+            }
 
-        static __m128 _Cmp_gt(const __m128 _First, const __m128 _Second) noexcept {
-            return _mm_cmpgt_ps(_First, _Second);
-        }
+            static __m128 _Cmp_gt(const __m128 _First, const __m128 _Second) noexcept {
+                return _mm_cmpgt_ps(_First, _Second);
+            }
 
-        static __m128i _Cmp_eq_idx(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_cmpeq_epi32(_First, _Second);
-        }
+            static __m128i _Cmp_eq_idx(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_cmpeq_epi32(_First, _Second);
+            }
 
-        static __m128 _Min(const __m128 _First, const __m128 _Second, __m128 = _mm_undefined_ps()) noexcept {
-            return _mm_min_ps(_Second, _First);
-        }
+            static __m128 _Min(const __m128 _First, const __m128 _Second, __m128 = _mm_undefined_ps()) noexcept {
+                return _mm_min_ps(_Second, _First);
+            }
 
-        static __m128 _Max(const __m128 _First, const __m128 _Second, __m128 = _mm_undefined_ps()) noexcept {
-            return _mm_max_ps(_Second, _First);
-        }
+            static __m128 _Max(const __m128 _First, const __m128 _Second, __m128 = _mm_undefined_ps()) noexcept {
+                return _mm_max_ps(_Second, _First);
+            }
 
-        static __m128i _Mask_cast(const __m128 _Mask) noexcept {
-            return _mm_castps_si128(_Mask);
-        }
-    };
+            static __m128i _Mask_cast(const __m128 _Mask) noexcept {
+                return _mm_castps_si128(_Mask);
+            }
+        };
 
-    struct _Minmax_traits_f_avx : _Minmax_traits_f_base, _Minmax_traits_avx_base {
-        static constexpr size_t _Tail_mask = 0x1C;
+        struct _Traits_f_avx : _Traits_f_base, _Traits_avx_base {
+            static constexpr size_t _Tail_mask = 0x1C;
 
-        static __m256 _Blendval(const __m256 _Px1, const __m256 _Px2, const __m256i _Msk) noexcept {
-            return _mm256_blendv_ps(_Px1, _Px2, _mm256_castsi256_ps(_Msk));
-        }
+            static __m256 _Blendval(const __m256 _Px1, const __m256 _Px2, const __m256i _Msk) noexcept {
+                return _mm256_blendv_ps(_Px1, _Px2, _mm256_castsi256_ps(_Msk));
+            }
 
-        static __m256 _Load(const void* const _Src) noexcept {
-            return _mm256_loadu_ps(reinterpret_cast<const float*>(_Src));
-        }
+            static __m256 _Load(const void* const _Src) noexcept {
+                return _mm256_loadu_ps(reinterpret_cast<const float*>(_Src));
+            }
 
-        static __m256 _Load_mask(const void* const _Src, const __m256i _Mask) noexcept {
-            return _mm256_maskload_ps(reinterpret_cast<const float*>(_Src), _Mask);
-        }
+            static __m256 _Load_mask(const void* const _Src, const __m256i _Mask) noexcept {
+                return _mm256_maskload_ps(reinterpret_cast<const float*>(_Src), _Mask);
+            }
 
-        static __m256 _Sign_correction(const __m256 _Val, bool) noexcept {
-            return _Val;
-        }
+            static __m256 _Sign_correction(const __m256 _Val, bool) noexcept {
+                return _Val;
+            }
 
-        static __m256i _Inc(const __m256i _Idx) noexcept {
-            return _mm256_add_epi32(_Idx, _mm256_set1_epi32(1));
-        }
+            static __m256i _Inc(const __m256i _Idx) noexcept {
+                return _mm256_add_epi32(_Idx, _mm256_set1_epi32(1));
+            }
 
-        template <class _Fn>
-        static __m256 _H_func(const __m256 _Cur, const _Fn _Funct) noexcept {
-            __m256 _H_min_val = _Cur;
-            _H_min_val        = _Funct(_mm256_shuffle_ps(_H_min_val, _H_min_val, _MM_SHUFFLE(2, 3, 0, 1)), _H_min_val);
-            _H_min_val        = _Funct(_mm256_shuffle_ps(_H_min_val, _H_min_val, _MM_SHUFFLE(1, 0, 3, 2)), _H_min_val);
-            _H_min_val        = _Funct(_mm256_permute2f128_ps(_H_min_val, _mm256_undefined_ps(), 0x01), _H_min_val);
-            return _H_min_val;
-        }
+            template <class _Fn>
+            static __m256 _H_func(const __m256 _Cur, const _Fn _Funct) noexcept {
+                __m256 _H_min_val = _Cur;
+                _H_min_val = _Funct(_mm256_shuffle_ps(_H_min_val, _H_min_val, _MM_SHUFFLE(2, 3, 0, 1)), _H_min_val);
+                _H_min_val = _Funct(_mm256_shuffle_ps(_H_min_val, _H_min_val, _MM_SHUFFLE(1, 0, 3, 2)), _H_min_val);
+                _H_min_val = _Funct(_mm256_permute2f128_ps(_H_min_val, _mm256_undefined_ps(), 0x01), _H_min_val);
+                return _H_min_val;
+            }
 
-        static __m256 _H_min(const __m256 _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m256 _Val1, const __m256 _Val2) noexcept { return _mm256_min_ps(_Val1, _Val2); });
-        }
+            static __m256 _H_min(const __m256 _Cur) noexcept {
+                return _H_func(
+                    _Cur, [](const __m256 _Val1, const __m256 _Val2) noexcept { return _mm256_min_ps(_Val1, _Val2); });
+            }
 
-        static __m256 _H_max(const __m256 _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m256 _Val1, const __m256 _Val2) noexcept { return _mm256_max_ps(_Val1, _Val2); });
-        }
+            static __m256 _H_max(const __m256 _Cur) noexcept {
+                return _H_func(
+                    _Cur, [](const __m256 _Val1, const __m256 _Val2) noexcept { return _mm256_max_ps(_Val1, _Val2); });
+            }
 
-        static __m256i _H_min_u(const __m256i _Cur) noexcept {
-            return _Minmax_traits_4_avx::_H_min_u(_Cur);
-        }
+            static __m256i _H_min_u(const __m256i _Cur) noexcept {
+                return _Traits_4_avx::_H_min_u(_Cur);
+            }
 
-        static __m256i _H_max_u(const __m256i _Cur) noexcept {
-            return _Minmax_traits_4_avx::_H_max_u(_Cur);
-        }
+            static __m256i _H_max_u(const __m256i _Cur) noexcept {
+                return _Traits_4_avx::_H_max_u(_Cur);
+            }
 
-        static float _Get_any(const __m256 _Cur) noexcept {
-            return _mm256_cvtss_f32(_Cur);
-        }
+            static float _Get_any(const __m256 _Cur) noexcept {
+                return _mm256_cvtss_f32(_Cur);
+            }
 
-        static uint32_t _Get_v_pos(const __m256i _Idx, const unsigned long _H_pos) noexcept {
-            return _Minmax_traits_4_avx::_Get_v_pos(_Idx, _H_pos);
-        }
+            static uint32_t _Get_v_pos(const __m256i _Idx, const unsigned long _H_pos) noexcept {
+                return _Traits_4_avx::_Get_v_pos(_Idx, _H_pos);
+            }
 
-        static __m256 _Cmp_eq(const __m256 _First, const __m256 _Second) noexcept {
-            return _mm256_cmp_ps(_First, _Second, _CMP_EQ_OQ);
-        }
+            static __m256 _Cmp_eq(const __m256 _First, const __m256 _Second) noexcept {
+                return _mm256_cmp_ps(_First, _Second, _CMP_EQ_OQ);
+            }
 
-        static __m256 _Cmp_gt(const __m256 _First, const __m256 _Second) noexcept {
-            return _mm256_cmp_ps(_First, _Second, _CMP_GT_OQ);
-        }
+            static __m256 _Cmp_gt(const __m256 _First, const __m256 _Second) noexcept {
+                return _mm256_cmp_ps(_First, _Second, _CMP_GT_OQ);
+            }
 
-        static __m256i _Cmp_eq_idx(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_cmpeq_epi32(_First, _Second);
-        }
+            static __m256i _Cmp_eq_idx(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_cmpeq_epi32(_First, _Second);
+            }
 
-        static __m256 _Min(const __m256 _First, const __m256 _Second, __m256 = _mm256_undefined_ps()) noexcept {
-            return _mm256_min_ps(_Second, _First);
-        }
+            static __m256 _Min(const __m256 _First, const __m256 _Second, __m256 = _mm256_undefined_ps()) noexcept {
+                return _mm256_min_ps(_Second, _First);
+            }
 
-        static __m256 _Max(const __m256 _First, const __m256 _Second, __m256 = _mm256_undefined_ps()) noexcept {
-            return _mm256_max_ps(_Second, _First);
-        }
+            static __m256 _Max(const __m256 _First, const __m256 _Second, __m256 = _mm256_undefined_ps()) noexcept {
+                return _mm256_max_ps(_Second, _First);
+            }
 
-        static __m256i _Mask_cast(const __m256 _Mask) noexcept {
-            return _mm256_castps_si256(_Mask);
-        }
-    };
+            static __m256i _Mask_cast(const __m256 _Mask) noexcept {
+                return _mm256_castps_si256(_Mask);
+            }
+        };
 #endif // !defined(_M_ARM64EC)
 
-    struct _Minmax_traits_d_base {
-        static constexpr bool _Is_floating = true;
+        struct _Traits_d_base {
+            static constexpr bool _Is_floating = true;
 
-        using _Signed_t   = double;
-        using _Unsigned_t = void;
+            using _Signed_t   = double;
+            using _Unsigned_t = void;
 
-        static constexpr _Signed_t _Init_min_val = __builtin_huge_val();
-        static constexpr _Signed_t _Init_max_val = -__builtin_huge_val();
+            static constexpr _Signed_t _Init_min_val = __builtin_huge_val();
+            static constexpr _Signed_t _Init_max_val = -__builtin_huge_val();
 
-        using _Minmax_i_t = _Min_max_d;
-        using _Minmax_u_t = void;
+            using _Minmax_i_t = _Min_max_d;
+            using _Minmax_u_t = void;
 
 #ifndef _M_ARM64EC
-        static constexpr bool _Has_portion_max = false;
+            static constexpr bool _Has_portion_max = false;
 #endif // !defined(_M_ARM64EC)
-    };
+        };
 
 #ifndef _M_ARM64EC
-    struct _Minmax_traits_d_sse : _Minmax_traits_d_base, _Minmax_traits_sse_base {
-        static __m128d _Load(const void* const _Src) noexcept {
-            return _mm_loadu_pd(reinterpret_cast<const double*>(_Src));
-        }
+        struct _Traits_d_sse : _Traits_d_base, _Traits_sse_base {
+            static __m128d _Load(const void* const _Src) noexcept {
+                return _mm_loadu_pd(reinterpret_cast<const double*>(_Src));
+            }
 
-        static __m128d _Sign_correction(const __m128d _Val, bool) noexcept {
-            return _Val;
-        }
+            static __m128d _Sign_correction(const __m128d _Val, bool) noexcept {
+                return _Val;
+            }
 
-        static __m128i _Inc(const __m128i _Idx) noexcept {
-            return _mm_add_epi64(_Idx, _mm_set1_epi64x(1));
-        }
+            static __m128i _Inc(const __m128i _Idx) noexcept {
+                return _mm_add_epi64(_Idx, _mm_set1_epi64x(1));
+            }
 
-        template <class _Fn>
-        static __m128d _H_func(const __m128d _Cur, const _Fn _Funct) noexcept {
-            __m128d _H_min_val = _Cur;
-            _H_min_val         = _Funct(_mm_shuffle_pd(_H_min_val, _H_min_val, 1), _H_min_val);
-            return _H_min_val;
-        }
+            template <class _Fn>
+            static __m128d _H_func(const __m128d _Cur, const _Fn _Funct) noexcept {
+                __m128d _H_min_val = _Cur;
+                _H_min_val         = _Funct(_mm_shuffle_pd(_H_min_val, _H_min_val, 1), _H_min_val);
+                return _H_min_val;
+            }
 
-        static __m128d _H_min(const __m128d _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m128d _Val1, const __m128d _Val2) noexcept { return _mm_min_pd(_Val1, _Val2); });
-        }
+            static __m128d _H_min(const __m128d _Cur) noexcept {
+                return _H_func(
+                    _Cur, [](const __m128d _Val1, const __m128d _Val2) noexcept { return _mm_min_pd(_Val1, _Val2); });
+            }
 
-        static __m128d _H_max(const __m128d _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m128d _Val1, const __m128d _Val2) noexcept { return _mm_max_pd(_Val1, _Val2); });
-        }
+            static __m128d _H_max(const __m128d _Cur) noexcept {
+                return _H_func(
+                    _Cur, [](const __m128d _Val1, const __m128d _Val2) noexcept { return _mm_max_pd(_Val1, _Val2); });
+            }
 
-        static __m128i _H_min_u(const __m128i _Cur) noexcept {
-            return _Minmax_traits_8_sse::_H_min_u(_Cur);
-        }
+            static __m128i _H_min_u(const __m128i _Cur) noexcept {
+                return _Traits_8_sse::_H_min_u(_Cur);
+            }
 
-        static __m128i _H_max_u(const __m128i _Cur) noexcept {
-            return _Minmax_traits_8_sse::_H_max_u(_Cur);
-        }
-        static double _Get_any(const __m128d _Cur) noexcept {
-            return _mm_cvtsd_f64(_Cur);
-        }
+            static __m128i _H_max_u(const __m128i _Cur) noexcept {
+                return _Traits_8_sse::_H_max_u(_Cur);
+            }
+            static double _Get_any(const __m128d _Cur) noexcept {
+                return _mm_cvtsd_f64(_Cur);
+            }
 
-        static uint64_t _Get_v_pos(const __m128i _Idx, const unsigned long _H_pos) noexcept {
-            return _Minmax_traits_8_sse::_Get_v_pos(_Idx, _H_pos);
-        }
+            static uint64_t _Get_v_pos(const __m128i _Idx, const unsigned long _H_pos) noexcept {
+                return _Traits_8_sse::_Get_v_pos(_Idx, _H_pos);
+            }
 
-        static __m128d _Cmp_eq(const __m128d _First, const __m128d _Second) noexcept {
-            return _mm_cmpeq_pd(_First, _Second);
-        }
+            static __m128d _Cmp_eq(const __m128d _First, const __m128d _Second) noexcept {
+                return _mm_cmpeq_pd(_First, _Second);
+            }
 
-        static __m128d _Cmp_gt(const __m128d _First, const __m128d _Second) noexcept {
-            return _mm_cmpgt_pd(_First, _Second);
-        }
+            static __m128d _Cmp_gt(const __m128d _First, const __m128d _Second) noexcept {
+                return _mm_cmpgt_pd(_First, _Second);
+            }
 
-        static __m128i _Cmp_eq_idx(const __m128i _First, const __m128i _Second) noexcept {
-            return _mm_cmpeq_epi64(_First, _Second);
-        }
+            static __m128i _Cmp_eq_idx(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_cmpeq_epi64(_First, _Second);
+            }
 
-        static __m128d _Min(const __m128d _First, const __m128d _Second, __m128d = _mm_undefined_pd()) noexcept {
-            return _mm_min_pd(_Second, _First);
-        }
+            static __m128d _Min(const __m128d _First, const __m128d _Second, __m128d = _mm_undefined_pd()) noexcept {
+                return _mm_min_pd(_Second, _First);
+            }
 
-        static __m128d _Max(const __m128d _First, const __m128d _Second, __m128d = _mm_undefined_pd()) noexcept {
-            return _mm_max_pd(_Second, _First);
-        }
+            static __m128d _Max(const __m128d _First, const __m128d _Second, __m128d = _mm_undefined_pd()) noexcept {
+                return _mm_max_pd(_Second, _First);
+            }
 
-        static __m128i _Mask_cast(const __m128d _Mask) noexcept {
-            return _mm_castpd_si128(_Mask);
-        }
-    };
+            static __m128i _Mask_cast(const __m128d _Mask) noexcept {
+                return _mm_castpd_si128(_Mask);
+            }
+        };
 
-    struct _Minmax_traits_d_avx : _Minmax_traits_d_base, _Minmax_traits_avx_base {
-        static constexpr size_t _Tail_mask = 0x18;
+        struct _Traits_d_avx : _Traits_d_base, _Traits_avx_base {
+            static constexpr size_t _Tail_mask = 0x18;
 
-        static __m256d _Blendval(const __m256d _Px1, const __m256d _Px2, const __m256i _Msk) noexcept {
-            return _mm256_blendv_pd(_Px1, _Px2, _mm256_castsi256_pd(_Msk));
-        }
+            static __m256d _Blendval(const __m256d _Px1, const __m256d _Px2, const __m256i _Msk) noexcept {
+                return _mm256_blendv_pd(_Px1, _Px2, _mm256_castsi256_pd(_Msk));
+            }
 
-        static __m256d _Load(const void* const _Src) noexcept {
-            return _mm256_loadu_pd(reinterpret_cast<const double*>(_Src));
-        }
+            static __m256d _Load(const void* const _Src) noexcept {
+                return _mm256_loadu_pd(reinterpret_cast<const double*>(_Src));
+            }
 
-        static __m256d _Load_mask(const void* const _Src, const __m256i _Mask) noexcept {
-            return _mm256_maskload_pd(reinterpret_cast<const double*>(_Src), _Mask);
-        }
+            static __m256d _Load_mask(const void* const _Src, const __m256i _Mask) noexcept {
+                return _mm256_maskload_pd(reinterpret_cast<const double*>(_Src), _Mask);
+            }
 
-        static __m256d _Sign_correction(const __m256d _Val, bool) noexcept {
-            return _Val;
-        }
+            static __m256d _Sign_correction(const __m256d _Val, bool) noexcept {
+                return _Val;
+            }
 
-        static __m256i _Inc(const __m256i _Idx) noexcept {
-            return _mm256_add_epi64(_Idx, _mm256_set1_epi64x(1));
-        }
+            static __m256i _Inc(const __m256i _Idx) noexcept {
+                return _mm256_add_epi64(_Idx, _mm256_set1_epi64x(1));
+            }
 
-        template <class _Fn>
-        static __m256d _H_func(const __m256d _Cur, const _Fn _Funct) noexcept {
-            __m256d _H_min_val = _Cur;
-            _H_min_val         = _Funct(_mm256_shuffle_pd(_H_min_val, _H_min_val, 0b0101), _H_min_val);
-            _H_min_val         = _Funct(_mm256_permute4x64_pd(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)), _H_min_val);
-            return _H_min_val;
-        }
+            template <class _Fn>
+            static __m256d _H_func(const __m256d _Cur, const _Fn _Funct) noexcept {
+                __m256d _H_min_val = _Cur;
+                _H_min_val         = _Funct(_mm256_shuffle_pd(_H_min_val, _H_min_val, 0b0101), _H_min_val);
+                _H_min_val         = _Funct(_mm256_permute4x64_pd(_H_min_val, _MM_SHUFFLE(1, 0, 3, 2)), _H_min_val);
+                return _H_min_val;
+            }
 
-        static __m256d _H_min(const __m256d _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m256d _Val1, const __m256d _Val2) noexcept { return _mm256_min_pd(_Val1, _Val2); });
-        }
+            static __m256d _H_min(const __m256d _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m256d _Val1, const __m256d _Val2) noexcept { return _mm256_min_pd(_Val1, _Val2); });
+            }
 
-        static __m256d _H_max(const __m256d _Cur) noexcept {
-            return _H_func(
-                _Cur, [](const __m256d _Val1, const __m256d _Val2) noexcept { return _mm256_max_pd(_Val1, _Val2); });
-        }
+            static __m256d _H_max(const __m256d _Cur) noexcept {
+                return _H_func(_Cur,
+                    [](const __m256d _Val1, const __m256d _Val2) noexcept { return _mm256_max_pd(_Val1, _Val2); });
+            }
 
-        static __m256i _H_min_u(const __m256i _Cur) noexcept {
-            return _Minmax_traits_8_avx::_H_min_u(_Cur);
-        }
+            static __m256i _H_min_u(const __m256i _Cur) noexcept {
+                return _Traits_8_avx::_H_min_u(_Cur);
+            }
 
-        static __m256i _H_max_u(const __m256i _Cur) noexcept {
-            return _Minmax_traits_8_avx::_H_max_u(_Cur);
-        }
+            static __m256i _H_max_u(const __m256i _Cur) noexcept {
+                return _Traits_8_avx::_H_max_u(_Cur);
+            }
 
-        static double _Get_any(const __m256d _Cur) noexcept {
-            return _mm256_cvtsd_f64(_Cur);
-        }
+            static double _Get_any(const __m256d _Cur) noexcept {
+                return _mm256_cvtsd_f64(_Cur);
+            }
 
-        static uint64_t _Get_v_pos(const __m256i _Idx, const unsigned long _H_pos) noexcept {
-            return _Minmax_traits_8_avx::_Get_v_pos(_Idx, _H_pos);
-        }
+            static uint64_t _Get_v_pos(const __m256i _Idx, const unsigned long _H_pos) noexcept {
+                return _Traits_8_avx::_Get_v_pos(_Idx, _H_pos);
+            }
 
-        static __m256d _Cmp_eq(const __m256d _First, const __m256d _Second) noexcept {
-            return _mm256_cmp_pd(_First, _Second, _CMP_EQ_OQ);
-        }
+            static __m256d _Cmp_eq(const __m256d _First, const __m256d _Second) noexcept {
+                return _mm256_cmp_pd(_First, _Second, _CMP_EQ_OQ);
+            }
 
-        static __m256d _Cmp_gt(const __m256d _First, const __m256d _Second) noexcept {
-            return _mm256_cmp_pd(_First, _Second, _CMP_GT_OQ);
-        }
+            static __m256d _Cmp_gt(const __m256d _First, const __m256d _Second) noexcept {
+                return _mm256_cmp_pd(_First, _Second, _CMP_GT_OQ);
+            }
 
-        static __m256i _Cmp_eq_idx(const __m256i _First, const __m256i _Second) noexcept {
-            return _mm256_cmpeq_epi64(_First, _Second);
-        }
+            static __m256i _Cmp_eq_idx(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_cmpeq_epi64(_First, _Second);
+            }
 
-        static __m256d _Min(const __m256d _First, const __m256d _Second, __m256d = _mm256_undefined_pd()) noexcept {
-            return _mm256_min_pd(_Second, _First);
-        }
+            static __m256d _Min(const __m256d _First, const __m256d _Second, __m256d = _mm256_undefined_pd()) noexcept {
+                return _mm256_min_pd(_Second, _First);
+            }
 
-        static __m256d _Max(const __m256d _First, const __m256d _Second, __m256d = _mm256_undefined_pd()) noexcept {
-            return _mm256_max_pd(_Second, _First);
-        }
+            static __m256d _Max(const __m256d _First, const __m256d _Second, __m256d = _mm256_undefined_pd()) noexcept {
+                return _mm256_max_pd(_Second, _First);
+            }
 
-        static __m256i _Mask_cast(const __m256d _Mask) noexcept {
-            return _mm256_castpd_si256(_Mask);
-        }
-    };
+            static __m256i _Mask_cast(const __m256d _Mask) noexcept {
+                return _mm256_castpd_si256(_Mask);
+            }
+        };
 #endif // !defined(_M_ARM64EC)
 
-    struct _Minmax_traits_1 {
-        using _Scalar = _Minmax_traits_scalar<_Minmax_traits_1_base>;
+        struct _Traits_1 {
+            using _Scalar = _Traits_scalar<_Traits_1_base>;
 #ifndef _M_ARM64EC
-        using _Sse = _Minmax_traits_1_sse;
-        using _Avx = _Minmax_traits_1_avx;
+            using _Sse = _Traits_1_sse;
+            using _Avx = _Traits_1_avx;
 #endif // !defined(_M_ARM64EC)
-    };
+        };
 
-    struct _Minmax_traits_2 {
-        using _Scalar = _Minmax_traits_scalar<_Minmax_traits_2_base>;
+        struct _Traits_2 {
+            using _Scalar = _Traits_scalar<_Traits_2_base>;
 #ifndef _M_ARM64EC
-        using _Sse = _Minmax_traits_2_sse;
-        using _Avx = _Minmax_traits_2_avx;
+            using _Sse = _Traits_2_sse;
+            using _Avx = _Traits_2_avx;
 #endif // !defined(_M_ARM64EC)
-    };
+        };
 
-    struct _Minmax_traits_4 {
-        using _Scalar = _Minmax_traits_scalar<_Minmax_traits_4_base>;
+        struct _Traits_4 {
+            using _Scalar = _Traits_scalar<_Traits_4_base>;
 #ifndef _M_ARM64EC
-        using _Sse = _Minmax_traits_4_sse;
-        using _Avx = _Minmax_traits_4_avx;
+            using _Sse = _Traits_4_sse;
+            using _Avx = _Traits_4_avx;
 #endif // !defined(_M_ARM64EC)
-    };
+        };
 
-    struct _Minmax_traits_8 {
-        using _Scalar = _Minmax_traits_scalar<_Minmax_traits_8_base>;
+        struct _Traits_8 {
+            using _Scalar = _Traits_scalar<_Traits_8_base>;
 #ifndef _M_ARM64EC
-        using _Sse = _Minmax_traits_8_sse;
-        using _Avx = _Minmax_traits_8_avx;
+            using _Sse = _Traits_8_sse;
+            using _Avx = _Traits_8_avx;
 #endif // !defined(_M_ARM64EC)
-    };
+        };
 
-    struct _Minmax_traits_f {
-        using _Scalar = _Minmax_traits_scalar<_Minmax_traits_f_base>;
+        struct _Traits_f {
+            using _Scalar = _Traits_scalar<_Traits_f_base>;
 #ifndef _M_ARM64EC
-        using _Sse = _Minmax_traits_f_sse;
-        using _Avx = _Minmax_traits_f_avx;
+            using _Sse = _Traits_f_sse;
+            using _Avx = _Traits_f_avx;
 #endif // !defined(_M_ARM64EC)
-    };
+        };
 
-    struct _Minmax_traits_d {
-        using _Scalar = _Minmax_traits_scalar<_Minmax_traits_d_base>;
+        struct _Traits_d {
+            using _Scalar = _Traits_scalar<_Traits_d_base>;
 #ifndef _M_ARM64EC
-        using _Sse = _Minmax_traits_d_sse;
-        using _Avx = _Minmax_traits_d_avx;
+            using _Sse = _Traits_d_sse;
+            using _Avx = _Traits_d_avx;
 #endif // !defined(_M_ARM64EC)
-    };
+        };
 
-    template <_Min_max_mode _Mode, class _Traits>
-    auto __std_minmax_element_impl(const void* _First, const void* const _Last, const bool _Sign) noexcept {
-        _Min_max_element_t _Res = {_First, _First};
-        auto _Cur_min_val       = _Traits::_Init_min_val;
-        auto _Cur_max_val       = _Traits::_Init_max_val;
+        template <_Min_max_mode _Mode, class _Traits>
+        auto _Minmax_element_impl(const void* _First, const void* const _Last, const bool _Sign) noexcept {
+            _Min_max_element_t _Res = {_First, _First};
+            auto _Cur_min_val       = _Traits::_Init_min_val;
+            auto _Cur_max_val       = _Traits::_Init_max_val;
 
-        if constexpr (_Traits::_Vectorized) {
+            if constexpr (_Traits::_Vectorized) {
 #ifdef _M_ARM64EC
-            static_assert(false, "No vectorization for _M_ARM64EC yet");
+                static_assert(false, "No vectorization for _M_ARM64EC yet");
 #else // ^^^ defined(_M_ARM64EC) / !defined(_M_ARM64EC) vvv
-            auto _Base                = static_cast<const char*>(_First);
-            size_t _Portion_byte_size = _Byte_length(_First, _Last) & ~_Traits::_Vec_mask;
+                auto _Base                = static_cast<const char*>(_First);
+                size_t _Portion_byte_size = _Byte_length(_First, _Last) & ~_Traits::_Vec_mask;
 
-            if constexpr (_Traits::_Has_portion_max) {
-                // vector of indices will wrap around at exactly this size
-                constexpr size_t _Max_portion_byte_size = _Traits::_Portion_max * _Traits::_Vec_size;
-                if (_Portion_byte_size > _Max_portion_byte_size) {
-                    _Portion_byte_size = _Max_portion_byte_size;
-                }
-            }
-
-            const void* _Stop_at = _First;
-            _Advance_bytes(_Stop_at, _Portion_byte_size);
-
-            // Load values and if unsigned adjust them to be signed (for signed vector comparisons)
-            auto _Cur_vals     = _Traits::_Sign_correction(_Traits::_Load(_First), _Sign);
-            auto _Cur_vals_min = _Cur_vals; // vector of vertical minimum values
-            auto _Cur_idx_min  = _Traits::_Zero(); // vector of vertical minimum indices
-            auto _Cur_vals_max = _Cur_vals; // vector of vertical maximum values
-            auto _Cur_idx_max  = _Traits::_Zero(); // vector of vertical maximum indices
-            auto _Cur_idx      = _Traits::_Zero(); // current vector of indices
-
-            const auto _Update_min_max = [&](const auto _Cur_vals, [[maybe_unused]] const auto _Blend_idx_0,
-                                             const auto _Blend_idx_1) noexcept {
-                if constexpr ((_Mode & _Mode_min) != 0) {
-                    // Looking for the first occurrence of minimum, don't overwrite with newly found occurrences
-                    const auto _Is_less = _Traits::_Cmp_gt(_Cur_vals_min, _Cur_vals); // _Cur_vals < _Cur_vals_min
-                    // Remember their vertical indices
-                    _Cur_idx_min  = _Blend_idx_1(_Cur_idx_min, _Cur_idx, _Traits::_Mask_cast(_Is_less));
-                    _Cur_vals_min = _Traits::_Min(_Cur_vals_min, _Cur_vals, _Is_less); // Update the current minimum
+                if constexpr (_Traits::_Has_portion_max) {
+                    // vector of indices will wrap around at exactly this size
+                    constexpr size_t _Max_portion_byte_size = _Traits::_Portion_max * _Traits::_Vec_size;
+                    if (_Portion_byte_size > _Max_portion_byte_size) {
+                        _Portion_byte_size = _Max_portion_byte_size;
+                    }
                 }
 
-                if constexpr (_Mode == _Mode_max) {
-                    // Looking for the first occurrence of maximum, don't overwrite with newly found occurrences
-                    const auto _Is_greater = _Traits::_Cmp_gt(_Cur_vals, _Cur_vals_max); // _Cur_vals > _Cur_vals_max
-                    // Remember their vertical indices
-                    _Cur_idx_max  = _Blend_idx_1(_Cur_idx_max, _Cur_idx, _Traits::_Mask_cast(_Is_greater));
-                    _Cur_vals_max = _Traits::_Max(_Cur_vals_max, _Cur_vals, _Is_greater); // Update the current maximum
-                } else if constexpr (_Mode == _Mode_both) {
-                    // Looking for the last occurrence of maximum, do overwrite with newly found occurrences
-                    const auto _Is_less = _Traits::_Cmp_gt(_Cur_vals_max, _Cur_vals); // !(_Cur_vals >= _Cur_vals_max)
-                    // Remember their vertical indices
-                    _Cur_idx_max  = _Blend_idx_0(_Cur_idx_max, _Cur_idx, _Traits::_Mask_cast(_Is_less));
-                    _Cur_vals_max = _Traits::_Max(_Cur_vals, _Cur_vals_max, _Is_less); // Update the current maximum
-                }
-            };
+                const void* _Stop_at = _First;
+                _Advance_bytes(_Stop_at, _Portion_byte_size);
 
-            const auto _Blend_idx_0 = [](const auto _Prev, const auto _Cur, const auto _Mask) noexcept {
-                return _Traits::_Blend(_Cur, _Prev, _Mask);
-            };
+                // Load values and if unsigned adjust them to be signed (for signed vector comparisons)
+                auto _Cur_vals     = _Traits::_Sign_correction(_Traits::_Load(_First), _Sign);
+                auto _Cur_vals_min = _Cur_vals; // vector of vertical minimum values
+                auto _Cur_idx_min  = _Traits::_Zero(); // vector of vertical minimum indices
+                auto _Cur_vals_max = _Cur_vals; // vector of vertical maximum values
+                auto _Cur_idx_max  = _Traits::_Zero(); // vector of vertical maximum indices
+                auto _Cur_idx      = _Traits::_Zero(); // current vector of indices
 
-            const auto _Blend_idx_1 = [](const auto _Prev, const auto _Cur, const auto _Mask) noexcept {
-                return _Traits::_Blend(_Prev, _Cur, _Mask);
-            };
-
-            for (;;) {
-                _Advance_bytes(_First, _Traits::_Vec_size);
-
-                // Increment vertical indices. Will stop at exactly wrap around, if not reach the end before
-                _Cur_idx = _Traits::_Inc(_Cur_idx);
-
-                if (_First != _Stop_at) {
-                    // This is the main part, finding vertical minimum/maximum
-
-                    // Load values and if unsigned adjust them to be signed (for signed vector comparisons)
-                    _Cur_vals = _Traits::_Sign_correction(_Traits::_Load(_First), _Sign);
-
-                    _Update_min_max(_Cur_vals, _Blend_idx_0, _Blend_idx_1);
-                } else {
-                    if constexpr (_Traits::_Tail_mask != 0) {
-                        const size_t _Remaining_byte_size = _Byte_length(_First, _Last);
-                        bool _Last_portion;
-
-                        if constexpr (_Traits::_Has_portion_max) {
-                            _Last_portion = (_Remaining_byte_size & ~_Traits::_Vec_mask) == 0;
-                        } else {
-                            _Last_portion = true;
-                        }
-
-                        const size_t _Tail_byte_size = _Remaining_byte_size & _Traits::_Tail_mask;
-
-                        if (_Last_portion && _Tail_byte_size != 0) {
-                            const auto _Tail_mask = _Avx2_tail_mask_32(_Tail_byte_size);
-                            const auto _Tail_vals =
-                                _Traits::_Sign_correction(_Traits::_Load_mask(_First, _Tail_mask), _Sign);
-                            _Cur_vals = _Traits::_Blendval(_Cur_vals, _Tail_vals, _Tail_mask);
-
-                            const auto _Blend_idx_0_mask = [_Tail_mask](const auto _Prev, const auto _Cur,
-                                                               const auto _Mask) noexcept {
-                                return _Traits::_Blend(_Prev, _Cur, _mm256_andnot_si256(_Mask, _Tail_mask));
-                            };
-
-                            const auto _Blend_idx_1_mask = [_Tail_mask](const auto _Prev, const auto _Cur,
-                                                               const auto _Mask) noexcept {
-                                return _Traits::_Blend(_Prev, _Cur, _mm256_and_si256(_Tail_mask, _Mask));
-                            };
-
-                            _Update_min_max(_Cur_vals, _Blend_idx_0_mask, _Blend_idx_1_mask);
-                            _Advance_bytes(_First, _Tail_byte_size);
-                        }
+                const auto _Update_min_max = [&](const auto _Cur_vals, [[maybe_unused]] const auto _Blend_idx_0,
+                                                 const auto _Blend_idx_1) noexcept {
+                    if constexpr ((_Mode & _Mode_min) != 0) {
+                        // Looking for the first occurrence of minimum, don't overwrite with newly found occurrences
+                        const auto _Is_less = _Traits::_Cmp_gt(_Cur_vals_min, _Cur_vals); // _Cur_vals < _Cur_vals_min
+                        // Remember their vertical indices
+                        _Cur_idx_min  = _Blend_idx_1(_Cur_idx_min, _Cur_idx, _Traits::_Mask_cast(_Is_less));
+                        _Cur_vals_min = _Traits::_Min(_Cur_vals_min, _Cur_vals, _Is_less); // Update the current minimum
                     }
 
-                    // Reached end or indices wrap around point.
-                    // Compute horizontal min and/or max. Determine horizontal and vertical position of it.
+                    if constexpr (_Mode == _Mode_max) {
+                        // Looking for the first occurrence of maximum, don't overwrite with newly found occurrences
+                        // _Cur_vals > _Cur_vals_max
+                        const auto _Is_greater = _Traits::_Cmp_gt(_Cur_vals, _Cur_vals_max);
+                        // Remember their vertical indices
+                        _Cur_idx_max = _Blend_idx_1(_Cur_idx_max, _Cur_idx, _Traits::_Mask_cast(_Is_greater));
+                        // Update the current maximum
+                        _Cur_vals_max = _Traits::_Max(_Cur_vals_max, _Cur_vals, _Is_greater);
+                    } else if constexpr (_Mode == _Mode_both) {
+                        // Looking for the last occurrence of maximum, do overwrite with newly found occurrences
+                        // !(_Cur_vals >= _Cur_vals_max)
+                        const auto _Is_less = _Traits::_Cmp_gt(_Cur_vals_max, _Cur_vals);
+                        // Remember their vertical indices
+                        _Cur_idx_max  = _Blend_idx_0(_Cur_idx_max, _Cur_idx, _Traits::_Mask_cast(_Is_less));
+                        _Cur_vals_max = _Traits::_Max(_Cur_vals, _Cur_vals_max, _Is_less); // Update the current maximum
+                    }
+                };
 
+                const auto _Blend_idx_0 = [](const auto _Prev, const auto _Cur, const auto _Mask) noexcept {
+                    return _Traits::_Blend(_Cur, _Prev, _Mask);
+                };
+
+                const auto _Blend_idx_1 = [](const auto _Prev, const auto _Cur, const auto _Mask) noexcept {
+                    return _Traits::_Blend(_Prev, _Cur, _Mask);
+                };
+
+                for (;;) {
+                    _Advance_bytes(_First, _Traits::_Vec_size);
+
+                    // Increment vertical indices. Will stop at exactly wrap around, if not reach the end before
+                    _Cur_idx = _Traits::_Inc(_Cur_idx);
+
+                    if (_First != _Stop_at) {
+                        // This is the main part, finding vertical minimum/maximum
+
+                        // Load values and if unsigned adjust them to be signed (for signed vector comparisons)
+                        _Cur_vals = _Traits::_Sign_correction(_Traits::_Load(_First), _Sign);
+
+                        _Update_min_max(_Cur_vals, _Blend_idx_0, _Blend_idx_1);
+                    } else {
+                        if constexpr (_Traits::_Tail_mask != 0) {
+                            const size_t _Remaining_byte_size = _Byte_length(_First, _Last);
+                            bool _Last_portion;
+
+                            if constexpr (_Traits::_Has_portion_max) {
+                                _Last_portion = (_Remaining_byte_size & ~_Traits::_Vec_mask) == 0;
+                            } else {
+                                _Last_portion = true;
+                            }
+
+                            const size_t _Tail_byte_size = _Remaining_byte_size & _Traits::_Tail_mask;
+
+                            if (_Last_portion && _Tail_byte_size != 0) {
+                                const auto _Tail_mask = _Avx2_tail_mask_32(_Tail_byte_size);
+                                const auto _Tail_vals =
+                                    _Traits::_Sign_correction(_Traits::_Load_mask(_First, _Tail_mask), _Sign);
+                                _Cur_vals = _Traits::_Blendval(_Cur_vals, _Tail_vals, _Tail_mask);
+
+                                const auto _Blend_idx_0_mask = [_Tail_mask](const auto _Prev, const auto _Cur,
+                                                                   const auto _Mask) noexcept {
+                                    return _Traits::_Blend(_Prev, _Cur, _mm256_andnot_si256(_Mask, _Tail_mask));
+                                };
+
+                                const auto _Blend_idx_1_mask = [_Tail_mask](const auto _Prev, const auto _Cur,
+                                                                   const auto _Mask) noexcept {
+                                    return _Traits::_Blend(_Prev, _Cur, _mm256_and_si256(_Tail_mask, _Mask));
+                                };
+
+                                _Update_min_max(_Cur_vals, _Blend_idx_0_mask, _Blend_idx_1_mask);
+                                _Advance_bytes(_First, _Tail_byte_size);
+                            }
+                        }
+
+                        // Reached end or indices wrap around point.
+                        // Compute horizontal min and/or max. Determine horizontal and vertical position of it.
+
+                        if constexpr ((_Mode & _Mode_min) != 0) {
+                            // Vector populated by the smallest element
+                            const auto _H_min     = _Traits::_H_min(_Cur_vals_min);
+                            const auto _H_min_val = _Traits::_Get_any(_H_min); // Get any element of it
+
+                            if (_H_min_val < _Cur_min_val) { // Current horizontal min is less than the old
+                                _Cur_min_val = _H_min_val; // update min
+                                // Mask of all elems eq to min
+                                const auto _Eq_mask = _Traits::_Cmp_eq(_H_min, _Cur_vals_min);
+                                unsigned long _Mask = _Traits::_Mask(_Traits::_Mask_cast(_Eq_mask));
+                                // Indices of minimum elements or the greatest index if none
+                                const auto _Idx_min_val =
+                                    _Traits::_Blend(_Traits::_All_ones(), _Cur_idx_min, _Traits::_Mask_cast(_Eq_mask));
+                                auto _Idx_min = _Traits::_H_min_u(_Idx_min_val); // The smallest indices
+                                // Select the smallest vertical indices from the smallest element mask
+                                _Mask &= _Traits::_Mask(_Traits::_Cmp_eq_idx(_Idx_min, _Idx_min_val));
+                                unsigned long _H_pos;
+
+                                // Find the smallest horizontal index
+
+                                // CodeQL [SM02313] _H_pos is always initialized: element exists, so _Mask != 0.
+                                _BitScanForward(&_H_pos, _Mask);
+
+                                // Extract its vertical index
+                                const auto _V_pos = _Traits::_Get_v_pos(_Cur_idx_min, _H_pos);
+                                // Finally, compute the pointer
+                                _Res._Min = _Base + static_cast<size_t>(_V_pos) * _Traits::_Vec_size + _H_pos;
+                            }
+                        }
+
+                        if constexpr ((_Mode & _Mode_max) != 0) {
+                            // Vector populated by the largest element
+                            const auto _H_max     = _Traits::_H_max(_Cur_vals_max);
+                            const auto _H_max_val = _Traits::_Get_any(_H_max); // Get any element of it
+
+                            if (_Mode == _Mode_both && _Cur_max_val <= _H_max_val
+                                || _Mode == _Mode_max && _Cur_max_val < _H_max_val) {
+                                // max_element: current horizontal max is greater than the old, update max
+                                // minmax_element: current horizontal max is not less than the old, update max
+                                _Cur_max_val = _H_max_val;
+
+                                // Mask of all elems eq to max
+                                const auto _Eq_mask = _Traits::_Cmp_eq(_H_max, _Cur_vals_max);
+                                unsigned long _Mask = _Traits::_Mask(_Traits::_Mask_cast(_Eq_mask));
+
+                                unsigned long _H_pos;
+                                if constexpr (_Mode == _Mode_both) {
+                                    // Looking for the last occurrence of maximum
+                                    // Indices of maximum elements or zero if none
+                                    const auto _Idx_max_val =
+                                        _Traits::_Blend(_Traits::_Zero(), _Cur_idx_max, _Traits::_Mask_cast(_Eq_mask));
+                                    const auto _Idx_max = _Traits::_H_max_u(_Idx_max_val); // The greatest indices
+                                    // Select the greatest vertical indices from the largest element mask
+                                    _Mask &= _Traits::_Mask(_Traits::_Cmp_eq_idx(_Idx_max, _Idx_max_val));
+
+                                    // Find the largest horizontal index
+
+                                    // CodeQL [SM02313] _H_pos is always initialized: element exists, so _Mask != 0.
+                                    _BitScanReverse(&_H_pos, _Mask);
+
+                                    _H_pos -= sizeof(_Cur_max_val) - 1; // Correct from highest val bit to lowest
+                                } else {
+                                    // Looking for the first occurrence of maximum
+                                    // Indices of maximum elements or the greatest index if none
+                                    const auto _Idx_max_val = _Traits::_Blend(
+                                        _Traits::_All_ones(), _Cur_idx_max, _Traits::_Mask_cast(_Eq_mask));
+                                    const auto _Idx_max = _Traits::_H_min_u(_Idx_max_val); // The smallest indices
+                                    // Select the smallest vertical indices from the largest element mask
+                                    _Mask &= _Traits::_Mask(_Traits::_Cmp_eq_idx(_Idx_max, _Idx_max_val));
+
+                                    // Find the smallest horizontal index
+
+                                    // CodeQL [SM02313] _H_pos is always initialized: element exists, so _Mask != 0.
+                                    _BitScanForward(&_H_pos, _Mask);
+                                }
+
+                                // Extract its vertical index
+                                const auto _V_pos = _Traits::_Get_v_pos(_Cur_idx_max, _H_pos);
+                                // Finally, compute the pointer
+                                _Res._Max = _Base + static_cast<size_t>(_V_pos) * _Traits::_Vec_size + _H_pos;
+                            }
+                        }
+                        // Horizontal part done, results are saved, now need to see if there is another portion.
+
+                        if constexpr (_Traits::_Has_portion_max) {
+                            // Either the last portion or wrapping point reached, need to determine
+                            _Portion_byte_size = _Byte_length(_First, _Last) & ~_Traits::_Vec_mask;
+                            if (_Portion_byte_size == 0) {
+                                break; // That was the last portion
+                            }
+                            // Start next portion to handle the wrapping indices. Assume _Cur_idx is zero
+                            constexpr size_t _Max_portion_byte_size = _Traits::_Portion_max * _Traits::_Vec_size;
+                            if (_Portion_byte_size > _Max_portion_byte_size) {
+                                _Portion_byte_size = _Max_portion_byte_size;
+                            }
+
+                            _Advance_bytes(_Stop_at, _Portion_byte_size);
+                            // Indices will be relative to the new base
+                            _Base = static_cast<const char*>(_First);
+                            // Load values and if unsigned adjust them to be signed (for signed vector comparisons)
+                            _Cur_vals = _Traits::_Sign_correction(_Traits::_Load(_First), _Sign);
+
+                            if constexpr ((_Mode & _Mode_min) != 0) {
+                                _Cur_vals_min = _Cur_vals;
+                                _Cur_idx_min  = _Traits::_Zero();
+                            }
+
+                            if constexpr ((_Mode & _Mode_max) != 0) {
+                                _Cur_vals_max = _Cur_vals;
+                                _Cur_idx_max  = _Traits::_Zero();
+                            }
+                        } else {
+                            break; // No wrapping, so it was the only portion
+                        }
+                    }
+                }
+
+                _Traits::_Exit_vectorized(); // TRANSITION, DevCom-10331414
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
+            }
+
+            if constexpr (_Traits::_Is_floating) {
+                if constexpr (_Mode == _Mode_min) {
+                    return _Min_tail(_First, _Last, _Res._Min, _Cur_min_val);
+                } else if constexpr (_Mode == _Mode_max) {
+                    return _Max_tail(_First, _Last, _Res._Max, _Cur_max_val);
+                } else {
+                    return _Both_tail(_First, _Last, _Res, _Cur_min_val, _Cur_max_val);
+                }
+            } else {
+                using _STy = _Traits::_Signed_t;
+                using _UTy = _Traits::_Unsigned_t;
+
+                constexpr _UTy _Correction = _UTy{1} << (sizeof(_UTy) * 8 - 1);
+
+                if constexpr (_Mode == _Mode_min) {
+                    if (_Sign) {
+                        return _Min_tail(_First, _Last, _Res._Min, static_cast<_STy>(_Cur_min_val));
+                    } else {
+                        return _Min_tail(_First, _Last, _Res._Min, static_cast<_UTy>(_Cur_min_val + _Correction));
+                    }
+                } else if constexpr (_Mode == _Mode_max) {
+                    if (_Sign) {
+                        return _Max_tail(_First, _Last, _Res._Max, static_cast<_STy>(_Cur_max_val));
+                    } else {
+                        return _Max_tail(_First, _Last, _Res._Max, static_cast<_UTy>(_Cur_max_val + _Correction));
+                    }
+                } else {
+                    if (_Sign) {
+                        return _Both_tail(
+                            _First, _Last, _Res, static_cast<_STy>(_Cur_min_val), static_cast<_STy>(_Cur_max_val));
+                    } else {
+                        return _Both_tail(_First, _Last, _Res, static_cast<_UTy>(_Cur_min_val + _Correction),
+                            static_cast<_UTy>(_Cur_max_val + _Correction));
+                    }
+                }
+            }
+        }
+
+        template <_Min_max_mode _Mode, class _Traits>
+        auto _Minmax_element_disp(const void* const _First, const void* const _Last, const bool _Sign) noexcept {
+#ifndef _M_ARM64EC
+            if (_Byte_length(_First, _Last) >= 32 && _Use_avx2()) {
+                return _Minmax_element_impl<_Mode, typename _Traits::_Avx>(_First, _Last, _Sign);
+            }
+
+            if (_Byte_length(_First, _Last) >= 16 && _Use_sse42()) {
+                return _Minmax_element_impl<_Mode, typename _Traits::_Sse>(_First, _Last, _Sign);
+            }
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
+            return _Minmax_element_impl<_Mode, typename _Traits::_Scalar>(_First, _Last, _Sign);
+        }
+
+        template <_Min_max_mode _Mode, class _Traits, bool _Sign>
+        auto _Minmax_impl(const void* _First, const void* const _Last) noexcept {
+            using _Ty = std::conditional_t<_Sign, typename _Traits::_Signed_t, typename _Traits::_Unsigned_t>;
+
+            _Ty _Cur_min_val; // initialized in both of the branches below
+            _Ty _Cur_max_val; // initialized in both of the branches below
+
+            if constexpr (_Traits::_Vectorized) {
+#ifdef _M_ARM64EC
+                static_assert(false, "No vectorization for _M_ARM64EC yet");
+#else // ^^^ defined(_M_ARM64EC) / !defined(_M_ARM64EC) vvv
+                const size_t _Total_size_bytes = _Byte_length(_First, _Last);
+                const size_t _Vec_byte_size    = _Total_size_bytes & ~_Traits::_Vec_mask;
+
+                const void* _Stop_at = _First;
+                _Advance_bytes(_Stop_at, _Vec_byte_size);
+
+                auto _Cur_vals = _Traits::_Load(_First);
+
+                // We don't have unsigned 64-bit stuff, so we'll use sign correction just for that case
+                constexpr bool _Sign_correction = sizeof(_Ty) == 8 && !_Sign;
+
+                if constexpr (_Sign_correction) {
+                    _Cur_vals = _Traits::_Sign_correction(_Cur_vals, false);
+                }
+
+                auto _Cur_vals_min = _Cur_vals; // vector of vertical minimum values
+                auto _Cur_vals_max = _Cur_vals; // vector of vertical maximum values
+
+                const auto _Update_min_max = [&](const auto _Cur_vals) noexcept {
                     if constexpr ((_Mode & _Mode_min) != 0) {
-                        const auto _H_min = _Traits::_H_min(_Cur_vals_min); // Vector populated by the smallest element
-                        const auto _H_min_val = _Traits::_Get_any(_H_min); // Get any element of it
-
-                        if (_H_min_val < _Cur_min_val) { // Current horizontal min is less than the old
-                            _Cur_min_val = _H_min_val; // update min
-                            const auto _Eq_mask =
-                                _Traits::_Cmp_eq(_H_min, _Cur_vals_min); // Mask of all elems eq to min
-                            unsigned long _Mask = _Traits::_Mask(_Traits::_Mask_cast(_Eq_mask));
-                            // Indices of minimum elements or the greatest index if none
-                            const auto _Idx_min_val =
-                                _Traits::_Blend(_Traits::_All_ones(), _Cur_idx_min, _Traits::_Mask_cast(_Eq_mask));
-                            auto _Idx_min = _Traits::_H_min_u(_Idx_min_val); // The smallest indices
-                            // Select the smallest vertical indices from the smallest element mask
-                            _Mask &= _Traits::_Mask(_Traits::_Cmp_eq_idx(_Idx_min, _Idx_min_val));
-                            unsigned long _H_pos;
-
-                            // Find the smallest horizontal index
-
-                            // CodeQL [SM02313] _H_pos is always initialized: element exists, so _Mask is non-zero.
-                            _BitScanForward(&_H_pos, _Mask);
-
-                            const auto _V_pos = _Traits::_Get_v_pos(_Cur_idx_min, _H_pos); // Extract its vertical index
-                            // Finally, compute the pointer
-                            _Res._Min = _Base + static_cast<size_t>(_V_pos) * _Traits::_Vec_size + _H_pos;
+                        if constexpr (_Sign || _Sign_correction) {
+                            _Cur_vals_min = _Traits::_Min(_Cur_vals_min, _Cur_vals); // Update the current minimum
+                        } else {
+                            _Cur_vals_min = _Traits::_Min_u(_Cur_vals_min, _Cur_vals); // Update the current minimum
                         }
                     }
 
                     if constexpr ((_Mode & _Mode_max) != 0) {
-                        const auto _H_max = _Traits::_H_max(_Cur_vals_max); // Vector populated by the largest element
-                        const auto _H_max_val = _Traits::_Get_any(_H_max); // Get any element of it
-
-                        if (_Mode == _Mode_both && _Cur_max_val <= _H_max_val
-                            || _Mode == _Mode_max && _Cur_max_val < _H_max_val) {
-                            // max_element: current horizontal max is greater than the old, update max
-                            // minmax_element: current horizontal max is not less than the old, update max
-                            _Cur_max_val = _H_max_val;
-                            const auto _Eq_mask =
-                                _Traits::_Cmp_eq(_H_max, _Cur_vals_max); // Mask of all elems eq to max
-                            unsigned long _Mask = _Traits::_Mask(_Traits::_Mask_cast(_Eq_mask));
-
-                            unsigned long _H_pos;
-                            if constexpr (_Mode == _Mode_both) {
-                                // Looking for the last occurrence of maximum
-                                // Indices of maximum elements or zero if none
-                                const auto _Idx_max_val =
-                                    _Traits::_Blend(_Traits::_Zero(), _Cur_idx_max, _Traits::_Mask_cast(_Eq_mask));
-                                const auto _Idx_max = _Traits::_H_max_u(_Idx_max_val); // The greatest indices
-                                // Select the greatest vertical indices from the largest element mask
-                                _Mask &= _Traits::_Mask(_Traits::_Cmp_eq_idx(_Idx_max, _Idx_max_val));
-
-                                // Find the largest horizontal index
-
-                                // CodeQL [SM02313] _H_pos is always initialized: element exists, so _Mask is non-zero.
-                                _BitScanReverse(&_H_pos, _Mask);
-
-                                _H_pos -= sizeof(_Cur_max_val) - 1; // Correct from highest val bit to lowest
-                            } else {
-                                // Looking for the first occurrence of maximum
-                                // Indices of maximum elements or the greatest index if none
-                                const auto _Idx_max_val =
-                                    _Traits::_Blend(_Traits::_All_ones(), _Cur_idx_max, _Traits::_Mask_cast(_Eq_mask));
-                                const auto _Idx_max = _Traits::_H_min_u(_Idx_max_val); // The smallest indices
-                                // Select the smallest vertical indices from the largest element mask
-                                _Mask &= _Traits::_Mask(_Traits::_Cmp_eq_idx(_Idx_max, _Idx_max_val));
-
-                                // Find the smallest horizontal index
-
-                                // CodeQL [SM02313] _H_pos is always initialized: element exists, so _Mask is non-zero.
-                                _BitScanForward(&_H_pos, _Mask);
-                            }
-
-                            const auto _V_pos = _Traits::_Get_v_pos(_Cur_idx_max, _H_pos); // Extract its vertical index
-                            // Finally, compute the pointer
-                            _Res._Max = _Base + static_cast<size_t>(_V_pos) * _Traits::_Vec_size + _H_pos;
+                        if constexpr (_Sign || _Sign_correction) {
+                            _Cur_vals_max = _Traits::_Max(_Cur_vals_max, _Cur_vals); // Update the current maximum
+                        } else {
+                            _Cur_vals_max = _Traits::_Max_u(_Cur_vals_max, _Cur_vals); // Update the current maximum
                         }
                     }
-                    // Horizontal part done, results are saved, now need to see if there is another portion to process
+                };
 
-                    if constexpr (_Traits::_Has_portion_max) {
-                        // Either the last portion or wrapping point reached, need to determine
-                        _Portion_byte_size = _Byte_length(_First, _Last) & ~_Traits::_Vec_mask;
-                        if (_Portion_byte_size == 0) {
-                            break; // That was the last portion
-                        }
-                        // Start next portion to handle the wrapping indices. Assume _Cur_idx is zero
-                        constexpr size_t _Max_portion_byte_size = _Traits::_Portion_max * _Traits::_Vec_size;
-                        if (_Portion_byte_size > _Max_portion_byte_size) {
-                            _Portion_byte_size = _Max_portion_byte_size;
+                for (;;) {
+                    _Advance_bytes(_First, _Traits::_Vec_size);
+
+                    if (_First != _Stop_at) {
+                        // This is the main part, finding vertical minimum/maximum
+
+                        _Cur_vals = _Traits::_Load(_First);
+
+                        if constexpr (_Sign_correction) {
+                            _Cur_vals = _Traits::_Sign_correction(_Cur_vals, false);
                         }
 
-                        _Advance_bytes(_Stop_at, _Portion_byte_size);
-                        // Indices will be relative to the new base
-                        _Base = static_cast<const char*>(_First);
-                        // Load values and if unsigned adjust them to be signed (for signed vector comparisons)
-                        _Cur_vals = _Traits::_Sign_correction(_Traits::_Load(_First), _Sign);
+                        _Update_min_max(_Cur_vals);
+                    } else {
+                        if constexpr (_Traits::_Tail_mask != 0) {
+                            const size_t _Tail_byte_size = _Total_size_bytes & _Traits::_Tail_mask;
+                            if (_Tail_byte_size != 0) {
+                                const auto _Tail_mask = _Avx2_tail_mask_32(_Tail_byte_size);
+                                auto _Tail_vals       = _Traits::_Load_mask(_First, _Tail_mask);
+
+                                if constexpr (_Sign_correction) {
+                                    _Tail_vals = _Traits::_Sign_correction(_Tail_vals, false);
+                                }
+
+                                _Tail_vals = _Traits::_Blendval(_Cur_vals, _Tail_vals, _Tail_mask);
+
+                                _Update_min_max(_Tail_vals);
+
+                                _Advance_bytes(_First, _Tail_byte_size);
+                            }
+                        }
+
+                        // Reached end. Compute horizontal min and/or max.
 
                         if constexpr ((_Mode & _Mode_min) != 0) {
-                            _Cur_vals_min = _Cur_vals;
-                            _Cur_idx_min  = _Traits::_Zero();
+                            if constexpr (_Sign || _Sign_correction) {
+                                // Vector populated by the smallest element
+                                const auto _H_min = _Traits::_H_min(_Cur_vals_min);
+                                _Cur_min_val      = _Traits::_Get_any(_H_min); // Get any element of it
+                            } else {
+                                // Vector populated by the smallest element
+                                const auto _H_min = _Traits::_H_min_u(_Cur_vals_min);
+                                _Cur_min_val      = _Traits::_Get_any(_H_min); // Get any element of it
+                            }
                         }
 
                         if constexpr ((_Mode & _Mode_max) != 0) {
-                            _Cur_vals_max = _Cur_vals;
-                            _Cur_idx_max  = _Traits::_Zero();
+                            if constexpr (_Sign || _Sign_correction) {
+                                // Vector populated by the largest element
+                                const auto _H_max = _Traits::_H_max(_Cur_vals_max);
+                                _Cur_max_val      = _Traits::_Get_any(_H_max); // Get any element of it
+                            } else {
+                                // Vector populated by the largest element
+                                const auto _H_max = _Traits::_H_max_u(_Cur_vals_max);
+                                _Cur_max_val      = _Traits::_Get_any(_H_max); // Get any element of it
+                            }
                         }
-                    } else {
-                        break; // No wrapping, so it was the only portion
+
+                        if constexpr (_Sign_correction) {
+                            constexpr _Ty _Correction = _Ty{1} << (sizeof(_Ty) * 8 - 1);
+
+                            if constexpr ((_Mode & _Mode_min) != 0) {
+                                _Cur_min_val += _Correction;
+                            }
+
+                            if constexpr ((_Mode & _Mode_max) != 0) {
+                                _Cur_max_val += _Correction;
+                            }
+                        }
+
+                        break;
                     }
                 }
-            }
 
-            _Traits::_Exit_vectorized(); // TRANSITION, DevCom-10331414
+                _Traits::_Exit_vectorized(); // TRANSITION, DevCom-10331414
 #endif // ^^^ !defined(_M_ARM64EC) ^^^
-        }
-
-        if constexpr (_Traits::_Is_floating) {
-            if constexpr (_Mode == _Mode_min) {
-                return _Min_tail(_First, _Last, _Res._Min, _Cur_min_val);
-            } else if constexpr (_Mode == _Mode_max) {
-                return _Max_tail(_First, _Last, _Res._Max, _Cur_max_val);
             } else {
-                return _Both_tail(_First, _Last, _Res, _Cur_min_val, _Cur_max_val);
-            }
-        } else {
-            using _STy = _Traits::_Signed_t;
-            using _UTy = _Traits::_Unsigned_t;
+                _Cur_min_val = *reinterpret_cast<const _Ty*>(_First);
+                _Cur_max_val = *reinterpret_cast<const _Ty*>(_First);
 
-            constexpr _UTy _Correction = _UTy{1} << (sizeof(_UTy) * 8 - 1);
-
-            if constexpr (_Mode == _Mode_min) {
-                if (_Sign) {
-                    return _Min_tail(_First, _Last, _Res._Min, static_cast<_STy>(_Cur_min_val));
-                } else {
-                    return _Min_tail(_First, _Last, _Res._Min, static_cast<_UTy>(_Cur_min_val + _Correction));
-                }
-            } else if constexpr (_Mode == _Mode_max) {
-                if (_Sign) {
-                    return _Max_tail(_First, _Last, _Res._Max, static_cast<_STy>(_Cur_max_val));
-                } else {
-                    return _Max_tail(_First, _Last, _Res._Max, static_cast<_UTy>(_Cur_max_val + _Correction));
-                }
-            } else {
-                if (_Sign) {
-                    return _Both_tail(
-                        _First, _Last, _Res, static_cast<_STy>(_Cur_min_val), static_cast<_STy>(_Cur_max_val));
-                } else {
-                    return _Both_tail(_First, _Last, _Res, static_cast<_UTy>(_Cur_min_val + _Correction),
-                        static_cast<_UTy>(_Cur_max_val + _Correction));
-                }
-            }
-        }
-    }
-
-    template <_Min_max_mode _Mode, class _Traits>
-    auto __std_minmax_element_disp(const void* const _First, const void* const _Last, const bool _Sign) noexcept {
-#ifndef _M_ARM64EC
-        if (_Byte_length(_First, _Last) >= 32 && _Use_avx2()) {
-            return __std_minmax_element_impl<_Mode, typename _Traits::_Avx>(_First, _Last, _Sign);
-        }
-
-        if (_Byte_length(_First, _Last) >= 16 && _Use_sse42()) {
-            return __std_minmax_element_impl<_Mode, typename _Traits::_Sse>(_First, _Last, _Sign);
-        }
-#endif // ^^^ !defined(_M_ARM64EC) ^^^
-        return __std_minmax_element_impl<_Mode, typename _Traits::_Scalar>(_First, _Last, _Sign);
-    }
-
-    template <_Min_max_mode _Mode, class _Traits, bool _Sign>
-    auto __std_minmax_impl(const void* _First, const void* const _Last) noexcept {
-        using _Ty = std::conditional_t<_Sign, typename _Traits::_Signed_t, typename _Traits::_Unsigned_t>;
-
-        _Ty _Cur_min_val; // initialized in both of the branches below
-        _Ty _Cur_max_val; // initialized in both of the branches below
-
-        if constexpr (_Traits::_Vectorized) {
-#ifdef _M_ARM64EC
-            static_assert(false, "No vectorization for _M_ARM64EC yet");
-#else // ^^^ defined(_M_ARM64EC) / !defined(_M_ARM64EC) vvv
-            const size_t _Total_size_bytes = _Byte_length(_First, _Last);
-            const size_t _Vec_byte_size    = _Total_size_bytes & ~_Traits::_Vec_mask;
-
-            const void* _Stop_at = _First;
-            _Advance_bytes(_Stop_at, _Vec_byte_size);
-
-            auto _Cur_vals = _Traits::_Load(_First);
-
-            // We don't have unsigned 64-bit stuff, so we'll use sign correction just for that case
-            constexpr bool _Sign_correction = sizeof(_Ty) == 8 && !_Sign;
-
-            if constexpr (_Sign_correction) {
-                _Cur_vals = _Traits::_Sign_correction(_Cur_vals, false);
+                _Advance_bytes(_First, sizeof(_Ty));
             }
 
-            auto _Cur_vals_min = _Cur_vals; // vector of vertical minimum values
-            auto _Cur_vals_max = _Cur_vals; // vector of vertical maximum values
-
-            const auto _Update_min_max = [&](const auto _Cur_vals) noexcept {
+            for (auto _Ptr = static_cast<const _Ty*>(_First); _Ptr != _Last; ++_Ptr) {
                 if constexpr ((_Mode & _Mode_min) != 0) {
-                    if constexpr (_Sign || _Sign_correction) {
-                        _Cur_vals_min = _Traits::_Min(_Cur_vals_min, _Cur_vals); // Update the current minimum
-                    } else {
-                        _Cur_vals_min = _Traits::_Min_u(_Cur_vals_min, _Cur_vals); // Update the current minimum
+                    if (*_Ptr < _Cur_min_val) {
+                        _Cur_min_val = *_Ptr;
                     }
                 }
 
                 if constexpr ((_Mode & _Mode_max) != 0) {
-                    if constexpr (_Sign || _Sign_correction) {
-                        _Cur_vals_max = _Traits::_Max(_Cur_vals_max, _Cur_vals); // Update the current maximum
-                    } else {
-                        _Cur_vals_max = _Traits::_Max_u(_Cur_vals_max, _Cur_vals); // Update the current maximum
+                    if (_Cur_max_val < *_Ptr) {
+                        _Cur_max_val = *_Ptr;
                     }
                 }
-            };
 
-            for (;;) {
-                _Advance_bytes(_First, _Traits::_Vec_size);
-
-                if (_First != _Stop_at) {
-                    // This is the main part, finding vertical minimum/maximum
-
-                    _Cur_vals = _Traits::_Load(_First);
-
-                    if constexpr (_Sign_correction) {
-                        _Cur_vals = _Traits::_Sign_correction(_Cur_vals, false);
-                    }
-
-                    _Update_min_max(_Cur_vals);
-                } else {
-                    if constexpr (_Traits::_Tail_mask != 0) {
-                        const size_t _Tail_byte_size = _Total_size_bytes & _Traits::_Tail_mask;
-                        if (_Tail_byte_size != 0) {
-                            const auto _Tail_mask = _Avx2_tail_mask_32(_Tail_byte_size);
-                            auto _Tail_vals       = _Traits::_Load_mask(_First, _Tail_mask);
-
-                            if constexpr (_Sign_correction) {
-                                _Tail_vals = _Traits::_Sign_correction(_Tail_vals, false);
-                            }
-
-                            _Tail_vals = _Traits::_Blendval(_Cur_vals, _Tail_vals, _Tail_mask);
-
-                            _Update_min_max(_Tail_vals);
-
-                            _Advance_bytes(_First, _Tail_byte_size);
-                        }
-                    }
-
-                    // Reached end. Compute horizontal min and/or max.
-
-                    if constexpr ((_Mode & _Mode_min) != 0) {
-                        if constexpr (_Sign || _Sign_correction) {
-                            const auto _H_min =
-                                _Traits::_H_min(_Cur_vals_min); // Vector populated by the smallest element
-                            _Cur_min_val = _Traits::_Get_any(_H_min); // Get any element of it
-                        } else {
-                            const auto _H_min =
-                                _Traits::_H_min_u(_Cur_vals_min); // Vector populated by the smallest element
-                            _Cur_min_val = _Traits::_Get_any(_H_min); // Get any element of it
-                        }
-                    }
-
-                    if constexpr ((_Mode & _Mode_max) != 0) {
-                        if constexpr (_Sign || _Sign_correction) {
-                            const auto _H_max =
-                                _Traits::_H_max(_Cur_vals_max); // Vector populated by the largest element
-                            _Cur_max_val = _Traits::_Get_any(_H_max); // Get any element of it
-                        } else {
-                            const auto _H_max =
-                                _Traits::_H_max_u(_Cur_vals_max); // Vector populated by the largest element
-                            _Cur_max_val = _Traits::_Get_any(_H_max); // Get any element of it
-                        }
-                    }
-
-                    if constexpr (_Sign_correction) {
-                        constexpr _Ty _Correction = _Ty{1} << (sizeof(_Ty) * 8 - 1);
-
-                        if constexpr ((_Mode & _Mode_min) != 0) {
-                            _Cur_min_val += _Correction;
-                        }
-
-                        if constexpr ((_Mode & _Mode_max) != 0) {
-                            _Cur_max_val += _Correction;
-                        }
-                    }
-
-                    break;
-                }
+                // _Mode_both could have been handled separately with 'else'.
+                // We have _Cur_min_val / _Cur_max_val initialized by processing at least one element,
+                // so the 'else' would be correct here.
+                // But still separate 'if' statements promote branchless codegen.
             }
 
-            _Traits::_Exit_vectorized(); // TRANSITION, DevCom-10331414
-#endif // ^^^ !defined(_M_ARM64EC) ^^^
-        } else {
-            _Cur_min_val = *reinterpret_cast<const _Ty*>(_First);
-            _Cur_max_val = *reinterpret_cast<const _Ty*>(_First);
-
-            _Advance_bytes(_First, sizeof(_Ty));
-        }
-
-        for (auto _Ptr = static_cast<const _Ty*>(_First); _Ptr != _Last; ++_Ptr) {
-            if constexpr ((_Mode & _Mode_min) != 0) {
-                if (*_Ptr < _Cur_min_val) {
-                    _Cur_min_val = *_Ptr;
-                }
-            }
-
-            if constexpr ((_Mode & _Mode_max) != 0) {
-                if (_Cur_max_val < *_Ptr) {
-                    _Cur_max_val = *_Ptr;
-                }
-            }
-
-            // _Mode_both could have been handled separately with 'else'.
-            // We have _Cur_min_val / _Cur_max_val initialized by processing at least one element,
-            // so the 'else' would be correct here.
-            // But still separate 'if' statements promote branchless codegen.
-        }
-
-        if constexpr (_Mode == _Mode_min) {
-            return _Cur_min_val;
-        } else if constexpr (_Mode == _Mode_max) {
-            return _Cur_max_val;
-        } else {
-            using _Rx = std::conditional_t<_Sign, typename _Traits::_Minmax_i_t, typename _Traits::_Minmax_u_t>;
-            return _Rx{_Cur_min_val, _Cur_max_val};
-        }
-    }
-
-#ifndef _M_ARM64EC
-    // TRANSITION, DevCom-10767462
-    template <_Min_max_mode _Mode, class _Traits, bool _Sign>
-    auto __std_minmax_impl_wrap(const void* const _First, const void* const _Last) noexcept {
-        auto _Rx = __std_minmax_impl<_Mode, _Traits, _Sign>(_First, _Last);
-        _mm256_zeroupper();
-        return _Rx;
-    }
-#endif // ^^^ !defined(_M_ARM64EC) ^^^
-
-    template <_Min_max_mode _Mode, class _Traits, bool _Sign>
-    auto __std_minmax_disp(const void* const _First, const void* const _Last) noexcept {
-#ifndef _M_ARM64EC
-        if (_Byte_length(_First, _Last) >= 32 && _Use_avx2()) {
-            if constexpr (_Traits::_Avx::_Is_floating) {
-                return __std_minmax_impl_wrap<_Mode, typename _Traits::_Avx, _Sign>(_First, _Last);
+            if constexpr (_Mode == _Mode_min) {
+                return _Cur_min_val;
+            } else if constexpr (_Mode == _Mode_max) {
+                return _Cur_max_val;
             } else {
-                return __std_minmax_impl<_Mode, typename _Traits::_Avx, _Sign>(_First, _Last);
+                using _Rx = std::conditional_t<_Sign, typename _Traits::_Minmax_i_t, typename _Traits::_Minmax_u_t>;
+                return _Rx{_Cur_min_val, _Cur_max_val};
             }
         }
 
-        if (_Byte_length(_First, _Last) >= 16 && _Use_sse42()) {
-            return __std_minmax_impl<_Mode, typename _Traits::_Sse, _Sign>(_First, _Last);
+#ifndef _M_ARM64EC
+        // TRANSITION, DevCom-10767462
+        template <_Min_max_mode _Mode, class _Traits, bool _Sign>
+        auto _Minmax_impl_wrap(const void* const _First, const void* const _Last) noexcept {
+            auto _Rx = _Minmax_impl<_Mode, _Traits, _Sign>(_First, _Last);
+            _mm256_zeroupper();
+            return _Rx;
         }
 #endif // ^^^ !defined(_M_ARM64EC) ^^^
-        return __std_minmax_impl<_Mode, typename _Traits::_Scalar, _Sign>(_First, _Last);
-    }
+
+        template <_Min_max_mode _Mode, class _Traits, bool _Sign>
+        auto _Minmax_disp(const void* const _First, const void* const _Last) noexcept {
+#ifndef _M_ARM64EC
+            if (_Byte_length(_First, _Last) >= 32 && _Use_avx2()) {
+                if constexpr (_Traits::_Avx::_Is_floating) {
+                    return _Minmax_impl_wrap<_Mode, typename _Traits::_Avx, _Sign>(_First, _Last);
+                } else {
+                    return _Minmax_impl<_Mode, typename _Traits::_Avx, _Sign>(_First, _Last);
+                }
+            }
+
+            if (_Byte_length(_First, _Last) >= 16 && _Use_sse42()) {
+                return _Minmax_impl<_Mode, typename _Traits::_Sse, _Sign>(_First, _Last);
+            }
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
+            return _Minmax_impl<_Mode, typename _Traits::_Scalar, _Sign>(_First, _Last);
+        }
 
 
-    template <class _Traits, class _Ty>
-    const void* __std_is_sorted_until_impl(const void* _First, const void* const _Last, const bool _Greater) noexcept {
-        const ptrdiff_t _Left_off  = 0 - static_cast<ptrdiff_t>(_Greater);
-        const ptrdiff_t _Right_off = static_cast<ptrdiff_t>(_Greater) - 1;
+        template <class _Traits, class _Ty>
+        const void* _Is_sorted_until_impl(const void* _First, const void* const _Last, const bool _Greater) noexcept {
+            const ptrdiff_t _Left_off  = 0 - static_cast<ptrdiff_t>(_Greater);
+            const ptrdiff_t _Right_off = static_cast<ptrdiff_t>(_Greater) - 1;
 
-        if constexpr (_Traits::_Vectorized) {
+            if constexpr (_Traits::_Vectorized) {
 #ifdef _M_ARM64EC
-            static_assert(false, "No vectorization for _M_ARM64EC yet");
+                static_assert(false, "No vectorization for _M_ARM64EC yet");
 #else // ^^^ defined(_M_ARM64EC) / !defined(_M_ARM64EC) vvv
-            constexpr bool _Sign_cor = static_cast<_Ty>(-1) > _Ty{0};
+                constexpr bool _Sign_cor = static_cast<_Ty>(-1) > _Ty{0};
 
-            const size_t _Total_size_bytes = _Byte_length(_First, _Last);
-            const size_t _Vec_byte_size    = _Total_size_bytes & ~_Traits::_Vec_mask;
+                const size_t _Total_size_bytes = _Byte_length(_First, _Last);
+                const size_t _Vec_byte_size    = _Total_size_bytes & ~_Traits::_Vec_mask;
 
-            const void* _Stop_at = _First;
-            _Advance_bytes(_Stop_at, _Vec_byte_size);
+                const void* _Stop_at = _First;
+                _Advance_bytes(_Stop_at, _Vec_byte_size);
 
-            do {
-                auto _Left  = _Traits::_Load(static_cast<const _Ty*>(_First) + _Left_off);
-                auto _Right = _Traits::_Load(static_cast<const _Ty*>(_First) + _Right_off);
-
-                if constexpr (_Sign_cor) {
-                    _Left  = _Traits::_Sign_correction(_Left, false);
-                    _Right = _Traits::_Sign_correction(_Right, false);
-                }
-
-                const auto _Is_less = _Traits::_Cmp_gt(_Right, _Left);
-                unsigned long _Mask = _Traits::_Mask(_Traits::_Mask_cast(_Is_less));
-
-                if (_Mask != 0) {
-                    unsigned long _H_pos;
-
-                    // CodeQL [SM02313] _H_pos is always initialized: we just tested `if (_Mask != 0)`.
-                    _BitScanForward(&_H_pos, _Mask);
-                    _Advance_bytes(_First, _H_pos);
-                    return _First;
-                }
-
-                _Advance_bytes(_First, _Traits::_Vec_size);
-            } while (_First != _Stop_at);
-
-            if constexpr (_Traits::_Tail_mask != 0) {
-                const size_t _Tail_byte_size = _Total_size_bytes & _Traits::_Tail_mask;
-                if (_Tail_byte_size != 0) {
-                    const auto _Tail_mask = _Avx2_tail_mask_32(_Tail_byte_size);
-
-                    auto _Left  = _Traits::_Load_mask(static_cast<const _Ty*>(_First) + _Left_off, _Tail_mask);
-                    auto _Right = _Traits::_Load_mask(static_cast<const _Ty*>(_First) + _Right_off, _Tail_mask);
+                do {
+                    auto _Left  = _Traits::_Load(static_cast<const _Ty*>(_First) + _Left_off);
+                    auto _Right = _Traits::_Load(static_cast<const _Ty*>(_First) + _Right_off);
 
                     if constexpr (_Sign_cor) {
                         _Left  = _Traits::_Sign_correction(_Left, false);
@@ -2348,7 +2343,7 @@ namespace {
                     }
 
                     const auto _Is_less = _Traits::_Cmp_gt(_Right, _Left);
-                    unsigned long _Mask = _Traits::_Mask(_mm256_and_si256(_Traits::_Mask_cast(_Is_less), _Tail_mask));
+                    unsigned long _Mask = _Traits::_Mask(_Traits::_Mask_cast(_Is_less));
 
                     if (_Mask != 0) {
                         unsigned long _H_pos;
@@ -2359,306 +2354,336 @@ namespace {
                         return _First;
                     }
 
-                    _Advance_bytes(_First, _Tail_byte_size);
-                }
-            }
+                    _Advance_bytes(_First, _Traits::_Vec_size);
+                } while (_First != _Stop_at);
 
-            _Traits::_Exit_vectorized(); // TRANSITION, DevCom-10331414
+                if constexpr (_Traits::_Tail_mask != 0) {
+                    const size_t _Tail_byte_size = _Total_size_bytes & _Traits::_Tail_mask;
+                    if (_Tail_byte_size != 0) {
+                        const auto _Tail_mask = _Avx2_tail_mask_32(_Tail_byte_size);
+
+                        auto _Left  = _Traits::_Load_mask(static_cast<const _Ty*>(_First) + _Left_off, _Tail_mask);
+                        auto _Right = _Traits::_Load_mask(static_cast<const _Ty*>(_First) + _Right_off, _Tail_mask);
+
+                        if constexpr (_Sign_cor) {
+                            _Left  = _Traits::_Sign_correction(_Left, false);
+                            _Right = _Traits::_Sign_correction(_Right, false);
+                        }
+
+                        const auto _Is_less = _Traits::_Cmp_gt(_Right, _Left);
+                        unsigned long _Mask =
+                            _Traits::_Mask(_mm256_and_si256(_Traits::_Mask_cast(_Is_less), _Tail_mask));
+
+                        if (_Mask != 0) {
+                            unsigned long _H_pos;
+
+                            // CodeQL [SM02313] _H_pos is always initialized: we just tested `if (_Mask != 0)`.
+                            _BitScanForward(&_H_pos, _Mask);
+                            _Advance_bytes(_First, _H_pos);
+                            return _First;
+                        }
+
+                        _Advance_bytes(_First, _Tail_byte_size);
+                    }
+                }
+
+                _Traits::_Exit_vectorized(); // TRANSITION, DevCom-10331414
 #endif // ^^^ !defined(_M_ARM64EC) ^^^
-        }
+            }
 
-        if constexpr ((_Traits::_Tail_mask & sizeof(_Ty)) != sizeof(_Ty)) {
-            for (const _Ty* _Ptr = static_cast<const _Ty*>(_First); _Ptr != _Last; ++_Ptr) {
-                if (_Ptr[_Left_off] < _Ptr[_Right_off]) {
-                    return _Ptr;
+            if constexpr ((_Traits::_Tail_mask & sizeof(_Ty)) != sizeof(_Ty)) {
+                for (const _Ty* _Ptr = static_cast<const _Ty*>(_First); _Ptr != _Last; ++_Ptr) {
+                    if (_Ptr[_Left_off] < _Ptr[_Right_off]) {
+                        return _Ptr;
+                    }
                 }
             }
+
+            return _Last;
         }
 
-        return _Last;
-    }
+        template <class _Traits, class _Ty>
+        const void* _Is_sorted_until_disp(const void* _First, const void* const _Last, const bool _Greater) noexcept {
+            if (_First == _Last) {
+                return _First;
+            }
 
-    template <class _Traits, class _Ty>
-    const void* __std_is_sorted_until_disp(const void* _First, const void* const _Last, const bool _Greater) noexcept {
-        if (_First == _Last) {
-            return _First;
-        }
-
-        _Advance_bytes(_First, sizeof(_Ty));
+            _Advance_bytes(_First, sizeof(_Ty));
 
 #ifndef _M_ARM64EC
-        if (_Byte_length(_First, _Last) >= 32 && _Use_avx2()) {
-            return __std_is_sorted_until_impl<typename _Traits::_Avx, _Ty>(_First, _Last, _Greater);
-        }
+            if (_Byte_length(_First, _Last) >= 32 && _Use_avx2()) {
+                return _Is_sorted_until_impl<typename _Traits::_Avx, _Ty>(_First, _Last, _Greater);
+            }
 
-        if (_Byte_length(_First, _Last) >= 16 && _Use_sse42()) {
-            return __std_is_sorted_until_impl<typename _Traits::_Sse, _Ty>(_First, _Last, _Greater);
-        }
+            if (_Byte_length(_First, _Last) >= 16 && _Use_sse42()) {
+                return _Is_sorted_until_impl<typename _Traits::_Sse, _Ty>(_First, _Last, _Greater);
+            }
 #endif // ^^^ !defined(_M_ARM64EC) ^^^
-        return __std_is_sorted_until_impl<typename _Traits::_Scalar, _Ty>(_First, _Last, _Greater);
-    }
+            return _Is_sorted_until_impl<typename _Traits::_Scalar, _Ty>(_First, _Last, _Greater);
+        }
+    } // namespace _Sorting
 } // unnamed namespace
 
 extern "C" {
 
 const void* __stdcall __std_min_element_1(
     const void* const _First, const void* const _Last, const bool _Signed) noexcept {
-    return __std_minmax_element_disp<_Mode_min, _Minmax_traits_1>(_First, _Last, _Signed);
+    return _Sorting::_Minmax_element_disp<_Sorting::_Mode_min, _Sorting::_Traits_1>(_First, _Last, _Signed);
 }
 
 const void* __stdcall __std_min_element_2(
     const void* const _First, const void* const _Last, const bool _Signed) noexcept {
-    return __std_minmax_element_disp<_Mode_min, _Minmax_traits_2>(_First, _Last, _Signed);
+    return _Sorting::_Minmax_element_disp<_Sorting::_Mode_min, _Sorting::_Traits_2>(_First, _Last, _Signed);
 }
 
 const void* __stdcall __std_min_element_4(
     const void* const _First, const void* const _Last, const bool _Signed) noexcept {
-    return __std_minmax_element_disp<_Mode_min, _Minmax_traits_4>(_First, _Last, _Signed);
+    return _Sorting::_Minmax_element_disp<_Sorting::_Mode_min, _Sorting::_Traits_4>(_First, _Last, _Signed);
 }
 
 const void* __stdcall __std_min_element_8(
     const void* const _First, const void* const _Last, const bool _Signed) noexcept {
-    return __std_minmax_element_disp<_Mode_min, _Minmax_traits_8>(_First, _Last, _Signed);
+    return _Sorting::_Minmax_element_disp<_Sorting::_Mode_min, _Sorting::_Traits_8>(_First, _Last, _Signed);
 }
 
 // TRANSITION, ABI: remove unused `bool`
 const void* __stdcall __std_min_element_f(const void* const _First, const void* const _Last, bool) noexcept {
-    return __std_minmax_element_disp<_Mode_min, _Minmax_traits_f>(_First, _Last, false);
+    return _Sorting::_Minmax_element_disp<_Sorting::_Mode_min, _Sorting::_Traits_f>(_First, _Last, false);
 }
 
 // TRANSITION, ABI: remove unused `bool`
 const void* __stdcall __std_min_element_d(const void* const _First, const void* const _Last, bool) noexcept {
-    return __std_minmax_element_disp<_Mode_min, _Minmax_traits_d>(_First, _Last, false);
+    return _Sorting::_Minmax_element_disp<_Sorting::_Mode_min, _Sorting::_Traits_d>(_First, _Last, false);
 }
 
 const void* __stdcall __std_max_element_1(
     const void* const _First, const void* const _Last, const bool _Signed) noexcept {
-    return __std_minmax_element_disp<_Mode_max, _Minmax_traits_1>(_First, _Last, _Signed);
+    return _Sorting::_Minmax_element_disp<_Sorting::_Mode_max, _Sorting::_Traits_1>(_First, _Last, _Signed);
 }
 
 const void* __stdcall __std_max_element_2(
     const void* const _First, const void* const _Last, const bool _Signed) noexcept {
-    return __std_minmax_element_disp<_Mode_max, _Minmax_traits_2>(_First, _Last, _Signed);
+    return _Sorting::_Minmax_element_disp<_Sorting::_Mode_max, _Sorting::_Traits_2>(_First, _Last, _Signed);
 }
 
 const void* __stdcall __std_max_element_4(
     const void* const _First, const void* const _Last, const bool _Signed) noexcept {
-    return __std_minmax_element_disp<_Mode_max, _Minmax_traits_4>(_First, _Last, _Signed);
+    return _Sorting::_Minmax_element_disp<_Sorting::_Mode_max, _Sorting::_Traits_4>(_First, _Last, _Signed);
 }
 
 const void* __stdcall __std_max_element_8(
     const void* const _First, const void* const _Last, const bool _Signed) noexcept {
-    return __std_minmax_element_disp<_Mode_max, _Minmax_traits_8>(_First, _Last, _Signed);
+    return _Sorting::_Minmax_element_disp<_Sorting::_Mode_max, _Sorting::_Traits_8>(_First, _Last, _Signed);
 }
 
 // TRANSITION, ABI: remove unused `bool`
 const void* __stdcall __std_max_element_f(const void* const _First, const void* const _Last, bool) noexcept {
-    return __std_minmax_element_disp<_Mode_max, _Minmax_traits_f>(_First, _Last, false);
+    return _Sorting::_Minmax_element_disp<_Sorting::_Mode_max, _Sorting::_Traits_f>(_First, _Last, false);
 }
 
 // TRANSITION, ABI: remove unused `bool`
 const void* __stdcall __std_max_element_d(const void* const _First, const void* const _Last, bool) noexcept {
-    return __std_minmax_element_disp<_Mode_max, _Minmax_traits_d>(_First, _Last, false);
+    return _Sorting::_Minmax_element_disp<_Sorting::_Mode_max, _Sorting::_Traits_d>(_First, _Last, false);
 }
 
 _Min_max_element_t __stdcall __std_minmax_element_1(
     const void* const _First, const void* const _Last, const bool _Signed) noexcept {
-    return __std_minmax_element_disp<_Mode_both, _Minmax_traits_1>(_First, _Last, _Signed);
+    return _Sorting::_Minmax_element_disp<_Sorting::_Mode_both, _Sorting::_Traits_1>(_First, _Last, _Signed);
 }
 
 _Min_max_element_t __stdcall __std_minmax_element_2(
     const void* const _First, const void* const _Last, const bool _Signed) noexcept {
-    return __std_minmax_element_disp<_Mode_both, _Minmax_traits_2>(_First, _Last, _Signed);
+    return _Sorting::_Minmax_element_disp<_Sorting::_Mode_both, _Sorting::_Traits_2>(_First, _Last, _Signed);
 }
 
 _Min_max_element_t __stdcall __std_minmax_element_4(
     const void* const _First, const void* const _Last, const bool _Signed) noexcept {
-    return __std_minmax_element_disp<_Mode_both, _Minmax_traits_4>(_First, _Last, _Signed);
+    return _Sorting::_Minmax_element_disp<_Sorting::_Mode_both, _Sorting::_Traits_4>(_First, _Last, _Signed);
 }
 
 _Min_max_element_t __stdcall __std_minmax_element_8(
     const void* const _First, const void* const _Last, const bool _Signed) noexcept {
-    return __std_minmax_element_disp<_Mode_both, _Minmax_traits_8>(_First, _Last, _Signed);
+    return _Sorting::_Minmax_element_disp<_Sorting::_Mode_both, _Sorting::_Traits_8>(_First, _Last, _Signed);
 }
 
 // TRANSITION, ABI: remove unused `bool`
 _Min_max_element_t __stdcall __std_minmax_element_f(const void* const _First, const void* const _Last, bool) noexcept {
-    return __std_minmax_element_disp<_Mode_both, _Minmax_traits_f>(_First, _Last, false);
+    return _Sorting::_Minmax_element_disp<_Sorting::_Mode_both, _Sorting::_Traits_f>(_First, _Last, false);
 }
 
 // TRANSITION, ABI: remove unused `bool`
 _Min_max_element_t __stdcall __std_minmax_element_d(const void* const _First, const void* const _Last, bool) noexcept {
-    return __std_minmax_element_disp<_Mode_both, _Minmax_traits_d>(_First, _Last, false);
+    return _Sorting::_Minmax_element_disp<_Sorting::_Mode_both, _Sorting::_Traits_d>(_First, _Last, false);
 }
 
 __declspec(noalias) int8_t __stdcall __std_min_1i(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_min, _Minmax_traits_1, true>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_min, _Sorting::_Traits_1, true>(_First, _Last);
 }
 
 __declspec(noalias) uint8_t __stdcall __std_min_1u(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_min, _Minmax_traits_1, false>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_min, _Sorting::_Traits_1, false>(_First, _Last);
 }
 
 __declspec(noalias) int16_t __stdcall __std_min_2i(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_min, _Minmax_traits_2, true>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_min, _Sorting::_Traits_2, true>(_First, _Last);
 }
 
 __declspec(noalias) uint16_t __stdcall __std_min_2u(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_min, _Minmax_traits_2, false>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_min, _Sorting::_Traits_2, false>(_First, _Last);
 }
 
 __declspec(noalias) int32_t __stdcall __std_min_4i(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_min, _Minmax_traits_4, true>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_min, _Sorting::_Traits_4, true>(_First, _Last);
 }
 
 __declspec(noalias) uint32_t __stdcall __std_min_4u(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_min, _Minmax_traits_4, false>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_min, _Sorting::_Traits_4, false>(_First, _Last);
 }
 
 __declspec(noalias) int64_t __stdcall __std_min_8i(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_min, _Minmax_traits_8, true>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_min, _Sorting::_Traits_8, true>(_First, _Last);
 }
 
 __declspec(noalias) uint64_t __stdcall __std_min_8u(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_min, _Minmax_traits_8, false>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_min, _Sorting::_Traits_8, false>(_First, _Last);
 }
 
 __declspec(noalias) float __stdcall __std_min_f(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_min, _Minmax_traits_f, true>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_min, _Sorting::_Traits_f, true>(_First, _Last);
 }
 
 __declspec(noalias) double __stdcall __std_min_d(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_min, _Minmax_traits_d, true>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_min, _Sorting::_Traits_d, true>(_First, _Last);
 }
 
 __declspec(noalias) int8_t __stdcall __std_max_1i(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_max, _Minmax_traits_1, true>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_max, _Sorting::_Traits_1, true>(_First, _Last);
 }
 
 __declspec(noalias) uint8_t __stdcall __std_max_1u(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_max, _Minmax_traits_1, false>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_max, _Sorting::_Traits_1, false>(_First, _Last);
 }
 
 __declspec(noalias) int16_t __stdcall __std_max_2i(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_max, _Minmax_traits_2, true>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_max, _Sorting::_Traits_2, true>(_First, _Last);
 }
 
 __declspec(noalias) uint16_t __stdcall __std_max_2u(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_max, _Minmax_traits_2, false>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_max, _Sorting::_Traits_2, false>(_First, _Last);
 }
 
 __declspec(noalias) int32_t __stdcall __std_max_4i(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_max, _Minmax_traits_4, true>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_max, _Sorting::_Traits_4, true>(_First, _Last);
 }
 
 __declspec(noalias) uint32_t __stdcall __std_max_4u(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_max, _Minmax_traits_4, false>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_max, _Sorting::_Traits_4, false>(_First, _Last);
 }
 
 __declspec(noalias) int64_t __stdcall __std_max_8i(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_max, _Minmax_traits_8, true>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_max, _Sorting::_Traits_8, true>(_First, _Last);
 }
 
 __declspec(noalias) uint64_t __stdcall __std_max_8u(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_max, _Minmax_traits_8, false>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_max, _Sorting::_Traits_8, false>(_First, _Last);
 }
 
 __declspec(noalias) float __stdcall __std_max_f(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_max, _Minmax_traits_f, true>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_max, _Sorting::_Traits_f, true>(_First, _Last);
 }
 
 __declspec(noalias) double __stdcall __std_max_d(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_max, _Minmax_traits_d, true>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_max, _Sorting::_Traits_d, true>(_First, _Last);
 }
 
 __declspec(noalias) _Min_max_1i __stdcall __std_minmax_1i(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_both, _Minmax_traits_1, true>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_both, _Sorting::_Traits_1, true>(_First, _Last);
 }
 
 __declspec(noalias) _Min_max_1u __stdcall __std_minmax_1u(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_both, _Minmax_traits_1, false>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_both, _Sorting::_Traits_1, false>(_First, _Last);
 }
 
 __declspec(noalias) _Min_max_2i __stdcall __std_minmax_2i(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_both, _Minmax_traits_2, true>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_both, _Sorting::_Traits_2, true>(_First, _Last);
 }
 
 __declspec(noalias) _Min_max_2u __stdcall __std_minmax_2u(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_both, _Minmax_traits_2, false>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_both, _Sorting::_Traits_2, false>(_First, _Last);
 }
 
 __declspec(noalias) _Min_max_4i __stdcall __std_minmax_4i(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_both, _Minmax_traits_4, true>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_both, _Sorting::_Traits_4, true>(_First, _Last);
 }
 
 __declspec(noalias) _Min_max_4u __stdcall __std_minmax_4u(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_both, _Minmax_traits_4, false>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_both, _Sorting::_Traits_4, false>(_First, _Last);
 }
 
 __declspec(noalias) _Min_max_8i __stdcall __std_minmax_8i(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_both, _Minmax_traits_8, true>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_both, _Sorting::_Traits_8, true>(_First, _Last);
 }
 
 __declspec(noalias) _Min_max_8u __stdcall __std_minmax_8u(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_both, _Minmax_traits_8, false>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_both, _Sorting::_Traits_8, false>(_First, _Last);
 }
 
 __declspec(noalias) _Min_max_f __stdcall __std_minmax_f(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_both, _Minmax_traits_f, true>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_both, _Sorting::_Traits_f, true>(_First, _Last);
 }
 
 __declspec(noalias) _Min_max_d __stdcall __std_minmax_d(const void* const _First, const void* const _Last) noexcept {
-    return __std_minmax_disp<_Mode_both, _Minmax_traits_d, true>(_First, _Last);
+    return _Sorting::_Minmax_disp<_Sorting::_Mode_both, _Sorting::_Traits_d, true>(_First, _Last);
 }
 
 const void* __stdcall __std_is_sorted_until_1i(
     const void* const _First, const void* const _Last, const bool _Greater) noexcept {
-    return __std_is_sorted_until_disp<_Minmax_traits_1, int8_t>(_First, _Last, _Greater);
+    return _Sorting::_Is_sorted_until_disp<_Sorting::_Traits_1, int8_t>(_First, _Last, _Greater);
 }
 
 const void* __stdcall __std_is_sorted_until_1u(
     const void* const _First, const void* const _Last, const bool _Greater) noexcept {
-    return __std_is_sorted_until_disp<_Minmax_traits_1, uint8_t>(_First, _Last, _Greater);
+    return _Sorting::_Is_sorted_until_disp<_Sorting::_Traits_1, uint8_t>(_First, _Last, _Greater);
 }
 
 const void* __stdcall __std_is_sorted_until_2i(
     const void* const _First, const void* const _Last, const bool _Greater) noexcept {
-    return __std_is_sorted_until_disp<_Minmax_traits_2, int16_t>(_First, _Last, _Greater);
+    return _Sorting::_Is_sorted_until_disp<_Sorting::_Traits_2, int16_t>(_First, _Last, _Greater);
 }
 
 const void* __stdcall __std_is_sorted_until_2u(
     const void* const _First, const void* const _Last, const bool _Greater) noexcept {
-    return __std_is_sorted_until_disp<_Minmax_traits_2, uint16_t>(_First, _Last, _Greater);
+    return _Sorting::_Is_sorted_until_disp<_Sorting::_Traits_2, uint16_t>(_First, _Last, _Greater);
 }
 
 const void* __stdcall __std_is_sorted_until_4i(
     const void* const _First, const void* const _Last, const bool _Greater) noexcept {
-    return __std_is_sorted_until_disp<_Minmax_traits_4, int32_t>(_First, _Last, _Greater);
+    return _Sorting::_Is_sorted_until_disp<_Sorting::_Traits_4, int32_t>(_First, _Last, _Greater);
 }
 
 const void* __stdcall __std_is_sorted_until_4u(
     const void* const _First, const void* const _Last, const bool _Greater) noexcept {
-    return __std_is_sorted_until_disp<_Minmax_traits_4, uint32_t>(_First, _Last, _Greater);
+    return _Sorting::_Is_sorted_until_disp<_Sorting::_Traits_4, uint32_t>(_First, _Last, _Greater);
 }
 
 const void* __stdcall __std_is_sorted_until_8i(
     const void* const _First, const void* const _Last, const bool _Greater) noexcept {
-    return __std_is_sorted_until_disp<_Minmax_traits_8, int64_t>(_First, _Last, _Greater);
+    return _Sorting::_Is_sorted_until_disp<_Sorting::_Traits_8, int64_t>(_First, _Last, _Greater);
 }
 
 const void* __stdcall __std_is_sorted_until_8u(
     const void* const _First, const void* const _Last, const bool _Greater) noexcept {
-    return __std_is_sorted_until_disp<_Minmax_traits_8, uint64_t>(_First, _Last, _Greater);
+    return _Sorting::_Is_sorted_until_disp<_Sorting::_Traits_8, uint64_t>(_First, _Last, _Greater);
 }
 
 const void* __stdcall __std_is_sorted_until_f(
     const void* const _First, const void* const _Last, const bool _Greater) noexcept {
-    return __std_is_sorted_until_disp<_Minmax_traits_f, float>(_First, _Last, _Greater);
+    return _Sorting::_Is_sorted_until_disp<_Sorting::_Traits_f, float>(_First, _Last, _Greater);
 }
 
 const void* __stdcall __std_is_sorted_until_d(
     const void* const _First, const void* const _Last, const bool _Greater) noexcept {
-    return __std_is_sorted_until_disp<_Minmax_traits_d, double>(_First, _Last, _Greater);
+    return _Sorting::_Is_sorted_until_disp<_Sorting::_Traits_d, double>(_First, _Last, _Greater);
 }
 
 } // extern "C"

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -3331,252 +3331,256 @@ const void* __stdcall __std_search_n_8(
 } // extern "C"
 
 namespace {
-    struct _Count_traits_8 : _Find_traits_8 {
+    namespace _Count {
+        struct _Count_traits_8 : _Find_traits_8 {
 #ifndef _M_ARM64EC
-        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
-            return _mm256_sub_epi64(_Lhs, _Rhs);
-        }
+            static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
+                return _mm256_sub_epi64(_Lhs, _Rhs);
+            }
 
-        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
-            return _mm_sub_epi64(_Lhs, _Rhs);
-        }
+            static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
+                return _mm_sub_epi64(_Lhs, _Rhs);
+            }
 
-        static size_t _Reduce_avx(const __m256i _Val) noexcept {
-            const __m128i _Lo64 = _mm256_extracti128_si256(_Val, 0);
-            const __m128i _Hi64 = _mm256_extracti128_si256(_Val, 1);
-            const __m128i _Rx8  = _mm_add_epi64(_Lo64, _Hi64);
-            return _Reduce_sse(_Rx8);
-        }
+            static size_t _Reduce_avx(const __m256i _Val) noexcept {
+                const __m128i _Lo64 = _mm256_extracti128_si256(_Val, 0);
+                const __m128i _Hi64 = _mm256_extracti128_si256(_Val, 1);
+                const __m128i _Rx8  = _mm_add_epi64(_Lo64, _Hi64);
+                return _Reduce_sse(_Rx8);
+            }
 
-        static size_t _Reduce_sse(const __m128i _Val) noexcept {
+            static size_t _Reduce_sse(const __m128i _Val) noexcept {
 #ifdef _M_IX86
-            return static_cast<uint32_t>(_mm_cvtsi128_si32(_Val)) + static_cast<uint32_t>(_mm_extract_epi32(_Val, 2));
+                return static_cast<uint32_t>(_mm_cvtsi128_si32(_Val))
+                     + static_cast<uint32_t>(_mm_extract_epi32(_Val, 2));
 #else // ^^^ defined(_M_IX86) / defined(_M_X64) vvv
-            return _mm_cvtsi128_si64(_Val) + _mm_extract_epi64(_Val, 1);
+                return _mm_cvtsi128_si64(_Val) + _mm_extract_epi64(_Val, 1);
 #endif // ^^^ defined(_M_X64) ^^^
-        }
+            }
 #endif // !_M_ARM64EC
-    };
+        };
 
-    struct _Count_traits_4 : _Find_traits_4 {
+        struct _Count_traits_4 : _Find_traits_4 {
 #ifndef _M_ARM64EC
-        // For AVX2, we use hadd_epi32 three times to combine pairs of 32-bit counters into 32-bit results.
-        // Therefore, _Max_count is 0x1FFF'FFFF, which is 0xFFFF'FFF8 when doubled three times; any more would overflow.
+            // For AVX2, we use hadd_epi32 three times to combine pairs of 32-bit counters into 32-bit results.
+            // Therefore, _Max_count is 0x1FFF'FFFF, which is 0xFFFF'FFF8 when doubled three times; any more would
+            // overflow.
 
-        // For SSE4.2, we use hadd_epi32 twice. This would allow a larger limit,
-        // but it's simpler to use the smaller limit for both codepaths.
+            // For SSE4.2, we use hadd_epi32 twice. This would allow a larger limit,
+            // but it's simpler to use the smaller limit for both codepaths.
 
-        static constexpr size_t _Max_count = 0x1FFF'FFFF;
+            static constexpr size_t _Max_count = 0x1FFF'FFFF;
 
-        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
-            return _mm256_sub_epi32(_Lhs, _Rhs);
-        }
+            static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
+                return _mm256_sub_epi32(_Lhs, _Rhs);
+            }
 
-        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
-            return _mm_sub_epi32(_Lhs, _Rhs);
-        }
+            static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
+                return _mm_sub_epi32(_Lhs, _Rhs);
+            }
 
-        static size_t _Reduce_avx(const __m256i _Val) noexcept {
-            constexpr auto _Shuf = _MM_SHUFFLE(3, 1, 2, 0); // Cross lane, to reduce further on low lane
-            const __m256i _Rx4   = _mm256_hadd_epi32(_Val, _mm256_setzero_si256()); // (0+1),(2+3),0,0 per lane
-            const __m256i _Rx5   = _mm256_permute4x64_epi64(_Rx4, _Shuf); // low lane  (0+1),(2+3),(4+5),(6+7)
-            const __m256i _Rx6   = _mm256_hadd_epi32(_Rx5, _mm256_setzero_si256()); // (0+...+3),(4+...+7),0,0
-            const __m256i _Rx7   = _mm256_hadd_epi32(_Rx6, _mm256_setzero_si256()); // (0+...+7),0,0,0
-            return static_cast<uint32_t>(_mm_cvtsi128_si32(_mm256_castsi256_si128(_Rx7)));
-        }
+            static size_t _Reduce_avx(const __m256i _Val) noexcept {
+                constexpr auto _Shuf = _MM_SHUFFLE(3, 1, 2, 0); // Cross lane, to reduce further on low lane
+                const __m256i _Rx4   = _mm256_hadd_epi32(_Val, _mm256_setzero_si256()); // (0+1),(2+3),0,0 per lane
+                const __m256i _Rx5   = _mm256_permute4x64_epi64(_Rx4, _Shuf); // low lane  (0+1),(2+3),(4+5),(6+7)
+                const __m256i _Rx6   = _mm256_hadd_epi32(_Rx5, _mm256_setzero_si256()); // (0+...+3),(4+...+7),0,0
+                const __m256i _Rx7   = _mm256_hadd_epi32(_Rx6, _mm256_setzero_si256()); // (0+...+7),0,0,0
+                return static_cast<uint32_t>(_mm_cvtsi128_si32(_mm256_castsi256_si128(_Rx7)));
+            }
 
-        static size_t _Reduce_sse(const __m128i _Val) noexcept {
-            const __m128i _Rx4 = _mm_hadd_epi32(_Val, _mm_setzero_si128()); // (0+1),(2+3),0,0
-            const __m128i _Rx5 = _mm_hadd_epi32(_Rx4, _mm_setzero_si128()); // (0+...+3),0,0,0
-            return static_cast<uint32_t>(_mm_cvtsi128_si32(_Rx5));
-        }
+            static size_t _Reduce_sse(const __m128i _Val) noexcept {
+                const __m128i _Rx4 = _mm_hadd_epi32(_Val, _mm_setzero_si128()); // (0+1),(2+3),0,0
+                const __m128i _Rx5 = _mm_hadd_epi32(_Rx4, _mm_setzero_si128()); // (0+...+3),0,0,0
+                return static_cast<uint32_t>(_mm_cvtsi128_si32(_Rx5));
+            }
 #endif // !_M_ARM64EC
-    };
+        };
 
-    struct _Count_traits_2 : _Find_traits_2 {
+        struct _Count_traits_2 : _Find_traits_2 {
 #ifndef _M_ARM64EC
-        // For both AVX2 and SSE4.2, we use hadd_epi16 once to combine pairs of 16-bit counters into 16-bit results.
-        // Therefore, _Max_count is 0x7FFF, which is 0xFFFE when doubled; any more would overflow.
+            // For both AVX2 and SSE4.2, we use hadd_epi16 once to combine pairs of 16-bit counters into 16-bit results.
+            // Therefore, _Max_count is 0x7FFF, which is 0xFFFE when doubled; any more would overflow.
 
-        static constexpr size_t _Max_count = 0x7FFF;
+            static constexpr size_t _Max_count = 0x7FFF;
 
-        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
-            return _mm256_sub_epi16(_Lhs, _Rhs);
-        }
+            static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
+                return _mm256_sub_epi16(_Lhs, _Rhs);
+            }
 
-        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
-            return _mm_sub_epi16(_Lhs, _Rhs);
-        }
+            static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
+                return _mm_sub_epi16(_Lhs, _Rhs);
+            }
 
-        static size_t _Reduce_avx(const __m256i _Val) noexcept {
-            const __m256i _Rx2 = _mm256_hadd_epi16(_Val, _mm256_setzero_si256());
-            const __m256i _Rx3 = _mm256_unpacklo_epi16(_Rx2, _mm256_setzero_si256());
-            return _Count_traits_4::_Reduce_avx(_Rx3);
-        }
+            static size_t _Reduce_avx(const __m256i _Val) noexcept {
+                const __m256i _Rx2 = _mm256_hadd_epi16(_Val, _mm256_setzero_si256());
+                const __m256i _Rx3 = _mm256_unpacklo_epi16(_Rx2, _mm256_setzero_si256());
+                return _Count_traits_4::_Reduce_avx(_Rx3);
+            }
 
-        static size_t _Reduce_sse(const __m128i _Val) noexcept {
-            const __m128i _Rx2 = _mm_hadd_epi16(_Val, _mm_setzero_si128());
-            const __m128i _Rx3 = _mm_unpacklo_epi16(_Rx2, _mm_setzero_si128());
-            return _Count_traits_4::_Reduce_sse(_Rx3);
-        }
+            static size_t _Reduce_sse(const __m128i _Val) noexcept {
+                const __m128i _Rx2 = _mm_hadd_epi16(_Val, _mm_setzero_si128());
+                const __m128i _Rx3 = _mm_unpacklo_epi16(_Rx2, _mm_setzero_si128());
+                return _Count_traits_4::_Reduce_sse(_Rx3);
+            }
 #endif // !_M_ARM64EC
-    };
+        };
 
-    struct _Count_traits_1 : _Find_traits_1 {
+        struct _Count_traits_1 : _Find_traits_1 {
 #ifndef _M_ARM64EC
-        // For AVX2, _Max_portion_size below is _Max_count * 32 bytes, and we have 1-byte elements.
-        // We're using packed 8-bit counters, and 32 of those fit in 256 bits.
+            // For AVX2, _Max_portion_size below is _Max_count * 32 bytes, and we have 1-byte elements.
+            // We're using packed 8-bit counters, and 32 of those fit in 256 bits.
 
-        // For SSE4.2, _Max_portion_size below is _Max_count * 16 bytes, and we have 1-byte elements.
-        // We're using packed 8-bit counters, and 16 of those fit in 128 bits.
+            // For SSE4.2, _Max_portion_size below is _Max_count * 16 bytes, and we have 1-byte elements.
+            // We're using packed 8-bit counters, and 16 of those fit in 128 bits.
 
-        // For both codepaths, this is why _Max_count is the maximum unsigned 8-bit integer.
-        // (The reduction steps aren't the limiting factor here.)
+            // For both codepaths, this is why _Max_count is the maximum unsigned 8-bit integer.
+            // (The reduction steps aren't the limiting factor here.)
 
-        static constexpr size_t _Max_count = 0xFF;
+            static constexpr size_t _Max_count = 0xFF;
 
-        static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
-            return _mm256_sub_epi8(_Lhs, _Rhs);
-        }
+            static __m256i _Sub_avx(const __m256i _Lhs, const __m256i _Rhs) noexcept {
+                return _mm256_sub_epi8(_Lhs, _Rhs);
+            }
 
-        static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
-            return _mm_sub_epi8(_Lhs, _Rhs);
-        }
+            static __m128i _Sub_sse(const __m128i _Lhs, const __m128i _Rhs) noexcept {
+                return _mm_sub_epi8(_Lhs, _Rhs);
+            }
 
-        static size_t _Reduce_avx(const __m256i _Val) noexcept {
-            const __m256i _Rx1 = _mm256_sad_epu8(_Val, _mm256_setzero_si256());
-            return _Count_traits_8::_Reduce_avx(_Rx1);
-        }
+            static size_t _Reduce_avx(const __m256i _Val) noexcept {
+                const __m256i _Rx1 = _mm256_sad_epu8(_Val, _mm256_setzero_si256());
+                return _Count_traits_8::_Reduce_avx(_Rx1);
+            }
 
-        static size_t _Reduce_sse(const __m128i _Val) noexcept {
-            const __m128i _Rx1 = _mm_sad_epu8(_Val, _mm_setzero_si128());
-            return _Count_traits_8::_Reduce_sse(_Rx1);
-        }
+            static size_t _Reduce_sse(const __m128i _Val) noexcept {
+                const __m128i _Rx1 = _mm_sad_epu8(_Val, _mm_setzero_si128());
+                return _Count_traits_8::_Reduce_sse(_Rx1);
+            }
 #endif // !_M_ARM64EC
-    };
+        };
 
-    template <class _Traits, class _Ty>
-    __declspec(noalias) size_t __stdcall __std_count_trivial_impl(
-        const void* _First, const void* const _Last, const _Ty _Val) noexcept {
-        size_t _Result = 0;
+        template <class _Traits, class _Ty>
+        __declspec(noalias) size_t __stdcall _Count_impl(
+            const void* _First, const void* const _Last, const _Ty _Val) noexcept {
+            size_t _Result = 0;
 
 #ifndef _M_ARM64EC
-        const size_t _Size_bytes = _Byte_length(_First, _Last);
+            const size_t _Size_bytes = _Byte_length(_First, _Last);
 
-        if (size_t _Avx_size = _Size_bytes & ~size_t{0x1F}; _Avx_size != 0 && _Use_avx2()) {
-            const __m256i _Comparand = _Traits::_Set_avx(_Val);
-            const void* _Stop_at     = _First;
+            if (size_t _Avx_size = _Size_bytes & ~size_t{0x1F}; _Avx_size != 0 && _Use_avx2()) {
+                const __m256i _Comparand = _Traits::_Set_avx(_Val);
+                const void* _Stop_at     = _First;
 
-            for (;;) {
-                if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
-                    _Advance_bytes(_Stop_at, _Avx_size);
-                } else {
-                    constexpr size_t _Max_portion_size = _Traits::_Max_count * 32;
-                    const size_t _Portion_size         = _Avx_size < _Max_portion_size ? _Avx_size : _Max_portion_size;
-                    _Advance_bytes(_Stop_at, _Portion_size);
-                    _Avx_size -= _Portion_size;
+                for (;;) {
+                    if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
+                        _Advance_bytes(_Stop_at, _Avx_size);
+                    } else {
+                        constexpr size_t _Max_portion_size = _Traits::_Max_count * 32;
+                        const size_t _Portion_size = _Avx_size < _Max_portion_size ? _Avx_size : _Max_portion_size;
+                        _Advance_bytes(_Stop_at, _Portion_size);
+                        _Avx_size -= _Portion_size;
+                    }
+
+                    __m256i _Count_vector = _mm256_setzero_si256();
+
+                    do {
+                        const __m256i _Data = _mm256_loadu_si256(static_cast<const __m256i*>(_First));
+                        const __m256i _Mask = _Traits::_Cmp_avx(_Data, _Comparand);
+                        _Count_vector       = _Traits::_Sub_avx(_Count_vector, _Mask);
+                        _Advance_bytes(_First, 32);
+                    } while (_First != _Stop_at);
+
+                    _Result += _Traits::_Reduce_avx(_Count_vector);
+
+                    if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
+                        break;
+                    } else {
+                        if (_Avx_size == 0) {
+                            break;
+                        }
+                    }
                 }
 
-                __m256i _Count_vector = _mm256_setzero_si256();
+                if (const size_t _Avx_tail_size = _Size_bytes & 0x1C; _Avx_tail_size != 0) {
+                    const __m256i _Tail_mask = _Avx2_tail_mask_32(_Avx_tail_size);
+                    const __m256i _Data      = _mm256_maskload_epi32(static_cast<const int*>(_First), _Tail_mask);
+                    const __m256i _Mask      = _mm256_and_si256(_Traits::_Cmp_avx(_Data, _Comparand), _Tail_mask);
+                    const int _Bingo         = _mm256_movemask_epi8(_Mask);
+                    const size_t _Tail_count = __popcnt(_Bingo); // Assume available with SSE4.2
+                    _Result += _Tail_count / sizeof(_Ty);
+                    _Advance_bytes(_First, _Avx_tail_size);
+                }
 
-                do {
-                    const __m256i _Data = _mm256_loadu_si256(static_cast<const __m256i*>(_First));
-                    const __m256i _Mask = _Traits::_Cmp_avx(_Data, _Comparand);
-                    _Count_vector       = _Traits::_Sub_avx(_Count_vector, _Mask);
-                    _Advance_bytes(_First, 32);
-                } while (_First != _Stop_at);
+                _mm256_zeroupper(); // TRANSITION, DevCom-10331414
 
-                _Result += _Traits::_Reduce_avx(_Count_vector);
+                if constexpr (sizeof(_Ty) >= 4) {
+                    return _Result;
+                }
+            } else if (size_t _Sse_size = _Size_bytes & ~size_t{0xF}; _Sse_size != 0 && _Use_sse42()) {
+                const __m128i _Comparand = _Traits::_Set_sse(_Val);
+                const void* _Stop_at     = _First;
 
-                if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
-                    break;
-                } else {
-                    if (_Avx_size == 0) {
+                for (;;) {
+                    if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
+                        _Advance_bytes(_Stop_at, _Sse_size);
+                    } else {
+                        constexpr size_t _Max_portion_size = _Traits::_Max_count * 16;
+                        const size_t _Portion_size = _Sse_size < _Max_portion_size ? _Sse_size : _Max_portion_size;
+                        _Advance_bytes(_Stop_at, _Portion_size);
+                        _Sse_size -= _Portion_size;
+                    }
+
+                    __m128i _Count_vector = _mm_setzero_si128();
+
+                    do {
+                        const __m128i _Data = _mm_loadu_si128(static_cast<const __m128i*>(_First));
+                        const __m128i _Mask = _Traits::_Cmp_sse(_Data, _Comparand);
+                        _Count_vector       = _Traits::_Sub_sse(_Count_vector, _Mask);
+                        _Advance_bytes(_First, 16);
+                    } while (_First != _Stop_at);
+
+                    _Result += _Traits::_Reduce_sse(_Count_vector);
+
+                    if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
                         break;
+                    } else {
+                        if (_Sse_size == 0) {
+                            break;
+                        }
                     }
                 }
             }
-
-            if (const size_t _Avx_tail_size = _Size_bytes & 0x1C; _Avx_tail_size != 0) {
-                const __m256i _Tail_mask = _Avx2_tail_mask_32(_Avx_tail_size);
-                const __m256i _Data      = _mm256_maskload_epi32(static_cast<const int*>(_First), _Tail_mask);
-                const __m256i _Mask      = _mm256_and_si256(_Traits::_Cmp_avx(_Data, _Comparand), _Tail_mask);
-                const int _Bingo         = _mm256_movemask_epi8(_Mask);
-                const size_t _Tail_count = __popcnt(_Bingo); // Assume available with SSE4.2
-                _Result += _Tail_count / sizeof(_Ty);
-                _Advance_bytes(_First, _Avx_tail_size);
-            }
-
-            _mm256_zeroupper(); // TRANSITION, DevCom-10331414
-
-            if constexpr (sizeof(_Ty) >= 4) {
-                return _Result;
-            }
-        } else if (size_t _Sse_size = _Size_bytes & ~size_t{0xF}; _Sse_size != 0 && _Use_sse42()) {
-            const __m128i _Comparand = _Traits::_Set_sse(_Val);
-            const void* _Stop_at     = _First;
-
-            for (;;) {
-                if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
-                    _Advance_bytes(_Stop_at, _Sse_size);
-                } else {
-                    constexpr size_t _Max_portion_size = _Traits::_Max_count * 16;
-                    const size_t _Portion_size         = _Sse_size < _Max_portion_size ? _Sse_size : _Max_portion_size;
-                    _Advance_bytes(_Stop_at, _Portion_size);
-                    _Sse_size -= _Portion_size;
-                }
-
-                __m128i _Count_vector = _mm_setzero_si128();
-
-                do {
-                    const __m128i _Data = _mm_loadu_si128(static_cast<const __m128i*>(_First));
-                    const __m128i _Mask = _Traits::_Cmp_sse(_Data, _Comparand);
-                    _Count_vector       = _Traits::_Sub_sse(_Count_vector, _Mask);
-                    _Advance_bytes(_First, 16);
-                } while (_First != _Stop_at);
-
-                _Result += _Traits::_Reduce_sse(_Count_vector);
-
-                if constexpr (sizeof(_Ty) >= sizeof(size_t)) {
-                    break;
-                } else {
-                    if (_Sse_size == 0) {
-                        break;
-                    }
-                }
-            }
-        }
 #endif // !_M_ARM64EC
 
-        for (auto _Ptr = static_cast<const _Ty*>(_First); _Ptr != _Last; ++_Ptr) {
-            if (*_Ptr == _Val) {
-                ++_Result;
+            for (auto _Ptr = static_cast<const _Ty*>(_First); _Ptr != _Last; ++_Ptr) {
+                if (*_Ptr == _Val) {
+                    ++_Result;
+                }
             }
+            return _Result;
         }
-        return _Result;
-    }
+    } // namespace _Count
 } // unnamed namespace
 
 extern "C" {
 
 __declspec(noalias) size_t __stdcall __std_count_trivial_1(
     const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
-    return __std_count_trivial_impl<_Count_traits_1>(_First, _Last, _Val);
+    return _Count::_Count_impl<_Count::_Count_traits_1>(_First, _Last, _Val);
 }
 
 __declspec(noalias) size_t __stdcall __std_count_trivial_2(
     const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
-    return __std_count_trivial_impl<_Count_traits_2>(_First, _Last, _Val);
+    return _Count::_Count_impl<_Count::_Count_traits_2>(_First, _Last, _Val);
 }
 
 __declspec(noalias) size_t __stdcall __std_count_trivial_4(
     const void* const _First, const void* const _Last, const uint32_t _Val) noexcept {
-    return __std_count_trivial_impl<_Count_traits_4>(_First, _Last, _Val);
+    return _Count::_Count_impl<_Count::_Count_traits_4>(_First, _Last, _Val);
 }
 
 __declspec(noalias) size_t __stdcall __std_count_trivial_8(
     const void* const _First, const void* const _Last, const uint64_t _Val) noexcept {
-    return __std_count_trivial_impl<_Count_traits_8>(_First, _Last, _Val);
+    return _Count::_Count_impl<_Count::_Count_traits_8>(_First, _Last, _Val);
 }
 
 } // extern "C"


### PR DESCRIPTION
Resolves #5418

# Why namespaces

The goals were:

* Being able to locate functions using IDE navigation
* Group related stuff to make it clearer what uses what

Both goals are achieved with partial success:

* IDE navigation is way better, but still clobbered with now-empty unnamed namespaces. DevCom-10889095 is about that.
* Grouping works, but some algorithms still use `_Find_trats_` or `find` itself, now it happens across namespaces

# Changes

* Move functions so that the related are grouped and unrelated are ungrouped; each group contains its trait structs, implementation functions, and export functions
* Separate traits from `_Find_traits_` where makes sense
* Rename existing namespaces and functions to match usual _Naming_style.
* Add new namespaces
* Rename some identifiers to shorter, as they now, in particular `_Predicate`
* Move comments, change comment, introduce variables to resist silly wrapping
* Remove some `using namespace` to make it more clear what is used from `_Bitmap_details`
* Exclude some traits from `_ARM64_EC` and replace by `void` or completely remove

Changes are incremental to enable per-commit review. 
(It may be complex to review the whole change, as something is both moved and modified)

# Algorithms and namespaces

Namespaces:
 * **_Bitset_from_string**, **_Bitset_to_string**: contain corresponding `bitset` member functions implementations. These were fine, just renamed.
 * **_Sorting**: `minmax_element`, `minmax`, `is_sorted_until`. These have obvious commonalities, and even referred by the Standard with this name.
 * **_Removing**: `remove`, `unique`, `remove_copy`, `unique_copy`: They do the same shuffle and share tables for it.
 * **_Mismatch**: only `mismatch` itself. Originally was among find-like algorithm due to sharing traits. Decided to move out as it does not resemble find, and re-implmenet similar traits separately, which only need some functions from find traits. The use of traits can be completely avoided for this algorithm, but that's another story.
 * **_Count**: only `count` itself. As originally implemented, it was seen as find-like algorithm, however later it was re-implemented with a dedicated approach. The traits are its own, but still inherit from `_Find_traits_`, as all functions from them are needed.
 * **_Find_meow_of**: `find_first_of` and `basic_string` members that match against a set of characters. Pre-existing namespace, but reorganized a bit, in particular, some `using namespace` removed.
 * **_Find_seq**: `search`, `find_end`, and `basic_string` members members that match subsequence. These are distinct enough from `_Find` in that they use SSE4.2 like `_Find_meow_of`. They still use `_Find_traits_`, but only for fallbacks. Although if there would ever be 32 and 64 bit implementation, it will likely use `_Find_traits_` fully.
 * **_Find**: `find`, `find_last`, `adjacent_find`, `search_n`, and `basic_string` members members that match one character, including single-chararcter `find_meow_not`. They have also much of commonality. `search_n` stands out a bit, but it still uses the same traits, and generally matches a string against a single character, so that is probably fine to keep it here.
 * **_Reversing**: `reverse`, `reverse_copy`. The namespace only contains common fallback

The algorithms that don't have traits or common functions don't need namespaces:
 * `swap_ranges`
 * `replace`

Though I'm sure it is now better with more structure, I'm not sure in particular namespaces usage.