### PR TITLE
Remove non-Standard `basic_istream::ipfx()`/`isfx()`, `basic_ostream::opfx()`/`osfx()`, and `locale::empty()`

### DIFF
--- a/stl/inc/__msvc_ostream.hpp
+++ b/stl/inc/__msvc_ostream.hpp
@@ -130,12 +130,9 @@ public:
         bool _Ok; // true if stream state okay at construction
     };
 
-#pragma push_macro("opfx")
-#pragma push_macro("osfx")
-#undef opfx
-#undef osfx
+#ifdef _CRTBLD
     // TRANSITION, ABI: non-Standard opfx() is preserved for binary compatibility
-    _DEPRECATE_IO_PFX_SFX bool __CLR_OR_THIS_CALL opfx() { // test stream state and flush tie stream as needed
+    bool __CLR_OR_THIS_CALL opfx() { // test stream state and flush tie stream as needed
         if (!this->good()) {
             return false;
         }
@@ -150,11 +147,10 @@ public:
     }
 
     // TRANSITION, ABI: non-Standard osfx() is preserved for binary compatibility
-    _DEPRECATE_IO_PFX_SFX void __CLR_OR_THIS_CALL osfx() noexcept { // perform any wrapup
+    void __CLR_OR_THIS_CALL osfx() noexcept { // perform any wrapup
         _Osfx();
     }
-#pragma pop_macro("osfx")
-#pragma pop_macro("opfx")
+#endif // ^^^ defined(_CRTBLD) ^^^
 
     void __CLR_OR_THIS_CALL _Osfx() noexcept { // perform any wrapup
         _TRY_BEGIN

--- a/stl/inc/istream
+++ b/stl/inc/istream
@@ -155,20 +155,16 @@ public:
         return this->good();
     }
 
-#pragma push_macro("ipfx")
-#pragma push_macro("isfx")
-#undef ipfx
-#undef isfx
+#ifdef _CRTBLD
     // TRANSITION, ABI: non-Standard ipfx() is preserved for binary compatibility
-    _DEPRECATE_IO_PFX_SFX bool __CLR_OR_THIS_CALL ipfx(bool _Noskip = false) {
+    bool __CLR_OR_THIS_CALL ipfx(bool _Noskip = false) {
         // test stream state and skip whitespace as needed
         return _Ipfx(_Noskip);
     }
 
     // TRANSITION, ABI: non-Standard isfx() is preserved for binary compatibility
-    _DEPRECATE_IO_PFX_SFX void __CLR_OR_THIS_CALL isfx() {} // perform any wrapup
-#pragma pop_macro("isfx")
-#pragma pop_macro("ipfx")
+    void __CLR_OR_THIS_CALL isfx() {} // perform any wrapup
+#endif // ^^^ defined(_CRTBLD) ^^^
 
 #ifdef _M_CEE_PURE
     basic_istream& __CLR_OR_THIS_CALL operator>>(basic_istream&(__clrcall* _Pfn)(basic_istream&) ) {

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -400,8 +400,10 @@ public:
 
     static _MRTIMP2_PURE locale __CLRCALL_PURE_OR_CDECL global(const locale&); // current locale
 
-    // TRANSITION, ABI: non-Standard empty() is preserved for binary compatibility
-    _DEPRECATE_LOCALE_EMPTY static _MRTIMP2_PURE locale __CLRCALL_PURE_OR_CDECL empty(); // empty (transparent) locale
+#ifdef _CRTBLD
+    // TRANSITION, ABI: non-Standard locale::empty() is preserved for binary compatibility
+    static _MRTIMP2_PURE locale __CLRCALL_PURE_OR_CDECL empty();
+#endif // ^^^ defined(_CRTBLD) ^^^
 
 private:
     struct _Secret_locale_construct_tag {

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1477,16 +1477,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 
 // STL4044 was "The contents of the stdext::cvt namespace are non-Standard extensions and will be removed"
 
-#if !defined(_SILENCE_IO_PFX_SFX_DEPRECATION_WARNING) && !defined(_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS)
-#define _DEPRECATE_IO_PFX_SFX                                                                                          \
-    [[deprecated(                                                                                                      \
-        "warning STL4045: The ipfx(), isfx(), opfx(), and osfx() functions are removed before C++98 (see WG21-N0794) " \
-        "but kept as non-Standard extensions. They will be removed in the future, and the member classes sentry "      \
-        "should be used instead. You can define _SILENCE_IO_PFX_SFX_DEPRECATION_WARNING or "                           \
-        "_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS to suppress this warning.")]]
-#else // ^^^ warning enabled / warning disabled vvv
-#define _DEPRECATE_IO_PFX_SFX
-#endif // ^^^ warning disabled ^^^
+// STL4045 was "The ipfx(), isfx(), opfx(), and osfx() functions are [...] non-Standard extensions"
 
 // STL4046 was "Non-Standard TR1 components in <random> are deprecated and will be REMOVED."
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1493,15 +1493,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define _CXX20_DEPRECATE_CODECVT_CHAR8_T_FACETS
 #endif // ^^^ warning disabled ^^^
 
-#if !defined(_SILENCE_LOCALE_EMPTY_DEPRECATION_WARNING) && !defined(_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS)
-#define _DEPRECATE_LOCALE_EMPTY                                                                                        \
-    [[deprecated(                                                                                                      \
-        "warning STL4048: locale::empty() is a non-Standard extension and will be removed in the future. A "           \
-        "default-constructed locale can be used instead. You can define _SILENCE_LOCALE_EMPTY_DEPRECATION_WARNING or " \
-        "_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS to suppress this warning.")]]
-#else // ^^^ warning enabled / warning disabled vvv
-#define _DEPRECATE_LOCALE_EMPTY
-#endif // ^^^ warning disabled ^^^
+// STL4048 was "locale::empty() is a non-Standard extension and will be removed in the future."
 
 // next warning number: STL4049
 

--- a/stl/src/locale0.cpp
+++ b/stl/src/locale0.cpp
@@ -9,8 +9,6 @@
 
 #undef _ENFORCE_ONLY_CORE_HEADERS // TRANSITION, <xfacet> should be a core header
 
-#define _SILENCE_LOCALE_EMPTY_DEPRECATION_WARNING
-
 #include <crtdbg.h>
 #include <internal_shared.h>
 #include <xatomic.h>
@@ -157,6 +155,7 @@ _MRTIMP2_PURE const locale& __CLRCALL_PURE_OR_CDECL locale::classic() { // get r
     return classic_locale;
 }
 
+// TRANSITION, ABI: non-Standard locale::empty() is preserved for binary compatibility
 _MRTIMP2_PURE locale __CLRCALL_PURE_OR_CDECL locale::empty() { // make empty transparent locale
     _Init();
     return locale{_Secret_locale_construct_tag{}, _Locimp::_New_Locimp(true)};

--- a/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
@@ -21,14 +21,13 @@
 #define make_unchecked_array_iterator delete
 #define unchecked_array_iterator      delete
 
+#define ipfx delete
+#define isfx delete
+#define opfx delete
+#define osfx delete
+
 // Test workaround for extensions of non-reserved names that can't be removed at this moment.
 #define raw_name 1001
-
-#define ipfx 1002
-#define isfx 1003
-
-#define opfx 1004
-#define osfx 1005
 
 // Also test GH-2645: <yvals_core.h>: Conformance issue on [[msvc::known_semantics]]
 #define msvc               1
@@ -72,19 +71,3 @@
 #if raw_name != 1001
 #error bad macro expansion
 #endif // raw_name != 1001
-
-#if ipfx != 1002
-#error bad macro expansion
-#endif // ipfx != 1002
-
-#if isfx != 1003
-#error bad macro expansion
-#endif // isfx != 1003
-
-#if opfx != 1004
-#error bad macro expansion
-#endif // opfx != 1004
-
-#if osfx != 1005
-#error bad macro expansion
-#endif // osfx != 1005


### PR DESCRIPTION
Let's finish cleaning house.

* `basic_istream::ipfx()`/`isfx()` and `basic_ostream::opfx()`/`osfx()` were deprecated since VS 2022 17.9 in February 2024 (for C++17 and later) and VS 2022 17.11 in August 2024 (unconditionally).
  + #4006
  + #4605
* `locale::empty()` was deprecated since VS 2022 17.14 in May 2025.
  + #5197

I've verified that the DLL's export surface is unchanged.

There appears to have been virtually zero usage; I see no occurrences of the silencing macros in our internal or Real World Code test suites (modulo preprocessed files), which is why I'm being a bit more aggressive here.

Although we shouldn't ever need to change them, I'm keeping the comments on the function definitions. However, the comment on the declaration of `locale::empty()` serves no purpose, so I'm removing it.