### PR TITLE
Fix operator precedence warning for right shift and bitwise AND

### DIFF
--- a/stl/src/_tolower.cpp
+++ b/stl/src/_tolower.cpp
@@ -72,7 +72,7 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Tolower(int c, const _Ctypevec* ploc)
 
     // convert int c to multibyte string
     if (ploc == nullptr ? _cpp_isleadbyte((c >> 8) & 0xff) : (ploc->_Table[(c >> 8) & 0xff] & _LEADBYTE) != 0) {
-        inbuffer[0] = (c >> 8 & 0xff);
+        inbuffer[0] = ((c >> 8) & 0xff);
         inbuffer[1] = static_cast<unsigned char>(c);
         inbuffer[2] = 0;
         size        = 2;

--- a/stl/src/_toupper.cpp
+++ b/stl/src/_toupper.cpp
@@ -71,7 +71,7 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Toupper(int c, const _Ctypevec* ploc)
 
     // convert int c to multibyte string
     if (ploc == nullptr ? _cpp_isleadbyte((c >> 8) & 0xff) : (ploc->_Table[(c >> 8) & 0xff] & _LEADBYTE) != 0) {
-        inbuffer[0] = (c >> 8 & 0xff);
+        inbuffer[0] = ((c >> 8) & 0xff);
         inbuffer[1] = static_cast<unsigned char>(c);
         inbuffer[2] = 0;
         size        = 2;


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
