### PR TITLE
`<flat_set>`: more invariants fixes

### DIFF
--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -486,9 +486,12 @@ private:
                 return pair{_Where, false};
             }
 
+            _Clear_guard _Guard{this};
             if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
                 _STL_INTERNAL_CHECK(_Can_insert(_Where, _Val));
-                return pair{_Mycont.emplace(_Where, _STD forward<_Ty>(_Val)), true};
+                iterator _Result = _Mycont.emplace(_Where, _STD forward<_Ty>(_Val));
+                _Guard._Target   = nullptr;
+                return pair{_STD move(_Result), true};
             } else {
                 // heterogeneous insertion
                 // FIXME: The standard only requires `find(_Val) == find(_Keyval)` (per N4958 [flat.set.modifiers]/2),
@@ -498,11 +501,16 @@ private:
                 _STL_ASSERT(_Can_insert(_Where, _Keyval),
                     "The conversion from the heterogeneous key to key_type should "
                     "be consistent with the heterogeneous lookup!");
-                return pair{_Mycont.emplace(_Where, _STD move(_Keyval)), true};
+                iterator _Result = _Mycont.emplace(_Where, _STD move(_Keyval));
+                _Guard._Target   = nullptr;
+                return pair{_STD move(_Result), true};
             }
         } else {
             _STL_INTERNAL_STATIC_ASSERT(is_same_v<remove_cvref_t<_Ty>, _Kty>);
-            return _Mycont.emplace(upper_bound(_Val), _STD forward<_Ty>(_Val));
+            _Clear_guard _Guard{this};
+            iterator _Result = _Mycont.emplace(upper_bound(_Val), _STD forward<_Ty>(_Val));
+            _Guard._Target   = nullptr;
+            return _Result;
         }
     }
 
@@ -530,9 +538,12 @@ private:
                 return _Where;
             }
 
+            _Clear_guard _Guard{this};
             if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
                 _STL_INTERNAL_CHECK(_Can_insert(_Where, _Val));
-                return _Mycont.emplace(_Where, _STD forward<_Ty>(_Val));
+                iterator _Result = _Mycont.emplace(_Where, _STD forward<_Ty>(_Val));
+                _Guard._Target   = nullptr;
+                return _Result;
             } else {
                 // heterogeneous insertion
                 // FIXME: The standard only requires `find(_Val) == find(_Keyval)` (per N4958 [flat.set.modifiers]/2),
@@ -542,7 +553,9 @@ private:
                 _STL_ASSERT(_Can_insert(_Where, _Keyval),
                     "The conversion from the heterogeneous key to key_type should "
                     "be consistent with the heterogeneous lookup!");
-                return _Mycont.emplace(_Where, _STD move(_Keyval));
+                iterator _Result = _Mycont.emplace(_Where, _STD move(_Keyval));
+                _Guard._Target   = nullptr;
+                return _Result;
             }
         } else {
             _STL_INTERNAL_STATIC_ASSERT(is_same_v<remove_cvref_t<_Ty>, _Kty>);
@@ -562,7 +575,10 @@ private:
             }
 
             _STL_INTERNAL_CHECK(_Can_insert(_Where, _Val));
-            return _Mycont.emplace(_Where, _STD forward<_Ty>(_Val));
+            _Clear_guard _Guard{this};
+            iterator _Result = _Mycont.emplace(_Where, _STD forward<_Ty>(_Val));
+            _Guard._Target   = nullptr;
+            return _Result;
         }
     }
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -323,15 +323,6 @@ std/containers/container.adaptors/flat.set/flat.set.cons/move.pass.cpp FAIL
 std/containers/container.adaptors/flat.multiset/flat.multiset.cons/move_assign.pass.cpp FAIL
 std/containers/container.adaptors/flat.set/flat.set.cons/move_assign.pass.cpp FAIL
 
-# FIXME! Assertion failed: std::is_sorted(m.begin(), m.end(), m.key_comp())
-std/containers/container.adaptors/flat.set/flat.set.modifiers/emplace_hint.pass.cpp FAIL
-std/containers/container.adaptors/flat.set/flat.set.modifiers/emplace.pass.cpp FAIL
-std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_cv.pass.cpp FAIL
-std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_iter_cv.pass.cpp FAIL
-std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_iter_rv.pass.cpp FAIL
-std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_rv.pass.cpp FAIL
-std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_transparent.pass.cpp FAIL
-
 # FIXME! Assertion failed: r == m.begin() + 2
 std/containers/container.adaptors/flat.multiset/flat.multiset.modifiers/emplace_hint.pass.cpp FAIL
 


### PR DESCRIPTION
Flat adapter rule: when in doubt, clear the underlying collection.