### PR TITLE
Build tests for ARM64EC pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,16 +101,14 @@ add_compile_definitions(
     _WIN32_WINNT=0x0A00 NTDDI_VERSION=NTDDI_WIN10_NI)
 
 if(STL_USE_ANALYZE)
-    # TRANSITION OS-40109504: Windows SDK: incorrect SAL annotations on functions the STL uses
-    # warning C6553: The annotation for function 'LCMapStringEx' on _Param_(9)
-    # does not apply to a value type.
-    # There's a bug in the declaration for LCMapStringEx - it applies _In_opt_ to an LPARAM.
-    # LPARAM is a LONG_PTR (intptr_t), and it's invalid to apply _In_opt_ to a non-pointer.
-    # As of the Windows 11 SDK (10.0.22621.0), there are 5 total occurrences of warning C6553 affecting the STL's build.
+    # TRANSITION, Windows SDK 10.0.22621.0 emits
+    # "warning C6553: The annotation for function 'LCMapStringEx' on _Param_(9) does not apply to a value type."
+    # Reported as OS-40109504 "Windows SDK: incorrect SAL annotations on functions the STL uses".
     add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/analyze:autolog-;/wd6553>")
 
     if(VCLIBS_TARGET_ARCHITECTURE STREQUAL "arm64ec")
-        # TRANSITION, the Windows SDK emits "warning C28301: No annotations for first declaration of 'meow'"
+        # TRANSITION, Windows SDK 10.0.22621.0 emits
+        # "warning C28301: No annotations for first declaration of 'meow'"
         # for various intrinsics when building for ARM64EC.
         add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/wd28301>")
     endif()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,3 +160,17 @@ stages:
           targetArch: arm64
           targetPlatform: arm64
           testsBuildOnly: true
+
+  - stage: Build_And_Test_ARM64EC
+    dependsOn: Build_And_Test_x64
+    displayName: 'Build and Test ARM64EC'
+    pool:
+      name: ${{ variables.poolName }}
+      demands: ${{ variables.poolDemands }}
+    jobs:
+      - template: azure-devops/build-and-test.yml
+        parameters:
+          hostArch: x64
+          targetArch: arm64
+          targetPlatform: arm64ec
+          testsBuildOnly: true

