### PR TITLE
Silence ABI warning C5291 for the entire STL

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -808,6 +808,9 @@
 // warning C5278: adding a specialization for 'type trait' has undefined behavior
 // warning C5280: a static operator '()' requires at least '/std:c++23preview'
 // warning C5281: a static lambda requires at least '/std:c++23preview'
+// warning C5291: 'DERIVED': deriving from the base class 'BASE' can cause potential runtime issues
+//                due to an ABI bug. Recommend adding a 4-byte data member to the base class
+//                for the padding at the end of it to work around this bug. (TRANSITION, ABI)
 // warning C6294: Ill-defined for-loop: initial condition does not satisfy test. Loop body not executed
 
 #ifndef _STL_DISABLED_WARNINGS
@@ -816,7 +819,7 @@
     4180 4324 4412 4455 4494 4514 4574 4582 4583 4587 \
     4588 4619 4623 4625 4626 4643 4648 4702 4793 4820 \
     4868 4988 5026 5027 5045 5220 5246 5278 5280 5281 \
-    6294                                              \
+    5291 6294                                         \
     _STL_DISABLED_WARNING_C4577                       \
     _STL_DISABLED_WARNING_C4984                       \
     _STL_DISABLED_WARNING_C5053                       \


### PR DESCRIPTION
Reverse-mirrored from toolset update MSVC-PR-650818 targeting MSVC `main`.

The compiler has implemented a new warning C5291: "'DERIVED': deriving from the base class 'BASE' can cause potential runtime issues due to an ABI bug. Recommend adding a 4-byte data member to the base class for the padding at the end of it to work around this bug." This is emitted in the STL for `basic_iostream` and `basic_ostringstream`, which each derive from `basic_ostream`, when we try to self-build MSVC with a sufficiently updated compiler.

Whatever this ABI bug is, it's frozen in our layout of `basic_ostream`. Since we can't do anything about it until vNext, I'm globally suppressing it in the STL, with a TRANSITION, ABI comment.

I considered fine-grained suppression around `basic_iostream` and `basic_ostringstream`, in case we wanted to leave this warning active for newly added internal classes, but the risk seems low; we virtually never use multiple inheritance in internal classes. To avoid risk for the internal toolset update, I went with the global suppression.

The compiler warning was implemented on 2025-06-03 by MSVC-PR-640189, where @xiangfan-ms said:

> When we determine the size of a class when it is used as a base class, we don't take the alignment of the class into consideration. This means we may incorrectly insert members from the derived class to the base class, even though the rest of the compiler doesn't expect this. This PR adds an off-by-default warning to help detect such cases.

I noticed the "off-by-default" part after making this change in MSVC; I'll follow up later to add our usual "(/Wall)" comment. Fortunately, this means that it won't cause warnings for users in our supported /W4 scenarios.