### PR TITLE
Test tooling: Use stricter regex for lines in `expected_results.txt` files, provide readable errors for format errors

### DIFF
--- a/tests/utils/stl/test/file_parsing.py
+++ b/tests/utils/stl/test/file_parsing.py
@@ -139,14 +139,14 @@ def parse_result_file(filename: Union[str, bytes, os.PathLike]) \
     for line in parse_commented_file(filename):
         m = _EXPECTED_RESULT_REGEX.match(line)
         if m is None:
-            raise Exception(f'Line "{line}" has incorrect format in {filename}.')
+            raise Exception(f'Incorrectly formatted line "{line}" in {filename}.')
         prefix = m.group("prefix")
         result = m.group("result")
         result_code = getattr(lit.Test, result, None)
         if result_code is None:
             result_code = getattr(stl.test.tests, result, None)
         if result_code is None:
-            raise Exception(f'Unknown result code "{result}" in "{line}" in {filename}.')
+            raise Exception(f'Unknown result code "{result}" in line "{line}" in {filename}.')
         res[prefix] = result_code
 
     _expected_result_entry_cache[str(filename)] = res


### PR DESCRIPTION
When parsing `expected_results.txt` for some test suite, the python script was not ready to handle the following issues:
- Missing result code (only file name present) yielded generic "AttributeError: 'NoneType' object has no attribute 'group'" when attempting to access regex match groups.
- Typo in result code yielded "AttributeError: module 'stl.test.tests' has no attribute", which is arguably better, but still could be better.

Both issues are quite easy to trigger when experimenting with a larger number of tests, so user-friendly error messages seem like a nice touch.