### PR TITLE
Update _MSVC_STL_UPDATE macro to 202506L

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -907,7 +907,7 @@
 
 #define _CPPLIB_VER       650
 #define _MSVC_STL_VERSION 145
-#define _MSVC_STL_UPDATE  202505L
+#define _MSVC_STL_UPDATE  202506L
 
 #ifndef _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
 #if defined(__CUDACC__) && defined(__CUDACC_VER_MAJOR__)


### PR DESCRIPTION
Fixes #5564

This updates the _MSVC_STL_UPDATE macro from 202505L to 202506L.
