### PR TITLE
Implement LWG-4243 `as_bytes`/`as_writable_bytes` is broken with `span<volatile T>`

### DIFF
--- a/stl/inc/span
+++ b/stl/inc/span
@@ -558,13 +558,14 @@ span(_Rng&&) -> span<remove_reference_t<_RANGES range_reference_t<_Rng>>>;
 #ifdef __cpp_lib_byte
 // [span.objectrep] Views of object representation
 _EXPORT_STD template <class _Ty, size_t _Extent>
+    requires (!is_volatile_v<_Ty>)
 _NODISCARD auto as_bytes(span<_Ty, _Extent> _Sp) noexcept {
     using _ReturnType = span<const byte, _Extent == dynamic_extent ? dynamic_extent : sizeof(_Ty) * _Extent>;
     return _ReturnType{reinterpret_cast<const byte*>(_Sp.data()), _Sp.size_bytes()};
 }
 
 _EXPORT_STD template <class _Ty, size_t _Extent>
-    requires (!is_const_v<_Ty>)
+    requires (!is_const_v<_Ty> && !is_volatile_v<_Ty>)
 _NODISCARD auto as_writable_bytes(span<_Ty, _Extent> _Sp) noexcept {
     using _ReturnType = span<byte, _Extent == dynamic_extent ? dynamic_extent : sizeof(_Ty) * _Extent>;
     return _ReturnType{reinterpret_cast<byte*>(_Sp.data()), _Sp.size_bytes()};

--- a/tests/std/tests/P0122R7_span/test.cpp
+++ b/tests/std/tests/P0122R7_span/test.cpp
@@ -153,11 +153,11 @@ using BorrowedContiguousSizedRange = BasicRange<int, true>;
 template <typename T, size_t Extent = dynamic_extent>
 constexpr void FunctionTakingSpan(type_identity_t<span<T, Extent>>) {}
 
-template <typename U, typename = void>
-constexpr bool AsWritableBytesCompilesFor = false;
+template <typename U>
+constexpr bool AsBytesCompilesFor = requires { as_bytes(declval<U>()); };
 
 template <typename U>
-constexpr bool AsWritableBytesCompilesFor<U, void_t<decltype(as_writable_bytes(declval<U>()))>> = true;
+constexpr bool AsWritableBytesCompilesFor = requires { as_writable_bytes(declval<U>()); };
 
 constexpr bool test() {
     {
@@ -1016,10 +1016,23 @@ void test_non_constexpr() {
     static_assert(noexcept(as_writable_bytes(sp_dyn)));
     static_assert(noexcept(as_writable_bytes(sp_nine)));
 
+    static_assert(AsBytesCompilesFor<span<int>>);
+    static_assert(AsBytesCompilesFor<span<int, 5>>);
+    static_assert(AsBytesCompilesFor<span<const int>>);
+    static_assert(AsBytesCompilesFor<span<const int, 6>>);
+    static_assert(!AsBytesCompilesFor<span<volatile int>>);
+    static_assert(!AsBytesCompilesFor<span<volatile int, 7>>);
+    static_assert(!AsBytesCompilesFor<span<const volatile int>>);
+    static_assert(!AsBytesCompilesFor<span<const volatile int, 8>>);
+
     static_assert(AsWritableBytesCompilesFor<span<int>>);
     static_assert(AsWritableBytesCompilesFor<span<int, 9>>);
     static_assert(!AsWritableBytesCompilesFor<span<const int>>);
-    static_assert(!AsWritableBytesCompilesFor<span<const int, 9>>);
+    static_assert(!AsWritableBytesCompilesFor<span<const int, 10>>);
+    static_assert(!AsWritableBytesCompilesFor<span<volatile int>>);
+    static_assert(!AsWritableBytesCompilesFor<span<volatile int, 11>>);
+    static_assert(!AsWritableBytesCompilesFor<span<const volatile int>>);
+    static_assert(!AsWritableBytesCompilesFor<span<const volatile int, 12>>);
 
     auto sp_1 = as_bytes(sp_dyn);
     auto sp_2 = as_bytes(sp_nine);


### PR DESCRIPTION
Fixes #5852. As drive-by, also upgrades the legacy SFINAE trick in the test to requires-expression.