### PR TITLE
Restore implicitly converting cases in the test for P0466R5

### DIFF
--- a/tests/std/tests/P0466R5_layout_compatibility_and_pointer_interconvertibility_traits/test.cpp
+++ b/tests/std/tests/P0466R5_layout_compatibility_and_pointer_interconvertibility_traits/test.cpp
@@ -176,6 +176,8 @@ constexpr bool test() {
             }
         };
 
+        struct NS : S1, S2 {}; // Non-standard layout
+
         ASSERT(is_corresponding_member(&S1::v1, &S::v1));
         ASSERT(is_corresponding_member(&S1::v2, &S::v2));
         ASSERT(is_corresponding_member(&S1::v1, &S1::v1));
@@ -197,6 +199,7 @@ constexpr bool test() {
         ASSERT(!is_corresponding_member(&S5::v1, &S6::v2));
         ASSERT(!is_corresponding_member(&S5::v2, &S6::v1));
         ASSERT(!is_corresponding_member(&S5::v3, &S6::v3));
+        ASSERT(!is_corresponding_member<NS, NS, int, int>(&NS::v1, &NS::w1));
         ASSERT(!is_corresponding_member(&S7::f1, &S7::f1));
         ASSERT(!is_corresponding_member(static_cast<int S1::*>(nullptr), static_cast<int S2::*>(nullptr)));
         ASSERT(!is_corresponding_member(&S1::v1, static_cast<int S2::*>(nullptr)));
@@ -230,6 +233,8 @@ constexpr bool test() {
         ASSERT(is_pointer_interconvertible_with_class(&U::v1));
         ASSERT(is_pointer_interconvertible_with_class(&U::v2));
 
+        ASSERT(!is_pointer_interconvertible_with_class<NS, int>(&NS::a));
+        ASSERT(!is_pointer_interconvertible_with_class<NS, int>(&NS::b));
         ASSERT(!is_pointer_interconvertible_with_class(&C::f1));
         ASSERT(!is_pointer_interconvertible_with_class(static_cast<int A::*>(nullptr)));
     }


### PR DESCRIPTION
Instead of removing the problematic test cases (#5730), this PR reintroduces and fixes them by fully specifying template arguments to enable intentional implicit conversions.

Corresponding fix for the example in the standard is submitted in cplusplus/draft#8245.