### PR TITLE
Mark templates users shouldn't specialize with _NO_SPECIALIZATIONS

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -103,8 +103,8 @@ AllowShortFunctionsOnASingleLine: Empty
 # AllowShortLoopsOnASingleLine: false
 # AlwaysBreakAfterDefinitionReturnType: None
 # AlwaysBreakBeforeMultilineStrings: false
-# AttributeMacros:
-#   - __capability
+AttributeMacros:
+  - _NO_SPECIALIZATIONS
 # BinPackArguments: true
 # BinPackParameters: true
 # BitFieldColonSpacing: Both

--- a/stl/inc/__msvc_chrono.hpp
+++ b/stl/inc/__msvc_chrono.hpp
@@ -31,7 +31,7 @@ namespace chrono {
     struct treat_as_floating_point : is_floating_point<_Rep> {}; // tests for floating-point type
 
     _EXPORT_STD template <class _Rep>
-    constexpr bool treat_as_floating_point_v = treat_as_floating_point<_Rep>::value;
+    _NO_SPECIALIZATIONS constexpr bool treat_as_floating_point_v = treat_as_floating_point<_Rep>::value;
 
     _EXPORT_STD template <class _Rep>
     struct duration_values { // gets arithmetic properties of a type
@@ -53,7 +53,7 @@ namespace chrono {
 
 #if _HAS_CXX20
     _EXPORT_STD template <class _Clock>
-    constexpr bool is_clock_v = requires {
+    _NO_SPECIALIZATIONS constexpr bool is_clock_v = requires {
         typename _Clock::rep;
         typename _Clock::period;
         typename _Clock::duration;
@@ -62,7 +62,7 @@ namespace chrono {
         _Clock::now();
     };
     _EXPORT_STD template <class _Clock>
-    struct is_clock : bool_constant<is_clock_v<_Clock>> {};
+    struct _NO_SPECIALIZATIONS is_clock : bool_constant<is_clock_v<_Clock>> {};
 
     template <class _Clock>
     constexpr bool _Is_clock_v = is_clock_v<_Clock>;

--- a/stl/inc/__msvc_iter_core.hpp
+++ b/stl/inc/__msvc_iter_core.hpp
@@ -34,7 +34,7 @@ _EXPORT_STD template <class _Ty, class _Alloc>
 struct uses_allocator : _Has_allocator_type<_Ty, _Alloc>::type {};
 
 _EXPORT_STD template <class _Ty, class _Alloc>
-constexpr bool uses_allocator_v = uses_allocator<_Ty, _Alloc>::value;
+_NO_SPECIALIZATIONS constexpr bool uses_allocator_v = uses_allocator<_Ty, _Alloc>::value;
 
 // from <iterator>
 _EXPORT_STD struct input_iterator_tag {};

--- a/stl/inc/__msvc_ranges_tuple_formatter.hpp
+++ b/stl/inc/__msvc_ranges_tuple_formatter.hpp
@@ -229,7 +229,7 @@ struct _Format_handler;
 _FMT_P2286_END
 
 _EXPORT_STD template <class _Context>
-class basic_format_arg {
+class _NO_SPECIALIZATIONS basic_format_arg {
 public:
     using _CharType = _Context::char_type;
 

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -321,7 +321,7 @@ using compare_three_way_result_t =
     decltype(_STD declval<const remove_reference_t<_Ty1>&>() <=> _STD declval<const remove_reference_t<_Ty2>&>());
 
 _EXPORT_STD template <class _Ty1, class _Ty2 = _Ty1>
-struct compare_three_way_result {};
+struct _NO_SPECIALIZATIONS compare_three_way_result {};
 
 template <class _Ty1, class _Ty2>
     requires requires { typename compare_three_way_result_t<_Ty1, _Ty2>; }

--- a/stl/inc/coroutine
+++ b/stl/inc/coroutine
@@ -46,7 +46,7 @@ _EXPORT_STD template <class _Ret, class...>
 struct coroutine_traits : _Coroutine_traits<_Ret> {};
 
 _EXPORT_STD template <class = void>
-struct coroutine_handle;
+struct _NO_SPECIALIZATIONS coroutine_handle;
 
 template <>
 struct coroutine_handle<void> {

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -2004,7 +2004,7 @@ template <class _Tx>
 struct is_placeholder<const volatile _Tx> : is_placeholder<_Tx>::type {}; // ignore cv-qualifiers
 
 _EXPORT_STD template <class _Ty>
-constexpr int is_placeholder_v = is_placeholder<_Ty>::value;
+_NO_SPECIALIZATIONS constexpr int is_placeholder_v = is_placeholder<_Ty>::value;
 
 template <class _Ret, class _Fx, class... _Types>
 class _Binder;
@@ -2025,7 +2025,7 @@ template <class _Tx>
 struct is_bind_expression<const volatile _Tx> : is_bind_expression<_Tx>::type {}; // ignore cv-qualifiers
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_bind_expression_v = is_bind_expression<_Ty>::value;
+_NO_SPECIALIZATIONS constexpr bool is_bind_expression_v = is_bind_expression<_Ty>::value;
 
 template <class _Cv_TiD, bool = _Is_specialization_v<remove_cv_t<_Cv_TiD>, reference_wrapper>,
     bool = is_bind_expression_v<_Cv_TiD>, int = is_placeholder_v<_Cv_TiD>>

--- a/stl/inc/generator
+++ b/stl/inc/generator
@@ -518,7 +518,7 @@ namespace _Gen_detail {
 } // namespace _Gen_detail
 
 _EXPORT_STD template <class _Rty, class _Vty, class _Alloc>
-class generator : public _RANGES view_interface<generator<_Rty, _Vty, _Alloc>> {
+class _NO_SPECIALIZATIONS generator : public _RANGES view_interface<generator<_Rty, _Vty, _Alloc>> {
 private:
     static_assert(_Gen_detail::_Valid_allocator<_Alloc>,
         "generator allocators must use raw pointers (N4988 [coro.generator.class]/1.1)");

--- a/stl/inc/initializer_list
+++ b/stl/inc/initializer_list
@@ -18,7 +18,7 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 _EXPORT_STD template <class _Elem>
-class initializer_list {
+class _NO_SPECIALIZATIONS initializer_list {
 public:
     using value_type      = _Elem;
     using reference       = const _Elem&;

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -546,7 +546,7 @@ namespace ranges {
 #if _HAS_CXX23
     _EXPORT_STD template <class _Derived>
         requires is_class_v<_Derived> && same_as<_Derived, remove_cv_t<_Derived>>
-    class range_adaptor_closure : public _Pipe::_Base<_Derived> {};
+    class _NO_SPECIALIZATIONS range_adaptor_closure : public _Pipe::_Base<_Derived> {};
 #endif // _HAS_CXX23
 
     _EXPORT_STD template <class _Ty>

--- a/stl/inc/ratio
+++ b/stl/inc/ratio
@@ -167,7 +167,7 @@ struct ratio_equal : bool_constant<_Rx1::num == _Rx2::num && _Rx1::den == _Rx2::
 };
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
-constexpr bool ratio_equal_v = ratio_equal<_Rx1, _Rx2>::value;
+_NO_SPECIALIZATIONS constexpr bool ratio_equal_v = ratio_equal<_Rx1, _Rx2>::value;
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
 struct ratio_not_equal : bool_constant<!ratio_equal_v<_Rx1, _Rx2>> { // tests if ratio != ratio
@@ -175,7 +175,7 @@ struct ratio_not_equal : bool_constant<!ratio_equal_v<_Rx1, _Rx2>> { // tests if
 };
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
-constexpr bool ratio_not_equal_v = ratio_not_equal<_Rx1, _Rx2>::value;
+_NO_SPECIALIZATIONS constexpr bool ratio_not_equal_v = ratio_not_equal<_Rx1, _Rx2>::value;
 
 struct _Big_uint128 {
     uint64_t _Upper;
@@ -231,7 +231,7 @@ struct ratio_less : bool_constant<_Ratio_less(_Rx1::num, _Rx1::den, _Rx2::num, _
 };
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
-constexpr bool ratio_less_v = ratio_less<_Rx1, _Rx2>::value;
+_NO_SPECIALIZATIONS constexpr bool ratio_less_v = ratio_less<_Rx1, _Rx2>::value;
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
 struct ratio_less_equal : bool_constant<!ratio_less_v<_Rx2, _Rx1>> { // tests if ratio <= ratio
@@ -240,7 +240,7 @@ struct ratio_less_equal : bool_constant<!ratio_less_v<_Rx2, _Rx1>> { // tests if
 };
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
-constexpr bool ratio_less_equal_v = ratio_less_equal<_Rx1, _Rx2>::value;
+_NO_SPECIALIZATIONS constexpr bool ratio_less_equal_v = ratio_less_equal<_Rx1, _Rx2>::value;
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
 struct ratio_greater : ratio_less<_Rx2, _Rx1>::type { // tests if ratio > ratio
@@ -248,7 +248,7 @@ struct ratio_greater : ratio_less<_Rx2, _Rx1>::type { // tests if ratio > ratio
 };
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
-constexpr bool ratio_greater_v = ratio_greater<_Rx1, _Rx2>::value;
+_NO_SPECIALIZATIONS constexpr bool ratio_greater_v = ratio_greater<_Rx1, _Rx2>::value;
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
 struct ratio_greater_equal : bool_constant<!ratio_less_v<_Rx1, _Rx2>> { // tests if ratio >= ratio
@@ -257,7 +257,7 @@ struct ratio_greater_equal : bool_constant<!ratio_less_v<_Rx1, _Rx2>> { // tests
 };
 
 _EXPORT_STD template <class _Rx1, class _Rx2>
-constexpr bool ratio_greater_equal_v = ratio_greater_equal<_Rx1, _Rx2>::value;
+_NO_SPECIALIZATIONS constexpr bool ratio_greater_equal_v = ratio_greater_equal<_Rx1, _Rx2>::value;
 
 _EXPORT_STD using atto  = ratio<1, 1000000000000000000LL>;
 _EXPORT_STD using femto = ratio<1, 1000000000000000LL>;

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -41,7 +41,7 @@ struct _Conjunction<true, _True, _Next, _Rest...> { // the first trait is true, 
 };
 
 _EXPORT_STD template <class... _Traits>
-struct conjunction : true_type {}; // If _Traits is empty, true_type
+struct _NO_SPECIALIZATIONS conjunction : true_type {}; // If _Traits is empty, true_type
 
 template <class _First, class... _Rest>
 struct conjunction<_First, _Rest...> : _Conjunction<static_cast<bool>(_First::value), _First, _Rest...>::type {
@@ -49,19 +49,21 @@ struct conjunction<_First, _Rest...> : _Conjunction<static_cast<bool>(_First::va
 };
 
 _EXPORT_STD template <class... _Traits>
-constexpr bool conjunction_v = conjunction<_Traits...>::value;
+_NO_SPECIALIZATIONS constexpr bool conjunction_v = conjunction<_Traits...>::value;
 
 _EXPORT_STD template <class _Trait>
-struct negation : bool_constant<!static_cast<bool>(_Trait::value)> {}; // The negated result of _Trait
+struct _NO_SPECIALIZATIONS negation : bool_constant<!static_cast<bool>(_Trait::value)> {
+    // The negated result of _Trait
+};
 
 _EXPORT_STD template <class _Trait>
-constexpr bool negation_v = negation<_Trait>::value;
+_NO_SPECIALIZATIONS constexpr bool negation_v = negation<_Trait>::value;
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_void_v = is_same_v<remove_cv_t<_Ty>, void>;
+_NO_SPECIALIZATIONS constexpr bool is_void_v = is_same_v<remove_cv_t<_Ty>, void>;
 
 _EXPORT_STD template <class _Ty>
-struct is_void : bool_constant<is_void_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_void : bool_constant<is_void_v<_Ty>> {};
 
 _EXPORT_STD template <class... _Types>
 using void_t = void;
@@ -75,7 +77,7 @@ using _Identity_t _MSVC_KNOWN_SEMANTICS = typename _Identity<_Ty>::type;
 
 // Type modifiers
 _EXPORT_STD template <class _Ty>
-struct add_const { // add top-level const qualifier
+struct _NO_SPECIALIZATIONS add_const { // add top-level const qualifier
     using type = const _Ty;
 };
 
@@ -83,7 +85,7 @@ _EXPORT_STD template <class _Ty>
 using add_const_t = typename add_const<_Ty>::type;
 
 _EXPORT_STD template <class _Ty>
-struct add_volatile { // add top-level volatile qualifier
+struct _NO_SPECIALIZATIONS add_volatile { // add top-level volatile qualifier
     using type = volatile _Ty;
 };
 
@@ -91,7 +93,7 @@ _EXPORT_STD template <class _Ty>
 using add_volatile_t = typename add_volatile<_Ty>::type;
 
 _EXPORT_STD template <class _Ty>
-struct add_cv { // add top-level const and volatile qualifiers
+struct _NO_SPECIALIZATIONS add_cv { // add top-level const and volatile qualifiers
     using type = const volatile _Ty;
 };
 
@@ -111,7 +113,7 @@ struct _Add_reference<_Ty, void_t<_Ty&>> { // (referenceable type)
 };
 
 _EXPORT_STD template <class _Ty>
-struct add_lvalue_reference {
+struct _NO_SPECIALIZATIONS add_lvalue_reference {
     using type = typename _Add_reference<_Ty>::_Lvalue;
 };
 
@@ -119,7 +121,7 @@ _EXPORT_STD template <class _Ty>
 using add_lvalue_reference_t = typename _Add_reference<_Ty>::_Lvalue;
 
 _EXPORT_STD template <class _Ty>
-struct add_rvalue_reference {
+struct _NO_SPECIALIZATIONS add_rvalue_reference {
     using type = typename _Add_reference<_Ty>::_Rvalue;
 };
 
@@ -132,7 +134,7 @@ add_rvalue_reference_t<_Ty> declval() noexcept {
 }
 
 _EXPORT_STD template <class _Ty>
-struct remove_extent { // remove array extent
+struct _NO_SPECIALIZATIONS remove_extent { // remove array extent
     using type = _Ty;
 };
 
@@ -150,7 +152,7 @@ _EXPORT_STD template <class _Ty>
 using remove_extent_t = typename remove_extent<_Ty>::type;
 
 _EXPORT_STD template <class _Ty>
-struct remove_all_extents { // remove all array extents
+struct _NO_SPECIALIZATIONS remove_all_extents { // remove all array extents
     using type = _Ty;
 };
 
@@ -168,7 +170,7 @@ _EXPORT_STD template <class _Ty>
 using remove_all_extents_t = typename remove_all_extents<_Ty>::type;
 
 _EXPORT_STD template <class _Ty>
-struct remove_pointer {
+struct _NO_SPECIALIZATIONS remove_pointer {
     using type = _Ty;
 };
 
@@ -206,7 +208,7 @@ struct _Add_pointer<_Ty, void_t<remove_reference_t<_Ty>*>> { // (pointer type ca
 };
 
 _EXPORT_STD template <class _Ty>
-struct add_pointer {
+struct _NO_SPECIALIZATIONS add_pointer {
     using type = typename _Add_pointer<_Ty>::type;
 };
 
@@ -214,7 +216,7 @@ _EXPORT_STD template <class _Ty>
 using add_pointer_t = typename _Add_pointer<_Ty>::type;
 
 _EXPORT_STD template <class>
-constexpr bool is_array_v = false; // determine whether type argument is an array
+_NO_SPECIALIZATIONS constexpr bool is_array_v = false; // determine whether type argument is an array
 
 template <class _Ty, size_t _Nx>
 constexpr bool is_array_v<_Ty[_Nx]> = true;
@@ -223,48 +225,50 @@ template <class _Ty>
 constexpr bool is_array_v<_Ty[]> = true;
 
 _EXPORT_STD template <class _Ty>
-struct is_array : bool_constant<is_array_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_array : bool_constant<is_array_v<_Ty>> {};
 
 #if _HAS_CXX20
 _EXPORT_STD template <class>
-constexpr bool is_bounded_array_v = false;
+_NO_SPECIALIZATIONS constexpr bool is_bounded_array_v = false;
 
 template <class _Ty, size_t _Nx>
 constexpr bool is_bounded_array_v<_Ty[_Nx]> = true;
 
 _EXPORT_STD template <class _Ty>
-struct is_bounded_array : bool_constant<is_bounded_array_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_bounded_array : bool_constant<is_bounded_array_v<_Ty>> {};
 
 _EXPORT_STD template <class>
-constexpr bool is_unbounded_array_v = false;
+_NO_SPECIALIZATIONS constexpr bool is_unbounded_array_v = false;
 
 template <class _Ty>
 constexpr bool is_unbounded_array_v<_Ty[]> = true;
 
 _EXPORT_STD template <class _Ty>
-struct is_unbounded_array : bool_constant<is_unbounded_array_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_unbounded_array : bool_constant<is_unbounded_array_v<_Ty>> {};
 #endif // _HAS_CXX20
 
 _EXPORT_STD template <class>
-constexpr bool is_lvalue_reference_v = false; // determine whether type argument is an lvalue reference
+_NO_SPECIALIZATIONS constexpr bool is_lvalue_reference_v =
+    false; // determine whether type argument is an lvalue reference
 
 template <class _Ty>
 constexpr bool is_lvalue_reference_v<_Ty&> = true;
 
 _EXPORT_STD template <class _Ty>
-struct is_lvalue_reference : bool_constant<is_lvalue_reference_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_lvalue_reference : bool_constant<is_lvalue_reference_v<_Ty>> {};
 
 _EXPORT_STD template <class>
-constexpr bool is_rvalue_reference_v = false; // determine whether type argument is an rvalue reference
+_NO_SPECIALIZATIONS constexpr bool is_rvalue_reference_v =
+    false; // determine whether type argument is an rvalue reference
 
 template <class _Ty>
 constexpr bool is_rvalue_reference_v<_Ty&&> = true;
 
 _EXPORT_STD template <class _Ty>
-struct is_rvalue_reference : bool_constant<is_rvalue_reference_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_rvalue_reference : bool_constant<is_rvalue_reference_v<_Ty>> {};
 
 _EXPORT_STD template <class>
-constexpr bool is_reference_v = false; // determine whether type argument is a reference
+_NO_SPECIALIZATIONS constexpr bool is_reference_v = false; // determine whether type argument is a reference
 
 template <class _Ty>
 constexpr bool is_reference_v<_Ty&> = true;
@@ -273,10 +277,10 @@ template <class _Ty>
 constexpr bool is_reference_v<_Ty&&> = true;
 
 _EXPORT_STD template <class _Ty>
-struct is_reference : bool_constant<is_reference_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_reference : bool_constant<is_reference_v<_Ty>> {};
 
 _EXPORT_STD template <class>
-constexpr bool is_pointer_v = false; // determine whether _Ty is a pointer
+_NO_SPECIALIZATIONS constexpr bool is_pointer_v = false; // determine whether _Ty is a pointer
 
 template <class _Ty>
 constexpr bool is_pointer_v<_Ty*> = true;
@@ -291,69 +295,73 @@ template <class _Ty>
 constexpr bool is_pointer_v<_Ty* const volatile> = true;
 
 _EXPORT_STD template <class _Ty>
-struct is_pointer : bool_constant<is_pointer_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_pointer : bool_constant<is_pointer_v<_Ty>> {};
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_null_pointer_v =
+_NO_SPECIALIZATIONS constexpr bool is_null_pointer_v =
     is_same_v<remove_cv_t<_Ty>, nullptr_t>; // determine whether _Ty is cv-qualified nullptr_t
 
 _EXPORT_STD template <class _Ty>
-struct is_null_pointer : bool_constant<is_null_pointer_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_null_pointer : bool_constant<is_null_pointer_v<_Ty>> {};
 
 _EXPORT_STD template <class _Ty>
-struct is_union : bool_constant<__is_union(_Ty)> {}; // determine whether _Ty is a union
+struct _NO_SPECIALIZATIONS is_union : bool_constant<__is_union(_Ty)> {}; // determine whether _Ty is a union
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_union_v = __is_union(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_union_v = __is_union(_Ty);
 
 _EXPORT_STD template <class _Ty>
-struct is_class : bool_constant<__is_class(_Ty)> {}; // determine whether _Ty is a class
+struct _NO_SPECIALIZATIONS is_class : bool_constant<__is_class(_Ty)> {}; // determine whether _Ty is a class
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_class_v = __is_class(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_class_v = __is_class(_Ty);
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_fundamental_v = is_arithmetic_v<_Ty> || is_void_v<_Ty> || is_null_pointer_v<_Ty>;
+_NO_SPECIALIZATIONS constexpr bool is_fundamental_v = is_arithmetic_v<_Ty> || is_void_v<_Ty> || is_null_pointer_v<_Ty>;
 
 _EXPORT_STD template <class _Ty>
-struct is_fundamental : bool_constant<is_fundamental_v<_Ty>> {}; // determine whether _Ty is a fundamental type
+struct _NO_SPECIALIZATIONS is_fundamental : bool_constant<is_fundamental_v<_Ty>> {
+    // determine whether _Ty is a fundamental type
+};
 
 _EXPORT_STD template <class _From, class _To>
-struct is_convertible : bool_constant<__is_convertible_to(_From, _To)> {
+struct _NO_SPECIALIZATIONS is_convertible : bool_constant<__is_convertible_to(_From, _To)> {
     // determine whether _From is convertible to _To
 };
 
 _EXPORT_STD template <class _From, class _To>
-constexpr bool is_convertible_v = __is_convertible_to(_From, _To);
+_NO_SPECIALIZATIONS constexpr bool is_convertible_v = __is_convertible_to(_From, _To);
 
 _EXPORT_STD template <class _Ty>
-struct is_enum : bool_constant<__is_enum(_Ty)> {}; // determine whether _Ty is an enumerated type
+struct _NO_SPECIALIZATIONS is_enum : bool_constant<__is_enum(_Ty)> {}; // determine whether _Ty is an enumerated type
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_enum_v = __is_enum(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_enum_v = __is_enum(_Ty);
 
 #if _HAS_CXX23
 #if defined(__clang__) && !defined(__EDG__) \
     && __clang_major__ >= 16 // TRANSITION, DevCom-10870354 (MSVC, EDG), VSO-2397560 (RWC relying on ancient Clang)
 _EXPORT_STD template <class _Ty>
-constexpr bool is_scoped_enum_v = __is_scoped_enum(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_scoped_enum_v = __is_scoped_enum(_Ty);
 
 _EXPORT_STD template <class _Ty>
-struct is_scoped_enum : bool_constant<__is_scoped_enum(_Ty)> {};
+struct _NO_SPECIALIZATIONS is_scoped_enum : bool_constant<__is_scoped_enum(_Ty)> {};
 #else // ^^^ no workaround / workaround vvv
 _EXPORT_STD template <class _Ty>
-constexpr bool is_scoped_enum_v = conjunction_v<is_enum<_Ty>, negation<is_convertible<_Ty, int>>>;
+_NO_SPECIALIZATIONS constexpr bool is_scoped_enum_v = conjunction_v<is_enum<_Ty>, negation<is_convertible<_Ty, int>>>;
 
 _EXPORT_STD template <class _Ty>
-struct is_scoped_enum : bool_constant<is_scoped_enum_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_scoped_enum : bool_constant<is_scoped_enum_v<_Ty>> {};
 #endif // ^^^ workaround ^^^
 #endif // _HAS_CXX23
 
 _EXPORT_STD template <class _Ty>
-struct is_compound : bool_constant<!is_fundamental_v<_Ty>> {}; // determine whether _Ty is a compound type
+struct _NO_SPECIALIZATIONS is_compound : bool_constant<!is_fundamental_v<_Ty>> {
+    // determine whether _Ty is a compound type
+};
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_compound_v = !is_fundamental_v<_Ty>;
+_NO_SPECIALIZATIONS constexpr bool is_compound_v = !is_fundamental_v<_Ty>;
 
 #define _EMIT_CDECL(FUNC, OPT1, OPT2, OPT3) FUNC(__cdecl, OPT1, OPT2, OPT3)
 
@@ -541,46 +549,46 @@ _NON_MEMBER_CALL(_IS_MEMFUNPTR_EXPLICIT_THIS_GUIDES, , , noexcept)
 
 #ifdef __clang__
 _EXPORT_STD template <class _Ty>
-constexpr bool is_member_function_pointer_v = __is_member_function_pointer(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_member_function_pointer_v = __is_member_function_pointer(_Ty);
 #else // ^^^ Clang / Other vvv
 _EXPORT_STD template <class _Ty>
-constexpr bool is_member_function_pointer_v = _Is_memfunptr<remove_cv_t<_Ty>>::_Bool_type::value;
+_NO_SPECIALIZATIONS constexpr bool is_member_function_pointer_v = _Is_memfunptr<remove_cv_t<_Ty>>::_Bool_type::value;
 #endif // ^^^ Other ^^^
 
 _EXPORT_STD template <class _Ty>
-struct is_member_function_pointer : bool_constant<is_member_function_pointer_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_member_function_pointer : bool_constant<is_member_function_pointer_v<_Ty>> {};
 
 _EXPORT_STD template <class>
-constexpr bool is_const_v = false; // determine whether type argument is const qualified
+_NO_SPECIALIZATIONS constexpr bool is_const_v = false; // determine whether type argument is const qualified
 
 template <class _Ty>
 constexpr bool is_const_v<const _Ty> = true;
 
 _EXPORT_STD template <class _Ty>
-struct is_const : bool_constant<is_const_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_const : bool_constant<is_const_v<_Ty>> {};
 
 _EXPORT_STD template <class>
-constexpr bool is_volatile_v = false; // determine whether type argument is volatile qualified
+_NO_SPECIALIZATIONS constexpr bool is_volatile_v = false; // determine whether type argument is volatile qualified
 
 template <class _Ty>
 constexpr bool is_volatile_v<volatile _Ty> = true;
 
 _EXPORT_STD template <class _Ty>
-struct is_volatile : bool_constant<is_volatile_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_volatile : bool_constant<is_volatile_v<_Ty>> {};
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_function_v = // only function types and reference types can't be const qualified
+_NO_SPECIALIZATIONS constexpr bool is_function_v = // only function types and reference types can't be const qualified
     !is_const_v<const _Ty> && !is_reference_v<_Ty>;
 
 _EXPORT_STD template <class _Ty>
-struct is_function : bool_constant<is_function_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_function : bool_constant<is_function_v<_Ty>> {};
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_object_v = // only function types and reference types can't be const qualified
+_NO_SPECIALIZATIONS constexpr bool is_object_v = // only function types and reference types can't be const qualified
     is_const_v<const _Ty> && !is_void_v<_Ty>;
 
 _EXPORT_STD template <class _Ty>
-struct is_object : bool_constant<is_object_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_object : bool_constant<is_object_v<_Ty>> {};
 
 template <class>
 struct _Is_member_object_pointer {
@@ -595,151 +603,163 @@ struct _Is_member_object_pointer<_Ty1 _Ty2::*> {
 
 #ifdef __clang__
 _EXPORT_STD template <class _Ty>
-constexpr bool is_member_object_pointer_v = __is_member_object_pointer(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_member_object_pointer_v = __is_member_object_pointer(_Ty);
 #else // ^^^ Clang / Other vvv
 _EXPORT_STD template <class _Ty>
-constexpr bool is_member_object_pointer_v = _Is_member_object_pointer<remove_cv_t<_Ty>>::value;
+_NO_SPECIALIZATIONS constexpr bool is_member_object_pointer_v = _Is_member_object_pointer<remove_cv_t<_Ty>>::value;
 #endif // ^^^ Other ^^^
 
 _EXPORT_STD template <class _Ty>
-struct is_member_object_pointer : bool_constant<is_member_object_pointer_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_member_object_pointer : bool_constant<is_member_object_pointer_v<_Ty>> {};
 
 #ifdef __clang__
 _EXPORT_STD template <class _Ty>
-constexpr bool is_member_pointer_v = __is_member_pointer(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_member_pointer_v = __is_member_pointer(_Ty);
 #else // ^^^ Clang / Other vvv
 _EXPORT_STD template <class _Ty>
-constexpr bool is_member_pointer_v = is_member_object_pointer_v<_Ty> || is_member_function_pointer_v<_Ty>;
+_NO_SPECIALIZATIONS constexpr bool is_member_pointer_v =
+    is_member_object_pointer_v<_Ty> || is_member_function_pointer_v<_Ty>;
 #endif // ^^^ Other ^^^
 
 _EXPORT_STD template <class _Ty>
-struct is_member_pointer : bool_constant<is_member_pointer_v<_Ty>> {}; // determine whether _Ty is a pointer to member
+struct _NO_SPECIALIZATIONS is_member_pointer : bool_constant<is_member_pointer_v<_Ty>> {
+    // determine whether _Ty is a pointer to member
+};
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_scalar_v = // determine whether _Ty is a scalar type
+_NO_SPECIALIZATIONS constexpr bool is_scalar_v = // determine whether _Ty is a scalar type
     is_arithmetic_v<_Ty> || is_enum_v<_Ty> || is_pointer_v<_Ty> || is_member_pointer_v<_Ty> || is_null_pointer_v<_Ty>;
 
 _EXPORT_STD template <class _Ty>
-struct is_scalar : bool_constant<is_scalar_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_scalar : bool_constant<is_scalar_v<_Ty>> {};
 
 _EXPORT_STD template <class _Ty>
-struct _CXX20_DEPRECATE_IS_POD is_pod : bool_constant<__is_pod(_Ty)> {}; // determine whether _Ty is a POD type
+struct _CXX20_DEPRECATE_IS_POD _NO_SPECIALIZATIONS is_pod : bool_constant<__is_pod(_Ty)> {
+    // determine whether _Ty is a POD type
+};
 
 _EXPORT_STD template <class _Ty>
-_CXX20_DEPRECATE_IS_POD constexpr bool is_pod_v = __is_pod(_Ty);
+_CXX20_DEPRECATE_IS_POD _NO_SPECIALIZATIONS constexpr bool is_pod_v = __is_pod(_Ty);
 
 _EXPORT_STD template <class _Ty>
-struct is_empty : bool_constant<__is_empty(_Ty)> {}; // determine whether _Ty is an empty class
+struct _NO_SPECIALIZATIONS is_empty : bool_constant<__is_empty(_Ty)> {}; // determine whether _Ty is an empty class
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_empty_v = __is_empty(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_empty_v = __is_empty(_Ty);
 
 _EXPORT_STD template <class _Ty>
-struct is_polymorphic : bool_constant<__is_polymorphic(_Ty)> {}; // determine whether _Ty is a polymorphic type
+struct _NO_SPECIALIZATIONS is_polymorphic : bool_constant<__is_polymorphic(_Ty)> {
+    // determine whether _Ty is a polymorphic type
+};
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_polymorphic_v = __is_polymorphic(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_polymorphic_v = __is_polymorphic(_Ty);
 
 _EXPORT_STD template <class _Ty>
-struct is_abstract : bool_constant<__is_abstract(_Ty)> {}; // determine whether _Ty is an abstract class
+struct _NO_SPECIALIZATIONS is_abstract : bool_constant<__is_abstract(_Ty)> {
+    // determine whether _Ty is an abstract class
+};
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_abstract_v = __is_abstract(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_abstract_v = __is_abstract(_Ty);
 
 _EXPORT_STD template <class _Ty>
-struct is_final : bool_constant<__is_final(_Ty)> {}; // determine whether _Ty is a final class
+struct _NO_SPECIALIZATIONS is_final : bool_constant<__is_final(_Ty)> {}; // determine whether _Ty is a final class
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_final_v = __is_final(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_final_v = __is_final(_Ty);
 
 _EXPORT_STD template <class _Ty>
-struct is_standard_layout : bool_constant<__is_standard_layout(_Ty)> {}; // determine whether _Ty is standard layout
+struct _NO_SPECIALIZATIONS is_standard_layout : bool_constant<__is_standard_layout(_Ty)> {
+    // determine whether _Ty is standard layout
+};
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_standard_layout_v = __is_standard_layout(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_standard_layout_v = __is_standard_layout(_Ty);
 
 #if _HAS_DEPRECATED_IS_LITERAL_TYPE
 _EXPORT_STD template <class _Ty>
-struct _CXX17_DEPRECATE_IS_LITERAL_TYPE is_literal_type : bool_constant<__is_literal_type(_Ty)> {
+struct _CXX17_DEPRECATE_IS_LITERAL_TYPE _NO_SPECIALIZATIONS is_literal_type : bool_constant<__is_literal_type(_Ty)> {
     // determine whether _Ty is a literal type
 };
 
 _EXPORT_STD template <class _Ty>
-_CXX17_DEPRECATE_IS_LITERAL_TYPE constexpr bool is_literal_type_v = __is_literal_type(_Ty);
+_CXX17_DEPRECATE_IS_LITERAL_TYPE _NO_SPECIALIZATIONS constexpr bool is_literal_type_v = __is_literal_type(_Ty);
 #endif // _HAS_DEPRECATED_IS_LITERAL_TYPE
 
 _EXPORT_STD template <class _Ty>
-struct is_trivial : bool_constant<__is_trivial(_Ty)> {}; // determine whether _Ty is a trivial type
+struct _NO_SPECIALIZATIONS is_trivial : bool_constant<__is_trivial(_Ty)> {}; // determine whether _Ty is a trivial type
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_trivial_v = __is_trivial(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_trivial_v = __is_trivial(_Ty);
 
 _EXPORT_STD template <class _Ty>
-struct is_trivially_copyable : bool_constant<__is_trivially_copyable(_Ty)> {
+struct _NO_SPECIALIZATIONS is_trivially_copyable : bool_constant<__is_trivially_copyable(_Ty)> {
     // determine whether _Ty is a trivially copyable type
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_trivially_copyable_v = __is_trivially_copyable(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_trivially_copyable_v = __is_trivially_copyable(_Ty);
 
 _EXPORT_STD template <class _Ty>
-struct has_virtual_destructor : bool_constant<__has_virtual_destructor(_Ty)> {
+struct _NO_SPECIALIZATIONS has_virtual_destructor : bool_constant<__has_virtual_destructor(_Ty)> {
     // determine whether _Ty has a virtual destructor
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool has_virtual_destructor_v = __has_virtual_destructor(_Ty);
+_NO_SPECIALIZATIONS constexpr bool has_virtual_destructor_v = __has_virtual_destructor(_Ty);
 
 #if _HAS_CXX17
 _EXPORT_STD template <class _Ty>
-struct has_unique_object_representations : bool_constant<__has_unique_object_representations(_Ty)> {
+struct _NO_SPECIALIZATIONS has_unique_object_representations : bool_constant<__has_unique_object_representations(_Ty)> {
     // determine whether _Ty has unique object representations
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool has_unique_object_representations_v = __has_unique_object_representations(_Ty);
+_NO_SPECIALIZATIONS constexpr bool has_unique_object_representations_v = __has_unique_object_representations(_Ty);
 
 #ifdef __EDG__ // TRANSITION, VSO-1690654
 template <class _Ty>
 struct _Is_aggregate_impl : bool_constant<__is_aggregate(_Ty)> {};
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_aggregate_v = disjunction_v<is_array<_Ty>, _Is_aggregate_impl<_Ty>>;
+_NO_SPECIALIZATIONS constexpr bool is_aggregate_v = disjunction_v<is_array<_Ty>, _Is_aggregate_impl<_Ty>>;
 
 _EXPORT_STD template <class _Ty>
-struct is_aggregate : bool_constant<is_aggregate_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_aggregate : bool_constant<is_aggregate_v<_Ty>> {};
 #else // ^^^ workaround / no workaround vvv
 _EXPORT_STD template <class _Ty>
-struct is_aggregate : bool_constant<__is_aggregate(_Ty)> {};
+struct _NO_SPECIALIZATIONS is_aggregate : bool_constant<__is_aggregate(_Ty)> {};
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_aggregate_v = __is_aggregate(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_aggregate_v = __is_aggregate(_Ty);
 #endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX17
 
 _EXPORT_STD template <class _Ty, class... _Args>
-struct is_constructible : bool_constant<__is_constructible(_Ty, _Args...)> {
+struct _NO_SPECIALIZATIONS is_constructible : bool_constant<__is_constructible(_Ty, _Args...)> {
     // determine whether _Ty can be direct-initialized with _Args...
 };
 
 _EXPORT_STD template <class _Ty, class... _Args>
-constexpr bool is_constructible_v = __is_constructible(_Ty, _Args...);
+_NO_SPECIALIZATIONS constexpr bool is_constructible_v = __is_constructible(_Ty, _Args...);
 
 _EXPORT_STD template <class _Ty>
-struct is_copy_constructible : bool_constant<__is_constructible(_Ty, add_lvalue_reference_t<const _Ty>)> {
+struct _NO_SPECIALIZATIONS is_copy_constructible
+    : bool_constant<__is_constructible(_Ty, add_lvalue_reference_t<const _Ty>)> {
     // determine whether _Ty can be direct-initialized with an lvalue const _Ty
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_copy_constructible_v = __is_constructible(_Ty, add_lvalue_reference_t<const _Ty>);
+_NO_SPECIALIZATIONS constexpr bool is_copy_constructible_v = __is_constructible(_Ty, add_lvalue_reference_t<const _Ty>);
 
 _EXPORT_STD template <class _Ty>
-struct is_default_constructible : bool_constant<__is_constructible(_Ty)> {
+struct _NO_SPECIALIZATIONS is_default_constructible : bool_constant<__is_constructible(_Ty)> {
     // determine whether _Ty can be value-initialized
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_default_constructible_v = __is_constructible(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_default_constructible_v = __is_constructible(_Ty);
 
 template <class _Ty, class = void>
 struct _Is_implicitly_default_constructible : false_type {
@@ -754,18 +774,20 @@ struct _Is_implicitly_default_constructible<_Ty, void_t<decltype(_Implicitly_def
 };
 
 _EXPORT_STD template <class _Ty>
-struct is_move_constructible : bool_constant<__is_constructible(_Ty, _Ty)> {
+struct _NO_SPECIALIZATIONS is_move_constructible : bool_constant<__is_constructible(_Ty, _Ty)> {
     // determine whether _Ty can be direct-initialized from an rvalue _Ty
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_move_constructible_v = __is_constructible(_Ty, _Ty);
+_NO_SPECIALIZATIONS constexpr bool is_move_constructible_v = __is_constructible(_Ty, _Ty);
 
 _EXPORT_STD template <class _To, class _From>
-struct is_assignable : bool_constant<__is_assignable(_To, _From)> {}; // determine whether _From can be assigned to _To
+struct _NO_SPECIALIZATIONS is_assignable : bool_constant<__is_assignable(_To, _From)> {
+    // determine whether _From can be assigned to _To
+};
 
 _EXPORT_STD template <class _To, class _From>
-constexpr bool is_assignable_v = __is_assignable(_To, _From);
+_NO_SPECIALIZATIONS constexpr bool is_assignable_v = __is_assignable(_To, _From);
 
 #if defined(_IS_ASSIGNABLE_NOCHECK_SUPPORTED) && !defined(__CUDACC__)
 template <class _To, class _From>
@@ -776,13 +798,14 @@ using _Is_assignable_no_precondition_check = is_assignable<_To, _From>;
 #endif // ^^^ intrinsic not supported ^^^
 
 _EXPORT_STD template <class _Ty>
-struct is_copy_assignable
+struct _NO_SPECIALIZATIONS is_copy_assignable
     : bool_constant<__is_assignable(add_lvalue_reference_t<_Ty>, add_lvalue_reference_t<const _Ty>)> {
     // determine whether an lvalue const _Ty can be assigned to an lvalue _Ty
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_copy_assignable_v = __is_assignable(add_lvalue_reference_t<_Ty>, add_lvalue_reference_t<const _Ty>);
+_NO_SPECIALIZATIONS constexpr bool is_copy_assignable_v =
+    __is_assignable(add_lvalue_reference_t<_Ty>, add_lvalue_reference_t<const _Ty>);
 
 #if defined(_IS_ASSIGNABLE_NOCHECK_SUPPORTED) && !defined(__CUDACC__)
 template <class _Ty>
@@ -802,12 +825,12 @@ constexpr bool _Is_copy_assignable_unchecked_v = is_copy_assignable_v<_Ty>;
 #endif // ^^^ intrinsic not supported ^^^
 
 _EXPORT_STD template <class _Ty>
-struct is_move_assignable : bool_constant<__is_assignable(add_lvalue_reference_t<_Ty>, _Ty)> {
+struct _NO_SPECIALIZATIONS is_move_assignable : bool_constant<__is_assignable(add_lvalue_reference_t<_Ty>, _Ty)> {
     // determine whether an rvalue _Ty can be assigned to an lvalue _Ty
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_move_assignable_v = __is_assignable(add_lvalue_reference_t<_Ty>, _Ty);
+_NO_SPECIALIZATIONS constexpr bool is_move_assignable_v = __is_assignable(add_lvalue_reference_t<_Ty>, _Ty);
 
 #if defined(_IS_ASSIGNABLE_NOCHECK_SUPPORTED) && !defined(__CUDACC__)
 template <class _Ty>
@@ -826,148 +849,154 @@ constexpr bool _Is_move_assignable_unchecked_v = is_move_assignable_v<_Ty>;
 #endif // ^^^ intrinsic not supported ^^^
 
 _EXPORT_STD template <class _Ty>
-struct is_destructible : bool_constant<__is_destructible(_Ty)> {
+struct _NO_SPECIALIZATIONS is_destructible : bool_constant<__is_destructible(_Ty)> {
     // true iff remove_all_extents_t<_Ty> is a reference type, or can be explicitly destroyed
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_destructible_v = __is_destructible(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_destructible_v = __is_destructible(_Ty);
 
 _EXPORT_STD template <class _Ty, class... _Args>
-struct is_trivially_constructible : bool_constant<__is_trivially_constructible(_Ty, _Args...)> {
+struct _NO_SPECIALIZATIONS is_trivially_constructible : bool_constant<__is_trivially_constructible(_Ty, _Args...)> {
     // determine whether direct-initialization of _Ty with _Args... is trivial
 };
 
 _EXPORT_STD template <class _Ty, class... _Args>
-constexpr bool is_trivially_constructible_v = __is_trivially_constructible(_Ty, _Args...);
+_NO_SPECIALIZATIONS constexpr bool is_trivially_constructible_v = __is_trivially_constructible(_Ty, _Args...);
 
 _EXPORT_STD template <class _Ty>
-struct is_trivially_copy_constructible
+struct _NO_SPECIALIZATIONS is_trivially_copy_constructible
     : bool_constant<__is_trivially_constructible(_Ty, add_lvalue_reference_t<const _Ty>)> {
     // determine whether direct-initialization of _Ty with an lvalue const _Ty is trivial
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_trivially_copy_constructible_v = __is_trivially_constructible(_Ty, add_lvalue_reference_t<const _Ty>);
+_NO_SPECIALIZATIONS constexpr bool is_trivially_copy_constructible_v =
+    __is_trivially_constructible(_Ty, add_lvalue_reference_t<const _Ty>);
 
 _EXPORT_STD template <class _Ty>
-struct is_trivially_default_constructible : bool_constant<__is_trivially_constructible(_Ty)> {
+struct _NO_SPECIALIZATIONS is_trivially_default_constructible : bool_constant<__is_trivially_constructible(_Ty)> {
     // determine whether value-initialization of _Ty is trivial
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_trivially_default_constructible_v = __is_trivially_constructible(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_trivially_default_constructible_v = __is_trivially_constructible(_Ty);
 
 _EXPORT_STD template <class _Ty>
-struct is_trivially_move_constructible : bool_constant<__is_trivially_constructible(_Ty, _Ty)> {
+struct _NO_SPECIALIZATIONS is_trivially_move_constructible : bool_constant<__is_trivially_constructible(_Ty, _Ty)> {
     // determine whether direct-initialization of _Ty with an rvalue _Ty is trivial
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_trivially_move_constructible_v = __is_trivially_constructible(_Ty, _Ty);
+_NO_SPECIALIZATIONS constexpr bool is_trivially_move_constructible_v = __is_trivially_constructible(_Ty, _Ty);
 
 _EXPORT_STD template <class _To, class _From>
-struct is_trivially_assignable : bool_constant<__is_trivially_assignable(_To, _From)> {
+struct _NO_SPECIALIZATIONS is_trivially_assignable : bool_constant<__is_trivially_assignable(_To, _From)> {
     // determine whether _From can be trivially assigned to _To
 };
 
 _EXPORT_STD template <class _To, class _From>
-constexpr bool is_trivially_assignable_v = __is_trivially_assignable(_To, _From);
+_NO_SPECIALIZATIONS constexpr bool is_trivially_assignable_v = __is_trivially_assignable(_To, _From);
 
 _EXPORT_STD template <class _Ty>
-struct is_trivially_copy_assignable
+struct _NO_SPECIALIZATIONS is_trivially_copy_assignable
     : bool_constant<__is_trivially_assignable(add_lvalue_reference_t<_Ty>, add_lvalue_reference_t<const _Ty>)> {
     // determine whether an lvalue const _Ty can be trivially assigned to an lvalue _Ty
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_trivially_copy_assignable_v =
+_NO_SPECIALIZATIONS constexpr bool is_trivially_copy_assignable_v =
     __is_trivially_assignable(add_lvalue_reference_t<_Ty>, add_lvalue_reference_t<const _Ty>);
 
 _EXPORT_STD template <class _Ty>
-struct is_trivially_move_assignable : bool_constant<__is_trivially_assignable(add_lvalue_reference_t<_Ty>, _Ty)> {
+struct _NO_SPECIALIZATIONS is_trivially_move_assignable
+    : bool_constant<__is_trivially_assignable(add_lvalue_reference_t<_Ty>, _Ty)> {
     // determine whether an rvalue _Ty can be trivially assigned to an lvalue _Ty
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_trivially_move_assignable_v = __is_trivially_assignable(add_lvalue_reference_t<_Ty>, _Ty);
+_NO_SPECIALIZATIONS constexpr bool is_trivially_move_assignable_v =
+    __is_trivially_assignable(add_lvalue_reference_t<_Ty>, _Ty);
 
 _EXPORT_STD template <class _Ty>
-struct is_trivially_destructible : bool_constant<__is_trivially_destructible(_Ty)> {
+struct _NO_SPECIALIZATIONS is_trivially_destructible : bool_constant<__is_trivially_destructible(_Ty)> {
     // determine whether remove_all_extents_t<_Ty> is a reference type or can trivially be explicitly destroyed
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_trivially_destructible_v = __is_trivially_destructible(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_trivially_destructible_v = __is_trivially_destructible(_Ty);
 
 _EXPORT_STD template <class _Ty, class... _Args>
-struct is_nothrow_constructible : bool_constant<__is_nothrow_constructible(_Ty, _Args...)> {
+struct _NO_SPECIALIZATIONS is_nothrow_constructible : bool_constant<__is_nothrow_constructible(_Ty, _Args...)> {
     // determine whether direct-initialization of _Ty from _Args... is both valid and not potentially-throwing
 };
 
 _EXPORT_STD template <class _Ty, class... _Args>
-constexpr bool is_nothrow_constructible_v = __is_nothrow_constructible(_Ty, _Args...);
+_NO_SPECIALIZATIONS constexpr bool is_nothrow_constructible_v = __is_nothrow_constructible(_Ty, _Args...);
 
 _EXPORT_STD template <class _Ty>
-struct is_nothrow_copy_constructible
+struct _NO_SPECIALIZATIONS is_nothrow_copy_constructible
     : bool_constant<__is_nothrow_constructible(_Ty, add_lvalue_reference_t<const _Ty>)> {
     // determine whether direct-initialization of _Ty from an lvalue const _Ty is both valid
     // and not potentially-throwing
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_nothrow_copy_constructible_v = __is_nothrow_constructible(_Ty, add_lvalue_reference_t<const _Ty>);
+_NO_SPECIALIZATIONS constexpr bool is_nothrow_copy_constructible_v =
+    __is_nothrow_constructible(_Ty, add_lvalue_reference_t<const _Ty>);
 
 _EXPORT_STD template <class _Ty>
-struct is_nothrow_default_constructible : bool_constant<__is_nothrow_constructible(_Ty)> {
+struct _NO_SPECIALIZATIONS is_nothrow_default_constructible : bool_constant<__is_nothrow_constructible(_Ty)> {
     // determine whether value-initialization of _Ty is both valid and not potentially-throwing
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_nothrow_default_constructible_v = __is_nothrow_constructible(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_nothrow_default_constructible_v = __is_nothrow_constructible(_Ty);
 
 _EXPORT_STD template <class _Ty>
-struct is_nothrow_move_constructible : bool_constant<__is_nothrow_constructible(_Ty, _Ty)> {
+struct _NO_SPECIALIZATIONS is_nothrow_move_constructible : bool_constant<__is_nothrow_constructible(_Ty, _Ty)> {
     // determine whether direct-initialization of _Ty from an rvalue _Ty is both valid and not potentially-throwing
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_nothrow_move_constructible_v = __is_nothrow_constructible(_Ty, _Ty);
+_NO_SPECIALIZATIONS constexpr bool is_nothrow_move_constructible_v = __is_nothrow_constructible(_Ty, _Ty);
 
 _EXPORT_STD template <class _To, class _From>
-struct is_nothrow_assignable : bool_constant<__is_nothrow_assignable(_To, _From)> {
+struct _NO_SPECIALIZATIONS is_nothrow_assignable : bool_constant<__is_nothrow_assignable(_To, _From)> {
     // determine whether assignment of _From to _To is both valid and not potentially-throwing
 };
 
 _EXPORT_STD template <class _To, class _From>
-constexpr bool is_nothrow_assignable_v = __is_nothrow_assignable(_To, _From);
+_NO_SPECIALIZATIONS constexpr bool is_nothrow_assignable_v = __is_nothrow_assignable(_To, _From);
 
 _EXPORT_STD template <class _Ty>
-struct is_nothrow_copy_assignable
+struct _NO_SPECIALIZATIONS is_nothrow_copy_assignable
     : bool_constant<__is_nothrow_assignable(add_lvalue_reference_t<_Ty>, add_lvalue_reference_t<const _Ty>)> {
     // determine whether assignment of an lvalue const _Ty to an lvalue _Ty is both valid and not potentially-throwing
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_nothrow_copy_assignable_v =
+_NO_SPECIALIZATIONS constexpr bool is_nothrow_copy_assignable_v =
     __is_nothrow_assignable(add_lvalue_reference_t<_Ty>, add_lvalue_reference_t<const _Ty>);
 
 _EXPORT_STD template <class _Ty>
-struct is_nothrow_move_assignable : bool_constant<__is_nothrow_assignable(add_lvalue_reference_t<_Ty>, _Ty)> {
+struct _NO_SPECIALIZATIONS is_nothrow_move_assignable
+    : bool_constant<__is_nothrow_assignable(add_lvalue_reference_t<_Ty>, _Ty)> {
     // determine whether assignment of an rvalue _Ty to an lvalue _Ty is both valid and not potentially-throwing
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_nothrow_move_assignable_v = __is_nothrow_assignable(add_lvalue_reference_t<_Ty>, _Ty);
+_NO_SPECIALIZATIONS constexpr bool is_nothrow_move_assignable_v =
+    __is_nothrow_assignable(add_lvalue_reference_t<_Ty>, _Ty);
 
 _EXPORT_STD template <class _Ty>
-struct is_nothrow_destructible : bool_constant<__is_nothrow_destructible(_Ty)> {
+struct _NO_SPECIALIZATIONS is_nothrow_destructible : bool_constant<__is_nothrow_destructible(_Ty)> {
     // determine whether remove_all_extents_t<_Ty> is a reference type or has
     // non-potentially-throwing explicit destruction
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_nothrow_destructible_v = __is_nothrow_destructible(_Ty);
+_NO_SPECIALIZATIONS constexpr bool is_nothrow_destructible_v = __is_nothrow_destructible(_Ty);
 
 template <class _Ty, bool = is_integral_v<_Ty>>
 struct _Sign_base { // determine whether integral type _Ty is signed or unsigned
@@ -985,16 +1014,20 @@ struct _Sign_base<_Ty, false> { // floating-point _Ty is signed
 };
 
 _EXPORT_STD template <class _Ty>
-struct is_signed : bool_constant<_Sign_base<_Ty>::_Signed> {}; // determine whether _Ty is a signed type
+struct _NO_SPECIALIZATIONS is_signed : bool_constant<_Sign_base<_Ty>::_Signed> {
+    // determine whether _Ty is a signed type
+};
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_signed_v = _Sign_base<_Ty>::_Signed;
+_NO_SPECIALIZATIONS constexpr bool is_signed_v = _Sign_base<_Ty>::_Signed;
 
 _EXPORT_STD template <class _Ty>
-struct is_unsigned : bool_constant<_Sign_base<_Ty>::_Unsigned> {}; // determine whether _Ty is an unsigned type
+struct _NO_SPECIALIZATIONS is_unsigned : bool_constant<_Sign_base<_Ty>::_Unsigned> {
+    // determine whether _Ty is an unsigned type
+};
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_unsigned_v = _Sign_base<_Ty>::_Unsigned;
+_NO_SPECIALIZATIONS constexpr bool is_unsigned_v = _Sign_base<_Ty>::_Unsigned;
 
 template <class _Ty>
 constexpr bool _Is_nonbool_integral = is_integral_v<_Ty> && !is_same_v<remove_cv_t<_Ty>, bool>;
@@ -1044,7 +1077,7 @@ using _Make_signed1 = // signed partner to cv-unqualified _Ty
     typename _Make_signed2<sizeof(_Ty)>::template _Apply<_Ty>;
 
 _EXPORT_STD template <class _Ty>
-struct make_signed { // signed partner to _Ty
+struct _NO_SPECIALIZATIONS make_signed { // signed partner to _Ty
     static_assert(_Is_nonbool_integral<_Ty> || is_enum_v<_Ty>,
         "make_signed<T> requires that T shall be a (possibly cv-qualified) "
         "integral type or enumeration but not a bool type.");
@@ -1089,7 +1122,7 @@ using _Make_unsigned1 = // unsigned partner to cv-unqualified _Ty
     typename _Make_unsigned2<sizeof(_Ty)>::template _Apply<_Ty>;
 
 _EXPORT_STD template <class _Ty>
-struct make_unsigned { // unsigned partner to _Ty
+struct _NO_SPECIALIZATIONS make_unsigned { // unsigned partner to _Ty
     static_assert(_Is_nonbool_integral<_Ty> || is_enum_v<_Ty>,
         "make_unsigned<T> requires that T shall be a (possibly cv-qualified) "
         "integral type or enumeration but not a bool type.");
@@ -1106,10 +1139,10 @@ constexpr make_unsigned_t<_Rep> _Unsigned_value(_Rep _Val) { // makes _Val unsig
 }
 
 _EXPORT_STD template <class _Ty>
-struct alignment_of : integral_constant<size_t, alignof(_Ty)> {}; // determine alignment of _Ty
+struct _NO_SPECIALIZATIONS alignment_of : integral_constant<size_t, alignof(_Ty)> {}; // determine alignment of _Ty
 
 _EXPORT_STD template <class _Ty>
-constexpr size_t alignment_of_v = alignof(_Ty);
+_NO_SPECIALIZATIONS constexpr size_t alignment_of_v = alignof(_Ty);
 
 template <class _Ty, size_t _Len>
 union _Align_type { // union with size _Len bytes and alignment of _Ty
@@ -1180,7 +1213,8 @@ template <size_t _Len, size_t _Align = alignof(max_align_t)>
 using _Aligned_storage_t = typename _Aligned_storage<_Len, _Align>::type;
 
 _EXPORT_STD template <size_t _Len, size_t _Align = alignof(max_align_t)>
-struct _CXX23_DEPRECATE_ALIGNED_STORAGE aligned_storage { // define type with size _Len and alignment _Align
+struct _CXX23_DEPRECATE_ALIGNED_STORAGE _NO_SPECIALIZATIONS aligned_storage {
+    // define type with size _Len and alignment _Align
     using type = _Aligned_storage_t<_Len, _Align>;
 };
 
@@ -1202,7 +1236,7 @@ struct _Maximum<_First, _Second, _Rest...> : _Maximum<(_First < _Second ? _Secon
 };
 
 _EXPORT_STD template <size_t _Len, class... _Types>
-struct _CXX23_DEPRECATE_ALIGNED_UNION aligned_union {
+struct _CXX23_DEPRECATE_ALIGNED_UNION _NO_SPECIALIZATIONS aligned_union {
     // define type with size at least _Len, for storing anything in _Types
     static constexpr size_t _Max_len        = _Maximum<_Len, sizeof(_Types)...>::value; // NOT sizeof...(_Types)
     static constexpr size_t alignment_value = _Maximum<alignof(_Types)...>::value;
@@ -1224,13 +1258,13 @@ template <class _Ty>
 struct _Underlying_type<_Ty, false> {};
 
 _EXPORT_STD template <class _Ty>
-struct underlying_type : _Underlying_type<_Ty> {}; // determine underlying type for enum
+struct _NO_SPECIALIZATIONS underlying_type : _Underlying_type<_Ty> {}; // determine underlying type for enum
 
 _EXPORT_STD template <class _Ty>
 using underlying_type_t = typename _Underlying_type<_Ty>::type;
 
 _EXPORT_STD template <class _Ty>
-constexpr size_t rank_v = 0; // determine number of dimensions of array _Ty
+_NO_SPECIALIZATIONS constexpr size_t rank_v = 0; // determine number of dimensions of array _Ty
 
 template <class _Ty, size_t _Nx>
 constexpr size_t rank_v<_Ty[_Nx]> = rank_v<_Ty> + 1;
@@ -1239,10 +1273,10 @@ template <class _Ty>
 constexpr size_t rank_v<_Ty[]> = rank_v<_Ty> + 1;
 
 _EXPORT_STD template <class _Ty>
-struct rank : integral_constant<size_t, rank_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS rank : integral_constant<size_t, rank_v<_Ty>> {};
 
 _EXPORT_STD template <class _Ty, unsigned int _Ix = 0>
-constexpr size_t extent_v = 0; // determine extent of dimension _Ix of array _Ty
+_NO_SPECIALIZATIONS constexpr size_t extent_v = 0; // determine extent of dimension _Ix of array _Ty
 
 template <class _Ty, size_t _Nx>
 constexpr size_t extent_v<_Ty[_Nx], 0> = _Nx;
@@ -1254,18 +1288,18 @@ template <class _Ty, unsigned int _Ix>
 constexpr size_t extent_v<_Ty[], _Ix> = extent_v<_Ty, _Ix - 1>;
 
 _EXPORT_STD template <class _Ty, unsigned int _Ix = 0>
-struct extent : integral_constant<size_t, extent_v<_Ty, _Ix>> {};
+struct _NO_SPECIALIZATIONS extent : integral_constant<size_t, extent_v<_Ty, _Ix>> {};
 
 _EXPORT_STD template <class _Base, class _Derived>
-struct is_base_of : bool_constant<__is_base_of(_Base, _Derived)> {
+struct _NO_SPECIALIZATIONS is_base_of : bool_constant<__is_base_of(_Base, _Derived)> {
     // determine whether _Base is a base of or the same as _Derived
 };
 
 _EXPORT_STD template <class _Base, class _Derived>
-constexpr bool is_base_of_v = __is_base_of(_Base, _Derived);
+_NO_SPECIALIZATIONS constexpr bool is_base_of_v = __is_base_of(_Base, _Derived);
 
 _EXPORT_STD template <class _Ty>
-struct decay { // determines decayed version of _Ty
+struct _NO_SPECIALIZATIONS decay { // determines decayed version of _Ty
     using _Ty1 = remove_reference_t<_Ty>;
     using _Ty2 = typename _Select<is_function_v<_Ty1>>::template _Apply<add_pointer<_Ty1>, remove_cv<_Ty1>>;
     using type = typename _Select<is_array_v<_Ty1>>::template _Apply<add_pointer<remove_extent_t<_Ty1>>, _Ty2>::type;
@@ -1384,7 +1418,9 @@ using _Cond_res = // N4950 [meta.trans.other]/2.4
     decltype(false ? _Returns_exactly<_Ty1>() : _Returns_exactly<_Ty2>());
 
 _EXPORT_STD template <class...>
-struct common_reference;
+struct _NO_SPECIALIZATIONS_MSG("Users are not allowed to specialize std::common_reference directly. "
+                               "You should instead specialize std::basic_common_reference, "
+                               "which std::common_reference will dispatch to.") common_reference;
 
 _EXPORT_STD template <class... _Types>
 using common_reference_t = common_reference<_Types...>::type;
@@ -1490,7 +1526,7 @@ struct common_reference<_Ty1, _Ty2, _Ty3, _Rest...> : common_reference<common_re
 };
 
 _EXPORT_STD template <class _Ty>
-struct type_identity {
+struct _NO_SPECIALIZATIONS type_identity {
     using type = _Ty;
 };
 _EXPORT_STD template <class _Ty>
@@ -1730,10 +1766,10 @@ struct _Is_nothrow_convertible : bool_constant<_Is_nothrow_convertible_v<_From, 
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _From, class _To>
-constexpr bool is_nothrow_convertible_v = _Is_nothrow_convertible_v<_From, _To>;
+_NO_SPECIALIZATIONS constexpr bool is_nothrow_convertible_v = _Is_nothrow_convertible_v<_From, _To>;
 
 _EXPORT_STD template <class _From, class _To>
-struct is_nothrow_convertible : bool_constant<_Is_nothrow_convertible_v<_From, _To>> {};
+struct _NO_SPECIALIZATIONS is_nothrow_convertible : bool_constant<_Is_nothrow_convertible_v<_From, _To>> {};
 #endif // _HAS_CXX20
 
 template <class _From, class _To, class = void>
@@ -1805,7 +1841,7 @@ using _Select_invoke_traits = conditional_t<sizeof...(_Args) == 0, _Invoke_trait
 
 #if _HAS_DEPRECATED_RESULT_OF
 _EXPORT_STD template <class _Fty>
-struct _CXX17_DEPRECATE_RESULT_OF result_of { // explain usage
+struct _CXX17_DEPRECATE_RESULT_OF _NO_SPECIALIZATIONS result_of { // explain usage
     static_assert(_Always_false<_Fty>, "result_of<CallableType> is invalid; use "
                                        "result_of<CallableType(zero or more argument types)> instead.");
 };
@@ -1838,7 +1874,7 @@ struct _Is_invocable_r : _Is_invocable_r_<_Rx, _Callable, _Args...> {
 
 #if _HAS_CXX17
 _EXPORT_STD template <class _Callable, class... _Args>
-struct invoke_result : _Select_invoke_traits<_Callable, _Args...> {
+struct _NO_SPECIALIZATIONS invoke_result : _Select_invoke_traits<_Callable, _Args...> {
     // determine the result type of invoking _Callable with _Args
 };
 
@@ -1846,60 +1882,66 @@ _EXPORT_STD template <class _Callable, class... _Args>
 using invoke_result_t = typename _Select_invoke_traits<_Callable, _Args...>::type;
 
 _EXPORT_STD template <class _Callable, class... _Args>
-struct is_invocable : _Select_invoke_traits<_Callable, _Args...>::_Is_invocable {
+struct _NO_SPECIALIZATIONS is_invocable : _Select_invoke_traits<_Callable, _Args...>::_Is_invocable {
     // determines whether _Callable is callable with _Args
 };
 
 _EXPORT_STD template <class _Callable, class... _Args>
-constexpr bool is_invocable_v = _Select_invoke_traits<_Callable, _Args...>::_Is_invocable::value;
+_NO_SPECIALIZATIONS constexpr bool is_invocable_v = _Select_invoke_traits<_Callable, _Args...>::_Is_invocable::value;
 
 _EXPORT_STD template <class _Callable, class... _Args>
-struct is_nothrow_invocable : _Select_invoke_traits<_Callable, _Args...>::_Is_nothrow_invocable {
+struct _NO_SPECIALIZATIONS is_nothrow_invocable : _Select_invoke_traits<_Callable, _Args...>::_Is_nothrow_invocable {
     // determines whether _Callable is nothrow-callable with _Args
 };
 
 _EXPORT_STD template <class _Callable, class... _Args>
-constexpr bool is_nothrow_invocable_v = _Select_invoke_traits<_Callable, _Args...>::_Is_nothrow_invocable::value;
+_NO_SPECIALIZATIONS constexpr bool is_nothrow_invocable_v =
+    _Select_invoke_traits<_Callable, _Args...>::_Is_nothrow_invocable::value;
 
 _EXPORT_STD template <class _Rx, class _Callable, class... _Args>
-struct is_invocable_r : _Is_invocable_r_<_Rx, _Callable, _Args...> {
+struct _NO_SPECIALIZATIONS is_invocable_r : _Is_invocable_r_<_Rx, _Callable, _Args...> {
     // determines whether _Callable is callable with _Args and return type _Rx
 };
 
 _EXPORT_STD template <class _Rx, class _Callable, class... _Args>
-constexpr bool is_invocable_r_v = _Is_invocable_r_<_Rx, _Callable, _Args...>::value;
+_NO_SPECIALIZATIONS constexpr bool is_invocable_r_v = _Is_invocable_r_<_Rx, _Callable, _Args...>::value;
 
 _EXPORT_STD template <class _Rx, class _Callable, class... _Args>
-struct is_nothrow_invocable_r : _Select_invoke_traits<_Callable, _Args...>::template _Is_nothrow_invocable_r<_Rx> {
+struct _NO_SPECIALIZATIONS is_nothrow_invocable_r
+    : _Select_invoke_traits<_Callable, _Args...>::template _Is_nothrow_invocable_r<_Rx> {
     // determines whether _Callable is nothrow-callable with _Args and return type _Rx
 };
 
 _EXPORT_STD template <class _Rx, class _Callable, class... _Args>
-constexpr bool is_nothrow_invocable_r_v =
+_NO_SPECIALIZATIONS constexpr bool is_nothrow_invocable_r_v =
     _Select_invoke_traits<_Callable, _Args...>::template _Is_nothrow_invocable_r<_Rx>::value;
 #endif // _HAS_CXX17
 
 #if _HAS_CXX20
 #ifndef __clang__ // TRANSITION, LLVM-48860
 _EXPORT_STD template <class _Ty1, class _Ty2>
-struct is_layout_compatible : bool_constant<__is_layout_compatible(_Ty1, _Ty2)> {};
+struct _NO_SPECIALIZATIONS is_layout_compatible : bool_constant<__is_layout_compatible(_Ty1, _Ty2)> {};
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
-constexpr bool is_layout_compatible_v = __is_layout_compatible(_Ty1, _Ty2);
+_NO_SPECIALIZATIONS constexpr bool is_layout_compatible_v = __is_layout_compatible(_Ty1, _Ty2);
 
 _EXPORT_STD template <class _Base, class _Derived>
-struct is_pointer_interconvertible_base_of : bool_constant<__is_pointer_interconvertible_base_of(_Base, _Derived)> {};
+struct _NO_SPECIALIZATIONS is_pointer_interconvertible_base_of
+    : bool_constant<__is_pointer_interconvertible_base_of(_Base, _Derived)> {};
 
 _EXPORT_STD template <class _Base, class _Derived>
-constexpr bool is_pointer_interconvertible_base_of_v = __is_pointer_interconvertible_base_of(_Base, _Derived);
+_NO_SPECIALIZATIONS constexpr bool is_pointer_interconvertible_base_of_v =
+    __is_pointer_interconvertible_base_of(_Base, _Derived);
 
 _EXPORT_STD template <class _ClassTy, class _MemberTy>
-_NODISCARD constexpr bool is_pointer_interconvertible_with_class(_MemberTy _ClassTy::* _Pm) noexcept {
+_NODISCARD _NO_SPECIALIZATIONS constexpr bool is_pointer_interconvertible_with_class(
+    _MemberTy _ClassTy::* _Pm) noexcept {
     return __is_pointer_interconvertible_with_class(_ClassTy, _Pm);
 }
 
 _EXPORT_STD template <class _ClassTy1, class _ClassTy2, class _MemberTy1, class _MemberTy2>
-_NODISCARD constexpr bool is_corresponding_member(_MemberTy1 _ClassTy1::* _Pm1, _MemberTy2 _ClassTy2::* _Pm2) noexcept {
+_NODISCARD _NO_SPECIALIZATIONS constexpr bool is_corresponding_member(
+    _MemberTy1 _ClassTy1::* _Pm1, _MemberTy2 _ClassTy2::* _Pm2) noexcept {
     return __is_corresponding_member(_ClassTy1, _ClassTy2, _Pm1, _Pm2);
 }
 #endif // ^^^ no workaround ^^^
@@ -2050,7 +2092,7 @@ _NODISCARD _CONSTEXPR20 reference_wrapper<const _Ty> cref(reference_wrapper<_Ty>
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _Ty>
-struct unwrap_reference {
+struct _NO_SPECIALIZATIONS unwrap_reference {
     using type = _Ty;
 };
 template <class _Ty>
@@ -2063,7 +2105,7 @@ using unwrap_reference_t = unwrap_reference<_Ty>::type;
 _EXPORT_STD template <class _Ty>
 using unwrap_ref_decay_t = unwrap_reference_t<decay_t<_Ty>>;
 _EXPORT_STD template <class _Ty>
-struct unwrap_ref_decay {
+struct _NO_SPECIALIZATIONS unwrap_ref_decay {
     using type = unwrap_ref_decay_t<_Ty>;
 };
 #endif // _HAS_CXX20
@@ -2124,37 +2166,39 @@ struct _Is_nothrow_swappable
 
 #if _HAS_CXX17
 _EXPORT_STD template <class _Ty1, class _Ty2>
-struct is_swappable_with : _Is_swappable_with<_Ty1, _Ty2>::type {
+struct _NO_SPECIALIZATIONS is_swappable_with : _Is_swappable_with<_Ty1, _Ty2>::type {
     // Determine if expressions with type and value category _Ty1 and _Ty2
     // can be swapped (and vice versa)
 };
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
-constexpr bool is_swappable_with_v =
+_NO_SPECIALIZATIONS constexpr bool is_swappable_with_v =
     conjunction_v<_Swappable_with_helper<_Ty1, _Ty2>, _Swappable_with_helper<_Ty2, _Ty1>>;
 
 _EXPORT_STD template <class _Ty>
-struct is_swappable : _Is_swappable<_Ty>::type {}; // Determine if _Ty lvalues satisfy is_swappable_with
+struct _NO_SPECIALIZATIONS is_swappable : _Is_swappable<_Ty>::type {
+    // Determine if _Ty lvalues satisfy is_swappable_with
+};
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_swappable_v = _Is_swappable<_Ty>::value;
+_NO_SPECIALIZATIONS constexpr bool is_swappable_v = _Is_swappable<_Ty>::value;
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
-struct is_nothrow_swappable_with : _Is_nothrow_swappable_with<_Ty1, _Ty2>::type {
+struct _NO_SPECIALIZATIONS is_nothrow_swappable_with : _Is_nothrow_swappable_with<_Ty1, _Ty2>::type {
     // Determine if expressions with type and value category _Ty1 and _Ty2
     // satisfy is_swappable_with, and can be swapped without emitting exceptions
 };
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
-constexpr bool is_nothrow_swappable_with_v = _Is_nothrow_swappable_with<_Ty1, _Ty2>::value;
+_NO_SPECIALIZATIONS constexpr bool is_nothrow_swappable_with_v = _Is_nothrow_swappable_with<_Ty1, _Ty2>::value;
 
 _EXPORT_STD template <class _Ty>
-struct is_nothrow_swappable : _Is_nothrow_swappable<_Ty>::type {
+struct _NO_SPECIALIZATIONS is_nothrow_swappable : _Is_nothrow_swappable<_Ty>::type {
     // Determine if _Ty lvalues satisfy is_nothrow_swappable_with
 };
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_nothrow_swappable_v = _Is_nothrow_swappable<_Ty>::value;
+_NO_SPECIALIZATIONS constexpr bool is_nothrow_swappable_v = _Is_nothrow_swappable<_Ty>::value;
 #endif // _HAS_CXX17
 
 namespace _Has_ADL_swap_detail {

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -158,7 +158,7 @@ struct _Ignore { // struct that ignores assignments
 _EXPORT_STD _INLINE_VAR constexpr _Ignore ignore{};
 
 _EXPORT_STD template <class... _Types>
-class tuple;
+class _NO_SPECIALIZATIONS tuple;
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 struct pair;
@@ -170,7 +170,7 @@ _EXPORT_STD template <class _Tuple>
 struct tuple_size;
 
 _EXPORT_STD template <class _Ty>
-constexpr size_t tuple_size_v = tuple_size<_Ty>::value;
+_NO_SPECIALIZATIONS constexpr size_t tuple_size_v = tuple_size<_Ty>::value;
 
 _EXPORT_STD template <size_t _Index, class _Tuple>
 struct tuple_element;

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -294,7 +294,7 @@ struct _CXX20_DEPRECATE_VOLATILE variant_size<volatile _Ty> : variant_size<_Ty>:
 template <class _Ty>
 struct _CXX20_DEPRECATE_VOLATILE variant_size<const volatile _Ty> : variant_size<_Ty>::type {};
 _EXPORT_STD template <class _Ty>
-constexpr size_t variant_size_v = variant_size<_Ty>::value;
+_NO_SPECIALIZATIONS constexpr size_t variant_size_v = variant_size<_Ty>::value;
 
 template <class... _Types>
 struct variant_size<variant<_Types...>> : integral_constant<size_t, sizeof...(_Types)> {};
@@ -928,7 +928,8 @@ template <size_t _Idx>
 constexpr bool _Is_in_place_index_specialization<in_place_index_t<_Idx>> = true;
 
 _EXPORT_STD template <class... _Types>
-class variant : private _SMF_control<_Variant_destroy_layer<_Types...>, _Types...> { // discriminated union
+class _NO_SPECIALIZATIONS variant
+    : private _SMF_control<_Variant_destroy_layer<_Types...>, _Types...> { // discriminated union
 public:
     static_assert(conjunction_v<is_object<_Types>..., negation<is_array<_Types>>..., is_destructible<_Types>...>,
         "variant<Types...> requires all of the Types to meet the Cpp17Destructible requirements "

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -756,8 +756,9 @@ struct _Default_allocator_traits { // traits for std::allocator
 };
 
 _EXPORT_STD template <class _Alloc>
-struct allocator_traits : conditional_t<_Is_default_allocator<_Alloc>::value, _Default_allocator_traits<_Alloc>,
-                              _Normal_allocator_traits<_Alloc>> {};
+struct _NO_SPECIALIZATIONS allocator_traits : conditional_t<_Is_default_allocator<_Alloc>::value,
+                                                  _Default_allocator_traits<_Alloc>, _Normal_allocator_traits<_Alloc>> {
+};
 
 // _Choose_pocca_v returns whether an attempt to propagate allocators is necessary in copy assignment operations.
 // Note that even when false_type, callers should call _Pocca as we want to assign allocators even when equal.

--- a/stl/inc/xtr1common
+++ b/stl/inc/xtr1common
@@ -23,7 +23,7 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 _EXPORT_STD template <class _Ty, _Ty _Val>
-struct integral_constant {
+struct _NO_SPECIALIZATIONS integral_constant {
     static constexpr _Ty value = _Val;
 
     using value_type = _Ty;
@@ -45,7 +45,7 @@ _EXPORT_STD using true_type  = bool_constant<true>;
 _EXPORT_STD using false_type = bool_constant<false>;
 
 _EXPORT_STD template <bool _Test, class _Ty = void>
-struct enable_if {}; // no member "type" when !_Test
+struct _NO_SPECIALIZATIONS enable_if {}; // no member "type" when !_Test
 
 template <class _Ty>
 struct enable_if<true, _Ty> { // type is _Ty for _Test
@@ -56,7 +56,7 @@ _EXPORT_STD template <bool _Test, class _Ty = void>
 using enable_if_t = typename enable_if<_Test, _Ty>::type;
 
 _EXPORT_STD template <bool _Test, class _Ty1, class _Ty2>
-struct conditional { // Choose _Ty1 if _Test is true, and _Ty2 otherwise
+struct _NO_SPECIALIZATIONS conditional { // Choose _Ty1 if _Test is true, and _Ty2 otherwise
     using type = _Ty1;
 };
 
@@ -70,22 +70,22 @@ using conditional_t = typename conditional<_Test, _Ty1, _Ty2>::type;
 
 #ifdef __clang__
 _EXPORT_STD template <class _Ty1, class _Ty2>
-constexpr bool is_same_v = __is_same(_Ty1, _Ty2);
+_NO_SPECIALIZATIONS constexpr bool is_same_v = __is_same(_Ty1, _Ty2);
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
-struct is_same : bool_constant<__is_same(_Ty1, _Ty2)> {};
+struct _NO_SPECIALIZATIONS is_same : bool_constant<__is_same(_Ty1, _Ty2)> {};
 #else // ^^^ Clang / not Clang vvv
 _EXPORT_STD template <class, class>
-constexpr bool is_same_v = false; // determine whether arguments are the same type
+_NO_SPECIALIZATIONS constexpr bool is_same_v = false; // determine whether arguments are the same type
 template <class _Ty>
 constexpr bool is_same_v<_Ty, _Ty> = true;
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
-struct is_same : bool_constant<is_same_v<_Ty1, _Ty2>> {};
+struct _NO_SPECIALIZATIONS is_same : bool_constant<is_same_v<_Ty1, _Ty2>> {};
 #endif // ^^^ not Clang ^^^
 
 _EXPORT_STD template <class _Ty>
-struct remove_const { // remove top-level const qualifier
+struct _NO_SPECIALIZATIONS remove_const { // remove top-level const qualifier
     using type = _Ty;
 };
 
@@ -98,7 +98,7 @@ _EXPORT_STD template <class _Ty>
 using remove_const_t = typename remove_const<_Ty>::type;
 
 _EXPORT_STD template <class _Ty>
-struct remove_volatile { // remove top-level volatile qualifier
+struct _NO_SPECIALIZATIONS remove_volatile { // remove top-level volatile qualifier
     using type = _Ty;
 };
 
@@ -111,7 +111,7 @@ _EXPORT_STD template <class _Ty>
 using remove_volatile_t = typename remove_volatile<_Ty>::type;
 
 _EXPORT_STD template <class _Ty>
-struct remove_cv { // remove top-level const and volatile qualifiers
+struct _NO_SPECIALIZATIONS remove_cv { // remove top-level const and volatile qualifiers
     using type = _Ty;
 
     template <template <class> class _Fn>
@@ -156,7 +156,7 @@ struct _Disjunction<false, _False, _Next, _Rest...> { // first trait is false, t
 };
 
 _EXPORT_STD template <class... _Traits>
-struct disjunction : false_type {}; // If _Traits is empty, false_type
+struct _NO_SPECIALIZATIONS disjunction : false_type {}; // If _Traits is empty, false_type
 
 template <class _First, class... _Rest>
 struct disjunction<_First, _Rest...> : _Disjunction<static_cast<bool>(_First::value), _First, _Rest...>::type {
@@ -164,7 +164,7 @@ struct disjunction<_First, _Rest...> : _Disjunction<static_cast<bool>(_First::va
 };
 
 _EXPORT_STD template <class... _Traits>
-constexpr bool disjunction_v = disjunction<_Traits...>::value;
+_NO_SPECIALIZATIONS constexpr bool disjunction_v = disjunction<_Traits...>::value;
 
 template <class _Ty, class... _Types>
 constexpr bool _Is_any_of_v = // true if and only if _Ty is in _Types
@@ -185,30 +185,31 @@ _EXPORT_STD _NODISCARD constexpr bool is_constant_evaluated() noexcept {
 #endif // _HAS_CXX20
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_integral_v = _Is_any_of_v<remove_cv_t<_Ty>, bool, char, signed char, unsigned char, wchar_t,
+_NO_SPECIALIZATIONS constexpr bool is_integral_v = _Is_any_of_v<remove_cv_t<_Ty>, bool, char, signed char,
+    unsigned char, wchar_t,
 #ifdef __cpp_char8_t
     char8_t,
 #endif // defined(__cpp_char8_t)
     char16_t, char32_t, short, unsigned short, int, unsigned int, long, unsigned long, long long, unsigned long long>;
 
 _EXPORT_STD template <class _Ty>
-struct is_integral : bool_constant<is_integral_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_integral : bool_constant<is_integral_v<_Ty>> {};
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_floating_point_v = _Is_any_of_v<remove_cv_t<_Ty>, float, double, long double>;
+_NO_SPECIALIZATIONS constexpr bool is_floating_point_v = _Is_any_of_v<remove_cv_t<_Ty>, float, double, long double>;
 
 _EXPORT_STD template <class _Ty>
-struct is_floating_point : bool_constant<is_floating_point_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_floating_point : bool_constant<is_floating_point_v<_Ty>> {};
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_arithmetic_v = // determine whether _Ty is an arithmetic type
+_NO_SPECIALIZATIONS constexpr bool is_arithmetic_v = // determine whether _Ty is an arithmetic type
     is_integral_v<_Ty> || is_floating_point_v<_Ty>;
 
 _EXPORT_STD template <class _Ty>
-struct is_arithmetic : bool_constant<is_arithmetic_v<_Ty>> {};
+struct _NO_SPECIALIZATIONS is_arithmetic : bool_constant<is_arithmetic_v<_Ty>> {};
 
 _EXPORT_STD template <class _Ty>
-struct remove_reference {
+struct _NO_SPECIALIZATIONS remove_reference {
     using type                 = _Ty;
     using _Const_thru_ref_type = const _Ty;
 };
@@ -239,7 +240,7 @@ _EXPORT_STD template <class _Ty>
 using remove_cvref_t = _Remove_cvref_t<_Ty>;
 
 _EXPORT_STD template <class _Ty>
-struct remove_cvref {
+struct _NO_SPECIALIZATIONS remove_cvref {
     using type = remove_cvref_t<_Ty>;
 };
 #endif // _HAS_CXX20

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1569,10 +1569,10 @@ using _Guide_pair_t =
 #endif // ^^^ !_HAS_CXX23 ^^^
 
 _EXPORT_STD template <class _Ty>
-struct is_execution_policy : false_type {};
+struct _NO_SPECIALIZATIONS is_execution_policy : false_type {};
 
 _EXPORT_STD template <class _Ty>
-constexpr bool is_execution_policy_v = is_execution_policy<_Ty>::value;
+_NO_SPECIALIZATIONS constexpr bool is_execution_policy_v = is_execution_policy<_Ty>::value;
 
 // Note: The noexcept specifiers on all parallel algorithm overloads enforce termination as per
 // N4950 [execpol.seq]/2, [execpol.par]/2, [execpol.parunseq]/2, and [execpol.unseq]/2

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -684,11 +684,13 @@
 #pragma push_macro("noop_dtor")
 #pragma push_macro("intrinsic")
 #pragma push_macro("lifetimebound")
+#pragma push_macro("no_specializations")
 #undef msvc
 #undef known_semantics
 #undef noop_dtor
 #undef intrinsic
 #undef lifetimebound
+#undef no_specializations
 
 #ifndef __has_cpp_attribute
 #define _HAS_MSVC_ATTRIBUTE(x) 0
@@ -731,6 +733,19 @@
 #define _MSVC_LIFETIMEBOUND
 #endif
 
+// Should we mark templates users shouldn't specialize with [[msvc::no_specializations]]
+// or [[clang::no_specializations]]?
+#if _HAS_MSVC_ATTRIBUTE(no_specializations)
+#define _NO_SPECIALIZATIONS_MSG(_Msg) [[msvc::no_specializations(_Msg)]]
+#elif defined(__has_cpp_attribute) && __has_cpp_attribute(_Clang::__no_specializations__)
+#define _NO_SPECIALIZATIONS_MSG(_Msg) [[_Clang::__no_specializations__(_Msg)]]
+#else
+#define _NO_SPECIALIZATIONS_MSG(_Msg)
+#endif
+
+#define _NO_SPECIALIZATIONS \
+    _NO_SPECIALIZATIONS_MSG("Users are not allowed to specialize this standard library template.")
+
 #if _HAS_CXX23 // TRANSITION, ABI, should just use [[no_unique_address]] when _HAS_CXX20.
 // Should we enable use of [[msvc::no_unique_address]] or [[no_unique_address]] to allow potentially-overlapping member
 // subobjects?
@@ -749,6 +764,7 @@
 #pragma pop_macro("noop_dtor")
 #pragma pop_macro("known_semantics")
 #pragma pop_macro("msvc")
+#pragma pop_macro("no_specializations")
 
 // warning C4577: 'noexcept' used with no exception handling mode specified;
 // termination on exception is not guaranteed. Specify /EHsc (/Wall)
@@ -808,6 +824,7 @@
 // warning C5278: adding a specialization for 'type trait' has undefined behavior
 // warning C5280: a static operator '()' requires at least '/std:c++23preview'
 // warning C5281: a static lambda requires at least '/std:c++23preview'
+// warning C5285: cannot declare a specialization for 'meow'
 // warning C6294: Ill-defined for-loop: initial condition does not satisfy test. Loop body not executed
 
 #ifndef _STL_DISABLED_WARNINGS
@@ -816,7 +833,7 @@
     4180 4324 4412 4455 4494 4514 4574 4582 4583 4587 \
     4588 4619 4623 4625 4626 4643 4648 4702 4793 4820 \
     4868 4988 5026 5027 5045 5220 5246 5278 5280 5281 \
-    6294                                              \
+    5285 6294                                         \
     _STL_DISABLED_WARNING_C4577                       \
     _STL_DISABLED_WARNING_C4984                       \
     _STL_DISABLED_WARNING_C5053                       \
@@ -833,18 +850,20 @@
 // warning: '#pragma float_control' is not supported on this target - ignored [-Wignored-pragmas]
 // warning: user-defined literal suffixes not starting with '_' are reserved [-Wuser-defined-literals]
 // warning: unknown pragma ignored [-Wunknown-pragmas]
+// warning: '%s' cannot be specialized [-Winvalid-specialization]
 #ifndef _STL_DISABLE_CLANG_WARNINGS
 #ifdef __clang__
 // clang-format off
-#define _STL_DISABLE_CLANG_WARNINGS                                 \
-    _Pragma("clang diagnostic push")                                \
-    _Pragma("clang diagnostic ignored \"-Wc++17-extensions\"")      \
-    _Pragma("clang diagnostic ignored \"-Wc++20-extensions\"")      \
-    _Pragma("clang diagnostic ignored \"-Wc++23-extensions\"")      \
-    _Pragma("clang diagnostic ignored \"-Wignored-attributes\"")    \
-    _Pragma("clang diagnostic ignored \"-Wignored-pragmas\"")       \
-    _Pragma("clang diagnostic ignored \"-Wuser-defined-literals\"") \
-    _Pragma("clang diagnostic ignored \"-Wunknown-pragmas\"")
+#define _STL_DISABLE_CLANG_WARNINGS                                  \
+    _Pragma("clang diagnostic push")                                 \
+    _Pragma("clang diagnostic ignored \"-Wc++17-extensions\"")       \
+    _Pragma("clang diagnostic ignored \"-Wc++20-extensions\"")       \
+    _Pragma("clang diagnostic ignored \"-Wc++23-extensions\"")       \
+    _Pragma("clang diagnostic ignored \"-Wignored-attributes\"")     \
+    _Pragma("clang diagnostic ignored \"-Wignored-pragmas\"")        \
+    _Pragma("clang diagnostic ignored \"-Wuser-defined-literals\"")  \
+    _Pragma("clang diagnostic ignored \"-Wunknown-pragmas\"")        \
+    _Pragma("clang diagnostic ignored \"-Winvalid-specialization\"")
 // clang-format on
 #else // ^^^ defined(__clang__) / !defined(__clang__) vvv
 #define _STL_DISABLE_CLANG_WARNINGS


### PR DESCRIPTION
This PR marks templates users shouldn't specialize with `[[msvc::no_specializations]]` or `[[clang::no_specializations]]`, depending on the compiler.

Resolves #5179.

The rule goes [namespace.std]:

- Specializing *class* templates is allowed, with the exception of:

  - `initializer_list`
  - `allocator_traits`
  - `coroutine_handle`
  - `compare_three_way_result`
  - `is_execution_policy`
  - `basic_format_arg`
  - `is_clock`
  - `generator`
  - `range_adaptor_closure`
  - `variant`
  - `tuple`

- Specializing *variable* templates is forbidden, with the exception of:

  - `format_kind`
  - `disable_sized_sentinel_for`
  - `enable_borrowed_range`
  - `disable_sized_range`
  - `enable_view`
  - `e_v`
  - `log2e_v`
  - `log10e_v`
  - `pi_v`
  - `inv_pi_v`
  - `inv_sqrtpi_v`
  - `ln2_v`
  - `ln10_v`
  - `sqrt2_v`
  - `sqrt3_v`
  - `inv_sqrt3_v`
  - `egamma_v`
  - `phi_v`

- Specializing *any* template in `<type_traits>` is forbidden, with the exception of:

  - `common_type`
  - `basic_common_reference`

- Specializing *function* templates is forbidden, but, following the decision made in #24, this PR doesn't touch any of them (except for `is_pointer_interconvertible_with_class` and `is_corresponding_member` in `<type_traits>`, as specializing those has *always* been forbidden).

Relevant: [PR implementing this warning in libc++](https://github.com/llvm/llvm-project/pull/118167)
