### PR TITLE
Reactivate Clang UBSan test coverage

### DIFF
--- a/tests/std/tests/VSO_0000000_vector_algorithms_floats/env.lst
+++ b/tests/std/tests/VSO_0000000_vector_algorithms_floats/env.lst
@@ -46,8 +46,7 @@ PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsin
 PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /EHsc /MDd /std:c++17 /w14640 /Zc:threadSafeInit- --start-no-unused-arguments"
 PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /EHsc /MT /std:c++20 /permissive- /w14640 /Zc:threadSafeInit- --start-no-unused-arguments"
 PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /EHsc /MTd /std:c++latest /permissive- /w14640 /Zc:threadSafeInit- --start-no-unused-arguments"
-# TRANSITION, GH-3568
-# PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /EHsc /MT /std:c++latest /permissive- /w14640 /Zc:threadSafeInit- -fsanitize=undefined -fno-sanitize-recover=undefined --start-no-unused-arguments"
+PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /EHsc /MT /std:c++latest /permissive- /w14640 /Zc:threadSafeInit- -fsanitize=undefined -fno-sanitize-recover=undefined --start-no-unused-arguments"
 RUNALL_CROSSLIST
 *	PM_CL="/fp:strict"
 *	PM_CL="/fp:precise"

--- a/tests/std/tests/VSO_0000000_vector_algorithms_mismatch_and_lex_compare/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms_mismatch_and_lex_compare/test.cpp
@@ -172,9 +172,13 @@ namespace test_mismatch_sizes_and_alignments {
 
     template <class T, size_t Size, size_t PadSize>
     char stack_array_various_alignments_impl() {
+#if defined(__clang__) && __has_feature(undefined_behavior_sanitizer)
+        // Avoid testing misaligned inputs, which UBSan would reject.
+#else // ^^^ UBSan / no UBSan vvv
         with_pad<T, Size + 1, PadSize + 1> a = {};
         with_pad<T, Size + 1, PadSize + 1> b = {};
         assert(mismatch(begin(a.v), end(a.v), begin(b.v), end(b.v)) == make_pair(end(a.v), end(b.v)));
+#endif // ^^^ no UBSan ^^^
         return 0;
     }
 

--- a/tests/std/tests/VSO_0000000_vector_algorithms_mismatch_and_lex_compare/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms_mismatch_and_lex_compare/test.cpp
@@ -172,7 +172,13 @@ namespace test_mismatch_sizes_and_alignments {
 
     template <class T, size_t Size, size_t PadSize>
     char stack_array_various_alignments_impl() {
-#if defined(__clang__) && __has_feature(undefined_behavior_sanitizer)
+#ifdef __clang__
+#if __has_feature(undefined_behavior_sanitizer)
+#define TESTING_UBSAN
+#endif
+#endif
+
+#ifdef TESTING_UBSAN
         // Avoid testing misaligned inputs, which UBSan would reject.
 #else // ^^^ UBSan / no UBSan vvv
         with_pad<T, Size + 1, PadSize + 1> a = {};

--- a/tests/std/tests/usual_matrix.lst
+++ b/tests/std/tests/usual_matrix.lst
@@ -53,5 +53,4 @@ PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsin
 PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /EHsc /MDd /std:c++17 /w14640 /Zc:threadSafeInit- --start-no-unused-arguments"
 PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /EHsc /MT /std:c++20 /permissive- /w14640 /Zc:threadSafeInit- --start-no-unused-arguments"
 PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /EHsc /MTd /std:c++latest /permissive- /fp:strict /w14640 /Zc:threadSafeInit- --start-no-unused-arguments"
-# TRANSITION, GH-3568
-# PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /EHsc /MT /std:c++latest /permissive- /fp:strict /w14640 /Zc:threadSafeInit- -fsanitize=undefined -fno-sanitize-recover=undefined --start-no-unused-arguments"
+PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /EHsc /MT /std:c++latest /permissive- /fp:strict /w14640 /Zc:threadSafeInit- -fsanitize=undefined -fno-sanitize-recover=undefined --start-no-unused-arguments"

--- a/tests/utils/stl/test/features.py
+++ b/tests/utils/stl/test/features.py
@@ -52,8 +52,7 @@ def getDefaultFeatures(config, litConfig):
         DEFAULT_FEATURES.append(Feature(name='x86'))
 
     elif litConfig.target_arch.casefold() == 'x64'.casefold():
-        # TRANSITION, GH-3568
-        # DEFAULT_FEATURES.append(Feature(name='ubsan'))
+        DEFAULT_FEATURES.append(Feature(name='ubsan'))
         DEFAULT_FEATURES.append(Feature(name='edg'))
         DEFAULT_FEATURES.append(Feature(name='arch_avx2'))
         DEFAULT_FEATURES.append(Feature(name='x64'))


### PR DESCRIPTION
Fixes #3568.

This was briefly enabled for Clang 15 by #3452 on 2023-03-13, then disabled for Clang 16 by #3711 on 2023-05-18. After updating to Clang 20 by #5717 on 2025-09-15, we can re-enable this test coverage.

Note that `tests/utils/stl/test/features.py` disabled the configurations. We accumulated a couple of changes to `tests/std/tests/VSO_0000000_vector_algorithms_floats/env.lst` and `tests/std/tests/usual_matrix.lst` commenting out configurations, but I believe those changes were unnecessary. This PR updates `features.py` to enable the feature, uncomments the commented-out configurations, and doesn't change the large number of already-uncommented configurations across other files.

I audited our `env.lst` and related files, and I believe our UBSan coverage is reasonably comprehensive now. For the tests it's missing from, they either have good reasons (e.g. compile-only, `/clr` specific, incompatible with Clang for other reasons, etc.) or already have a blizzard of configurations where UBSan wouldn't be worth the extra cost.

Notably, UBSan has never been enabled for libcxx, and I am not attempting to do so here. libcxx configurations are extremely expensive (that's why we have only three). It may be reasonable to explore this in the future, but I don't want to spend developer and machine time on that now.

I'll leave Clang UBSan disabled for the MSVC-internal test harness (this was `src/qa/VC/shared/testenv/bin/run.pl` in MSVC-PR-457627, for future reference). I don't know if it works now, but it would provide negative value by burning a lot of machine time when GitHub is providing sufficient coverage of the STL's product and test code.

We've already merged a couple of fixes for bugs in `vector<bool>` and `independent_bits_engine` found by this impending PR:

* #5720
  + Fixed by @AlexGuteniev with #5726
* #5719
  + Fixed by @MattStephanson with #5740

# :gear: Commits
* Activate UBSan.
* Avoid `duration_cast()` UB, tracked by LWG-3921.
  + `D:\GitHub\STL\out\x64\out\inc\__msvc_chrono.hpp:451:52: runtime error: signed integer overflow: 9223372036854775806 * 1000000 cannot be represented in type '_CR' (aka 'long long')`
* Avoid UB caused by deliberate misalignment with `#pragma pack`.
  + `D:\GitHub\STL\tests\std\tests\VSO_0000000_vector_algorithms_mismatch_and_lex_compare\test.cpp:177:9: runtime error: reference binding to misaligned address 0x002ec5cfe1bb for type 'short[1]', which requires 2 byte alignment`
* Permanently avoid `wmemcmp()` UB, reported as VSO-2583476 "`wmemcmp()` triggers UB with a misaligned load".
  + `C:\Program Files (x86)\Windows Kits\10\include\10.0.26100.0\ucrt\wchar.h:458:37: runtime error: load of misaligned address 0x7ff647c3b7bc for type 'unsigned long long', which requires 8 byte alignment`
  + The offending line is: `unsigned __int64 __v1 = *(unsigned __int64*)__s1;`
* Properly detect UBSan in test code.
  + This is necessary because MSVC doesn't understand `__has_feature`. (I initially missed this because I was testing Clang only.)
