### PR TITLE
Clang support for LWG-3617 `function`/`packaged_task` deduction guides and deducing `this`

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -539,7 +539,7 @@ _MEMBER_CALL_CV_REF_NOEXCEPT(_IS_MEMFUNPTR)
 _CLASS_DEFINE_CV_REF_NOEXCEPT(_IS_MEMFUNPTR_ELLIPSIS)
 #undef _IS_MEMFUNPTR_ELLIPSIS
 
-#if _HAS_CXX23 && !defined(__clang__) // TRANSITION, DevCom-10107077, Clang has not implemented Deducing this
+#if _HAS_CXX23
 #define _IS_MEMFUNPTR_EXPLICIT_THIS_GUIDES(CALL_OPT, CV_OPT, REF_OPT, NOEXCEPT_OPT) \
     template <class _Ret, class _Self, class... _Args>                              \
     struct _Is_memfunptr<_Ret(CALL_OPT*)(_Self, _Args...) NOEXCEPT_OPT> {           \
@@ -553,7 +553,7 @@ _NON_MEMBER_CALL(_IS_MEMFUNPTR_EXPLICIT_THIS_GUIDES, , , noexcept)
 #endif // defined(__cpp_noexcept_function_type)
 
 #undef _IS_MEMFUNPTR_EXPLICIT_THIS_GUIDES
-#endif // _HAS_CXX23 && !defined(__clang__)
+#endif // _HAS_CXX23
 
 #ifdef __clang__
 _EXPORT_STD template <class _Ty>

--- a/tests/std/tests/P0433R2_deduction_guides/test.cpp
+++ b/tests/std/tests/P0433R2_deduction_guides/test.cpp
@@ -37,10 +37,6 @@
 #include <valarray>
 #include <vector>
 
-#if _HAS_CXX23 && !defined(__clang__) // TRANSITION, DevCom-10107077, Clang has not implemented Deducing this
-#define HAS_EXPLICIT_THIS_PARAMETER
-#endif // _HAS_CXX23 && !defined(__clang__)
-
 using namespace std;
 
 template <typename T>
@@ -327,7 +323,7 @@ void test_function_wrapper() {
     static_assert(is_same_v<decltype(f9), F<double(const double&, const double&)>>);
     static_assert(is_same_v<decltype(f10), F<int(int, int)>>);
 
-#ifdef HAS_EXPLICIT_THIS_PARAMETER
+#if _HAS_CXX23
     struct ExplicitThisByVal {
         void operator()(this ExplicitThisByVal, char) {}
     };
@@ -409,7 +405,7 @@ void test_function_wrapper() {
     static_assert(is_same_v<decltype(f25), F<float(double)>>);
     static_assert(is_same_v<decltype(f26), F<float(double)>>);
     static_assert(is_same_v<decltype(f27), F<float(double)>>);
-#endif // HAS_EXPLICIT_THIS_PARAMETER
+#endif // _HAS_CXX23
 }
 
 void test_searchers() {


### PR DESCRIPTION
We merged #2966 on 2022-08-05, shipped in VS 2022 17.4, for MSVC and EDG. At that time, we were requiring Clang 14, which didn't support "deducing `this`".

In VS 2022 17.14, we began requiring Clang 19, which added support for "deducing `this`". I didn't notice this in #5247 merged on 2025-01-24. Nobody else noticed either, but it's my job! :joy_cat:

We should activate the product and test code for this LWG issue resolution for Clang now.