### PR TITLE
`P0811R3_midpoint_lerp`: Suppress warning C4756

### DIFF
--- a/tests/std/tests/P0811R3_midpoint_lerp/test.cpp
+++ b/tests/std/tests/P0811R3_midpoint_lerp/test.cpp
@@ -1031,6 +1031,8 @@ bool test_lerp() {
     return true;
 }
 
+#pragma warning(push)
+#pragma warning(disable : 4756) // ignore constant arithmetic overflow warning
 void test_gh_1917() {
     // GH-1917 <cmath>: lerp(1e+308, 5e+307, 4.0) spuriously overflows
     using bit_type       = unsigned long long;
@@ -1110,6 +1112,7 @@ void test_gh_1917() {
     }
 #endif // _M_FP_STRICT
 }
+#pragma warning(pop)
 
 constexpr bool test_gh_2112() {
     // GH-2112 <cmath>: std::lerp is missing Arithmetic overloads


### PR DESCRIPTION
This mirrors the STL part of the compiler backend MSVC-PR-661055 "Inlining Related Fixes" by @manbearian:

> Disable warning about overflow in constant math that shows up if the inliner does more aggressive inlining.

Although this MSVC-PR is targeted at internal `prod/be`, it's safe to mirror this suppression to GitHub and our usual branch `prod/fe`, where they'll merge harmlessly in MSVC `main`.