### PR TITLE
Fix non-inline `random_bool_vector` in benchmarks

### DIFF
--- a/benchmarks/inc/utility.hpp
+++ b/benchmarks/inc/utility.hpp
@@ -13,12 +13,11 @@
 template <class Contained, template <class> class Alloc = std::allocator>
 std::vector<Contained, Alloc<Contained>> random_vector(size_t n) {
     std::vector<Contained, Alloc<Contained>> res(n);
+    std::mt19937_64 prng;
 
     if constexpr (std::is_same_v<Contained, bool>) {
-        std::mt19937 prng;
         std::generate(res.begin(), res.end(), [&prng] { return static_cast<bool>(prng() & 1); });
     } else {
-        std::mt19937_64 prng;
 // Here, the type Contained can be char, int, aggregate<Data>, or non_trivial<Data> where Data is char or int.
 // (aggregate<Data> and non_trivial<Data> are defined in udt.hpp.)
 // static_cast<Contained> silences truncation warnings when Contained is directly char or int,

--- a/benchmarks/inc/utility.hpp
+++ b/benchmarks/inc/utility.hpp
@@ -15,9 +15,8 @@ std::vector<Contained, Alloc<Contained>> random_vector(size_t n) {
     std::vector<Contained, Alloc<Contained>> res(n);
 
     if constexpr (std::is_same_v<Contained, bool>) {
-        std::mt19937 gen;
-        std::bernoulli_distribution dist{0.5};
-        std::generate(res.begin(), res.end(), [&] { return dist(gen); });
+        std::mt19937 prng;
+        std::generate(res.begin(), res.end(), [&prng] { return static_cast<bool>(prng() & 1); });
     } else {
         std::mt19937_64 prng;
 // Here, the type Contained can be char, int, aggregate<Data>, or non_trivial<Data> where Data is char or int.

--- a/benchmarks/inc/utility.hpp
+++ b/benchmarks/inc/utility.hpp
@@ -7,30 +7,28 @@
 #include <cstddef>
 #include <memory>
 #include <random>
+#include <type_traits>
 #include <vector>
 
 template <class Contained, template <class> class Alloc = std::allocator>
 std::vector<Contained, Alloc<Contained>> random_vector(size_t n) {
-    std::mt19937_64 prng;
-
     std::vector<Contained, Alloc<Contained>> res(n);
 
+    if constexpr (std::is_same_v<Contained, bool>) {
+        std::mt19937 gen;
+        std::bernoulli_distribution dist{0.5};
+        std::generate(res.begin(), res.end(), [&] { return dist(gen); });
+    } else {
+        std::mt19937_64 prng;
 // Here, the type Contained can be char, int, aggregate<Data>, or non_trivial<Data> where Data is char or int.
 // (aggregate<Data> and non_trivial<Data> are defined in udt.hpp.)
 // static_cast<Contained> silences truncation warnings when Contained is directly char or int,
 // but is insufficient for aggregate<Data> or non_trivial<Data>.
 #pragma warning(push)
 #pragma warning(disable : 4244) // warning C4244: conversion from 'uint64_t' to 'Data', possible loss of data
-    std::generate(res.begin(), res.end(), [&prng] { return static_cast<Contained>(prng()); });
+        std::generate(res.begin(), res.end(), [&prng] { return static_cast<Contained>(prng()); });
 #pragma warning(pop)
+    }
 
     return res;
-}
-
-std::vector<bool> random_bool_vector(const size_t size) {
-    std::mt19937 gen;
-    std::bernoulli_distribution dist{0.5};
-    std::vector<bool> result(size);
-    std::generate(result.begin(), result.end(), [&] { return dist(gen); });
-    return result;
 }

--- a/benchmarks/src/vector_bool_copy.cpp
+++ b/benchmarks/src/vector_bool_copy.cpp
@@ -14,7 +14,7 @@ using namespace std;
 
 void copy_block_aligned(benchmark::State& state) {
     const auto size     = static_cast<size_t>(state.range(0));
-    vector<bool> source = random_bool_vector(size);
+    vector<bool> source = random_vector<bool>(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
@@ -26,7 +26,7 @@ void copy_block_aligned(benchmark::State& state) {
 
 void copy_source_misaligned(benchmark::State& state) {
     const auto size     = static_cast<size_t>(state.range(0));
-    vector<bool> source = random_bool_vector(size);
+    vector<bool> source = random_vector<bool>(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
@@ -38,7 +38,7 @@ void copy_source_misaligned(benchmark::State& state) {
 
 void copy_dest_misaligned(benchmark::State& state) {
     const auto size     = static_cast<size_t>(state.range(0));
-    vector<bool> source = random_bool_vector(size);
+    vector<bool> source = random_vector<bool>(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
@@ -51,7 +51,7 @@ void copy_dest_misaligned(benchmark::State& state) {
 // Special benchmark for matching char alignment
 void copy_matching_alignment(benchmark::State& state) {
     const auto size     = static_cast<size_t>(state.range(0));
-    vector<bool> source = random_bool_vector(size);
+    vector<bool> source = random_vector<bool>(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
@@ -63,7 +63,7 @@ void copy_matching_alignment(benchmark::State& state) {
 
 // Special benchmarks for single block corner case
 void copy_both_single_blocks(benchmark::State& state) {
-    vector<bool> source = random_bool_vector(50);
+    vector<bool> source = random_vector<bool>(50);
     vector<bool> dest(50, false);
 
     const size_t length = 20;
@@ -75,7 +75,7 @@ void copy_both_single_blocks(benchmark::State& state) {
 }
 
 void copy_source_single_block(benchmark::State& state) {
-    vector<bool> source = random_bool_vector(50);
+    vector<bool> source = random_vector<bool>(50);
     vector<bool> dest(50, false);
 
     const size_t length = 20;
@@ -87,7 +87,7 @@ void copy_source_single_block(benchmark::State& state) {
 }
 
 void copy_dest_single_block(benchmark::State& state) {
-    vector<bool> source = random_bool_vector(50);
+    vector<bool> source = random_vector<bool>(50);
     vector<bool> dest(50, false);
 
     const size_t length = 20;

--- a/benchmarks/src/vector_bool_copy_n.cpp
+++ b/benchmarks/src/vector_bool_copy_n.cpp
@@ -14,7 +14,7 @@ using namespace std;
 
 void copy_n_block_aligned(benchmark::State& state) {
     const auto size     = static_cast<size_t>(state.range(0));
-    vector<bool> source = random_bool_vector(size);
+    vector<bool> source = random_vector<bool>(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
@@ -26,7 +26,7 @@ void copy_n_block_aligned(benchmark::State& state) {
 
 void copy_n_source_misaligned(benchmark::State& state) {
     const auto size     = static_cast<size_t>(state.range(0));
-    vector<bool> source = random_bool_vector(size);
+    vector<bool> source = random_vector<bool>(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
@@ -38,7 +38,7 @@ void copy_n_source_misaligned(benchmark::State& state) {
 
 void copy_n_dest_misaligned(benchmark::State& state) {
     const auto size     = static_cast<size_t>(state.range(0));
-    vector<bool> source = random_bool_vector(size);
+    vector<bool> source = random_vector<bool>(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
@@ -51,7 +51,7 @@ void copy_n_dest_misaligned(benchmark::State& state) {
 // Special benchmark for matching char alignment
 void copy_n_matching_alignment(benchmark::State& state) {
     const auto size     = static_cast<size_t>(state.range(0));
-    vector<bool> source = random_bool_vector(size);
+    vector<bool> source = random_vector<bool>(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
@@ -63,7 +63,7 @@ void copy_n_matching_alignment(benchmark::State& state) {
 
 // Special benchmarks for single block corner case
 void copy_n_both_single_blocks(benchmark::State& state) {
-    vector<bool> source = random_bool_vector(50);
+    vector<bool> source = random_vector<bool>(50);
     vector<bool> dest(50, false);
 
     const size_t length = 20;
@@ -75,7 +75,7 @@ void copy_n_both_single_blocks(benchmark::State& state) {
 }
 
 void copy_n_source_single_block(benchmark::State& state) {
-    vector<bool> source = random_bool_vector(50);
+    vector<bool> source = random_vector<bool>(50);
     vector<bool> dest(50, false);
 
     const size_t length = 20;
@@ -87,7 +87,7 @@ void copy_n_source_single_block(benchmark::State& state) {
 }
 
 void copy_n_dest_single_block(benchmark::State& state) {
-    vector<bool> source = random_bool_vector(50);
+    vector<bool> source = random_vector<bool>(50);
     vector<bool> dest(50, false);
 
     const size_t length = 20;

--- a/benchmarks/src/vector_bool_count.cpp
+++ b/benchmarks/src/vector_bool_count.cpp
@@ -14,7 +14,7 @@ using namespace std;
 
 void count_aligned(benchmark::State& state) {
     const auto size = static_cast<size_t>(state.range(0));
-    vector<bool> v  = random_bool_vector(size);
+    vector<bool> v  = random_vector<bool>(size);
 
     bool b = false;
 

--- a/benchmarks/src/vector_bool_move.cpp
+++ b/benchmarks/src/vector_bool_move.cpp
@@ -14,7 +14,7 @@ using namespace std;
 
 void move_block_aligned(benchmark::State& state) {
     const auto size     = static_cast<size_t>(state.range(0));
-    vector<bool> source = random_bool_vector(size);
+    vector<bool> source = random_vector<bool>(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
@@ -26,7 +26,7 @@ void move_block_aligned(benchmark::State& state) {
 
 void move_source_misaligned(benchmark::State& state) {
     const auto size     = static_cast<size_t>(state.range(0));
-    vector<bool> source = random_bool_vector(size);
+    vector<bool> source = random_vector<bool>(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
@@ -38,7 +38,7 @@ void move_source_misaligned(benchmark::State& state) {
 
 void move_dest_misaligned(benchmark::State& state) {
     const auto size     = static_cast<size_t>(state.range(0));
-    vector<bool> source = random_bool_vector(size);
+    vector<bool> source = random_vector<bool>(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
@@ -51,7 +51,7 @@ void move_dest_misaligned(benchmark::State& state) {
 // Special benchmark for matching char alignment
 void move_matching_alignment(benchmark::State& state) {
     const auto size     = static_cast<size_t>(state.range(0));
-    vector<bool> source = random_bool_vector(size);
+    vector<bool> source = random_vector<bool>(size);
     vector<bool> dest(size, false);
 
     for (auto _ : state) {
@@ -63,7 +63,7 @@ void move_matching_alignment(benchmark::State& state) {
 
 // Special benchmarks for single block corner case
 void move_both_single_blocks(benchmark::State& state) {
-    vector<bool> source = random_bool_vector(50);
+    vector<bool> source = random_vector<bool>(50);
     vector<bool> dest(50, false);
 
     const size_t length = 20;
@@ -75,7 +75,7 @@ void move_both_single_blocks(benchmark::State& state) {
 }
 
 void move_source_single_block(benchmark::State& state) {
-    vector<bool> source = random_bool_vector(50);
+    vector<bool> source = random_vector<bool>(50);
     vector<bool> dest(50, false);
 
     const size_t length = 20;
@@ -87,7 +87,7 @@ void move_source_single_block(benchmark::State& state) {
 }
 
 void move_dest_single_block(benchmark::State& state) {
-    vector<bool> source = random_bool_vector(50);
+    vector<bool> source = random_vector<bool>(50);
     vector<bool> dest(50, false);
 
     const size_t length = 20;


### PR DESCRIPTION
Fuse `random_bool_vector` into  `random_vector`