### PR TITLE
`<type_traits>`: Partially unblock P0466R5 for Clang

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1880,19 +1880,32 @@ constexpr bool is_nothrow_invocable_r_v =
 #endif // _HAS_CXX17
 
 #if _HAS_CXX20
-#ifndef __clang__ // TRANSITION, LLVM-48860
+#if !defined(__clang__) || defined(__EDG__) \
+    || (defined(__clang__) && __clang_major__ >= 19) // TRANSITION, VSO-2397560 (RWC relying on ancient Clang)
 _EXPORT_STD template <class _Ty1, class _Ty2>
 struct is_layout_compatible : bool_constant<__is_layout_compatible(_Ty1, _Ty2)> {};
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 constexpr bool is_layout_compatible_v = __is_layout_compatible(_Ty1, _Ty2);
 
+#if !defined(__clang__) || defined(__EDG__) // TRANSITION, LLVM-135273
 _EXPORT_STD template <class _Base, class _Derived>
 struct is_pointer_interconvertible_base_of : bool_constant<__is_pointer_interconvertible_base_of(_Base, _Derived)> {};
 
 _EXPORT_STD template <class _Base, class _Derived>
 constexpr bool is_pointer_interconvertible_base_of_v = __is_pointer_interconvertible_base_of(_Base, _Derived);
+#else // ^^^ no workaround / workaround vvv
+_EXPORT_STD template <class _Base, class _Derived>
+struct is_pointer_interconvertible_base_of
+    : bool_constant<__is_pointer_interconvertible_base_of(remove_cv_t<_Base>, remove_cv_t<_Derived>)> {};
 
+_EXPORT_STD template <class _Base, class _Derived>
+constexpr bool is_pointer_interconvertible_base_of_v =
+    __is_pointer_interconvertible_base_of(remove_cv_t<_Base>, remove_cv_t<_Derived>);
+#endif // ^^^ workaround ^^^
+#endif // ^^^ no workaround ^^^
+
+#ifndef __clang__ // TRANSITION, LLVM-48860
 _EXPORT_STD template <class _ClassTy, class _MemberTy>
 _NODISCARD constexpr bool is_pointer_interconvertible_with_class(_MemberTy _ClassTy::* _Pm) noexcept {
     return __is_pointer_interconvertible_with_class(_ClassTy, _Pm);

--- a/tests/std/tests/P0466R5_layout_compatibility_and_pointer_interconvertibility_traits/test.cpp
+++ b/tests/std/tests/P0466R5_layout_compatibility_and_pointer_interconvertibility_traits/test.cpp
@@ -14,7 +14,6 @@ struct S { // Must be declared at namespace scope due to static data member
 };
 
 constexpr bool test() {
-#if defined(__cpp_lib_is_layout_compatible) && defined(__cpp_lib_is_pointer_interconvertible) // TRANSITION, LLVM-48860
     // is_layout_compatible tests
     {
         struct S0 {
@@ -42,14 +41,28 @@ constexpr bool test() {
             int v1;
 
         private:
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-private-field"
+#endif // defined(__clang__)
             int v2;
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif // defined(__clang__)
         };
 
         struct S5 {
             int v1;
 
         private:
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-private-field"
+#endif // defined(__clang__)
             int v2;
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif // defined(__clang__)
         };
 
         enum E1 { e1, e2, e3, e4 };
@@ -94,13 +107,21 @@ constexpr bool test() {
             int : 0;
         };
         class D : public C {};
-// Disable warning C4408: anonymous union did not declare any data members
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-declarations"
+#else // ^^^ defined(__clang__) / !defined(__clang__) vvv
 #pragma warning(push)
-#pragma warning(disable : 4408)
+#pragma warning(disable : 4408) // C4408: anonymous union did not declare any data members
+#endif // ^^^ !defined(__clang__) ^^^
         class E : public A {
             union {};
         };
+#ifdef __clang__
+#pragma clang diagnostic pop
+#else // ^^^ defined(__clang__) / !defined(__clang__) vvv
 #pragma warning(pop)
+#endif // ^^^ !defined(__clang__) ^^^
         class F : private A {}; // Non-public inheritance
         class NS : public B, public C {}; // Non-standard layout
         class I; // Incomplete
@@ -134,6 +155,7 @@ constexpr bool test() {
         ASSERT(!is_pointer_interconvertible_base_of_v<U, I>);
     }
 
+#ifndef __clang__ // TRANSITION, LLVM-48860
     // is_corresponding_member tests
     {
         struct S1 {
@@ -238,7 +260,7 @@ constexpr bool test() {
         ASSERT(!is_pointer_interconvertible_with_class(&C::f1));
         ASSERT(!is_pointer_interconvertible_with_class(static_cast<int A::*>(nullptr)));
     }
-#endif // ^^^ defined(__cpp_lib_is_layout_compatible) && defined(__cpp_lib_is_pointer_interconvertible) ^^^
+#endif // ^^^ no workaround ^^^
     return true;
 }
 


### PR DESCRIPTION
Intrinsics `__is_layout_compatible` and `__is_pointer_interconvertible_base_of` are implemented in Clang 19 (LLVM-81506, LLVM-88473), so this PR unblocks the corresponding standard library components for Clang.

Unfortunately, according to WG21-P0466R5,
- `__cpp_lib_is_layout_compatible` covers `is_layout_compatible(_v)` and `__is_corresponding_member`, and
- `__cpp_lib_is_pointer_interconvertible` covers `is_pointer_interconvertible_base_of(_v)` and `is_pointer_interconvertible_with_class`,

so no feature-test macro should be unblocked for Clang at this moment.

Also adds workaround for LLVM-135273 and RWC, and specially handles EDG for IntelliSense with LLVM toolset.