### PR TITLE
`<vector>`: Silence static analysis warning C26450

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -3202,8 +3202,11 @@ public:
             return _Diff_max;
         }
 
+#pragma warning(push)
+#pragma warning(disable : 26450) // TRANSITION, VSO-2565428
         // max_size bound by underlying storage limits
         return static_cast<size_type>(_Ints_max * _VBITS);
+#pragma warning(pop)
     }
 
     _NODISCARD_EMPTY_MEMBER _CONSTEXPR20 bool empty() const noexcept {


### PR DESCRIPTION
In certain cases (not found by our test coverage, but by the MSVC codebase's own usage), `/analyze` emits a false positive warning about integer overflow, when we've carefully guarded against integer overflow. @carsonRadtke has filed VSO-2565428 "C26450 FP in STL/vector" to track fixing this in `/analyze`. Until then, we should push-disable-pop the warning around the affected code.

Followup to #5550 and #5566. So it's time for a quote:

> "I remember that we cleared this world out. We won. Is a future coming in which we will, eventually, truly, have won?"

\- Ra (Abstract Weapon) by qntm