--- a/tests/std/tests/GH_001103_countl_zero_correctness/test.cpp
+++ b/tests/std/tests/GH_001103_countl_zero_correctness/test.cpp
@@ -12,7 +12,7 @@ using namespace std;
 
 int main() {
     // This test is applicable only to x86 and x64 platforms
-#if defined(_M_IX86) || defined(_M_X64)
+#if (defined(_M_IX86) && !defined(_M_HYBRID_X86_ARM64)) || (defined(_M_X64) && !defined(_M_ARM64EC))
     assert(_Countl_zero_bsr(static_cast<unsigned char>(0x00)) == 8);
     assert(_Countl_zero_bsr(static_cast<unsigned char>(0x13)) == 3);
     assert(_Countl_zero_bsr(static_cast<unsigned char>(0x83)) == 0);
@@ -67,5 +67,5 @@ int main() {
     assert(_Countr_zero_bsf(static_cast<unsigned long long>(0x8000'0000'0000'0002)) == 1);
     assert(_Countr_zero_bsf(static_cast<unsigned long long>(0x8000'0000'0000'0000)) == 63);
     assert(_Countr_zero_bsf(static_cast<unsigned long long>(0xF000'0000'0000'0008)) == 3);
-#endif // ^^^ defined(_M_IX86) || defined(_M_X64) ^^^
+#endif // ^^^ (defined(_M_IX86) && !defined(_M_HYBRID_X86_ARM64)) || (defined(_M_X64) && !defined(_M_ARM64EC)) ^^^
 }

--- a/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
@@ -41,7 +41,7 @@
 // TRANSITION, Windows SDK 10.0.22621.0 uses '#pragma intrinsic(fabsf)' in corecrt_math.h when _M_ARM64EC is defined.
 // This use is no longer present in Windows SDK 10.0.26100.0.
 #undef intrinsic
-#endif
+#endif // ^^^ workaround ^^^
 
 #include <__msvc_all_public_headers.hpp>
 
@@ -53,9 +53,11 @@
 #error bad macro expansion
 #endif // known_semantics != 2
 
+#ifndef _M_ARM64EC // TRANSITION, Windows SDK
 #if intrinsic != 3
 #error bad macro expansion
 #endif // intrinsic != 3
+#endif // ^^^ no workaround ^^^
 
 #if lifetimebound != 4
 #error bad macro expansion

--- a/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
@@ -33,9 +33,8 @@
 #define msvc            1
 #define known_semantics 2
 
-#ifndef _M_ARM64EC
-// TRANSITION, Windows SDK 10.0.22621.0 uses '#pragma intrinsic(fabsf)' in corecrt_math.h when _M_ARM64EC is defined.
-// This use is no longer present in Windows SDK 10.0.26100.0.
+#ifndef _M_ARM64EC // TRANSITION, Windows SDK 10.0.22621.0 uses '#pragma intrinsic(fabsf)' for ARM64EC.
+                   // This use is no longer present in Windows SDK 10.0.26100.0.
 #define intrinsic 3
 #endif // ^^^ no workaround ^^^
 
@@ -53,7 +52,7 @@
 #error bad macro expansion
 #endif // known_semantics != 2
 
-#ifndef _M_ARM64EC // TRANSITION, Windows SDK
+#ifndef _M_ARM64EC // TRANSITION, Windows SDK 10.0.22621.0
 #if intrinsic != 3
 #error bad macro expansion
 #endif // intrinsic != 3

--- a/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
@@ -32,16 +32,16 @@
 // Also test GH-2645: <yvals_core.h>: Conformance issue on [[msvc::known_semantics]]
 #define msvc            1
 #define known_semantics 2
-#define intrinsic       3
-#define lifetimebound   4
-#define noop_dtor       5
-#define empty_bases     6
 
-#ifdef _M_ARM64EC
+#ifndef _M_ARM64EC
 // TRANSITION, Windows SDK 10.0.22621.0 uses '#pragma intrinsic(fabsf)' in corecrt_math.h when _M_ARM64EC is defined.
 // This use is no longer present in Windows SDK 10.0.26100.0.
-#undef intrinsic
-#endif // ^^^ workaround ^^^
+#define intrinsic 3
+#endif // ^^^ no workaround ^^^
+
+#define lifetimebound 4
+#define noop_dtor     5
+#define empty_bases   6
 
 #include <__msvc_all_public_headers.hpp>
 

--- a/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
@@ -37,6 +37,12 @@
 #define noop_dtor       5
 #define empty_bases     6
 
+#ifdef _M_ARM64EC
+// TRANSITION, Windows SDK 10.0.22621.0 uses '#pragma intrinsic(fabsf)' in corecrt_math.h when _M_ARM64EC is defined.
+// This use is no longer present in Windows SDK 10.0.26100.0.
+#undef intrinsic
+#endif
+
 #include <__msvc_all_public_headers.hpp>
 
 #if msvc != 1

--- a/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
@@ -124,6 +124,8 @@ class CustomTestFormat(STLTestFormat):
         if noisyProgress:
             print('Creating library...')
         cmd = ['lib.exe', '/nologo', f'/out:{libFilename}', *objFilenames]
+        if litConfig.target_arch.casefold() == 'arm64ec'.casefold():
+            cmd.append('/machine:arm64ec')
         yield TestStep(cmd, shared.execDir, shared.env, False)
 
         if compileTestCppWithEdg:

--- a/tests/std/tests/P1502R1_standard_library_header_units/custombuild.pl
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custombuild.pl
@@ -173,6 +173,7 @@ sub CustomBuildHook()
     # For convenience, create a library file containing all of the object files that were produced.
     my $libFilename = "stl_header_units.lib";
     Run::ExecuteCommand(join(" ", "lib.exe", "/nologo", "/out:$libFilename", @objFilenames));
+    # TRANSITION, when we test ARM64EC internally, add "/machine:arm64ec" here to match custom_format.py.
 
     Run::ExecuteCL(join(" ", "test.cpp", "/Fe$cwd.exe", @consumeBuiltHeaderUnits, $libFilename));
 }

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -9,6 +9,11 @@
 // This EXCLUDES the <cmeow> headers in:
 // [tab:headers.cpp.c]: "Table 22: C++ headers for C library facilities"
 
+// TRANSITION, this test fails for ARM64EC when built with Windows SDK 10.0.22621.0.
+// "error LNK2019: unresolved external symbol fabsf referenced in function #fabsf$exit_thunk (EC Symbol)"
+// It passes when built with Windows SDK 10.0.26100.0.
+// UNSUPPORTED: arm64ec
+
 import <algorithm>;
 import <any>;
 import <array>;

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -9,7 +9,7 @@
 // This EXCLUDES the <cmeow> headers in:
 // [tab:headers.cpp.c]: "Table 22: C++ headers for C library facilities"
 
-// TRANSITION, this test fails for ARM64EC when built with Windows SDK 10.0.22621.0.
+// TRANSITION, Windows SDK 10.0.22621.0 causes this test to fail for ARM64EC with:
 // "error LNK2019: unresolved external symbol fabsf referenced in function #fabsf$exit_thunk (EC Symbol)"
 // It passes when built with Windows SDK 10.0.26100.0.
 // UNSUPPORTED: arm64ec

--- a/tests/std/tests/P2465R3_standard_library_modules/test.cpp
+++ b/tests/std/tests/P2465R3_standard_library_modules/test.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// TRANSITION, this test fails for ARM64EC when built with Windows SDK 10.0.22621.0.
+// TRANSITION, Windows SDK 10.0.22621.0 causes this test to fail for ARM64EC with:
 // "error LNK2019: unresolved external symbol fabsf referenced in function #fabsf$exit_thunk (EC Symbol)"
 // It passes when built with Windows SDK 10.0.26100.0.
 // UNSUPPORTED: arm64ec

--- a/tests/std/tests/P2465R3_standard_library_modules/test.cpp
+++ b/tests/std/tests/P2465R3_standard_library_modules/test.cpp
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// TRANSITION, this test fails for ARM64EC when built with Windows SDK 10.0.22621.0.
+// "error LNK2019: unresolved external symbol fabsf referenced in function #fabsf$exit_thunk (EC Symbol)"
+// It passes when built with Windows SDK 10.0.26100.0.
+// UNSUPPORTED: arm64ec
+
 import std;
 
 #include <assert.h> // intentionally not <cassert>

--- a/tests/std/tests/VSO_1775715_user_defined_modules/test.cpp
+++ b/tests/std/tests/VSO_1775715_user_defined_modules/test.cpp
@@ -3,8 +3,9 @@
 
 // Note: To properly test the fix for VSO-1775715, don't include any headers here.
 
-// TRANSITION, this test fails for ARM64EC when built with Windows SDK 10.0.22621.0.
+// TRANSITION, Windows SDK 10.0.22621.0 causes this test to fail for ARM64EC with:
 // "error LNK2019: unresolved external symbol fabsf referenced in function #fabsf$exit_thunk (EC Symbol)"
+// It passes when built with Windows SDK 10.0.26100.0.
 // UNSUPPORTED: arm64ec
 
 import User;

--- a/tests/std/tests/VSO_1775715_user_defined_modules/test.cpp
+++ b/tests/std/tests/VSO_1775715_user_defined_modules/test.cpp
@@ -5,7 +5,9 @@
 
 // TRANSITION, Windows SDK 10.0.22621.0 causes this test to fail for ARM64EC with:
 // "error LNK2019: unresolved external symbol fabsf referenced in function #fabsf$exit_thunk (EC Symbol)"
-// It passes when built with Windows SDK 10.0.26100.0.
+// Windows SDK 10.0.26100.0 will avoid that error, but we'll need to investigate why user.ixx emits:
+// "error C2678: binary '==': no operator found which takes a left-hand operand of type 'const std::string'
+// (or there is no acceptable conversion)"
 // UNSUPPORTED: arm64ec
 
 import User;

--- a/tests/std/tests/VSO_1775715_user_defined_modules/test.cpp
+++ b/tests/std/tests/VSO_1775715_user_defined_modules/test.cpp
@@ -3,6 +3,10 @@
 
 // Note: To properly test the fix for VSO-1775715, don't include any headers here.
 
+// TRANSITION, this test fails for ARM64EC when built with Windows SDK 10.0.22621.0.
+// "error LNK2019: unresolved external symbol fabsf referenced in function #fabsf$exit_thunk (EC Symbol)"
+// UNSUPPORTED: arm64ec
+
 import User;
 
 int main() {

--- a/tests/utils/stl/test/features.py
+++ b/tests/utils/stl/test/features.py
@@ -65,4 +65,7 @@ def getDefaultFeatures(config, litConfig):
     elif litConfig.target_arch.casefold() == 'arm64'.casefold():
         DEFAULT_FEATURES.append(Feature(name='arm64'))
 
+    elif litConfig.target_arch.casefold() == 'arm64ec'.casefold():
+        DEFAULT_FEATURES.append(Feature(name='arm64ec'))
+
     return DEFAULT_FEATURES

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -259,6 +259,7 @@ class STLTest(Test):
             if (targetArch == 'arm64ec'.casefold()):
                 self.compileFlags.append('/arm64EC')
                 self.linkFlags.append('/machine:arm64ec')
+
                 # TRANSITION, Windows SDK 10.0.22621.0 emits
                 # "warning C28301: No annotations for first declaration of 'meow'"
                 # for various intrinsics when building for ARM64EC.

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -232,11 +232,11 @@ class STLTest(Test):
         self.compileFlags.extend(self.envlstEntry.getEnvVal('PM_CL', '').split())
         self.linkFlags.extend(self.envlstEntry.getEnvVal('PM_LINK', '').split())
 
+        targetArch = litConfig.target_arch.casefold()
         if ('clang'.casefold() in os.path.basename(cxx).casefold()):
             self._addCustomFeature('clang')
             self._addCustomFeature('gcc-style-warnings')
 
-            targetArch = litConfig.target_arch.casefold()
             if (targetArch == 'x64'.casefold()):
                 self.compileFlags.append('-m64')
             elif (targetArch == 'x86'.casefold()):
@@ -245,6 +245,9 @@ class STLTest(Test):
                 return Result(UNSUPPORTED, 'clang targeting arm is not supported')
             elif (targetArch == 'arm64'.casefold()):
                 self.compileFlags.append('--target=arm64-pc-windows-msvc')
+            elif (targetArch == 'arm64ec'.casefold()):
+                self.compileFlags.append('/arm64EC')
+                self.linkFlags.append('/machine:arm64ec')
         elif ('nvcc'.casefold() in os.path.basename(cxx).casefold()):
             self._addCustomFeature('nvcc')
 
@@ -252,6 +255,10 @@ class STLTest(Test):
             self.requires.append('x64')
         else:
             self._addCustomFeature('cl-style-warnings')
+
+            if (targetArch == 'arm64ec'.casefold()):
+                self.compileFlags.append('/arm64EC')
+                self.linkFlags.append('/machine:arm64ec')
 
         self.cxx = os.path.normpath(cxx)
         return None

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -260,6 +260,10 @@ class STLTest(Test):
                 self.compileFlags.append('/arm64EC')
                 self.linkFlags.append('/machine:arm64ec')
 
+                # TRANSITION, the Windows SDK emits "warning C28301: No annotations for first declaration of 'meow'"
+                # for various intrinsics when building for ARM64EC.
+                self.compileFlags.append('/wd28301')
+
         self.cxx = os.path.normpath(cxx)
         return None
 

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -259,8 +259,8 @@ class STLTest(Test):
             if (targetArch == 'arm64ec'.casefold()):
                 self.compileFlags.append('/arm64EC')
                 self.linkFlags.append('/machine:arm64ec')
-
-                # TRANSITION, the Windows SDK emits "warning C28301: No annotations for first declaration of 'meow'"
+                # TRANSITION, Windows SDK 10.0.22621.0 emits
+                # "warning C28301: No annotations for first declaration of 'meow'"
                 # for various intrinsics when building for ARM64EC.
                 self.compileFlags.append('/wd28301')
 

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -246,8 +246,8 @@ class STLTest(Test):
             elif (targetArch == 'arm64'.casefold()):
                 self.compileFlags.append('--target=arm64-pc-windows-msvc')
             elif (targetArch == 'arm64ec'.casefold()):
-                self.compileFlags.append('/arm64EC')
-                self.linkFlags.append('/machine:arm64ec')
+                # TRANSITION, LLVM-116256 (fixed in Clang 20)
+                return Result(UNSUPPORTED, 'clang targeting arm64ec is not supported')
         elif ('nvcc'.casefold() in os.path.basename(cxx).casefold()):
             self._addCustomFeature('nvcc')
 


### PR DESCRIPTION
Closes #2310 

- 7 libc++ tests and 51 std tests include `<Windows.h>` (possibly via a centralized header, e.g. `test_death.hpp`), and produce warning C28301: `C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\um\winnt.h(3209) : warning C28301: No annotations for first declaration of '_InterlockedCompareExchange128'. See c:\program files\microsoft visual studio\2022\preview\vc\tools\msvc\14.44.35207\include\intrin0.inl.h(185).`
  - I've suppressed the warning by adding the `/wd28301` compiler option. It might also be possible to instead add a pragma to each affected file.
- Windows SDK 10.0.22621.0 uses `#pragma intrinsic(fabsf)` in `<corecrt_math.h>` for ARM64EC, which seems to cause problems in several tests.
  - `GH_002206_unreserved_names` needs to avoid defining `intrinsic` as a macro.
  - 3 modules tests fail with `error LNK2019: unresolved external symbol fabsf referenced in function #fabsf$exit_thunk (EC Symbol)`.
    - 2 of them pass locally with Windows SDK 10.0.26100.0, but `VSO_1775715_user_defined_modules` is still failing with `tests\std\tests\VSO_1775715_user_defined_modules\user.ixx(24): error C2678: binary '==': no operator found which takes a left-hand operand of type 'const std::string' (or there is no acceptable conversion)`.
- Windows SDK 10.0.26100.0 instead uses `#pragma function(fabsf)` in `<corecrt_math.h>`, which seems to fix the abovementioned problems, but breaks Clang 19. This is LLVM-116256 and fixed in Clang 20.
   - I didn't check whether all tests pass with Clang 19 and Windows SDK 10.0.22621.0.
- `GH_001103_countl_zero_correctness` needs to update its preprocessor condition to exclude ARM64EC. I've copied the condition from `<__msvc_bit_utils.hpp>`.
