### PR TITLE
[WIP] Transition away from OS-33790456

### DIFF
--- a/stl/inc/ctime
+++ b/stl/inc/ctime
@@ -29,7 +29,10 @@ _EXPORT_STD using _CSTD strftime;
 _EXPORT_STD using _CSTD timespec;
 #endif // _HAS_CXX17
 
-#ifdef _BUILD_STD_MODULE // TRANSITION, OS-33790456; `template <int = 0>` avoids ambiguity
+// `_STATIC_INLINE_UCRT_FUNCTIONS` is exposed by the UCRT. When set to `1`, several UCRT functions are declared as
+// `static inline`, which prevents them from being naively exported through modules. Therefore, we templates
+// to effectively shadow their name, allowing us forcibly to expose those CRT functions.
+#if _STATIC_INLINE_UCRT_FUNCTIONS == 1
 _STL_DISABLE_DEPRECATED_WARNING
 
 _EXPORT_STD template <int = 0>
@@ -75,7 +78,7 @@ _Check_return_ inline int __CRTDECL timespec_get(_Out_ timespec* const _Ts, _In_
 _STL_RESTORE_DEPRECATED_WARNING
 #else // ^^^ workaround / no workaround vvv
 
-// _EXPORT_STD has no effect while the workaround is present.
+// _EXPORT_STD has no effect when `_BUILD_STD_MODULE` is not defined.
 _EXPORT_STD using _CSTD ctime;
 _EXPORT_STD using _CSTD difftime;
 _EXPORT_STD using _CSTD gmtime;


### PR DESCRIPTION
**Context:**

As reported in [devcomm 1126857](https://developercommunity.visualstudio.com/t/Visual-Studio-cant-find-time-function/1126857), several UCRT functions are declare as `static inline`, especially those in `time.h`.

This is a non-conforming signature, and prevents us from naively exporting those functions through modules. We have workarounds for this, but they're imperfect.

Thankfully - we _just_ merged code in the UCRT that should improve this.

Soon, the UCRT will expose a binary macro, `_STATIC_INLINE_UCRT_FUNCTIONS` to control these signatures. When set to `0`, these functions will have external linkage (conforming behavior) and when set to `1` they will continue to have static linkage (i.e. this is the escape hatch for backwards compatibility).

**This PR:**

Consumes this macro so that we can expose these `time`-related CRT functions via modules when the UCRT allows it. In short - we disable the workaround for exporting `ctime` functions via modules by inspecting the value of `_STATIC_INLINE_UCRT_FUNCTIONS`

**Still pending:**
* Adding a test
* The release of the corresponding Windows SDK. ETA: October.