### PR TITLE
format: we need to include the last byte

### DIFF
--- a/stl/src/format.cpp
+++ b/stl/src/format.cpp
@@ -31,7 +31,7 @@ extern "C" [[nodiscard]] __std_win_error __stdcall __std_get_cvt(
             break;
         }
 
-        for (unsigned char _First = _Info.LeadByte[_Idx], _Last = _Info.LeadByte[_Idx + 1]; _First != _Last; ++_First) {
+        for (int _First = _Info.LeadByte[_Idx], _Last = _Info.LeadByte[_Idx + 1]; _First <= _Last; ++_First) {
             _Pcvt->_Isleadbyte[_First >> 3] |= 1u << (_First & 0b111u);
         }
     }


### PR DESCRIPTION
We skip the last byte, which I guess happens to work for us, but is still improper.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
