### PR TITLE
`<xlocnum>`: Defend against `sprintf_s()` failure in `num_put::do_put()`

### DIFF
--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -1313,7 +1313,9 @@ protected:
         char _Buf[2 * _Max_int_dig];
         char _Fmt[6];
 
-        const int _Count = _CSTD sprintf_s(_Buf, sizeof(_Buf), _Ifmt(_Fmt, "ld", _Iosbase.flags()), _Val);
+        (void) _Ifmt(_Fmt, "ld", _Iosbase.flags());
+
+        const int _Count = _CSTD sprintf_s(_Buf, sizeof(_Buf), _Fmt, _Val);
 
         if (_Count < 0) { // It should be impossible for sprintf_s() to fail here.
             _STL_INTERNAL_CHECK(false); // In STL tests, report an error.
@@ -1328,7 +1330,9 @@ protected:
         char _Buf[2 * _Max_int_dig];
         char _Fmt[6];
 
-        const int _Count = _CSTD sprintf_s(_Buf, sizeof(_Buf), _Ifmt(_Fmt, "lu", _Iosbase.flags()), _Val);
+        (void) _Ifmt(_Fmt, "lu", _Iosbase.flags());
+
+        const int _Count = _CSTD sprintf_s(_Buf, sizeof(_Buf), _Fmt, _Val);
 
         if (_Count < 0) { // It should be impossible for sprintf_s() to fail here.
             _STL_INTERNAL_CHECK(false); // In STL tests, report an error.
@@ -1343,7 +1347,9 @@ protected:
         char _Buf[2 * _Max_int_dig];
         char _Fmt[8];
 
-        const int _Count = _CSTD sprintf_s(_Buf, sizeof(_Buf), _Ifmt(_Fmt, "Ld", _Iosbase.flags()), _Val);
+        (void) _Ifmt(_Fmt, "Ld", _Iosbase.flags());
+
+        const int _Count = _CSTD sprintf_s(_Buf, sizeof(_Buf), _Fmt, _Val);
 
         if (_Count < 0) { // It should be impossible for sprintf_s() to fail here.
             _STL_INTERNAL_CHECK(false); // In STL tests, report an error.
@@ -1358,7 +1364,9 @@ protected:
         char _Buf[2 * _Max_int_dig];
         char _Fmt[8];
 
-        const int _Count = _CSTD sprintf_s(_Buf, sizeof(_Buf), _Ifmt(_Fmt, "Lu", _Iosbase.flags()), _Val);
+        (void) _Ifmt(_Fmt, "Lu", _Iosbase.flags());
+
+        const int _Count = _CSTD sprintf_s(_Buf, sizeof(_Buf), _Fmt, _Val);
 
         if (_Count < 0) { // It should be impossible for sprintf_s() to fail here.
             _STL_INTERNAL_CHECK(false); // In STL tests, report an error.
@@ -1390,8 +1398,9 @@ protected:
         const auto _Adjusted_flags = // TRANSITION, DevCom-10519861
             _Is_finite ? _Iosbase.flags() : _Iosbase.flags() & ~ios_base::showpoint;
 
-        const int _Count =
-            _CSTD sprintf_s(&_Buf[0], _Buf.size(), _Ffmt(_Fmt, 0, _Adjusted_flags), static_cast<int>(_Precision), _Val);
+        (void) _Ffmt(_Fmt, 0, _Adjusted_flags);
+
+        const int _Count = _CSTD sprintf_s(&_Buf[0], _Buf.size(), _Fmt, static_cast<int>(_Precision), _Val);
 
         if (_Count < 0) { // It should be impossible for sprintf_s() to fail here.
             _STL_INTERNAL_CHECK(false); // In STL tests, report an error.
@@ -1423,8 +1432,9 @@ protected:
         const auto _Adjusted_flags = // TRANSITION, DevCom-10519861
             _Is_finite ? _Iosbase.flags() : _Iosbase.flags() & ~ios_base::showpoint;
 
-        const int _Count = _CSTD sprintf_s(
-            &_Buf[0], _Buf.size(), _Ffmt(_Fmt, 'L', _Adjusted_flags), static_cast<int>(_Precision), _Val);
+        (void) _Ffmt(_Fmt, 'L', _Adjusted_flags);
+
+        const int _Count = _CSTD sprintf_s(&_Buf[0], _Buf.size(), _Fmt, static_cast<int>(_Precision), _Val);
 
         if (_Count < 0) { // It should be impossible for sprintf_s() to fail here.
             _STL_INTERNAL_CHECK(false); // In STL tests, report an error.
@@ -1450,8 +1460,9 @@ protected:
     }
 
 private:
-    char* __CLRCALL_OR_CDECL _Ffmt(
-        char* _Fmt, char _Spec, ios_base::fmtflags _Flags) const { // generate sprintf format for floating-point
+    // TRANSITION, ABI: This always returns _Fmt, which is now ignored.
+    char* __CLRCALL_OR_CDECL _Ffmt(char* _Fmt, char _Spec, ios_base::fmtflags _Flags) const {
+        // generate sprintf format for floating-point
         char* _Ptr = _Fmt;
         *_Ptr++    = '%';
 
@@ -1573,8 +1584,9 @@ private:
         return _Rep(_Dest, _Fill, _Fillcount); // put trailing fill
     }
 
-    char* __CLRCALL_OR_CDECL _Ifmt(
-        char* _Fmt, const char* _Spec, ios_base::fmtflags _Flags) const { // generate sprintf format for integer
+    // TRANSITION, ABI: This always returns _Fmt, which is now ignored.
+    char* __CLRCALL_OR_CDECL _Ifmt(char* _Fmt, const char* _Spec, ios_base::fmtflags _Flags) const {
+        // generate sprintf format for integer
         char* _Ptr = _Fmt;
         *_Ptr++    = '%';
 


### PR DESCRIPTION
Prompted by a customer report (which I'm guessing involved some kind of static analysis tool), internal VSO-2644079.

The `num_put::do_put()` overloads prepare format strings at runtime (controlled by various flags), then they call `sprintf_s()` with appropriately sized buffers. This should always succeed (even if the logic to calculate the size of the floating-point buffers is looser than I'd prefer, with a "fudge factor", I believe the calculated size is never too small). However, we were unconditionally using `static_cast<size_t>` on the return value of [`sprintf_s()`][], which is documented to return "The number of characters written, or -1 if an error occurred." That looks bad, even if no badness happens at runtime.

To improve this, I was inspired by the otherwise-terrible code (see #770) in `money_put::do_put()`, which does handle `sprintf_s()` returning negative values:

https://github.com/microsoft/STL/blob/2e27f1f05a155bb3637dad04b4d9c4c4590c8542/stl/inc/xlocmon#L674-L678

As this should be a can't-happen case, I think that just returning `_Dest` (saying "we didn't write anything") is the simplest option. Throwing an exception would be much more impactful (and we shouldn't throw for STL logic errors). An alternative would be to fastfail in production, similar to what we do for hardening.

I'm additionally extracting the calls to `_Ffmt()` and `_Ifmt()`, which prepare the runtime format strings. There's no functional change, but it makes `num_put::do_put()` easier to understand when we avoid doing tons of things in a single expression.

[`sprintf_s()`]: https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/sprintf-s-sprintf-s-l-swprintf-s-swprintf-s-l?view=msvc-170
