### PR TITLE
`<regex>`: Skip stack unwinding when encountering a successful match of an ECMAScript regex

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1764,7 +1764,6 @@ public:
         _Matched = false;
 
         bool _Succeeded = _Match_pat(_Rep) || _Matched;
-        _STL_INTERNAL_CHECK(_Frames_count == 0);
 
         if (!_Succeeded) {
             return false;
@@ -4157,7 +4156,9 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
                         && _Begin == _Tgt_state._Cur)
                     || (_Full && _Tgt_state._Cur != _End)) {
                     _Failed = true;
-                } else if (_Longest && (!_Matched || _Better_match())) { // record successful match
+                } else if (!_Longest) { // match result found, skip unwinding
+                    return true;
+                } else if (!_Matched || _Better_match()) { // record successful match
                     _Res     = _Tgt_state;
                     _Matched = true;
                 }
@@ -4319,6 +4320,7 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
     }
 
     _Decrease_stack_usage_count();
+    _STL_INTERNAL_CHECK(_Frames_count == 0);
 
     return !_Failed;
 }


### PR DESCRIPTION
In ECMAScript mode (and in those cases where leftmost-longest mode behaves the same), the matcher returns the first encountered successful match. This means that `_Match_pat()` can be left immediately when a match is found, skipping the usual unwinding of the stack frames.

This should result in some slight performance improvements for ECMAScript regexes, as the matcher will do strictly less work. At least on my machine, though, any actual performance difference vanishes in the noise when I run the regex_search benchmark. That's why I don't provide any benchmark results.

But the main point of this change is that it is a prerequisite for further changes that will speed up matching by reducing the number of allocations the matcher performs.