### PR TITLE
Add evil tests for negative duration formatting

### DIFF
--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -287,6 +287,20 @@ void test_duration_formatter() {
     // GH-4247: <chrono>: format() should accept %X and %EX for duration and hh_mm_ss
     assert(format(STR("{:%X}"), 9h + 7min + 5s) == STR("09:07:05"));
     assert(format(STR("{:%EX}"), 9h + 7min + 5s) == STR("09:07:05"));
+
+    // N4950 [time.format]/4
+    // "The result of formatting a std::chrono::duration instance holding a negative value, or an hh_mm_ss object h for
+    // which h.is_negative() is true, is equivalent to the output of the corresponding positive value, with a
+    // STATICALLY-WIDEN <charT>("-") character sequence placed before the replacement of the initial conversion
+    // specifier."
+    const auto minus_1s = -1s;
+    assert(format(STR("{:%Q}"), minus_1s) == STR("-1"));
+    assert(format(STR("{:%q}"), minus_1s) == STR("-s"));
+    assert(format(STR("{:%Q%Q}"), minus_1s) == STR("-11"));
+    assert(format(STR("{:%Q%q}"), minus_1s) == STR("-1s"));
+    assert(format(STR("{:%q%Q}"), minus_1s) == STR("-s1"));
+    assert(format(STR("{:%q%q}"), minus_1s) == STR("-ss"));
+    assert(format(STR("{:%%%t%n%q%Q hello world}"), minus_1s) == STR("-%\t\ns1 hello world"));
 }
 
 template <typename CharT>


### PR DESCRIPTION
This pr adds some evil tests for negative duration formatting. The background is https://github.com/microsoft/STL/issues/1902. The first case is not very hard to fix in itself, but I noticed something very tricky about it. Initially I thought it can be fixed by removing both signedness checks...

https://github.com/microsoft/STL/blob/85e4b574ca1f127993538673d3560dd4fbb4e27d/stl/inc/chrono#L5469-L5470
https://github.com/microsoft/STL/blob/85e4b574ca1f127993538673d3560dd4fbb4e27d/stl/inc/chrono#L5612

But but after looking into the standard, I found myself wrong. The standard says (https://eel.is/c++draft/time.format#4):
```
The result of formatting a std​::​chrono​::​duration instance holding a negative value, or an hh_mm_ss object h
for which h.is_negative() is true, is equivalent to the output of the corresponding positive value, with a
STATICALLY-WIDEN<charT>("-") character sequence placed before the replacement of the initial conversion specifier.
```

Which means the '-' is added unconditionally, regardless of conversion specifiers. Thus this pr. I call these tests "evil" as as a user I won't expect the formatting to work this way (for example, when it comes to `"%%%Q"`, I would expect `"%-1"` instead of `-%1`.)

Neither gcc nor clang can pass this test. https://godbolt.org/z/aqYYWhv75

---

(Additionally, the second case in the issue is not directly due to formatting impl, but the converted `hh_mm_ss` having negative `subseconds()`.)
```cpp
#include <chrono>
#include <cassert>

int main() {
    const auto dur = std::chrono::duration<float, std::ratio<1, 10'000'000>>{ 179999981568.0f };
    // format("{:%T}", dur); // This calls `_Write_seconds(... , dur)`, which converts dur to hh_mm_ss...
    const auto dur_hh_mm_ss = std::chrono::hh_mm_ss{ dur };
    assert(dur_hh_mm_ss.subseconds().count() < 0);
}
```