### PR TITLE
`includes` benchmark: handle edge case simpler

### DIFF
--- a/benchmarks/src/includes.cpp
+++ b/benchmarks/src/includes.cpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
+#include <limits>
 #include <random>
 #include <ranges>
 #include <type_traits>
@@ -74,9 +75,8 @@ void bm_includes(benchmark::State& state) {
 
     if (!expected_match) {
         const T v = needle[needle_size / 2];
-        const T r = static_cast<T>(static_cast<make_unsigned_t<T>>(v) + 1);
+        const T r = v != numeric_limits<T>::max() ? v + 1 : v - 1;
         ranges::replace(hay, v, r);
-        ranges::sort(hay);
     }
 
     for (auto _ : state) {


### PR DESCRIPTION
Avoid overflow without cast, also avoid repeated sorting

Followup to #5543.