### PR TITLE
Use the `_Transparent` concept for `flat_meow`

### DIFF
--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -624,7 +624,7 @@ public:
     }
 
     template <class _OtherKey>
-        requires _Is_transparent_v<key_compare> && (!is_convertible_v<_OtherKey, iterator>)
+        requires _Transparent<key_compare> && (!is_convertible_v<_OtherKey, iterator>)
               && (!is_convertible_v<_OtherKey, const_iterator>)
     size_type erase(_OtherKey&& _Key_val) {
         return _Erase_key(_STD forward<_OtherKey>(_Key_val));
@@ -673,7 +673,7 @@ public:
 
     template <class _OtherKey>
     _NODISCARD iterator find(const _OtherKey& _Key_val)
-        requires _Is_transparent_v<key_compare>
+        requires _Transparent<key_compare>
     {
         return _Find(_Key_val);
     }
@@ -684,7 +684,7 @@ public:
 
     template <class _OtherKey>
     _NODISCARD const_iterator find(const _OtherKey& _Key_val) const
-        requires _Is_transparent_v<key_compare>
+        requires _Transparent<key_compare>
     {
         return _Find(_Key_val);
     }
@@ -695,7 +695,7 @@ public:
 
     template <class _OtherKey>
     _NODISCARD size_type count(const _OtherKey& _Key_val) const
-        requires _Is_transparent_v<key_compare>
+        requires _Transparent<key_compare>
     {
         return _Count(_Key_val);
     }
@@ -706,7 +706,7 @@ public:
 
     template <class _OtherKey>
     _NODISCARD bool contains(const _OtherKey& _Key_val) const
-        requires _Is_transparent_v<key_compare>
+        requires _Transparent<key_compare>
     {
         return _Contains(_Key_val);
     }
@@ -717,7 +717,7 @@ public:
 
     template <class _OtherKey>
     _NODISCARD iterator lower_bound(const _OtherKey& _Key_val)
-        requires _Is_transparent_v<key_compare>
+        requires _Transparent<key_compare>
     {
         return _Lower_bound(_Key_val);
     }
@@ -728,7 +728,7 @@ public:
 
     template <class _OtherKey>
     _NODISCARD const_iterator lower_bound(const _OtherKey& _Key_val) const
-        requires _Is_transparent_v<key_compare>
+        requires _Transparent<key_compare>
     {
         return _Lower_bound(_Key_val);
     }
@@ -739,7 +739,7 @@ public:
 
     template <class _OtherKey>
     _NODISCARD iterator upper_bound(const _OtherKey& _Key_val)
-        requires _Is_transparent_v<key_compare>
+        requires _Transparent<key_compare>
     {
         return _Upper_bound(_Key_val);
     }
@@ -750,7 +750,7 @@ public:
 
     template <class _OtherKey>
     _NODISCARD const_iterator upper_bound(const _OtherKey& _Key_val) const
-        requires _Is_transparent_v<key_compare>
+        requires _Transparent<key_compare>
     {
         return _Upper_bound(_Key_val);
     }
@@ -761,7 +761,7 @@ public:
 
     template <class _OtherKey>
     _NODISCARD pair<iterator, iterator> equal_range(const _OtherKey& _Key_val)
-        requires _Is_transparent_v<key_compare>
+        requires _Transparent<key_compare>
     {
         return _Equal_range(_Key_val);
     }
@@ -772,7 +772,7 @@ public:
 
     template <class _OtherKey>
     _NODISCARD pair<const_iterator, const_iterator> equal_range(const _OtherKey& _Key_val) const
-        requires _Is_transparent_v<key_compare>
+        requires _Transparent<key_compare>
     {
         return _Equal_range(_Key_val);
     }
@@ -818,10 +818,9 @@ protected:
 
     template <bool _OverwriteIfExists, class _OtherKey, class... _MappedArgTypes>
     iterator _Emplace_hint(const const_iterator _Position, _OtherKey&& _Key_val, _MappedArgTypes&&... _Args) {
-        _STL_INTERNAL_STATIC_ASSERT(
-            is_constructible_v<mapped_type, _MappedArgTypes...>
-            && (is_same_v<remove_cvref_t<_OtherKey>, key_type>
-                || (is_constructible_v<key_type, _OtherKey> && _Is_transparent_v<key_compare>) ));
+        _STL_INTERNAL_STATIC_ASSERT(is_constructible_v<mapped_type, _MappedArgTypes...>
+                                    && (is_same_v<remove_cvref_t<_OtherKey>, key_type>
+                                        || (is_constructible_v<key_type, _OtherKey> && _Transparent<key_compare>) ));
         static_assert(_IsUnique || !_OverwriteIfExists,
             "Overwriting is not supported when the container allows multiple copies of a key.");
         const const_iterator _Begin = cbegin();
@@ -908,7 +907,7 @@ protected:
         _STL_INTERNAL_STATIC_ASSERT(
             (is_same_v<remove_cvref_t<_KeyTy1>, key_type> && is_same_v<remove_cvref_t<_KeyTy2>, key_type>)
             || (is_constructible_v<key_type, _KeyTy1> && is_constructible_v<key_type, _KeyTy2>
-                && _Is_transparent_v<key_compare>) );
+                && _Transparent<key_compare>) );
         return !_Key_compare(_STD forward<_KeyTy1>(_Left), _STD forward<_KeyTy2>(_Right))
             && !_Key_compare(_STD forward<_KeyTy2>(_Right), _STD forward<_KeyTy1>(_Left));
     }
