### PR TITLE
Improve existing `vector<bool>` benchmarks

### DIFF
--- a/benchmarks/inc/utility.hpp
+++ b/benchmarks/inc/utility.hpp
@@ -26,3 +26,11 @@ std::vector<Contained, Alloc<Contained>> random_vector(size_t n) {
 
     return res;
 }
+
+std::vector<bool> random_bool_vector(const size_t size) {
+    std::mt19937 gen;
+    std::bernoulli_distribution dist{0.5};
+    std::vector<bool> result(size);
+    std::generate(result.begin(), result.end(), [&] { return dist(gen); });
+    return result;
+}

--- a/benchmarks/src/vector_bool_copy.cpp
+++ b/benchmarks/src/vector_bool_copy.cpp
@@ -8,84 +8,93 @@
 #include <random>
 #include <vector>
 
+#include "utility.hpp"
+
 using namespace std;
 
-vector<bool> createRandomVector(const size_t size) {
-    static mt19937 gen;
-    vector<bool> result(size);
-    generate_n(result.begin(), size, [] { return bernoulli_distribution{0.5}(gen); });
-    return result;
-}
-
 void copy_block_aligned(benchmark::State& state) {
-    const auto size           = static_cast<size_t>(state.range(0));
-    const vector<bool> source = createRandomVector(size);
+    const auto size     = static_cast<size_t>(state.range(0));
+    vector<bool> source = random_bool_vector(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         copy(source.cbegin(), source.cend(), dest.begin());
+        benchmark::DoNotOptimize(dest);
     }
 }
 
 void copy_source_misaligned(benchmark::State& state) {
-    const auto size           = static_cast<size_t>(state.range(0));
-    const vector<bool> source = createRandomVector(size);
+    const auto size     = static_cast<size_t>(state.range(0));
+    vector<bool> source = random_bool_vector(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         copy(source.cbegin() + 1, source.cend(), dest.begin());
+        benchmark::DoNotOptimize(dest);
     }
 }
 
 void copy_dest_misaligned(benchmark::State& state) {
-    const auto size           = static_cast<size_t>(state.range(0));
-    const vector<bool> source = createRandomVector(size);
+    const auto size     = static_cast<size_t>(state.range(0));
+    vector<bool> source = random_bool_vector(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         copy(source.cbegin(), source.cend() - 1, dest.begin() + 1);
+        benchmark::DoNotOptimize(dest);
     }
 }
 
 // Special benchmark for matching char alignment
 void copy_matching_alignment(benchmark::State& state) {
-    const auto size           = static_cast<size_t>(state.range(0));
-    const vector<bool> source = createRandomVector(size);
+    const auto size     = static_cast<size_t>(state.range(0));
+    vector<bool> source = random_bool_vector(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         copy(source.cbegin() + 5, source.cend(), dest.begin() + 5);
+        benchmark::DoNotOptimize(dest);
     }
 }
 
 // Special benchmarks for single block corner case
 void copy_both_single_blocks(benchmark::State& state) {
-    const vector<bool> source = createRandomVector(50);
+    vector<bool> source = random_bool_vector(50);
     vector<bool> dest(50, false);
 
     const size_t length = 20;
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         copy(source.cbegin() + 5, source.cbegin() + 5 + length, dest.begin() + 5);
+        benchmark::DoNotOptimize(dest);
     }
 }
 
 void copy_source_single_block(benchmark::State& state) {
-    const vector<bool> source = createRandomVector(50);
+    vector<bool> source = random_bool_vector(50);
     vector<bool> dest(50, false);
 
     const size_t length = 20;
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         copy(source.cbegin() + 5, source.cbegin() + 5 + length, dest.begin() + 25);
+        benchmark::DoNotOptimize(dest);
     }
 }
 
 void copy_dest_single_block(benchmark::State& state) {
-    const vector<bool> source = createRandomVector(50);
+    vector<bool> source = random_bool_vector(50);
     vector<bool> dest(50, false);
 
     const size_t length = 20;
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         copy(source.cbegin() + 25, source.cbegin() + 25 + length, dest.begin() + 5);
+        benchmark::DoNotOptimize(dest);
     }
 }
 

