### PR TITLE
Categorize remaining regex-related libcxx test failures

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -30,6 +30,9 @@ std/time/time.syn/formatter.year_month_weekday.pass.cpp:1 FAIL
 std/time/time.syn/formatter.zoned_time.pass.cpp:0 FAIL
 std/time/time.syn/formatter.zoned_time.pass.cpp:1 FAIL
 
+# LLVM-74838: [libc++] std::regex match_prev_avail implementation is regressed
+std/re/re.const/re.matchflag/match_prev_avail.pass.cpp FAIL
+
 # LLVM-90196: [libc++][format] Formatting range with m range-type is incorrect
 std/utilities/format/format.range/format.range.formatter/format.functions.format.pass.cpp FAIL
 std/utilities/format/format.range/format.range.formatter/format.functions.vformat.pass.cpp FAIL
@@ -797,6 +800,25 @@ std/input.output/string.streams/stringbuf/stringbuf.members/view.pass.cpp FAIL
 std/input.output/syncstream/syncbuf/syncstream.syncbuf.cons/dtor.pass.cpp FAIL
 std/input.output/syncstream/syncbuf/syncstream.syncbuf.members/emit.pass.cpp FAIL
 
+# GH-5393: <regex>: What names can and should regex_traits::lookup_collatename() recognize?
+std/re/re.alg/re.alg.match/awk.locale.pass.cpp FAIL
+std/re/re.alg/re.alg.match/awk.pass.cpp FAIL
+std/re/re.alg/re.alg.match/basic.locale.pass.cpp FAIL
+std/re/re.alg/re.alg.match/basic.pass.cpp FAIL
+std/re/re.alg/re.alg.match/ecma.locale.pass.cpp FAIL
+std/re/re.alg/re.alg.match/ecma.pass.cpp FAIL
+std/re/re.alg/re.alg.match/extended.locale.pass.cpp FAIL
+std/re/re.alg/re.alg.match/extended.pass.cpp FAIL
+std/re/re.alg/re.alg.search/awk.locale.pass.cpp FAIL
+std/re/re.alg/re.alg.search/awk.pass.cpp FAIL
+std/re/re.alg/re.alg.search/basic.locale.pass.cpp FAIL
+std/re/re.alg/re.alg.search/basic.pass.cpp FAIL
+std/re/re.alg/re.alg.search/ecma.locale.pass.cpp FAIL
+std/re/re.alg/re.alg.search/ecma.pass.cpp FAIL
+std/re/re.alg/re.alg.search/extended.locale.pass.cpp FAIL
+std/re/re.alg/re.alg.search/extended.pass.cpp FAIL
+std/re/re.traits/lookup_collatename.pass.cpp FAIL
+
 
 # *** VCRUNTIME BUGS ***
 
@@ -959,17 +981,6 @@ std/utilities/format/format.functions/fill.unicode.pass.cpp:1 FAIL
 
 # *** LIKELY STL BUGS ***
 # Not analyzed, likely STL bugs. Various assertions.
-std/re/re.alg/re.alg.match/awk.pass.cpp FAIL
-std/re/re.alg/re.alg.match/basic.pass.cpp FAIL
-std/re/re.alg/re.alg.match/ecma.pass.cpp FAIL
-std/re/re.alg/re.alg.match/extended.pass.cpp FAIL
-std/re/re.alg/re.alg.search/awk.pass.cpp FAIL
-std/re/re.alg/re.alg.search/basic.pass.cpp FAIL
-std/re/re.alg/re.alg.search/ecma.pass.cpp FAIL
-std/re/re.alg/re.alg.search/extended.pass.cpp FAIL
-std/re/re.traits/lookup_collatename.pass.cpp FAIL
-
-# Not analyzed, likely STL bugs. Various assertions.
 std/numerics/complex.number/complex.ops/complex_divide_complex.pass.cpp FAIL
 std/numerics/complex.number/complex.ops/complex_times_complex.pass.cpp FAIL
 std/numerics/complex.number/complex.ops/scalar_divide_complex.pass.cpp FAIL
@@ -1095,19 +1106,6 @@ std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp:1 FAIL
 
 # Not analyzed. Frequent timeouts
 std/containers/sequences/deque/deque.modifiers/insert_iter_iter.pass.cpp SKIPPED
-
-# Not analyzed. Failing after LLVM-D75622.
-std/re/re.const/re.matchflag/match_prev_avail.pass.cpp FAIL
-
-# Not analyzed. Failing for "[a[.ch.]z]".
-std/re/re.alg/re.alg.match/awk.locale.pass.cpp FAIL
-std/re/re.alg/re.alg.match/basic.locale.pass.cpp FAIL
-std/re/re.alg/re.alg.match/ecma.locale.pass.cpp FAIL
-std/re/re.alg/re.alg.match/extended.locale.pass.cpp FAIL
-std/re/re.alg/re.alg.search/awk.locale.pass.cpp FAIL
-std/re/re.alg/re.alg.search/basic.locale.pass.cpp FAIL
-std/re/re.alg/re.alg.search/ecma.locale.pass.cpp FAIL
-std/re/re.alg/re.alg.search/extended.locale.pass.cpp FAIL
 
 # Not analyzed. Seems to force a sign conversion error?
 std/iterators/iterator.primitives/iterator.operations/advance.pass.cpp SKIPPED


### PR DESCRIPTION
There are two remaining reasons for failing libcxx tests related to `regex`:

* libc++'s implementation of `match_prev_avail` is broken, see llvm/llvm-project#74838.
* the remaining failing tests are related to the recognition of collating elements, so are covered by issue #5393. (If preferred, we could make an additional distinction: the "locale" test failures are about the "can" in the issue question, the failures of the other grammar-specific tests are about the "should", and the failure of the `lookup_collatename()` test is about both.) 