### PR TITLE
`<regex>`: Fix quadratic complexity in `regex_search` when regex starts with `?` quantifier or several alternatives

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -3937,7 +3937,7 @@ _BidIt _Matcher<_BidIt, _Elem, _RxTraits, _It>::_Skip(_BidIt _First_arg, _BidIt 
                 // Thus, we only continue if this node has a single branch only.
                 _Node_if* _Node = static_cast<_Node_if*>(_Nx);
 
-                if (_Node->_Child != nullptr) {
+                if (_Node->_Child) {
                     return _First_arg;
                 }
                 break;

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -3931,23 +3931,22 @@ _BidIt _Matcher<_BidIt, _Elem, _RxTraits, _It>::_Skip(_BidIt _First_arg, _BidIt 
             break;
 
         case _N_if:
-            { // check for soonest string match
+            {
+                // GH-5452: If this node has two or more branches,
+                // examining all these branches has quadratic worst-case complexity.
+                // Thus, we only continue if this node has a single branch only.
                 _Node_if* _Node = static_cast<_Node_if*>(_Nx);
 
-                for (; _First_arg != _Last && _Node; _Node = _Node->_Child) {
-                    _Last = _Skip(_First_arg, _Last, _Node->_Next);
+                if (_Node->_Child != nullptr) {
+                    return _First_arg;
                 }
-
-                return _Last;
+                break;
             }
 
         case _N_begin:
             break;
 
         case _N_end:
-            _Nx = nullptr;
-            break;
-
         case _N_none:
         case _N_wbound:
         case _N_dot:


### PR DESCRIPTION
Fixes #5452. This is the minimal fix in `_Matcher::_Skip` that I mentioned in the issue: It avoids worst-case running time quadratic in the size of the searched string by giving up on `_N_if` nodes with two or more branches.

Unfortunately, we can't just give up whenever an `_N_if` is encountered because the parser currently likes to generate such nodes with a single branch. In particular, there is one such node at the beginning of each generated NFA. This means that giving up on such nodes would render `_Skip` pointless for all regular expressions.

I confirmed locally that this change is sufficient to fix the quadratic running time that #5452's test case exposes (though the quantifiers still almost double the running time.)