### PR TITLE
`<chrono>`: Overhaul `zoned_time` to use concepts instead of SFINAE

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -2490,7 +2490,7 @@ namespace chrono {
             requires requires {
                 { _Traits::locate_zone(_Name) } -> convertible_to<_TimeZonePtr>;
             }
-            : zoned_time{_Traits::locate_zone(_Name), _Sys} {}
+            : _Zone{_Traits::locate_zone(_Name)}, _Tp{_Sys} {}
 
         zoned_time(_TimeZonePtr _Tz, const local_time<_Duration>& _Local)
             requires requires {
@@ -2503,7 +2503,7 @@ namespace chrono {
                 { _Traits::locate_zone(_Name) } -> convertible_to<_TimeZonePtr>;
                 { _STD declval<_TimeZonePtr&>() -> to_sys(_Local) } -> convertible_to<sys_time<duration>>;
             }
-            : zoned_time{_Traits::locate_zone(_Name), _Local} {}
+            : _Zone{_Traits::locate_zone(_Name)}, _Tp{_Zone->to_sys(_Local)} {}
 
         zoned_time(_TimeZonePtr _Tz, const local_time<_Duration>& _Local, choose _Choose)
             requires requires {
@@ -2516,7 +2516,7 @@ namespace chrono {
                 { _Traits::locate_zone(_Name) } -> convertible_to<_TimeZonePtr>;
                 { _STD declval<_TimeZonePtr&>() -> to_sys(_Local, _Choose) } -> convertible_to<sys_time<duration>>;
             }
-            : zoned_time{_Traits::locate_zone(_Name), _Local, _Choose} {}
+            : _Zone{_Traits::locate_zone(_Name)}, _Tp{_Zone->to_sys(_Local, _Choose)} {}
 
         template <class _Duration2, class _TimeZonePtr2>
             requires is_convertible_v<sys_time<_Duration2>, sys_time<_Duration>>
@@ -2527,21 +2527,21 @@ namespace chrono {
             requires is_convertible_v<sys_time<_Duration2>, sys_time<_Duration>>
         zoned_time(
             _TimeZonePtr _Tz, const zoned_time<_Duration2, _TimeZonePtr2>& _Zt, choose) noexcept /* strengthened */
-            : zoned_time{_Tz, _Zt} {}
+            : _Zone{_STD move(_Tz)}, _Tp{_Zt.get_sys_time()} {}
 
         template <class _Duration2, class _TimeZonePtr2>
         zoned_time(string_view _Name, const zoned_time<_Duration2, _TimeZonePtr2>& _Zt)
             requires requires {
                 { _Traits::locate_zone(_Name) } -> convertible_to<_TimeZonePtr>;
             } && is_convertible_v<sys_time<_Duration2>, sys_time<_Duration>>
-            : zoned_time{_Traits::locate_zone(_Name), _Zt} {}
+            : _Zone{_Traits::locate_zone(_Name)}, _Tp{_Zt.get_sys_time()} {}
 
         template <class _Duration2, class _TimeZonePtr2>
-        zoned_time(string_view _Name, const zoned_time<_Duration2, _TimeZonePtr2>& _Zt, choose _Choose)
+        zoned_time(string_view _Name, const zoned_time<_Duration2, _TimeZonePtr2>& _Zt, choose)
             requires requires {
                 { _Traits::locate_zone(_Name) } -> convertible_to<_TimeZonePtr>;
             } && is_convertible_v<sys_time<_Duration2>, sys_time<_Duration>>
-            : zoned_time{_Traits::locate_zone(_Name), _Zt, _Choose} {}
+            : _Zone{_Traits::locate_zone(_Name)}, _Tp{_Zt.get_sys_time()} {}
 
         zoned_time& operator=(const sys_time<_Duration>& _Sys) noexcept /* strengthened */ {
             _Tp = _Sys;


### PR DESCRIPTION
Works towards #602. Fixes #1910.

LWG-4067 "Inconsistency and potential infinity meta-recursion in `std::chrono::zoned_time`'s constructors" is relevant, but it's P3 according to LWG so it probably won't be resolved any time soon. I believe that converting our constraints to concepts is an improvement, even if the Standard is kind of confused right now.

* Move ref within `type_identity_t` for consistency.
* `zoned_time` overhaul: Convert SFINAE to concepts.
  + I'm phrasing the constraints slightly differently from the Standard to perma-workaround EDG bugs, but I believe they're morally equivalent, and in practice everyone uses `const time_zone*` anyways.
* `zoned_time`: Avoid delegating constructors.
  + In theory this repeats a bit of code, but IMO it clarifies what's happening (because `zoned_time` has so many constructors). This also avoids repeatedly evaluating constraints.
