### PR TITLE
`<flat_map>`, `<flat_set>`: mark unused variables and typedef libc++ test failures as known upstream

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -60,6 +60,13 @@ std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_iter_rv.pas
 std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_rv.pass.cpp FAIL
 std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_transparent.pass.cpp FAIL
 
+# LLVM-155679: [libcxx][test] Avoid warnings about unused variables and typedefs if _LIBCPP_VERSION is not defined
+std/containers/container.adaptors/flat.map/flat.map.cons/move_assign_noexcept.compile.pass.cpp:2 FAIL
+std/containers/container.adaptors/flat.multimap/flat.multimap.cons/move_assign_noexcept.compile.pass.cpp:2 FAIL
+std/containers/container.adaptors/flat.map/flat.map.erasure/erase_if_exceptions.pass.cpp:2 FAIL
+std/containers/container.adaptors/flat.multimap/flat.multimap.erasure/erase_if_exceptions.pass.cpp:2 FAIL
+std/containers/container.adaptors/flat.set/flat.set.erasure/erase_if_exceptions.pass.cpp:2 FAIL
+
 # Non-Standard regex behavior.
 # "It seems likely that the test is still non-conforming due to how libc++ handles the 'w' character class."
 std/re/re.traits/lookup_classname.pass.cpp FAIL
@@ -288,14 +295,6 @@ std/containers/container.adaptors/flat.multimap/flat.multimap.cons/sorted_iter_i
 std/containers/container.adaptors/flat.multimap/flat.multimap.modifiers/erase_key.pass.cpp:0 FAIL
 std/containers/container.adaptors/flat.multimap/flat.multimap.modifiers/erase_key.pass.cpp:1 FAIL
 
-# FIXME! error: unused type alias 'C' [-Werror,-Wunused-local-typedef]
-std/containers/container.adaptors/flat.map/flat.map.cons/move_assign_noexcept.compile.pass.cpp:2 FAIL
-std/containers/container.adaptors/flat.multimap/flat.multimap.cons/move_assign_noexcept.compile.pass.cpp:2 FAIL
-
-# FIXME! error: unused variable 'expected' [-Werror,-Wunused-variable]
-std/containers/container.adaptors/flat.map/flat.map.erasure/erase_if_exceptions.pass.cpp:2 FAIL
-std/containers/container.adaptors/flat.multimap/flat.multimap.erasure/erase_if_exceptions.pass.cpp:2 FAIL
-
 # FIXME! C++26 "P3372R3 constexpr Containers And Adaptors" isn't completely guarded with `TEST_STD_VER >= 26`.
 std/containers/container.adaptors/flat.map/flat.map.access/at_transparent.pass.cpp:0 FAIL
 std/containers/container.adaptors/flat.map/flat.map.access/at_transparent.pass.cpp:1 FAIL
@@ -406,9 +405,6 @@ std/containers/container.adaptors/flat.multiset/flat.multiset.cons/sorted_iter_i
 std/containers/container.adaptors/flat.multiset/flat.multiset.cons/sorted_iter_iter.pass.cpp:1 FAIL
 std/containers/container.adaptors/flat.set/flat.set.cons/sorted_iter_iter.pass.cpp:0 FAIL
 std/containers/container.adaptors/flat.set/flat.set.cons/sorted_iter_iter.pass.cpp:1 FAIL
-
-# FIXME! error: unused variable 'expected' [-Werror,-Wunused-variable]
-std/containers/container.adaptors/flat.set/flat.set.erasure/erase_if_exceptions.pass.cpp:2 FAIL
 
 # FIXME! Asserts while testing insert_range's exception guarantee.
 std/containers/container.adaptors/flat.multiset/flat.multiset.modifiers/insert_range.pass.cpp FAIL


### PR DESCRIPTION
See LLVM-155679