### PR TITLE
`<array>`: Reduce template instantiation in the deduction guide for `array`

### DIFF
--- a/stl/inc/array
+++ b/stl/inc/array
@@ -577,6 +577,8 @@ private:
 
 #if _HAS_CXX17
 #if defined(_WIN64) || !defined(__clang__) // TRANSITION, unknown LLD failure
+template <int = 0>
+#endif // ^^^ workaround ^^^
 constexpr bool _Are_bools_all_true(const initializer_list<bool> _Il) noexcept {
     for (const auto _Elem : _Il) {
         if (!_Elem) {
@@ -592,14 +594,6 @@ struct _Enforce_same {
         "N4950 [array.cons]/2: Mandates: (is_same_v<T, U> && ...) is true.");
     using type = _First;
 };
-#else // ^^^ no workaround / workaround vvv
-template <class _First, class... _Rest>
-struct _Enforce_same {
-    static_assert(
-        conjunction_v<is_same<_First, _Rest>...>, "N4950 [array.cons]/2: Mandates: (is_same_v<T, U> && ...) is true.");
-    using type = _First;
-};
-#endif // ^^^ workaround ^^^
 
 template <class _First, class... _Rest>
 array(_First, _Rest...) -> array<typename _Enforce_same<_First, _Rest...>::type, 1 + sizeof...(_Rest)>;

--- a/stl/inc/array
+++ b/stl/inc/array
@@ -576,12 +576,30 @@ private:
 };
 
 #if _HAS_CXX17
+#if defined(_WIN64) || !defined(__clang__) // TRANSITION, unknown LLD failure
+constexpr bool _Are_bools_all_true(const initializer_list<bool> _Il) noexcept {
+    for (const auto _Elem : _Il) {
+        if (!_Elem) {
+            return false;
+        }
+    }
+    return true;
+}
+
+template <class _First, class... _Rest>
+struct _Enforce_same {
+    static_assert(_STD _Are_bools_all_true({is_same_v<_First, _Rest>...}),
+        "N4950 [array.cons]/2: Mandates: (is_same_v<T, U> && ...) is true.");
+    using type = _First;
+};
+#else // ^^^ no workaround / workaround vvv
 template <class _First, class... _Rest>
 struct _Enforce_same {
     static_assert(
         conjunction_v<is_same<_First, _Rest>...>, "N4950 [array.cons]/2: Mandates: (is_same_v<T, U> && ...) is true.");
     using type = _First;
 };
+#endif // ^^^ workaround ^^^
 
 template <class _First, class... _Rest>
 array(_First, _Rest...) -> array<typename _Enforce_same<_First, _Rest...>::type, 1 + sizeof...(_Rest)>;

--- a/stl/inc/array
+++ b/stl/inc/array
@@ -576,9 +576,6 @@ private:
 };
 
 #if _HAS_CXX17
