### PR TITLE
`<flat_map>`: move invariants preserving

### DIFF
--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -442,17 +442,13 @@ public:
         : _Flat_map_base(_Tag, _Ilist, key_compare(), _Alloc) {}
 
     // Copy constructors
-    _Flat_map_base(const _Flat_map_base& _Other)
-        : _Key_compare(static_cast<const _Flat_map_base&>(_Other)._Key_compare),
-          _Data(static_cast<const _Flat_map_base&>(_Other)._Data) {}
+    _Flat_map_base(const _Flat_map_base& _Other) : _Key_compare(_Other._Key_compare), _Data(_Other._Data) {}
 
     template <_Usable_allocator_for<key_container_type, mapped_container_type> _Allocator>
-    _Flat_map_base(const _Derived& _Other, const _Allocator& _Alloc)
-        : _Key_compare(static_cast<const _Flat_map_base&>(_Other)._Key_compare),
-          _Data{.keys = _STD make_obj_using_allocator<key_container_type>(
-                    _Alloc, static_cast<const _Flat_map_base&>(_Other)._Data.keys),
-              .values = _STD make_obj_using_allocator<mapped_container_type>(
-                  _Alloc, static_cast<const _Flat_map_base&>(_Other)._Data.values)} {}
+    _Flat_map_base(const _Flat_map_base& _Other, const _Allocator& _Alloc)
+        : _Key_compare(_Other._Key_compare),
+          _Data{.keys = _STD make_obj_using_allocator<key_container_type>(_Alloc, _Other._Data.keys),
+              .values = _STD make_obj_using_allocator<mapped_container_type>(_Alloc, _Other._Data.values)} {}
 
     // Move constructors
     _Flat_map_base(_Flat_map_base&& _Other)
@@ -462,12 +458,11 @@ public:
         : _Key_compare(_Other._Key_compare), _Data(_STD move(_Other).extract()) {}
 
     template <_Usable_allocator_for<key_container_type, mapped_container_type> _Allocator>
-    _Flat_map_base(_Derived&& _Other, const _Allocator& _Alloc)
+    _Flat_map_base(_Flat_map_base&& _Other, const _Allocator& _Alloc)
         noexcept(is_nothrow_copy_constructible_v<key_compare> && is_nothrow_move_constructible_v<key_compare>
                  && is_nothrow_move_constructible_v<key_container_type>
                  && is_nothrow_move_constructible_v<mapped_container_type>)
-        : _Key_compare(static_cast<_Flat_map_base&>(_Other)._Key_compare),
-          _Data{static_cast<_Flat_map_base&>(_Other)._Extract_using_allocator(_Alloc)} {}
+        : _Key_compare(_Other._Key_compare), _Data{_Other._Extract_using_allocator(_Alloc)} {}
 
     // Assignment
     _Flat_map_base& operator=(const _Flat_map_base& _Other)

--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -466,11 +466,7 @@ public:
         noexcept(is_nothrow_move_constructible_v<key_compare> && is_nothrow_move_constructible_v<key_container_type>
                  && is_nothrow_move_constructible_v<mapped_container_type>)
         : _Key_compare(static_cast<_Flat_map_base&>(_Other)._Key_compare),
-          _Data{.keys = _STD make_obj_using_allocator<key_container_type>(
-                    _Alloc, _STD move(static_cast<_Flat_map_base&>(_Other)._Data.keys)),
-              .values = _STD make_obj_using_allocator<mapped_container_type>(_Alloc,
-                  _STD move(static_cast<_Flat_map_base&>(_Other)._Data.values))} { // FIXME: Keep invariant on exception
-    }
+          _Data{static_cast<_Flat_map_base&>(_Other)._Exract_using_allocator(_Alloc)} {}
 
     // Assignment
     _Flat_map_base& operator=(const _Flat_map_base& _Other)
