### PR TITLE
Make sure expected `__isa_enabled` bit was set before disabling it in feature-dependent tests

### DIFF
--- a/tests/std/include/test_vector_algorithms_support.hpp
+++ b/tests/std/include/test_vector_algorithms_support.hpp
@@ -71,21 +71,26 @@ inline void disable_instructions(ISA_AVAILABILITY isa) {
 constexpr std::size_t dataCount = 1024;
 
 template <class TestFunc>
-void run_randomized_tests_with_different_isa_levels(TestFunc tests) {
-    std::mt19937_64 gen;
-    initialize_randomness(gen);
-
-    tests(gen);
+void run_tests_with_different_isa_levels(TestFunc tests) {
+    tests();
 
 #if (defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC))) && !defined(_M_CEE_PURE)
     const auto original_isa = __isa_enabled;
 
     disable_instructions(__ISA_AVAILABLE_AVX2);
-    tests(gen);
+    tests();
 
     disable_instructions(__ISA_AVAILABLE_SSE42);
-    tests(gen);
+    tests();
 
     __isa_enabled = original_isa;
 #endif // (defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC))) && !defined(_M_CEE_PURE)
+}
+
+template <class TestFunc>
+void run_randomized_tests_with_different_isa_levels(TestFunc tests) {
+    std::mt19937_64 gen;
+    initialize_randomness(gen);
+
+    run_tests_with_different_isa_levels([&] { tests(gen); });
 }

--- a/tests/std/tests/GH_002431_byte_range_find_with_unreachable_sentinel/test.cpp
+++ b/tests/std/tests/GH_002431_byte_range_find_with_unreachable_sentinel/test.cpp
@@ -4,7 +4,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
-#include <isa_availability.h>
 #include <ranges>
 
 #pragma warning(push) // TRANSITION, OS-23694920
@@ -52,13 +51,7 @@ int main() {
     void* p2 = VirtualAlloc(p, page, MEM_COMMIT, PAGE_READWRITE);
     assert(p2 != nullptr);
 
-    test_all_element_sizes(p, page);
-#if defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC))
-    disable_instructions(__ISA_AVAILABLE_AVX2);
-    test_all_element_sizes(p, page);
-    disable_instructions(__ISA_AVAILABLE_SSE42);
-    test_all_element_sizes(p, page);
-#endif // defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC))
+    run_tests_with_different_isa_levels([&] { test_all_element_sizes(p, page); });
 
     VirtualFree(p, 0, MEM_RELEASE);
 }

--- a/tests/std/tests/GH_003617_vectorized_meow_element/test.cpp
+++ b/tests/std/tests/GH_003617_vectorized_meow_element/test.cpp
@@ -6,7 +6,6 @@
 #ifdef _M_X64
 
 #include <cstddef>
-#include <isa_availability.h>
 #include <vector>
 
 #include "test_min_max_element_support.hpp"
@@ -26,15 +25,7 @@ void test_gh_3617() {
 }
 
 int main() {
-    test_gh_3617();
-
-#ifndef _M_ARM64EC
-    disable_instructions(__ISA_AVAILABLE_AVX2);
-    test_gh_3617();
-
-    disable_instructions(__ISA_AVAILABLE_SSE42);
-    test_gh_3617();
-#endif // !defined(_M_ARM64EC)
+    run_tests_with_different_isa_levels([] { test_gh_3617(); });
 }
 #else // ^^^ x64 / other architectures vvv
 int main() {}


### PR DESCRIPTION
This makes sure that tests are running all code paths.

Currently it is not much needed, AVX2 is everywhere. 
But we may pick next x64 features someday, and also may pick up ARM64 not always available features.

We also need to be able to execute tests intentionally on downlevel host to see if we haven't used instructions that are not available. Here escape environment variable `STL_TEST_DOWNLEVEL_HOST` set to `1` will help.