### PR TITLE
Build the benchmark with clang-cl only on x64

### DIFF
--- a/azure-devops/build-benchmarks.yml
+++ b/azure-devops/build-benchmarks.yml
@@ -29,10 +29,10 @@ steps:
   displayName: 'Configure the benchmarks for ${{ parameters.compiler }}'
   timeoutInMinutes: 2
   env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
-  # TRANSITION, we currently don't build the benchmarks with Clang for ARM64 or ARM64EC
+  # TRANSITION, we currently only build the benchmarks with Clang for x64
   condition: >
     and(succeeded(), ${{ parameters.buildBenchmarks }},
-      not(and(eq('${{ parameters.compiler }}', 'clang-cl'), startsWith('${{ parameters.targetPlatform }}', 'arm64'))))
+      not(and(eq('${{ parameters.compiler }}', 'clang-cl'), not(startsWith('${{ parameters.targetPlatform }}', 'x64')))))
 - script: |
     call "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\Common7\Tools\VsDevCmd.bat" ^
     -host_arch=${{ parameters.hostArch }} -arch=${{ parameters.targetArch }} -no_logo
@@ -40,7 +40,7 @@ steps:
   displayName: 'Build the benchmarks for ${{ parameters.compiler }}'
   timeoutInMinutes: 2
   env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
-  # TRANSITION, we currently don't build the benchmarks with Clang for ARM64 or ARM64EC
+  # TRANSITION, we currently only build the benchmarks with Clang for x64
   condition: >
     and(succeeded(), ${{ parameters.buildBenchmarks }},
-      not(and(eq('${{ parameters.compiler }}', 'clang-cl'), startsWith('${{ parameters.targetPlatform }}', 'arm64'))))
+      not(and(eq('${{ parameters.compiler }}', 'clang-cl'), not(startsWith('${{ parameters.targetPlatform }}', 'x64')))))


### PR DESCRIPTION
There's infrequent but not very rara access violation when linking with the benchmark using clang-cl on x86.

Apparently x64 works always.

Let's keep only x64 built on CI. It might worth giving another try when clang-cl is updated to the next major.

Note that this change does not prevent building x86 benchmark with clang-cl locally, only makes it possible for this configuration to bit rot.