### PR TITLE
`<filesystem>`: Fix the `path` returned when there is an error with `temp_directory_path` and simplify the validation logic

### DIFF
--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -618,6 +618,7 @@ namespace filesystem {
         friend inline path absolute(const path& _Input, error_code& _Ec);
         friend inline __std_win_error _Canonical(path& _Result, const wstring& _Text);
         friend inline path temp_directory_path(error_code& _Ec);
+        friend inline path temp_directory_path();
         friend inline path current_path(error_code& _Ec);
         friend inline void current_path(const path& _To);
         friend inline void current_path(const path& _To, error_code& _Ec) noexcept;
@@ -3945,7 +3946,7 @@ namespace filesystem {
         if (_Error == __std_win_error::_Success) {
             _Result = file_time_type{file_time_type::duration{_Stats._Last_write_time}};
         } else {
-            _Result = (file_time_type::min)();
+            _Result = (file_time_type::min) ();
         }
 
         return _Error;
@@ -4045,11 +4046,12 @@ namespace filesystem {
         path _Result;
         _Result._Text.resize(__std_fs_temp_path_max);
         const auto _Temp_result = __std_fs_get_temp_path(_Result._Text.data());
-        _Result._Text.resize(_Temp_result._Size);
-        if (_Temp_result._Error == __std_win_error::_Max) { // path could be retrieved, but was not a directory
-            _Ec = _STD make_error_code(errc::not_a_directory);
-        } else {
+        if (_Temp_result._Error != __std_win_error::_Success) {
+            // When there is an error, returns path() (N5008 [fs.op.temp.dir.path]/3)
+            _Result._Text.clear();
             _Ec = _Make_ec(_Temp_result._Error);
+        } else {
+            _Result._Text.resize(_Temp_result._Size);
         }
 
         return _Result;
@@ -4057,11 +4059,15 @@ namespace filesystem {
 
     _EXPORT_STD _NODISCARD inline path temp_directory_path() {
         // get a location suitable for temporary storage, and verify that it is a directory
-        error_code _Ec; // unusual arrangement to allow thrown error_code to have generic_category()
-        path _Result(_STD filesystem::temp_directory_path(_Ec));
-        if (_Ec) {
-            _Throw_fs_error("temp_directory_path", _Ec, _Result);
+        error_code _Ec;
+        path _Result;
+        _Result._Text.resize(__std_fs_temp_path_max);
+        const auto _Temp_result = __std_fs_get_temp_path(_Result._Text.data());
+        _Result._Text.resize(_Temp_result._Size);
+        if (_Temp_result._Error != __std_win_error::_Success) {
+            _Throw_fs_error("temp_directory_path", _Make_ec(_Temp_result._Error), _Result);
         }
+
         return _Result;
     }
 

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -3946,7 +3946,7 @@ namespace filesystem {
         if (_Error == __std_win_error::_Success) {
             _Result = file_time_type{file_time_type::duration{_Stats._Last_write_time}};
         } else {
-            _Result = (file_time_type::min) ();
+            _Result = (file_time_type::min)();
         }
 
         return _Error;

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -827,7 +827,7 @@ namespace {
                 reinterpret_cast<HANDLE>(_Handle), FileBasicInfo, &_Ex_info, sizeof(_Ex_info))) {
             _Result._Error = __std_win_error{GetLastError()};
         } else if (!(_Ex_info.FileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
-            _Result._Error = __std_win_error::_Max;
+            _Result._Error = __std_win_error::_Directory_name_is_invalid;
         }
 
         __std_fs_close_handle(_Handle);

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -807,26 +807,27 @@ namespace {
 [[nodiscard]] _Success_(return._Error == __std_win_error::_Success) __std_ulong_and_error
     __stdcall __std_fs_get_temp_path(_Out_writes_z_(__std_fs_temp_path_max) wchar_t* const _Target) noexcept {
     // calls GetTempPath2W if available (Win11+), else calls GetTempPathW
-    // When there is an error, returns 0 size (N5008 [fs.op.temp.dir.path]/3); otherwise,
-    // returns the size of the expected directory.
-    const auto _Size = _Stl_GetTempPath2W(__std_fs_temp_path_max, _Target);
-    if (_Size == 0) {
-        return {0, __std_win_error{GetLastError()}};
+    // If getting the path failed, returns 0 size; otherwise, returns the size of the
+    // expected directory. If the path could be resolved to an existing directory,
+    // returns __std_win_error::_Success; otherwise, returns __std_win_error::_Max.
+    __std_ulong_and_error _Result{_Stl_GetTempPath2W(__std_fs_temp_path_max, _Target), __std_win_error{GetLastError()}};
+    if (_Result._Size == 0) {
+        return _Result;
     }
 
     // Effects: If exists(p) is false or is_directory(p) is false, an error is reported
     __std_fs_file_handle _Handle;
-    __std_ulong_and_error _Result{};
+
     // Following symlinks
     _Result._Error = __std_fs_open_handle(
         &_Handle, _Target, __std_access_rights::_File_read_attributes, __std_fs_file_flags::_Backup_semantics);
     if (_Handle != __std_fs_file_handle::_Invalid) {
         FILE_BASIC_INFO _Ex_info;
-        if (GetFileInformationByHandleEx(reinterpret_cast<HANDLE>(_Handle), FileBasicInfo, &_Ex_info, sizeof(_Ex_info))
-            && _Ex_info.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-            _Result._Size = _Size;
-        } else {
+        if (!GetFileInformationByHandleEx(
+                reinterpret_cast<HANDLE>(_Handle), FileBasicInfo, &_Ex_info, sizeof(_Ex_info))) {
             _Result._Error = __std_win_error{GetLastError()};
+        } else if (!(_Ex_info.FileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+            _Result._Error = __std_win_error::_Max;
         }
 
         __std_fs_close_handle(_Handle);

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -2532,11 +2532,11 @@ void test_conversions() {
 
     static_assert(!is_constructible_v<path, basic_string<signed char>>);
     static_assert(!is_constructible_v<path, basic_string_view<signed char>>);
-    static_assert(!is_constructible_v<path, const signed char (&)[5]>);
+    static_assert(!is_constructible_v<path, const signed char(&)[5]>);
     static_assert(!is_constructible_v<path, const signed char*>);
     static_assert(!is_constructible_v<path, basic_string<unsigned char>>);
     static_assert(!is_constructible_v<path, basic_string_view<unsigned char>>);
-    static_assert(!is_constructible_v<path, const unsigned char (&)[5]>);
+    static_assert(!is_constructible_v<path, const unsigned char(&)[5]>);
     static_assert(!is_constructible_v<path, const unsigned char*>);
     static_assert(!is_constructible_v<path, char>);
     static_assert(!is_constructible_v<path, double>);

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -2494,14 +2494,14 @@ void test_conversions() {
     static_assert(is_constructible_v<path, basic_string_view<char16_t, MyTraits<char16_t>>>);
     static_assert(is_constructible_v<path, basic_string_view<char32_t, MyTraits<char32_t>>>);
 
-    static_assert(is_constructible_v<path, char (&)[5]>);
+    static_assert(is_constructible_v<path, char(&)[5]>);
     static_assert(is_constructible_v<path, wchar_t(&)[5]>);
-    static_assert(is_constructible_v<path, char16_t (&)[5]>);
-    static_assert(is_constructible_v<path, char32_t (&)[5]>);
-    static_assert(is_constructible_v<path, const char (&)[5]>);
+    static_assert(is_constructible_v<path, char16_t(&)[5]>);
+    static_assert(is_constructible_v<path, char32_t(&)[5]>);
+    static_assert(is_constructible_v<path, const char(&)[5]>);
     static_assert(is_constructible_v<path, const wchar_t(&)[5]>);
-    static_assert(is_constructible_v<path, const char16_t (&)[5]>);
-    static_assert(is_constructible_v<path, const char32_t (&)[5]>);
+    static_assert(is_constructible_v<path, const char16_t(&)[5]>);
+    static_assert(is_constructible_v<path, const char32_t(&)[5]>);
 
     static_assert(is_constructible_v<path, char*>);
     static_assert(is_constructible_v<path, wchar_t*>);

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -2494,14 +2494,14 @@ void test_conversions() {
     static_assert(is_constructible_v<path, basic_string_view<char16_t, MyTraits<char16_t>>>);
     static_assert(is_constructible_v<path, basic_string_view<char32_t, MyTraits<char32_t>>>);
 
-    static_assert(is_constructible_v<path, char(&)[5]>);
+    static_assert(is_constructible_v<path, char (&)[5]>);
     static_assert(is_constructible_v<path, wchar_t(&)[5]>);
-    static_assert(is_constructible_v<path, char16_t(&)[5]>);
-    static_assert(is_constructible_v<path, char32_t(&)[5]>);
-    static_assert(is_constructible_v<path, const char(&)[5]>);
+    static_assert(is_constructible_v<path, char16_t (&)[5]>);
+    static_assert(is_constructible_v<path, char32_t (&)[5]>);
+    static_assert(is_constructible_v<path, const char (&)[5]>);
     static_assert(is_constructible_v<path, const wchar_t(&)[5]>);
-    static_assert(is_constructible_v<path, const char16_t(&)[5]>);
-    static_assert(is_constructible_v<path, const char32_t(&)[5]>);
+    static_assert(is_constructible_v<path, const char16_t (&)[5]>);
+    static_assert(is_constructible_v<path, const char32_t (&)[5]>);
 
     static_assert(is_constructible_v<path, char*>);
     static_assert(is_constructible_v<path, wchar_t*>);
@@ -2532,11 +2532,11 @@ void test_conversions() {
 
     static_assert(!is_constructible_v<path, basic_string<signed char>>);
     static_assert(!is_constructible_v<path, basic_string_view<signed char>>);
-    static_assert(!is_constructible_v<path, const signed char(&)[5]>);
+    static_assert(!is_constructible_v<path, const signed char (&)[5]>);
     static_assert(!is_constructible_v<path, const signed char*>);
     static_assert(!is_constructible_v<path, basic_string<unsigned char>>);
     static_assert(!is_constructible_v<path, basic_string_view<unsigned char>>);
-    static_assert(!is_constructible_v<path, const unsigned char(&)[5]>);
+    static_assert(!is_constructible_v<path, const unsigned char (&)[5]>);
     static_assert(!is_constructible_v<path, const unsigned char*>);
     static_assert(!is_constructible_v<path, char>);
     static_assert(!is_constructible_v<path, double>);
@@ -3569,15 +3569,15 @@ void test_temp_directory_path() {
         (void) temp_directory_path();
         EXPECT(false);
     } catch (const filesystem_error& err) {
-        EXPECT(err.code() == make_error_code(errc::not_a_directory));
+        EXPECT(errc{err.code().value()} == errc::no_such_file_or_directory);
         const auto& p1Native = err.path1().native();
         EXPECT(p1Native.find(LR"(\nonexistent.dir\)") == p1Native.size() - 17);
         EXPECT(err.path2().empty());
     }
 
-    const auto nonexistentTemp = temp_directory_path(ec).native();
-    EXPECT(nonexistentTemp.find(LR"(\nonexistent.dir\)") == nonexistentTemp.size() - 17);
-    EXPECT(ec == make_error_code(errc::not_a_directory));
+    const auto nonexistentTemp = temp_directory_path(ec);
+    EXPECT(nonexistentTemp.empty());
+    EXPECT(errc{ec.value()} == errc::no_such_file_or_directory);
 
     // TODO: automated test is_directory(p) is false, symlinks, after other filesystem components are implemented
 


### PR DESCRIPTION
Fix #5557.

In the current implementation, `temp_directory_path` would first use `GetTempPath`/`GetTempPath2W` to obtain the temp path, then use `GetFileAttributesW` to obtain file attributes to verify if it was a directory. If the file is not a directory but is a symlink, the symlink would be opened to verify that the symlink is correct. Since `GetFileAttributesW` internally opens the file and uses `GetFileInformationByHandleEx` to obtain file attributes, the current logic contains redundancy. Instead, we should unconditionally open the path obtained by `GetTempPath`/`GetTempPath2W`, follow symlinks, and verify that it is a directory through `GetFileInformationByHandleEx`.

