### PR TITLE
`<locale>`: make `collate::hash` return the same hash for strings that collate the same

### DIFF
--- a/stl/inc/locale
+++ b/stl/inc/locale
@@ -183,8 +183,8 @@ protected:
 
     _NODISCARD virtual long __CLR_OR_THIS_CALL do_hash(const _Elem* _First, const _Elem* _Last) const {
         // compute hash code for [_First, _Last)
-        _Adl_verify_range(_First, _Last);
-        return static_cast<long>(_Hash_array_representation(_First, static_cast<size_t>(_Last - _First)));
+        const auto _Sortkey = collate::do_transform(_First, _Last);
+        return static_cast<long>(_Hash_array_representation(_Sortkey.data(), _Sortkey.size()));
     }
 
 private:

--- a/tests/std/tests/GH_005236_collate_facet/test.cpp
+++ b/tests/std/tests/GH_005236_collate_facet/test.cpp
@@ -96,10 +96,6 @@ void test_gh_5210() {
 #endif // !defined(SKIP_COLLATE_TRANSFORM_TESTS)
 }
 
-// GH-5469 fixed this by making collate::do_hash() call collate::do_transform()
-#ifdef SKIP_COLLATE_TRANSFORM_TESTS
-void test_gh_5212() {}
-#else // ^^^ defined(SKIP_COLLATE_TRANSFORM_TESTS) / !defined(SKIP_COLLATE_TRANSFORM_TESTS) vvv
 void test_gh_5212_compare_hash(const collate<wchar_t>& coll, const wstring& string1, const wstring& string2) {
     assert(coll.hash(string1.data(), string1.data() + string1.size())
            == coll.hash(string2.data(), string2.data() + string2.size()));
@@ -117,7 +113,6 @@ void test_gh_5212() {
     // umlaut A collates like "AE"
     test_gh_5212_compare_hash(coll, L"AErmel", L"\u00C4rmel"); // U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS
 }
-#endif // ^^^ !defined(SKIP_COLLATE_TRANSFORM_TESTS) ^^^
 
 // GH-5236 "std::collate<wchar_t> does not respect collation order when compiled with /MD(d) /Zc:wchar_t-"
 void test_gh_5236() {

--- a/tests/std/tests/GH_005236_collate_facet/test.cpp
+++ b/tests/std/tests/GH_005236_collate_facet/test.cpp
@@ -96,7 +96,7 @@ void test_gh_5210() {
 #endif // !defined(SKIP_COLLATE_TRANSFORM_TESTS)
 }
 
-void test_gh_5212_compare_hash(const collate<wchar_t>& coll, wstring string1, wstring string2) {
+void test_gh_5212_compare_hash(const collate<wchar_t>& coll, const wstring& string1, const wstring& string2) {
     assert(coll.hash(string1.data(), string1.data() + string1.size())
            == coll.hash(string2.data(), string2.data() + string2.size()));
 }

--- a/tests/std/tests/GH_005236_collate_facet/test.cpp
+++ b/tests/std/tests/GH_005236_collate_facet/test.cpp
@@ -96,6 +96,24 @@ void test_gh_5210() {
 #endif // !defined(SKIP_COLLATE_TRANSFORM_TESTS)
 }
 
+void test_gh_5212_compare_hash(const collate<wchar_t>& coll, wstring string1, wstring string2) {
+    assert(coll.hash(string1.data(), string1.data() + string1.size())
+           == coll.hash(string2.data(), string2.data() + string2.size()));
+}
+
+// GH-5212: std::collate_byname<_Elem>::hash() yields different hashes for strings that collate the same
+void test_gh_5212() {
+    const locale loc("de-DE_phoneb");
+    const auto& coll = use_facet<collate<wchar_t>>(loc);
+
+    // sharp s collates like "ss"
+    test_gh_5212_compare_hash(coll, L"Strasse", L"Stra\u00DFe"); // U+00DF LATIN SMALL LETTER SHARP S
+    // umlaut a collates like "ae"
+    test_gh_5212_compare_hash(coll, L"Kaetzchen", L"K\u00E4tzchen"); // U+00E4 LATIN SMALL LETTER A WITH DIAERESIS
+    // umlaut A collates like "AE"
+    test_gh_5212_compare_hash(coll, L"AErmel", L"\u00C4rmel"); // U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS
+}
+
 // GH-5236 "std::collate<wchar_t> does not respect collation order when compiled with /MD(d) /Zc:wchar_t-"
 void test_gh_5236() {
     const wchar_t Ue = L'\u00DC'; // U+00DC LATIN CAPITAL LETTER U WITH DIARESIS
@@ -117,5 +135,6 @@ void test_gh_5236() {
 
 int main() {
     test_gh_5210();
+    test_gh_5212();
     test_gh_5236();
 }

--- a/tests/std/tests/GH_005236_collate_facet/test.cpp
+++ b/tests/std/tests/GH_005236_collate_facet/test.cpp
@@ -96,6 +96,10 @@ void test_gh_5210() {
 #endif // !defined(SKIP_COLLATE_TRANSFORM_TESTS)
 }
 
+// GH-5469 fixed this by making collate::do_hash() call collate::do_transform()
+#ifdef SKIP_COLLATE_TRANSFORM_TESTS
+void test_gh_5212() {}
+#else // ^^^ defined(SKIP_COLLATE_TRANSFORM_TESTS) / !defined(SKIP_COLLATE_TRANSFORM_TESTS) vvv
 void test_gh_5212_compare_hash(const collate<wchar_t>& coll, const wstring& string1, const wstring& string2) {
     assert(coll.hash(string1.data(), string1.data() + string1.size())
            == coll.hash(string2.data(), string2.data() + string2.size()));
@@ -113,6 +117,7 @@ void test_gh_5212() {
     // umlaut A collates like "AE"
     test_gh_5212_compare_hash(coll, L"AErmel", L"\u00C4rmel"); // U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS
 }
+#endif // ^^^ !defined(SKIP_COLLATE_TRANSFORM_TESTS) ^^^
 
 // GH-5236 "std::collate<wchar_t> does not respect collation order when compiled with /MD(d) /Zc:wchar_t-"
 void test_gh_5236() {


### PR DESCRIPTION
Fixes #5212.

At first glance, calling `LCMapStringEx` with `LCMAP_HASH` seems to be the obvious solution, [but the docs state](https://learn.microsoft.com/en-us/windows/win32/api/winnls/nf-winnls-lcmapstringex) (emphasis mine):

> Strings that appear equivalent **typically** return the same hash (for example, "hello" and "HELLO" with LCMAP_IGNORECASE). **However, some complex cases, such as East Asian languages, can have similar strings with identical weights that compare as equal but do not return the same hash.**

I briefly tested this and the warning seems to be true, as the following program finds some single-character strings that collate the same but yield different hashes:

```cpp
#include <iostream>
#include <windows.h>

using namespace std;

int main() {
	const wchar_t* locale = L"ja-JP";
	for (wchar_t w = 1; w != 0; ++w) {
		int hashw;
		if (LCMapStringEx(locale, LCMAP_HASH, &w, 1, reinterpret_cast<LPWSTR>(&hashw), sizeof(int), nullptr, nullptr, 0) == 0) {
			continue;
		}

		for (wchar_t x = w + 1; x != 0; ++x) {
			int hashx;
			if (LCMapStringEx(locale, LCMAP_HASH, &x, 1, reinterpret_cast<LPWSTR>(&hashx), sizeof(int), nullptr, nullptr, 0) == 0) {
				continue;
			}
			if (hashw != hashx && CompareStringEx(locale, 0, &w, 1, &x, 1, nullptr, nullptr, 0) == CSTR_EQUAL) {
				cout << "found different hashes for characters collating the same at: " << int(w) << " : " << int(x) << '\n';
			}
		}
	}
}
```
Output:
```
found different hashes for characters collating the same at: 1556 : 64606
found different hashes for characters collating the same at: 1611 : 65137
found different hashes for characters collating the same at: 1614 : 65143
[...]
```


This means that `LCMapStringEx` with `LCMAP_HASH` is not good enough to meet the requirements in [\[locale.collate.virtuals\]/3](https://eel.is/c++draft/locale.collate.virtuals#3).

For this reason, this PR computes the sort key first (by calling `do_transform`) and then hashes the sort key.

