### PR TITLE
Fix UB in `vector<bool>` by adding missing special case

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -3859,7 +3859,7 @@ _CONSTEXPR20 _OutIt _Copy_vbool(_VbIt _First, _VbIt _Last, _OutIt _Dest) {
 
         const auto _DestMask = _FirstDestMask | (_DestEnd._Myoff == 0 ? 0 : _LastDestMask);
         if (_Last._Myoff != 0) {
-            const auto _LastShift     = _DestEnd._Myoff - _Last._Myoff;
+            const auto _LastShift     = _DestEnd._Myoff != 0 ? _DestEnd._Myoff - _Last._Myoff : _VBITS - _Last._Myoff;
             const auto _LastSourceVal = (*_VbLast & _LastSourceMask) << _LastShift;
             *_VbDest                  = (*_VbDest & _DestMask) | _SourceVal | _LastSourceVal;
         } else {


### PR DESCRIPTION
Fixes #5720.

`_IsSingleBlockDest` has special case when that single block touches edge, and `_DestEnd` is greater that `_Dest`, and `_DestEnd._Myoff == 0`. This is handled elsewhere:

https://github.com/microsoft/STL/blob/43e96b29a971a7a26aceaa539d22cbedfcf13687/stl/inc/vector#L3834
https://github.com/microsoft/STL/blob/43e96b29a971a7a26aceaa539d22cbedfcf13687/stl/inc/vector#L3843
https://github.com/microsoft/STL/blob/43e96b29a971a7a26aceaa539d22cbedfcf13687/stl/inc/vector#L3860

Now we need to add missing handling in the UB causing line. If `_DestEnd._Myoff == 0`, we have the only case when the subtraction result is negative. We actually need to subtract from full 32 bits in this case.

The UB didn't cause runtime behavior difference, as the shift instruction just ignores high bits.