### PR TITLE
Implement LWG-4312 Const and value category mismatch for `allocator_arg_t`/`allocator_arg` in the description of uses-allocator construction

### DIFF
--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -142,7 +142,7 @@ struct _Tuple_val { // stores each value in a tuple
                         _STD is_constructible<_Ty, _STD allocator_arg_t, const _Alloc&, _Other...>>,
             int> = 0>
     constexpr _Tuple_val(const _Alloc& _Al, allocator_arg_t, _Other&&... _Arg)
-        : _Val(allocator_arg, _Al, _STD forward<_Other>(_Arg)...) {}
+        : _Val(allocator_arg_t{}, _Al, _STD forward<_Other>(_Arg)...) {}
 
     template <class _Alloc, class... _Other,
         enable_if_t<conjunction_v<_STD uses_allocator<_Dty, _Alloc>,

--- a/stl/inc/xpolymorphic_allocator.h
+++ b/stl/inc/xpolymorphic_allocator.h
@@ -28,7 +28,7 @@ void _Uses_alloc_construct_non_pair(_Ty* const _Ptr, _Outer_alloc& _Outer, _Inne
     if constexpr (uses_allocator_v<remove_cv_t<_Ty>, _Inner_alloc>) {
         if constexpr (is_constructible_v<_Ty, allocator_arg_t, _Inner_alloc&, _Types...>) {
             allocator_traits<_Outer_alloc>::construct(
-                _Outer, _Ptr, allocator_arg, _Inner, _STD forward<_Types>(_Args)...);
+                _Outer, _Ptr, allocator_arg_t{}, _Inner, _STD forward<_Types>(_Args)...);
         } else {
             static_assert(is_constructible_v<_Ty, _Types..., _Inner_alloc&>,
                 "N4950 [allocator.uses.trait]/1 requires "

--- a/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
+++ b/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
@@ -137,7 +137,11 @@ namespace {
 
         int i_ = 0;
 
-        uses_allocator_thing(std::allocator_arg_t, Alloc const& a, int i = 0) : Alloc(a), i_{i} {}
+        // Such overload set is used for testing LWG-4312.
+        uses_allocator_thing(std::allocator_arg_t&&, Alloc const& a, int i = 0) : Alloc(a), i_{i} {}
+        uses_allocator_thing(std::allocator_arg_t&, Alloc const&, int = 0)       = delete;
+        uses_allocator_thing(const std::allocator_arg_t&, Alloc const&, int = 0) = delete;
+
         Alloc get_allocator() const {
             return *this;
         }
@@ -151,8 +155,8 @@ namespace {
     };
     template <class Alloc>
     struct uses_allocator_thing<Alloc, false> : uses_allocator_thing<Alloc, true> {
-        uses_allocator_thing(int i, Alloc const& a) : uses_allocator_thing<Alloc, true>{std::allocator_arg, a, i} {}
-        uses_allocator_thing(Alloc const& a) : uses_allocator_thing<Alloc, true>{std::allocator_arg, a} {}
+        uses_allocator_thing(int i, Alloc const& a) : uses_allocator_thing<Alloc, true>{std::allocator_arg_t{}, a, i} {}
+        uses_allocator_thing(Alloc const& a) : uses_allocator_thing<Alloc, true>{std::allocator_arg_t{}, a} {}
     };
 
     struct malloc_resource final : std::pmr::memory_resource {
@@ -690,6 +694,25 @@ namespace {
                     test_throws();
                 }
             } // namespace construct
+
+
+            // Also test LWG-4312 "Const and value category mismatch for allocator_arg_t/allocator_arg in the
+            // description of uses-allocator construction"
+            namespace uses_allocator_construct {
+                void test() {
+                    malloc_resource mr;
+                    std::pmr::polymorphic_allocator<not_constructible> alloc = &mr;
+
+                    using T = uses_allocator_thing<std::pmr::polymorphic_allocator<int>, true>;
+
+                    alignas(T) unsigned char space[sizeof(T)];
+                    const auto rawptr = reinterpret_cast<T*>(space);
+                    alloc.construct(rawptr);
+                    placement_ptr<T> ptr{rawptr};
+
+                    CHECK(ptr->get_allocator().resource() == &mr);
+                }
+            } // namespace uses_allocator_construct
 
             namespace piecewise_construct {
                 void test() {
@@ -1573,6 +1596,7 @@ int main() {
     polymorphic_allocator::ctor::rebind::test();
     polymorphic_allocator::mem::allocate_deallocate::test();
     polymorphic_allocator::mem::construct::test();
+    polymorphic_allocator::mem::uses_allocator_construct::test();
     polymorphic_allocator::mem::piecewise_construct::test();
     polymorphic_allocator::mem::construct_pair::test();
     polymorphic_allocator::mem::construct_pair_U_V::test();

--- a/tests/std/tests/VSO_0224478_scoped_allocator/test.cpp
+++ b/tests/std/tests/VSO_0224478_scoped_allocator/test.cpp
@@ -119,6 +119,23 @@ void test_case_LWG_2586() {
     sa.deallocate(ptr, 1);
 }
 
+struct lwg_4312 {
+    using allocator_type = allocator<lwg_4312>;
+    lwg_4312(allocator_arg_t&&, const allocator_type&) {}
+    lwg_4312(allocator_arg_t&, const allocator_type&)       = delete;
+    lwg_4312(const allocator_arg_t&, const allocator_type&) = delete;
+};
+
+void test_case_LWG_4312() {
+    // LWG-4312 "Const and value category mismatch for allocator_arg_t/allocator_arg in the description of
+    // uses-allocator construction"
+    scoped_allocator_adaptor<allocator<lwg_4312>> sa;
+    const auto ptr = sa.allocate(1);
+    sa.construct(ptr);
+    sa.destroy(ptr);
+    sa.deallocate(ptr, 1);
+}
+
 void test_case_move_rebind_one_alloc() {
     scoped_allocator_adaptor<allocator<int>> sa;
     scoped_allocator_adaptor<allocator<double>> target(move(sa));
@@ -159,5 +176,6 @@ int main() {
     test_case_VSO_224478_allow_stacking();
     test_case_VSO_224478_piecewise_construct_calls_allocator_construct();
     test_case_LWG_2586();
+    test_case_LWG_4312();
     test_case_move_rebind_one_alloc();
 }


### PR DESCRIPTION
Fixes #5866.

Note that the difference between `allocator_arg`/`allocator_arg_t{}` is only observable for (contrived) user-defined types, so we only need to modify `_Tuple_val` and `_Uses_alloc_construct_non_pair` (pre-C++20 only).

For `scoped_allocator_adaptor` and `polymorphic_allocator`, the changes make the pre-C++20 behavior more consistent and closer to C++20 behavior.