### PR TITLE
Implement LWG-4222 `expected` constructor from a single value missing a constraint

### DIFF
--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -306,6 +306,7 @@ public:
 
     template <class _Uty = remove_cv_t<_Ty>>
         requires (!is_same_v<remove_cvref_t<_Uty>, in_place_t> && !is_same_v<remove_cvref_t<_Uty>, expected>
+                     && !is_same_v<remove_cvref_t<_Uty>, unexpect_t>
                      && !_Is_specialization_v<remove_cvref_t<_Uty>, unexpected>
                      && (!is_same_v<remove_cv_t<_Ty>, bool>
 #if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10655311

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -2509,6 +2509,21 @@ static_assert(!is_assignable_v<expected<void, move_only>&, ambiguating_expected_
 
 static_assert(test_lwg_3886());
 
+// Test LWG-4222 "expected constructor from a single value missing a constraint"
+
+struct ConstructibleFromEverything {
+    explicit ConstructibleFromEverything(auto);
+};
+
+struct ConvertibleFromInt {
+    ConvertibleFromInt(int);
+};
+
+static_assert(!is_constructible_v<expected<ConstructibleFromEverything, ConvertibleFromInt>, unexpect_t&>);
+static_assert(!is_constructible_v<expected<ConstructibleFromEverything, ConvertibleFromInt>, const unexpect_t&>);
+static_assert(!is_constructible_v<expected<ConstructibleFromEverything, ConvertibleFromInt>, unexpect_t>);
+static_assert(!is_constructible_v<expected<ConstructibleFromEverything, ConvertibleFromInt>, const unexpect_t>);
+
 int main() {
     test_unexpected::test_all();
     static_assert(test_unexpected::test_all());


### PR DESCRIPTION
Per LWG-4222/WG21-P3742R0 ([alternative link](https://isocpp.org/files/papers/P3742R0.html)).