### PR TITLE
fixing MSVC_STL_UPDATE Macro

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -934,7 +934,7 @@
 
 #define _CPPLIB_VER       650
 #define _MSVC_STL_VERSION 145
-#define _MSVC_STL_UPDATE  202509L
+#define _MSVC_STL_UPDATE  202510L
 
 #ifndef _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
 #if defined(__CUDACC__) && defined(__CUDACC_VER_MAJOR__)


### PR DESCRIPTION
Resolves #5750 
This change updates the implementation-specific library version macro **`_MSVC_STL_UPDATE`** in `STL/stl/inc/yvals_core.h`.
Following the established YYYYMM format, the value is updated from `202509L` (September 2025) to **`202510L`** (October 2025). 