### PR TITLE
Cleanup: Mostly remove `_VCRT_ALLOW_INTERNALS`

### DIFF
--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -419,7 +419,7 @@ set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "")
 set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "")
 
 # Toolset options must appear before add_library() for the options to take effect.
-add_compile_definitions(_CRTBLD _VCRT_ALLOW_INTERNALS _HAS_OLD_IOSTREAMS_MEMBERS=1)
+add_compile_definitions(_CRTBLD _HAS_OLD_IOSTREAMS_MEMBERS=1)
 
 # /Z7 for MSVC, /Zi for MASM
 set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "Embedded")

--- a/stl/msbuild/stl_1/msvcp_1.settings.targets
+++ b/stl/msbuild/stl_1/msvcp_1.settings.targets
@@ -29,7 +29,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <LibOutputFileName>msvcprt_1$(BuildSuffix)$(ClrLibSuffix)</LibOutputFileName>
         <LibOutputFile>$(LibOutputFileName).lib</LibOutputFile>
 
-        <ClDefines>_VCRT_ALLOW_INTERNALS;$(ClDefines)</ClDefines>
         <ClDefines Condition="'$(MsvcpFlavor)' == 'app'">$(ClDefines);_CRT_APP</ClDefines>
 
         <UseMsvcrt>false</UseMsvcrt>

--- a/stl/msbuild/stl_2/msvcp_2.settings.targets
+++ b/stl/msbuild/stl_2/msvcp_2.settings.targets
@@ -29,7 +29,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <LibOutputFileName>msvcprt_2$(BuildSuffix)$(ClrLibSuffix)</LibOutputFileName>
         <LibOutputFile>$(LibOutputFileName).lib</LibOutputFile>
 
-        <ClDefines>_VCRT_ALLOW_INTERNALS;$(ClDefines)</ClDefines>
         <ClDefines Condition="'$(MsvcpFlavor)' == 'app'">$(ClDefines);_CRT_APP</ClDefines>
 
         <UseMsvcrt>false</UseMsvcrt>

--- a/stl/msbuild/stl_atomic_wait/msvcp_atomic_wait.settings.targets
+++ b/stl/msbuild/stl_atomic_wait/msvcp_atomic_wait.settings.targets
@@ -29,7 +29,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <LibOutputFileName>msvcprt$(BuildSuffix)_atomic_wait$(ClrLibSuffix)</LibOutputFileName>
         <LibOutputFile>$(LibOutputFileName).lib</LibOutputFile>
 
-        <ClDefines>_VCRT_ALLOW_INTERNALS;$(ClDefines)</ClDefines>
         <ClDefines Condition="'$(MsvcpFlavor)' == 'app'">$(ClDefines);_CRT_APP</ClDefines>
 
         <UseMsvcrt>false</UseMsvcrt>

--- a/stl/msbuild/stl_base/libcp.settings.targets
+++ b/stl/msbuild/stl_base/libcp.settings.targets
@@ -27,7 +27,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <PropertyGroup>
         <ClProgramDataBaseFileName>$(OutputLibPdbPath)$(OutputName)$(PdbVerName).pdb</ClProgramDataBaseFileName>
-        <ClDefines>$(ClDefines);_VCRT_ALLOW_INTERNALS;_ANNOTATE_STL</ClDefines>
+        <ClDefines>$(ClDefines);_ANNOTATE_STL</ClDefines>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)\stl.files.settings.targets"/>

--- a/stl/msbuild/stl_base/msvcp.settings.targets
+++ b/stl/msbuild/stl_base/msvcp.settings.targets
@@ -32,7 +32,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <LibOutputFileName>msvcprt_base$(BuildSuffix)$(ClrLibSuffix)</LibOutputFileName>
         <LibOutputFile>$(LibOutputFileName).lib</LibOutputFile>
 
-        <ClDefines>_VCRT_ALLOW_INTERNALS;$(ClDefines)</ClDefines>
         <ClDefines Condition="'$(MsvcpFlavor)' == 'app'">$(ClDefines);_CRT_APP</ClDefines>
 
         <UseMsvcrt>false</UseMsvcrt>

--- a/stl/msbuild/stl_codecvt_ids/msvcp_codecvt_ids.settings.targets
+++ b/stl/msbuild/stl_codecvt_ids/msvcp_codecvt_ids.settings.targets
@@ -29,7 +29,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <LibOutputFileName>msvcprt$(BuildSuffix)_codecvt_ids$(ClrLibSuffix)</LibOutputFileName>
         <LibOutputFile>$(LibOutputFileName).lib</LibOutputFile>
 
-        <ClDefines>_VCRT_ALLOW_INTERNALS;$(ClDefines)</ClDefines>
         <ClDefines Condition="'$(MsvcpFlavor)' == 'app'">$(ClDefines);_CRT_APP</ClDefines>
 
         <UseMsvcrt>false</UseMsvcrt>

--- a/stl/src/excptptr.cpp
+++ b/stl/src/excptptr.cpp
@@ -8,7 +8,7 @@
 
 #ifndef _VCRT_ALLOW_INTERNALS
 #define _VCRT_ALLOW_INTERNALS
-#endif // !defined(_VCRT_ALLOW_INTERNALS)
+#endif
 
 #include <Unknwn.h>
 #include <cstdlib> // for abort

--- a/stl/src/pplerror.cpp
+++ b/stl/src/pplerror.cpp
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#ifndef _VCRT_ALLOW_INTERNALS
+#define _VCRT_ALLOW_INTERNALS
+#endif
+
 #include <ppltasks.h>
 
 #if defined(_CRT_APP) || defined(UNDOCKED_WINDOWS_UCRT)


### PR DESCRIPTION
Defining `_VCRT_ALLOW_INTERNALS` allows `<vcruntime_internal.h>` to be dragged in:

```cpp
#if !defined _VCRT_BUILD && !defined _VCRT_ALLOW_INTERNALS
    // This is an internal C Runtime header file.  It is used when building the
    // C Runtime only.  It is not to be used as a public header file.
    #error ERROR: Use of C Runtime library internal header file.
#endif
```

The entire STL build (in CMake and MSBuild) defines this macro, but only two translation units need it (for EH machinery). To prevent unintentionally using VCRuntime internals in the future, we should limit the use of the macro to where it's needed.

Ordinarily, I would hiss at defining macros in source files, as opposed to in the build system. However, because this merely guards an `#error` (instead of affecting something ODR-relevant), it's very safe to define this way. Defining per-file macros in the build system(s) is not worth the trouble here.

I've validated this with an internal build.