### PR TITLE
Optimize `find` for ARM64EC

### DIFF
--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -3297,12 +3297,20 @@ const void* __stdcall __std_find_trivial_unsized_8(const void* const _First, con
 
 const void* __stdcall __std_find_trivial_1(
     const void* const _First, const void* const _Last, const uint8_t _Val) noexcept {
+#ifdef _M_ARM64EC
+    return memchr(_First, _Val, _Byte_length(_First, _Last));
+#else
     return _Finding::_Find_impl<_Finding::_Find_traits_1, _Finding::_Predicate::_Equal>(_First, _Last, _Val);
+#endif
 }
 
 const void* __stdcall __std_find_trivial_2(
     const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
+#ifdef _M_ARM64EC
+    return wmemchr(static_cast<const wchar_t*>(_First), static_cast<wchar_t>(_Val), _Byte_length(_First, _Last) * 2);
+#else
     return _Finding::_Find_impl<_Finding::_Find_traits_2, _Finding::_Predicate::_Equal>(_First, _Last, _Val);
+#endif
 }
 
 const void* __stdcall __std_find_trivial_4(

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -3307,7 +3307,7 @@ const void* __stdcall __std_find_trivial_1(
 const void* __stdcall __std_find_trivial_2(
     const void* const _First, const void* const _Last, const uint16_t _Val) noexcept {
 #ifdef _M_ARM64EC
-    return wmemchr(static_cast<const wchar_t*>(_First), static_cast<wchar_t>(_Val), _Byte_length(_First, _Last) * 2);
+    return wmemchr(static_cast<const wchar_t*>(_First), _Val, _Byte_length(_First, _Last) / sizeof(wchar_t));
 #else
     return _Finding::_Find_impl<_Finding::_Find_traits_2, _Finding::_Predicate::_Equal>(_First, _Last, _Val);
 #endif


### PR DESCRIPTION
I'm not completely sure what exactly ARM64EC is (#2740). 
But the upstream `memchr` / `wmemchr` are apparently properly optimized for it.

I didn't benchmark or test this change. It seems to compile though.