### PR TITLE
Fix operator precedence warning for logical AND and logical OR

### DIFF
--- a/stl/src/mutex.cpp
+++ b/stl/src/mutex.cpp
@@ -95,7 +95,7 @@ static _Thrd_result mtx_do_lock(_Mtx_t mtx, const _timespec64* target) noexcept 
 
             res = WAIT_OBJECT_0;
 
-        } else if (target->tv_sec < 0 || target->tv_sec == 0 && target->tv_nsec <= 0) {
+        } else if (target->tv_sec < 0 || (target->tv_sec == 0 && target->tv_nsec <= 0)) {
             // target time <= 0 --> plain trylock or timed wait for time that has passed; try to lock with 0 timeout
             if (mtx->_Thread_id != current_thread_id) { // not this thread, lock it
                 if (TryAcquireSRWLockExclusive(get_srw_lock(mtx)) != 0) {
@@ -109,7 +109,7 @@ static _Thrd_result mtx_do_lock(_Mtx_t mtx, const _timespec64* target) noexcept 
             // TRANSITION, ABI: this branch is preserved for `_Mtx_timedlock`
             _timespec64 now;
             _Timespec64_get_sys(&now);
-            while (now.tv_sec < target->tv_sec || now.tv_sec == target->tv_sec && now.tv_nsec < target->tv_nsec) {
+            while (now.tv_sec < target->tv_sec || (now.tv_sec == target->tv_sec && now.tv_nsec < target->tv_nsec)) {
                 // time has not expired
                 if (mtx->_Thread_id == current_thread_id
                     || TryAcquireSRWLockExclusive(get_srw_lock(mtx)) != 0) { // stop waiting


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
