### PR TITLE
`<regex>`: Remove `error_syntax`

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -164,7 +164,7 @@ namespace regex_constants {
         error_complexity,
         error_stack,
         _Error_parse, // TRANSITION, was error_parse, keeping behavior
-        error_syntax
+        _Error_syntax // TRANSITION, was error_syntax, keeping behavior
     };
 } // namespace regex_constants
 
@@ -574,7 +574,7 @@ private:
                    "could match the specified character sequence.";
         case regex_constants::_Error_parse: // TRANSITION, keeping behavior
             return "regex_error(error_parse)";
-        case regex_constants::error_syntax:
+        case regex_constants::_Error_syntax:
             return "regex_error(error_syntax)";
         default:
             return "regex_error";
@@ -4596,7 +4596,7 @@ bool _Parser2<_FwdIt, _Elem, _RxTraits>::_Wrapped_disjunction() { // add disjunc
             --_Disj_count;
             return false;
         } else {
-            _Error(regex_constants::error_syntax);
+            _Error(regex_constants::error_badrepeat);
         }
     } else if (_Flags & regex_constants::nosubs) {
         _Do_noncapture_group();
@@ -5007,9 +5007,7 @@ _Root_node* _Parser2<_FwdIt, _Elem, _RxTraits>::_Compile() { // compile regular 
     _Tidy_guard<decltype(_Nfa)> _Guard{_STD addressof(_Nfa)};
     _Node_base* _Pos1 = _Nfa._Begin_capture_group(0);
     _Disjunction();
-    if (_Pat != _End) {
-        _Error(regex_constants::error_syntax);
-    }
+    _STL_INTERNAL_CHECK(_Pat == _End);
 
     _Nfa._End_group(_Pos1);
     _Res         = _Nfa._End_pattern();

--- a/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
@@ -3,6 +3,7 @@
 
 #define ISA_AVAILABILITY delete
 #define error_parse      delete
+#define error_syntax     delete
 #define nsec             delete
 #define sec              delete
 #define xtime            delete

--- a/tests/std/tests/VSO_0000000_regex_use/test.cpp
+++ b/tests/std/tests/VSO_0000000_regex_use/test.cpp
@@ -307,8 +307,8 @@ void test_dev10_897466_regex_should_support_more_than_31_capture_groups() {
 }
 
 void test_regex_should_throw_for_lookbehind() {
-    g_regexTester.should_throw(R"((?<=abc))", error_syntax);
-    g_regexTester.should_throw(R"((?<!abc))", error_syntax);
+    g_regexTester.should_throw(R"((?<=abc))", error_badrepeat);
+    g_regexTester.should_throw(R"((?<!abc))", error_badrepeat);
 }
 
 void test_regex_simple_loop_detection_enters_alternations_and_assertions() {


### PR DESCRIPTION
Resolves #438. There were two remaining uses of `error_syntax`:

* One is in the region parsing non-capturing groups and assertions. If it is not one of these, then `?` is essentially a quantifier applied to nothing, so `error_badrepeat` seems an apt choice among the available codes to me. (The error code `error_paren` used by libstdc++ feels a bit weird to me in this context because this error code is intended for unbalanced parentheses, which this isn't.)
* The other case can only be reached by an STL or compiler bug, so I replaced it by `_STL_INTERNAL_CHECK`: `_Alternative()` only returns normally when `_Mchar` is `_Meta_eos`, `_Meta_bar` or it is `_Meta_rpar` while `_Disj_count != 0`. Its caller, `_Disjunction()`, only returns if `_Mchar` is not `_Meta_bar` after `_Alternative()` returned. So this means the error could only be thrown when `_Mchar` is `_Meta_eos` or `_Meta_rpar` with `_Disj_count != 0`. But in either case, this is a bug in the parser: Either `_Meta_eos` was assigned to `_Mchar` before the end of the regex was reached (but see `_Trans()` for the only case where `_Meta_eos` is assigned) or an unbalanced number of increments and decrements to `Disj_count` were performed.