### PR TITLE
Restore `wmemchr` optimization in `ranges::find`

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6266,12 +6266,13 @@ namespace ranges {
     template <input_iterator _It, sentinel_for<_It> _Se, class _Ty, class _Pj = identity>
         requires indirect_binary_predicate<ranges::equal_to, projected<_It, _Pj>, const _Ty*>
     _NODISCARD constexpr _It _Find_unchecked(_It _First, const _Se _Last, const _Ty& _Val, _Pj _Proj = {}) {
-        constexpr bool _Elements_are_1_byte = sizeof(_Iter_value_t<_It>) == 1;
-        constexpr bool _Is_sized            = sized_sentinel_for<_Se, _It>;
+        constexpr bool _Elements_are_1_byte  = sizeof(_Iter_value_t<_It>) == 1;
+        constexpr bool _Elements_are_2_bytes = sizeof(_Iter_value_t<_It>) == 2;
+        constexpr bool _Is_sized             = sized_sentinel_for<_Se, _It>;
 
         if constexpr (_Vector_alg_in_find_is_safe<_It, _Ty>
                       && (_Elements_are_1_byte ? _Is_sized || same_as<_Se, unreachable_sentinel_t>
-                                               : _Is_sized && _USE_STD_VECTOR_ALGORITHMS)
+                                               : _Is_sized && (_Elements_are_2_bytes || _USE_STD_VECTOR_ALGORITHMS))
                       && same_as<_Pj, identity>) {
             if (!_STD is_constant_evaluated()) {
                 if (!_STD _Could_compare_equal_to_value_type<_It>(_Val)) {
@@ -6295,23 +6296,30 @@ namespace ranges {
                 } else
 #endif // ^^^ _USE_STD_VECTOR_ALGORITHMS ^^^
                 {
-                    _STL_INTERNAL_STATIC_ASSERT(_Elements_are_1_byte);
-                    size_t _Count;
-                    if constexpr (_Is_sized) {
-                        _Count = static_cast<size_t>(_Last - _First);
+                    if constexpr (_Elements_are_2_bytes) {
+                        _STL_INTERNAL_STATIC_ASSERT(_Is_sized);
+                        _Result =
+                            _CSTD wmemchr(_First_ptr, static_cast<wchar_t>(_Val), static_cast<size_t>(_Last - _First));
                     } else {
-                        _Count = SIZE_MAX;
-                    }
+                        _STL_INTERNAL_STATIC_ASSERT(_Elements_are_1_byte);
+                        size_t _Count;
+                        if constexpr (_Is_sized) {
+                            _Count = static_cast<size_t>(_Last - _First);
+                        } else {
+                            _Count = SIZE_MAX;
+                        }
 
-                    // C23 7.27.5.2 "The memchr generic function"/2 says "The implementation shall behave as if
-                    // it reads the characters sequentially and stops as soon as a matching character is found."
-                    // C23 7.32.4.6.9 "The wmemchr generic function"/2 lacks such wording,
-                    // so we don't use wmemchr(), avoiding issues with unreachable_sentinel_t.
-                    _Result = static_cast<_Ptr_t>(_CSTD memchr(_First_ptr, static_cast<unsigned char>(_Val), _Count));
+                        // C23 7.27.5.2 "The memchr generic function"/2 says "The implementation shall behave as if
+                        // it reads the characters sequentially and stops as soon as a matching character is found."
+                        // C23 7.32.4.6.9 "The wmemchr generic function"/2 lacks such wording,
+                        // so we don't use wmemchr(), avoiding issues with unreachable_sentinel_t.
+                        _Result =
+                            static_cast<_Ptr_t>(_CSTD memchr(_First_ptr, static_cast<unsigned char>(_Val), _Count));
 
-                    if constexpr (_Is_sized) {
-                        if (_Result == nullptr) {
-                            return _RANGES next(_STD move(_First), _Last);
+                        if constexpr (_Is_sized) {
+                            if (_Result == nullptr) {
+                                return _RANGES next(_STD move(_First), _Last);
+                            }
                         }
                     }
                 }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6270,10 +6270,10 @@ namespace ranges {
         constexpr bool _Elements_are_2_bytes = sizeof(_Iter_value_t<_It>) == 2;
         constexpr bool _Is_sized             = sized_sentinel_for<_Se, _It>;
 
-        if constexpr (_Vector_alg_in_find_is_safe<_It, _Ty>
-                      && (_Elements_are_1_byte ? _Is_sized || same_as<_Se, unreachable_sentinel_t>
-                                               : _Is_sized && (_Elements_are_2_bytes || _USE_STD_VECTOR_ALGORITHMS))
-                      && same_as<_Pj, identity>) {
+        if constexpr (_Vector_alg_in_find_is_safe<_It, _Ty> && same_as<_Pj, identity>
+                      && (_Elements_are_1_byte    ? _Is_sized || same_as<_Se, unreachable_sentinel_t>
+                          : _Elements_are_2_bytes ? _Is_sized
+                                                  : _Is_sized && _USE_STD_VECTOR_ALGORITHMS)) {
             if (!_STD is_constant_evaluated()) {
                 if (!_STD _Could_compare_equal_to_value_type<_It>(_Val)) {
                     if constexpr (_Is_sized) {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6298,8 +6298,9 @@ namespace ranges {
                 {
                     if constexpr (_Elements_are_2_bytes) {
                         _STL_INTERNAL_STATIC_ASSERT(_Is_sized);
-                        _Result =
-                            _CSTD wmemchr(_First_ptr, static_cast<wchar_t>(_Val), static_cast<size_t>(_Last - _First));
+                        _Result = reinterpret_cast<_Ptr_t>(
+                            const_cast<wchar_t*>(_CSTD wmemchr(reinterpret_cast<const wchar_t*>(_First_ptr),
+                                static_cast<wchar_t>(_Val), static_cast<size_t>(_Last - _First))));
                     } else {
                         _STL_INTERNAL_STATIC_ASSERT(_Elements_are_1_byte);
                         size_t _Count;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6301,10 +6301,6 @@ namespace ranges {
                         _Result = reinterpret_cast<_Ptr_t>(
                             const_cast<wchar_t*>(_CSTD wmemchr(reinterpret_cast<const wchar_t*>(_First_ptr),
                                 static_cast<wchar_t>(_Val), static_cast<size_t>(_Last - _First))));
-
-                        if (_Result == nullptr) {
-                            return _RANGES next(_STD move(_First), _Last);
-                        }
                     } else {
                         _STL_INTERNAL_STATIC_ASSERT(_Elements_are_1_byte);
                         size_t _Count;
@@ -6320,11 +6316,11 @@ namespace ranges {
                         // so we don't use wmemchr(), avoiding issues with unreachable_sentinel_t.
                         _Result =
                             static_cast<_Ptr_t>(_CSTD memchr(_First_ptr, static_cast<unsigned char>(_Val), _Count));
+                    }
 
-                        if constexpr (_Is_sized) {
-                            if (_Result == nullptr) {
-                                return _RANGES next(_STD move(_First), _Last);
-                            }
+                    if constexpr (_Is_sized) {
+                        if (_Result == nullptr) {
+                            return _RANGES next(_STD move(_First), _Last);
                         }
                     }
                 }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6301,6 +6301,10 @@ namespace ranges {
                         _Result = reinterpret_cast<_Ptr_t>(
                             const_cast<wchar_t*>(_CSTD wmemchr(reinterpret_cast<const wchar_t*>(_First_ptr),
                                 static_cast<wchar_t>(_Val), static_cast<size_t>(_Last - _First))));
+
+                        if (_Result == nullptr) {
+                            return _RANGES next(_STD move(_First), _Last);
+                        }
                     } else {
                         _STL_INTERNAL_STATIC_ASSERT(_Elements_are_1_byte);
                         size_t _Count;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6290,7 +6290,7 @@ namespace ranges {
                 _Ptr_t _Result;
 #if _USE_STD_VECTOR_ALGORITHMS
                 if constexpr (_Is_sized) {
-                    // When _Is_sized && _Elements_are_1_byte, prefer this over memchr() for performance
+                    // Prefer this over memchr()/wmemchr() below for performance
                     const auto _Last_ptr = _First_ptr + static_cast<ptrdiff_t>(_Last - _First);
                     _Result              = _STD _Find_vectorized(_First_ptr, _Last_ptr, _Val);
                 } else


### PR DESCRIPTION
`ranges::find` is not using `wmemchr` after #5284. Yet, `std::find` uses it.

For `wmemchr` we drag in `<cwchar>` which is heavy, specifically due to `wmemchr` optimization. So it seems silly not to take the full advantage of `wmemchr`. The PR addresses that by making `ranges::find` also using `wmemchr`.

This affects ARM64 (non-EC), and builds with vector algorithms disabled.

See also #5596. Not sure if this PR closes that issue, because merging the PR does not preclude doing also Windows SDK throughput optimization or otherwise addressing the throughput in the future.
