### PR TITLE
RWC workaround: Use `__builtin_trap` for ancient Clang

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -335,7 +335,7 @@ constexpr bool is_enum_v = __is_enum(_Ty);
 
 #if _HAS_CXX23
 #if defined(__clang__) && !defined(__EDG__) \
-    && __clang_major__ >= 16 // TRANSITION, DevCom-10870354, Real World Code relying on ancient Clang
+    && __clang_major__ >= 16 // TRANSITION, DevCom-10870354 (MSVC, EDG), VSO-2397560 (RWC relying on ancient Clang)
 _EXPORT_STD template <class _Ty>
 constexpr bool is_scoped_enum_v = __is_scoped_enum(_Ty);
 

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -244,6 +244,8 @@ _EMIT_STL_ERROR(STL1008, "_STL_CALL_ABORT_INSTEAD_OF_INVALID_PARAMETER has been 
 #ifndef _MSVC_STL_DOOM_FUNCTION
 #ifdef _MSVC_STL_USE_ABORT_AS_DOOM_FUNCTION // The user wants to use abort():
 #define _MSVC_STL_DOOM_FUNCTION(mesg) _CSTD abort()
+#elif defined(__clang__) && __clang_major__ < 19 // TRANSITION, VSO-2397560, Real World Code relying on ancient Clang
+#define _MSVC_STL_DOOM_FUNCTION(mesg) __builtin_trap()
 #elif defined(__clang__) // Use the Clang intrinsic:
 #define _MSVC_STL_DOOM_FUNCTION(mesg) __builtin_verbose_trap("MSVC STL error", mesg)
 #elif defined(_M_CEE) // TRANSITION, VSO-2457624 (/clr silent bad codegen for __fastfail); /clr:pure lacks __fastfail


### PR DESCRIPTION
Once again, we need to add a workaround for the Taichi project in our Real World Code test suite, which is using an ancient version of Clang that we don't generally support (Clang 14). It turns out that the [`__builtin_verbose_trap`](https://clang.llvm.org/docs/LanguageExtensions.html#builtin-verbose-trap) intrinsic that I used in #5433 was only added in Clang 19. 

As a workaround, we can use the [`__builtin_trap`](https://clang.llvm.org/docs/LanguageExtensions.html#builtin-trap) intrinsic, which has been supported since the Age of Legends.

(At some point, if this keeps causing headaches, I'll throw up my hands and declare that we can't keep quasi-supporting this scenario anymore. But for now, adding a couple of lines isn't too intrusive, and it may also help with our quasi-support of the Clang-based Intel compiler.)

Additionally, I am expanding our TRANSITION comment for the `__is_scoped_enum` intrinsic that was added by #5358. There are actually two workarounds here: DevCom-10870354 "MSVC and EDG should provide the `__is_scoped_enum` intrinsic to improve throughput" and VSO-2397560 "\[RWC\]\[prod/fe\]\[Regression\] Taichi build failed with error G444FFF0D: overloaded 'operator()' cannot be a static member function" (which was originally filed for our usage of the static function call operator, but is reasonable to cite for all ancient-Clang workarounds for Taichi). Usually when we say "TRANSITION, bug-number, explain-reason", we're explaining what the bug-number is about, but this comment was citing one workaround with bug-number and another workaround with explain-reason.