### PR TITLE
`<regex>`: Restrict control letters in escapes to alphabetic ASCII characters

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -4707,7 +4707,11 @@ bool _Parser<_FwdIt, _Elem, _RxTraits>::_CharacterEscape(bool _In_character_clas
         _Next();
     } else if (_Char == _Esc_ctrl && (_L_flags & _L_esc_ctrl)) { // handle control escape sequence
         _Next();
-        if (!_Traits.isctype(_Char, _RxTraits::_Ch_alpha)) {
+
+        using _Uelem = typename _RxTraits::_Uelem;
+        _Uelem _UCh  = static_cast<_Uelem>(_Char);
+        if ((static_cast<_Uelem>('a') > _UCh || static_cast<_Uelem>('z') < _UCh)
+            && (static_cast<_Uelem>('A') > _UCh || static_cast<_Uelem>('Z') < _UCh)) {
             _Error(regex_constants::error_escape);
         }
 

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -4710,8 +4710,8 @@ bool _Parser<_FwdIt, _Elem, _RxTraits>::_CharacterEscape(bool _In_character_clas
 
         using _Uelem = typename _RxTraits::_Uelem;
         _Uelem _UCh  = static_cast<_Uelem>(_Char);
-        if ((static_cast<_Uelem>('a') > _UCh || static_cast<_Uelem>('z') < _UCh)
-            && (static_cast<_Uelem>('A') > _UCh || static_cast<_Uelem>('Z') < _UCh)) {
+        if (!((static_cast<_Uelem>('a') <= _UCh && _UCh <= static_cast<_Uelem>('z'))
+                || (static_cast<_Uelem>('A') <= _UCh && _UCh <= static_cast<_Uelem>('Z')))) {
             _Error(regex_constants::error_escape);
         }
 

--- a/tests/std/include/test_regex_support.hpp
+++ b/tests/std/include/test_regex_support.hpp
@@ -181,6 +181,25 @@ public:
             }
         }
     }
+
+    void should_throw(const std::wstring& pattern, const std::regex_constants::error_type expectedCode,
+        const std::regex_constants::syntax_option_type syntax = std::regex_constants::ECMAScript) {
+        try {
+            const std::wregex r(pattern, syntax);
+            wprintf(LR"(wregex r("%s", 0x%X) succeeded (which is bad).)"
+                    L"\n",
+                pattern.c_str(), static_cast<unsigned int>(syntax));
+            fail_regex();
+        } catch (const std::regex_error& e) {
+            if (e.code() != expectedCode) {
+                wprintf(LR"(wregex r("%s", 0x%X) threw 0x%X; expected 0x%X)"
+                        "\n",
+                    pattern.c_str(), static_cast<unsigned int>(syntax), static_cast<unsigned int>(e.code()),
+                    static_cast<unsigned int>(expectedCode));
+                fail_regex();
+            }
+        }
+    }
 };
 
 class test_regex {

--- a/tests/std/include/test_regex_support.hpp
+++ b/tests/std/include/test_regex_support.hpp
@@ -193,7 +193,7 @@ public:
         } catch (const std::regex_error& e) {
             if (e.code() != expectedCode) {
                 wprintf(LR"(wregex r("%s", 0x%X) threw 0x%X; expected 0x%X)"
-                        "\n",
+                        L"\n",
                     pattern.c_str(), static_cast<unsigned int>(syntax), static_cast<unsigned int>(e.code()),
                     static_cast<unsigned int>(expectedCode));
                 fail_regex();

--- a/tests/std/tests/GH_005244_regex_escape_sequences/test.cpp
+++ b/tests/std/tests/GH_005244_regex_escape_sequences/test.cpp
@@ -25,9 +25,7 @@ public:
     using char_class_type = typename rx_traits::char_class_type;
 
     // TRANSITION, GH-995
-    using _Uelem                    = typename rx_traits::_Uelem;
-    static constexpr auto _Ch_upper = rx_traits::_Ch_upper;
-    static constexpr auto _Ch_alpha = rx_traits::_Ch_alpha;
+    using _Uelem = typename rx_traits::_Uelem;
 
     test_regex_traits() = default;
 
@@ -192,7 +190,11 @@ void test_gh_5244_atomescape_ecmascript() {
     g_regexTester.should_not_match("c", R"(\ca)", ECMAScript);
     g_regexTester.should_not_match("ca", R"(\ca)", ECMAScript);
     g_regexTester.should_throw(R"(\c0)", error_escape, ECMAScript);
-    g_regexTester.should_throw(R"(\c)", error_escape, ECMAScript);
+    g_regexTester.should_throw(R"(\c@)", error_escape, ECMAScript);
+    g_regexTester.should_throw(R"(\c[)", error_escape, ECMAScript);
+    g_regexTester.should_throw(R"(\c`)", error_escape, ECMAScript);
+    g_regexTester.should_throw(R"(\c{)", error_escape, ECMAScript);
+    g_regexTester.should_throw(L"\\c\u00C0", error_escape, ECMAScript); // U+00C0 LATIN CAPITAL LETTER A WITH GRAVE
 
     // AtomEscape :: CharacterEscape :: HexEscapeSequence
     g_regexTester.should_match("\x00"s, R"(\x00)", ECMAScript);

--- a/tests/std/tests/GH_005244_regex_escape_sequences/test.cpp
+++ b/tests/std/tests/GH_005244_regex_escape_sequences/test.cpp
@@ -190,6 +190,7 @@ void test_gh_5244_atomescape_ecmascript() {
     g_regexTester.should_not_match("c", R"(\ca)", ECMAScript);
     g_regexTester.should_not_match("ca", R"(\ca)", ECMAScript);
     g_regexTester.should_throw(R"(\c0)", error_escape, ECMAScript);
+    g_regexTester.should_throw(R"(\c)", error_escape, ECMAScript);
     g_regexTester.should_throw(R"(\c@)", error_escape, ECMAScript);
     g_regexTester.should_throw(R"(\c[)", error_escape, ECMAScript);
     g_regexTester.should_throw(R"(\c`)", error_escape, ECMAScript);


### PR DESCRIPTION
Towards #995. ECMAScript 15.10.1 defines the production `ControlLetter` such that only ASCII alphabetic characters are allowed. Such restricted character sets are often extended to corresponding POSIX character classes (to include Unicode characters) by Boost.Regex or `<regex>` implementations. But such an extension doesn't make much sense in this specific case, because these `\c` + letter escapes are supposed to emulate what pressing Ctrl + ASCII character does in the terminal. (It would actually make more sense to support "\c[" and similar, but the ECMAScript standard doesn't say so.)

Alternative: If non-ASCII characters should remain supported, we could query the bitmask of the character class "alpha" from the traits class.