### PR TITLE
Toolset update: VS 2022 17.14.8 Preview 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.31.0)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 
-if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.44.35209")
-    message(FATAL_ERROR "The STL must be built with VS 2022 17.14.5 Preview 1 or later.")
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.44.35211")
+    message(FATAL_ERROR "The STL must be built with VS 2022 17.14.8 Preview 1 or later.")
 endif()
 
 include(CheckCXXSourceCompiles)

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.14.5 Preview 1 or later.
+1. Install Visual Studio 2022 17.14.8 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.26100.3916)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.
@@ -160,7 +160,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.14.5 Preview 1 or later.
+1. Install Visual Studio 2022 17.14.8 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.26100.3916)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,7 +5,7 @@
 
 variables:
 - name: poolName
-  value: 'StlBuild-2025-06-10T1243-Pool'
+  value: 'StlBuild-2025-07-09T1240-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -25,7 +25,6 @@ $VisualStudioWorkloads = @(
   'Microsoft.VisualStudio.Component.VC.CMake.Project',
   'Microsoft.VisualStudio.Component.VC.CoreIde',
   'Microsoft.VisualStudio.Component.VC.Llvm.Clang',
-  'Microsoft.VisualStudio.Component.VC.Tools.ARM',
   'Microsoft.VisualStudio.Component.VC.Tools.ARM64',
   'Microsoft.VisualStudio.Component.VC.Tools.ARM64EC',
   'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -39,7 +39,7 @@ foreach ($workload in $VisualStudioWorkloads) {
 }
 
 # https://github.com/PowerShell/PowerShell/releases/latest
-$PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.5.1/PowerShell-7.5.1-win-x64.msi'
+$PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.5.2/PowerShell-7.5.2-win-x64.msi'
 $PowerShellArgs = @('/quiet', '/norestart')
 
 $PythonUrl = 'https://www.python.org/ftp/python/3.13.4/python-3.13.4-amd64.exe'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -42,7 +42,7 @@ foreach ($workload in $VisualStudioWorkloads) {
 $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.5.2/PowerShell-7.5.2-win-x64.msi'
 $PowerShellArgs = @('/quiet', '/norestart')
 
-$PythonUrl = 'https://www.python.org/ftp/python/3.13.4/python-3.13.4-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.13.5/python-3.13.5-amd64.exe'
 $PythonArgs = @('/quiet', 'InstallAllUsers=1', 'PrependPath=1', 'CompileAll=1', 'Include_doc=0')
 
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/12.4.0/local_installers/cuda_12.4.0_551.61_windows.exe'


### PR DESCRIPTION
# :scroll: Changelog
- Infrastructure improvements:
  * Updated dependencies.
    + Updated build compiler to VS 2022 17.14.8 Preview 1.
    + Updated Python to 3.13.5.

# :gear: Commits
* provision-image.ps1: Remove 32-bit ARM (from #5594)
* PowerShell 7.5.2.
* Python 3.13.5.
* VS 2022 17.14.8 Preview 1.
* Newer pool.
