### PR TITLE
`vector_algorithms.cpp`: remove incorrect `__assume`

### DIFF
--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -6999,7 +6999,6 @@ namespace {
             }
 
             if (_Size_bits > 0) {
-                __assume(_Size_bits < sizeof(typename _Traits::_Value_type));
                 typename _Traits::_Value_type _Val;
                 memcpy(&_Val, _Src, sizeof(_Val));
                 const auto _Elems = _Traits::_Step(_Val, _Px0, _Px1);


### PR DESCRIPTION
The idea behind that `__assume` was to tell the compiler that `memcpy` is small. 

Unfortunately, the compilers are still only able to optimize `memcpy` only for exactly known size, not "small" size or other size characteristics.

The `__assume` was also incorrect. as the comparison was bits vs bytes. 