### PR TITLE
Fix a typo

### DIFF
--- a/stl/src/wiostrea.cpp
+++ b/stl/src/wiostrea.cpp
@@ -30,5 +30,6 @@ _CRTIMP2_PURE __thiscall _Winit::~_Winit() noexcept { // flush standard wide str
             _Ptr_wclog->flush();
         }
     }
-    _STD_END
 }
+
+_STD_END


### PR DESCRIPTION
The original scoping looks very weird to me. By searching ` _STD_END` (one blank before `_STD_END`) in this project, I believe this is not intentional. (And this is the only exception.)