### PR TITLE
`<flat_map>`: drop bogus exception specifications

### DIFF
--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -460,15 +460,10 @@ public:
 
     template <_Usable_allocator_for<key_container_type, mapped_container_type> _Allocator>
     _Flat_map_base(_Flat_map_base&& _Other, const _Allocator& _Alloc)
-        noexcept(is_nothrow_copy_constructible_v<key_compare> && is_nothrow_move_constructible_v<key_compare>
-                 && is_nothrow_move_constructible_v<key_container_type>
-                 && is_nothrow_move_constructible_v<mapped_container_type>)
         : _Key_compare(_Other._Key_compare), _Data{_Other._Extract_using_allocator(_Alloc)} {}
 
     // Assignment
-    _Flat_map_base& operator=(const _Flat_map_base& _Other)
-        noexcept(is_nothrow_copy_assignable_v<key_compare> && is_nothrow_copy_assignable_v<key_container_type>
-                 && is_nothrow_copy_assignable_v<mapped_container_type>) {
+    _Flat_map_base& operator=(const _Flat_map_base& _Other) {
         _Clear_guard _Guard{this};
         _Key_compare   = _Other._Key_compare;
         _Data          = _Other._Data;
@@ -647,8 +642,7 @@ public:
     }
 
     template <class _Allocator>
-    containers _Extract_using_allocator(const _Allocator& _Alloc) noexcept(
-        is_nothrow_move_constructible_v<key_container_type> && is_nothrow_move_constructible_v<mapped_container_type>) {
+    containers _Extract_using_allocator(const _Allocator& _Alloc) {
         _Clear_guard _Guard{this};
         return containers{.keys = _STD make_obj_using_allocator<key_container_type>(_Alloc, _STD move(_Data.keys)),
             .values = _STD make_obj_using_allocator<mapped_container_type>(_Alloc, _STD move(_Data.values))};


### PR DESCRIPTION
Remove these exception specifications:
* move-with-allocator constructor throws because allocator throws
* ditto the extracted machinery `_Extract_using_allocator`
* ditto copy assignment

Bugs introduced in #5454, before that there was only one of them, and it was in a constructor that was never called.

I'm not sure if move constructor and move assignment exception specifications are right. That's vector-like thing we have in `flat_map`, not necessarily `vector`, what if it might not have `noexcept` moves.