### PR TITLE
Win10 baseline: Drop support for Win8.1 / Server 2012 R2

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1974,18 +1974,12 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 #endif // defined(MRTDLL) && !defined(_M_CEE_PURE)
 
 #define _STL_WIN32_WINNT_VISTA 0x0600 // _WIN32_WINNT_VISTA from sdkddkver.h
-#define _STL_WIN32_WINNT_WIN8  0x0602 // _WIN32_WINNT_WIN8 from sdkddkver.h
 #define _STL_WIN32_WINNT_WIN10 0x0A00 // _WIN32_WINNT_WIN10 from sdkddkver.h
 
 // Note that the STL DLL builds will set this to XP for ABI compatibility with VS2015 which supported XP.
 #ifndef _STL_WIN32_WINNT
-#if defined(_M_ARM64)
-// The first ARM64 Windows was Windows 10
+// The earliest Windows supported by this implementation is Windows 10
 #define _STL_WIN32_WINNT _STL_WIN32_WINNT_WIN10
-#else // ^^^ defined(_M_ARM64) / !defined(_M_ARM64) vvv
-// The earliest Windows supported by this implementation is Windows 8
-#define _STL_WIN32_WINNT _STL_WIN32_WINNT_WIN8
-#endif // ^^^ !defined(_M_ARM64) ^^^
 #endif // !defined(_STL_WIN32_WINNT)
 
 #ifdef __cpp_noexcept_function_type


### PR DESCRIPTION
# :world_map: Overview
* Followup to #5432.
* The impact on the GitHub side is minimal, but I'll be adding more significant MSVC-internal changes when mirroring.
  + Together, the removal of Win7, Win8, and Win8.1 support will shrink the VCRedist executables by 6.7 MB each.
* Works towards #4858.
  + I'll need to get our documentation updated.
* This is for VS 18.0 Preview 1 and will not be backported.
  + For the rest of its lifecycle, VS 2022 17.14 will support Win7, Win8, and Win8.1.

This removal was formally approved today (internal VSO-2441848). We are fully aware that their counterparts Server 2012 and Server 2012 R2 are entering their final year of ultra-extended super-premium paid support.

# :scroll: Changelog
* The STL no longer supports targeting Windows 7 / Server 2008 R2, Windows 8 / Server 2012, and Windows 8.1 / Server 2012 R2.