@@ -643,6 +639,14 @@ public:
     containers extract() && {
         _Clear_guard _Guard{this};
         return _STD move(_Data);
+    }
+
+    template <class _Allocator>
+    containers _Exract_using_allocator(const _Allocator& _Alloc) noexcept(
+        is_nothrow_move_constructible_v<key_container_type> && is_nothrow_move_constructible_v<mapped_container_type>) {
+        _Clear_guard _Guard{this};
+        return containers{.keys = _STD make_obj_using_allocator<key_container_type>(_Alloc, _Data.keys),
+            .values             = _STD make_obj_using_allocator<mapped_container_type>(_Alloc, _Data.values)};
     }
 
     void replace(key_container_type&& _Key_cont, mapped_container_type&& _Mapped_cont) {

--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -476,8 +476,10 @@ public:
     _Flat_map_base& operator=(_Flat_map_base&& _Other)
         noexcept(is_nothrow_copy_assignable_v<key_compare> && is_nothrow_move_assignable_v<key_container_type>
                  && is_nothrow_move_assignable_v<mapped_container_type>) {
-        _Key_compare = _Other._Key_compare;
-        _Data        = _STD move(_Other).extract();
+        _Clear_guard _Guard{this};
+        _Key_compare   = _Other._Key_compare;
+        _Data          = _STD move(_Other).extract();
+        _Guard._Target = nullptr;
         return *this;
     }
 

--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -442,7 +442,7 @@ public:
         : _Flat_map_base(_Tag, _Ilist, key_compare(), _Alloc) {}
 
     // Copy constructors
-    _Flat_map_base(const _Derived& _Other)
+    _Flat_map_base(const _Flat_map_base& _Other)
         : _Key_compare(static_cast<const _Flat_map_base&>(_Other)._Key_compare),
           _Data(static_cast<const _Flat_map_base&>(_Other)._Data) {}
 
@@ -455,21 +455,35 @@ public:
                   _Alloc, static_cast<const _Flat_map_base&>(_Other)._Data.values)} {}
 
     // Move constructors
-    _Flat_map_base(_Derived&& _Other)
-        noexcept(is_nothrow_move_constructible_v<key_compare> && is_nothrow_move_constructible_v<key_container_type>
+    _Flat_map_base(_Flat_map_base&& _Other)
+        noexcept(is_nothrow_copy_constructible_v<key_compare> && is_nothrow_move_constructible_v<key_compare>
+                 && is_nothrow_move_constructible_v<key_container_type>
                  && is_nothrow_move_constructible_v<mapped_container_type>)
-        : _Key_compare(_STD move(static_cast<_Flat_map_base&>(_Other)._Key_compare)),
-          _Data(_STD move(static_cast<_Flat_map_base&>(_Other).extract())) {}
+        : _Key_compare(_Other._Key_compare), _Data(_STD move(_Other).extract()) {}
 
     template <_Usable_allocator_for<key_container_type, mapped_container_type> _Allocator>
     _Flat_map_base(_Derived&& _Other, const _Allocator& _Alloc)
         noexcept(is_nothrow_move_constructible_v<key_compare> && is_nothrow_move_constructible_v<key_container_type>
                  && is_nothrow_move_constructible_v<mapped_container_type>)
-        : _Key_compare(_STD move(static_cast<_Flat_map_base&>(_Other)._Key_compare)),
+        : _Key_compare(static_cast<_Flat_map_base&>(_Other)._Key_compare),
           _Data{.keys = _STD make_obj_using_allocator<key_container_type>(
                     _Alloc, _STD move(static_cast<_Flat_map_base&>(_Other)._Data.keys)),
-              .values = _STD make_obj_using_allocator<mapped_container_type>(
-                  _Alloc, _STD move(static_cast<_Flat_map_base&>(_Other)._Data.values))} {}
+              .values = _STD make_obj_using_allocator<mapped_container_type>(_Alloc,
+                  _STD move(static_cast<_Flat_map_base&>(_Other)._Data.values))} { // FIXME: Keep invariant on exception
+    }
+
+    // Assignment
+    _Flat_map_base& operator=(const _Flat_map_base& _Other)
+        noexcept(is_nothrow_copy_assignable_v<key_compare> && is_nothrow_copy_assignable_v<key_container_type>
+                 && is_nothrow_copy_assignable_v<mapped_container_type>) = default;
+
+    _Flat_map_base& operator=(_Flat_map_base&& _Other)
+        noexcept(is_nothrow_copy_assignable_v<key_compare> && is_nothrow_move_assignable_v<key_container_type>
+                 && is_nothrow_move_assignable_v<mapped_container_type>) {
+        _Key_compare = _Other._Key_compare;
+        _Data        = _STD move(_Other).extract();
+        return *this;
+    }
 
     // [container.reqmts] iterators
     _NODISCARD iterator begin() noexcept {

--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -467,7 +467,7 @@ public:
                  && is_nothrow_move_constructible_v<key_container_type>
                  && is_nothrow_move_constructible_v<mapped_container_type>)
         : _Key_compare(static_cast<_Flat_map_base&>(_Other)._Key_compare),
