### PR TITLE
Remove the `/RTCc` escape hatch

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1497,7 +1497,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 
 // next warning number: STL4049
 
-// next error number: STL1013
+// next error number: STL1014
 
 // P0619R4 Removing C++17-Deprecated Features
 #ifndef _HAS_FEATURES_REMOVED_IN_CXX20
@@ -1885,11 +1885,8 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #endif
 
 #ifdef _RTC_CONVERSION_CHECKS_ENABLED
-#ifndef _ALLOW_RTCc_IN_STL
-#error /RTCc rejects conformant code, so it is not supported by the C++ Standard Library. Either remove this \
-compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
-#endif // !defined(_ALLOW_RTCc_IN_STL)
-#endif // defined(_RTC_CONVERSION_CHECKS_ENABLED)
+_EMIT_STL_ERROR(STL1013, "The STL doesn't support /RTCc because it rejects conformant code. Remove the /RTCc option.");
+#endif
 
 #define _EMPTY_ARGUMENT // for empty macro argument
 


### PR DESCRIPTION
Fixes DevCom-11003754 VSO-2644054.

MSVC has good and bad [`/RTC`](https://learn.microsoft.com/en-us/cpp/build/reference/rtc-run-time-error-checks?view=msvc-170) options. `/RTCs` and `/RTCu` (combined into `/RTC1`) are good; they only complain about undefined behavior.

`/RTCc` is bad and should feel bad. It rejects Standard-conforming code with well-defined behavior that is often desired by programs. There are no compiler warnings for when `/RTCc` will strike, and `static_cast`s to explicitly narrow integers **do not** avoid `/RTCc`'s wrath at runtime. Only explicit masking with `& mask` will avoid `/RTCc` termination.

Playing whack-a-mole with `/RTCc` runtime errors was utterly intolerable, so many years ago I requested FE support to detect `/RTCc`'s presence via a macro (originally it was undetectable), and added code to the STL to reject it at compile-time, with what I thought was an exceptionally clear message.

However, users have occasionally misunderstood the existence of the escape hatch I left in the code, thinking that they could define it and all would be well. All is not well. This escape hatch is more trouble than it's worth (yes, theoretically one could still use the "core" functionality like type traits regardless of `/RTCc`'s evil; that's what I intended the escape hatch for, but it was not used that way).

It's time to utterly reject `/RTCc`. Users should remove the compiler option. Impact should be very low because we were already emitting an error for this by default.

The message now looks like:

```
C:\Temp>type meow.cpp
#include <regex>
int main() {}

C:\Temp>cl /EHsc /nologo /W4 meow.cpp
meow.cpp

C:\Temp>cl /EHsc /nologo /W4 /RTC1 meow.cpp
meow.cpp

C:\Temp>cl /EHsc /nologo /W4 /RTCc meow.cpp
meow.cpp
D:\GitHub\STL\out\x64\out\inc\yvals_core.h(1888): error C2338: static assertion failed: 'error STL1013: The STL doesn't support /RTCc because it rejects conformant code. Remove the /RTCc option.'
```