### PR TITLE
Backport LWG-3187 to pre-C++20 modes

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -168,6 +168,9 @@ std/language.support/support.limits/support.limits.general/format.version.compil
 # libc++ doesn't implement LWG-2584 (LLVM-99976)
 std/re/re.regex/re.regex.construct/bad_escape.pass.cpp FAIL
 
+# libc++ doesn't implement LWG-3187
+std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_piecewise_pair_evil.pass.cpp FAIL
+
 # libc++ doesn't implement LWG-3670
 std/ranges/range.factories/range.iota.view/iterator/member_typedefs.compile.pass.cpp FAIL
 
@@ -1206,9 +1209,6 @@ std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_const_move.pass.cpp FAIL
 # Not analyzed, possible path length issue. With a repo root of D:\GitHub\STL (13 characters), fails with:
 # "error RC2136 : missing '=' in EXSTYLE=<flags>" followed by "LINK : fatal error LNK1327: failure during running rc.exe"
 std/thread/thread.mutex/thread.mutex.requirements/thread.sharedtimedmutex.requirements/thread.sharedtimedmutex.class/try_lock_until_deadlock_bug.pass.cpp SKIPPED
-
-# Not analyzed, possible bug in uses_allocator_construction_args
-std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_piecewise_pair_evil.pass.cpp FAIL
 
 # Not analyzed, failing due to constexpr step limits.
 std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.pass.cpp:2 FAIL

--- a/tests/std/tests/Dev11_0343056_pair_tuple_ctor_sfinae/test.cpp
+++ b/tests/std/tests/Dev11_0343056_pair_tuple_ctor_sfinae/test.cpp
@@ -165,52 +165,65 @@ void test_lwg3677_volatile() {
     assert(get<0>(t6).get_payload() == 252);
 }
 
+// LWG-3187 "P0591R4 reverted DR 2586 fixes to scoped_allocator_adaptor::construct()"
 // LWG-4312 "Const and value category mismatch for allocator_arg_t/allocator_arg in the description of uses-allocator
 // construction"
 
