### PR TITLE
`<regex>`: Remove capture validity vectors from stack frames

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1682,16 +1682,21 @@ enum class _Rx_unwind_ops {
     _Loop_greedy,
     _Loop_restore_vals,
     _Capture_restore_begin,
-    _Capture_restore_end,
+    _Capture_restore_unmatched_end,
+    _Capture_restore_matched_end,
+    _Capture_restore_matched,
 };
 
 template <class _BidIt>
 class _Rx_state_frame_t {
 public:
     _Rx_unwind_ops _Code;
-    int _Loop_idx_sav;
+    union {
+        int _Loop_idx_sav;
+        unsigned int _Capture_idx;
+    };
     _Node_base* _Node;
-    _Bt_state_t<_BidIt> _Match_state;
+    _BidIt _Pos;
     size_t _Loop_frame_idx_sav;
 };
 
@@ -1820,6 +1825,7 @@ private:
 
     void _Prepare_rep(_Node_rep*);
     bool _Find_first_inner_capture_group(_Node_base*, _Loop_vals_v2_t*);
+    void _Reset_capture_groups(unsigned int _First);
     _It _Do_class(_Node_base*, _It);
     bool _Match_pat(_Node_base*);
     bool _Better_match();
@@ -3373,12 +3379,12 @@ void _Builder2<_FwdIt, _Elem, _RxTraits>::_Tidy() noexcept { // free memory
 template <class _BidIt, class _Elem, class _RxTraits, class _It, class _Alloc>
 size_t _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Push_frame(_Rx_unwind_ops _Code, _Node_base* _Node) {
     if (_Frames_count >= _Frames.size()) {
-        _Frames.push_back({_Code, 0, _Node, _Tgt_state, size_t{}});
+        _Frames.push_back({_Code, {0}, _Node, _Tgt_state._Cur, size_t{}});
     } else {
-        auto& _Frame        = _Frames[_Frames_count];
-        _Frame._Code        = _Code;
-        _Frame._Node        = _Node;
-        _Frame._Match_state = _Tgt_state;
+        auto& _Frame = _Frames[_Frames_count];
+        _Frame._Code = _Code;
+        _Frame._Node = _Node;
+        _Frame._Pos  = _Tgt_state._Cur;
     }
     return _Frames_count++;
 }
@@ -3518,6 +3524,18 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Find_first_inner_capture
     }
 
     return _Found_group;
+}
+
+template <class _BidIt, class _Elem, class _RxTraits, class _It, class _Alloc>
+void _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Reset_capture_groups(unsigned int _First) {
+    size_t _Size = _Tgt_state._Grp_valid.size();
+    for (; _First < _Size; ++_First) {
+        if (_Tgt_state._Grp_valid[_First]) {
+            _Tgt_state._Grp_valid[_First]    = false;
+            auto _Frame_idx                  = _Push_frame(_Rx_unwind_ops::_Capture_restore_matched, nullptr);
+            _Frames[_Frame_idx]._Capture_idx = _First;
+        }
+    }
 }
 
 template <class _BidIt1, class _BidIt2, class _Pr>
