### PR TITLE
Reject overlong forms and out-of-range code points in _Mbrtowc

### DIFF
--- a/stl/src/xmbtowc.cpp
+++ b/stl/src/xmbtowc.cpp
@@ -126,6 +126,12 @@ _MRTIMP2 _Success_(return >= 0) int __cdecl _Mbrtowc(
             }
         }
 
+        // Reject overlong forms and out-of-range code points (see N4950 [locale.codecvt.virtuals]/3)
+        if ((consumedCount == 2 && wch < 0x80u) || (consumedCount == 3 && wch < 0x800u) || wch > 0x10FFFFu) {
+            errno = EILSEQ;
+            return -1;
+        }
+
         if (wch >= 0xD800u && wch <= 0xDFFFu) { // tried to decode unpaired surrogate
             errno = EILSEQ;
             return -1;


### PR DESCRIPTION
Added UTF-8 validation in _Mbrtowc to reject overlong encodings and out-of-range code points, returning EILSEQ instead of accepting ill-formed sequences.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
