### PR TITLE
`<regex>`: Avoid generating unnecessary single-branch `_N_if` nodes

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -4125,6 +4125,9 @@ _BidIt _Matcher2<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Skip(_BidIt _First_arg
                 // GH-5452: If this node has two or more branches,
                 // examining all these branches has quadratic worst-case complexity.
                 // Thus, we only continue if this node has a single branch only.
+                // TRANSITION, ABI: After GH-5539, the parser no longer generates single-branch _N_if nodes.
+                // But we have to retain this special handling to avoid performance regression
+                // when an old parser gets mixed with a new matcher.
                 _Node_if* _Node = static_cast<_Node_if*>(_Nx);
 
                 if (_Node->_Child) {
@@ -4903,15 +4906,17 @@ void _Parser2<_FwdIt, _Elem, _RxTraits>::_Disjunction() { // check for valid dis
         _Nfa._End_group(_Pos3);
     }
 
-    _Node_base* _Pos2 = _Nfa._Begin_if(_Pos1);
-    while (_Mchar == _Meta_bar) { // append terms as long as we keep finding | characters
-        _Next();
-        if (!_Alternative()) { // zero-length trailing alternative
-            _Node_base* _Pos3 = _Nfa._Begin_group();
-            _Nfa._End_group(_Pos3);
-        }
+    if (_Mchar == _Meta_bar) {
+        _Node_base* _Pos2 = _Nfa._Begin_if(_Pos1);
+        do { // append terms as long as we keep finding | characters
+            _Next();
+            if (!_Alternative()) { // zero-length trailing alternative
+                _Node_base* _Pos3 = _Nfa._Begin_group();
+                _Nfa._End_group(_Pos3);
+            }
 
-        _Nfa._Else_if(_Pos1, _Pos2);
+            _Nfa._Else_if(_Pos1, _Pos2);
+        } while (_Mchar == _Meta_bar);
     }
 }
 
@@ -4979,6 +4984,17 @@ void _Parser2<_FwdIt, _Elem, _RxTraits>::_Calculate_loop_simplicity(
                 }
             }
             break;
+
+        case _N_group:
+        case _N_capture:
+            // TRANSITION, requires more research to decide on the subset of loops that we can make simple:
+            // - Simple mode can square the running time when matching a regex to an input string in the current matcher
+            // - The optimal subset of simple loops for a non-recursive rewrite of the matcher aren't clear yet
+            if (_Outer_rep) {
+                _Outer_rep->_Simple_loop = 0;
+            }
+            break;
+
         case _N_none:
         case _N_nop:
         case _N_bol:
@@ -4986,10 +5002,8 @@ void _Parser2<_FwdIt, _Elem, _RxTraits>::_Calculate_loop_simplicity(
         case _N_wbound:
         case _N_dot:
         case _N_str:
-        case _N_group:
         case _N_end_group:
         case _N_end_assert:
-        case _N_capture:
         case _N_end_capture:
         case _N_back:
         case _N_endif:


### PR DESCRIPTION
The parser likes to generate single-branch `_N_if` nodes in the NFA for no good reason. These nodes have a noticeable runtime cost in the matcher. This PR avoids generating these nodes.

This change has side effects:
* It strictly reduces the necessary recursion in the matcher to match a specific input string to a specific regex. This means that some strings that ran into a stack overflow or an `error_stack` exception before will match successfully after this PR.
* Conversely, this means that some `_Matcher2::_Do_rep()` calls can now take the place previously occupied by recursive calls of `_Matcher2::_Do_if()`. `_Matcher2::_Do_rep()` takes more bytes from the stack (I didn't check recently, but I remember it was about 100 bytes per call?), so there will be a very small set of input strings that will run into an actual stack overflow now instead of an `error_stack` exception.

Without further changes, there would be more side effects because some loops would get classified as simple now. However, I preempted this reclassification by adjusting `_Parser2::_Calculate_loop_simplicity()`. There are two reasons for this.
* The simple loop optimization, as implemented, reduces the required amount of stack space but in exchange can square the running time when matching some input strings to a regex. I think, though, that we could take this risk because the input strings couldn't be longer than a few hundred characters anyway before running into a stack overflow, so it's unlikely to make a major runtime difference in practice when matching didn't run into a stack overflow or `error_stack` exception before, and it's more important to make more regexes resistant against stack overflow. For example, if we were to allow the reclassification, this would fix the stack overflow for the regex in #997.
* The more important reason is that I'm not sure yet what the best subset of simple loops is for a non-recursive matcher, so I would like to retain more wiggle room here until the requirements become clearer while rewriting the matcher.

I added no new tests because (a) there is no obvious additional set of regexes to test and (b) this change affects the generated NFAs for all regexes without exception (all of them contained at least one single-branch `_N_if` node before), so the whole existing test suite serves as test coverage for this change.

### Benchmark
| Benchmark                     | Before       | After         | Speedup |
| ----------------------------- | ------------ | ------------- | ------- |
| bm_lorem_search/"bibe"/2      |     31145 ns |      28878 ns |    1.08 |
| bm_lorem_search/"bibe"/3      |     61384 ns |      57199 ns |    1.07 |
| bm_lorem_search/"bibe"/4      |    122768 ns |     114397 ns |    1.07 |
| bm_lorem_search/"(bibe)"/2    |     57812 ns |      43945 ns |    1.32 |
| bm_lorem_search/"(bibe)"/3    |    141246 ns |      92072 ns |    1.53 |
| bm_lorem_search/"(bibe)"/4    |    284934 ns |     187976 ns |    1.52 |
| bm_lorem_search/"(bibe)+"/2   |     92072 ns |      62779 ns |    1.47 | 
| bm_lorem_search/"(bibe)+"/3   |    179983 ns |     122768 ns |    1.47 |
| bm_lorem_search/"(bibe)+"/4   |    376607 ns |     256319 ns |    1.47 |
| bm_lorem_search/"(?:bibe)+"/2 |     55804 ns |      48652 ns |    1.15 |
| bm_lorem_search/"(?:bibe)+"/3 |    112305 ns |     96257 ns |    1.17 |
| bm_lorem_search/"(?:bibe)+"/4 |    224609 ns |     196725 ns |    1.14 |
