### PR TITLE
Disable `/analyze` for libcxx

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -142,11 +142,6 @@ std/language.support/support.limits/support.limits.general/cstring.version.compi
 # libc++ has not implemented P3323R1: "Forbid atomic<cv T>, Specify atomic_ref<cv T>"
 std/atomics/atomics.ref/member_types.compile.pass.cpp FAIL
 
-# Various bogosity (LLVM-D141004), warning C6011: Dereferencing NULL pointer
-# Note: The :1 (ASan) configuration doesn't run static analysis.
-std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair_const_lvalue_pair.pass.cpp:0 FAIL
-std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair_values.pass.cpp:0 FAIL
-
 # Various bogosity (LLVM-D141004)
 std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.ctor/ctor_does_not_allocate.pass.cpp FAIL
 std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.ctor/sync_with_default_resource.pass.cpp FAIL
@@ -610,11 +605,6 @@ std/thread/thread.condition/notify_all_at_thread_exit_lwg3343.pass.cpp SKIPPED
 
 
 # *** C1XX COMPILER BUGS ***
-# VSO-1271673 "static analyzer doesn't know about short-circuiting"
-# Note: The :1 (ASan) configuration doesn't run static analysis.
-std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort.pass.cpp:0 FAIL
-std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort_comp.pass.cpp:0 FAIL
-
 # DevCom-1436243 VSO-1335743 constexpr new initialized array
 std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset_self.pass.cpp:0 FAIL
 std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset_self.pass.cpp:1 FAIL
@@ -638,11 +628,6 @@ std/utilities/variant/variant.relops/three_way.pass.cpp:1 FAIL
 # VSO-2188243 constexpr ICE in C1XX adapt::to_prvalue
 std/algorithms/robust_re_difference_type.compile.pass.cpp:0 FAIL
 std/algorithms/robust_re_difference_type.compile.pass.cpp:1 FAIL
-
-# DevCom-1638563 VSO-1457836: icky static analysis false positive
-# Resolved wontfix, need to report again.
-# Note: The :1 (ASan) configuration doesn't run static analysis.
-std/language.support/support.coroutines/end.to.end/go.pass.cpp:0 FAIL
 
 # DevCom-10026599 VSO-1532879: conditional expression has two different types
 std/concepts/concepts.compare/concept.equalitycomparable/equality_comparable_with.compile.pass.cpp:0 FAIL
@@ -1263,25 +1248,6 @@ std/utilities/format/format.range/format.range.fmtmap/format.pass.cpp FAIL
 std/utilities/format/format.range/format.range.fmtset/format.pass.cpp FAIL
 std/utilities/format/format.range/format.range.fmtstr/format.pass.cpp FAIL
 std/utilities/format/format.tuple/format.pass.cpp FAIL
-
-# Not analyzed. Static analysis thinks that array indexing is out of bounds because it can't prove otherwise.
-# warning C28020: The expression '_Param_(1)<1' is not true at this call.
-# Note: The :1 (ASan) configuration doesn't run static analysis.
-std/containers/views/mdspan/extents/ctor_default.pass.cpp:0 FAIL
-std/containers/views/mdspan/extents/ctor_from_array.pass.cpp:0 FAIL
-std/containers/views/mdspan/extents/ctor_from_integral.pass.cpp:0 FAIL
-std/containers/views/mdspan/extents/ctor_from_span.pass.cpp:0 FAIL
-std/containers/views/mdspan/layout_stride/comparison.pass.cpp:0 FAIL
-std/containers/views/mdspan/layout_stride/ctor.strided_mapping.pass.cpp:0 FAIL
-std/containers/views/mdspan/mdspan/conversion.pass.cpp:0 FAIL
-std/containers/views/mdspan/mdspan/ctor.dh_array.pass.cpp:0 FAIL
-std/containers/views/mdspan/mdspan/ctor.dh_span.pass.cpp:0 FAIL
-
-# Not analyzed. Apparent false positives from static analysis where it thinks `new (std::nothrow)` could return null, despite an assert().
-# warning C28182: Dereferencing NULL pointer.
-# Note: The :1 (ASan) configuration doesn't run static analysis.
-std/language.support/support.dynamic/new.delete/new.delete.array/new.size_align_nothrow.pass.cpp:0 FAIL
-std/language.support/support.dynamic/new.delete/new.delete.array/new.size_nothrow.pass.cpp:0 FAIL
 
 # Not analyzed, unexpected separators. Assertion failed: stream_fr_FR_locale<CharT>(-1'000'000s) == SV("-1 000 000s")
 std/time/time.duration/time.duration.nonmember/ostream.pass.cpp FAIL

--- a/tests/libcxx/usual_matrix.lst
+++ b/tests/libcxx/usual_matrix.lst
@@ -5,6 +5,6 @@ RUNALL_INCLUDE ..\universal_prefix.lst
 RUNALL_CROSSLIST
 *	PM_CL="/EHsc /MTd /std:c++latest /permissive- /utf-8 /FImsvc_stdlib_force_include.h /wd4643"
 RUNALL_CROSSLIST
-PM_CL="/analyze:autolog- /Zc:preprocessor /wd6262"
+PM_CL="/Zc:preprocessor"
 ASAN	PM_CL="-fsanitize=address /Zi" PM_LINK="/debug"
 PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call"


### PR DESCRIPTION
While working on a compiler improvement that slightly increases compiler memory consumption, Jennifer Yao encountered a libcxx failure due to the x86-hosted compiler running out of memory. What was happening is that our use of `/analyze` in the libcxx test suite was causing a ranges test to consume a wild 3.34 GB, so any slight increase would push it over the edge.

To be a good kitty, I reported this as VSO-2576569 "`/analyze` consumes 13.9x more memory for a ranges algorithm test". And of course, x86-hosted tools in the year 2025 are an abomination, and it's bad and wrong that we're still shipping them. But as long as we do, we need to exercise them. (And also, switching over our internal test harness to use x64-hosted x86-targeting tools would be moderately obnoxious.)

Instead of skipping the affected test, or scouting for similarly memory-hungry tests, I rethought why we're using `/analyze` in libcxx in the first place. We pioneered aggressively using `/analyze` in the STL's test suites, and its usage in `tests/std` provides extremely valuable coverage. We run far fewer libcxx configurations (as libcxx has a ton of tests, every compiler configuration is very expensive), so we figured that we may as well add `/analyze` while we were at it. However, in addition to increasing test runtime (and compiler memory consumption!), this regularly causes headaches because libcxx developers naturally don't audit their tests with MSVC, much less MSVC `/analyze`, so we have to deal with warnings emitted by test code. And while this coverage *has* found a moderate number of compiler bugs in `/analyze` itself, it generally hasn't found unique problems in the STL which weren't found by `tests/std` already.

Finally, in the last year or two, MS has gotten significantly more serious about increasing `/analyze` adoption internally, with all of MSVC now routinely being built with `/analyze`. This means that the STL is being exercised far more widely with static analysis, and by realistic usage instead of the unusual patterns of a Standard Library test suite, so running it in the libcxx test suite is less important than it used to be.

This PR removes `/analyze` from libcxx and restores all of the tests we had knownfailed. On my 5950X, this results in a nice speedup, from 1590s (26m 30s) to 892s (14m 52s), a 1.78x speedup.