### PR TITLE
Remove comments for LWG-4245

### DIFF
--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -1312,12 +1312,12 @@ public:
     }
 
     _NODISCARD friend constexpr iter_difference_t<_Iter> operator-(
-        const counted_iterator& _Left, default_sentinel_t) noexcept /* strengthened */ {
+        const counted_iterator& _Left, default_sentinel_t) noexcept {
         return -_Left._Length;
     }
 
     _NODISCARD friend constexpr iter_difference_t<_Iter> operator-(
-        default_sentinel_t, const counted_iterator& _Right) noexcept /* strengthened */ {
+        default_sentinel_t, const counted_iterator& _Right) noexcept {
         return _Right._Length;
     }
 
@@ -1342,8 +1342,7 @@ public:
         return _Left._Length == _Right.count();
     }
 
-    _NODISCARD friend constexpr bool operator==(const counted_iterator& _Left, default_sentinel_t) noexcept
-    /* strengthened */ {
+    _NODISCARD friend constexpr bool operator==(const counted_iterator& _Left, default_sentinel_t) noexcept {
         return _Left._Length == 0;
     }
 


### PR DESCRIPTION
Closes #5582

Removed the `/* strengthened */` comments from [`STL/stl/inc/iterator`](https://github.com/microsoft/STL/blob/7841cf88ff9af837fb980f2d2d4ac0f267e714c7/stl/inc/iterator#L1314-L1317) at all the necessary locations where `noexcept` is now expected as per LWG-4245.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
