### PR TITLE
`<random>`: Replace inaccurate `_XLgamma()` with UCRT `lgamma()`

### DIFF
--- a/stl/inc/random
+++ b/stl/inc/random
@@ -65,10 +65,6 @@ _INLINE_VAR constexpr long double _Exp1   = 2.7182818284590452353602874713526625
 _INLINE_VAR constexpr long double _Two32  = 4294967296.0L;
 _INLINE_VAR constexpr long double _Two31  = 2147483648.0L;
 
-extern "C++" _CRTIMP2_PURE float __CLRCALL_PURE_OR_CDECL _XLgamma(float) noexcept;
-extern "C++" _CRTIMP2_PURE double __CLRCALL_PURE_OR_CDECL _XLgamma(double) noexcept;
-extern "C++" _CRTIMP2_PURE long double __CLRCALL_PURE_OR_CDECL _XLgamma(long double) noexcept;
-
 _INLINE_VAR constexpr int _Nwords = 4;
 
 template <class _Elem, class _Traits>
@@ -1926,7 +1922,7 @@ public:
             }
             _Sqrt = _CSTD sqrt(2.0 * _Mean0);
             _Logm = _CSTD log(_Mean0);
-            _Gx1  = _Mean0 * _Logm - _XLgamma(_Mean0 + 1.0);
+            _Gx1  = _Mean0 * _Logm - _STD lgamma(_Mean0 + 1.0);
         }
 
         _Ty1 _Mean = 0.0;
@@ -2030,7 +2026,7 @@ private:
             }
 
             if (_Nrand_impl<_Ty1>(_Eng)
-                <= 0.9 * (1.0 + _Yx * _Yx) * _CSTD exp(_Res * _Par0._Logm - _XLgamma(_Res + 1.0) - _Par0._Gx1)) {
+                <= 0.9 * (1.0 + _Yx * _Yx) * _CSTD exp(_Res * _Par0._Logm - _STD lgamma(_Res + 1.0) - _Par0._Gx1)) {
                 return _Res;
             }
         }
@@ -2086,7 +2082,7 @@ public:
             _Px    = _Px0;
             _Pp    = _Px < 0.5 ? _Px : (1.0 - _Px);
             _Mean  = _Tx * _Pp;
-            _Gx1   = _XLgamma(_Tx + 1.0);
+            _Gx1   = _STD lgamma(_Tx + 1.0);
             _Sqrt  = _CSTD sqrt(2 * _Mean * (1 - _Pp));
             _Logp  = _CSTD log(_Pp);
             _Logp1 = _CSTD log(1.0 - _Pp);
