### PR TITLE
`<chrono>`: Properly handle `duration` with unsigned rep when formatting

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5612,7 +5612,11 @@ namespace chrono {
                 return true;
             case 'Q':
                 if constexpr (_Is_specialization_v<_Ty, duration>) {
-                    _Os << _STD abs(_Val.count());
+                    if constexpr (is_unsigned_v<typename _Ty::rep>) {
+                        _Os << _Val.count();
+                    } else {
+                        _Os << _STD abs(_Val.count());
+                    }
                 } else {
                     _STL_INTERNAL_CHECK(false);
                 }


### PR DESCRIPTION
Fixed call to `::std::abs(_Val.count())` when formatting duration with conversion specifier `%Q`, as it failed to compile when `_Val` was duration with unsigned representation. Added tests.

Fixes #5945

I have checked the headers `chrono` and `__msvc_chrono` and found no other potentially problematic uses of `abs` - all occurences are in strictly signed context and I found no way for the user to supply unsigned args to them.