@@ -992,7 +991,7 @@ private:
 
     template <class _KeyTy>
     _NODISCARD iterator _Find(const _KeyTy& _Key_val) {
-        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Is_transparent_v<key_compare>);
+        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Transparent<key_compare>);
         iterator _Position = lower_bound(_Key_val);
         if (_Position != end() && !_Key_compare(_Key_val, _Position->first)) {
             return _Position;
@@ -1003,7 +1002,7 @@ private:
 
     template <class _KeyTy>
     _NODISCARD const_iterator _Find(const _KeyTy& _Key_val) const {
-        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Is_transparent_v<key_compare>);
+        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Transparent<key_compare>);
         const_iterator _Position = lower_bound(_Key_val);
         if (_Position != cend() && !_Key_compare(_Key_val, _Position->first)) {
             return _Position;
@@ -1014,19 +1013,19 @@ private:
 
     template <class _KeyTy>
     _NODISCARD size_type _Count(const _KeyTy& _Key_val) const {
-        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Is_transparent_v<key_compare>);
+        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Transparent<key_compare>);
         return upper_bound(_Key_val) - lower_bound(_Key_val);
     }
 
     template <class _KeyTy>
     _NODISCARD bool _Contains(const _KeyTy& _Key_val) const {
-        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Is_transparent_v<key_compare>);
+        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Transparent<key_compare>);
         return find(_Key_val) != cend();
     }
 
     template <class _KeyTy>
     _NODISCARD iterator _Lower_bound(const _KeyTy& _Key_val) {
-        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Is_transparent_v<key_compare>);
+        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Transparent<key_compare>);
         const auto _Key_unchecked_begin = _STD _Get_unwrapped(_STD cbegin(_Data.keys));
         const auto _Key_unchecked_it =
             _STD lower_bound(_Key_unchecked_begin, _STD _Get_unwrapped(_STD cend(_Data.keys)), _Key_val, _Key_compare);
@@ -1040,7 +1039,7 @@ private:
 
     template <class _KeyTy>
     _NODISCARD const_iterator _Lower_bound(const _KeyTy& _Key_val) const {
-        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Is_transparent_v<key_compare>);
+        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Transparent<key_compare>);
         const auto _Key_unchecked_begin = _STD _Get_unwrapped(_STD cbegin(_Data.keys));
         const auto _Key_unchecked_it =
             _STD lower_bound(_Key_unchecked_begin, _STD _Get_unwrapped(_STD cend(_Data.keys)), _Key_val, _Key_compare);
@@ -1055,7 +1054,7 @@ private:
 
     template <class _KeyTy>
     _NODISCARD iterator _Upper_bound(const _KeyTy& _Key_val) {
-        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Is_transparent_v<key_compare>);
+        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Transparent<key_compare>);
         const auto _Key_unchecked_begin = _STD _Get_unwrapped(_STD cbegin(_Data.keys));
         const auto _Key_unchecked_it =
             _STD upper_bound(_Key_unchecked_begin, _STD _Get_unwrapped(_STD cend(_Data.keys)), _Key_val, _Key_compare);
