### PR TITLE
Add test coverage for `<flat_set>` to `test_header_units_and_modules.hpp`

### DIFF
--- a/tests/std/include/test_header_units_and_modules.hpp
+++ b/tests/std/include/test_header_units_and_modules.hpp
@@ -281,12 +281,12 @@ void test_flat_set() {
     assert(erase_if(fs, simple_truth) == 1);
     assert(fs.empty());
 
-    flat_multiset<int> fss;
-    fss.emplace(42);
-    fss.emplace(42);
-    assert(fss.size() == 2);
-    assert(erase_if(fss, simple_truth) == 2);
-    assert(fss.empty());
+    flat_multiset<int> fms;
+    fms.emplace(42);
+    fms.emplace(42);
+    assert(fms.size() == 2);
+    assert(erase_if(fms, simple_truth) == 2);
+    assert(fms.empty());
 }
 #endif // TEST_STANDARD >= 23
 


### PR DESCRIPTION
Add `<flat_set>` test coverage to `test/std/include/test_header_units_and_modules.hpp`.
Test is consistent with previously existing `<flat_map>` test.

Fixes (see https://discord.com/channels/737189251069771789/1120873380615295027/1450952672982204468)
>[...]. One of FIXMEs is in tests/std/include/test_header_units_and_modules.hpp where we need some coverage of the adaptors (if you look at the other coverage, it intentionally doesn't attempt to exercise everything, just a reasonable test of basic usage so we'll know if modules catastrophically fail to work with the code).