--- a/benchmarks/src/vector_bool_copy_n.cpp
+++ b/benchmarks/src/vector_bool_copy_n.cpp
@@ -8,84 +8,93 @@
 #include <random>
 #include <vector>
 
+#include "utility.hpp"
+
 using namespace std;
 
-vector<bool> createRandomVector(const size_t size) {
-    static mt19937 gen;
-    vector<bool> result(size);
-    generate_n(result.begin(), size, [] { return bernoulli_distribution{0.5}(gen); });
-    return result;
-}
-
 void copy_n_block_aligned(benchmark::State& state) {
-    const auto size           = static_cast<size_t>(state.range(0));
-    const vector<bool> source = createRandomVector(size);
+    const auto size     = static_cast<size_t>(state.range(0));
+    vector<bool> source = random_bool_vector(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         copy_n(source.cbegin(), size, dest.begin());
+        benchmark::DoNotOptimize(dest);
     }
 }
 
 void copy_n_source_misaligned(benchmark::State& state) {
-    const auto size           = static_cast<size_t>(state.range(0));
-    const vector<bool> source = createRandomVector(size);
+    const auto size     = static_cast<size_t>(state.range(0));
+    vector<bool> source = random_bool_vector(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         copy_n(source.cbegin() + 1, size - 1, dest.begin());
+        benchmark::DoNotOptimize(dest);
     }
 }
 
 void copy_n_dest_misaligned(benchmark::State& state) {
-    const auto size           = static_cast<size_t>(state.range(0));
-    const vector<bool> source = createRandomVector(size);
+    const auto size     = static_cast<size_t>(state.range(0));
+    vector<bool> source = random_bool_vector(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         copy_n(source.cbegin(), size - 1, dest.begin() + 1);
+        benchmark::DoNotOptimize(dest);
     }
 }
 
 // Special benchmark for matching char alignment
 void copy_n_matching_alignment(benchmark::State& state) {
-    const auto size           = static_cast<size_t>(state.range(0));
-    const vector<bool> source = createRandomVector(size);
+    const auto size     = static_cast<size_t>(state.range(0));
+    vector<bool> source = random_bool_vector(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         copy_n(source.cbegin() + 5, size - 5, dest.begin() + 5);
+        benchmark::DoNotOptimize(dest);
     }
 }
 
 // Special benchmarks for single block corner case
 void copy_n_both_single_blocks(benchmark::State& state) {
-    const vector<bool> source = createRandomVector(50);
+    vector<bool> source = random_bool_vector(50);
     vector<bool> dest(50, false);
 
     const size_t length = 20;
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         copy_n(source.cbegin() + 5, length, dest.begin() + 5);
+        benchmark::DoNotOptimize(dest);
     }
 }
 
 void copy_n_source_single_block(benchmark::State& state) {
-    const vector<bool> source = createRandomVector(50);
+    vector<bool> source = random_bool_vector(50);
     vector<bool> dest(50, false);
 
     const size_t length = 20;
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         copy_n(source.cbegin() + 5, length, dest.begin() + 25);
+        benchmark::DoNotOptimize(dest);
     }
 }
 
 void copy_n_dest_single_block(benchmark::State& state) {
-    const vector<bool> source = createRandomVector(50);
+    vector<bool> source = random_bool_vector(50);
     vector<bool> dest(50, false);
 
     const size_t length = 20;
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         copy_n(source.cbegin() + 25, length, dest.begin() + 5);
+        benchmark::DoNotOptimize(dest);
     }
 }
 

--- a/benchmarks/src/vector_bool_count.cpp
+++ b/benchmarks/src/vector_bool_count.cpp
@@ -8,19 +8,13 @@
 #include <random>
 #include <vector>
 
-using namespace std;
+#include "utility.hpp"
 
-vector<bool> createRandomVector(const size_t size) {
-    mt19937 gen;
-    bernoulli_distribution dist{0.5};
-    vector<bool> result(size);
-    generate(result.begin(), result.end(), [&] { return dist(gen); });
-    return result;
-}
+using namespace std;
 
 void count_aligned(benchmark::State& state) {
     const auto size = static_cast<size_t>(state.range(0));
-    vector<bool> v  = createRandomVector(size);
+    vector<bool> v  = random_bool_vector(size);
 
     bool b = false;
 
@@ -32,7 +26,6 @@ void count_aligned(benchmark::State& state) {
         b = !b;
     }
 }
