### PR TITLE
`<regex>`: Limit recursion in the parser

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -4236,7 +4236,7 @@ _BidIt _Matcher2<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Skip(
                 }
 
                 _Node_assert* _Node = static_cast<_Node_assert*>(_Nx);
-                _First_arg          = _Skip(_First_arg, _Last, _Node->_Child);
+                _First_arg          = _Skip(_First_arg, _Last, _Node->_Child, _Recursion_depth + 1U);
                 _BidIt _Next;
                 for (;;) {
                     _Next = _Skip(_First_arg, _Last, _Node->_Next, _Recursion_depth + 1U);
@@ -4703,6 +4703,10 @@ void _Parser2<_FwdIt, _Elem, _RxTraits>::_Do_assert_group(bool _Neg) { // add as
 template <class _FwdIt, class _Elem, class _RxTraits>
 bool _Parser2<_FwdIt, _Elem, _RxTraits>::_Wrapped_disjunction() { // add disjunction inside group
     ++_Disj_count;
+    if (_Disj_count >= 1000) { // hardcoded limit
+        _Error(regex_constants::error_stack);
+    }
+
     if (!(_L_flags & _L_empty_grp) && _Mchar == _Meta_rpar) {
         _Error(regex_constants::error_paren);
     } else if ((_L_flags & _L_nc_asrt) && _Mchar == _Meta_query) { // check for valid ECMAScript (?x ... ) group


### PR DESCRIPTION
#4451 limited recursion for capture groups in the parser. However, unlimited recursion in the parser is still possible for regexes that use non-capturing groups or lookahead assertions. This PR similarly limits the recursion for such constructs by using the parser's pre-existing internal recursion counter, `_Disj_count`.

This supersedes the capture group limit introduced by #4451 as a way to prevent stack overflows. But I'm leaving it in because regexes using more than 1000 capture groups strike me as bogus anyway. (I think the error code `error_space` would be more appropriate in this case now, since the limit is no longer about preventing recursion, but it's probably not worth introducing a minor behavior difference just for this reason. One could even argue that `error_space` is more appropriate for the new stack limit introduced by this PR, too, because `error_space` is about regex construction, while `error_stack` is about regex matching.)

I also fix a mistake in `_Matcher2::_Skip()`'s recursion limitation: In #5576, I accidentally missed to pass the recursion counter as an argument to one of the recursive calls.