-#if defined(_WIN64) || !defined(__clang__) // TRANSITION, unknown LLD failure
-template <int = 0>
-#endif // ^^^ workaround ^^^
 constexpr bool _Are_bools_all_true(const initializer_list<bool> _Il) noexcept {
     for (const auto& _Elem : _Il) {
         if (!_Elem) {

--- a/stl/inc/array
+++ b/stl/inc/array
@@ -580,7 +580,7 @@ private:
 template <int = 0>
 #endif // ^^^ workaround ^^^
 constexpr bool _Are_bools_all_true(const initializer_list<bool> _Il) noexcept {
-    for (const auto _Elem : _Il) {
+    for (const auto& _Elem : _Il) {
         if (!_Elem) {
             return false;
         }

--- a/tests/std/tests/P0433R2_deduction_guides/test.cpp
+++ b/tests/std/tests/P0433R2_deduction_guides/test.cpp
@@ -539,6 +539,34 @@ void test_array() {
     static_assert(is_same_v<decltype(a3), array<long, 3>>);
     static_assert(is_same_v<decltype(b), array<long, 3>>);
 
+    // GH-5665 "<array>: CTAD and element count limit" (stress test)
+    // TRANSITION, LLVM-119600, DevCom-10946374, test longer arrays when compiler bugs are fixed
+#if defined(_WIN64) || !defined(__clang__) // TRANSITION, unknown LLD failure
+#define MAKE10    0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+#define MAKE100   MAKE10, MAKE10, MAKE10, MAKE10, MAKE10, MAKE10, MAKE10, MAKE10, MAKE10, MAKE10
+#define MAKE1000  MAKE100, MAKE100, MAKE100, MAKE100, MAKE100, MAKE100, MAKE100, MAKE100, MAKE100, MAKE100
+#define MAKE10000 MAKE1000, MAKE1000, MAKE1000, MAKE1000, MAKE1000, MAKE1000, MAKE1000, MAKE1000, MAKE1000, MAKE1000
+    // clang-format off
+#define MAKEALL   MAKE10000, MAKE10000, MAKE10000, MAKE10000, MAKE10000, MAKE10000, \
+    MAKE1000, MAKE1000, MAKE1000, MAKE1000,                                         \
+    MAKE1000, MAKE100, MAKE100, MAKE100, MAKE100, MAKE100,                          \
+    MAKE10, MAKE10, MAKE10,                                                         \
+    0, 1, 2, 3, 4
+    // clang-format on
+
+    static constexpr array stress_test{MAKEALL};
+    static_assert(is_same_v<decltype(stress_test), const array<int, 65535>>);
+    for (size_t i = 0; i != stress_test.size(); ++i) {
+        assert(stress_test[i] == static_cast<int>(i) % 10);
+    }
+
+#undef MAKEALL
+#undef MAKE10000
+#undef MAKE1000
+#undef MAKE100
+#undef MAKE10
+#endif // ^^^ no workaround ^^^
+
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif // __clang__

--- a/tests/std/tests/P0433R2_deduction_guides/test.cpp
+++ b/tests/std/tests/P0433R2_deduction_guides/test.cpp
@@ -541,7 +541,6 @@ void test_array() {
 
     // GH-5665 "<array>: CTAD and element count limit" (stress test)
     // TRANSITION, LLVM-119600, DevCom-10946374, test longer arrays when compiler bugs are fixed
-#if defined(_WIN64) || !defined(__clang__) // TRANSITION, unknown LLD failure
 #define MAKE10    0, 1, 2, 3, 4, 5, 6, 7, 8, 9
 #define MAKE100   MAKE10, MAKE10, MAKE10, MAKE10, MAKE10, MAKE10, MAKE10, MAKE10, MAKE10, MAKE10
 #define MAKE1000  MAKE100, MAKE100, MAKE100, MAKE100, MAKE100, MAKE100, MAKE100, MAKE100, MAKE100, MAKE100
@@ -565,7 +564,6 @@ void test_array() {
 #undef MAKE1000
 #undef MAKE100
 #undef MAKE10
-#endif // ^^^ no workaround ^^^
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/tests/std/tests/P0433R2_deduction_guides/test.cpp
+++ b/tests/std/tests/P0433R2_deduction_guides/test.cpp
@@ -547,8 +547,8 @@ void test_array() {
 #define MAKE10000 MAKE1000, MAKE1000, MAKE1000, MAKE1000, MAKE1000, MAKE1000, MAKE1000, MAKE1000, MAKE1000, MAKE1000
     // clang-format off
 #define MAKEALL   MAKE10000, MAKE10000, MAKE10000, MAKE10000, MAKE10000, MAKE10000, \
-    MAKE1000, MAKE1000, MAKE1000, MAKE1000,                                         \
-    MAKE1000, MAKE100, MAKE100, MAKE100, MAKE100, MAKE100,                          \
+    MAKE1000, MAKE1000, MAKE1000, MAKE1000, MAKE1000,                               \
+    MAKE100, MAKE100, MAKE100, MAKE100, MAKE100,                                    \
     MAKE10, MAKE10, MAKE10,                                                         \
     0, 1, 2, 3, 4
     // clang-format on


### PR DESCRIPTION
When the numbers of template parameters are large enough, either recursive instantiation or fold expression are rejected, see also LLVM-132021. So we need some other approach to achieve CTAD for a long `std::array`.

This PR eliminates recursive template instantiation in the deduction guide for `array` by using a single non-template `constexpr` function to calculate the result.  Shortcut instantiation doesn't seem very useful as instantiation of `is_same_v` is quite cheap.

For MSVC and Clang, if the number of template arguments in the deduction guide is larger than 65535, the compilers will crash. This is tracked in LLVM-119600 and DevCom-10946374. As a result, CTAD for longer `array`s is not supported yet.

Fixes #5665.