### PR TITLE
Remove comments after LWG-3454 "pointer_traits::pointer_to should be constexpr" was accepted

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -624,7 +624,7 @@ struct _Ptr_traits_base {
     using _Reftype = conditional_t<is_void_v<_Elem>, char, _Elem>&;
 
     _NODISCARD static _CONSTEXPR20 pointer pointer_to(_Reftype _Val)
-        noexcept(noexcept(_Ty::pointer_to(_Val))) /* strengthened */ { // Per LWG-3454
+        noexcept(noexcept(_Ty::pointer_to(_Val))) /* strengthened */ {
         return _Ty::pointer_to(_Val);
     }
 };


### PR DESCRIPTION
Only one reference was found and removed at
https://github.com/microsoft/STL/blob/5459853bf78ceef1137d845bfeca98f658659691/stl/inc/xutility#L626-L629

Fixes #5864 