### PR TITLE
`<algorithm>`: Avoid integer overflow in `stable_sort()` and `ranges::stable_sort` for huge inputs on x86

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -395,6 +395,7 @@ _STD_BEGIN
     static_assert(_Is_ranges_bidi_iter_v<_Iter>, "This algorithm requires bidirectional iterators or stronger.")
 
 _INLINE_VAR constexpr int _ISORT_MAX = 32; // maximum size for insertion sort
+// If _ISORT_MAX is ever changed from 32 == 2^5, re-analyze the implementation of stable_sort for integer overflow.
 
 template <class _It>
 constexpr _Iter_diff_t<_It> _Isort_max{_ISORT_MAX};
@@ -9220,12 +9221,19 @@ void _Buffered_merge_sort_unchecked(const _BidIt _First, const _BidIt _Last, con
     auto _Chunk = _Isort_max<_BidIt>;
     for (;;) {
         // unconditionally merge elements back into the source buffer
+
+        // _Chunk starts at 2^5 and is doubled twice in this loop.
+        // The first doubling (to 2^6, 2^8, 2^10, ...) doesn't check for overflow as it doesn't pose a risk.
+        // The second doubling (to 2^7, 2^9, 2^11, ..., 2^15, ..., 2^31, ...) defends against overflow below.
         _Chunk <<= 1;
         _STD _Chunked_merge_unchecked(_Temp_ptr, _Temp_ptr + _Count, _First, static_cast<ptrdiff_t>(_Chunk),
             static_cast<ptrdiff_t>(_Count), _Pred);
 
-        // In general, this is equivalent to `_Chunk <<= 1;` followed by testing `_Count <= _Chunk`,
-        // except that it doesn't risk overflowing. `(_Count - 1) / 2` correctly handles even/odd _Count.
+        // This is equivalent to doubling _Chunk followed by returning when `_Count <= _Chunk`,
+        // except that it doesn't risk overflowing.
+        // Note that returning when `_Count / 2 <= _Chunk` before doubling _Chunk
+        // would behave differently for odd _Count due to truncating integer division.
+        // Returning when `(_Count - 1) / 2 < _Chunk` correctly handles both even and odd _Count.
         // We have an early return for small _Count above, so `_Count - 1` is safe to form.
         if ((_Count - 1) / 2 < _Chunk) {
             return; // if the input would be a single chunk, it's already sorted and we're done
@@ -9396,11 +9404,18 @@ namespace ranges {
             ptrdiff_t _Chunk_size = _ISORT_MAX;
             for (;;) {
                 // unconditionally merge elements back into the source buffer
+
+                // _Chunk_size starts at 2^5 and is doubled twice in this loop.
+                // The first doubling (to 2^6, 2^8, 2^10, ...) doesn't check for overflow as it doesn't pose a risk.
+                // The second doubling (to 2^7, 2^9, 2^11, ..., 2^15, ..., 2^31, ...) defends against overflow below.
                 _Chunk_size <<= 1;
                 _Chunked_merge_common(_Temp_ptr, _Temp_ptr + _Count, _First, _Chunk_size, _Count, _Pred, _Proj);
 
-                // In general, this is equivalent to `_Chunk_size <<= 1;` followed by testing `_Count <= _Chunk_size`,
-                // except that it doesn't risk overflowing. `(_Count - 1) / 2` correctly handles even/odd _Count.
+                // This is equivalent to doubling _Chunk_size followed by returning when `_Count <= _Chunk_size`,
+                // except that it doesn't risk overflowing.
+                // Note that returning when `_Count / 2 <= _Chunk_size` before doubling _Chunk_size
+                // would behave differently for odd _Count due to truncating integer division.
+                // Returning when `(_Count - 1) / 2 < _Chunk_size` correctly handles both even and odd _Count.
                 // We have an early return for small _Count above, so `_Count - 1` is safe to form.
                 if ((_Count - 1) / 2 < _Chunk_size) {
                     return; // if the input would be a single chunk, it's already sorted and we're done

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -9223,10 +9223,14 @@ void _Buffered_merge_sort_unchecked(const _BidIt _First, const _BidIt _Last, con
         _Chunk <<= 1;
         _STD _Chunked_merge_unchecked(_Temp_ptr, _Temp_ptr + _Count, _First, static_cast<ptrdiff_t>(_Chunk),
             static_cast<ptrdiff_t>(_Count), _Pred);
-        _Chunk <<= 1;
-        if (_Count <= _Chunk) { // if the input would be a single chunk, it's already sorted and we're done
-            return;
+
+        // In general, this is equivalent to `_Chunk <<= 1;` followed by testing `_Count <= _Chunk`,
+        // except that it doesn't risk overflowing. `(_Count - 1) / 2` correctly handles even/odd _Count.
+        // We have an early return for small _Count above, so `_Count - 1` is safe to form.
+        if ((_Count - 1) / 2 < _Chunk) {
+            return; // if the input would be a single chunk, it's already sorted and we're done
         }
+        _Chunk <<= 1;
 
         // more merges necessary; merge to temporary buffer
         _STD _Chunked_merge_unchecked(_First, _Last, _Temp_ptr, _Chunk, _Count, _Pred);
@@ -9394,10 +9398,14 @@ namespace ranges {
                 // unconditionally merge elements back into the source buffer
                 _Chunk_size <<= 1;
                 _Chunked_merge_common(_Temp_ptr, _Temp_ptr + _Count, _First, _Chunk_size, _Count, _Pred, _Proj);
-                _Chunk_size <<= 1;
-                if (_Count <= _Chunk_size) { // if the input would be a single chunk, it's already sorted and we're done
-                    return;
+
+                // In general, this is equivalent to `_Chunk_size <<= 1;` followed by testing `_Count <= _Chunk_size`,
+                // except that it doesn't risk overflowing. `(_Count - 1) / 2` correctly handles even/odd _Count.
+                // We have an early return for small _Count above, so `_Count - 1` is safe to form.
+                if ((_Count - 1) / 2 < _Chunk_size) {
+                    return; // if the input would be a single chunk, it's already sorted and we're done
                 }
+                _Chunk_size <<= 1;
 
                 // more merges necessary; merge to temporary buffer
                 _Chunked_merge_common(_First, _Last, _Temp_ptr, _Chunk_size, _Count, _Pred, _Proj);

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -2275,8 +2275,8 @@ namespace ranges {
                 _First = _STD move(_Mid);
                 ++_First;
 
-                using _Uty = _Make_unsigned_like_t<iter_difference_t<_It>>;
-                if (static_cast<_Uty>(_Skip) <= (static_cast<_Uty>(-1) >> 1)) {
+                constexpr auto _Half_max = (numeric_limits<iter_difference_t<_It>>::max)() / 2;
+                if (_Skip <= _Half_max) {
                     _Skip <<= 1;
                 }
             }


### PR DESCRIPTION
Reported by Aditya Anand to our internal C++ mailing list.

On x86, it's barely possible for `stable_sort()` to trigger an integer overflow when repeatedly doubling a chunk size. This happens when sorting over a billion 1-byte elements; the test case below uses 2^30 + 2 bytes. Surprisingly, this bug has been present since the beginning of time; we've historically been pretty good about checking for overflow before multiplying (e.g. in geometric growth), but missed this case.

We can avoid this integer overflow by testing whether we're done before doubling the chunk size. As the comment explains, I've carefully transformed the test to avoid even/odd issues. `ranges::stable_sort` was equally affected.

I'm not altering the initial doubling in this loop. Because we start with 32, i.e. 2^5, the first doubling is always safe (e.g. from 2^29 to 2^30). It's only the second doubling that might overflow (e.g. from 2^30 to 2^31 here). At this time I simply don't care about pathological `_Iter_diff_t` that might have a limit other than a normal power of 2. (Note that this logic still works for 16-bit ultra-narrow difference types; it would have to be *extremely* pathological for this to be an issue.)

# Manual Testing

Because this involves allocating an enormous amount of memory, automated test coverage isn't appropriate. I manually tested the fix, and the detailed comments should be sufficient to avoid regressions during future maintenance.

```
C:\Temp>type meow.cpp
```
```cpp
#include <algorithm>
#include <print>
#include <vector>
using namespace std;

static_assert(sizeof(void*) == 4, "This test requires x86.");

int main() {
    println("_MSVC_STL_UPDATE: {}", _MSVC_STL_UPDATE);

    const int count = (1 << 30) + 2;
    vector<unsigned char> v(count);

    for (int i = 0; i < count; ++i) {
        v[i] = i % 10;
    }

    println("Before std::stable_sort: {}", is_sorted(v.begin(), v.end()));
    stable_sort(v.begin(), v.end());
    println(" After std::stable_sort: {}", is_sorted(v.begin(), v.end()));

    for (int i = 0; i < count; ++i) {
        v[i] = i % 10;
    }

    println("Before ranges::stable_sort: {}", is_sorted(v.begin(), v.end()));
    ranges::stable_sort(v);
    println(" After ranges::stable_sort: {}", is_sorted(v.begin(), v.end()));
}
```

Plain VS 2022 17.14.12 x86 simply crashes:

```
C:\Temp>cl /EHsc /nologo /W4 /std:c++latest /MT /O2 meow.cpp /link /largeaddressaware
meow.cpp

C:\Temp>meow && echo SUCCESS || echo FAILURE
_MSVC_STL_UPDATE: 202503
Before std::stable_sort: false
FAILURE
```

After this PR:

```
C:\Temp>cl /EHsc /nologo /W4 /std:c++latest /MT /O2 meow.cpp /link /largeaddressaware
meow.cpp

C:\Temp>meow && echo SUCCESS || echo FAILURE
_MSVC_STL_UPDATE: 202508
Before std::stable_sort: false
 After std::stable_sort: true
Before ranges::stable_sort: false
 After ranges::stable_sort: true
SUCCESS
```

These tests are compiled with optimizations so they finish in a reasonable amount of time. The behavior is the same, just agonizingly slower, with `/MTd /Od`.