@@ -3923,19 +3941,21 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
             case _N_end_assert:
                 {
                     size_t _Last_capture_restore_frame = 0U;
+                    unsigned int _Capture_first        = UINT_MAX;
+                    unsigned int _Capture_back         = 0U;
                     for (;;) {
                         --_Frames_count;
                         const auto& _Frame = _Frames[_Frames_count];
                         const auto _Code   = _Frame._Code;
                         if (_Code == _Rx_unwind_ops::_After_assert || _Code == _Rx_unwind_ops::_After_neg_assert) {
-                            _Tgt_state._Cur = _Frame._Match_state._Cur;
                             _Decrease_stack_usage_count();
                             if (_Code == _Rx_unwind_ops::_After_assert) {
-                                _Next = _Frame._Node->_Next;
+                                _Tgt_state._Cur = _Frame._Pos;
+                                _Next           = _Frame._Node->_Next;
                                 if (_Last_capture_restore_frame != 0U) {
                                     auto _Not_capture_restore = [](const auto& _Other_frame) _STATIC_LAMBDA {
                                         return _Other_frame._Code != _Rx_unwind_ops::_Capture_restore_begin
-                                            && _Other_frame._Code != _Rx_unwind_ops::_Capture_restore_end;
+                                            && _Other_frame._Code != _Rx_unwind_ops::_Capture_restore_unmatched_end;
                                     };
                                     const auto _Effective_frames_end =
                                         _STD remove_if(_Frames.begin() + static_cast<ptrdiff_t>(_Frames_count),
@@ -3945,6 +3965,11 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
                                 }
                             } else {
                                 _Failed = true;
+                                if (_Capture_first <= _Capture_back) {
+                                    _STD fill(_Tgt_state._Grp_valid.begin() + static_cast<ptrdiff_t>(_Capture_first),
+                                        _Tgt_state._Grp_valid.begin() + static_cast<ptrdiff_t>(_Capture_back + 1U),
+                                        false);
+                                }
                             }
                             break;
                         } else if (_Code == _Rx_unwind_ops::_Disjunction_eval_alt_on_failure
@@ -3953,8 +3978,20 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
                                    || _Code == _Rx_unwind_ops::_Loop_nongreedy
                                    || _Code == _Rx_unwind_ops::_Loop_restore_vals) {
                             _Decrease_stack_usage_count();
-                        } else if (_Code == _Rx_unwind_ops::_Capture_restore_end && _Last_capture_restore_frame == 0U) {
-                            _Last_capture_restore_frame = _Frames_count;
+                        } else if (_Code == _Rx_unwind_ops::_Capture_restore_unmatched_end) {
+                            auto _Node        = static_cast<_Node_capture*>(_Frame._Node);
+                            auto _Capture_idx = _Node->_Idx;
+                            if (_Capture_first > _Capture_idx) {
+                                _Capture_first = _Capture_idx;
+                            }
+
+                            if (_Capture_back < _Capture_idx) {
+                                _Capture_back = _Capture_idx;
+                            }
+
+                            if (_Last_capture_restore_frame == 0U) {
+                                _Last_capture_restore_frame = _Frames_count;
+                            }
                         }
                     }
                 }
@@ -3962,26 +3999,35 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
 
             case _N_capture:
                 { // record current position
-                    _Node_capture* _Node = static_cast<_Node_capture*>(_Nx);
-                    if (_Node->_Idx != 0U) {
-                        auto& _Group    = _Tgt_state._Grps[_Node->_Idx];
-                        auto _Frame_idx = _Push_frame(_Rx_unwind_ops::_Capture_restore_begin, _Node);
-                        _Frames[_Frame_idx]._Match_state._Cur = _Group._Begin;
-                        _Group._Begin                         = _Tgt_state._Cur;
+                    auto _Node = static_cast<_Node_capture*>(_Nx);
+                    auto _Idx  = _Node->_Idx;
+                    if (_Idx != 0U) {
+                        auto& _Group        = _Tgt_state._Grps[_Idx];
+                        auto _Frame_idx     = _Push_frame(_Rx_unwind_ops::_Capture_restore_begin, _Node);
+                        auto& _Frame        = _Frames[_Frame_idx];
+                        _Frame._Pos         = _Group._Begin;
+                        _Frame._Capture_idx = _Idx;
+                        _Group._Begin       = _Tgt_state._Cur;
                     }
                     break;
                 }
 
             case _N_end_capture:
                 { // record successful capture
-                    _Node_end_group* _Node = static_cast<_Node_end_group*>(_Nx);
-                    _Node_capture* _Node0  = static_cast<_Node_capture*>(_Node->_Back);
-                    if (_Node0->_Idx != 0U) { // update capture data
-                        auto& _Group    = _Tgt_state._Grps[_Node0->_Idx];
-                        auto _Frame_idx = _Push_frame(_Rx_unwind_ops::_Capture_restore_end, _Node0);
-                        _Frames[_Frame_idx]._Match_state._Cur = _Group._End;
-                        _Tgt_state._Grp_valid[_Node0->_Idx]   = true;
-                        _Group._End                           = _Tgt_state._Cur;
+                    auto _Node  = static_cast<_Node_end_group*>(_Nx);
+                    auto _Node0 = static_cast<_Node_capture*>(_Node->_Back);
+                    auto _Idx   = _Node0->_Idx;
+                    if (_Idx != 0U) { // update capture data
+                        auto& _Group                = _Tgt_state._Grps[_Idx];
+                        bool _Matched               = _Tgt_state._Grp_valid[_Idx];
+                        const auto _Code            = _Matched ? _Rx_unwind_ops::_Capture_restore_matched_end
+                                                               : _Rx_unwind_ops::_Capture_restore_unmatched_end;
+                        auto _Frame_idx             = _Push_frame(_Code, _Node0);
+                        auto& _Frame                = _Frames[_Frame_idx];
+                        _Frame._Pos                 = _Group._End;
+                        _Frame._Capture_idx         = _Idx;
+                        _Group._End                 = _Tgt_state._Cur;
+                        _Tgt_state._Grp_valid[_Idx] = true;
                     }
                     break;
                 }
@@ -4091,8 +4137,7 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
                     bool _Greedy   = (_Nr->_Flags & _Fl_greedy) != 0;
                     if (_Nr->_Simple_loop != 0) {
                         if (_Sav._Loop_idx == 1
-                            && _Tgt_state._Cur
-                                   == _Frames[_Sav._Loop_frame_idx]._Match_state._Cur) { // initial match empty
+                            && _Tgt_state._Cur == _Frames[_Sav._Loop_frame_idx]._Pos) { // initial match empty
                             // loop is branchless, so it will only ever match empty strings
                             // -> we only try tail for POSIX or if minimum number of reps is non-zero
                             // _Next is already assigned correctly for matching tail
@@ -4123,7 +4168,7 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
                             _Increase_complexity_count();
                         }
                     } else {
-                        const bool _Progress = _Frames[_Sav._Loop_frame_idx]._Match_state._Cur != _Tgt_state._Cur;
+                        const bool _Progress = _Frames[_Sav._Loop_frame_idx]._Pos != _Tgt_state._Cur;
                         if (_Sav._Loop_idx < _Nr->_Min) { // try another required match
                             auto _Frame_idx            = _Push_frame(_Rx_unwind_ops::_Loop_restore_vals, _Nr);
                             auto& _Frame               = _Frames[_Frame_idx];
@@ -4139,8 +4184,7 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
                                 ++_Sav._Loop_idx;
                             }
 
-                            _STD fill(_Tgt_state._Grp_valid.begin() + static_cast<ptrdiff_t>(_Sav._Group_first),
-                                _Tgt_state._Grp_valid.end(), false);
+                            _Reset_capture_groups(_Sav._Group_first);
                             _Next = _Nr->_Next;
                             _Increase_stack_usage_count();
                         } else if (!_Progress) { // latest rep match empty
@@ -4165,8 +4209,7 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
                                 ++_Sav._Loop_idx;
                             }
 
-                            _STD fill(_Tgt_state._Grp_valid.begin() + static_cast<ptrdiff_t>(_Sav._Group_first),
-                                _Tgt_state._Grp_valid.end(), false);
+                            _Reset_capture_groups(_Sav._Group_first);
                             _Next = _Nr->_Next;
                             _Increase_stack_usage_count();
                         } else { // non-greedy matching or greedy matching with maximum reached
@@ -4234,10 +4277,9 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
                 { // matching pattern of negative assert failed
                     _STL_INTERNAL_CHECK(_Failed);
                     _Decrease_stack_usage_count();
-                    const _Bt_state_t<_It>& _St = _Frame._Match_state;
-                    _Tgt_state                  = _St;
-                    _Nx                         = _Frame._Node->_Next;
-                    _Failed                     = false;
+                    _Tgt_state._Cur = _Frame._Pos;
+                    _Nx             = _Frame._Node->_Next;
+                    _Failed         = false;
                     break;
                 }
 
@@ -4252,10 +4294,10 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
             case _Rx_unwind_ops::_Disjunction_eval_alt_always:
                 // evaluate next alternative no matter if matching prior alternatives succeeded
                 {
-                    auto _Node = static_cast<_Node_if*>(_Frame._Node);
-                    _Nx        = _Node->_Next;
-                    _Tgt_state = _Frame._Match_state;
-                    _Failed    = false;
+                    auto _Node      = static_cast<_Node_if*>(_Frame._Node);
+                    _Nx             = _Node->_Next;
+                    _Tgt_state._Cur = _Frame._Pos;
+                    _Failed         = false;
                     _Increase_complexity_count();
                     if (_Node->_Child) {
                         _Frame._Node = _Node->_Child;
@@ -4276,10 +4318,9 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
                     auto& _Sav = _Loop_vals[_Node->_Loop_number];
 
                     _Increase_complexity_count();
-                    _Nx                   = _Node->_Next;
-                    _Tgt_state._Cur       = _Frame._Match_state._Cur;
-                    _Tgt_state._Grp_valid = _Frames[_Sav._Loop_frame_idx]._Match_state._Grp_valid;
-                    _Failed               = false;
+                    _Nx             = _Node->_Next;
+                    _Tgt_state._Cur = _Frame._Pos;
+                    _Failed         = false;
                     if (_Sav._Loop_idx < INT_MAX) { // avoid overflowing _Loop_idx
                         ++_Sav._Loop_idx;
                     }
@@ -4292,10 +4333,9 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
                     auto _Node = static_cast<_Node_rep*>(_Frame._Node);
 
                     _Increase_complexity_count();
-                    _Nx                   = _Node->_End_rep->_Next;
-                    _Tgt_state._Cur       = _Frame._Match_state._Cur;
-                    _Tgt_state._Grp_valid = _Frame._Match_state._Grp_valid;
-                    _Failed               = false;
+                    _Nx             = _Node->_End_rep->_Next;
+                    _Tgt_state._Cur = _Frame._Pos;
+                    _Failed         = false;
                 }
                 break;
 
@@ -4305,9 +4345,9 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
                     auto _Node = static_cast<_Node_rep*>(_Frame._Node);
 
                     _Increase_complexity_count();
-                    _Nx        = _Node->_End_rep->_Next;
-                    _Tgt_state = _Frame._Match_state;
-                    _Failed    = false;
+                    _Nx             = _Node->_End_rep->_Next;
+                    _Tgt_state._Cur = _Frame._Pos;
+                    _Failed         = false;
                 }
                 _FALLTHROUGH;
 
@@ -4330,31 +4370,40 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
                     auto& _Sav = _Loop_vals[_Node->_Loop_number];
 
                     _Increase_complexity_count();
-                    _Nx        = _Node->_Next;
-                    _Tgt_state = _Frame._Match_state;
-                    _STD fill(_Tgt_state._Grp_valid.begin() + static_cast<ptrdiff_t>(_Sav._Group_first),
-                        _Tgt_state._Grp_valid.end(), false);
-                    _Failed = false;
+                    _Nx             = _Node->_Next;
+                    _Tgt_state._Cur = _Frame._Pos;
+                    _Failed         = false;
                     if (_Sav._Loop_idx < INT_MAX) { // avoid overflowing _Loop_idx
                         ++_Sav._Loop_idx;
                     }
 
                     _Frame._Code = _Rx_unwind_ops::_Loop_restore_vals;
                     ++_Frames_count;
+                    _Reset_capture_groups(_Sav._Group_first);
                 }
                 break;
 
             case _Rx_unwind_ops::_Capture_restore_begin:
                 { // restore begin of capturing group
-                    auto _Node                           = static_cast<_Node_capture*>(_Frame._Node);
-                    _Tgt_state._Grps[_Node->_Idx]._Begin = _Frame._Match_state._Cur;
+                    _Tgt_state._Grps[_Frame._Capture_idx]._Begin = _Frame._Pos;
                 }
                 break;
 
-            case _Rx_unwind_ops::_Capture_restore_end:
-                { // restore end of capturing group
-                    auto _Node                         = static_cast<_Node_capture*>(_Frame._Node);
-                    _Tgt_state._Grps[_Node->_Idx]._End = _Frame._Match_state._Cur;
+            case _Rx_unwind_ops::_Capture_restore_unmatched_end:
+                { // restore end of capturing group that was previously unmatched
+                    _Tgt_state._Grp_valid[_Frame._Capture_idx] = false;
+                }
+                _FALLTHROUGH;
+
+            case _Rx_unwind_ops::_Capture_restore_matched_end:
+                { // restore end of capturing group that was already matched
+                    _Tgt_state._Grps[_Frame._Capture_idx]._End = _Frame._Pos;
+                }
+                break;
+
+            case _Rx_unwind_ops::_Capture_restore_matched:
+                { // restore matched status of capturing group
+                    _Tgt_state._Grp_valid[_Frame._Capture_idx] = true;
                 }
                 break;
 

--- a/tests/std/tests/VSO_0000000_regex_use/test.cpp
+++ b/tests/std/tests/VSO_0000000_regex_use/test.cpp
@@ -2353,6 +2353,14 @@ void test_gh_5865() {
     g_regexTester.should_capture("abab", "(?:(?=(.*))ab)*ab", "abab");
 }
 
+void test_gh_5918() {
+    // GH-5918: Remove capture validity vectors from stack frames
+    // These tests verify that reset capturing groups are restored correctly when backtracking.
+    g_regexTester.should_match("ababa", R"((?:(a)(?:|b\1b))*)");
+    g_regexTester.should_match("ababa", R"((?:(a)(?:|b\1b))*?)");
+    g_regexTester.should_match("ababa", R"((?:(a)(?:|b\1b)){2})");
+}
+
 int main() {
     test_dev10_449367_case_insensitivity_should_work();
     test_dev11_462743_regex_collate_should_not_disable_regex_icase();
@@ -2411,6 +2419,7 @@ int main() {
     test_gh_5797();
     test_gh_5798();
     test_gh_5865();
+    test_gh_5918();
 
     return g_regexTester.result();
 }


### PR DESCRIPTION
This removes the capturing group validity vectors in stack frames that were used to snapshot the validity/matched status of capturing groups whenever a stack frame was pushed. The restoration of this status is now achieved by processing new or modified opcodes during unwinding plus some changed logic when the pattern of a lookahead assertion matched:
* The opcode `_Capture_restore_end` is split into `_Capture_restore_matched_end` and `_Capture_restore_unmatched_end`, which are pushed depending on whether a capturing group is already matched while the `_N_end_capture` node is processed. `_Capture_restore_matched_end` keeps the capturing group matched (so doesn't do anything about the matched status), `_Capture_restore_unmatched_end` resets it to unmatched.
* The reset of the status to unmatched at the start of a loop in ECMAScript is now performed by `_Matcher3::_Reset_capture_groups()`, replacing the prior calls to `std::fill()`. This function pushes a new stack frame with opcode `_Capture_restore_matched` for every capture group whose status is changed to unmatched.
  - The new test cases fail when the status is reset to unmatched, but the reset is not undone when backtracking.
* For successful positive lookahead assertions, we keep the stack frames with opcodes `_Capture_restore_unmatched_end` and any with opcode `_Capture_restore_begin` before them on the stack. We don't have to keep those with opcode `_Capture_restore_matched_end` because ECMAScript rules guarantee that the capturing groups inside the lookahead assertion are unmatched when processing the lookahead assertion starts, so the stack frame pushed for the first modification of a capturing group's end pointer in this lookahead assertion must have opcode `_Capture_restore_unmatched_end`.
* For a failed negative lookahead assertion (i.e., one whose asserted pattern matched), we have to reset all the capturing groups to unmatched status. When going through the stack frames pushed by such an assertion, the code is changed to track the first and last matched capturing group inside this assertion, and then calls `std::fill()` to reset their status to unmatched. (We don't have to worry about restoring the begin and end pointers of the capturing groups because the capturing groups are always unmatched when leaving a negative lookahead assertion, so the pointers are meaningless.)

With this PR, the worst-case number of allocations is logarithmic in the size of the input (pattern + searched string) and no longer linear. But even for patterns like "a*", where the capture extent and validity vectors in the stack frames did not actually allocate, we still see some major performance improvement, probably because the overhead of managing these vectors is gone.

This change also makes the structure `_Rx_state_frame` trivially copyable and destructible iff the unwrapped iterator type is trivially copyable or destructible, usually simplifying destruction of the stack frame vector.

Drive-by change: Since the stack frames have a new member `_Capture_idx`, this member is now used to store the relevant index of the capturing group for all `_Capture` opcodes, so they no longer have to access the contents of the `_Node_capture` NFA node.

## Benchmark

benchmark | before [ns] | after [ns] | speedup
-- | -- | -- | --
bm_match_sequence_of_as/"a*"/100 | 4324.78 | 2148.44 | 2.01
bm_match_sequence_of_as/"a*"/200 | 6975.45 | 3379.61 | 2.06
bm_match_sequence_of_as/"a*"/400 | 21972.4 | 5580.36 | 3.94
bm_match_sequence_of_as/"a*?"/100 | 2887.83 | 1967.08 | 1.47
bm_match_sequence_of_as/"a*?"/200 | 5312.5 | 3717.91 | 1.43
bm_match_sequence_of_as/"a*?"/400 | 10009.8 | 6835.94 | 1.46
bm_match_sequence_of_as/"(?:a)*"/100 | 4973.5 | 2622.77 | 1.90
bm_match_sequence_of_as/"(?:a)*"/200 | 7498.6 | 4237.58 | 1.77
bm_match_sequence_of_as/"(?:a)*"/400 | 23123.3 | 7952.01 | 2.91
bm_match_sequence_of_as/"(a)*"/100 | 42481.2 | 3989.95 | 10.65
bm_match_sequence_of_as/"(a)*"/200 | 69754.5 | 6835.94 | 10.20
bm_match_sequence_of_as/"(a)*"/400 | 125552 | 32994.1 | 3.81
bm_match_sequence_of_as/"(?:b\|a)*"/100 | 6975.45 | 3923.69 | 1.78
bm_match_sequence_of_as/"(?:b\|a)*"/200 | 12276.8 | 7149.83 | 1.72
bm_match_sequence_of_as/"(?:b\|a)*"/400 | 25111.3 | 13183.5 | 1.90
bm_match_sequence_of_as/"(b\|a)*"/100 | 35156.8 | 6417.41 | 5.48
bm_match_sequence_of_as/"(b\|a)*"/200 | 71498.3 | 16043.5 | 4.46
bm_match_sequence_of_as/"(b\|a)*"/400 | 141246 | 53013.4 | 2.66
bm_match_sequence_of_as/"(a)(?:b\|a)*"/100 | 13671.9 | 4464.29 | 3.06
bm_match_sequence_of_as/"(a)(?:b\|a)*"/200 | 23437.5 | 7672.99 | 3.05
bm_match_sequence_of_as/"(a)(?:b\|a)*"/400 | 53013.4 | 14125.2 | 3.75
bm_match_sequence_of_as/"(a)(b\|a)*"/100 | 30482.6 | 6406.25 | 4.76
bm_match_sequence_of_as/"(a)(b\|a)*"/200 | 62779 | 14648.4 | 4.29
bm_match_sequence_of_as/"(a)(b\|a)*"/400 | 128348 | 53013.4 | 2.42
bm_match_sequence_of_as/"(a)(?:b\|a)*c"/100 | 14753 | 5161.83 | 2.86
bm_match_sequence_of_as/"(a)(?:b\|a)*c"/200 | 26785.7 | 10253.9 | 2.61
bm_match_sequence_of_as/"(a)(?:b\|a)*c"/400 | 54687.5 | 18415.3 | 2.97

<details>
<summary>Improvement beginning with #5865 (capture extent vector removal)</summary>

benchmark | before [ns] | after [ns] | speedup
-- | -- | -- | --
bm_match_sequence_of_as/"a*"/100 | 5859.38 | 2148.44 | 2.73
bm_match_sequence_of_as/"a*"/200 | 10009.8 | 3379.61 | 2.96
bm_match_sequence_of_as/"a*"/400 | 34379 | 5580.36 | 6.16
bm_match_sequence_of_as/"a*?"/100 | 3609.79 | 1967.08 | 1.84
bm_match_sequence_of_as/"a*?"/200 | 6696.43 | 3717.91 | 1.80
bm_match_sequence_of_as/"a*?"/400 | 13183.5 | 6835.94 | 1.93
bm_match_sequence_of_as/"(?:a)*"/100 | 6277.9 | 2622.77 | 2.39
bm_match_sequence_of_as/"(?:a)*"/200 | 10498 | 4237.58 | 2.48
bm_match_sequence_of_as/"(?:a)*"/400 | 36272.3 | 7952.01 | 4.56
bm_match_sequence_of_as/"(a)*"/100 | 20089.5 | 3989.95 | 5.04
bm_match_sequence_of_as/"(a)*"/200 | 38505 | 6835.94 | 5.63
bm_match_sequence_of_as/"(a)*"/400 | 102539 | 32994.1 | 3.11
bm_match_sequence_of_as/"(?:b\|a)*"/100 | 9277.34 | 3923.69 | 2.36
bm_match_sequence_of_as/"(?:b\|a)*"/200 | 17159.8 | 7149.83 | 2.40
bm_match_sequence_of_as/"(?:b\|a)*"/400 | 39236.9 | 13183.5 | 2.98
bm_match_sequence_of_as/"(b\|a)*"/100 | 24588.2 | 6417.41 | 3.83
bm_match_sequence_of_as/"(b\|a)*"/200 | 43945.3 | 16043.5 | 2.74
bm_match_sequence_of_as/"(b\|a)*"/400 | 97656.2 | 53013.4 | 1.84
bm_match_sequence_of_as/"(a)(?:b\|a)*"/100 | 22949.2 | 4464.29 | 5.14
bm_match_sequence_of_as/"(a)(?:b\|a)*"/200 | 41712.6 | 7672.99 | 5.44
bm_match_sequence_of_as/"(a)(?:b\|a)*"/400 | 89979.2 | 14125.2 | 6.37
bm_match_sequence_of_as/"(a)(b\|a)*"/100 | 22460.9 | 6406.25 | 3.51
bm_match_sequence_of_as/"(a)(b\|a)*"/200 | 42968.8 | 14648.4 | 2.93
bm_match_sequence_of_as/"(a)(b\|a)*"/400 | 96256.9 | 53013.4 | 1.82
bm_match_sequence_of_as/"(a)(?:b\|a)*c"/100 | 22495.6 | 5161.83 | 4.36
bm_match_sequence_of_as/"(a)(?:b\|a)*c"/200 | 45515.6 | 10253.9 | 4.44
bm_match_sequence_of_as/"(a)(?:b\|a)*c"/400 | 100442 | 18415.3 | 5.45

</details>