### PR TITLE
Implement P3223R2 Making `istream::ignore()` Less Surprising

### DIFF
--- a/stl/inc/istream
+++ b/stl/inc/istream
@@ -528,6 +528,11 @@ public:
         return *this;
     }
 
+    template <class _CharType = _Elem, enable_if_t<is_same_v<_CharType, char>, int> = 0>
+    basic_istream& ignore(const streamsize _Count, const _Elem _Delim) {
+        return ignore(_Count, _Traits::to_int_type(_Delim));
+    }
+
     basic_istream& __CLR_OR_THIS_CALL read(_Elem* _Str, streamsize _Count) { // read up to _Count characters into buffer
         ios_base::iostate _State = ios_base::goodbit;
         _Chcount                 = 0;

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -80,6 +80,7 @@
 //     (__cpp_lib_freestanding_algorithm and __cpp_lib_freestanding_array only)
 // P2937R0 Freestanding Library: Remove strtok
 // P2968R2 Make std::ignore A First-Class Object
+// P3223R2 Making istream::ignore() Less Surprising
 // P3323R1 Forbid atomic<cv T>, Specify atomic_ref<cv T>
 //     (for atomic<cv T>)
 

--- a/tests/std/tests/VSO_0000000_nullptr_stream_out/test.cpp
+++ b/tests/std/tests/VSO_0000000_nullptr_stream_out/test.cpp
@@ -64,4 +64,17 @@ int main() {
     STATIC_ASSERT(OstreamInsertable<PublicOstream, int>);
     STATIC_ASSERT(OstreamInsertable<PrivateOstream&, int>);
     STATIC_ASSERT(!OstreamInsertable<PrivateOstream, int>);
+
+    { // Test P3223R2 "Making std::istream::ignore Less Surprising"
+        istringstream in{"\xF0\x9F\xA4\xA1 Clown Face"};
+        decltype(auto) ret = in.ignore(100, '\xA1');
+
+        STATIC_ASSERT(is_same_v<decltype(ret), istream&>);
+        assert(&ret == &static_cast<istream&>(in));
+        assert(in.gcount() == 4);
+
+        string s;
+        in >> s;
+        assert(s == "Clown");
+    }
 }


### PR DESCRIPTION
As a Defect Report against old standard modes. Fixes #5618.

As a result of DR-backing [P3223R2](https://isocpp.org/files/papers/P3223R2.html), the new overload is templated, and thus this PR happens to "constrain the new overload to prevent ambiguities" and keeps `in.ignore(100, -1L)` well-formed.