-struct allocator_arg_mutable_rvalue_only {
-    allocator_arg_mutable_rvalue_only() = default;
+struct allocator_arg_and_ator_cvref_requirer {
+    allocator_arg_and_ator_cvref_requirer() = default;
 
     template <class A>
-    constexpr allocator_arg_mutable_rvalue_only(allocator_arg_t&&, const A&) {}
+    constexpr allocator_arg_and_ator_cvref_requirer(allocator_arg_t&&, const A&) {}
     template <class A>
-    constexpr allocator_arg_mutable_rvalue_only(allocator_arg_t&&, const A&, const allocator_arg_mutable_rvalue_only&) {
-    }
+    constexpr allocator_arg_and_ator_cvref_requirer(
+        allocator_arg_t&&, const A&, const allocator_arg_and_ator_cvref_requirer&) {}
     template <class A>
-    constexpr allocator_arg_mutable_rvalue_only(allocator_arg_t&&, const A&, allocator_arg_mutable_rvalue_only&&) {}
+    constexpr allocator_arg_and_ator_cvref_requirer(
+        allocator_arg_t&&, const A&, allocator_arg_and_ator_cvref_requirer&&) {}
+
+    template <class T>
+    allocator_arg_and_ator_cvref_requirer(allocator_arg_t&&, T&&) = delete;
+    template <class T>
+    allocator_arg_and_ator_cvref_requirer(
+        allocator_arg_t&&, T&&, const allocator_arg_and_ator_cvref_requirer&) = delete;
+    template <class T>
+    allocator_arg_and_ator_cvref_requirer(allocator_arg_t&&, T&&, allocator_arg_and_ator_cvref_requirer&&) = delete;
 
     template <class A>
-    allocator_arg_mutable_rvalue_only(allocator_arg_t&, const A&) = delete;
+    allocator_arg_and_ator_cvref_requirer(allocator_arg_t&, const A&) = delete;
     template <class A>
-    allocator_arg_mutable_rvalue_only(allocator_arg_t&, const A&, const allocator_arg_mutable_rvalue_only&) = delete;
+    allocator_arg_and_ator_cvref_requirer(
+        allocator_arg_t&, const A&, const allocator_arg_and_ator_cvref_requirer&) = delete;
     template <class A>
-    allocator_arg_mutable_rvalue_only(allocator_arg_t&, const A&, allocator_arg_mutable_rvalue_only&&) = delete;
+    allocator_arg_and_ator_cvref_requirer(allocator_arg_t&, const A&, allocator_arg_and_ator_cvref_requirer&&) = delete;
 
     template <class A>
-    allocator_arg_mutable_rvalue_only(const allocator_arg_t&, const A&) = delete;
+    allocator_arg_and_ator_cvref_requirer(const allocator_arg_t&, const A&) = delete;
     template <class A>
-    allocator_arg_mutable_rvalue_only(
-        const allocator_arg_t&, const A&, const allocator_arg_mutable_rvalue_only&) = delete;
+    allocator_arg_and_ator_cvref_requirer(
+        const allocator_arg_t&, const A&, const allocator_arg_and_ator_cvref_requirer&) = delete;
     template <class A>
-    allocator_arg_mutable_rvalue_only(const allocator_arg_t&, const A&, allocator_arg_mutable_rvalue_only&&) = delete;
+    allocator_arg_and_ator_cvref_requirer(
+        const allocator_arg_t&, const A&, allocator_arg_and_ator_cvref_requirer&&) = delete;
 };
 
 template <class A>
-struct std::uses_allocator<allocator_arg_mutable_rvalue_only, A> : true_type {};
+struct std::uses_allocator<allocator_arg_and_ator_cvref_requirer, A> : true_type {};
 
-CONSTEXPR20 bool test_lwg4312() {
-    tuple<allocator_arg_mutable_rvalue_only> t1{allocator_arg, allocator<int>{}};
-    tuple<allocator_arg_mutable_rvalue_only> t2{allocator_arg, allocator<int>{}, get<0>(t1)};
-    tuple<allocator_arg_mutable_rvalue_only> t3{allocator_arg, allocator<int>{}, allocator_arg_mutable_rvalue_only{}};
+CONSTEXPR20 bool test_lwg4312() { // also test LWG-3187
+    using tuple_type = tuple<allocator_arg_and_ator_cvref_requirer>;
+
+    tuple_type t1{allocator_arg, allocator<int>{}};
+    tuple_type t2{allocator_arg, allocator<int>{}, get<0>(t1)};
+    tuple_type t3{allocator_arg, allocator<int>{}, allocator_arg_and_ator_cvref_requirer{}};
 
     (void) t1;
     (void) t2;
     (void) t3;
 
-    tuple<allocator_arg_mutable_rvalue_only> t4{allocator_arg, payloaded_allocator<int>{42}};
-    tuple<allocator_arg_mutable_rvalue_only> t5{allocator_arg, payloaded_allocator<int>{84}, get<0>(t1)};
-    tuple<allocator_arg_mutable_rvalue_only> t6{
-        allocator_arg, payloaded_allocator<int>{168}, allocator_arg_mutable_rvalue_only{}};
+    tuple_type t4{allocator_arg, payloaded_allocator<int>{42}};
+    tuple_type t5{allocator_arg, payloaded_allocator<int>{84}, get<0>(t4)};
+    tuple_type t6{allocator_arg, payloaded_allocator<int>{168}, allocator_arg_and_ator_cvref_requirer{}};
 
     (void) t4;
     (void) t5;


### PR DESCRIPTION
MSVC STL has completely implemented LWG-3187 (referring to the allocator as a const lvalue in uses-allocator construction) in C++20 and later modes. Before C++20, LWG-3187 (as translated to the pre-C++20 specification) can be considered partially implemented - for uses-allocator construction in `tuple`, but not in the pre-C++20 mechanisms for `scoped_allocator_adaptor` or `polymorphic_allocator`.

This PR changes pre-C++20 mechanisms to use const lvalue references to allocators, and add test coverage for uses-allocator construction in `tuple`, `scoped_allocator_adaptor` and `polymorphic_allocator`.

Drive-by: Get one failed libcxx test analyzed. The failure is due to dependence on using non-const lvalue reference to the allocator, which is made invalid by LWG-3187.