### PR TITLE
Provide definitions for std::size_t and std::ptrdiff_t through type deduction

### DIFF
--- a/stl/inc/cstddef
+++ b/stl/inc/cstddef
@@ -25,8 +25,9 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef intrinsic
 
 _STD_BEGIN
-_EXPORT_STD using _CSTD ptrdiff_t;
-_EXPORT_STD using _CSTD size_t;
+// using deduction to define size_t and ptrdiff_t for better diagnostics, see GH-5699
+_EXPORT_STD using ptrdiff_t   = decltype((int*) (nullptr) - (int*) (nullptr));
+_EXPORT_STD using size_t      = decltype(sizeof(0));
 _EXPORT_STD using max_align_t = double; // most aligned type
 _EXPORT_STD using nullptr_t   = decltype(nullptr);
 

--- a/stl/inc/cstdio
+++ b/stl/inc/cstdio
@@ -32,7 +32,7 @@ _STD_BEGIN
 
 using _CSTD _Mbstatet;
 
-_EXPORT_STD using _CSTD size_t;
+_EXPORT_STD using size_t = decltype(sizeof(0));
 _EXPORT_STD using _CSTD fpos_t;
 _EXPORT_STD using _CSTD FILE;
 _EXPORT_STD using _CSTD clearerr;

--- a/stl/inc/cstdlib
+++ b/stl/inc/cstdlib
@@ -34,7 +34,7 @@ _NODISCARD _Check_return_ inline long double abs(_In_ long double _Xx) noexcept 
 _END_EXTERN_CXX_WORKAROUND
 
 _STD_BEGIN
-_EXPORT_STD using _CSTD size_t;
+_EXPORT_STD using size_t = decltype(sizeof(0));
 _EXPORT_STD using _CSTD div_t;
 _EXPORT_STD using _CSTD ldiv_t;
 _EXPORT_STD using _CSTD abort;

--- a/stl/inc/cstring
+++ b/stl/inc/cstring
@@ -21,7 +21,7 @@ _STD_BEGIN
 #pragma warning(push)
 #pragma warning(disable : 4995) // name was marked as #pragma deprecated
 
-_EXPORT_STD using _CSTD size_t;
+_EXPORT_STD using size_t = decltype(sizeof(0));
 _EXPORT_STD using _CSTD memchr;
 _EXPORT_STD using _CSTD memcmp;
 _EXPORT_STD using _CSTD memcpy;

--- a/stl/inc/ctime
+++ b/stl/inc/ctime
@@ -19,7 +19,7 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 _EXPORT_STD using _CSTD clock_t;
-_EXPORT_STD using _CSTD size_t;
+_EXPORT_STD using size_t = decltype(sizeof(0));
 _EXPORT_STD using _CSTD time_t;
 _EXPORT_STD using _CSTD tm;
 _EXPORT_STD using _CSTD asctime;

--- a/stl/inc/cuchar
+++ b/stl/inc/cuchar
@@ -19,7 +19,7 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 _EXPORT_STD using _CSTD mbstate_t;
-_EXPORT_STD using _CSTD size_t;
+_EXPORT_STD using size_t = decltype(sizeof(0));
 _EXPORT_STD using _CSTD mbrtoc16;
 _EXPORT_STD using _CSTD c16rtomb;
 _EXPORT_STD using _CSTD mbrtoc32;

--- a/stl/inc/cwchar
+++ b/stl/inc/cwchar
@@ -29,7 +29,7 @@ _STD_BEGIN
 using _CSTD _Mbstatet;
 
 _EXPORT_STD using _CSTD mbstate_t;
-_EXPORT_STD using _CSTD size_t;
+_EXPORT_STD using size_t = decltype(sizeof(0));
 _EXPORT_STD using _CSTD tm;
 _EXPORT_STD using _CSTD wint_t;
 


### PR DESCRIPTION
I previously added a feature to Clang that allows expressions producing `size_t` and `ptrdiff_t` through built-in language mechanisms (eg. `sizeof`) to have the sugared types `__size_t` and `__ptrdiff_t`, instead of `unsigned int`/`long`/`long long` and `int`/`long`/`long long` (https://github.com/llvm/llvm-project/pull/143653). This helps generate more portable diagnostic messages. However, the definitions of `size_t` and `ptrdiff_t` in the STL and `vcruntime.h` are hardcoded to fixed built-in types, causing this benefit to be lost when arithmetic operations are performed, as Clang does not treat `std::size_t` and `std::ptrdiff_t` differ from other `typedef`s when evaluates common sugared types.

By using deduction to define `std::size_t` and `std::ptrdiff_t`, this advantage can be preserved.

<img width="884" height="448" alt="clangd-screenshot" src="https://github.com/user-attachments/assets/ba57a444-e4b4-43d1-9ff8-d63d6bed7466" />
