### PR TITLE
`tzdb.cpp`: Fall back to numeric offset when the current code page cannot represent the time zone short ID

### DIFF
--- a/stl/src/tzdb.cpp
+++ b/stl/src/tzdb.cpp
@@ -567,7 +567,7 @@ void __stdcall __std_tzdb_delete_current_zone(__std_tzdb_current_zone_info* cons
 
     _Info->_Abbrev = _Allocate_wide_to_narrow(_Abbrev.get(), _Abbrev_len, _Info->_Err);
     if (_Info->_Abbrev == nullptr) {
-        const auto _Fallback_abbrev = new (_STD nothrow) char[]{"+0000"};
+        _STD unique_ptr<char[]> _Fallback_abbrev{new (_STD nothrow) char[]{"+0000"}};
 
         if (_Fallback_abbrev == nullptr) {
             return nullptr;
@@ -590,7 +590,7 @@ void __stdcall __std_tzdb_delete_current_zone(__std_tzdb_current_zone_info* cons
         }
 
         _Info->_Err    = __std_tzdb_error::_Success;
-        _Info->_Abbrev = _Fallback_abbrev;
+        _Info->_Abbrev = _Fallback_abbrev.release();
     }
 
     return _Info.release();

--- a/stl/src/tzdb.cpp
+++ b/stl/src/tzdb.cpp
@@ -567,16 +567,16 @@ void __stdcall __std_tzdb_delete_current_zone(__std_tzdb_current_zone_info* cons
 
     _Info->_Abbrev = _Allocate_wide_to_narrow(_Abbrev.get(), _Abbrev_len, _Info->_Err);
     if (_Info->_Abbrev == nullptr) {
-        _STD unique_ptr<char[]> _Fallback_abbrev{new (_STD nothrow) char[]{"+0000"}};
-
-        if (_Fallback_abbrev == nullptr) {
-            return nullptr;
-        }
-
         const auto _Abs_offset        = _Info->_Offset < 0 ? -_Info->_Offset : _Info->_Offset;
         const auto _Offset_in_minutes = _Abs_offset / (60 * 1000);
         const auto _Hours             = _Offset_in_minutes / 60;
         const auto _Mins              = _Offset_in_minutes % 60;
+
+        _STD unique_ptr<char[]> _Fallback_abbrev{new (_STD nothrow) char[_Mins == 0 ? 4 : 6]};
+
+        if (_Fallback_abbrev == nullptr) {
+            return nullptr;
+        }
 
         _Fallback_abbrev[0] = _Info->_Offset < 0 ? '-' : '+';
         _Fallback_abbrev[1] = static_cast<char>('0' + _Hours / 10);
@@ -587,6 +587,7 @@ void __stdcall __std_tzdb_delete_current_zone(__std_tzdb_current_zone_info* cons
         } else {
             _Fallback_abbrev[3] = static_cast<char>('0' + _Mins / 10);
             _Fallback_abbrev[4] = static_cast<char>('0' + _Mins % 10);
+            _Fallback_abbrev[5] = '\0';
         }
 
         _Info->_Err    = __std_tzdb_error::_Success;

--- a/stl/src/tzdb.cpp
+++ b/stl/src/tzdb.cpp
@@ -567,7 +567,30 @@ void __stdcall __std_tzdb_delete_current_zone(__std_tzdb_current_zone_info* cons
 
     _Info->_Abbrev = _Allocate_wide_to_narrow(_Abbrev.get(), _Abbrev_len, _Info->_Err);
     if (_Info->_Abbrev == nullptr) {
-        return _Propagate_error(_Info);
+        const auto _Fallback_abbrev = new (_STD nothrow) char[]{"+0000"};
+
+        if (_Fallback_abbrev == nullptr) {
+            return nullptr;
+        }
+
+        const auto _Abs_offset        = _Info->_Offset < 0 ? -_Info->_Offset : _Info->_Offset;
+        const auto _Offset_in_minutes = _Abs_offset / (60 * 1000);
+        const auto _Hours             = _Offset_in_minutes / 60;
+        const auto _Mins              = _Offset_in_minutes % 60;
+
+        _Fallback_abbrev[0] = _Info->_Offset < 0 ? '-' : '+';
+        _Fallback_abbrev[1] = static_cast<char>('0' + _Hours / 10);
+        _Fallback_abbrev[2] = static_cast<char>('0' + _Hours % 10);
+
+        if (_Mins == 0) {
+            _Fallback_abbrev[3] = '\0';
+        } else {
+            _Fallback_abbrev[3] = static_cast<char>('0' + _Mins / 10);
+            _Fallback_abbrev[4] = static_cast<char>('0' + _Mins % 10);
+        }
+
+        _Info->_Err    = __std_tzdb_error::_Success;
+        _Info->_Abbrev = _Fallback_abbrev;
     }
 
     return _Info.release();


### PR DESCRIPTION
This PR adds a fallback time zone abbreviation of the form  `-05` or `+0530` when the system's code page cannot represent the localized time zone short ID produced by ICU. Previously such time zone short ID would result in `ERROR_NO_UNICODE_TRANSLATION` exceptions.

The numeric offset form (`-05` or `+0530`) is chosen because it is similar to the time zone abbreviation in [`tzdb`](https://data.iana.org/time-zones/tzdb/theory.html#abbreviations), and distinguishable from ICU's output.

The behavior depends on the current user locale and the current code page. For [ICU 77.1](https://github.com/unicode-org/icu/tree/release-77-1), the following locales have time zone short ID with non-ASCII characters, and thus might be affected by this fallback: `am`, `ar`, `as`, `bg`, `blo`, `brx`, `ckb`, `cs`, `dz`, `fa`, `ff_Adlm`, `ga`, `gd`, `he`, `hi`, `ii`, `km`, `ks`, `ks_Deva`, `ku`, `mai`, `ml`, `mni`, `nqo`, `sa`, `sat`, `sd`, `sd_Deva`, `si`, `sk`, `vi`, `xnr`.

No tests are added because the `en` locale is unaffected.

Fixes #3158 
Fixes #5482 