-
 
 BENCHMARK(count_aligned)->RangeMultiplier(64)->Range(64, 64 << 10);
 

--- a/benchmarks/src/vector_bool_move.cpp
+++ b/benchmarks/src/vector_bool_move.cpp
@@ -8,84 +8,93 @@
 #include <random>
 #include <vector>
 
+#include "utility.hpp"
+
 using namespace std;
 
-vector<bool> createRandomVector(const size_t size) {
-    static mt19937 gen;
-    vector<bool> result(size);
-    generate_n(result.begin(), size, [] { return bernoulli_distribution{0.5}(gen); });
-    return result;
-}
-
 void move_block_aligned(benchmark::State& state) {
-    const auto size           = static_cast<size_t>(state.range(0));
-    const vector<bool> source = createRandomVector(size);
+    const auto size     = static_cast<size_t>(state.range(0));
+    vector<bool> source = random_bool_vector(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         move(source.cbegin(), source.cend(), dest.begin());
+        benchmark::DoNotOptimize(dest);
     }
 }
 
 void move_source_misaligned(benchmark::State& state) {
-    const auto size           = static_cast<size_t>(state.range(0));
-    const vector<bool> source = createRandomVector(size);
+    const auto size     = static_cast<size_t>(state.range(0));
+    vector<bool> source = random_bool_vector(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         move(source.cbegin() + 1, source.cend(), dest.begin());
+        benchmark::DoNotOptimize(dest);
     }
 }
 
 void move_dest_misaligned(benchmark::State& state) {
-    const auto size           = static_cast<size_t>(state.range(0));
-    const vector<bool> source = createRandomVector(size);
+    const auto size     = static_cast<size_t>(state.range(0));
+    vector<bool> source = random_bool_vector(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         move(source.cbegin(), source.cend() - 1, dest.begin() + 1);
+        benchmark::DoNotOptimize(dest);
     }
 }
 
 // Special benchmark for matching char alignment
 void move_matching_alignment(benchmark::State& state) {
-    const auto size           = static_cast<size_t>(state.range(0));
-    const vector<bool> source = createRandomVector(size);
+    const auto size     = static_cast<size_t>(state.range(0));
+    vector<bool> source = random_bool_vector(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         move(source.cbegin() + 5, source.cend(), dest.begin() + 5);
+        benchmark::DoNotOptimize(dest);
     }
 }
 
 // Special benchmarks for single block corner case
 void move_both_single_blocks(benchmark::State& state) {
-    const vector<bool> source = createRandomVector(50);
+    vector<bool> source = random_bool_vector(50);
     vector<bool> dest(50, false);
 
     const size_t length = 20;
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         move(source.cbegin() + 5, source.cbegin() + 5 + length, dest.begin() + 5);
+        benchmark::DoNotOptimize(dest);
     }
 }
 
 void move_source_single_block(benchmark::State& state) {
-    const vector<bool> source = createRandomVector(50);
+    vector<bool> source = random_bool_vector(50);
     vector<bool> dest(50, false);
 
     const size_t length = 20;
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         move(source.cbegin() + 5, source.cbegin() + 5 + length, dest.begin() + 25);
+        benchmark::DoNotOptimize(dest);
     }
 }
 
 void move_dest_single_block(benchmark::State& state) {
-    const vector<bool> source = createRandomVector(50);
+    vector<bool> source = random_bool_vector(50);
     vector<bool> dest(50, false);
 
     const size_t length = 20;
     for (auto _ : state) {
+        benchmark::DoNotOptimize(source);
         move(source.cbegin() + 25, source.cbegin() + 25 + length, dest.begin() + 5);
+        benchmark::DoNotOptimize(dest);
     }
 }
 


### PR DESCRIPTION
The following minor changes:
 - Extract `createRandomVector`, use the version that doesn't use `static`, and rename it to `random_bool_vector` for consitency.
 - Use optimization barriers, and avoid `const` on `source` to make them effective.
 - Remove one stray newline.