### PR TITLE
`<vector>`: Avoid a compiler warning with Defect Report P2280R4

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -3193,8 +3193,11 @@ public:
     }
 
     _NODISCARD _CONSTEXPR20 size_type max_size() const noexcept {
-        constexpr auto _Diff_max  = static_cast<size_type>(_STD _Max_limit<difference_type>());
-        const size_type _Ints_max = this->_Myvec.max_size();
+        constexpr auto _Diff_max = static_cast<size_type>(_STD _Max_limit<difference_type>());
+
+        // _Ints_max is non-const to avoid warning C4127 "conditional expression is constant" with Defect Report P2280R4
+        size_type _Ints_max = this->_Myvec.max_size();
+
         if (_Ints_max > _Diff_max / _VBITS) { // max_size bound by difference_type limits
             return _Diff_max;
         }

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -3196,7 +3196,7 @@ public:
         constexpr auto _Diff_max  = static_cast<size_type>(_STD _Max_limit<difference_type>());
         const size_type _Ints_max = this->_Myvec.max_size();
 
-        // Avoid warning C4127 "conditional expression is constant" with Defect Report P2280R4
+        // Use a const bool to avoid warning C4127 "conditional expression is constant" with Defect Report P2280R4
         const bool _Would_overflow = _Ints_max > _Diff_max / _VBITS;
         if (_Would_overflow) { // max_size bound by difference_type limits
             return _Diff_max;

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -3193,12 +3193,12 @@ public:
     }
 
     _NODISCARD _CONSTEXPR20 size_type max_size() const noexcept {
-        constexpr auto _Diff_max = static_cast<size_type>(_STD _Max_limit<difference_type>());
+        constexpr auto _Diff_max  = static_cast<size_type>(_STD _Max_limit<difference_type>());
+        const size_type _Ints_max = this->_Myvec.max_size();
 
-        // _Ints_max is non-const to avoid warning C4127 "conditional expression is constant" with Defect Report P2280R4
-        size_type _Ints_max = this->_Myvec.max_size();
-
-        if (_Ints_max > _Diff_max / _VBITS) { // max_size bound by difference_type limits
+        // Avoid warning C4127 "conditional expression is constant" with Defect Report P2280R4
+        const bool _Would_overflow = _Ints_max > _Diff_max / _VBITS;
+        if (_Would_overflow) { // max_size bound by difference_type limits
             return _Diff_max;
         }
 


### PR DESCRIPTION
@Codiferous is implementing WG21-P2280R4 in MSVC. With this Defect Report implemented, MSVC emits its (extremely annoying) warning C4127 "conditional expression is constant" for `vector<bool>::max_size()`, because we marked a local variable as `const` and that causes "trial evaluation" to happen. With WG21-P2280R4, `_Ints_max` is recognized as a compile-time constant, causing the `if`-statement below to emit the warning.

Unfortunately, the underlying `vector`'s `max_size()` has to be implemented in terms of the allocator's `max_size()`, and there's no requirement that it be a compile-time constant. So we can't just boil this whole thing down to an `if constexpr`.

To avoid this, we can extract the condition into a `const bool` and add a comment why. C4127 has a special case to avoid warnings when a single variable is being tested.

(I am somewhat tempted to globally suppress C4127 in STL headers, but it hasn't been quite enough of a nuisance to resort to that... yet.)