### PR TITLE
`<flat_map>`: Minor cleanups of iterator operations in flat_map members `_Erase_if()` etc.

### DIFF
--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -1073,7 +1073,7 @@ private:
         const auto _Num_sorted = _RANGES is_sorted_until(_Data.keys, _Pass_key_comp()) - _Data.keys.begin();
 
         auto _View                        = _View_to_mutate();
-        auto const _Begin_unsorted_values = _STD begin(_View) + _Num_sorted;
+        const auto _Begin_unsorted_values = _STD begin(_View) + _Num_sorted;
 
         _RANGES sort(_Begin_unsorted_values, _STD end(_View), value_compare{_Key_compare});
         _RANGES inplace_merge(_View, _Begin_unsorted_values, value_compare{_Key_compare});


### PR DESCRIPTION
Minor cleanups without changing meaning - removing single-use local variables and cleanups in iterator arithmetic. Also minor renaming in `_Flat_map_base` for consistency with `_Flat_set_base`.