### PR TITLE
Add assertions on ios_base::setf to prevent invalid flag combination.

### DIFF
--- a/stl/inc/xiosbase
+++ b/stl/inc/xiosbase
@@ -249,9 +249,10 @@ public:
         const ios_base::fmtflags _Oldfmtflags = _Fmtfl;
         _Fmtfl |= _Newfmtflags & _Fmtmask;
 
-        _STL_ASSERT(__popcnt(_Fmtfl & basefield) < 2, "Multiple basefield flags set. Try setf(flags, mask) instead.");
-        _STL_ASSERT(__popcnt(_Fmtfl & floatfield) < 2, "Multiple floatfield flags set. Try setf(flags, mask) instead.");
-        _STL_ASSERT(__popcnt(_Fmtfl & adjustfield) < 2, "Multiple adjustfield flags set. Try setf(flags, mask) instead.");
+        _STL_ASSERT(
+            _Checked_popcount(_Fmtfl & basefield) < 2, "Multiple basefield flags set. Try setf(flags, mask) instead.");
+        _STL_ASSERT(_Checked_popcount(_Fmtfl & adjustfield) < 2,
+            "Multiple adjustfield flags set. Try setf(flags, mask) instead.");
 
         return _Oldfmtflags;
     }

--- a/stl/inc/xiosbase
+++ b/stl/inc/xiosbase
@@ -7,6 +7,7 @@
 #define _XIOSBASE_
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
+#include <__msvc_bit_utils.hpp>
 #include <share.h>
 #include <system_error>
 #include <xlocale>

--- a/stl/inc/xiosbase
+++ b/stl/inc/xiosbase
@@ -248,6 +248,11 @@ public:
         // merge in format flags argument
         const ios_base::fmtflags _Oldfmtflags = _Fmtfl;
         _Fmtfl |= _Newfmtflags & _Fmtmask;
+
+        _STL_ASSERT(__popcnt(_Fmtfl & basefield) < 2, "Multiple basefield flags set. Try setf(flags, mask) instead.");
+        _STL_ASSERT(__popcnt(_Fmtfl & floatfield) < 2, "Multiple floatfield flags set. Try setf(flags, mask) instead.");
+        _STL_ASSERT(__popcnt(_Fmtfl & adjustfield) < 2, "Multiple adjustfield flags set. Try setf(flags, mask) instead.");
+
         return _Oldfmtflags;
     }
 


### PR DESCRIPTION
## Explanation
Calling `ios_base::setf` method can lead to invalid combinations on `fmtflags` bitflag.

I know there's way to use `setf(flag, mask)` but below code doesn't omit any errors, so user can misuse it.

This PR adds some `STL_ASSERT` on `setf` to prevent invalid flag status.

## Before changes
```cpp
cout.setf(ios_base::dec);
cout.setf(ios_base::hex); // No compiler or runtime error

cout << 42 << endl; // Outputs 42, but intent is unclear
```

## After changes
```cpp
cout.setf(ios_base::dec);
cout.setf(ios_base::hex); // Debug assertion failed

cout << 42 << endl;
```
