### PR TITLE
Revert incorrect `<flat_set>` change, and update test failure reason

### DIFF
--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -486,12 +486,9 @@ private:
                 return pair{_Where, false};
             }
 
-            _Clear_guard _Guard{this};
             if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
                 _STL_INTERNAL_CHECK(_Can_insert(_Where, _Val));
-                iterator _Result = _Mycont.emplace(_Where, _STD forward<_Ty>(_Val));
-                _Guard._Target   = nullptr;
-                return pair{_STD move(_Result), true};
+                return pair{_Mycont.emplace(_Where, _STD forward<_Ty>(_Val)), true};
             } else {
                 // heterogeneous insertion
                 // FIXME: The standard only requires `find(_Val) == find(_Keyval)` (per N4958 [flat.set.modifiers]/2),
@@ -501,16 +498,11 @@ private:
                 _STL_ASSERT(_Can_insert(_Where, _Keyval),
                     "The conversion from the heterogeneous key to key_type should "
                     "be consistent with the heterogeneous lookup!");
-                iterator _Result = _Mycont.emplace(_Where, _STD move(_Keyval));
-                _Guard._Target   = nullptr;
-                return pair{_STD move(_Result), true};
+                return pair{_Mycont.emplace(_Where, _STD move(_Keyval)), true};
             }
         } else {
             _STL_INTERNAL_STATIC_ASSERT(is_same_v<remove_cvref_t<_Ty>, _Kty>);
-            _Clear_guard _Guard{this};
-            iterator _Result = _Mycont.emplace(upper_bound(_Val), _STD forward<_Ty>(_Val));
-            _Guard._Target   = nullptr;
-            return _Result;
+            return _Mycont.emplace(upper_bound(_Val), _STD forward<_Ty>(_Val));
         }
     }
 
@@ -538,12 +530,9 @@ private:
                 return _Where;
             }
 
-            _Clear_guard _Guard{this};
             if constexpr (is_same_v<remove_cvref_t<_Ty>, _Kty>) {
                 _STL_INTERNAL_CHECK(_Can_insert(_Where, _Val));
-                iterator _Result = _Mycont.emplace(_Where, _STD forward<_Ty>(_Val));
-                _Guard._Target   = nullptr;
-                return _Result;
+                return _Mycont.emplace(_Where, _STD forward<_Ty>(_Val));
             } else {
                 // heterogeneous insertion
                 // FIXME: The standard only requires `find(_Val) == find(_Keyval)` (per N4958 [flat.set.modifiers]/2),
@@ -553,9 +542,7 @@ private:
                 _STL_ASSERT(_Can_insert(_Where, _Keyval),
                     "The conversion from the heterogeneous key to key_type should "
                     "be consistent with the heterogeneous lookup!");
-                iterator _Result = _Mycont.emplace(_Where, _STD move(_Keyval));
-                _Guard._Target   = nullptr;
-                return _Result;
+                return _Mycont.emplace(_Where, _STD move(_Keyval));
             }
         } else {
             _STL_INTERNAL_STATIC_ASSERT(is_same_v<remove_cvref_t<_Ty>, _Kty>);
@@ -575,10 +562,7 @@ private:
             }
 
             _STL_INTERNAL_CHECK(_Can_insert(_Where, _Val));
-            _Clear_guard _Guard{this};
-            iterator _Result = _Mycont.emplace(_Where, _STD forward<_Ty>(_Val));
-            _Guard._Target   = nullptr;
-            return _Result;
+            return _Mycont.emplace(_Where, _STD forward<_Ty>(_Val));
         }
     }
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -59,7 +59,7 @@ std/containers/container.adaptors/flat.set/flat.set.cons/assign_initializer_list
 std/containers/container.adaptors/flat.multiset/flat.multiset.modifiers/insert_range.pass.cpp FAIL
 std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_range.pass.cpp FAIL
 
