### PR TITLE
Use the `_Transparent` concept and remove `_Is_transparent`

### DIFF
--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -100,8 +100,7 @@ struct _Uhash_choose_transparency {
 };
 
 #if _HAS_CXX20
-template <class _Kty, class _Hasher, class _Keyeq>
-    requires _Is_transparent_v<_Hasher> && _Is_transparent_v<_Keyeq>
+template <class _Kty, _Transparent _Hasher, _Transparent _Keyeq>
 struct _Uhash_choose_transparency<_Kty, _Hasher, _Keyeq> {
     // transparency selector for transparent hashed containers
     static constexpr bool _Has_transparent_overloads = true;

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2734,18 +2734,9 @@ _EXPORT_STD inline void* align(size_t _Bound, size_t _Size, void*& _Ptr, size_t&
     return _Ptr;
 }
 
-template <class _Ty, class = void>
-constexpr bool _Is_transparent_v = false;
-
-template <class _Ty>
-constexpr bool _Is_transparent_v<_Ty, void_t<typename _Ty::is_transparent>> = true;
-
-template <class _Ty>
-struct _Is_transparent : bool_constant<_Is_transparent_v<_Ty>> {};
-
 #if _HAS_CXX20
 template <class _Ty>
-concept _Transparent = _Is_transparent_v<_Ty>;
+concept _Transparent = requires { typename _Ty::is_transparent; };
 #endif // _HAS_CXX20
 
 #if _HAS_CXX23

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -21,6 +21,17 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 
 _STD_BEGIN
+#if _HAS_CXX20
+template <class _Ty>
+constexpr bool _Is_transparent_v = _Transparent<_Ty>;
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
+template <class _Ty, class = void>
+constexpr bool _Is_transparent_v = false;
+
+template <class _Ty>
+constexpr bool _Is_transparent_v<_Ty, void_t<typename _Ty::is_transparent>> = true;
+#endif // ^^^ !_HAS_CXX20 ^^^
+
 template <class _Mytree, class _Base = _Iterator_base0>
 class _Tree_unchecked_const_iterator : public _Base {
 public:
@@ -1360,7 +1371,7 @@ public:
 
 #if _HAS_CXX23
     template <class _Kx>
-        requires _Is_transparent_v<key_compare> && (!is_convertible_v<_Kx, const_iterator>)
+        requires _Transparent<key_compare> && (!is_convertible_v<_Kx, const_iterator>)
               && (!is_convertible_v<_Kx, iterator>)
     size_type erase(_Kx&& _Keyval) noexcept(noexcept(_Eqrange(_Keyval))) /* strengthened */ {
         return _Erase(_Eqrange(_Keyval));
@@ -1414,7 +1425,7 @@ public:
     }
 
     template <class _Other>
-        requires _Is_transparent_v<key_compare>
+        requires _Transparent<key_compare>
     _NODISCARD bool contains(const _Other& _Keyval) const {
         return _Lower_bound_duplicate(_Find_lower_bound(_Keyval)._Bound, _Keyval);
     }
@@ -1764,7 +1775,7 @@ public:
 
 #if _HAS_CXX23
     template <class _Kx>
-        requires _Is_transparent_v<key_compare> && (!is_convertible_v<_Kx, const_iterator>)
+        requires _Transparent<key_compare> && (!is_convertible_v<_Kx, const_iterator>)
               && (!is_convertible_v<_Kx, iterator>)
     node_type extract(_Kx&& _Keyval) {
         const const_iterator _Where = find(_Keyval);


### PR DESCRIPTION
#3736 added `_Is_transparent` and `_Transparent` but didn't use them.

I think it's time to use the `_Transparent` concept for C++20-and-later-only code. And it seems less burdensome for compilers if `_Is_transparent_v` is changed to be implemented with a concept. After the changes, `_Is_transparent_v` will be only necessary for `<xtree>`, so this PR moves `_Is_transparent_v` to that header.

`<flat_map>` and `<flat_set>` will be changed in another PR.

Theoretically, `_Is_transparent` would be useful in the cases where `conjunction(_v)` or `disjunction(_v)` is used. But I think there won't be such a case in MSVC STL - for new code it's probably better to use requires-clauses, and the uses of `_Is_transparent_v` in `<xtree>` seem stable enough. So I decide to remove it.