@@ -1069,7 +1068,7 @@ private:
 
     template <class _KeyTy>
     _NODISCARD const_iterator _Upper_bound(const _KeyTy& _Key_val) const {
-        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Is_transparent_v<key_compare>);
+        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Transparent<key_compare>);
         const auto _Key_unchecked_begin = _STD _Get_unwrapped(_STD cbegin(_Data.keys));
         const auto _Key_unchecked_it =
             _STD upper_bound(_Key_unchecked_begin, _STD _Get_unwrapped(_STD cend(_Data.keys)), _Key_val, _Key_compare);
@@ -1084,13 +1083,13 @@ private:
 
     template <class _KeyTy>
     _NODISCARD pair<iterator, iterator> _Equal_range(const _KeyTy& _Key_val) {
-        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Is_transparent_v<key_compare>);
+        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Transparent<key_compare>);
         return {lower_bound(_Key_val), upper_bound(_Key_val)};
     }
 
     template <class _KeyTy>
     _NODISCARD pair<const_iterator, const_iterator> _Equal_range(const _KeyTy& _Key_val) const {
-        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Is_transparent_v<key_compare>);
+        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Transparent<key_compare>);
         return {lower_bound(_Key_val), upper_bound(_Key_val)};
     }
 };
@@ -1143,7 +1142,7 @@ public:
 
     template <class _OtherKey>
     mapped_type& operator[](_OtherKey&& _Key_val)
-        requires _Is_transparent_v<key_compare> && is_constructible_v<key_type, _OtherKey>
+        requires _Transparent<key_compare> && is_constructible_v<key_type, _OtherKey>
               && is_default_constructible_v<mapped_type>
     {
         return this->try_emplace(_STD forward<_OtherKey>(_Key_val)).first->second;
@@ -1159,14 +1158,14 @@ public:
 
     template <class _OtherKey>
     _NODISCARD mapped_type& at(const _OtherKey& _Key_val)
-        requires _Is_transparent_v<key_compare>
+        requires _Transparent<key_compare>
     {
         return _At(_Key_val);
     }
 
     template <class _OtherKey>
     _NODISCARD const mapped_type& at(const _OtherKey& _Key_val) const
-        requires _Is_transparent_v<key_compare>
+        requires _Transparent<key_compare>
     {
         return _At(_Key_val);
     }
@@ -1208,7 +1207,7 @@ public:
     }
 
     template <class _OtherKey, class... _MappedArgTypes>
