### PR TITLE
Deduction failures in pointer interconvertibility trait tests

### DIFF
--- a/tests/std/tests/P0466R5_layout_compatibility_and_pointer_interconvertibility_traits/test.cpp
+++ b/tests/std/tests/P0466R5_layout_compatibility_and_pointer_interconvertibility_traits/test.cpp
@@ -176,8 +176,6 @@ constexpr bool test() {
             }
         };
 
-        struct NS : S1, S2 {}; // Non-standard layout
-
         ASSERT(is_corresponding_member(&S1::v1, &S::v1));
         ASSERT(is_corresponding_member(&S1::v2, &S::v2));
         ASSERT(is_corresponding_member(&S1::v1, &S1::v1));
@@ -199,7 +197,6 @@ constexpr bool test() {
         ASSERT(!is_corresponding_member(&S5::v1, &S6::v2));
         ASSERT(!is_corresponding_member(&S5::v2, &S6::v1));
         ASSERT(!is_corresponding_member(&S5::v3, &S6::v3));
-        ASSERT(!is_corresponding_member<NS, NS>(&NS::v1, &NS::w1));
         ASSERT(!is_corresponding_member(&S7::f1, &S7::f1));
         ASSERT(!is_corresponding_member(static_cast<int S1::*>(nullptr), static_cast<int S2::*>(nullptr)));
         ASSERT(!is_corresponding_member(&S1::v1, static_cast<int S2::*>(nullptr)));
@@ -233,8 +230,6 @@ constexpr bool test() {
         ASSERT(is_pointer_interconvertible_with_class(&U::v1));
         ASSERT(is_pointer_interconvertible_with_class(&U::v2));
 
-        ASSERT(!is_pointer_interconvertible_with_class<NS>(&NS::a));
-        ASSERT(!is_pointer_interconvertible_with_class<NS>(&NS::b));
         ASSERT(!is_pointer_interconvertible_with_class(&C::f1));
         ASSERT(!is_pointer_interconvertible_with_class(static_cast<int A::*>(nullptr)));
     }


### PR DESCRIPTION
An upcoming MSVC version will fix a bug that caused us to accept some template argument deduction cases that should be deduction failures. Specifically, with a template parameter `R (C::*)` where `C` was explicity specified you can't deduce `R` from a pointer-to-member with a mismatched class type, even one that has an implicit conversion.

The pointer interconvertibility trait tests included a few of these situations where a template argument was explicitly specified but a pointer-to-member of a base class type was provided.

