### PR TITLE
`<vector>`: Fix UB in `vector<bool>` by rotating instead of shifting

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -3859,8 +3859,8 @@ _CONSTEXPR20 _OutIt _Copy_vbool(_VbIt _First, _VbIt _Last, _OutIt _Dest) {
 
         const auto _DestMask = _FirstDestMask | (_DestEnd._Myoff == 0 ? 0 : _LastDestMask);
         if (_Last._Myoff != 0) {
-            const auto _LastShift     = _DestEnd._Myoff - _Last._Myoff;
-            const auto _LastSourceVal = (*_VbLast & _LastSourceMask) << _LastShift;
+            const int _LastRotate     = static_cast<int>(_DestEnd._Myoff) - static_cast<int>(_Last._Myoff);
+            const auto _LastSourceVal = _rotl(*_VbLast & _LastSourceMask, _LastRotate);
             *_VbDest                  = (*_VbDest & _DestMask) | _SourceVal | _LastSourceVal;
         } else {
             *_VbDest = (*_VbDest & _DestMask) | _SourceVal;


### PR DESCRIPTION
Fixes #5720.
The UB manifested as correctly working machine code.
The fix imitates the UB manifestation without running into the UB,

The negative big shift happened to turn into positive large shift.
The rotate is performance equivalent<sup>1</sup>, that can accept negative amount.

Beware, intrinsic! Seems to work even in `/clr:pure` though, as I don't see any attempts to escape it in `<bit>`.

___
<sup>1</sup> On x64. Apparently, on ARM64, `rotr` and swapping the subtraction would be performance equivalent, and `rotl` is slightly slower. Still keeping `rotl` to minimize the amount of changes.

---

This seems to open possibility of considering rotates elsewhere, collapsing conditionals and branches. May look into this later.