@@ -2232,7 +2228,7 @@ private:
                 }
                 if (_Nrand_impl<_Ty1>(_Eng)
                     <= 1.2 * _Par0._Sqrt * (1.0 + _Yx * _Yx)
-                           * _CSTD exp(_Par0._Gx1 - _XLgamma(_Res + 1.0) - _XLgamma(_Par0._Tx - _Res + 1.0)
+                           * _CSTD exp(_Par0._Gx1 - _STD lgamma(_Res + 1.0) - _STD lgamma(_Par0._Tx - _Res + 1.0)
                                        + _Res * _Par0._Logp + (_Par0._Tx - _Res) * _Par0._Logp1)) {
                     break;
                 }

--- a/stl/src/xlgamma.cpp
+++ b/stl/src/xlgamma.cpp
@@ -1,63 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// moderately accurate lgamma function for random
-
-// TRANSITION, ABI: This should be superseded by the CRT's lgamma().
-
 #include <cmath>
 
-//  #include <random>
 _STD_BEGIN
-_CRTIMP2_PURE float __CLRCALL_PURE_OR_CDECL _XLgamma(float) noexcept;
-_CRTIMP2_PURE double __CLRCALL_PURE_OR_CDECL _XLgamma(double) noexcept;
-_CRTIMP2_PURE long double __CLRCALL_PURE_OR_CDECL _XLgamma(long double) noexcept;
-
-float __CLRCALL_PURE_OR_CDECL _XLgamma(float x) noexcept { // moderately accurate log gamma
-    static const float coeff[6] = {76.18009172947146F, -86.50532032941677F, 24.01409824083091F, -1.23173972450155F,
-        0.1208650973866179E-2F, -0.5395239384953E-5F};
-
-    float val0 = x + 5.5F;
-    val0 -= (x + 0.5F) * _STD log(val0);
-    float val1 = 1.000000000190015F;
-    float y    = x + 1.0F;
-
-    for (int i = 0; i < 6; ++i, y += 1.0) {
-        val1 += coeff[i] / y;
-    }
-
-    return -val0 + _STD log(2.5066282746310005F * val1 / x);
+// TRANSITION, ABI: preserved for binary compatibility
+_CRTIMP2_PURE float __CLRCALL_PURE_OR_CDECL _XLgamma(float x) noexcept {
+    return _STD lgamma(x);
 }
 
-double __CLRCALL_PURE_OR_CDECL _XLgamma(double x) noexcept { // moderately accurate log gamma
-    static const double coeff[6] = {76.18009172947146, -86.50532032941677, 24.01409824083091, -1.23173972450155,
-        0.1208650973866179E-2, -0.5395239384953E-5};
-
-    double val0 = x + 5.5;
-    val0 -= (x + 0.5) * _STD log(val0);
-    double val1 = 1.000000000190015;
-    double y    = x + 1;
-
-    for (int i = 0; i < 6; ++i, y += 1.0) {
-        val1 += coeff[i] / y;
-    }
-
-    return -val0 + _STD log(2.5066282746310005 * val1 / x);
+// TRANSITION, ABI: preserved for binary compatibility
+_CRTIMP2_PURE double __CLRCALL_PURE_OR_CDECL _XLgamma(double x) noexcept {
+    return _STD lgamma(x);
 }
 
-long double __CLRCALL_PURE_OR_CDECL _XLgamma(long double x) noexcept { // moderately accurate log gamma
-    static const long double coeff[6] = {76.18009172947146, -86.50532032941677, 24.01409824083091, -1.23173972450155,
-        0.1208650973866179E-2, -0.5395239384953E-5};
-
-    long double val0 = x + 5.5;
-    val0 -= (x + 0.5) * _STD log(val0);
-    long double val1 = 1.000000000190015;
-    long double y    = x + 1;
-
-    for (int i = 0; i < 6; ++i, y += 1.0) {
-        val1 += coeff[i] / y;
-    }
-
-    return -val0 + _STD log(2.5066282746310005 * val1 / x);
+// TRANSITION, ABI: preserved for binary compatibility
+_CRTIMP2_PURE long double __CLRCALL_PURE_OR_CDECL _XLgamma(long double x) noexcept {
+    return _STD lgamma(x);
 }
 _STD_END


### PR DESCRIPTION
Fixes #5577.

# Overview
To implement `<random>`'s `poisson_distribution` and `binomial_distribution`, the STL had a "log gamma" function for historical reasons. As the UCRT provides C99 `lgamma()`, we should just call that. This will increase accuracy and reduce the amount of code we need to maintain.

# Accuracy
I used Boost.Math's test coverage to compare UCRT `lgamma()` to STL `_XLgamma()`. Boost.Math's own implementation is the best (0 failures). UCRT `lgamma()` has minor accuracy issues (7 failures). STL `_XLgamma()` was extremely inaccurate (648 failures); @statementreply observed on Discord that this inaccuracy was around +/- 10^-9, which is millions of ULPs for `double`. Woof. :dog:

<details><summary>Click to expand the details of my hacked-up accuracy testing:</summary>

I used `boost_1_89_0\libs\math\test\test_gamma.cpp` and `test_gamma.hpp`. At the end of `test_gamma.cpp`, to make it header-only, I followed [the docs](https://www.boost.org/doc/libs/latest/libs/test/doc/html/boost_test/adv_scenarios/single_header_customizations/multiple_translation_units.html) and added:

```cpp
#define BOOST_TEST_MODULE header-only multiunit test
#include <boost/test/included/unit_test.hpp>
```

In `test_gamma.hpp` I added:

```cpp
#include <cmath>
#include <random>
float ucrt_lgamma(float val) {
    return std::lgamma(val);
}
double ucrt_lgamma(double val) {
    return std::lgamma(val);
}
long double ucrt_lgamma(long double val) {
    return std::lgamma(val);
}
float stl_xlgamma(float val) {
    return std::_XLgamma(val);
}
double stl_xlgamma(double val) {
    return std::_XLgamma(val);
}
long double stl_xlgamma(long double val) {
    return std::_XLgamma(val);
}
```

Results:

```
C:\Temp>cl /EHsc /nologo /W4 /wd4459 /std:c++latest /MTd /Od test_gamma.cpp /I. /I D:\GitHub\DELME\boost_1_89_0\libs\math\test /I D:\GitHub\DELME\boost_1_89_0 /DBOOST_TEST_NO_LIB /DBOOST_MATH_NO_REAL_CONCEPT_TESTS && test_gamma.exe
[...]
*** No errors detected

C:\Temp>cl /EHsc /nologo /W4 /wd4459 /std:c++latest /MTd /Od test_gamma.cpp /I. /I D:\GitHub\DELME\boost_1_89_0\libs\math\test /I D:\GitHub\DELME\boost_1_89_0 /DBOOST_TEST_NO_LIB /DLGAMMA_FUNCTION_TO_TEST=ucrt_lgamma /DBOOST_MATH_NO_REAL_CONCEPT_TESTS && test_gamma.exe
[...]
*** 7 failures are detected in the test module "Master Test Suite"

C:\Temp>cl /EHsc /nologo /W4 /wd4459 /std:c++latest /MTd /Od test_gamma.cpp /I. /I D:\GitHub\DELME\boost_1_89_0\libs\math\test /I D:\GitHub\DELME\boost_1_89_0 /DBOOST_TEST_NO_LIB /DLGAMMA_FUNCTION_TO_TEST=stl_xlgamma /DBOOST_MATH_NO_REAL_CONCEPT_TESTS && test_gamma.exe
[...]
*** 648 failures are detected in the test module "Master Test Suite"
```
</details>

# Changes
## `<random>`
Don't declare `_XLgamma()` anymore. (The all-important `_CRTIMP2_PURE` will be preserved on the definitions.)

Call `_STD lgamma()`, which is similarly overloaded for `float` / `double` / `long double`.

## `xlgamma.cpp`
Transfer `_CRTIMP2_PURE` to the definitions, which will keep them dllexported. This replaces a silly pattern of "declare with `_CRTIMP2_PURE` but define without".

Mark them as preserved for bincompat.

Replace their guts with calls to `_STD lgamma()`, which preserves the interface but improves the behavior.