### PR TITLE
Update CRT build to .NET 8.0

### DIFF
--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -440,6 +440,10 @@ private:
 #endif // ^^^ !defined(_M_CEE_PURE) ^^^
 #endif // !defined(_PREPARE_CONSTRAINED_REGIONS)
 
+// Note: PrepareConstrainedRegions is not supported in .NET versions 6.0 and later. /clr:pure is
+// also not supported in /clr:netcore mode (which targets .NET 8.0 and later), so
+// _PREPARE_CONSTRAINED_REGIONS == 0 in that case.
+
 #if _PREPARE_CONSTRAINED_REGIONS
 #define _BEGIN_LOCK(_Kind)                                                                  \
     {                                                                                       \

--- a/stl/src/xmtx.hpp
+++ b/stl/src/xmtx.hpp
@@ -10,10 +10,20 @@
 #include <Windows.h>
 
 #ifdef _M_CEE
+#if _PREPARE_CONSTRAINED_REGIONS
+#define _CRT_SUPPRESS_C4950
+#define _CRT_RESTORE_C4950
+#else // ^^^ _PREPARE_CONSTRAINED_REGIONS / !_PREPARE_CONSTRAINED_REGIONS vvv
+// Constrained regions are obsolete in .NET 6 and above.
+#define _CRT_SUPPRESS_C4950 __pragma(warning(push)) _pragma(warning(disable : 4950))
+#define _CRT_RESTORE_C4950  __pragma(warning(pop))
+#endif // ^^^ !_PREPARE_CONSTRAINED_REGIONS ^^^
 #define _RELIABILITY_CONTRACT                                                    \
+    _CRT_SUPPRESS_C4950                                                          \
     [System::Runtime::ConstrainedExecution::ReliabilityContract(                 \
         System::Runtime::ConstrainedExecution::Consistency::WillNotCorruptState, \
-        System::Runtime::ConstrainedExecution::Cer::Success)]
+        System::Runtime::ConstrainedExecution::Cer::Success)] /**/               \
+        _CRT_RESTORE_C4950
 #else // ^^^ defined(_M_CEE) / !defined(_M_CEE) vvv
 #define _RELIABILITY_CONTRACT
 #endif // ^^^ !defined(_M_CEE) ^^^


### PR DESCRIPTION
This is a reverse mirror of @tgani-msft's MSVC-PR-677732 "Update CRT build to .NET 8.0" which is a substantial PR with minor STL impacts. I've verified that it's properly clang-formatted.