### PR TITLE
Enable `thread::hardware_concurrency()` to handle more than 64 processors

### DIFF
--- a/stl/msbuild/stl_base/msvcp.settings.targets
+++ b/stl/msbuild/stl_base/msvcp.settings.targets
@@ -71,6 +71,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <TargetLib Include="$(CrtLibPath)\msvcrt$(BuildSuffix)$(ClrLibSuffix).lib"/>
         <TargetLib Include="$(CrtLibPath)\vcruntime$(BuildSuffix)$(ClrLibSuffix).lib"/>
         <TargetLib Include="$(UniversalCRTLib)"/>
+        <TargetLib Condition="'$(BuildArchitecture)' == 'arm64' or '$(BuildArchitecture)' == 'arm64ec'" Include="$(SdkLibPath)\softintrin.lib"/>
     </ItemGroup>
 
     <!-- Copy the output dll and pdb to various destinations -->

--- a/stl/src/cthread.cpp
+++ b/stl/src/cthread.cpp
@@ -111,7 +111,7 @@ _CRTIMP2_PURE unsigned int __cdecl _Thrd_hardware_concurrency() noexcept { // re
 #elif defined(_M_IX86) || defined(_M_ARM) // 12 bytes per group
     constexpr int stack_buffer_size = 44;
 #else
-    constexpr int stack_buffer_size = 0;
+#error Unknown architecture
 #endif
     alignas(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX) unsigned char buffer[stack_buffer_size];
     using buffer_ptr_t = PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX;

--- a/stl/src/cthread.cpp
+++ b/stl/src/cthread.cpp
@@ -123,7 +123,6 @@ _CRTIMP2_PURE unsigned int __cdecl _Thrd_hardware_concurrency() noexcept { // re
 
         if (GetLogicalProcessorInformationEx(RelationProcessorPackage, buffer_ptr, buffer_size)) {
             for (WORD i = 0; i != buffer_ptr->Processor.GroupCount; ++i) {
-                // Mask is 8 bytes on ARM64 and X64, and 4 bytes on X86 and ARM32
                 count += _STD popcount(buffer_ptr->Processor.GroupMask[i].Mask);
             }
         }

--- a/stl/src/cthread.cpp
+++ b/stl/src/cthread.cpp
@@ -113,17 +113,17 @@ _CRTIMP2_PURE unsigned int __cdecl _Thrd_hardware_concurrency() noexcept { // re
 #else
     constexpr int stack_buffer_size = 0;
 #endif
-    unsigned char buffer[stack_buffer_size];
+    alignas(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX) unsigned char buffer[stack_buffer_size];
     using buffer_ptr_t = PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX;
     DWORD buffer_size  = stack_buffer_size;
 
-    const auto try_query = [](buffer_ptr_t buffer_ptr, PDWORD buffer_size) _STATIC_CALL_OPERATOR {
+    const auto try_query = [](buffer_ptr_t buffer_ptr, PDWORD buffer_size) _STATIC_CALL_OPERATOR noexcept {
         unsigned int count = 0;
         _ASSERT(buffer_ptr != nullptr);
 
         if (GetLogicalProcessorInformationEx(RelationProcessorPackage, buffer_ptr, buffer_size) == TRUE) {
             for (WORD i = 0; i != buffer_ptr->Processor.GroupCount; ++i) {
-                // Mask is 8 bytes on ARM64 and X64, and 4 bytes on X86 and ARM32.
+                // Mask is 8 bytes on ARM64 and X64, and 4 bytes on X86 and ARM32
                 count += std::popcount(buffer_ptr->Processor.GroupMask[i].Mask);
             }
         }

--- a/stl/src/cthread.cpp
+++ b/stl/src/cthread.cpp
@@ -106,13 +106,12 @@ _CRTIMP2_PURE _Thrd_id_t __cdecl _Thrd_id() noexcept { // return unique id for c
 
 _CRTIMP2_PURE unsigned int __cdecl _Thrd_hardware_concurrency() noexcept { // return number of processors
     // Most devices have only one processor group and thus have the same buffer_size
-#if defined(_M_X64) || defined(_M_ARM64) // 16 bytes per group
-    constexpr int stack_buffer_size = 48;
-#elif defined(_M_IX86) || defined(_M_ARM) // 12 bytes per group
-    constexpr int stack_buffer_size = 44;
-#else
-#error Unknown architecture
-#endif
+#ifdef _WIN64
+    constexpr int stack_buffer_size = 48; // 16 bytes per group
+#else // ^^^ 64-bit / 32-bit vvv
+    constexpr int stack_buffer_size = 44; // 12 bytes per group
+#endif // ^^^ 32-bit ^^^
+
     alignas(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX) unsigned char buffer[stack_buffer_size];
     using buffer_ptr_t = PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX;
     DWORD buffer_size  = stack_buffer_size;

--- a/stl/src/cthread.cpp
+++ b/stl/src/cthread.cpp
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <bit>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <memory>
 #include <process.h>
 #include <xthreads.h>
 

--- a/stl/src/cthread.cpp
+++ b/stl/src/cthread.cpp
@@ -112,8 +112,8 @@ _CRTIMP2_PURE unsigned int __cdecl _Thrd_hardware_concurrency() noexcept { // re
     constexpr int stack_buffer_size = 44; // 12 bytes per group
 #endif // ^^^ 32-bit ^^^
 
-    alignas(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX) unsigned char buffer[stack_buffer_size];
-    auto buffer_ptr   = reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(&buffer);
+    alignas(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX) unsigned char stack_buffer[stack_buffer_size];
+    auto buffer_ptr   = reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(&stack_buffer);
     DWORD buffer_size = stack_buffer_size;
     _STD unique_ptr<unsigned char[]> new_buffer;
 

--- a/stl/src/cthread.cpp
+++ b/stl/src/cthread.cpp
@@ -119,11 +119,11 @@ _CRTIMP2_PURE unsigned int __cdecl _Thrd_hardware_concurrency() noexcept { // re
 
     for (;;) {
         if (GetLogicalProcessorInformationEx(RelationProcessorPackage, buffer_ptr, &buffer_size)) {
-            unsigned int count = 0;
+            unsigned int logical_processors = 0;
             for (WORD i = 0; i != buffer_ptr->Processor.GroupCount; ++i) {
-                count += _STD popcount(buffer_ptr->Processor.GroupMask[i].Mask);
+                logical_processors += _STD popcount(buffer_ptr->Processor.GroupMask[i].Mask);
             }
-            return count;
+            return logical_processors;
         }
 
         if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {

--- a/stl/src/cthread.cpp
+++ b/stl/src/cthread.cpp
@@ -103,9 +103,7 @@ _CRTIMP2_PURE _Thrd_id_t __cdecl _Thrd_id() noexcept { // return unique id for c
 }
 
 _CRTIMP2_PURE unsigned int __cdecl _Thrd_hardware_concurrency() noexcept { // return number of processors
-    SYSTEM_INFO info;
-    GetNativeSystemInfo(&info);
-    return info.dwNumberOfProcessors;
+    return GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
 }
 
 // TRANSITION, ABI: _Thrd_create() is preserved for binary compatibility

--- a/stl/src/cthread.cpp
+++ b/stl/src/cthread.cpp
@@ -121,7 +121,7 @@ _CRTIMP2_PURE unsigned int __cdecl _Thrd_hardware_concurrency() noexcept { // re
         unsigned int count = 0;
         _ASSERT(buffer_ptr != nullptr);
 
-        if (GetLogicalProcessorInformationEx(RelationProcessorPackage, buffer_ptr, buffer_size) == TRUE) {
+        if (GetLogicalProcessorInformationEx(RelationProcessorPackage, buffer_ptr, buffer_size)) {
             for (WORD i = 0; i != buffer_ptr->Processor.GroupCount; ++i) {
                 // Mask is 8 bytes on ARM64 and X64, and 4 bytes on X86 and ARM32
                 count += _STD popcount(buffer_ptr->Processor.GroupMask[i].Mask);

--- a/stl/src/cthread.cpp
+++ b/stl/src/cthread.cpp
@@ -124,7 +124,7 @@ _CRTIMP2_PURE unsigned int __cdecl _Thrd_hardware_concurrency() noexcept { // re
         if (GetLogicalProcessorInformationEx(RelationProcessorPackage, buffer_ptr, buffer_size) == TRUE) {
             for (WORD i = 0; i != buffer_ptr->Processor.GroupCount; ++i) {
                 // Mask is 8 bytes on ARM64 and X64, and 4 bytes on X86 and ARM32
-                count += std::popcount(buffer_ptr->Processor.GroupMask[i].Mask);
+                count += _STD popcount(buffer_ptr->Processor.GroupMask[i].Mask);
             }
         }
 


### PR DESCRIPTION
[Microsoft Learn `GetLogicalProcessorInformationEx`](https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getlogicalprocessorinformationex)
Fix #5453.