### PR TITLE
`<vector>`: Fix allocator types in reallocation guards

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -607,17 +607,17 @@ private:
     using _Scary_val = _Vector_val<conditional_t<_Is_simple_alloc_v<_Alty>, _Simple_types<_Ty>,
         _Vec_iter_types<_Ty, size_type, difference_type, pointer, const_pointer>>>;
 
-    struct _NODISCARD _Reallocation_guard {
-        _Alloc& _Al;
+    struct _NODISCARD _Reallocation_guard2 {
+        _Alty& _Al;
         pointer _New_begin;
         size_type _New_capacity;
         pointer _Constructed_first;
         pointer _Constructed_last;
 
-        _Reallocation_guard& operator=(const _Reallocation_guard&) = delete;
-        _Reallocation_guard& operator=(_Reallocation_guard&&)      = delete;
+        _Reallocation_guard2& operator=(const _Reallocation_guard2&) = delete;
+        _Reallocation_guard2& operator=(_Reallocation_guard2&&)      = delete;
 
-        _CONSTEXPR20 ~_Reallocation_guard() noexcept {
+        _CONSTEXPR20 ~_Reallocation_guard2() noexcept {
             if (_New_begin != nullptr) {
                 _STD _Destroy_range(_Constructed_first, _Constructed_last, _Al);
                 _Al.deallocate(_New_begin, _New_capacity);
@@ -625,15 +625,15 @@ private:
         }
     };
 
-    struct _NODISCARD _Simple_reallocation_guard {
-        _Alloc& _Al;
+    struct _NODISCARD _Simple_reallocation_guard2 {
+        _Alty& _Al;
         pointer _New_begin;
         size_type _New_capacity;
 
-        _Simple_reallocation_guard& operator=(const _Simple_reallocation_guard&) = delete;
-        _Simple_reallocation_guard& operator=(_Simple_reallocation_guard&&)      = delete;
+        _Simple_reallocation_guard2& operator=(const _Simple_reallocation_guard2&) = delete;
+        _Simple_reallocation_guard2& operator=(_Simple_reallocation_guard2&&)      = delete;
 
-        _CONSTEXPR20 ~_Simple_reallocation_guard() noexcept {
+        _CONSTEXPR20 ~_Simple_reallocation_guard2() noexcept {
             if (_New_begin != nullptr) {
                 _Al.deallocate(_New_begin, _New_capacity);
             }
@@ -894,7 +894,7 @@ private:
         const pointer _Newvec           = _STD _Allocate_at_least_helper(_Al, _Newcapacity);
         const pointer _Constructed_last = _Newvec + _Whereoff + 1;
 
-        _Reallocation_guard _Guard{_Al, _Newvec, _Newcapacity, _Constructed_last, _Constructed_last};
+        _Reallocation_guard2 _Guard{_Al, _Newvec, _Newcapacity, _Constructed_last, _Constructed_last};
         auto& _Constructed_first = _Guard._Constructed_first;
 
         _Alty_traits::construct(_Al, _STD _Unfancy(_Newvec + _Whereoff), _STD forward<_Valty>(_Val)...);
@@ -978,7 +978,7 @@ private:
             const pointer _Newvec           = _Allocate_at_least_helper(_Al, _Newcapacity);
             const pointer _Constructed_last = _Newvec + _Oldsize + _Count;
 
-            _Reallocation_guard _Guard{_Al, _Newvec, _Newcapacity, _Constructed_last, _Constructed_last};
+            _Reallocation_guard2 _Guard{_Al, _Newvec, _Newcapacity, _Constructed_last, _Constructed_last};
             auto& _Constructed_first = _Guard._Constructed_first;
 
             _Uninitialized_copy_n(_STD move(_First), _Count, _Newvec + _Oldsize, _Al);
@@ -1096,7 +1096,7 @@ public:
             const pointer _Newvec           = _Allocate_at_least_helper(_Al, _Newcapacity);
             const pointer _Constructed_last = _Newvec + _Whereoff + _Count;
 
-            _Reallocation_guard _Guard{_Al, _Newvec, _Newcapacity, _Constructed_last, _Constructed_last};
+            _Reallocation_guard2 _Guard{_Al, _Newvec, _Newcapacity, _Constructed_last, _Constructed_last};
             auto& _Constructed_first = _Guard._Constructed_first;
 
             _Uninitialized_fill_n(_Newvec + _Whereoff, _Count, _Val, _Al);
@@ -1189,7 +1189,7 @@ private:
             const auto _Whereoff            = static_cast<size_type>(_Whereptr - _Oldfirst);
             const pointer _Constructed_last = _Newvec + _Whereoff + _Count;
 
-            _Reallocation_guard _Guard{_Al, _Newvec, _Newcapacity, _Constructed_last, _Constructed_last};
+            _Reallocation_guard2 _Guard{_Al, _Newvec, _Newcapacity, _Constructed_last, _Constructed_last};
             auto& _Constructed_first = _Guard._Constructed_first;
 
             _STD _Uninitialized_copy_n(_STD move(_First), _Count, _Newvec + _Whereoff, _Al);
@@ -1565,7 +1565,7 @@ private:
         const pointer _Newvec         = _Allocate_at_least_helper(_Al, _Newcapacity);
         const pointer _Appended_first = _Newvec + _Oldsize;
 
-        _Reallocation_guard _Guard{_Al, _Newvec, _Newcapacity, _Appended_first, _Appended_first};
+        _Reallocation_guard2 _Guard{_Al, _Newvec, _Newcapacity, _Appended_first, _Appended_first};
         auto& _Appended_last = _Guard._Constructed_last;
 
         if constexpr (is_same_v<_Ty2, _Ty>) {
@@ -1656,7 +1656,7 @@ private:
             _Newvec = _Al.allocate(_Newcapacity);
         }
 
-        _Simple_reallocation_guard _Guard{_Al, _Newvec, _Newcapacity};
+        _Simple_reallocation_guard2 _Guard{_Al, _Newvec, _Newcapacity};
 
         if constexpr (is_nothrow_move_constructible_v<_Ty> || !is_copy_constructible_v<_Ty>) {
             _Uninitialized_move(_Myfirst, _Mylast, _Newvec, _Al);


### PR DESCRIPTION
Reported by Weipeng Liu internally. Consider the following code, which is activating our escape hatch to disable enforcement of WG21-N5014 \[container.alloc.reqmts\]/5 "*Mandates:* `allocator_type::value_type` is the same as `X::value_type`."

```
D:\GitHub\STL\out\x64>type meow.cpp
```
```cpp
#include <memory_resource>
#include <vector>
using namespace std;

int main() {
    vector<int, pmr::polymorphic_allocator<double>> my_vector;

    my_vector.emplace_back(3);
}
```
```
D:\GitHub\STL\out\x64>cl /EHsc /nologo /W4 /std:c++latest /D_ENFORCE_MATCHING_ALLOCATORS=0 meow.cpp
meow.cpp
D:\GitHub\STL\out\x64\out\inc\vector(897): error C2440: 'initializing': cannot convert from 'std::pmr::polymorphic_allocator<_Newfirst>' to '_Alloc &'
        with
        [
            _Newfirst=int
        ]
        and
        [
            _Alloc=std::pmr::polymorphic_allocator<double>
        ]
[...]
```

Although I grumbled at the use of our escape hatch allowing non-conformantly mismatched allocators, Weipeng identified the problem - `vector`'s reallocation guards mention the wrong allocator type. In STL containers, we have a convention that `_Alloc` is the user's original allocator, while `_Alty` is the properly rebound allocator. The reallocation guards refer to original `_Alloc`, contrary to our convention.

This was introduced by #4977 on 2024-10-11 in VS 2022 17.13, so it's a recent regression.

Because the reallocation guard types are used locally within member functions, we can fix this in an ABI-compatible way by renaming the guard types while fixing the allocator reference types.

I am not adding test coverage because we have none for the escape hatch, and this fix is unlikely to accidentally regress again.