### PR TITLE
Block building for the wrong target arch in Developer Command Prompt

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,7 +22,7 @@
       },
       "condition": {
         "type": "inList",
-        "string": "$env{Platform}",
+        "string": "$env{VSCMD_ARG_TGT_ARCH}",
         "list": [
           "x64",
           ""
@@ -39,7 +39,7 @@
       },
       "condition": {
         "type": "inList",
-        "string": "$env{Platform}",
+        "string": "$env{VSCMD_ARG_TGT_ARCH}",
         "list": [
           "x86",
           ""
@@ -56,7 +56,7 @@
       },
       "condition": {
         "type": "inList",
-        "string": "$env{Platform}",
+        "string": "$env{VSCMD_ARG_TGT_ARCH}",
         "list": [
           "arm64",
           ""
@@ -76,7 +76,7 @@
       },
       "condition": {
         "type": "inList",
-        "string": "$env{Platform}",
+        "string": "$env{VSCMD_ARG_TGT_ARCH}",
         "list": [
           "arm64",
           ""

--- a/tests/utils/stl-lit/stl-lit.in
+++ b/tests/utils/stl-lit/stl-lit.in
@@ -30,8 +30,8 @@ builtin_parameters= {}
 builtin_parameters['config_map'] = config_map
 
 def assert_same_platform_for_build_and_test():
-    build_platform = '$ENV{Platform}'
-    test_platform = os.getenv('Platform', default='')
+    build_platform = '$ENV{VSCMD_ARG_TGT_ARCH}'
+    test_platform = os.getenv('VSCMD_ARG_TGT_ARCH', default='')
     if build_platform != '' and test_platform != '' and build_platform != test_platform:
         exit(f'Target platform mismatch: the STL was built for {build_platform} but tested for {test_platform}.')
 


### PR DESCRIPTION
#4709 and #4717 make it impossible to build in the wrong command prompt (e.g. if someone builds the STL in an "x64 Native Tools Command Prompt" and runs the tests in an "x86 Native Tools Command Prompt"). But they are ineffective in a "Developer Command Prompt" because they examine the `Platform` env var, which is not defined there.

This PR examines `VSCMD_ARG_TGT_ARCH` instead, which is defined in both the Developer Command Prompt and the Native Tools Command Prompt.

It's unclear to me whether it is safe to use such an undocumented env var. But anyway, if someone encounters an unexpected error, they can just manually unset `VSCMD_ARG_TGT_ARCH` when building.