-# LLVM-140448: [libc++][test] flat_set std test uses EmplaceUnsafeContainer which is non-standard 
+# LLVM-140448: [libc++][test] flat_set std test uses EmplaceUnsafeContainer which is non-standard
 std/containers/container.adaptors/flat.set/flat.set.modifiers/emplace_hint.pass.cpp FAIL
 std/containers/container.adaptors/flat.set/flat.set.modifiers/emplace.pass.cpp FAIL
 std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_cv.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -51,6 +51,15 @@ std/strings/basic.string/string.modifiers/string_append/initializer_list.pass.cp
 std/strings/basic.string/string.modifiers/string_assign/string.pass.cpp:0 FAIL
 std/strings/basic.string/string.modifiers/string_assign/string.pass.cpp:1 FAIL
 
+# LLVM-140448: [libc++][test] flat_set std test uses EmplaceUnsafeContainer which is non-standard 
+std/containers/container.adaptors/flat.set/flat.set.modifiers/emplace_hint.pass.cpp FAIL
+std/containers/container.adaptors/flat.set/flat.set.modifiers/emplace.pass.cpp FAIL
+std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_cv.pass.cpp FAIL
+std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_iter_cv.pass.cpp FAIL
+std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_iter_rv.pass.cpp FAIL
+std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_rv.pass.cpp FAIL
+std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_transparent.pass.cpp FAIL
+
 # Non-Standard regex behavior.
 # "It seems likely that the test is still non-conforming due to how libc++ handles the 'w' character class."
 std/re/re.traits/lookup_classname.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -51,6 +51,14 @@ std/strings/basic.string/string.modifiers/string_append/initializer_list.pass.cp
 std/strings/basic.string/string.modifiers/string_assign/string.pass.cpp:0 FAIL
 std/strings/basic.string/string.modifiers/string_assign/string.pass.cpp:1 FAIL
 
+# LLVM-140287: libc++ test: update MinSequenceContainer.h to make some tests pass on MSVC STL #140287
+std/containers/container.adaptors/flat.multiset/flat.multiset.capacity/empty.pass.cpp FAIL
+std/containers/container.adaptors/flat.multiset/flat.multiset.cons/assign_initializer_list.pass.cpp FAIL
+std/containers/container.adaptors/flat.set/flat.set.capacity/empty.pass.cpp FAIL
+std/containers/container.adaptors/flat.set/flat.set.cons/assign_initializer_list.pass.cpp FAIL
+std/containers/container.adaptors/flat.multiset/flat.multiset.modifiers/insert_range.pass.cpp FAIL
+std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_range.pass.cpp FAIL
+
 # LLVM-140448: [libc++][test] flat_set std test uses EmplaceUnsafeContainer which is non-standard 
 std/containers/container.adaptors/flat.set/flat.set.modifiers/emplace_hint.pass.cpp FAIL
 std/containers/container.adaptors/flat.set/flat.set.modifiers/emplace.pass.cpp FAIL
@@ -617,20 +625,6 @@ std/depr/depr.c.headers/stddef_h.compile.pass.cpp:1 FAIL
 
 
 # *** LIKELY BOGUS TESTS ***
-
-# P1222R4 <flat_set>;
-# error: no member named 'assign' in 'MinSequenceContainer<int>';
-# it is mandatory according to [sequence.reqmts]/104
-std/containers/container.adaptors/flat.multiset/flat.multiset.capacity/empty.pass.cpp FAIL
-std/containers/container.adaptors/flat.multiset/flat.multiset.cons/assign_initializer_list.pass.cpp FAIL
-std/containers/container.adaptors/flat.set/flat.set.capacity/empty.pass.cpp FAIL
-std/containers/container.adaptors/flat.set/flat.set.cons/assign_initializer_list.pass.cpp FAIL
-
-# P1222R4 <flat_set>;
-# error: no member named 'insert_range' in 'MinSequenceContainer<int>';
-# it is mandatory according to [sequence.reqmts]/40
-std/containers/container.adaptors/flat.multiset/flat.multiset.modifiers/insert_range.pass.cpp FAIL
-std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_range.pass.cpp FAIL
 
 # Test bug after LWG-2899 "is_(nothrow_)move_constructible and tuple, optional and unique_ptr" was accepted.
 std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.pass.cpp FAIL


### PR DESCRIPTION
 * Reverts #5516, as supporting non-standard requirement is non-goal
    - #5514 still looks valid
 * Link these test failures to LLVM-140448
 * Also link previously reported test failures to LLVM-140287