### PR TITLE
Fix consteval case for _STL_REPORT_ERROR

### DIFF
--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -259,9 +259,13 @@ extern "C" __declspec(noreturn) void __fastfail(unsigned int); // declared by <i
 #endif // choose "doom function"
 #endif // ^^^ !defined(_MSVC_STL_DOOM_FUNCTION) ^^^
 
-#define _STL_REPORT_ERROR(mesg) \
-    _RPTF0(_CRT_ASSERT, mesg);  \
-    _MSVC_STL_DOOM_FUNCTION(mesg)
+#define _STL_REPORT_ERROR(mesg)        \
+    if (_Is_constant_evaluated()) {    \
+        static_assert(false, mesg);    \
+    } else {                           \
+        _RPTF0(_CRT_ASSERT, mesg);     \
+        _MSVC_STL_DOOM_FUNCTION(mesg); \
+    }
 
 #define _STL_VERIFY(cond, mesg)  \
     if (!(cond)) {               \


### PR DESCRIPTION
Fixes repro case: https://godbolt.org/z/YPex3q69z
Short description: `_STL_REPORT_ERROR` did not consider constant evaluation and emitted code that would still cause an expected build failure, but hid the intended error message
The change now explicitly uses a `static_assert` for this case.