-        requires _Is_transparent_v<key_compare> && is_constructible_v<key_type, _OtherKey>
+        requires _Transparent<key_compare> && is_constructible_v<key_type, _OtherKey>
               && is_constructible_v<mapped_type, _MappedArgTypes...> && (!is_convertible_v<_OtherKey, const_iterator>)
               && (!is_convertible_v<_OtherKey, iterator>)
     pair<iterator, bool> try_emplace(_OtherKey&& _Key_val, _MappedArgTypes&&... _Mapped_args) {
@@ -1232,7 +1231,7 @@ public:
 
     template <class _OtherKey, class... _MappedArgTypes>
     iterator try_emplace(const_iterator _Position, _OtherKey&& _Key_val, _MappedArgTypes&&... _Mapped_args)
-        requires _Is_transparent_v<key_compare> && is_constructible_v<key_type, _OtherKey>
+        requires _Transparent<key_compare> && is_constructible_v<key_type, _OtherKey>
               && is_constructible_v<mapped_type, _MappedArgTypes&&...>
     {
         return this->template _Emplace_hint<false>(
@@ -1255,7 +1254,7 @@ public:
 
     template <class _OtherKey, class _MappedTy>
     pair<iterator, bool> insert_or_assign(_OtherKey&& _Key_val, _MappedTy&& _Mapped_val)
-        requires _Is_transparent_v<key_compare> && is_constructible_v<key_type, _OtherKey>
+        requires _Transparent<key_compare> && is_constructible_v<key_type, _OtherKey>
               && is_assignable_v<mapped_type&, _MappedTy> && is_constructible_v<mapped_type, _MappedTy>
     {
         return _Insert_or_assign(_STD forward<_OtherKey>(_Key_val), _STD forward<_MappedTy>(_Mapped_val));
@@ -1277,7 +1276,7 @@ public:
 
     template <class _OtherKey, class _MappedTy>
     iterator insert_or_assign(const_iterator _Position, _OtherKey&& _Key_val, _MappedTy&& _Mapped_val)
-        requires _Is_transparent_v<key_compare> && is_constructible_v<key_type, _OtherKey>
+        requires _Transparent<key_compare> && is_constructible_v<key_type, _OtherKey>
               && is_assignable_v<mapped_type&, _MappedTy> && is_constructible_v<mapped_type, _MappedTy>
     {
         return this->template _Emplace_hint<true>(
@@ -1296,7 +1295,7 @@ private:
 
     template <class _KeyTy>
     _NODISCARD mapped_type& _At(const _KeyTy& _Key_val) {
-        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Is_transparent_v<key_compare>);
+        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Transparent<key_compare>);
         const auto _Position = this->find(_Key_val);
         if (_Position == this->end()) {
             _Xout_of_range("std::flat_map::at: the specified key does not exist.");
@@ -1307,7 +1306,7 @@ private:
 
     template <class _KeyTy>
     _NODISCARD const mapped_type& _At(const _KeyTy& _Key_val) const {
-        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Is_transparent_v<key_compare>);
+        _STL_INTERNAL_STATIC_ASSERT(is_same_v<_KeyTy, key_type> || _Transparent<key_compare>);
         const auto _Position = this->find(_Key_val);
         if (_Position == this->end()) {
             _Xout_of_range("std::flat_map::at: the specified key does not exist.");

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -37,7 +37,6 @@ private:
     using _Derived =
         conditional_t<_IsUnique, flat_set<_Kty, _Keylt, _Container>, flat_multiset<_Kty, _Keylt, _Container>>;
 
-    static constexpr bool _Keylt_transparent     = _Is_transparent_v<_Keylt>;
     static constexpr const char* _Msg_not_sorted = _IsUnique ? "Input was not sorted-unique!" : "Input was not sorted!";
 
 public:
@@ -271,7 +270,7 @@ public:
         return _Emplace(_STD move(_Val));
     }
     template <_Different_from<_Kty> _Other>
-        requires _IsUnique && _Keylt_transparent && is_constructible_v<_Kty, _Other>
+        requires _IsUnique && _Transparent<key_compare> && is_constructible_v<_Kty, _Other>
     auto insert(_Other&& _Val) {
         return _Emplace(_STD forward<_Other>(_Val));
     }
@@ -283,7 +282,7 @@ public:
         return _Emplace_hint(_Hint, _STD move(_Val));
     }
     template <_Different_from<_Kty> _Other>
-        requires _IsUnique && _Keylt_transparent && is_constructible_v<_Kty, _Other>
+        requires _IsUnique && _Transparent<key_compare> && is_constructible_v<_Kty, _Other>
     iterator insert(const_iterator _Hint, _Other&& _Val) {
         return _Emplace_hint(_Hint, _STD forward<_Other>(_Val));
     }
@@ -336,7 +335,7 @@ public:
         return _Erase(_Val);
     }
     template <_Different_from<_Kty> _Other>
-        requires (_Keylt_transparent && !is_convertible_v<_Other, const_iterator>)
+        requires _Transparent<key_compare> && (!is_convertible_v<_Other, const_iterator>)
     size_type erase(_Other&& _Val) {
         return _Erase(_Val);
     }
@@ -370,7 +369,7 @@ public:
         return _Find(_Val);
     }
     template <class _Other>
-        requires _Keylt_transparent
+        requires _Transparent<key_compare>
     _NODISCARD const_iterator find(const _Other& _Val) const {
         return _Find(_Val);
     }
@@ -384,7 +383,7 @@ public:
         }
     }
     template <class _Other>
-        requires _Keylt_transparent
+        requires _Transparent<key_compare>
     _NODISCARD size_type count(const _Other& _Val) const {
         const auto [_First, _Last] = equal_range(_Val);
         return static_cast<size_type>(_Last - _First);
@@ -394,7 +393,7 @@ public:
         return _STD binary_search(cbegin(), cend(), _Val, _Pass_comp());
     }
     template <class _Other>
-        requires _Keylt_transparent
+        requires _Transparent<key_compare>
     _NODISCARD bool contains(const _Other& _Val) const {
         return _STD binary_search(cbegin(), cend(), _Val, _Pass_comp());
     }
@@ -403,7 +402,7 @@ public:
         return _STD lower_bound(cbegin(), cend(), _Val, _Pass_comp());
     }
     template <class _Other>
