### PR TITLE
`<xloctime>`: Silence CodeQL warning SM03231 about leap years, again

### DIFF
--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -421,6 +421,7 @@ protected:
                     // CodeQL [SM03231] This is parsing tm_year (years since 1900); leap years are irrelevant.
                     _Pt->tm_year = _Ans + 100; // [00, 68] parsed as [2000, 2068]
                 } else if (_Ans < 100) {
+                    // CodeQL [SM03231] This is parsing tm_year (years since 1900); leap years are irrelevant.
                     _Pt->tm_year = _Ans; // [69, 99] parsed as [1969, 1999]
                 }
             } else {
@@ -556,6 +557,7 @@ protected:
                     // CodeQL [SM03231] This is parsing tm_year (years since 1900); leap years are irrelevant.
                     _Pt->tm_year = _Ans + 100; // [00, 68] parsed as [2000, 2068]
                 } else {
+                    // CodeQL [SM03231] This is parsing tm_year (years since 1900); leap years are irrelevant.
                     _Pt->tm_year = _Ans; // [69, 99] parsed as [1969, 1999]
                 }
             }


### PR DESCRIPTION
Followup to #5625. Fixes internal VSO-2566953.

Previously, I silenced "Year field changed using an arithmetic operation without checking for leap year" for all of the locations that were performing arithmetic. Now we've got a new round of warnings, same opaque ID SM03231 but a different message "Field `tm_year` on variable `_Pt` has been modified, but no appropriate check for LeapYear was found", so we need to suppress every line modifying `tm_year`.

Once again it's time to quote:

> "I remember that we cleared this world out. We won. Is a future coming in which we will, eventually, truly, have won?"

\- Ra (Abstract Weapon) by qntm
