### PR TITLE
`<regex>`: Process minimum number of reps in simple loops non-recursively

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1679,6 +1679,7 @@ enum class _Rx_unwind_ops {
     _After_neg_assert,
     _Disjunction_eval_alt_on_failure,
     _Disjunction_eval_alt_always,
+    _Do_nothing,
 };
 
 template <class _BidIt>
@@ -1811,10 +1812,11 @@ private:
 
     void _Increase_stack_usage_count();
     void _Decrease_stack_usage_count();
+    void _Increase_complexity_count();
 
     bool _Do_rep0(_Node_rep*, bool);
     bool _Do_rep(_Node_rep*, bool, int);
-    bool _Do_rep_first(_Node_rep*);
+    void _Prepare_rep(_Node_rep*);
     bool _Find_first_inner_capture_group(_Node_base*, _Loop_vals_v2_t*);
     _It _Do_class(_Node_base*, _It);
     bool _Match_pat(_Node_base*);
@@ -3404,33 +3406,18 @@ void _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Decrease_stack_usage_cou
 }
 
 template <class _BidIt, class _Elem, class _RxTraits, class _It, class _Alloc>
+void _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Increase_complexity_count() {
+    if (0 < _Max_complexity_count && --_Max_complexity_count <= 0) {
+        _Xregex_error(regex_constants::error_complexity);
+    }
+}
+
+template <class _BidIt, class _Elem, class _RxTraits, class _It, class _Alloc>
 bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Do_rep0(_Node_rep* _Node, bool _Greedy) {
     // apply repetition to loop with no nested if/do
-    int _Ix                 = 0;
-    const size_t _Frame_idx = _Push_frame();
-
-    if (0 < _Node->_Min) {
-        // GH-5365: We can avoid resetting capture groups for the first iteration
-        // because we know that a simple repetition of this loop was not encountered before.
-        if (!_Match_pat(_Node->_Next)) { // didn't match minimum number of reps, fail
-            _Pop_frame(_Frame_idx);
-            return false;
-        } else if (_Tgt_state._Cur == _Frames[_Frame_idx]._Match_state._Cur) { // matches empty string
-            // loop is branchless, so it will only ever match empty strings
-            // -> skip all other matches as they don't change state and immediately try tail
-            _Pop_frame(_Frame_idx);
-            return _Match_pat(_Node->_End_rep->_Next);
-        } else { // loop never matches the empty string
-            for (_Ix = 1; _Ix < _Node->_Min; ++_Ix) { // do minimum number of reps
-                // GH-5365: We have to reset the capture groups from the second iteration on.
-                _Tgt_state._Grp_valid = _Frames[_Frame_idx]._Match_state._Grp_valid;
-                if (!_Match_pat(_Node->_Next)) { // didn't match minimum number of reps, fail
-                    _Pop_frame(_Frame_idx);
-                    return false;
-                }
-            }
-        }
-    }
+    int _Ix                                   = _Node->_Min;
+    const size_t _Frame_idx                   = _Loop_vals[_Node->_Loop_number]._Loop_frame_idx;
+    _Loop_vals[_Node->_Loop_number]._Loop_idx = _Ix + 1;
 
     _Tgt_state_t<_It> _Final;
     bool _Matched0 = false;
@@ -3439,7 +3426,6 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Do_rep0(_Node_rep* _Node
 
     if (_Match_pat(_Node->_End_rep->_Next)) {
         if (!_Greedy) {
-            _Pop_frame(_Frame_idx);
             return true; // go with current match
         }
 
@@ -3458,14 +3444,12 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Do_rep0(_Node_rep* _Node
             _Done = true;
             // we only potentially accept/try tail for POSIX
             if ((_Sflags & regex_constants::_Any_posix) && _Match_pat(_Node->_End_rep->_Next)) {
-                _Pop_frame(_Frame_idx);
                 return true; // go with current match
             }
         } else {
             _Saved_pos = _Tgt_state._Cur;
             if (_Match_pat(_Node->_End_rep->_Next)) {
                 if (!_Greedy) {
-                    _Pop_frame(_Frame_idx);
                     return true; // go with current match
                 }
 
@@ -3489,7 +3473,6 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Do_rep0(_Node_rep* _Node
             _Saved_pos = _Tgt_state._Cur;
             if (_Match_pat(_Node->_End_rep->_Next)) {
                 if (!_Greedy) {
-                    _Pop_frame(_Frame_idx);
                     return true; // go with current match
                 }
 
@@ -3504,7 +3487,6 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Do_rep0(_Node_rep* _Node
         _Tgt_state = _Final;
     }
 
-    _Pop_frame(_Frame_idx);
     return _Matched0;
 }
 
@@ -3577,12 +3559,7 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Do_rep(_Node_rep* _Node,
 }
 
 template <class _BidIt, class _Elem, class _RxTraits, class _It, class _Alloc>
-bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Do_rep_first(_Node_rep* _Node) {
-    bool _Greedy = (_Node->_Flags & _Fl_greedy) != 0;
-    // apply repetition
-    if (_Node->_Simple_loop == 1) {
-        return _Do_rep0(_Node, _Greedy);
-    }
+void _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Prepare_rep(_Node_rep* _Node) {
     _Loop_vals_v2_t* _Psav = &_Loop_vals[_Node->_Loop_number];
 
     // Determine first capture group in repetition for later capture group reset, if not done so previously.
@@ -3593,8 +3570,6 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Do_rep_first(_Node_rep* 
             _Psav->_Group_first = static_cast<unsigned int>(_Tgt_state._Grp_valid.size());
         }
     }
-
-    return _Do_rep(_Node, _Greedy, 0);
 }
 
 template <class _BidIt, class _Elem, class _RxTraits, class _It, class _Alloc>
@@ -4153,22 +4128,58 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
                 break;
 
             case _N_rep:
-                if (!_Do_rep_first(static_cast<_Node_rep*>(_Nx))) {
-                    _Failed = true;
+                {
+                    auto _Node = static_cast<_Node_rep*>(_Nx);
+                    _Prepare_rep(_Node);
+                    bool _Greedy = (_Node->_Flags & _Fl_greedy) != 0;
+
+                    if (_Node->_Simple_loop == 1) {
+                        auto& _Sav           = _Loop_vals[_Node->_Loop_number];
+                        _Sav._Loop_idx       = 1;
+                        _Sav._Loop_frame_idx = _Push_frame(_Rx_unwind_ops::_Do_nothing);
+                        if (_Node->_Min == 0) {
+                            _Failed = !_Do_rep0(_Node, _Greedy);
+                            _Next   = nullptr;
+                        } else {
+                            _Increase_complexity_count();
+                        }
+                    } else {
+                        _Failed = !_Do_rep(_Node, _Greedy, 0);
+                        _Next   = nullptr;
+                    }
                 }
 
-                _Next = nullptr;
                 break;
 
             case _N_end_rep:
                 {
                     _Node_rep* _Nr = static_cast<_Node_end_rep*>(_Nx)->_Begin_rep;
-                    if (_Nr->_Simple_loop == 0
-                        && !_Do_rep(_Nr, (_Nr->_Flags & _Fl_greedy) != 0, _Loop_vals[_Nr->_Loop_number]._Loop_idx)) {
-                        _Failed = true; // recurse only if loop contains if/do
+                    auto& _Sav     = _Loop_vals[_Nr->_Loop_number];
+                    if (_Nr->_Simple_loop != 0) {
+                        if (_Sav._Loop_idx <= _Nr->_Min) {
+                            if (_Sav._Loop_idx == 1
+                                && _Tgt_state._Cur == _Frames[_Sav._Loop_frame_idx]._Match_state._Cur) { // match empty
+                                // loop is branchless, so it will only ever match empty strings
+                                // -> skip all other matches as they don't change state and immediately try tail
+                                _Increase_complexity_count();
+                                // _Next is already assigned correctly for matching tail
+                            } else if (_Sav._Loop_idx < _Nr->_Min) { // needs at least one more rep to reach minimum
+                                _Increase_complexity_count();
+                                // GH-5365: We have to reset the capture groups from the second iteration on.
+                                _Tgt_state._Grp_valid = _Frames[_Sav._Loop_frame_idx]._Match_state._Grp_valid;
+                                _Next                 = _Nr->_Next;
+                                ++_Sav._Loop_idx;
+                            } else { // minimum number of reps reached
+                                _Failed = !_Do_rep0(_Nr, (_Nr->_Flags & _Fl_greedy) != 0);
+                                _Next   = nullptr;
+                            }
+                        } else { // internal _Match_pat(_Node->_Next) call in _Do_rep0()
+                            _Next = nullptr;
+                        }
+                    } else {
+                        _Failed = !_Do_rep(_Nr, (_Nr->_Flags & _Fl_greedy) != 0, _Sav._Loop_idx);
+                        _Next   = nullptr;
                     }
-
-                    _Next = nullptr;
                     break;
                 }
 
@@ -4243,6 +4254,7 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
                     _Nx        = _Node->_Next;
                     _Tgt_state = _Frame._Match_state;
                     _Failed    = false;
+                    _Increase_complexity_count();
                     if (_Node->_Child) {
                         _Frame._Node = _Node->_Child;
                         ++_Frames_count;
@@ -4251,6 +4263,9 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
                     }
                     break;
                 }
+
+            case _Rx_unwind_ops::_Do_nothing:
+                break;
 
             default:
 #if _ITERATOR_DEBUG_LEVEL != 0


### PR DESCRIPTION
Towards #997 and #1528.

Simple loops are a subset of all loops with the following properties:
1. In each trajectory in the NFA, the surrounding loops will not be repeated.
2. As a corollary, simple loops can be entered at most once in each trajectory.
3. The repeated pattern is branchless (no `_Do_if` node, no character class matching collating elements of various sizes).
4. The repeated pattern always matches strings of the same length.
5. The repeated pattern does not introduce new captures. (But I'm not sure whether I want to lift this restriction in the future,  so I haven't taken advantage of this property yet.)

Properties 1-3 mean that we don't have to worry about restoring loop state: Whenever we enter the loop, we can just overwrite it because the data relates to a trajectory the processing of which is complete. Moreover, the repeated pattern is branchless, so it can't happen that we try some first branch in the repeated pattern, have to backtrack and then have to restore the loop state (especially any counters) before trying another branch in the repeated pattern.

As long as we haven't reached the minimum number of reps, we must match more repetitions, so we do not try to match the tail of the regex. Thus, there is also no branch after matching a repetition until the minimum is reached. This means that we don't have to add any stack frames with non-trivial unwinding logic that try the other branch or restore the loop state during backtracking.

For now, this results in the following implementation to match the minimum number of reps in a simple loop:
* Matching `_N_rep` just sets up the loop state for the first repetition if at least one repetition is necessary. No unwinding logic is added to restore the loop state because the state relates to an outdated trajectory (or is just the initial state). If this isn't a simple loop or a simple one which doesn't have to match at least one rep, we essentially delegate to the old code.
* When matching `_N_end_rep`, we first check whether this is a simple loop and whether we are still processing the minimum number of reps.
  - If this isn't a simple loop, we delegate to `_Do_rep()`.
  -  If this is a simple loop, but we aren't processing the minimum number of reps of a simple loop anymore, then this is a recursive `_Match_pat(_Node->_Next)` call in `_Do_rep0()`, so we have to keep doing what `_N_end_rep` did previously in this case: Set `_Next` to `nullptr` so that we exit `_Match_pat()`.
  - If we are still processing the minimum number of reps and we just completed the first repetition, we have to check whether the first repetition matched an empty string. If so, we know that this repeated pattern always matches an empty string, so we can just stop repeating the pattern and immediately try matching the tail of the regex (non-recursively).
  - If we have to do one more repetition to reach the minimum, we reset the capturing groups, increase the loop counter and set `_Next` to the start of the repeated pattern.
  - If we have reached the minimum number of repetitions, we hand off the processing to the old `_Do_rep0()` code.

We don't have to run any stack unwinding logic during backtracking to process the minimum number of reps of a simple loop, but we still have to add a stack frame to save the match state at the time when the simple loop was entered. For this reason, we add a new opcode for doing nothing during stack unwinding. Since we can leave this stack frame to the standard unwinding logic in `_Match_pat()` now, we can remove all explicit `_Pop_frame()` calls in `_Do_rep0()`.

Repetitions of simple loops didn't really increase the stack usage counter (other than some temporary increase by 1) prior to this PR, so to reduce complexity I have decided to not replicate the updates to the stack usage counter in the new logic. Even so, this PR replicates the updates to the complexity counter. (This PR also adds an update to the complexity counter to the logic of `_Disjunction_eval_alt_always` which was missing from #5745.)