-        requires _Keylt_transparent
+        requires _Transparent<key_compare>
     _NODISCARD const_iterator lower_bound(const _Other& _Val) const {
         return _STD lower_bound(cbegin(), cend(), _Val, _Pass_comp());
     }
@@ -412,7 +411,7 @@ public:
         return _STD upper_bound(cbegin(), cend(), _Val, _Pass_comp());
     }
     template <class _Other>
-        requires _Keylt_transparent
+        requires _Transparent<key_compare>
     _NODISCARD const_iterator upper_bound(const _Other& _Val) const {
         return _STD upper_bound(cbegin(), cend(), _Val, _Pass_comp());
     }
@@ -421,7 +420,7 @@ public:
         return _STD equal_range(cbegin(), cend(), _Val, _Pass_comp());
     }
     template <class _Other>
-        requires _Keylt_transparent
+        requires _Transparent<key_compare>
     _NODISCARD pair<const_iterator, const_iterator> equal_range(const _Other& _Val) const {
         return _STD equal_range(cbegin(), cend(), _Val, _Pass_comp());
     }
@@ -494,7 +493,7 @@ private:
                 // heterogeneous insertion
                 // FIXME: The standard only requires `find(_Val) == find(_Keyval)` (per N4958 [flat.set.modifiers]/2),
                 // which cannot guarantee `_Can_insert(_Where, _Keyval)`.
-                _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
+                _STL_INTERNAL_STATIC_ASSERT(_Transparent<key_compare> && is_constructible_v<_Kty, _Ty>);
                 _Kty _Keyval(_STD forward<_Ty>(_Val));
                 _STL_ASSERT(_Can_insert(_Where, _Keyval),
                     "The conversion from the heterogeneous key to key_type should "
@@ -538,7 +537,7 @@ private:
                 // heterogeneous insertion
                 // FIXME: The standard only requires `find(_Val) == find(_Keyval)` (per N4958 [flat.set.modifiers]/2),
                 // which cannot guarantee `_Can_insert(_Where, _Keyval)`.
-                _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent && is_constructible_v<_Kty, _Ty>);
+                _STL_INTERNAL_STATIC_ASSERT(_Transparent<key_compare> && is_constructible_v<_Kty, _Ty>);
                 _Kty _Keyval(_STD forward<_Ty>(_Val));
                 _STL_ASSERT(_Can_insert(_Where, _Keyval),
                     "The conversion from the heterogeneous key to key_type should "
@@ -576,7 +575,7 @@ private:
 
     template <class _Ty>
     _NODISCARD size_type _Erase(const _Ty& _Val) {
-        _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent || is_same_v<_Ty, _Kty>);
+        _STL_INTERNAL_STATIC_ASSERT(_Transparent<key_compare> || is_same_v<_Ty, _Kty>);
 
         if constexpr (_IsUnique && is_same_v<_Ty, _Kty>) {
             const const_iterator _Where = lower_bound(_Val);
@@ -596,7 +595,7 @@ private:
 
     template <class _Ty>
     _NODISCARD const_iterator _Find(const _Ty& _Val) const {
-        _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent || is_same_v<_Ty, _Kty>);
+        _STL_INTERNAL_STATIC_ASSERT(_Transparent<key_compare> || is_same_v<_Ty, _Kty>);
 
         const const_iterator _End   = cend();
         const const_iterator _Where = lower_bound(_Val);
@@ -656,7 +655,7 @@ private:
     template <class _Lty, class _Rty>
     _NODISCARD bool _Compare(const _Lty& _Lhs, const _Rty& _Rhs) const
         noexcept(noexcept(_DEBUG_LT_PRED(_Mycomp, _Lhs, _Rhs))) {
-        _STL_INTERNAL_STATIC_ASSERT(_Keylt_transparent || (is_same_v<_Kty, _Lty> && is_same_v<_Kty, _Rty>) );
+        _STL_INTERNAL_STATIC_ASSERT(_Transparent<key_compare> || (is_same_v<_Kty, _Lty> && is_same_v<_Kty, _Rty>) );
 
         return _DEBUG_LT_PRED(_Mycomp, _Lhs, _Rhs);
     }


### PR DESCRIPTION
#5498 will change `_Transparent` to be implemented in a simpler way, and it seemingly causes less burdensome to directly use `_Transparent` in `flat_meow`. Also, switching to use `_Transparent` ensures that uses of `_Is_transparent_v` can be restricted within `<xtree>`.