### PR TITLE
Optimize core loop of `_Count_vbool`

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -3790,7 +3790,7 @@ _NODISCARD _CONSTEXPR20 _Iter_diff_t<_VbIt> _Count_vbool(_VbIt _First, const _Vb
             _Iter_diff_t<_VbIt> _Count = _Popcount_impl(_FirstVal);
             ++_VbFirst;
 
-            const _Iter_diff_t<_VbIt> _Bits = (_VbLast - _VbFirst) * _VBITS;
+            const auto _Bits                = static_cast<_Iter_diff_t<_VbIt>>(_VbLast - _VbFirst) * _VBITS;
             _Iter_diff_t<_VbIt> _Count_ones = 0;
 
             for (; _VbFirst != _VbLast; ++_VbFirst) {

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -3790,10 +3790,14 @@ _NODISCARD _CONSTEXPR20 _Iter_diff_t<_VbIt> _Count_vbool(_VbIt _First, const _Vb
             _Iter_diff_t<_VbIt> _Count = _Popcount_impl(_FirstVal);
             ++_VbFirst;
 
+            const _Iter_diff_t<_VbIt> _Bits = (_VbLast - _VbFirst) * _VBITS;
+            _Iter_diff_t<_VbIt> _Count_ones = 0;
+
             for (; _VbFirst != _VbLast; ++_VbFirst) {
-                const auto _SelectVal = _Val ? *_VbFirst : ~*_VbFirst;
-                _Count += _Popcount_impl(_SelectVal);
+                _Count_ones += _Popcount_impl(*_VbFirst);
             }
+
+            _Count += _Val ? _Count_ones : _Bits - _Count_ones;
 
             if (_Last._Myoff != 0) {
                 const auto _LastSourceMask = static_cast<_Vbase>(-1) >> (_VBITS - _Last._Myoff);


### PR DESCRIPTION
To handle the difference between counting ones and counting zeros, `_Count_vbool`'s core loop conditionally complements every block it processes: that's O(n) work. We can do better: we can unconditionally count ones, then, after the loop, if we actually wanted zeros, subtract the number of ones from the number of bits we processed: O(1) work.