### PR TITLE
Update `source_location` tests for upcoming EDG changes

### DIFF
--- a/tests/std/tests/P1208R6_source_location/header.h
+++ b/tests/std/tests/P1208R6_source_location/header.h
@@ -18,11 +18,11 @@ constexpr void header_test() {
     assert(x.column() == 37);
 #endif // ^^^ C1XX ^^^
 #if _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
-#ifdef __EDG__
-    assert(x.function_name() == "void header_test()"sv);
-#else // ^^^ EDG / Other vvv
+#ifdef __EDG__ // TRANSITION, EDG is changing to match C1XX's output
+    assert(x.function_name() == "void __cdecl header_test(void)"sv || x.function_name() == "void header_test()"sv);
+#else // ^^^ workaround / no workaround vvv
     assert(x.function_name() == "void __cdecl header_test(void)"sv);
-#endif // ^^^ Other ^^^
+#endif // ^^^ no workaround ^^^
 #else // ^^^ detailed / basic vvv
     assert(x.function_name() == "header_test"sv);
 #endif // ^^^ basic ^^^

--- a/tests/std/tests/P1208R6_source_location/test.cpp
+++ b/tests/std/tests/P1208R6_source_location/test.cpp
@@ -68,11 +68,11 @@ constexpr void local_test() {
     assert(x.column() == 37);
 #endif // ^^^ C1XX ^^^
 #if _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
-#ifdef __EDG__
-    assert(x.function_name() == "void local_test()"sv);
-#else // ^^^ EDG / Other vvv
+#ifdef __EDG__ // TRANSITION, EDG is changing to match C1XX's output
+    assert(x.function_name() == "void __cdecl local_test(void)"sv || x.function_name() == "void local_test()"sv);
+#else // ^^^ workaround / no workaround vvv
     assert(x.function_name() == "void __cdecl local_test(void)"sv);
-#endif // ^^^ Other ^^^
+#endif // ^^^ no workaround ^^^
 #else // ^^^ detailed / basic vvv
     assert(x.function_name() == "local_test"sv);
 #endif // ^^^ basic ^^^
@@ -84,11 +84,11 @@ constexpr void argument_test(
     assert(x.line() == line);
     assert(x.column() == column);
 #if _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
-#ifdef __EDG__
-    assert(x.function_name() == "bool test()"sv);
-#else // ^^^ EDG / Other vvv
+#ifdef __EDG__ // TRANSITION, EDG is changing to match C1XX's output
+    assert(x.function_name() == "bool __cdecl test(void)"sv || x.function_name() == "bool test()"sv);
+#else // ^^^ workaround / no workaround vvv
     assert(x.function_name() == "bool __cdecl test(void)"sv);
-#endif // ^^^ Other ^^^
+#endif // ^^^ no workaround ^^^
 #else // ^^^ detailed / basic vvv
     assert(x.function_name() == "test"sv);
 #endif // ^^^ basic ^^^
@@ -110,11 +110,12 @@ constexpr void sloc_constructor_test() {
     } else
 #endif // ^^^ workaround ^^^
     {
-#ifdef __EDG__
-        assert(x.loc.function_name() == "void sloc_constructor_test()"sv);
-#else // ^^^ EDG / Other vvv
+#ifdef __EDG__ // TRANSITION, EDG is changing to match C1XX's output
+        assert(x.loc.function_name() == "void __cdecl sloc_constructor_test(void)"sv
+               || x.loc.function_name() == "void sloc_constructor_test()"sv);
+#else // ^^^ workaround / no workaround vvv
         assert(x.loc.function_name() == "void __cdecl sloc_constructor_test(void)"sv);
-#endif // ^^^ Other ^^^
+#endif // ^^^ no workaround ^^^
     }
 #else // ^^^ detailed / basic vvv
 #if !defined(__clang__) && !defined(__EDG__) // TRANSITION, VSO-1285783
@@ -140,11 +141,11 @@ constexpr void different_constructor_test() {
     assert(x.loc.column() == 5);
 #endif // ^^^ C1XX ^^^
 #if _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
-#ifdef __EDG__
-    assert(x.loc.function_name() == "s::s(int)"sv);
-#else // ^^^ EDG / Other vvv
+#ifdef __EDG__ // TRANSITION, EDG is changing to match C1XX's output
+    assert(x.loc.function_name() == THISCALL_OR_CDECL " s::s(int)"sv || x.loc.function_name() == "s::s(int)"sv);
+#else // ^^^ workaround / no workaround vvv
     assert(x.loc.function_name() == THISCALL_OR_CDECL " s::s(int)"sv);
-#endif // ^^^ Other ^^^
+#endif // ^^^ no workaround ^^^
 #else // ^^^ detailed / basic vvv
     assert(x.loc.function_name() == "s"sv);
 #endif // ^^^ basic ^^^
@@ -166,11 +167,12 @@ constexpr void sub_member_test() {
     } else
 #endif // ^^^ workaround ^^^
     {
-#ifdef __EDG__
-        assert(s.x.loc.function_name() == "void sub_member_test()"sv);
-#else // ^^^ EDG / Other vvv
+#ifdef __EDG__ // TRANSITION, EDG is changing to match C1XX's output
+        assert(s.x.loc.function_name() == "void __cdecl sub_member_test(void)"sv
+               || s.x.loc.function_name() == "void sub_member_test()"sv);
+#else // ^^^ workaround / no workaround vvv
         assert(s.x.loc.function_name() == "void __cdecl sub_member_test(void)"sv);
-#endif // ^^^ Other ^^^
+#endif // ^^^ no workaround ^^^
     }
 #else // ^^^ detailed / basic vvv
 #if !defined(__clang__) && !defined(__EDG__) // TRANSITION, VSO-1285783
@@ -194,11 +196,12 @@ constexpr void sub_member_test() {
     assert(s_i.x.loc.column() == 5);
 #endif // ^^^ C1XX ^^^
 #if _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
-#ifdef __EDG__
-    assert(s_i.x.loc.function_name() == "s2::s2(int)"sv);
-#else // ^^^ EDG / Other vvv
+#ifdef __EDG__ // TRANSITION, EDG is changing to match C1XX's output
+    assert(s_i.x.loc.function_name() == THISCALL_OR_CDECL " s2::s2(int)"sv
+           || s_i.x.loc.function_name() == "s2::s2(int)"sv);
+#else // ^^^ workaround / no workaround vvv
     assert(s_i.x.loc.function_name() == THISCALL_OR_CDECL " s2::s2(int)"sv);
-#endif // ^^^ Other ^^^
+#endif // ^^^ no workaround ^^^
 #else // ^^^ detailed / basic vvv
     assert(s_i.x.loc.function_name() == "s2"sv);
 #endif // ^^^ basic ^^^
@@ -223,11 +226,11 @@ constexpr void lambda_test() {
     assert(x2.column() == 50);
 #endif // ^^^ C1XX ^^^
 #if _USE_DETAILED_FUNCTION_NAME_IN_SOURCE_LOCATION
-#ifdef __EDG__
-    assert(x1.function_name() == "void lambda_test()"sv);
-#else // ^^^ EDG / Other vvv
+#ifdef __EDG__ // TRANSITION, EDG is changing to match C1XX's output
+    assert(x1.function_name() == "void __cdecl lambda_test(void)"sv || x1.function_name() == "void lambda_test()"sv);
+#else // ^^^ workaround / no workaround vvv
     assert(x1.function_name() == "void __cdecl lambda_test(void)"sv);
-#endif // ^^^ Other ^^^
+#endif // ^^^ no workaround ^^^
 #else // ^^^ detailed / basic vvv
     assert(x1.function_name() == "lambda_test"sv);
 #endif // ^^^ basic ^^^
@@ -241,7 +244,9 @@ constexpr void lambda_test() {
 #elif defined(__clang__) // ^^^ basic / detailed Clang vvv
     assert(fun2 == "auto " THISCALL_OR_CDECL " lambda_test()::(anonymous class)::operator()(void) const"sv);
 #elif defined(__EDG__) // ^^^ detailed Clang / detailed __EDG__ vvv
-    assert(fun2 == "lambda []()->auto::operator()()->auto"sv);
+    // TRANSITION, EDG is changing to resemble C1XX's output somewhat more closely
+    assert(fun2 == THISCALL_OR_CDECL " lambda [](void)->auto::operator()(void)->auto"sv
+           || fun2 == "lambda []()->auto::operator()()->auto"sv);
 #else // ^^^ detailed __EDG__ / detailed C1XX vvv
     assert(fun2.starts_with("struct std::source_location " THISCALL_OR_CDECL " lambda_test::<lambda_"sv));
     assert(fun2.ends_with("::operator ()(void) const"sv));
@@ -270,7 +275,9 @@ constexpr void function_template_test() {
 #elif defined(__clang__) // ^^^ basic / detailed Clang vvv
     assert(x1.function_name() == "source_location __cdecl function_template(void) [T = void]"sv);
 #elif defined(__EDG__) // ^^^ detailed Clang / detailed __EDG__ vvv
-    assert(x1.function_name() == "std::source_location function_template<void>()"sv);
+    // TRANSITION, EDG is changing to almost match C1XX's output
+    assert(x1.function_name() == "std::source_location __cdecl function_template<void>(void)"sv
+           || x1.function_name() == "std::source_location function_template<void>()"sv);
 #else // ^^^ detailed __EDG__ / detailed C1XX vvv
     assert(x1.function_name() == "struct std::source_location __cdecl function_template<void>(void)"sv);
 #endif // ^^^ detailed C1XX ^^^
@@ -284,7 +291,9 @@ constexpr void function_template_test() {
 #elif defined(__clang__) // ^^^ basic / detailed Clang vvv
     assert(x2.function_name() == "source_location __cdecl function_template(void) [T = int]"sv);
 #elif defined(__EDG__) // ^^^ detailed Clang / detailed __EDG__ vvv
-    assert(x2.function_name() == "std::source_location function_template<int>()"sv);
+    // TRANSITION, EDG is changing to almost match C1XX's output
+    assert(x2.function_name() == "std::source_location __cdecl function_template<int>(void)"sv
+           || x2.function_name() == "std::source_location function_template<int>()"sv);
 #else // ^^^ detailed __EDG__ / detailed C1XX vvv
     assert(x2.function_name() == "struct std::source_location __cdecl function_template<int>(void)"sv);
 #endif // ^^^ detailed C1XX ^^^


### PR DESCRIPTION
EDG is changing their `source_location` builtins to produce output that more closely resembles C1XX's. To keep our tests passing as these changes are introduced into VS, I'm updating the tests to accept either the old output or the new output. After the changes have shipped and we can update the toolset on GitHub, I can remove the old expected outputs.

@jgoshi has validated that this passes with the upcoming changes.