### PR TITLE
ios_base::_Addstd: need to check last byte

### DIFF
--- a/stl/src/ios.cpp
+++ b/stl/src/ios.cpp
@@ -36,7 +36,7 @@ void __CLRCALL_PURE_OR_CDECL ios_base::_Ios_base_dtor(ios_base* _This) { // dest
 
 void __CLRCALL_PURE_OR_CDECL ios_base::_Addstd(ios_base* _This) { // add standard stream to destructor list
     _BEGIN_LOCK(_LOCK_STREAM)
-    for (_This->_Stdstr = 1; _This->_Stdstr < _Nstdstr; ++_This->_Stdstr) {
+    for (_This->_Stdstr = 1; _This->_Stdstr <= _Nstdstr; ++_This->_Stdstr) {
         if (stdstr[_This->_Stdstr] == nullptr || stdstr[_This->_Stdstr] == _This) {
             break; // found a candidate
         }


### PR DESCRIPTION
wclog is not checked, it seems to be forgotten about when _Addstd is called.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
