### PR TITLE
`<regex>`: Process negative lookahead assertions non-recursively

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1674,7 +1674,10 @@ public:
     }
 };
 
-enum class _Rx_unwind_ops { _After_assert = _N_end + 1 };
+enum class _Rx_unwind_ops {
+    _After_assert = _N_end + 1,
+    _After_neg_assert,
+};
 
 template <class _BidIt>
 class _Rx_state_frame_t {
@@ -1807,7 +1810,6 @@ private:
     void _Increase_stack_usage_count();
     void _Decrease_stack_usage_count();
 
-    bool _Do_neg_assert(_Node_assert*);
     bool _Do_if(_Node_if*);
     bool _Do_rep0(_Node_rep*, bool);
     bool _Do_rep(_Node_rep*, bool, int);
@@ -3401,19 +3403,6 @@ void _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Decrease_stack_usage_cou
 }
 
 template <class _BidIt, class _Elem, class _RxTraits, class _It, class _Alloc>
-bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Do_neg_assert(_Node_assert* _Node) {
-    // apply negative assert node
-    const size_t _Frame_idx = _Push_frame();
-    bool _Succeeded         = !_Match_pat(_Node->_Child);
-    if (_Succeeded) {
-        const _Bt_state_t<_It>& _St = _Frames[_Frame_idx]._Match_state;
-        _Tgt_state                  = _St;
-    }
-    _Pop_frame(_Frame_idx);
-    return _Succeeded;
-}
-
-template <class _BidIt, class _Elem, class _RxTraits, class _It, class _Alloc>
 bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Do_if(_Node_if* _Node) { // apply if node
     const size_t _Frame_idx = _Push_frame();
 
@@ -4130,7 +4119,11 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
 
             case _N_neg_assert:
                 { // check negative assert
-                    _Failed = !_Do_neg_assert(static_cast<_Node_assert*>(_Nx));
+                    auto _Node = static_cast<_Node_assert*>(_Nx);
+                    _Push_frame(_Rx_unwind_ops::_After_neg_assert, _Node);
+                    _Next = _Node->_Child;
+
+                    _Increase_stack_usage_count();
                     break;
                 }
 
@@ -4253,6 +4246,18 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
                         _Tgt_state._Cur = _Frame._Match_state._Cur;
                         _Nx             = _Frame._Node->_Next;
                     }
+                    break;
+                }
+
+            case _Rx_unwind_ops::_After_neg_assert:
+                { // negative assert completed
+                    _Decrease_stack_usage_count();
+                    if (_Failed) {
+                        const _Bt_state_t<_It>& _St = _Frame._Match_state;
+                        _Tgt_state                  = _St;
+                        _Nx                         = _Frame._Node->_Next;
+                    }
+                    _Failed = !_Failed;
                     break;
                 }
 


### PR DESCRIPTION
Towards #997 and #1528. Negative lookahead assertions can be handled very similarly to positive ones, but two things have to be kept in mind after the assertion is processed: (a) Failure must be inverted and (b) one must reset not just the position (as is sufficient for positive lookahead assertions), but also the capture groups.