### PR TITLE
Toolset update: VS 2022 17.14.12 Preview 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.31.0)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 
-if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.44.35211")
-    message(FATAL_ERROR "The STL must be built with VS 2022 17.14.8 Preview 1 or later.")
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.44.35214")
+    message(FATAL_ERROR "The STL must be built with VS 2022 17.14.12 Preview 1 or later.")
 endif()
 
 include(CheckCXXSourceCompiles)

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.14.8 Preview 1 or later.
+1. Install Visual Studio 2022 17.14.12 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.26100.4188)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.
@@ -158,7 +158,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.14.8 Preview 1 or later.
+1. Install Visual Studio 2022 17.14.12 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.26100.4188)" in the VS Installer.
     * Select "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)" in the VS Installer
     if you would like to build the ARM64/ARM64EC target.

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,7 +5,7 @@
 
 variables:
 - name: poolName
-  value: 'StlBuild-2025-07-09T1240-Pool'
+  value: 'StlBuild-2025-08-12T1208-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -42,7 +42,7 @@ foreach ($workload in $VisualStudioWorkloads) {
 $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.5.2/PowerShell-7.5.2-win-x64.msi'
 $PowerShellArgs = @('/quiet', '/norestart')
 
-$PythonUrl = 'https://www.python.org/ftp/python/3.13.5/python-3.13.5-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.13.6/python-3.13.6-amd64.exe'
 $PythonArgs = @('/quiet', 'InstallAllUsers=1', 'PrependPath=1', 'CompileAll=1', 'Include_doc=0')
 
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/12.4.0/local_installers/cuda_12.4.0_551.61_windows.exe'

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -308,18 +308,11 @@ public:
         requires (!is_same_v<remove_cvref_t<_Uty>, in_place_t> && !is_same_v<remove_cvref_t<_Uty>, expected>
                      && !is_same_v<remove_cvref_t<_Uty>, unexpect_t>
                      && !_Is_specialization_v<remove_cvref_t<_Uty>, unexpected>
-                     && (!is_same_v<remove_cv_t<_Ty>, bool>
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10655311
-                         || !_Is_specialization_v<remove_cvref_t<_Uty>, expected>
-#else // ^^^ no workaround / workaround vvv
-                         || !_Is_specialization_v<remove_cvref_t<_Uty>, _STD expected>
-#endif // ^^^ workaround ^^^
-                         )
+                     && (!is_same_v<remove_cv_t<_Ty>, bool> || !_Is_specialization_v<remove_cvref_t<_Uty>, expected>)
                      && is_constructible_v<_Ty, _Uty>)
     constexpr explicit(!is_convertible_v<_Uty, _Ty>) expected(_Uty&& _Other)
         noexcept(is_nothrow_constructible_v<_Ty, _Uty>) // strengthened
-        : _Value(_STD forward<_Uty>(_Other)), _Has_value(true) {
-    }
+        : _Value(_STD forward<_Uty>(_Other)), _Has_value(true) {}
 
     template <class _UErr>
         requires is_constructible_v<_Err, const _UErr&>

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -2445,7 +2445,7 @@ void test_lwg_3886_volatile() {
 static_assert(copyable<expected<any, int>>);
 static_assert(copyable<expected<void, any>>);
 
-// Test workaround for DevCom-10655311: Class derived from std::expected can't be constructed with bool value type
+// Test DevCom-10655311: Class derived from std::expected can't be constructed with bool value type
 template <class T, class E>
 class DerivedFromExpected : private expected<T, E> {
 public:


### PR DESCRIPTION
# :scroll: Changelog
- Code cleanups:
  * Removed compiler bug workarounds.
- Infrastructure improvements:
  * Updated dependencies.
    + Updated build compiler to VS 2022 17.14.12 Preview 1.
    + Updated Python to 3.13.6.

# :gear: Commits
* Python 3.13.6.
* VS 2022 17.14.12 Preview 1.
* New pool.
* Remove workaround for DevCom-10655311.
