### PR TITLE
`<xstring>`: Add more casts to `basic_string` for ASan

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1570,8 +1570,9 @@ public:
         // append _Count * _Ch
         const size_type _Old_size = _Mypair._Myval2._Mysize;
         if (_Count <= _Mypair._Myval2._Myres - _Old_size) {
-            _ASAN_STRING_MODIFY(*this, _Old_size, static_cast<size_type>(_Old_size + _Count));
-            _Mypair._Myval2._Mysize = static_cast<size_type>(_Old_size + _Count);
+            const auto _New_size = static_cast<size_type>(_Old_size + _Count);
+            _ASAN_STRING_MODIFY(*this, _Old_size, _New_size);
+            _Mypair._Myval2._Mysize = _New_size;
             _Elem* const _Old_ptr   = _Mypair._Myval2._Myptr();
             _Traits::assign(_Old_ptr + _Old_size, static_cast<size_t>(_Count), _Ch);
             _Traits::assign(_Old_ptr[_Old_size + _Count], _Elem());
@@ -1759,8 +1760,9 @@ public:
         _Mypair._Myval2._Check_offset(_Off);
         const size_type _Old_size = _Mypair._Myval2._Mysize;
         if (_Count <= _Mypair._Myval2._Myres - _Old_size) {
-            _ASAN_STRING_MODIFY(*this, _Old_size, static_cast<size_type>(_Old_size + _Count));
-            _Mypair._Myval2._Mysize = static_cast<size_type>(_Old_size + _Count);
+            const auto _New_size = static_cast<size_type>(_Old_size + _Count);
+            _ASAN_STRING_MODIFY(*this, _Old_size, _New_size);
+            _Mypair._Myval2._Mysize = _New_size;
             _Elem* const _Old_ptr   = _Mypair._Myval2._Myptr();
             _Elem* const _Insert_at = _Old_ptr + _Off;
             _Traits::move(
@@ -2202,8 +2204,9 @@ public:
     _CONSTEXPR20 void push_back(const _Elem _Ch) { // insert element at end
         const size_type _Old_size = _Mypair._Myval2._Mysize;
         if (_Old_size < _Mypair._Myval2._Myres) {
-            _ASAN_STRING_MODIFY(*this, _Old_size, static_cast<size_type>(_Old_size + 1));
-            _Mypair._Myval2._Mysize = static_cast<size_type>(_Old_size + 1);
+            const auto _New_size = static_cast<size_type>(_Old_size + 1);
+            _ASAN_STRING_MODIFY(*this, _Old_size, _New_size);
+            _Mypair._Myval2._Mysize = _New_size;
             _Elem* const _Ptr       = _Mypair._Myval2._Myptr();
             _Traits::assign(_Ptr[_Old_size], _Ch);
             _Traits::assign(_Ptr[_Old_size + 1], _Elem());
@@ -3026,8 +3029,9 @@ private:
 
         const size_type _Old_size = _Mypair._Myval2._Mysize;
         if (_Count <= _Mypair._Myval2._Myres - _Old_size) {
-            _ASAN_STRING_MODIFY(*this, _Old_size, static_cast<size_type>(_Old_size + _Count));
-            _Mypair._Myval2._Mysize = static_cast<size_type>(_Old_size + _Count);
+            const auto _New_size = static_cast<size_type>(_Old_size + _Count);
+            _ASAN_STRING_MODIFY(*this, _Old_size, _New_size);
+            _Mypair._Myval2._Mysize = _New_size;
             _Elem* const _Old_ptr   = _Mypair._Myval2._Myptr();
             _STD _Traits_move_batch<_Traits>(_Old_ptr + _Old_size, _Ptr, static_cast<size_t>(_Count));
             _Traits::assign(_Old_ptr[_Old_size + _Count], _Elem());
@@ -3088,8 +3092,9 @@ private:
 #endif // ^^^ !_HAS_CXX20 ^^^
 
         if (_Check_overlap) {
-            _ASAN_STRING_MODIFY(*this, _Old_size, static_cast<size_type>(_Old_size + _Count));
-            _Mypair._Myval2._Mysize = static_cast<size_type>(_Old_size + _Count);
+            const auto _New_size = static_cast<size_type>(_Old_size + _Count);
+            _ASAN_STRING_MODIFY(*this, _Old_size, _New_size);
+            _Mypair._Myval2._Mysize = _New_size;
             _Elem* const _Old_ptr   = _Mypair._Myval2._Myptr();
             _Elem* const _Insert_at = _Old_ptr + _Off;
             // the range [_Ptr, _Ptr + _Ptr_shifted_after) is left alone by moving the suffix out,
@@ -3159,8 +3164,9 @@ private:
 #endif // _HAS_CXX20
         {
             if (_Growth <= _Mypair._Myval2._Myres - _Old_size) { // growth fits
-                _ASAN_STRING_MODIFY(*this, _Old_size, static_cast<size_type>(_Old_size + _Growth));
-                _Mypair._Myval2._Mysize = static_cast<size_type>(_Old_size + _Growth);
+                const auto _New_size = static_cast<size_type>(_Old_size + _Growth);
+                _ASAN_STRING_MODIFY(*this, _Old_size, _New_size);
+                _Mypair._Myval2._Mysize = _New_size;
                 _Elem* const _Old_ptr   = _Mypair._Myval2._Myptr();
                 _Elem* const _Insert_at = _Old_ptr + _Off;
                 _Elem* const _Suffix_at = _Insert_at + _Nx;


### PR DESCRIPTION
Followup to #5562.

I forgot that ASan activates conditionally compiled code, which also needs casts to avoid compiler warnings.

To simplify things, I'm also consistently extracting `_New_size` so we don't need to repeat the cast expressions. I verified that this isn't introducing any shadowing.

Thanks to @davidmrdavid and @zacklj89 for bringing this to my attention.