### PR TITLE
`<__msvc_string_view.hpp>`: Avoid redundant forwarding in `char_traits::assign`

### DIFF
--- a/stl/inc/__msvc_string_view.hpp
+++ b/stl/inc/__msvc_string_view.hpp
@@ -418,11 +418,6 @@ public:
     }
 
     static _CONSTEXPR17 void assign(_Elem& _Left, const _Elem& _Right) noexcept {
-#if _HAS_CXX20
-        if (_STD is_constant_evaluated()) {
-            return _Primary_char_traits::assign(_Left, _Right);
-        }
-#endif // _HAS_CXX20
         _Left = _Right;
     }
 
@@ -573,11 +568,6 @@ public:
     }
 
     static _CONSTEXPR17 void assign(_Elem& _Left, const _Elem& _Right) noexcept {
-#if _HAS_CXX20
-        if (_STD is_constant_evaluated()) {
-            return _Primary_char_traits::assign(_Left, _Right);
-        }
-#endif // _HAS_CXX20
         _Left = _Right;
     }
 


### PR DESCRIPTION
#3334 (and following-up #4047) made `basic_string` correctly handle lifetime of elements in constant evaluation, and #4613 made `char_traits::assign` no longer consider lifetime of elements (as specified by the standard).

However, there're some forwarding calls in `char_traits::assign` (added by #2305) that were made redundant but not removed. This PR removes the redundant forwarding.