### PR TITLE
Update WinSDK comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ int main() {}
 ]=] WINDOWS_SDK_VERSION_CHECK)
 
 if(NOT WINDOWS_SDK_VERSION_CHECK)
-    message(FATAL_ERROR "The STL must be built with the Windows 11 SDK (10.0.26100.3916) or later. Make sure it's available by selecting it in the Individual Components tab of the VS Installer.")
+    message(FATAL_ERROR "The STL must be built with the Windows 11 SDK (10.0.26100.4188) or later. Make sure it's available by selecting it in the Individual Components tab of the VS Installer.")
 endif()
 
 if(NOT DEFINED VCLIBS_TARGET_ARCHITECTURE)
@@ -92,20 +92,18 @@ set(STL_ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/out/lib/${VCLIBS_I386_OR
 set(STL_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/out/lib/${VCLIBS_I386_OR_AMD64}")
 set(STL_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/out/bin/${VCLIBS_I386_OR_AMD64}")
 
-# TRANSITION, update internal crt-common.settings.targets, atlmfc.settings.targets, and fe-components.settings.targets
-# from NTDDI_WIN10_NI to NTDDI_WIN11_GE when the internal WinSDK is updated.
 add_compile_definitions(
     _ALLOW_ITERATOR_DEBUG_LEVEL_MISMATCH WIN32_LEAN_AND_MEAN STRICT _CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS
     _WIN32_WINNT=0x0A00 NTDDI_VERSION=NTDDI_WIN11_GE)
 
 if(STL_USE_ANALYZE)
-    # TRANSITION, Windows SDK 10.0.26100.3916 emits
+    # TRANSITION, Windows SDK 10.0.26100.4188 emits
     # "warning C6553: The annotation for function 'LCMapStringEx' on _Param_(9) does not apply to a value type."
     # Reported as OS-40109504 "Windows SDK: incorrect SAL annotations on functions the STL uses".
     add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/analyze:autolog-;/wd6553>")
 
     if(VCLIBS_TARGET_ARCHITECTURE STREQUAL "arm64ec")
-        # TRANSITION, Windows SDK 10.0.26100.3916 emits
+        # TRANSITION, Windows SDK 10.0.26100.4188 emits
         # "warning C28301: No annotations for first declaration of 'meow'"
         # for various intrinsics when building for ARM64EC.
         add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/wd28301>")

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 # How To Build With The Visual Studio IDE
 
 1. Install Visual Studio 2022 17.14.8 Preview 1 or later.
-    * Select "Windows 11 SDK (10.0.26100.3916)" in the VS Installer.
+    * Select "Windows 11 SDK (10.0.26100.4188)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
@@ -159,7 +159,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 # How To Build With A Native Tools Command Prompt
 
 1. Install Visual Studio 2022 17.14.8 Preview 1 or later.
-    * Select "Windows 11 SDK (10.0.26100.3916)" in the VS Installer.
+    * Select "Windows 11 SDK (10.0.26100.4188)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -258,7 +258,7 @@ class STLTest(Test):
                 self.compileFlags.append('/arm64EC')
                 self.linkFlags.append('/machine:arm64ec')
 
-                # TRANSITION, Windows SDK 10.0.26100.3916 emits
+                # TRANSITION, Windows SDK 10.0.26100.4188 emits
                 # "warning C28301: No annotations for first declaration of 'meow'"
                 # for various intrinsics when building for ARM64EC.
                 self.compileFlags.append('/wd28301')


### PR DESCRIPTION
Reverse-mirrors MSVC-PR-656388 "Update WinSDK to 10.0.26100.4654", where I'm updating the MSVC toolset's usage of the WinSDK. This is a major change for MSVC but has extremely limited impact for the STL as we've already made this change for the GitHub build on 2025-06-13, when #5580 updated azure-devops/provision-image.ps1 to select `Microsoft.VisualStudio.Component.Windows11SDK.26100`.

* Drop TRANSITION comment now that we set `NTDDI_WIN11_GE` internally.
* The WinSDK in the VS Installer has been updated in-place from 10.0.26100.3916 (released 2025-04) to 10.0.26100.4188 (released 2025-05). Update our various comments accordingly.
  + I checked that all of the TRANSITION bugs are still present. Note that as of VS 17.14.10 Preview 1, WinSDK 10.0.26100.4654 (released 2025-07) is not yet available.