-          _Data{static_cast<_Flat_map_base&>(_Other)._Exract_using_allocator(_Alloc)} {}
+          _Data{static_cast<_Flat_map_base&>(_Other)._Extract_using_allocator(_Alloc)} {}
 
     // Assignment
     _Flat_map_base& operator=(const _Flat_map_base& _Other)
@@ -651,7 +651,7 @@ public:
     }
 
     template <class _Allocator>
-    containers _Exract_using_allocator(const _Allocator& _Alloc) noexcept(
+    containers _Extract_using_allocator(const _Allocator& _Alloc) noexcept(
         is_nothrow_move_constructible_v<key_container_type> && is_nothrow_move_constructible_v<mapped_container_type>) {
         _Clear_guard _Guard{this};
         return containers{.keys = _STD make_obj_using_allocator<key_container_type>(_Alloc, _STD move(_Data.keys)),

--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -463,7 +463,8 @@ public:
 
     template <_Usable_allocator_for<key_container_type, mapped_container_type> _Allocator>
     _Flat_map_base(_Derived&& _Other, const _Allocator& _Alloc)
-        noexcept(is_nothrow_move_constructible_v<key_compare> && is_nothrow_move_constructible_v<key_container_type>
+        noexcept(is_nothrow_copy_constructible_v<key_compare> && is_nothrow_move_constructible_v<key_compare>
+                 && is_nothrow_move_constructible_v<key_container_type>
                  && is_nothrow_move_constructible_v<mapped_container_type>)
         : _Key_compare(static_cast<_Flat_map_base&>(_Other)._Key_compare),
           _Data{static_cast<_Flat_map_base&>(_Other)._Exract_using_allocator(_Alloc)} {}

--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -655,7 +655,7 @@ public:
         is_nothrow_move_constructible_v<key_container_type> && is_nothrow_move_constructible_v<mapped_container_type>) {
         _Clear_guard _Guard{this};
         return containers{.keys = _STD make_obj_using_allocator<key_container_type>(_Alloc, _STD move(_Data.keys)),
-            .values             = _STD make_obj_using_allocator<mapped_container_type>(_Alloc, STD move(_Data.values))};
+            .values = _STD make_obj_using_allocator<mapped_container_type>(_Alloc, _STD move(_Data.values))};
     }
 
     void replace(key_container_type&& _Key_cont, mapped_container_type&& _Mapped_cont) {

--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -479,9 +479,9 @@ public:
         return *this;
     }
 
-    _Flat_map_base& operator=(_Flat_map_base&& _Other)
-        noexcept(is_nothrow_copy_assignable_v<key_compare> && is_nothrow_move_assignable_v<key_container_type>
-                 && is_nothrow_move_assignable_v<mapped_container_type>) {
+    _Flat_map_base& operator=(_Flat_map_base&& _Other) noexcept(
+        is_nothrow_copy_assignable_v<key_compare> && is_nothrow_move_assignable_v<key_compare>
+        && is_nothrow_move_assignable_v<key_container_type> && is_nothrow_move_assignable_v<mapped_container_type>) {
         _Clear_guard _Guard{this};
         _Key_compare   = _Other._Key_compare;
         _Data          = _STD move(_Other).extract();

--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -471,7 +471,13 @@ public:
     // Assignment
     _Flat_map_base& operator=(const _Flat_map_base& _Other)
         noexcept(is_nothrow_copy_assignable_v<key_compare> && is_nothrow_copy_assignable_v<key_container_type>
-                 && is_nothrow_copy_assignable_v<mapped_container_type>) = default;
+                 && is_nothrow_copy_assignable_v<mapped_container_type>) {
+        _Clear_guard _Guard{this};
+        _Key_compare   = _Other._Key_compare;
+        _Data          = _Other._Data;
+        _Guard._Target = nullptr;
+        return *this;
+    }
 
     _Flat_map_base& operator=(_Flat_map_base&& _Other)
         noexcept(is_nothrow_copy_assignable_v<key_compare> && is_nothrow_move_assignable_v<key_container_type>

--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -654,8 +654,8 @@ public:
     containers _Exract_using_allocator(const _Allocator& _Alloc) noexcept(
         is_nothrow_move_constructible_v<key_container_type> && is_nothrow_move_constructible_v<mapped_container_type>) {
         _Clear_guard _Guard{this};
-        return containers{.keys = _STD make_obj_using_allocator<key_container_type>(_Alloc, _Data.keys),
-            .values             = _STD make_obj_using_allocator<mapped_container_type>(_Alloc, _Data.values)};
+        return containers{.keys = _STD make_obj_using_allocator<key_container_type>(_Alloc, _STD move(_Data.keys)),
+            .values             = _STD make_obj_using_allocator<mapped_container_type>(_Alloc, STD move(_Data.values))};
     }
 
     void replace(key_container_type&& _Key_cont, mapped_container_type&& _Mapped_cont) {

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -577,10 +577,6 @@ std/depr/depr.c.headers/stddef_h.compile.pass.cpp:1 FAIL
 
 # *** LIKELY BOGUS TESTS ***
 
-# A moved-from flat_map is not empty, which doesn't seem to be required
-std/containers/container.adaptors/flat.map/flat.map.cons/move_alloc.pass.cpp FAIL
-std/containers/container.adaptors/flat.multimap/flat.multimap.cons/move_alloc.pass.cpp FAIL
-
 # Test bug after LWG-2899 "is_(nothrow_)move_constructible and tuple, optional and unique_ptr" was accepted.
 std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.pass.cpp FAIL
 std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.runtime.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -236,26 +236,6 @@ std/strings/c.strings/cuchar.compile.pass.cpp FAIL
 std/containers/container.adaptors/flat.map/flat.map.cons/deduct.pass.cpp FAIL
 std/containers/container.adaptors/flat.multimap/flat.multimap.cons/deduct.pass.cpp FAIL
 
-# FIXME! Assertion failed: m.keys().size() == m.values().size()
-# [flat.map.defn] doesn't declare a move constructor, which seems to imply that moving from a flat_map should behave
-# as if the move constructor were implicitly defined, i.e. it can't restore the invariants
-# P2767R2 does not specify move constructor, which is broken
-# P3567R0 adds a move constructor that asks to restore invariants
-# P3567R0 constructor also moves comparator, which we should veto if it makes into the Standard
-std/containers/container.adaptors/flat.map/flat.map.cons/move_assign_clears.pass.cpp FAIL
-std/containers/container.adaptors/flat.map/flat.map.cons/move_exceptions.pass.cpp FAIL
-std/containers/container.adaptors/flat.multimap/flat.multimap.cons/move_assign_clears.pass.cpp FAIL
-std/containers/container.adaptors/flat.multimap/flat.multimap.cons/move_exceptions.pass.cpp FAIL
-
-# FIXME! abort() has been called
-# caused by insert failing when called on a moved-from flat_map due to its comparator being moved from,
-# but this seems to be in line with the specification: flat_map::insert transitively requires that the comparator
-# "induce a strict weak ordering on the values"
-# P2767R2 does not specify move constructor, which is broken
-# P3567R0 constructor is still asked to move comparator, which is also broken
-std/containers/container.adaptors/flat.map/flat.map.cons/move.pass.cpp FAIL
-std/containers/container.adaptors/flat.multimap/flat.multimap.cons/move.pass.cpp FAIL
-
 # FIXME! warning C4242: 'initializing': conversion from '_Ty' to '_Ty2', possible loss of data
 std/containers/container.adaptors/flat.map/flat.map.cons/copy_assign.pass.cpp:0 FAIL
 std/containers/container.adaptors/flat.map/flat.map.cons/copy_assign.pass.cpp:1 FAIL


### PR DESCRIPTION
There are some situations to care about:
 * The comparator should always be copied, not ever moved, since moved out comparator may not satisfy invariants as it may not be able to compare at all (consider moved-out `std::function`)
 * The keys and values size should always be equal, even for moved-out container when exception is thrown. The easiest way to accomplish that is to clear both in a scope guard
 * For assignment, need to care about the target object as well

The PR addresses these situations as follows:
 * Turn `_Flat_map_base(_Derived&& _Other)` to actual move constructor
 * Add copy and move assignment operators
 * In `noexcept()` of move constructor and move-with-allocator constructor ask for both noexcept-copy (as we need it) and noexcept-move (as per spec, there is a test for that)
 * Rely on `extract()` to keep container size invariant (pre-existing)
 * Move `extract()` target object, the result is rvalue enough
 * For move-with-allocator constructor add a special implementation of `extract()`
 * Always copy comparator in mentioned constructors
 * Always copy assign comparator in move-assignment
 * Use guards in assignments to preserve target invariants on exception

The following were not addressed for now:
 * Add own coverage for that. Specifically, we apparently have no coverage for assignment target invariants
 * Look if anything is wrong with `<flat_set>` in this regard