### PR TITLE
`features.py`: Recognize the `'Czech_Czechia.1250'` locale

### DIFF
--- a/tests/utils/stl/test/features.py
+++ b/tests/utils/stl/test/features.py
@@ -39,10 +39,8 @@ def getDefaultFeatures(config, litConfig):
       'cs_CZ.ISO8859-2': ['cs_CZ.ISO8859-2', 'Czech_Czechia.1250']
     }
     for loc, alts in locales.items():
-      # Note: Using alts directly in the lambda body here will bind it to the value at the
-      # end of the loop. Assigning it to a default argument works around this issue.
-      DEFAULT_FEATURES.append(Feature(name='locale.{}'.format(loc),
-                                      when=lambda cfg, alts=alts: any(hasLocale(alt) for alt in alts)))
+      if any(hasLocale(alt) for alt in alts):
+        DEFAULT_FEATURES.append(Feature(name=f'locale.{loc}'))
     env_var = 'STL_EDG_DROP'
     litConfig.edg_drop = None
     if env_var in os.environ and os.environ[env_var] is not None:

--- a/tests/utils/stl/test/features.py
+++ b/tests/utils/stl/test/features.py
@@ -36,7 +36,7 @@ def getDefaultFeatures(config, litConfig):
       'ru_RU.UTF-8':     ['ru_RU.UTF-8', 'ru_RU.utf8', 'Russian_Russia.1251'],
       'zh_CN.UTF-8':     ['zh_CN.UTF-8', 'zh_CN.utf8', 'Chinese_China.936'],
       'fr_CA.ISO8859-1': ['fr_CA.ISO8859-1', 'French_Canada.1252'],
-      'cs_CZ.ISO8859-2': ['cs_CZ.ISO8859-2', 'Czech_Czech Republic.1250']
+      'cs_CZ.ISO8859-2': ['cs_CZ.ISO8859-2', 'Czech_Czechia.1250']
     }
     for loc, alts in locales.items():
       # Note: Using alts directly in the lambda body here will bind it to the value at the


### PR DESCRIPTION
Noticed by @muellerj2 in https://github.com/microsoft/STL/pull/5444#discussion_r2078610648. Windows 11 24H2 recognizes the locale name `'Czech_Czechia.1250'` and doesn't recognize `'Czech_Czech Republic.1250'`. I wasn't able to figure out *when* this change happened in Windows (a moderate amount of searching turned up nothing, and I even tried GitHub Copilot but it neither provided consistent answers nor cited any authoritative sources I could confirm), but it seems to have happened a while ago. (Presumably after our Python-powered test harness was added in 2020.)

We can assume/require that contributors and maintainers are running modern builds of Win11, and our CI infrastructure is now using Windows Server 2025, so we should switch to looking for the new locale name here. I believe our MSVC-internal infrastructure isn't using Server 2025 yet, but it doesn't use the Python-powered test harness, so this is irrelevant for it. (It doesn't even understand "REQUIRES" lines.)

Additionally, I have a logic cleanup to simplify how we add locale features. This just uses an if-statement instead of a when-lambda. It also uses a formatted string literal for clarity.

To validate this, I ran the test directories that require the `cs_CZ.ISO8859-2` locale:

```
python tests\utils\stl-lit\stl-lit.py -o testing_x64.log -Dnotags=ASAN --order=random %STL%\llvm-project\libcxx\test\std\re\re.traits %STL%\llvm-project\libcxx\test\std\re\re.alg\re.alg.search %STL%\llvm-project\libcxx\test\std\re\re.alg\re.alg.match
```

There are 132 total discovered tests here. I then compared `main`, #5444, this PR, and #5444 merged with this PR:

Result            | `main` | #5444 | This PR | Both PRs
-----------------:|-------:|------:|--------:|---------------:
Skipped           |     44 |    44 |      44 | 44
Unsupported       |     22 |    22 |       0 |  0
Passed            |     46 |    46 |      48 | 50
Expectedly Failed |     20 |    20 |      40 | 38
