### PR TITLE
(Semi-)vectorize `includes`

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -85,6 +85,23 @@ const void* __stdcall __std_is_sorted_until_8u(const void* _First, const void* _
 const void* __stdcall __std_is_sorted_until_f(const void* _First, const void* _Last, bool _Greater) noexcept;
 const void* __stdcall __std_is_sorted_until_d(const void* _First, const void* _Last, bool _Greater) noexcept;
 
+__declspec(noalias) bool __stdcall __std_includes_less_1i(
+    const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept;
+__declspec(noalias) bool __stdcall __std_includes_less_1u(
+    const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept;
+__declspec(noalias) bool __stdcall __std_includes_less_2i(
+    const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept;
+__declspec(noalias) bool __stdcall __std_includes_less_2u(
+    const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept;
+__declspec(noalias) bool __stdcall __std_includes_less_4i(
+    const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept;
+__declspec(noalias) bool __stdcall __std_includes_less_4u(
+    const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept;
+__declspec(noalias) bool __stdcall __std_includes_less_8i(
+    const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept;
+__declspec(noalias) bool __stdcall __std_includes_less_8u(
+    const void* _First1, const void* _Last1, const void* _First2, const void* _Last2) noexcept;
+
 // TRANSITION, DevCom-10610477
 __declspec(noalias) void __stdcall __std_replace_4(
     void* _First, void* _Last, uint32_t _Old_val, uint32_t _New_val) noexcept;
@@ -255,6 +272,40 @@ _Ty* _Is_sorted_until_vectorized(_Ty* const _First, _Ty* const _Last, const bool
     }
 }
 
+template <class _Ty>
+bool _Includes_vectorized(
+    const _Ty* const _First1, const _Ty* const _Last1, const _Ty* const _First2, const _Ty* const _Last2) noexcept {
+    constexpr bool _Signed = is_signed_v<_Ty>;
+
+    if constexpr (sizeof(_Ty) == 1) {
+        if constexpr (_Signed) {
+            return ::__std_includes_less_1i(_First1, _Last1, _First2, _Last2);
+        } else {
+            return ::__std_includes_less_1u(_First1, _Last1, _First2, _Last2);
+        }
+    } else if constexpr (sizeof(_Ty) == 2) {
+        if constexpr (_Signed) {
+            return ::__std_includes_less_2i(_First1, _Last1, _First2, _Last2);
+        } else {
+            return ::__std_includes_less_2u(_First1, _Last1, _First2, _Last2);
+        }
+    } else if constexpr (sizeof(_Ty) == 4) {
+        if constexpr (_Signed) {
+            return ::__std_includes_less_4i(_First1, _Last1, _First2, _Last2);
+        } else {
+            return ::__std_includes_less_4u(_First1, _Last1, _First2, _Last2);
+        }
+    } else if constexpr (sizeof(_Ty) == 8) {
+        if constexpr (_Signed) {
+            return ::__std_includes_less_8i(_First1, _Last1, _First2, _Last2);
+        } else {
+            return ::__std_includes_less_8u(_First1, _Last1, _First2, _Last2);
+        }
+    } else {
+        _STL_INTERNAL_STATIC_ASSERT(false); // unexpected size
+    }
+}
+
 template <class _Ty, class _TVal1, class _TVal2>
 __declspec(noalias) void _Replace_vectorized(
     _Ty* const _First, _Ty* const _Last, const _TVal1 _Old_val, const _TVal2 _New_val) noexcept {
@@ -383,6 +434,13 @@ constexpr bool _Output_iterator_for_vector_alg_is_safe() {
     }
 }
 
+// Can we activate the vector algorithms for includes?
+template <class _Iter1, class _Iter2, class _Elem = _Iter_value_t<_Iter1>>
+constexpr bool _Vector_alg_includes_iterators_safe =
+    _Iterators_are_contiguous<_Iter1, _Iter2> // Iterators must be contiguous so we can get raw pointers.
+    && !_Iterator_is_volatile<_Iter1> && !_Iterator_is_volatile<_Iter2> // Iterators must not be volatile.
+    && is_same_v<_Elem, _Iter_value_t<_Iter2>> // Iterators value is same
+    && disjunction_v<is_integral<_Elem>, is_pointer<_Elem>>; // Integral or pointer type.
 _STD_END
 #endif // _USE_STD_VECTOR_ALGORITHMS
 
@@ -10165,6 +10223,15 @@ _NODISCARD _CONSTEXPR20 bool includes(_InIt1 _First1, _InIt1 _Last1, _InIt2 _Fir
         return false;
     }
 
+#if _USE_STD_VECTOR_ALGORITHMS
+    if constexpr (_Vector_alg_includes_iterators_safe<_InIt1, _InIt2> && _Is_predicate_less<_InIt1, _Pr>) {
+        if (!_STD _Is_constant_evaluated()) {
+            return _STD _Includes_vectorized(_STD _To_address(_First1), _STD _To_address(_Last1),
+                _STD _To_address(_First2), _STD _To_address(_Last2));
+        }
+    }
+#endif // _USE_STD_VECTOR_ALGORITHMS
+
     for (;;) {
         if (_DEBUG_LT_PRED(_Pred, *_UFirst1, *_UFirst2)) {
             ++_UFirst1;
@@ -10253,6 +10320,20 @@ namespace ranges {
             } else if (_First1 == _Last1) {
                 return false;
             }
+
+#if _USE_STD_VECTOR_ALGORITHMS
+            if constexpr (_Vector_alg_includes_iterators_safe<_It1, _It2> && _Is_predicate_less<_It1, _Pr>
+                          && sized_sentinel_for<_Se1, _It1> && sized_sentinel_for<_Se2, _It2>
+                          && is_same_v<_Pj1, identity> && is_same_v<_Pj2, identity>) {
+                if (!_STD _Is_constant_evaluated()) {
+                    const auto _First1_ptr = _STD to_address(_First1);
+                    const auto _First2_ptr = _STD to_address(_First2);
+                    const auto _Last1_ptr  = _First1_ptr + static_cast<ptrdiff_t>(_Last1 - _First1);
+                    const auto _Last2_ptr  = _First2_ptr + static_cast<ptrdiff_t>(_Last2 - _First2);
+                    return _STD _Includes_vectorized(_First1_ptr, _Last1_ptr, _First2_ptr, _Last2_ptr);
+                }
+            }
+#endif // _USE_STD_VECTOR_ALGORITHMS
 
             for (;;) {
                 if (_STD invoke(_Pred, _STD invoke(_Proj1, *_First1), _STD invoke(_Proj2, *_First2))) {

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -6846,6 +6846,330 @@ void* __stdcall __std_unique_copy_8(const void* _First, const void* const _Last,
 } // extern "C"
 
 namespace {
+    namespace _Sorted_ranges {
+#ifdef _M_ARM64EC
+        static_assert(false, "No vectorization for _M_ARM64EC yet");
+#else // ^^^ defined(_M_ARM64EC) / !defined(_M_ARM64EC) vvv
+        struct _Traits_avx {
+            using _Guard                       = _Zeroupper_on_exit;
+            static constexpr size_t _Vec_size  = 32;
+            static constexpr size_t _Tail_mask = 0x1C;
+
+            static __m256i _Load(const void* const _Src) noexcept {
+                return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(_Src));
+            }
+
+            static __m256i _Load_mask(const void* const _Src, const __m256i _Mask) noexcept {
+                return _mm256_maskload_epi32(reinterpret_cast<const int*>(_Src), _Mask);
+            }
+
+            static unsigned long _Mask(const __m256i _Val) noexcept {
+                return _mm256_movemask_epi8(_Val);
+            }
+
+            static uint32_t _Bsf(const uint32_t _Val) noexcept {
+                return _tzcnt_u32(_Val);
+            }
+        };
+
+        struct _Traits_1_avx : _Traits_avx {
+            static __m256i _Broadcast(const uint8_t _Data) noexcept {
+                return _mm256_broadcastb_epi8(_mm_cvtsi32_si128(static_cast<uint32_t>(_Data)));
+            }
+
+            static __m256i _Cmp_gt(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_cmpgt_epi8(_First, _Second);
+            }
+        };
+
+        struct _Traits_2_avx : _Traits_avx {
+            static __m256i _Broadcast(const uint16_t _Data) noexcept {
+                return _mm256_broadcastw_epi16(_mm_cvtsi32_si128(static_cast<uint32_t>(_Data)));
+            }
+
+            static __m256i _Cmp_gt(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_cmpgt_epi16(_First, _Second);
+            }
+        };
+
+        struct _Traits_4_avx : _Traits_avx {
+            static __m256i _Broadcast(const uint32_t _Data) noexcept {
+                return _mm256_broadcastd_epi32(_mm_cvtsi32_si128(_Data));
+            }
+
+            static __m256i _Cmp_gt(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_cmpgt_epi32(_First, _Second);
+            }
+        };
+
+        struct _Traits_8_avx : _Traits_avx {
+            static __m256i _Broadcast(const uint64_t _Data) noexcept {
+                return _mm256_broadcastq_epi64(_mm_cvtsi64x_si128(_Data));
+            }
+
+            static __m256i _Cmp_gt(const __m256i _First, const __m256i _Second) noexcept {
+                return _mm256_cmpgt_epi64(_First, _Second);
+            }
+        };
+
+        struct _Traits_sse {
+            using _Guard                       = char;
+            static constexpr size_t _Vec_size  = 16;
+            static constexpr size_t _Tail_mask = 0;
+
+            static __m128i _Load(const void* const _Src) noexcept {
+                return _mm_loadu_si128(reinterpret_cast<const __m128i*>(_Src));
+            }
+
+            static unsigned long _Mask(const __m128i _Val) noexcept {
+                return _mm_movemask_epi8(_Val);
+            }
+
+            static uint32_t _Bsf(const uint32_t _Val) noexcept {
+                unsigned long _Index;
+                // CodeQL [SM02313] _Index is always initialized: _Val != 0; see explanastion at call sites.
+                _BitScanForward(&_Index, _Val);
+                return _Index;
+            }
+        };
+
+        struct _Traits_1_sse : _Traits_sse {
+            static __m128i _Broadcast(const uint8_t _Data) noexcept {
+                return _mm_shuffle_epi8(_mm_cvtsi32_si128(static_cast<uint32_t>(_Data)), _mm_setzero_si128());
+            }
+
+            static __m128i _Cmp_gt(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_cmpgt_epi8(_First, _Second);
+            }
+        };
+
+        struct _Traits_2_sse : _Traits_sse {
+            static __m128i _Broadcast(const uint16_t _Data) noexcept {
+                return _mm_shuffle_epi8(_mm_cvtsi32_si128(static_cast<uint32_t>(_Data)), _mm_set1_epi16(0x0100));
+            }
+
+            static __m128i _Cmp_gt(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_cmpgt_epi16(_First, _Second);
+            }
+        };
+
+        struct _Traits_4_sse : _Traits_sse {
+            static __m128i _Broadcast(const uint32_t _Data) noexcept {
+                return _mm_shuffle_epi32(_mm_cvtsi32_si128(_Data), _MM_SHUFFLE(0, 0, 0, 0));
+            }
+
+            static __m128i _Cmp_gt(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_cmpgt_epi32(_First, _Second);
+            }
+        };
+
+        struct _Traits_8_sse : _Traits_sse {
+            static __m128i _Broadcast(const uint64_t _Data) noexcept {
+                return _mm_shuffle_epi32(_mm_cvtsi64x_si128(_Data), _MM_SHUFFLE(1, 0, 1, 0));
+            }
+
+            static __m128i _Cmp_gt(const __m128i _First, const __m128i _Second) noexcept {
+                return _mm_cmpgt_epi64(_First, _Second);
+            }
+        };
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
+
+        template <class _Traits, class _Ty>
+        bool _Includes_impl(
+            const void* _First1, const void* const _Last1, const void* _First2, const void* const _Last2) noexcept {
+            if constexpr (!std::is_same_v<_Traits, void>) {
+#ifdef _M_ARM64EC
+                static_assert(false, "No vectorization for _M_ARM64EC yet");
+#else // ^^^ defined(_M_ARM64EC) / !defined(_M_ARM64EC) vvv
+
+                // Only skipping some parts of haystack that are less than current needle element is vectorzied.
+                // Otherwise this is scalar algorithm.
+
+                constexpr uint32_t _All_ones_mask    = uint32_t{(uint64_t{1} << _Traits::_Vec_size) - 1};
+                constexpr uint32_t _Highest_one_mask = 1u << (_Traits::_Vec_size - 1);
+                [[maybe_unused]] typename _Traits::_Guard _Guard; // TRANSITION, DevCom-10331414
+
+                const size_t _Size_bytes_1 = _Byte_length(_First1, _Last1);
+                const void* _Stop1         = _First1;
+                _Advance_bytes(_Stop1, _Size_bytes_1 & ~(_Traits::_Vec_size - 1));
+
+                _Ty _Val2    = *reinterpret_cast<const _Ty*>(_First2);
+                auto _Start2 = _Traits::_Broadcast(_Val2);
+
+                do {
+                    const auto _Data1  = _Traits::_Load(_First1);
+                    const void* _Next1 = _First1;
+                    _Advance_bytes(_Next1, _Traits::_Vec_size);
+
+                    const uint32_t _Greater_start_2 = _Traits::_Mask(_Traits::_Cmp_gt(_Start2, _Data1));
+                    // Testing _Highest_one_mask can be a bit more effecient on AVX2 than comparing against
+                    // _All_ones_mask (will test sign, and can share comparison with != 0 below).
+                    if ((_Greater_start_2 & _Highest_one_mask) != 0) {
+                        // Needle first element is greater than each element of haystack vector.
+                        // Proceed to the next one, without updationg the needle comparand.
+                        _First1 = _Next1;
+                    } else {
+                        if (_Greater_start_2 != 0) {
+                            // Needle first element is greater than some first elements of haystack part.
+                            // Advance past these elements.
+                            // The input is nonzero because we handled that case with _Highest_one_mask branch above.
+                            const uint32_t _Skip = _Traits::_Bsf(_Greater_start_2 ^ _All_ones_mask);
+                            _Advance_bytes(_First1, _Skip);
+                        }
+
+                        // The rest is scalar loop that completes the remaining  vector-sized haystack part.
+                        // Except that it updates current needle value to compare against.
+                        do {
+                            const _Ty _Val1 = *static_cast<const _Ty*>(_First1);
+
+                            if (_Val2 < _Val1) {
+                                return false;
+                            }
+
+                            if (_Val2 == _Val1) {
+                                _Advance_bytes(_First2, sizeof(_Ty));
+                                if (_First2 == _Last2) {
+                                    return true;
+                                }
+
+                                _Val2 = *reinterpret_cast<const _Ty*>(_First2);
+                            }
+
+                            _Advance_bytes(_First1, sizeof(_Ty));
+                        } while (_First1 != _Next1);
+
+                        _Start2 = _Traits::_Broadcast(_Val2);
+                    }
+                } while (_First1 != _Stop1);
+
+                if constexpr (_Traits::_Tail_mask != 0) {
+                    const size_t _Tail_bytes_size_1 = _Size_bytes_1 & _Traits::_Tail_mask;
+                    if (_Tail_bytes_size_1 != 0) {
+                        // Just try to advance pass less one omre time.
+                        // Don't neet to repeat the scalar part here -- falling to scalar loop anyway.
+                        const auto _Tail_mask           = _Avx2_tail_mask_32(_Tail_bytes_size_1);
+                        const auto _Data1               = _Traits::_Load_mask(_First1, _Tail_mask);
+                        const auto _Cmp                 = _Traits::_Cmp_gt(_Start2, _Data1);
+                        const uint32_t _Greater_start_2 = _Traits::_Mask(_mm256_and_si256(_Cmp, _Tail_mask));
+                        if (_Greater_start_2 != 0) {
+                            // Needle first element is greater than some first elements of haystack part.
+                            // Advance past these elements.
+                            // The input is nonzero because tail mask will have zeros for remaining enements.
+                            const uint32_t _Skip = _Traits::_Bsf(_Greater_start_2 ^ _All_ones_mask);
+                            _Advance_bytes(_First1, _Skip);
+                        }
+                    }
+                }
+
+                if (_First1 == _Last1) {
+                    return false;
+                }
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
+            }
+
+            auto _Ptr1 = static_cast<const _Ty*>(_First1);
+            auto _Ptr2 = static_cast<const _Ty*>(_First2);
+
+            for (;;) {
+                if (*_Ptr1 < *_Ptr2) {
+                    ++_Ptr1;
+                    if (_Ptr1 == _Last1) {
+                        return false;
+                    }
+                } else if (*_Ptr2 < *_Ptr1) {
+                    return false;
+                } else {
+                    ++_Ptr1;
+                    ++_Ptr2;
+                    if (_Ptr2 == _Last2) {
+                        return true;
+                    } else if (_Ptr1 == _Last1) {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        template <class _Traits_avx, class _Traits_sse, class _Ty>
+        bool __stdcall _Includes_disp(const void* const _First1, const void* const _Last1, const void* const _First2,
+            const void* const _Last2) noexcept {
+            const size_t _Size_bytes_1 = _Byte_length(_First1, _Last1);
+            const size_t _Size_bytes_2 = _Byte_length(_First2, _Last2);
+            if (_Size_bytes_2 == 0) {
+                return true;
+            } else if (_Size_bytes_1 < _Size_bytes_2) {
+                return false;
+            }
+
+#ifndef _M_ARM64EC
+            if constexpr (std::_Is_any_of_v<_Ty, int8_t, int16_t, int32_t, int64_t>) {
+                if (_Size_bytes_1 >= 32 && _Use_avx2()) {
+                    return _Includes_impl<_Traits_avx, _Ty>(_First1, _Last1, _First2, _Last2);
+                }
+
+                if (_Size_bytes_1 >= 16 && _Use_sse42()) {
+                    return _Includes_impl<_Traits_sse, _Ty>(_First1, _Last1, _First2, _Last2);
+                }
+            }
+#endif // ^^^ !defined(_M_ARM64EC) ^^^
+            return _Includes_impl<void, _Ty>(_First1, _Last1, _First2, _Last2);
+        }
+    } // namespace _Sorted_ranges
+} // unnamed namespace
+
+extern "C" {
+
+__declspec(noalias) bool __stdcall __std_includes_less_1i(
+    const void* const _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
+    return _Sorted_ranges::_Includes_disp<_Sorted_ranges::_Traits_1_avx, _Sorted_ranges::_Traits_1_sse, int8_t>(
+        _First1, _Last1, _First2, _Last2);
+}
+
+__declspec(noalias) bool __stdcall __std_includes_less_1u(
+    const void* const _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
+    return _Sorted_ranges::_Includes_disp<_Sorted_ranges::_Traits_1_avx, _Sorted_ranges::_Traits_1_sse, uint8_t>(
+        _First1, _Last1, _First2, _Last2);
+}
+
+__declspec(noalias) bool __stdcall __std_includes_less_2i(
+    const void* const _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
+    return _Sorted_ranges::_Includes_disp<_Sorted_ranges::_Traits_2_avx, _Sorted_ranges::_Traits_2_sse, int16_t>(
+        _First1, _Last1, _First2, _Last2);
+}
+
+__declspec(noalias) bool __stdcall __std_includes_less_2u(
+    const void* const _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
+    return _Sorted_ranges::_Includes_disp<_Sorted_ranges::_Traits_2_avx, _Sorted_ranges::_Traits_2_sse, uint16_t>(
+        _First1, _Last1, _First2, _Last2);
+}
+
+__declspec(noalias) bool __stdcall __std_includes_less_4i(
+    const void* const _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
+    return _Sorted_ranges::_Includes_disp<_Sorted_ranges::_Traits_4_avx, _Sorted_ranges::_Traits_4_sse, int32_t>(
+        _First1, _Last1, _First2, _Last2);
+}
+
+__declspec(noalias) bool __stdcall __std_includes_less_4u(
+    const void* const _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
+    return _Sorted_ranges::_Includes_disp<_Sorted_ranges::_Traits_4_avx, _Sorted_ranges::_Traits_4_sse, uint32_t>(
+        _First1, _Last1, _First2, _Last2);
+}
+
+__declspec(noalias) bool __stdcall __std_includes_less_8i(
+    const void* const _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
+    return _Sorted_ranges::_Includes_disp<_Sorted_ranges::_Traits_8_avx, _Sorted_ranges::_Traits_8_sse, int64_t>(
+        _First1, _Last1, _First2, _Last2);
+}
+
+__declspec(noalias) bool __stdcall __std_includes_less_8u(
+    const void* const _First1, const void* const _Last1, const void* const _First2, const void* const _Last2) noexcept {
+    return _Sorted_ranges::_Includes_disp<_Sorted_ranges::_Traits_8_avx, _Sorted_ranges::_Traits_8_sse, uint64_t>(
+        _First1, _Last1, _First2, _Last2);
+}
+
+} // extern "C"
+
+namespace {
     namespace _Bitset_to_string {
 #ifdef _M_ARM64EC
         using _Traits_1_avx = void;


### PR DESCRIPTION
# ❓ Draft PR
Not sure if this is good, because it optimizes best cases, whereas pessimizing some worse cases.
Unlike `std::search` vectorization:
 * The set of worse cases seems larger.
 * For `std::search` there's intuitive understanding of an "usual" case: it is "usual" language text search. The "usual" case for `includes` is not known.

I'm not implementing the following for a draft PR, would like the approach to be approved or rejected first:
 * ➕ unsigned types (matter of few adjustments, although this means that unsigned will be less efficient)
 * ✔️ test coverage (the benchmark gives some minimal coverage by checking the expected result for every case)

# ½ Half-vectorization approach

 * Iterate haystack by vector-sized units
 * Skip the whole vector, if all elements are less than the current needle element
 * Skip the vector part is some elements are less than the current needle element
 * Proceed the rest of the current vector in a scalar way

# 😾 Which full vectorization approaches considered and failed

Generally, any of these aproaches result in major slowdown for the following case:
 * Hay: `0,0,1,1,2,2,...999,999`
 * Needle: `0,1,2,...999`

The approaches considered:
* Compare the needle for equality using vector comparison, skip all equal elements. This ends up being close to scalar but using inefficient instructions, when the needle is large and spread nearly equally
* Use `*cmpestr*` in any-to-any match mode. Could possibly have worked if there were no duplicates to consider
* Use `remove`/`unique` approach in a loop. When the needle is large and spread nearly equally, it takes up to half vector size iterations, which is very slow

# ⏱️ Benchmark results

Benchmark                                              |    Before    |   After    | Speedup
-------------------------------------------------------|--------------|------------|----------
bm_includes<int8_t, alg_type::std_fn>/3000/3/0/1       |    370 ns    |   36.8 ns  |   10.05
bm_includes<int8_t, alg_type::std_fn>/3000/22/0/1      |    586 ns    |   60.0 ns  |   9.77
bm_includes<int8_t, alg_type::std_fn>/3000/105/0/1     |    558 ns    |   86.4 ns  |   6.46
bm_includes<int8_t, alg_type::std_fn>/3000/1504/0/1    |    954 ns    |   1026 ns  |   0.93
bm_includes<int8_t, alg_type::std_fn>/3000/2750/0/1    |   1372 ns    |   1488 ns  |   0.92
bm_includes<int8_t, alg_type::std_fn>/300/3/0/1        |   56.3 ns    |   5.55 ns  |   10.14
bm_includes<int8_t, alg_type::std_fn>/300/22/0/1       |   91.6 ns    |   23.9 ns  |   3.83
bm_includes<int8_t, alg_type::std_fn>/300/105/0/1      |    119 ns    |   83.5 ns  |   1.43
bm_includes<int8_t, alg_type::std_fn>/300/290/0/1      |    153 ns    |    231 ns  |   0.66
bm_includes<int8_t, alg_type::std_fn>/3000/3/0/0       |    363 ns    |   36.2 ns  |   10.03
bm_includes<int8_t, alg_type::std_fn>/3000/22/0/0      |    369 ns    |   45.4 ns  |   8.13
bm_includes<int8_t, alg_type::std_fn>/3000/105/0/0     |    399 ns    |   55.1 ns  |   7.24
bm_includes<int8_t, alg_type::std_fn>/3000/1504/0/0    |    560 ns    |    584 ns  |   0.96
bm_includes<int8_t, alg_type::std_fn>/3000/2750/0/0    |    728 ns    |    701 ns  |   1.04
bm_includes<int8_t, alg_type::std_fn>/300/3/0/0        |   51.6 ns    |   5.08 ns  |   10.16
bm_includes<int8_t, alg_type::std_fn>/300/22/0/0       |   80.6 ns    |   16.4 ns  |   4.91
bm_includes<int8_t, alg_type::std_fn>/300/105/0/0      |   82.5 ns    |   35.1 ns  |   2.35
bm_includes<int8_t, alg_type::std_fn>/300/290/0/0      |   83.3 ns    |   88.2 ns  |   0.94
bm_includes<int8_t, alg_type::std_fn>/3000/3/1/1       |    367 ns    |   36.6 ns  |   10.03
bm_includes<int8_t, alg_type::std_fn>/3000/22/1/1      |    456 ns    |   66.6 ns  |   6.85
bm_includes<int8_t, alg_type::std_fn>/3000/105/1/1     |    556 ns    |    163 ns  |   3.41
bm_includes<int8_t, alg_type::std_fn>/3000/1504/1/1    |    935 ns    |   1101 ns  |   0.85
bm_includes<int8_t, alg_type::std_fn>/3000/2750/1/1    |   1355 ns    |   1455 ns  |   0.93
bm_includes<int8_t, alg_type::std_fn>/300/3/1/1        |   55.8 ns    |   13.6 ns  |   4.10
bm_includes<int8_t, alg_type::std_fn>/300/22/1/1       |   99.6 ns    |   34.4 ns  |   2.90
bm_includes<int8_t, alg_type::std_fn>/300/105/1/1      |    151 ns    |    105 ns  |   1.44
bm_includes<int8_t, alg_type::std_fn>/300/290/1/1      |    152 ns    |    227 ns  |   0.67
bm_includes<int8_t, alg_type::std_fn>/3000/3/1/0       |    362 ns    |   33.1 ns  |   10.94
bm_includes<int8_t, alg_type::std_fn>/3000/22/1/0      |    374 ns    |   43.5 ns  |   8.60
bm_includes<int8_t, alg_type::std_fn>/3000/105/1/0     |    729 ns    |   94.7 ns  |   7.70
bm_includes<int8_t, alg_type::std_fn>/3000/1504/1/0    |    560 ns    |    581 ns  |   0.96
bm_includes<int8_t, alg_type::std_fn>/3000/2750/1/0    |    719 ns    |    696 ns  |   1.03
bm_includes<int8_t, alg_type::std_fn>/300/3/1/0        |   51.3 ns    |   5.76 ns  |   8.91
bm_includes<int8_t, alg_type::std_fn>/300/22/1/0       |   67.9 ns    |   19.8 ns  |   3.43
bm_includes<int8_t, alg_type::std_fn>/300/105/1/0      |    105 ns    |   57.7 ns  |   1.82
bm_includes<int8_t, alg_type::std_fn>/300/290/1/0      |   83.5 ns    |   81.2 ns  |   1.03
bm_includes<int8_t, alg_type::std_fn>/3000/3/2/1       |    632 ns    |   59.7 ns  |   10.59
bm_includes<int8_t, alg_type::std_fn>/3000/22/2/1      |    988 ns    |    196 ns  |   5.04
bm_includes<int8_t, alg_type::std_fn>/3000/105/2/1     |   1601 ns    |    851 ns  |   1.88
bm_includes<int8_t, alg_type::std_fn>/3000/1504/2/1    |   2653 ns    |   1964 ns  |   1.35
bm_includes<int8_t, alg_type::std_fn>/3000/2750/2/1    |   2140 ns    |   1612 ns  |   1.33
bm_includes<int8_t, alg_type::std_fn>/300/3/2/1        |    107 ns    |   24.4 ns  |   4.39
bm_includes<int8_t, alg_type::std_fn>/300/22/2/1       |    137 ns    |    140 ns  |   0.98
bm_includes<int8_t, alg_type::std_fn>/300/105/2/1      |    244 ns    |    197 ns  |   1.24
bm_includes<int8_t, alg_type::std_fn>/300/290/2/1      |    235 ns    |    162 ns  |   1.45
bm_includes<int8_t, alg_type::std_fn>/3000/3/2/0       |    378 ns    |   38.1 ns  |   9.92
bm_includes<int8_t, alg_type::std_fn>/3000/22/2/0      |    529 ns    |    123 ns  |   4.30
bm_includes<int8_t, alg_type::std_fn>/3000/105/2/0     |    745 ns    |    420 ns  |   1.77
bm_includes<int8_t, alg_type::std_fn>/3000/1504/2/0    |   1324 ns    |    973 ns  |   1.36
bm_includes<int8_t, alg_type::std_fn>/3000/2750/2/0    |    838 ns    |    801 ns  |   1.05
bm_includes<int8_t, alg_type::std_fn>/300/3/2/0        |   65.7 ns    |   16.2 ns  |   4.06
bm_includes<int8_t, alg_type::std_fn>/300/22/2/0       |   72.5 ns    |   78.6 ns  |   0.92
bm_includes<int8_t, alg_type::std_fn>/300/105/2/0      |    120 ns    |   99.6 ns  |   1.20
bm_includes<int8_t, alg_type::std_fn>/300/290/2/0      |    118 ns    |   83.3 ns  |   1.42
bm_includes<int8_t, alg_type::std_fn>/3000/3/3/1       |    668 ns    |   72.8 ns  |   9.18
bm_includes<int8_t, alg_type::std_fn>/3000/22/3/1      |    976 ns    |    216 ns  |   4.52
bm_includes<int8_t, alg_type::std_fn>/3000/105/3/1     |   1427 ns    |    638 ns  |   2.24
bm_includes<int8_t, alg_type::std_fn>/3000/1504/3/1    |   2476 ns    |   2065 ns  |   1.20
bm_includes<int8_t, alg_type::std_fn>/3000/2750/3/1    |   2336 ns    |   1611 ns  |   1.45
bm_includes<int8_t, alg_type::std_fn>/300/3/3/1        |    117 ns    |   24.4 ns  |   4.80
bm_includes<int8_t, alg_type::std_fn>/300/22/3/1       |    154 ns    |    109 ns  |   1.41
bm_includes<int8_t, alg_type::std_fn>/300/105/3/1      |    228 ns    |    206 ns  |   1.11
bm_includes<int8_t, alg_type::std_fn>/300/290/3/1      |    210 ns    |    162 ns  |   1.30
bm_includes<int8_t, alg_type::std_fn>/3000/3/3/0       |    504 ns    |   56.6 ns  |   8.90
bm_includes<int8_t, alg_type::std_fn>/3000/22/3/0      |    608 ns    |    120 ns  |   5.07
bm_includes<int8_t, alg_type::std_fn>/3000/105/3/0     |    808 ns    |    326 ns  |   2.48
bm_includes<int8_t, alg_type::std_fn>/3000/1504/3/0    |   1229 ns    |    976 ns  |   1.26
bm_includes<int8_t, alg_type::std_fn>/3000/2750/3/0    |    866 ns    |    820 ns  |   1.06
bm_includes<int8_t, alg_type::std_fn>/300/3/3/0        |   87.7 ns    |   17.6 ns  |   4.98
bm_includes<int8_t, alg_type::std_fn>/300/22/3/0       |   71.8 ns    |   62.5 ns  |   1.15
bm_includes<int8_t, alg_type::std_fn>/300/105/3/0      |    117 ns    |    101 ns  |   1.16
bm_includes<int8_t, alg_type::std_fn>/300/290/3/0      |   79.2 ns    |   81.9 ns  |   0.97
bm_includes<int16_t, alg_type::std_fn>/3000/3/0/1      |    373 ns    |   54.4 ns  |   6.86
bm_includes<int16_t, alg_type::std_fn>/3000/22/0/1     |    405 ns    |   64.7 ns  |   6.26
bm_includes<int16_t, alg_type::std_fn>/3000/105/0/1    |    426 ns    |    109 ns  |   3.91
bm_includes<int16_t, alg_type::std_fn>/3000/1504/0/1   |    909 ns    |    788 ns  |   1.15
bm_includes<int16_t, alg_type::std_fn>/3000/2750/0/1   |   1341 ns    |   1378 ns  |   0.97
bm_includes<int16_t, alg_type::std_fn>/300/3/0/1       |   55.8 ns    |   12.1 ns  |   4.61
bm_includes<int16_t, alg_type::std_fn>/300/22/0/1      |   75.3 ns    |   24.3 ns  |   3.10
bm_includes<int16_t, alg_type::std_fn>/300/105/0/1     |    105 ns    |   71.7 ns  |   1.46
bm_includes<int16_t, alg_type::std_fn>/300/290/0/1     |    154 ns    |    162 ns  |   0.95
bm_includes<int16_t, alg_type::std_fn>/3000/3/0/0      |    367 ns    |   52.8 ns  |   6.95
bm_includes<int16_t, alg_type::std_fn>/3000/22/0/0     |    378 ns    |   54.6 ns  |   6.92
bm_includes<int16_t, alg_type::std_fn>/3000/105/0/0    |    395 ns    |   77.2 ns  |   5.12
bm_includes<int16_t, alg_type::std_fn>/3000/1504/0/0   |    558 ns    |    416 ns  |   1.34
bm_includes<int16_t, alg_type::std_fn>/3000/2750/0/0   |    703 ns    |    699 ns  |   1.01
bm_includes<int16_t, alg_type::std_fn>/300/3/0/0       |   52.6 ns    |   10.7 ns  |   4.92
bm_includes<int16_t, alg_type::std_fn>/300/22/0/0      |   64.4 ns    |   18.0 ns  |   3.58
bm_includes<int16_t, alg_type::std_fn>/300/105/0/0     |   81.8 ns    |   42.6 ns  |   1.92
bm_includes<int16_t, alg_type::std_fn>/300/290/0/0     |   86.2 ns    |   83.7 ns  |   1.03
bm_includes<int16_t, alg_type::std_fn>/3000/3/1/1      |    369 ns    |   55.8 ns  |   6.61
bm_includes<int16_t, alg_type::std_fn>/3000/22/1/1     |    400 ns    |   82.1 ns  |   4.87
bm_includes<int16_t, alg_type::std_fn>/3000/105/1/1    |    780 ns    |    190 ns  |   4.11
bm_includes<int16_t, alg_type::std_fn>/3000/1504/1/1   |    909 ns    |    805 ns  |   1.13
bm_includes<int16_t, alg_type::std_fn>/3000/2750/1/1   |   1342 ns    |   1375 ns  |   0.98
bm_includes<int16_t, alg_type::std_fn>/300/3/1/1       |   55.0 ns    |   14.7 ns  |   3.74
bm_includes<int16_t, alg_type::std_fn>/300/22/1/1      |   85.6 ns    |   34.9 ns  |   2.45
bm_includes<int16_t, alg_type::std_fn>/300/105/1/1     |    185 ns    |    111 ns  |   1.67
bm_includes<int16_t, alg_type::std_fn>/300/290/1/1     |    154 ns    |    162 ns  |   0.95
bm_includes<int16_t, alg_type::std_fn>/3000/3/1/0      |    366 ns    |   56.6 ns  |   6.47
bm_includes<int16_t, alg_type::std_fn>/3000/22/1/0     |    380 ns    |   65.1 ns  |   5.84
bm_includes<int16_t, alg_type::std_fn>/3000/105/1/0    |    477 ns    |    123 ns  |   3.88
bm_includes<int16_t, alg_type::std_fn>/3000/1504/1/0   |    558 ns    |    417 ns  |   1.34
bm_includes<int16_t, alg_type::std_fn>/3000/2750/1/0   |    703 ns    |    701 ns  |   1.00
bm_includes<int16_t, alg_type::std_fn>/300/3/1/0       |   51.8 ns    |   12.2 ns  |   4.25
bm_includes<int16_t, alg_type::std_fn>/300/22/1/0      |   65.7 ns    |   22.2 ns  |   2.96
bm_includes<int16_t, alg_type::std_fn>/300/105/1/0     |    109 ns    |   58.0 ns  |   1.88
bm_includes<int16_t, alg_type::std_fn>/300/290/1/0     |   86.5 ns    |   85.4 ns  |   1.01
bm_includes<int16_t, alg_type::std_fn>/3000/3/2/1      |    632 ns    |    104 ns  |   6.08
bm_includes<int16_t, alg_type::std_fn>/3000/22/2/1     |   1017 ns    |    223 ns  |   4.56
bm_includes<int16_t, alg_type::std_fn>/3000/105/2/1    |   1418 ns    |    659 ns  |   2.15
bm_includes<int16_t, alg_type::std_fn>/3000/1504/2/1   |   1792 ns    |   1815 ns  |   0.99
bm_includes<int16_t, alg_type::std_fn>/3000/2750/2/1   |   1842 ns    |   1891 ns  |   0.97
bm_includes<int16_t, alg_type::std_fn>/300/3/2/1       |    106 ns    |   29.3 ns  |   3.62
bm_includes<int16_t, alg_type::std_fn>/300/22/2/1      |    140 ns    |    106 ns  |   1.32
bm_includes<int16_t, alg_type::std_fn>/300/105/2/1     |    220 ns    |    209 ns  |   1.05
bm_includes<int16_t, alg_type::std_fn>/300/290/2/1     |    254 ns    |    170 ns  |   1.49
bm_includes<int16_t, alg_type::std_fn>/3000/3/2/0      |    382 ns    |   67.7 ns  |   5.64
bm_includes<int16_t, alg_type::std_fn>/3000/22/2/0     |    536 ns    |    110 ns  |   4.87
bm_includes<int16_t, alg_type::std_fn>/3000/105/2/0    |    737 ns    |    324 ns  |   2.27
bm_includes<int16_t, alg_type::std_fn>/3000/1504/2/0   |    993 ns    |    924 ns  |   1.07
bm_includes<int16_t, alg_type::std_fn>/3000/2750/2/0   |    846 ns    |    923 ns  |   0.92
bm_includes<int16_t, alg_type::std_fn>/300/3/2/0       |   67.0 ns    |   18.6 ns  |   3.60
bm_includes<int16_t, alg_type::std_fn>/300/22/2/0      |   91.8 ns    |   60.0 ns  |   1.53
bm_includes<int16_t, alg_type::std_fn>/300/105/2/0     |    121 ns    |   98.0 ns  |   1.23
bm_includes<int16_t, alg_type::std_fn>/300/290/2/0     |    129 ns    |   86.8 ns  |   1.49
bm_includes<int16_t, alg_type::std_fn>/3000/3/3/1      |    665 ns    |    114 ns  |   5.83
bm_includes<int16_t, alg_type::std_fn>/3000/22/3/1     |    980 ns    |    203 ns  |   4.83
bm_includes<int16_t, alg_type::std_fn>/3000/105/3/1    |   1423 ns    |    542 ns  |   2.63
bm_includes<int16_t, alg_type::std_fn>/3000/1504/3/1   |   2795 ns    |   2256 ns  |   1.24
bm_includes<int16_t, alg_type::std_fn>/3000/2750/3/1   |   2173 ns    |   1685 ns  |   1.29
bm_includes<int16_t, alg_type::std_fn>/300/3/3/1       |    118 ns    |   29.3 ns  |   4.03
bm_includes<int16_t, alg_type::std_fn>/300/22/3/1      |    144 ns    |   97.3 ns  |   1.48
bm_includes<int16_t, alg_type::std_fn>/300/105/3/1     |    230 ns    |    200 ns  |   1.15
bm_includes<int16_t, alg_type::std_fn>/300/290/3/1     |    216 ns    |    174 ns  |   1.24
bm_includes<int16_t, alg_type::std_fn>/3000/3/3/0      |    504 ns    |   82.4 ns  |   6.12
bm_includes<int16_t, alg_type::std_fn>/3000/22/3/0     |    608 ns    |    116 ns  |   5.24
bm_includes<int16_t, alg_type::std_fn>/3000/105/3/0    |    767 ns    |    273 ns  |   2.81
bm_includes<int16_t, alg_type::std_fn>/3000/1504/3/0   |   1393 ns    |   1103 ns  |   1.26
bm_includes<int16_t, alg_type::std_fn>/3000/2750/3/0   |   1085 ns    |    855 ns  |   1.27
bm_includes<int16_t, alg_type::std_fn>/300/3/3/0       |   88.9 ns    |   22.3 ns  |   3.99
bm_includes<int16_t, alg_type::std_fn>/300/22/3/0      |   69.3 ns    |   52.5 ns  |   1.32
bm_includes<int16_t, alg_type::std_fn>/300/105/3/0     |    119 ns    |   93.6 ns  |   1.27
bm_includes<int16_t, alg_type::std_fn>/300/290/3/0     |    111 ns    |   89.7 ns  |   1.24
bm_includes<int32_t, alg_type::std_fn>/3000/3/0/1      |    370 ns    |   89.2 ns  |   4.15
bm_includes<int32_t, alg_type::std_fn>/3000/22/0/1     |    392 ns    |   98.6 ns  |   3.98
bm_includes<int32_t, alg_type::std_fn>/3000/105/0/1    |    424 ns    |    153 ns  |   2.77
bm_includes<int32_t, alg_type::std_fn>/3000/1504/0/1   |    959 ns    |    861 ns  |   1.11
bm_includes<int32_t, alg_type::std_fn>/3000/2750/0/1   |   1351 ns    |   1491 ns  |   0.91
bm_includes<int32_t, alg_type::std_fn>/300/3/0/1       |   55.5 ns    |   16.6 ns  |   3.34
bm_includes<int32_t, alg_type::std_fn>/300/22/0/1      |   74.9 ns    |   26.2 ns  |   2.86
bm_includes<int32_t, alg_type::std_fn>/300/105/0/1     |    104 ns    |   74.7 ns  |   1.39
bm_includes<int32_t, alg_type::std_fn>/300/290/0/1     |    152 ns    |    169 ns  |   0.90
bm_includes<int32_t, alg_type::std_fn>/3000/3/0/0      |    367 ns    |   88.0 ns  |   4.17
bm_includes<int32_t, alg_type::std_fn>/3000/22/0/0     |    451 ns    |   92.6 ns  |   4.87
bm_includes<int32_t, alg_type::std_fn>/3000/105/0/0    |    392 ns    |    126 ns  |   3.11
bm_includes<int32_t, alg_type::std_fn>/3000/1504/0/0   |    557 ns    |    458 ns  |   1.22
bm_includes<int32_t, alg_type::std_fn>/3000/2750/0/0   |    704 ns    |    750 ns  |   0.94
bm_includes<int32_t, alg_type::std_fn>/300/3/0/0       |   51.2 ns    |   15.3 ns  |   3.35
bm_includes<int32_t, alg_type::std_fn>/300/22/0/0      |   67.6 ns    |   19.9 ns  |   3.40
bm_includes<int32_t, alg_type::std_fn>/300/105/0/0     |   78.5 ns    |   39.1 ns  |   2.01
bm_includes<int32_t, alg_type::std_fn>/300/290/0/0     |   82.5 ns    |   91.3 ns  |   0.90
bm_includes<int32_t, alg_type::std_fn>/3000/3/1/1      |    370 ns    |   92.1 ns  |   4.02
bm_includes<int32_t, alg_type::std_fn>/3000/22/1/1     |    408 ns    |    113 ns  |   3.61
bm_includes<int32_t, alg_type::std_fn>/3000/105/1/1    |    576 ns    |    204 ns  |   2.82
bm_includes<int32_t, alg_type::std_fn>/3000/1504/1/1   |    909 ns    |    855 ns  |   1.06
bm_includes<int32_t, alg_type::std_fn>/3000/2750/1/1   |   1344 ns    |   1490 ns  |   0.90
bm_includes<int32_t, alg_type::std_fn>/300/3/1/1       |   55.6 ns    |   18.3 ns  |   3.04
bm_includes<int32_t, alg_type::std_fn>/300/22/1/1      |   90.4 ns    |   34.9 ns  |   2.59
bm_includes<int32_t, alg_type::std_fn>/300/105/1/1     |    155 ns    |    105 ns  |   1.48
bm_includes<int32_t, alg_type::std_fn>/300/290/1/1     |    151 ns    |    169 ns  |   0.89
bm_includes<int32_t, alg_type::std_fn>/3000/3/1/0      |    367 ns    |   90.6 ns  |   4.05
bm_includes<int32_t, alg_type::std_fn>/3000/22/1/0     |    511 ns    |   96.5 ns  |   5.30
bm_includes<int32_t, alg_type::std_fn>/3000/105/1/0    |    434 ns    |    153 ns  |   2.84
bm_includes<int32_t, alg_type::std_fn>/3000/1504/1/0   |    556 ns    |    463 ns  |   1.20
bm_includes<int32_t, alg_type::std_fn>/3000/2750/1/0   |    700 ns    |    749 ns  |   0.93
bm_includes<int32_t, alg_type::std_fn>/300/3/1/0       |   51.8 ns    |   17.8 ns  |   2.91
bm_includes<int32_t, alg_type::std_fn>/300/22/1/0      |   72.8 ns    |   26.2 ns  |   2.78
bm_includes<int32_t, alg_type::std_fn>/300/105/1/0     |    103 ns    |   58.0 ns  |   1.78
bm_includes<int32_t, alg_type::std_fn>/300/290/1/0     |   82.5 ns    |   92.7 ns  |   0.89
bm_includes<int32_t, alg_type::std_fn>/3000/3/2/1      |    635 ns    |    168 ns  |   3.78
bm_includes<int32_t, alg_type::std_fn>/3000/22/2/1     |   1003 ns    |    246 ns  |   4.08
bm_includes<int32_t, alg_type::std_fn>/3000/105/2/1    |   1392 ns    |    545 ns  |   2.55
bm_includes<int32_t, alg_type::std_fn>/3000/1504/2/1   |   1185 ns    |   1867 ns  |   0.63
bm_includes<int32_t, alg_type::std_fn>/3000/2750/2/1   |   1495 ns    |   1643 ns  |   0.91
bm_includes<int32_t, alg_type::std_fn>/300/3/2/1       |    107 ns    |   28.8 ns  |   3.72
bm_includes<int32_t, alg_type::std_fn>/300/22/2/1      |    140 ns    |   97.8 ns  |   1.43
bm_includes<int32_t, alg_type::std_fn>/300/105/2/1     |    222 ns    |    194 ns  |   1.14
bm_includes<int32_t, alg_type::std_fn>/300/290/2/1     |    236 ns    |    181 ns  |   1.30
bm_includes<int32_t, alg_type::std_fn>/3000/3/2/0      |    379 ns    |    105 ns  |   3.61
bm_includes<int32_t, alg_type::std_fn>/3000/22/2/0     |    524 ns    |    122 ns  |   4.30
bm_includes<int32_t, alg_type::std_fn>/3000/105/2/0    |    683 ns    |    282 ns  |   2.42
bm_includes<int32_t, alg_type::std_fn>/3000/1504/2/0   |    594 ns    |    935 ns  |   0.64
bm_includes<int32_t, alg_type::std_fn>/3000/2750/2/0   |    689 ns    |    830 ns  |   0.83
bm_includes<int32_t, alg_type::std_fn>/300/3/2/0       |   65.0 ns    |   20.4 ns  |   3.19
bm_includes<int32_t, alg_type::std_fn>/300/22/2/0      |   83.2 ns    |   50.3 ns  |   1.65
bm_includes<int32_t, alg_type::std_fn>/300/105/2/0     |    118 ns    |   91.5 ns  |   1.29
bm_includes<int32_t, alg_type::std_fn>/300/290/2/0     |    114 ns    |   89.2 ns  |   1.28
bm_includes<int32_t, alg_type::std_fn>/3000/3/3/1      |    667 ns    |    197 ns  |   3.39
bm_includes<int32_t, alg_type::std_fn>/3000/22/3/1     |    953 ns    |    234 ns  |   4.07
bm_includes<int32_t, alg_type::std_fn>/3000/105/3/1    |   1391 ns    |    509 ns  |   2.73
bm_includes<int32_t, alg_type::std_fn>/3000/1504/3/1   |   2565 ns    |   2107 ns  |   1.22
bm_includes<int32_t, alg_type::std_fn>/3000/2750/3/1   |   2106 ns    |   1566 ns  |   1.34
bm_includes<int32_t, alg_type::std_fn>/300/3/3/1       |    117 ns    |   31.6 ns  |   3.70
bm_includes<int32_t, alg_type::std_fn>/300/22/3/1      |    148 ns    |   84.6 ns  |   1.75
bm_includes<int32_t, alg_type::std_fn>/300/105/3/1     |    234 ns    |    176 ns  |   1.33
bm_includes<int32_t, alg_type::std_fn>/300/290/3/1     |    261 ns    |    165 ns  |   1.58
bm_includes<int32_t, alg_type::std_fn>/3000/3/3/0      |    510 ns    |    133 ns  |   3.83
bm_includes<int32_t, alg_type::std_fn>/3000/22/3/0     |    619 ns    |    152 ns  |   4.07
bm_includes<int32_t, alg_type::std_fn>/3000/105/3/0    |    787 ns    |    260 ns  |   3.03
bm_includes<int32_t, alg_type::std_fn>/3000/1504/3/0   |   1320 ns    |   1011 ns  |   1.31
bm_includes<int32_t, alg_type::std_fn>/3000/2750/3/0   |    884 ns    |    784 ns  |   1.13
bm_includes<int32_t, alg_type::std_fn>/300/3/3/0       |   88.2 ns    |   26.9 ns  |   3.28
bm_includes<int32_t, alg_type::std_fn>/300/22/3/0      |   73.9 ns    |   50.4 ns  |   1.47
bm_includes<int32_t, alg_type::std_fn>/300/105/3/0     |    112 ns    |   82.6 ns  |   1.36
bm_includes<int32_t, alg_type::std_fn>/300/290/3/0     |   80.0 ns    |   84.4 ns  |   0.95
bm_includes<int64_t, alg_type::std_fn>/3000/3/0/1      |    370 ns    |    159 ns  |   2.33
bm_includes<int64_t, alg_type::std_fn>/3000/22/0/1     |    397 ns    |    195 ns  |   2.04
bm_includes<int64_t, alg_type::std_fn>/3000/105/0/1    |    441 ns    |    250 ns  |   1.76
bm_includes<int64_t, alg_type::std_fn>/3000/1504/0/1   |    911 ns    |    986 ns  |   0.92
bm_includes<int64_t, alg_type::std_fn>/3000/2750/0/1   |   1347 ns    |   1695 ns  |   0.79
bm_includes<int64_t, alg_type::std_fn>/300/3/0/1       |   55.7 ns    |   33.1 ns  |   1.68
bm_includes<int64_t, alg_type::std_fn>/300/22/0/1      |   75.2 ns    |   47.9 ns  |   1.57
bm_includes<int64_t, alg_type::std_fn>/300/105/0/1     |    106 ns    |   99.1 ns  |   1.07
bm_includes<int64_t, alg_type::std_fn>/300/290/0/1     |    154 ns    |    188 ns  |   0.82
bm_includes<int64_t, alg_type::std_fn>/3000/3/0/0      |    368 ns    |    152 ns  |   2.42
bm_includes<int64_t, alg_type::std_fn>/3000/22/0/0     |    380 ns    |    161 ns  |   2.36
bm_includes<int64_t, alg_type::std_fn>/3000/105/0/0    |    406 ns    |    199 ns  |   2.04
bm_includes<int64_t, alg_type::std_fn>/3000/1504/0/0   |    579 ns    |    544 ns  |   1.06
bm_includes<int64_t, alg_type::std_fn>/3000/2750/0/0   |    703 ns    |    843 ns  |   0.83
bm_includes<int64_t, alg_type::std_fn>/300/3/0/0       |   52.7 ns    |   32.6 ns  |   1.62
bm_includes<int64_t, alg_type::std_fn>/300/22/0/0      |   64.5 ns    |   38.3 ns  |   1.68
bm_includes<int64_t, alg_type::std_fn>/300/105/0/0     |   81.8 ns    |   67.6 ns  |   1.21
bm_includes<int64_t, alg_type::std_fn>/300/290/0/0     |   86.2 ns    |    104 ns  |   0.83
bm_includes<int64_t, alg_type::std_fn>/3000/3/1/1      |    370 ns    |    157 ns  |   2.36
bm_includes<int64_t, alg_type::std_fn>/3000/22/1/1     |    400 ns    |    194 ns  |   2.06
bm_includes<int64_t, alg_type::std_fn>/3000/105/1/1    |    617 ns    |    297 ns  |   2.08
bm_includes<int64_t, alg_type::std_fn>/3000/1504/1/1   |    910 ns    |    980 ns  |   0.93
bm_includes<int64_t, alg_type::std_fn>/3000/2750/1/1   |   1342 ns    |   1660 ns  |   0.81
bm_includes<int64_t, alg_type::std_fn>/300/3/1/1       |   55.4 ns    |   33.4 ns  |   1.66
bm_includes<int64_t, alg_type::std_fn>/300/22/1/1      |   85.6 ns    |   56.2 ns  |   1.52
bm_includes<int64_t, alg_type::std_fn>/300/105/1/1     |    184 ns    |    122 ns  |   1.51
bm_includes<int64_t, alg_type::std_fn>/300/290/1/1     |    154 ns    |    188 ns  |   0.82
bm_includes<int64_t, alg_type::std_fn>/3000/3/1/0      |    368 ns    |    157 ns  |   2.34
bm_includes<int64_t, alg_type::std_fn>/3000/22/1/0     |    381 ns    |    172 ns  |   2.22
bm_includes<int64_t, alg_type::std_fn>/3000/105/1/0    |    524 ns    |    233 ns  |   2.25
bm_includes<int64_t, alg_type::std_fn>/3000/1504/1/0   |    562 ns    |    544 ns  |   1.03
bm_includes<int64_t, alg_type::std_fn>/3000/2750/1/0   |    704 ns    |    848 ns  |   0.83
bm_includes<int64_t, alg_type::std_fn>/300/3/1/0       |   52.2 ns    |   32.2 ns  |   1.62
bm_includes<int64_t, alg_type::std_fn>/300/22/1/0      |   65.8 ns    |   40.1 ns  |   1.64
bm_includes<int64_t, alg_type::std_fn>/300/105/1/0     |    110 ns    |   73.9 ns  |   1.49
bm_includes<int64_t, alg_type::std_fn>/300/290/1/0     |   86.3 ns    |    104 ns  |   0.83
bm_includes<int64_t, alg_type::std_fn>/3000/3/2/1      |    632 ns    |    291 ns  |   2.17
bm_includes<int64_t, alg_type::std_fn>/3000/22/2/1     |    996 ns    |    527 ns  |   1.89
bm_includes<int64_t, alg_type::std_fn>/3000/105/2/1    |   1338 ns    |    633 ns  |   2.11
bm_includes<int64_t, alg_type::std_fn>/3000/1504/2/1   |   1201 ns    |   2940 ns  |   0.41
bm_includes<int64_t, alg_type::std_fn>/3000/2750/2/1   |   1361 ns    |   1739 ns  |   0.78
bm_includes<int64_t, alg_type::std_fn>/300/3/2/1       |    107 ns    |   38.8 ns  |   2.76
bm_includes<int64_t, alg_type::std_fn>/300/22/2/1      |    142 ns    |   86.9 ns  |   1.63
bm_includes<int64_t, alg_type::std_fn>/300/105/2/1     |    227 ns    |    325 ns  |   0.70
bm_includes<int64_t, alg_type::std_fn>/300/290/2/1     |    252 ns    |    213 ns  |   1.18
bm_includes<int64_t, alg_type::std_fn>/3000/3/2/0      |    381 ns    |    181 ns  |   2.10
bm_includes<int64_t, alg_type::std_fn>/3000/22/2/0     |    534 ns    |    272 ns  |   1.96
bm_includes<int64_t, alg_type::std_fn>/3000/105/2/0    |    695 ns    |    336 ns  |   2.07
bm_includes<int64_t, alg_type::std_fn>/3000/1504/2/0   |    601 ns    |   1490 ns  |   0.40
bm_includes<int64_t, alg_type::std_fn>/3000/2750/2/0   |    690 ns    |    873 ns  |   0.79
bm_includes<int64_t, alg_type::std_fn>/300/3/2/0       |   66.5 ns    |   25.5 ns  |   2.61
bm_includes<int64_t, alg_type::std_fn>/300/22/2/0      |   91.2 ns    |   49.7 ns  |   1.84
bm_includes<int64_t, alg_type::std_fn>/300/105/2/0     |    121 ns    |    153 ns  |   0.79
bm_includes<int64_t, alg_type::std_fn>/300/290/2/0     |    129 ns    |    102 ns  |   1.26
bm_includes<int64_t, alg_type::std_fn>/3000/3/3/1      |    667 ns    |    335 ns  |   1.99
bm_includes<int64_t, alg_type::std_fn>/3000/22/3/1     |    968 ns    |    422 ns  |   2.29
bm_includes<int64_t, alg_type::std_fn>/3000/105/3/1    |   1438 ns    |    607 ns  |   2.37
bm_includes<int64_t, alg_type::std_fn>/3000/1504/3/1   |   2801 ns    |   2336 ns  |   1.20
bm_includes<int64_t, alg_type::std_fn>/3000/2750/3/1   |   2198 ns    |   1927 ns  |   1.14
bm_includes<int64_t, alg_type::std_fn>/300/3/3/1       |    117 ns    |   52.8 ns  |   2.22
bm_includes<int64_t, alg_type::std_fn>/300/22/3/1      |    139 ns    |   86.4 ns  |   1.61
bm_includes<int64_t, alg_type::std_fn>/300/105/3/1     |    233 ns    |    218 ns  |   1.07
bm_includes<int64_t, alg_type::std_fn>/300/290/3/1     |    217 ns    |    191 ns  |   1.14
bm_includes<int64_t, alg_type::std_fn>/3000/3/3/0      |    507 ns    |    228 ns  |   2.22
bm_includes<int64_t, alg_type::std_fn>/3000/22/3/0     |    608 ns    |    281 ns  |   2.16
bm_includes<int64_t, alg_type::std_fn>/3000/105/3/0    |    774 ns    |    327 ns  |   2.37
bm_includes<int64_t, alg_type::std_fn>/3000/1504/3/0   |   1398 ns    |   1112 ns  |   1.26
bm_includes<int64_t, alg_type::std_fn>/3000/2750/3/0   |   1087 ns    |    975 ns  |   1.11
bm_includes<int64_t, alg_type::std_fn>/300/3/3/0       |   90.0 ns    |   43.2 ns  |   2.08
bm_includes<int64_t, alg_type::std_fn>/300/22/3/0      |   68.9 ns    |   45.8 ns  |   1.50
bm_includes<int64_t, alg_type::std_fn>/300/105/3/0     |    119 ns    |    106 ns  |   1.12
bm_includes<int64_t, alg_type::std_fn>/300/290/3/0     |    118 ns    |    115 ns  |   1.03
bm_includes<int8_t, alg_type::rng>/3000/3/0/1          |    370 ns    |   35.1 ns  |   10.54
bm_includes<int8_t, alg_type::rng>/3000/22/0/1         |    430 ns    |   54.8 ns  |   7.85
bm_includes<int8_t, alg_type::rng>/3000/105/0/1        |    450 ns    |   85.1 ns  |   5.29
bm_includes<int8_t, alg_type::rng>/3000/1504/0/1       |    933 ns    |   1053 ns  |   0.89
bm_includes<int8_t, alg_type::rng>/3000/2750/0/1       |   1363 ns    |   1400 ns  |   0.97
bm_includes<int8_t, alg_type::rng>/300/3/0/1           |   54.6 ns    |   5.70 ns  |   9.58
bm_includes<int8_t, alg_type::rng>/300/22/0/1          |   72.1 ns    |   22.7 ns  |   3.18
bm_includes<int8_t, alg_type::rng>/300/105/0/1         |    131 ns    |   84.6 ns  |   1.55
bm_includes<int8_t, alg_type::rng>/300/290/0/1         |    154 ns    |    225 ns  |   0.68
bm_includes<int8_t, alg_type::rng>/3000/3/0/0          |    375 ns    |   31.1 ns  |   12.06
bm_includes<int8_t, alg_type::rng>/3000/22/0/0         |    377 ns    |   39.3 ns  |   9.59
bm_includes<int8_t, alg_type::rng>/3000/105/0/0        |    402 ns    |   63.2 ns  |   6.36
bm_includes<int8_t, alg_type::rng>/3000/1504/0/0       |    567 ns    |    552 ns  |   1.03
bm_includes<int8_t, alg_type::rng>/3000/2750/0/0       |    715 ns    |    707 ns  |   1.01
bm_includes<int8_t, alg_type::rng>/300/3/0/0           |   69.6 ns    |   5.06 ns  |   13.75
bm_includes<int8_t, alg_type::rng>/300/22/0/0          |   84.7 ns    |   15.4 ns  |   5.50
bm_includes<int8_t, alg_type::rng>/300/105/0/0         |   80.4 ns    |   34.6 ns  |   2.32
bm_includes<int8_t, alg_type::rng>/300/290/0/0         |   86.2 ns    |   81.1 ns  |   1.06
bm_includes<int8_t, alg_type::rng>/3000/3/1/1          |    369 ns    |   35.3 ns  |   10.45
bm_includes<int8_t, alg_type::rng>/3000/22/1/1         |    507 ns    |   64.9 ns  |   7.81
bm_includes<int8_t, alg_type::rng>/3000/105/1/1        |    981 ns    |    162 ns  |   6.06
bm_includes<int8_t, alg_type::rng>/3000/1504/1/1       |    920 ns    |   1023 ns  |   0.90
bm_includes<int8_t, alg_type::rng>/3000/2750/1/1       |   1358 ns    |   1450 ns  |   0.94
bm_includes<int8_t, alg_type::rng>/300/3/1/1           |   55.2 ns    |   13.2 ns  |   4.18
bm_includes<int8_t, alg_type::rng>/300/22/1/1          |    176 ns    |   34.1 ns  |   5.16
bm_includes<int8_t, alg_type::rng>/300/105/1/1         |    524 ns    |    106 ns  |   4.94
bm_includes<int8_t, alg_type::rng>/300/290/1/1         |    154 ns    |    227 ns  |   0.68
bm_includes<int8_t, alg_type::rng>/3000/3/1/0          |    402 ns    |   32.3 ns  |   12.45
bm_includes<int8_t, alg_type::rng>/3000/22/1/0         |    403 ns    |   41.5 ns  |   9.71
bm_includes<int8_t, alg_type::rng>/3000/105/1/0        |    675 ns    |   94.8 ns  |   7.12
bm_includes<int8_t, alg_type::rng>/3000/1504/1/0       |    570 ns    |    558 ns  |   1.02
bm_includes<int8_t, alg_type::rng>/3000/2750/1/0       |    714 ns    |    710 ns  |   1.01
bm_includes<int8_t, alg_type::rng>/300/3/1/0           |   73.7 ns    |   5.84 ns  |   12.62
bm_includes<int8_t, alg_type::rng>/300/22/1/0          |   65.4 ns    |   19.4 ns  |   3.37
bm_includes<int8_t, alg_type::rng>/300/105/1/0         |    284 ns    |   56.5 ns  |   5.03
bm_includes<int8_t, alg_type::rng>/300/290/1/0         |   84.2 ns    |   79.6 ns  |   1.06
bm_includes<int8_t, alg_type::rng>/3000/3/2/1          |    676 ns    |   59.2 ns  |   11.42
bm_includes<int8_t, alg_type::rng>/3000/22/2/1         |   1053 ns    |    195 ns  |   5.40
bm_includes<int8_t, alg_type::rng>/3000/105/2/1        |   2038 ns    |    843 ns  |   2.42
bm_includes<int8_t, alg_type::rng>/3000/1504/2/1       |  11426 ns    |   1951 ns  |   5.86
bm_includes<int8_t, alg_type::rng>/3000/2750/2/1       |   3719 ns    |   1616 ns  |   2.30
bm_includes<int8_t, alg_type::rng>/300/3/2/1           |    105 ns    |   24.3 ns  |   4.32
bm_includes<int8_t, alg_type::rng>/300/22/2/1          |    279 ns    |    138 ns  |   2.02
bm_includes<int8_t, alg_type::rng>/300/105/2/1         |    886 ns    |    207 ns  |   4.28
bm_includes<int8_t, alg_type::rng>/300/290/2/1         |    219 ns    |    161 ns  |   1.36
bm_includes<int8_t, alg_type::rng>/3000/3/2/0          |    382 ns    |   38.1 ns  |   10.03
bm_includes<int8_t, alg_type::rng>/3000/22/2/0         |    544 ns    |    123 ns  |   4.42
bm_includes<int8_t, alg_type::rng>/3000/105/2/0        |    992 ns    |    422 ns  |   2.35
bm_includes<int8_t, alg_type::rng>/3000/1504/2/0       |   5637 ns    |    963 ns  |   5.85
bm_includes<int8_t, alg_type::rng>/3000/2750/2/0       |   1833 ns    |    798 ns  |   2.30
bm_includes<int8_t, alg_type::rng>/300/3/2/0           |   67.0 ns    |   16.2 ns  |   4.14
bm_includes<int8_t, alg_type::rng>/300/22/2/0          |    140 ns    |   79.8 ns  |   1.75
bm_includes<int8_t, alg_type::rng>/300/105/2/0         |    384 ns    |    101 ns  |   3.80
bm_includes<int8_t, alg_type::rng>/300/290/2/0         |    110 ns    |   84.3 ns  |   1.30
bm_includes<int8_t, alg_type::rng>/3000/3/3/1          |    667 ns    |   71.2 ns  |   9.37
bm_includes<int8_t, alg_type::rng>/3000/22/3/1         |    991 ns    |    217 ns  |   4.57
bm_includes<int8_t, alg_type::rng>/3000/105/3/1        |   1814 ns    |    626 ns  |   2.90
bm_includes<int8_t, alg_type::rng>/3000/1504/3/1       |  10880 ns    |   1981 ns  |   5.49
bm_includes<int8_t, alg_type::rng>/3000/2750/3/1       |   3694 ns    |   1608 ns  |   2.30
bm_includes<int8_t, alg_type::rng>/300/3/3/1           |    116 ns    |   24.2 ns  |   4.79
bm_includes<int8_t, alg_type::rng>/300/22/3/1          |    286 ns    |    110 ns  |   2.60
bm_includes<int8_t, alg_type::rng>/300/105/3/1         |    812 ns    |    204 ns  |   3.98
bm_includes<int8_t, alg_type::rng>/300/290/3/1         |    215 ns    |    162 ns  |   1.33
bm_includes<int8_t, alg_type::rng>/3000/3/3/0          |    502 ns    |   54.3 ns  |   9.24
bm_includes<int8_t, alg_type::rng>/3000/22/3/0         |    610 ns    |    120 ns  |   5.08
bm_includes<int8_t, alg_type::rng>/3000/105/3/0        |    959 ns    |    323 ns  |   2.97
bm_includes<int8_t, alg_type::rng>/3000/1504/3/0       |   5297 ns    |    973 ns  |   5.44
bm_includes<int8_t, alg_type::rng>/3000/2750/3/0       |   1852 ns    |    815 ns  |   2.27
bm_includes<int8_t, alg_type::rng>/300/3/3/0           |   87.9 ns    |   17.8 ns  |   4.94
bm_includes<int8_t, alg_type::rng>/300/22/3/0          |    155 ns    |   62.6 ns  |   2.48
bm_includes<int8_t, alg_type::rng>/300/105/3/0         |    350 ns    |   99.8 ns  |   3.51
bm_includes<int8_t, alg_type::rng>/300/290/3/0         |    100 ns    |   82.2 ns  |   1.22
bm_includes<int16_t, alg_type::rng>/3000/3/0/1         |    369 ns    |   56.3 ns  |   6.55
bm_includes<int16_t, alg_type::rng>/3000/22/0/1        |    394 ns    |   75.2 ns  |   5.24
bm_includes<int16_t, alg_type::rng>/3000/105/0/1       |    445 ns    |    110 ns  |   4.05
bm_includes<int16_t, alg_type::rng>/3000/1504/0/1      |    914 ns    |    790 ns  |   1.16
bm_includes<int16_t, alg_type::rng>/3000/2750/0/1      |   1350 ns    |   1381 ns  |   0.98
bm_includes<int16_t, alg_type::rng>/300/3/0/1          |   56.5 ns    |   12.9 ns  |   4.38
bm_includes<int16_t, alg_type::rng>/300/22/0/1         |   77.6 ns    |   24.9 ns  |   3.12
bm_includes<int16_t, alg_type::rng>/300/105/0/1        |    106 ns    |   72.5 ns  |   1.46
bm_includes<int16_t, alg_type::rng>/300/290/0/1        |    154 ns    |    162 ns  |   0.95
bm_includes<int16_t, alg_type::rng>/3000/3/0/0         |    367 ns    |   58.6 ns  |   6.26
bm_includes<int16_t, alg_type::rng>/3000/22/0/0        |    383 ns    |   57.6 ns  |   6.65
bm_includes<int16_t, alg_type::rng>/3000/105/0/0       |    399 ns    |   78.4 ns  |   5.09
bm_includes<int16_t, alg_type::rng>/3000/1504/0/0      |    562 ns    |    421 ns  |   1.33
bm_includes<int16_t, alg_type::rng>/3000/2750/0/0      |    705 ns    |    704 ns  |   1.00
bm_includes<int16_t, alg_type::rng>/300/3/0/0          |   52.5 ns    |   11.4 ns  |   4.61
bm_includes<int16_t, alg_type::rng>/300/22/0/0         |   64.8 ns    |   19.4 ns  |   3.34
bm_includes<int16_t, alg_type::rng>/300/105/0/0        |   82.0 ns    |   43.4 ns  |   1.89
bm_includes<int16_t, alg_type::rng>/300/290/0/0        |   86.5 ns    |   85.6 ns  |   1.01
bm_includes<int16_t, alg_type::rng>/3000/3/1/1         |    372 ns    |   55.9 ns  |   6.65
bm_includes<int16_t, alg_type::rng>/3000/22/1/1        |    401 ns    |   84.8 ns  |   4.73
bm_includes<int16_t, alg_type::rng>/3000/105/1/1       |    742 ns    |    191 ns  |   3.88
bm_includes<int16_t, alg_type::rng>/3000/1504/1/1      |    909 ns    |    789 ns  |   1.15
bm_includes<int16_t, alg_type::rng>/3000/2750/1/1      |   1342 ns    |   1382 ns  |   0.97
bm_includes<int16_t, alg_type::rng>/300/3/1/1          |   55.0 ns    |   15.5 ns  |   3.55
bm_includes<int16_t, alg_type::rng>/300/22/1/1         |   85.4 ns    |   35.9 ns  |   2.38
bm_includes<int16_t, alg_type::rng>/300/105/1/1        |    185 ns    |    113 ns  |   1.64
bm_includes<int16_t, alg_type::rng>/300/290/1/1        |    154 ns    |    164 ns  |   0.94
bm_includes<int16_t, alg_type::rng>/3000/3/1/0         |    367 ns    |   57.4 ns  |   6.39
bm_includes<int16_t, alg_type::rng>/3000/22/1/0        |    380 ns    |   64.2 ns  |   5.92
bm_includes<int16_t, alg_type::rng>/3000/105/1/0       |    523 ns    |    123 ns  |   4.25
bm_includes<int16_t, alg_type::rng>/3000/1504/1/0      |    562 ns    |    421 ns  |   1.33
bm_includes<int16_t, alg_type::rng>/3000/2750/1/0      |    702 ns    |    699 ns  |   1.00
bm_includes<int16_t, alg_type::rng>/300/3/1/0          |   51.7 ns    |   12.8 ns  |   4.04
bm_includes<int16_t, alg_type::rng>/300/22/1/0         |   65.8 ns    |   22.6 ns  |   2.91
bm_includes<int16_t, alg_type::rng>/300/105/1/0        |    111 ns    |   57.9 ns  |   1.92
bm_includes<int16_t, alg_type::rng>/300/290/1/0        |   86.6 ns    |   83.9 ns  |   1.03
bm_includes<int16_t, alg_type::rng>/3000/3/2/1         |    632 ns    |    103 ns  |   6.14
bm_includes<int16_t, alg_type::rng>/3000/22/2/1        |    995 ns    |    224 ns  |   4.44
bm_includes<int16_t, alg_type::rng>/3000/105/2/1       |   1426 ns    |    657 ns  |   2.17
bm_includes<int16_t, alg_type::rng>/3000/1504/2/1      |   1798 ns    |   1788 ns  |   1.01
bm_includes<int16_t, alg_type::rng>/3000/2750/2/1      |   1843 ns    |   1874 ns  |   0.98
bm_includes<int16_t, alg_type::rng>/300/3/2/1          |    108 ns    |   28.9 ns  |   3.74
bm_includes<int16_t, alg_type::rng>/300/22/2/1         |    139 ns    |    108 ns  |   1.29
bm_includes<int16_t, alg_type::rng>/300/105/2/1        |    220 ns    |    206 ns  |   1.07
bm_includes<int16_t, alg_type::rng>/300/290/2/1        |    252 ns    |    172 ns  |   1.47
bm_includes<int16_t, alg_type::rng>/3000/3/2/0         |    381 ns    |   68.8 ns  |   5.54
bm_includes<int16_t, alg_type::rng>/3000/22/2/0        |    540 ns    |    114 ns  |   4.74
bm_includes<int16_t, alg_type::rng>/3000/105/2/0       |    727 ns    |    327 ns  |   2.22
bm_includes<int16_t, alg_type::rng>/3000/1504/2/0      |    998 ns    |    925 ns  |   1.08
bm_includes<int16_t, alg_type::rng>/3000/2750/2/0      |    842 ns    |    956 ns  |   0.88
bm_includes<int16_t, alg_type::rng>/300/3/2/0          |   66.7 ns    |   19.2 ns  |   3.47
bm_includes<int16_t, alg_type::rng>/300/22/2/0         |   91.7 ns    |   60.4 ns  |   1.52
bm_includes<int16_t, alg_type::rng>/300/105/2/0        |    120 ns    |    101 ns  |   1.19
bm_includes<int16_t, alg_type::rng>/300/290/2/0        |    129 ns    |   89.5 ns  |   1.44
bm_includes<int16_t, alg_type::rng>/3000/3/3/1         |    667 ns    |    115 ns  |   5.80
bm_includes<int16_t, alg_type::rng>/3000/22/3/1        |    973 ns    |    203 ns  |   4.79
bm_includes<int16_t, alg_type::rng>/3000/105/3/1       |   1452 ns    |    550 ns  |   2.64
bm_includes<int16_t, alg_type::rng>/3000/1504/3/1      |   2790 ns    |   2270 ns  |   1.23
bm_includes<int16_t, alg_type::rng>/3000/2750/3/1      |   2182 ns    |   1710 ns  |   1.28
bm_includes<int16_t, alg_type::rng>/300/3/3/1          |    118 ns    |   29.8 ns  |   3.96
bm_includes<int16_t, alg_type::rng>/300/22/3/1         |    140 ns    |   98.9 ns  |   1.42
bm_includes<int16_t, alg_type::rng>/300/105/3/1        |    231 ns    |    199 ns  |   1.16
bm_includes<int16_t, alg_type::rng>/300/290/3/1        |    217 ns    |    175 ns  |   1.24
bm_includes<int16_t, alg_type::rng>/3000/3/3/0         |    504 ns    |   83.0 ns  |   6.07
bm_includes<int16_t, alg_type::rng>/3000/22/3/0        |    612 ns    |    116 ns  |   5.28
bm_includes<int16_t, alg_type::rng>/3000/105/3/0       |    801 ns    |    273 ns  |   2.93
bm_includes<int16_t, alg_type::rng>/3000/1504/3/0      |   1428 ns    |   1098 ns  |   1.30
bm_includes<int16_t, alg_type::rng>/3000/2750/3/0      |   1106 ns    |    865 ns  |   1.28
bm_includes<int16_t, alg_type::rng>/300/3/3/0          |   89.6 ns    |   22.5 ns  |   3.98
bm_includes<int16_t, alg_type::rng>/300/22/3/0         |   69.6 ns    |   53.9 ns  |   1.29
bm_includes<int16_t, alg_type::rng>/300/105/3/0        |    119 ns    |   94.6 ns  |   1.26
bm_includes<int16_t, alg_type::rng>/300/290/3/0        |    112 ns    |   90.6 ns  |   1.24
bm_includes<int32_t, alg_type::rng>/3000/3/0/1         |    376 ns    |   90.4 ns  |   4.16
bm_includes<int32_t, alg_type::rng>/3000/22/0/1        |    393 ns    |   96.2 ns  |   4.09
bm_includes<int32_t, alg_type::rng>/3000/105/0/1       |    426 ns    |    153 ns  |   2.78
bm_includes<int32_t, alg_type::rng>/3000/1504/0/1      |    917 ns    |    854 ns  |   1.07
bm_includes<int32_t, alg_type::rng>/3000/2750/0/1      |   1383 ns    |   1478 ns  |   0.94
bm_includes<int32_t, alg_type::rng>/300/3/0/1          |   58.7 ns    |   16.6 ns  |   3.54
bm_includes<int32_t, alg_type::rng>/300/22/0/1         |   70.8 ns    |   25.8 ns  |   2.74
bm_includes<int32_t, alg_type::rng>/300/105/0/1        |    106 ns    |   73.8 ns  |   1.44
bm_includes<int32_t, alg_type::rng>/300/290/0/1        |    153 ns    |    171 ns  |   0.89
bm_includes<int32_t, alg_type::rng>/3000/3/0/0         |    378 ns    |   90.4 ns  |   4.18
bm_includes<int32_t, alg_type::rng>/3000/22/0/0        |    376 ns    |   92.3 ns  |   4.07
bm_includes<int32_t, alg_type::rng>/3000/105/0/0       |    394 ns    |    124 ns  |   3.18
bm_includes<int32_t, alg_type::rng>/3000/1504/0/0      |    568 ns    |    461 ns  |   1.23
bm_includes<int32_t, alg_type::rng>/3000/2750/0/0      |    713 ns    |    760 ns  |   0.94
bm_includes<int32_t, alg_type::rng>/300/3/0/0          |   56.4 ns    |   15.1 ns  |   3.74
bm_includes<int32_t, alg_type::rng>/300/22/0/0         |   58.8 ns    |   20.4 ns  |   2.88
bm_includes<int32_t, alg_type::rng>/300/105/0/0        |   79.3 ns    |   42.3 ns  |   1.87
bm_includes<int32_t, alg_type::rng>/300/290/0/0        |   83.4 ns    |   91.8 ns  |   0.91
bm_includes<int32_t, alg_type::rng>/3000/3/1/1         |    374 ns    |   92.7 ns  |   4.03
bm_includes<int32_t, alg_type::rng>/3000/22/1/1        |    409 ns    |    113 ns  |   3.62
bm_includes<int32_t, alg_type::rng>/3000/105/1/1       |    507 ns    |    202 ns  |   2.51
bm_includes<int32_t, alg_type::rng>/3000/1504/1/1      |    916 ns    |    862 ns  |   1.06
bm_includes<int32_t, alg_type::rng>/3000/2750/1/1      |   1374 ns    |   1490 ns  |   0.92
bm_includes<int32_t, alg_type::rng>/300/3/1/1          |   57.9 ns    |   18.5 ns  |   3.13
bm_includes<int32_t, alg_type::rng>/300/22/1/1         |   91.1 ns    |   34.6 ns  |   2.63
bm_includes<int32_t, alg_type::rng>/300/105/1/1        |    164 ns    |    105 ns  |   1.56
bm_includes<int32_t, alg_type::rng>/300/290/1/1        |    152 ns    |    170 ns  |   0.89
bm_includes<int32_t, alg_type::rng>/3000/3/1/0         |    368 ns    |   90.6 ns  |   4.06
bm_includes<int32_t, alg_type::rng>/3000/22/1/0        |    385 ns    |   96.6 ns  |   3.99
bm_includes<int32_t, alg_type::rng>/3000/105/1/0       |    438 ns    |    151 ns  |   2.90
bm_includes<int32_t, alg_type::rng>/3000/1504/1/0      |    560 ns    |    460 ns  |   1.22
bm_includes<int32_t, alg_type::rng>/3000/2750/1/0      |    707 ns    |    752 ns  |   0.94
bm_includes<int32_t, alg_type::rng>/300/3/1/0          |   54.2 ns    |   17.5 ns  |   3.10
bm_includes<int32_t, alg_type::rng>/300/22/1/0         |   70.1 ns    |   26.1 ns  |   2.69
bm_includes<int32_t, alg_type::rng>/300/105/1/0        |    104 ns    |   57.9 ns  |   1.80
bm_includes<int32_t, alg_type::rng>/300/290/1/0        |   83.4 ns    |   93.5 ns  |   0.89
bm_includes<int32_t, alg_type::rng>/3000/3/2/1         |    633 ns    |    174 ns  |   3.64
bm_includes<int32_t, alg_type::rng>/3000/22/2/1        |   1025 ns    |    252 ns  |   4.07
bm_includes<int32_t, alg_type::rng>/3000/105/2/1       |   1635 ns    |    572 ns  |   2.86
bm_includes<int32_t, alg_type::rng>/3000/1504/2/1      |   1205 ns    |   1897 ns  |   0.64
bm_includes<int32_t, alg_type::rng>/3000/2750/2/1      |   1362 ns    |   1634 ns  |   0.83
bm_includes<int32_t, alg_type::rng>/300/3/2/1          |    107 ns    |   29.3 ns  |   3.65
bm_includes<int32_t, alg_type::rng>/300/22/2/1         |    180 ns    |   98.1 ns  |   1.83
bm_includes<int32_t, alg_type::rng>/300/105/2/1        |    244 ns    |    195 ns  |   1.25
bm_includes<int32_t, alg_type::rng>/300/290/2/1        |    224 ns    |    180 ns  |   1.24
bm_includes<int32_t, alg_type::rng>/3000/3/2/0         |    389 ns    |    104 ns  |   3.74
bm_includes<int32_t, alg_type::rng>/3000/22/2/0        |    556 ns    |    122 ns  |   4.56
bm_includes<int32_t, alg_type::rng>/3000/105/2/0       |    827 ns    |    284 ns  |   2.91
bm_includes<int32_t, alg_type::rng>/3000/1504/2/0      |    597 ns    |    935 ns  |   0.64
bm_includes<int32_t, alg_type::rng>/3000/2750/2/0      |    682 ns    |    834 ns  |   0.82
bm_includes<int32_t, alg_type::rng>/300/3/2/0          |   70.2 ns    |   20.4 ns  |   3.44
bm_includes<int32_t, alg_type::rng>/300/22/2/0         |   93.1 ns    |   50.7 ns  |   1.84
bm_includes<int32_t, alg_type::rng>/300/105/2/0        |    131 ns    |   88.1 ns  |   1.49
bm_includes<int32_t, alg_type::rng>/300/290/2/0        |    100 ns    |   84.7 ns  |   1.18
bm_includes<int32_t, alg_type::rng>/3000/3/3/1         |    665 ns    |    175 ns  |   3.80
bm_includes<int32_t, alg_type::rng>/3000/22/3/1        |    992 ns    |    234 ns  |   4.24
bm_includes<int32_t, alg_type::rng>/3000/105/3/1       |   1661 ns    |    512 ns  |   3.24
bm_includes<int32_t, alg_type::rng>/3000/1504/3/1      |   2431 ns    |   2070 ns  |   1.17
bm_includes<int32_t, alg_type::rng>/3000/2750/3/1      |   1631 ns    |   1572 ns  |   1.04
bm_includes<int32_t, alg_type::rng>/300/3/3/1          |    118 ns    |   31.5 ns  |   3.75
bm_includes<int32_t, alg_type::rng>/300/22/3/1         |    157 ns    |   84.0 ns  |   1.87
bm_includes<int32_t, alg_type::rng>/300/105/3/1        |    215 ns    |    175 ns  |   1.23
bm_includes<int32_t, alg_type::rng>/300/290/3/1        |    155 ns    |    165 ns  |   0.94
bm_includes<int32_t, alg_type::rng>/3000/3/3/0         |    515 ns    |    130 ns  |   3.96
bm_includes<int32_t, alg_type::rng>/3000/22/3/0        |    611 ns    |    144 ns  |   4.24
bm_includes<int32_t, alg_type::rng>/3000/105/3/0       |    855 ns    |    255 ns  |   3.35
bm_includes<int32_t, alg_type::rng>/3000/1504/3/0      |   1269 ns    |   1034 ns  |   1.23
bm_includes<int32_t, alg_type::rng>/3000/2750/3/0      |    781 ns    |    785 ns  |   0.99
bm_includes<int32_t, alg_type::rng>/300/3/3/0          |   92.7 ns    |   27.1 ns  |   3.42
bm_includes<int32_t, alg_type::rng>/300/22/3/0         |   89.0 ns    |   50.7 ns  |   1.76
bm_includes<int32_t, alg_type::rng>/300/105/3/0        |    110 ns    |   82.3 ns  |   1.34
bm_includes<int32_t, alg_type::rng>/300/290/3/0        |   94.6 ns    |   83.1 ns  |   1.14
bm_includes<int64_t, alg_type::rng>/3000/3/0/1         |    375 ns    |    155 ns  |   2.42
bm_includes<int64_t, alg_type::rng>/3000/22/0/1        |    388 ns    |    174 ns  |   2.23
bm_includes<int64_t, alg_type::rng>/3000/105/0/1       |    422 ns    |    230 ns  |   1.83
bm_includes<int64_t, alg_type::rng>/3000/1504/0/1      |    913 ns    |    979 ns  |   0.93
bm_includes<int64_t, alg_type::rng>/3000/2750/0/1      |   1340 ns    |   1655 ns  |   0.81
bm_includes<int64_t, alg_type::rng>/300/3/0/1          |   57.7 ns    |   32.7 ns  |   1.76
bm_includes<int64_t, alg_type::rng>/300/22/0/1         |   71.2 ns    |   48.5 ns  |   1.47
bm_includes<int64_t, alg_type::rng>/300/105/0/1        |    106 ns    |   99.4 ns  |   1.07
bm_includes<int64_t, alg_type::rng>/300/290/0/1        |    152 ns    |    187 ns  |   0.81
bm_includes<int64_t, alg_type::rng>/3000/3/0/0         |    371 ns    |    154 ns  |   2.41
bm_includes<int64_t, alg_type::rng>/3000/22/0/0        |    385 ns    |    160 ns  |   2.41
bm_includes<int64_t, alg_type::rng>/3000/105/0/0       |    393 ns    |    200 ns  |   1.97
bm_includes<int64_t, alg_type::rng>/3000/1504/0/0      |    561 ns    |    542 ns  |   1.04
bm_includes<int64_t, alg_type::rng>/3000/2750/0/0      |    701 ns    |    849 ns  |   0.83
bm_includes<int64_t, alg_type::rng>/300/3/0/0          |   58.4 ns    |   32.0 ns  |   1.83
bm_includes<int64_t, alg_type::rng>/300/22/0/0         |   64.6 ns    |   37.8 ns  |   1.71
bm_includes<int64_t, alg_type::rng>/300/105/0/0        |   79.3 ns    |   67.2 ns  |   1.18
bm_includes<int64_t, alg_type::rng>/300/290/0/0        |   84.6 ns    |    105 ns  |   0.81
bm_includes<int64_t, alg_type::rng>/3000/3/1/1         |    370 ns    |    164 ns  |   2.26
bm_includes<int64_t, alg_type::rng>/3000/22/1/1        |    403 ns    |    205 ns  |   1.97
bm_includes<int64_t, alg_type::rng>/3000/105/1/1       |    524 ns    |    298 ns  |   1.76
bm_includes<int64_t, alg_type::rng>/3000/1504/1/1      |    911 ns    |    983 ns  |   0.93
bm_includes<int64_t, alg_type::rng>/3000/2750/1/1      |   1342 ns    |   1652 ns  |   0.81
bm_includes<int64_t, alg_type::rng>/300/3/1/1          |   56.2 ns    |   32.4 ns  |   1.73
bm_includes<int64_t, alg_type::rng>/300/22/1/1         |   84.6 ns    |   55.3 ns  |   1.53
bm_includes<int64_t, alg_type::rng>/300/105/1/1        |    158 ns    |    121 ns  |   1.31
bm_includes<int64_t, alg_type::rng>/300/290/1/1        |    152 ns    |    187 ns  |   0.81
bm_includes<int64_t, alg_type::rng>/3000/3/1/0         |    372 ns    |    155 ns  |   2.40
bm_includes<int64_t, alg_type::rng>/3000/22/1/0        |    384 ns    |    169 ns  |   2.27
bm_includes<int64_t, alg_type::rng>/3000/105/1/0       |    438 ns    |    232 ns  |   1.89
bm_includes<int64_t, alg_type::rng>/3000/1504/1/0      |    561 ns    |    541 ns  |   1.04
bm_includes<int64_t, alg_type::rng>/3000/2750/1/0      |    702 ns    |    840 ns  |   0.84
bm_includes<int64_t, alg_type::rng>/300/3/1/0          |   54.4 ns    |   31.7 ns  |   1.72
bm_includes<int64_t, alg_type::rng>/300/22/1/0         |   66.5 ns    |   38.6 ns  |   1.72
bm_includes<int64_t, alg_type::rng>/300/105/1/0        |    105 ns    |   73.8 ns  |   1.42
bm_includes<int64_t, alg_type::rng>/300/290/1/0        |   84.8 ns    |    105 ns  |   0.81
bm_includes<int64_t, alg_type::rng>/3000/3/2/1         |    633 ns    |    291 ns  |   2.18
bm_includes<int64_t, alg_type::rng>/3000/22/2/1        |   1017 ns    |    540 ns  |   1.88
bm_includes<int64_t, alg_type::rng>/3000/105/2/1       |   1647 ns    |    642 ns  |   2.57
bm_includes<int64_t, alg_type::rng>/3000/1504/2/1      |   1209 ns    |   2975 ns  |   0.41
bm_includes<int64_t, alg_type::rng>/3000/2750/2/1      |   1360 ns    |   1737 ns  |   0.78
bm_includes<int64_t, alg_type::rng>/300/3/2/1          |    108 ns    |   39.5 ns  |   2.73
bm_includes<int64_t, alg_type::rng>/300/22/2/1         |    173 ns    |   88.3 ns  |   1.96
bm_includes<int64_t, alg_type::rng>/300/105/2/1        |    217 ns    |    325 ns  |   0.67
bm_includes<int64_t, alg_type::rng>/300/290/2/1        |    233 ns    |    215 ns  |   1.08
bm_includes<int64_t, alg_type::rng>/3000/3/2/0         |    389 ns    |    182 ns  |   2.14
bm_includes<int64_t, alg_type::rng>/3000/22/2/0        |    560 ns    |    272 ns  |   2.06
bm_includes<int64_t, alg_type::rng>/3000/105/2/0       |    835 ns    |    333 ns  |   2.51
bm_includes<int64_t, alg_type::rng>/3000/1504/2/0      |    595 ns    |   1470 ns  |   0.40
bm_includes<int64_t, alg_type::rng>/3000/2750/2/0      |    685 ns    |    876 ns  |   0.78
bm_includes<int64_t, alg_type::rng>/300/3/2/0          |   70.3 ns    |   26.0 ns  |   2.70
bm_includes<int64_t, alg_type::rng>/300/22/2/0         |   99.6 ns    |   49.6 ns  |   2.01
bm_includes<int64_t, alg_type::rng>/300/105/2/0        |    116 ns    |    154 ns  |   0.75
bm_includes<int64_t, alg_type::rng>/300/290/2/0        |   95.1 ns    |    101 ns  |   0.94
bm_includes<int64_t, alg_type::rng>/3000/3/3/1         |    669 ns    |    303 ns  |   2.21
bm_includes<int64_t, alg_type::rng>/3000/22/3/1        |   1012 ns    |    415 ns  |   2.44
bm_includes<int64_t, alg_type::rng>/3000/105/3/1       |   1559 ns    |    609 ns  |   2.56
bm_includes<int64_t, alg_type::rng>/3000/1504/3/1      |   2442 ns    |   2334 ns  |   1.05
bm_includes<int64_t, alg_type::rng>/3000/2750/3/1      |   1548 ns    |   1968 ns  |   0.79
bm_includes<int64_t, alg_type::rng>/300/3/3/1          |    118 ns    |   51.3 ns  |   2.30
bm_includes<int64_t, alg_type::rng>/300/22/3/1         |    164 ns    |   87.2 ns  |   1.88
bm_includes<int64_t, alg_type::rng>/300/105/3/1        |    223 ns    |    217 ns  |   1.03
bm_includes<int64_t, alg_type::rng>/300/290/3/1        |    157 ns    |    194 ns  |   0.81
bm_includes<int64_t, alg_type::rng>/3000/3/3/0         |    517 ns    |    228 ns  |   2.27
bm_includes<int64_t, alg_type::rng>/3000/22/3/0        |    620 ns    |    279 ns  |   2.22
bm_includes<int64_t, alg_type::rng>/3000/105/3/0       |    847 ns    |    324 ns  |   2.61
bm_includes<int64_t, alg_type::rng>/3000/1504/3/0      |   1237 ns    |   1127 ns  |   1.10
bm_includes<int64_t, alg_type::rng>/3000/2750/3/0      |    798 ns    |    984 ns  |   0.81
bm_includes<int64_t, alg_type::rng>/300/3/3/0          |   96.1 ns    |   42.9 ns  |   2.24
bm_includes<int64_t, alg_type::rng>/300/22/3/0         |   89.4 ns    |   46.3 ns  |   1.93
bm_includes<int64_t, alg_type::rng>/300/105/3/0        |    118 ns    |    106 ns  |   1.11
bm_includes<int64_t, alg_type::rng>/300/290/3/0        |   80.9 ns    |    113 ns  |   0.72

