### PR TITLE
`Dev11_0000000_null_forward_iterators`: Avoid Clang warnings, guard headers for C++17/20

### DIFF
--- a/tests/std/tests/Dev11_0000000_null_forward_iterators/test.cpp
+++ b/tests/std/tests/Dev11_0000000_null_forward_iterators/test.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#define _SILENCE_CXX23_ALIGNED_UNION_DEPRECATION_WARNING
 #define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
 #define _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING
 
@@ -31,10 +30,6 @@
 #if _HAS_CXX20
 #include <span>
 #endif // _HAS_CXX20
-
-#ifdef __clang__
-#pragma clang diagnostic ignored "-Wnontrivial-memcall"
-#endif // __clang__
 
 using namespace std;
 
@@ -102,14 +97,14 @@ void test_iterator() {
     }
 
     {
-        aligned_union_t<0, FwdIt> au3;
-        aligned_union_t<0, FwdIt> au4;
+        alignas(FwdIt) unsigned char buf3[sizeof(FwdIt)];
+        alignas(FwdIt) unsigned char buf4[sizeof(FwdIt)];
 
-        FwdIt* p3 = reinterpret_cast<FwdIt*>(&au3);
-        FwdIt* p4 = reinterpret_cast<FwdIt*>(&au4);
+        memset(buf3, 0xCC, sizeof(FwdIt));
+        memset(buf4, 0xDD, sizeof(FwdIt));
 
-        memset(p3, 0xCC, sizeof(FwdIt));
-        memset(p4, 0xDD, sizeof(FwdIt));
+        FwdIt* p3 = reinterpret_cast<FwdIt*>(buf3);
+        FwdIt* p4 = reinterpret_cast<FwdIt*>(buf4);
 
         new (p3) FwdIt{};
         new (p4) FwdIt{};

--- a/tests/std/tests/Dev11_0000000_null_forward_iterators/test.cpp
+++ b/tests/std/tests/Dev11_0000000_null_forward_iterators/test.cpp
@@ -10,7 +10,9 @@
 #include <cstring>
 #include <deque>
 #include <experimental/filesystem>
+#if _HAS_CXX17
 #include <filesystem>
+#endif // _HAS_CXX17
 #include <forward_list>
 #include <iterator>
 #include <list>
@@ -18,12 +20,18 @@
 #include <new>
 #include <regex>
 #include <set>
+#if _HAS_CXX20
 #include <span>
+#endif // _HAS_CXX20
 #include <string>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wnontrivial-memcall"
+#endif // __clang__
 
 using namespace std;
 

--- a/tests/std/tests/Dev11_0000000_null_forward_iterators/test.cpp
+++ b/tests/std/tests/Dev11_0000000_null_forward_iterators/test.cpp
@@ -10,9 +10,6 @@
 #include <cstring>
 #include <deque>
 #include <experimental/filesystem>
-#if _HAS_CXX17
-#include <filesystem>
-#endif // _HAS_CXX17
 #include <forward_list>
 #include <iterator>
 #include <list>
@@ -20,14 +17,20 @@
 #include <new>
 #include <regex>
 #include <set>
-#if _HAS_CXX20
-#include <span>
-#endif // _HAS_CXX20
 #include <string>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+#if _HAS_CXX17
+#include <filesystem>
+#include <string_view>
+#endif // _HAS_CXX17
+
+#if _HAS_CXX20
+#include <span>
+#endif // _HAS_CXX20
 
 #ifdef __clang__
 #pragma clang diagnostic ignored "-Wnontrivial-memcall"


### PR DESCRIPTION
The merged PR [#117387](https://github.com/llvm/llvm-project/pull/117387) in Clang warnings when a parameter of memcpy is pointer to non-trivial-copyable types. This PR suppress the warning to avoid test failures.

Also, the `<filesystem>` and `<span>` headers were not properly guarded, and this PR guards them as seen in L166 and L182. The above two issues would cause this test to fail.
https://github.com/microsoft/STL/blob/f015db5833e8daf3a5534c4ce2b6c9acc9689b0c/tests/std/tests/Dev11_0000000_null_forward_iterators/test.cpp#L166-L168