### PR TITLE
Remove MSVC-specific workarounds for references-to-functions

### DIFF
--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -1073,15 +1073,9 @@ namespace iterator_cust_move_test {
     static_assert(noexcept(ranges::iter_move(static_cast<int const*>(&some_ints[2]))));
 
     static_assert(same_as<iter_rvalue_reference_t<int[]>, int&&>);
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1008447
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1008447, VSO-2066340
     static_assert(same_as<iter_rvalue_reference_t<int(int)>, int (&)(int)>);
-#else // ^^^ no workaround / workaround vvv
-#ifdef _MSVC_INTERNAL_TESTING // TRANSITION, assertion will fire once VSO-2066340 ships.
-    static_assert(same_as<iter_rvalue_reference_t<int(int)>, int (&&)(int)>);
-#else // ^^^ defined(_MSVC_INTERNAL_TESTING) / !defined(_MSVC_INTERNAL_TESTING) vvv
-    static_assert(same_as<iter_rvalue_reference_t<int(int)>, int (*)(int)>);
-#endif // ^^^ !defined(_MSVC_INTERNAL_TESTING)
-#endif // ^^^ workaround ^^^
+#endif // ^^^ no workaround ^^^
 
     static_assert(same_as<iter_rvalue_reference_t<int[4]>, int&&>);
     static_assert(ranges::iter_move(some_ints) == 0);
@@ -1092,9 +1086,7 @@ namespace iterator_cust_move_test {
     }
 #if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1008447
     static_assert(same_as<iter_rvalue_reference_t<int (*)(int)>, int (&)(int)>);
-#else // ^^^ no workaround / workaround vvv
-    static_assert(same_as<iter_rvalue_reference_t<int (*)(int)>, int (&&)(int)>);
-#endif // ^^^ workaround ^^^
+#endif // ^^^ no workaround ^^^
     static_assert(ranges::iter_move(&f)(42) == 43);
     static_assert(noexcept(ranges::iter_move(&f)));
 


### PR DESCRIPTION
Fixes to the value category of rvalue-reference-to-function in decltype processing have merged to the internal MSVC repo (MSVC-PR-656711).