### PR TITLE
`<bit>`: Use popcount for `has_single_bit()` if it's always available

### DIFF
--- a/stl/inc/__msvc_bit_utils.hpp
+++ b/stl/inc/__msvc_bit_utils.hpp
@@ -386,7 +386,6 @@ _CONSTEXPR20 decltype(auto) _Select_popcount_impl(_Fn _Callback) {
 
 #undef _HAS_POPCNT_INTRINSICS
 #undef _HAS_TZCNT_BSF_INTRINSICS
-#undef _POPCNT_INTRINSICS_ALWAYS_AVAILABLE
 
 _STD_END
 

--- a/stl/inc/__msvc_bit_utils.hpp
+++ b/stl/inc/__msvc_bit_utils.hpp
@@ -281,7 +281,8 @@ _NODISCARD int _Checked_x86_x64_countr_zero(const _Ty _Val) noexcept {
 #define _POPCNT_INTRINSICS_ALWAYS_AVAILABLE 0
 #endif // ^^^ intrinsics not always available ^^^
 #else // ^^^ intrinsics available / intrinsics unavailable vvv
-#define _HAS_POPCNT_INTRINSICS 0
+#define _HAS_POPCNT_INTRINSICS              0
+#define _POPCNT_INTRINSICS_ALWAYS_AVAILABLE 0
 #endif // ^^^ intrinsics unavailable ^^^
 
 #if _HAS_POPCNT_INTRINSICS
@@ -384,7 +385,6 @@ _CONSTEXPR20 decltype(auto) _Select_popcount_impl(_Fn _Callback) {
     return _Callback([](_Ty _Val) _STATIC_LAMBDA { return _Popcount_fallback(_Val); });
 }
 
-#undef _HAS_POPCNT_INTRINSICS
 #undef _HAS_TZCNT_BSF_INTRINSICS
 
 _STD_END

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -84,7 +84,14 @@ _NODISCARD constexpr int countl_zero(_Ty _Val) noexcept;
 
 _EXPORT_STD template <_Standard_unsigned_integral _Ty>
 _NODISCARD constexpr bool has_single_bit(const _Ty _Val) noexcept {
+#if defined(_POPCNT_INTRINSICS_ALWAYS_AVAILABLE) && _POPCNT_INTRINSICS_ALWAYS_AVAILABLE
+    if (_STD is_constant_evaluated()) {
+        return (_Val ^ (_Val - 1)) > _Val - 1;
+    }
+    return _Unchecked_popcount(_Val) == 1;
+#else
     return (_Val ^ (_Val - 1)) > _Val - 1;
+#endif // ! _POPCNT_INTRINSICS_ALWAYS_AVAILABLE
 }
 
 inline void _Precondition_violation_in_bit_ceil() noexcept {}

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -85,13 +85,12 @@ _NODISCARD constexpr int countl_zero(_Ty _Val) noexcept;
 _EXPORT_STD template <_Standard_unsigned_integral _Ty>
 _NODISCARD constexpr bool has_single_bit(const _Ty _Val) noexcept {
 #if _POPCNT_INTRINSICS_ALWAYS_AVAILABLE
-    if (_STD is_constant_evaluated()) {
-        return (_Val ^ (_Val - 1)) > _Val - 1;
+    if (!_STD is_constant_evaluated()) {
+        return _Unchecked_popcount(_Val) == 1;
     }
-    return _Unchecked_popcount(_Val) == 1;
-#else // ^^^ _POPCNT_INTRINSICS_ALWAYS_AVAILABLE / !_POPCNT_INTRINSICS_ALWAYS_AVAILABLE vvv
+#endif // ^^^ _POPCNT_INTRINSICS_ALWAYS_AVAILABLE ^^^
+
     return (_Val ^ (_Val - 1)) > _Val - 1;
-#endif // ^^^ !_POPCNT_INTRINSICS_ALWAYS_AVAILABLE ^^^
 }
 
 inline void _Precondition_violation_in_bit_ceil() noexcept {}

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -89,9 +89,9 @@ _NODISCARD constexpr bool has_single_bit(const _Ty _Val) noexcept {
         return (_Val ^ (_Val - 1)) > _Val - 1;
     }
     return _Unchecked_popcount(_Val) == 1;
-#else
+#else // ^^^ popcnt intrinsic always available / popcnt intrinsic not always available vvv
     return (_Val ^ (_Val - 1)) > _Val - 1;
-#endif // ! _POPCNT_INTRINSICS_ALWAYS_AVAILABLE
+#endif // ^^^ popcnt intrinsic not always available ^^^
 }
 
 inline void _Precondition_violation_in_bit_ceil() noexcept {}

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -84,14 +84,14 @@ _NODISCARD constexpr int countl_zero(_Ty _Val) noexcept;
 
 _EXPORT_STD template <_Standard_unsigned_integral _Ty>
 _NODISCARD constexpr bool has_single_bit(const _Ty _Val) noexcept {
-#if defined(_POPCNT_INTRINSICS_ALWAYS_AVAILABLE) && _POPCNT_INTRINSICS_ALWAYS_AVAILABLE
+#if _POPCNT_INTRINSICS_ALWAYS_AVAILABLE
     if (_STD is_constant_evaluated()) {
         return (_Val ^ (_Val - 1)) > _Val - 1;
     }
     return _Unchecked_popcount(_Val) == 1;
-#else // ^^^ popcnt intrinsic always available / popcnt intrinsic not always available vvv
+#else // ^^^ _POPCNT_INTRINSICS_ALWAYS_AVAILABLE / !_POPCNT_INTRINSICS_ALWAYS_AVAILABLE vvv
     return (_Val ^ (_Val - 1)) > _Val - 1;
-#endif // ^^^ popcnt intrinsic not always available ^^^
+#endif // ^^^ !_POPCNT_INTRINSICS_ALWAYS_AVAILABLE ^^^
 }
 
 inline void _Precondition_violation_in_bit_ceil() noexcept {}


### PR DESCRIPTION
provides 1.05 to 1.1 times speed up on x64 targets.

**x64 results**
```
Benchmark                               Time 
---------------------------------------------
bm_has_single_bit_if<uint8_t>        13.4 ns 
bm_has_single_bit_if_new<uint8_t>    12.7 ns 
bm_has_single_bit_if<uint16_t>       13.9 ns 
bm_has_single_bit_if_new<uint16_t>   10.8 ns 
bm_has_single_bit_if<uint32_t>       15.9 ns 
bm_has_single_bit_if_new<uint32_t>   12.6 ns 
bm_has_single_bit_if<uint64_t>       14.3 ns 
bm_has_single_bit_if_new<uint64_t>   11.0 ns 
bm_has_single_bit<uint8_t>           6.34 ns 
bm_has_single_bit_new<uint8_t>       5.88 ns 
bm_has_single_bit<uint16_t>          6.19 ns 
bm_has_single_bit_new<uint16_t>      4.52 ns 
bm_has_single_bit<uint32_t>          5.57 ns 
bm_has_single_bit_new<uint32_t>      5.99 ns 
bm_has_single_bit<uint64_t>          6.07 ns 
bm_has_single_bit_new<uint64_t>      5.41 ns 
```

fixes #5359