### PR TITLE
Fix GH_001923_filesystem_long_path_support/custombuild.pl for the MSVC-internal test harness

### DIFF
--- a/tests/std/tests/GH_001923_filesystem_long_path_support/custombuild.pl
+++ b/tests/std/tests/GH_001923_filesystem_long_path_support/custombuild.pl
@@ -10,6 +10,7 @@ sub CustomBuildHook()
 {
     my $cwd = Run::GetCWDName();
 
-    Run::ExecuteCL(join(" ", "test.cpp", "/Fe$cwd.exe", "/link", "/MANIFESTINPUT:long_path_aware.manifest"));
+    Run::ExecuteCL("/c test.cpp");
+    Run::ExecuteLink("/MANIFESTINPUT:long_path_aware.manifest /OUT:$cwd.exe test.obj");
 }
 1


### PR DESCRIPTION
In toolset update #5783 I added test coverage for `<filesystem>` long path support. This requires a manifest to be embedded into the executable with a special linker option. The MSVC-internal test harness uses Perl for this, and I used a single `cl` command. It turns out that in certain configurations (of course only run in CI checks, not in PR checks where I would have discovered this earlier), the MSVC-internal test harness adds `/FastFailDump`. When compiling with Clang, that gets sent to lld-link, which emits

```
lld-link: error: could not open '/FastFailDump': no such file or directory
```

I should have followed precedent and used separate compile and link commands, which avoids confusing lld-link (as in this case I believe we invoke MSVC link.exe):

https://github.com/microsoft/STL/blob/249cb012aa0b6edf48bb970549e6d5dfbfa34859/tests/std/tests/Dev09_056375_locale_cleanup/custombuild.pl#L12-L13
