### PR TITLE
`filesystem.cpp`: `__std_fs_write_reparse_data_buffer()` should use the size of the buffer, not buffer pointer

### DIFF
--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -488,7 +488,7 @@ struct __std_fs_file_id { // typedef struct _FILE_ID_INFO {
 [[nodiscard]] __std_win_error __stdcall __std_fs_write_reparse_data_buffer(
     _In_ const __std_fs_file_handle _Handle, _In_ const __std_fs_reparse_data_buffer* const _Buffer) noexcept {
     if (DeviceIoControl(reinterpret_cast<HANDLE>(_Handle), FSCTL_SET_REPARSE_POINT,
-            const_cast<__std_fs_reparse_data_buffer*>(_Buffer), sizeof(_Buffer) + _Buffer->_Reparse_data_length,
+            const_cast<__std_fs_reparse_data_buffer*>(_Buffer), sizeof(*_Buffer) + _Buffer->_Reparse_data_length,
             nullptr, 0, nullptr, nullptr)) {
         return __std_win_error::_Success;
     }


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
