### PR TITLE
`<vector>`: Avoid another compiler warning with Defect Report P2280R4

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -3203,7 +3203,7 @@ public:
         }
 
         // max_size bound by underlying storage limits
-        return _Ints_max * _VBITS;
+        return static_cast<size_type>(_Ints_max * _VBITS);
     }
 
     _NODISCARD_EMPTY_MEMBER _CONSTEXPR20 bool empty() const noexcept {


### PR DESCRIPTION
Followup to #5550.

When Defect Report WG21-P2280R4 is implemented in MSVC, for libcxx's pathological tests for allocators with tiny `size_type`s like `uint8_t`, the compiler will notice that `_Ints_max * _VBITS` undergoes integral promotion, but isn't smart enough to realize that we've avoided actual truncation.

We should consistently follow our pattern of `static_cast`ing to avoid warnings with integral promotions.