### PR TITLE
`VSO_0180466_algorithm_overhauls`: Suppress `-Wcharacter-conversion` for Clang 21

### DIFF
--- a/tests/std/tests/VSO_0180466_algorithm_overhauls/test.cpp
+++ b/tests/std/tests/VSO_0180466_algorithm_overhauls/test.cpp
@@ -6,8 +6,10 @@
 #pragma warning(disable : 4389) // signed/unsigned mismatch in arithmetic
 
 #ifdef __clang__
-#pragma clang diagnostic ignored "-Wsign-compare"
+#if __clang_major__ >= 21 // TRANSITION, unconditionally silence this warning when Clang 21 is available
 #pragma clang diagnostic ignored "-Wcharacter-conversion"
+#endif // __clang_major__ >= 21
+#pragma clang diagnostic ignored "-Wsign-compare"
 #endif // __clang__
 
 #include <algorithm>

--- a/tests/std/tests/VSO_0180466_algorithm_overhauls/test.cpp
+++ b/tests/std/tests/VSO_0180466_algorithm_overhauls/test.cpp
@@ -7,6 +7,7 @@
 
 #ifdef __clang__
 #pragma clang diagnostic ignored "-Wsign-compare"
+#pragma clang diagnostic ignored "-Wcharacter-conversion"
 #endif // __clang__
 
 #include <algorithm>


### PR DESCRIPTION
Lines 35-84 of this test involve comparisons between different `charN_t` types, so similar to #5653, Clang will also generate warnings for this.

https://github.com/microsoft/STL/blob/f015db5833e8daf3a5534c4ce2b6c9acc9689b0c/tests/std/tests/VSO_0180466_algorithm_overhauls/test.cpp#L35-L84
