### PR TITLE
`<flat_set>`: insert range invariant fix

### DIFF
--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -569,8 +569,10 @@ private:
     template <bool _NeedSorting, class _Iter>
     void _Insert_range(const _Iter _First, const _Iter _Last) {
         const size_type _Old_size = size();
+        _Clear_guard _Guard{this};
         _Mycont.insert(_Mycont.end(), _First, _Last);
         _Restore_invariants_after_insert<_NeedSorting>(_Old_size);
+        _Guard._Target = nullptr;
     }
 
     template <class _Ty>

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -324,10 +324,6 @@ std/containers/container.adaptors/flat.multiset/flat.multiset.cons/move_assign.p
 std/containers/container.adaptors/flat.set/flat.set.cons/move_assign.pass.cpp FAIL
 
 # FIXME! Assertion failed: std::is_sorted(m.begin(), m.end(), m.key_comp())
-std/containers/container.adaptors/flat.multiset/flat.multiset.modifiers/insert_initializer_list.pass.cpp FAIL
-std/containers/container.adaptors/flat.multiset/flat.multiset.modifiers/insert_iter_iter.pass.cpp FAIL
-std/containers/container.adaptors/flat.multiset/flat.multiset.modifiers/insert_sorted_initializer_list.pass.cpp FAIL
-std/containers/container.adaptors/flat.multiset/flat.multiset.modifiers/insert_sorted_iter_iter.pass.cpp FAIL
 std/containers/container.adaptors/flat.set/flat.set.modifiers/emplace_hint.pass.cpp FAIL
 std/containers/container.adaptors/flat.set/flat.set.modifiers/emplace.pass.cpp FAIL
 std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_cv.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -327,13 +327,9 @@ std/containers/container.adaptors/flat.set/flat.set.cons/move_assign.pass.cpp FA
 std/containers/container.adaptors/flat.set/flat.set.modifiers/emplace_hint.pass.cpp FAIL
 std/containers/container.adaptors/flat.set/flat.set.modifiers/emplace.pass.cpp FAIL
 std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_cv.pass.cpp FAIL
-std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_initializer_list.pass.cpp FAIL
 std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_iter_cv.pass.cpp FAIL
-std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_iter_iter.pass.cpp FAIL
 std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_iter_rv.pass.cpp FAIL
 std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_rv.pass.cpp FAIL
-std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_sorted_initializer_list.pass.cpp FAIL
-std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_sorted_iter_iter.pass.cpp FAIL
 std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_transparent.pass.cpp FAIL
 
 # FIXME! Assertion failed: r == m.begin() + 2


### PR DESCRIPTION
On exception have to restore invariants. As usual, the only easy way is to clear it.