### PR TITLE
STL.natvis: Add `c_str` intrinsic function

### DIFF
--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -1011,6 +1011,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <Intrinsic Name="bufSize" Expression="16 / sizeof($T1) &lt; 1 ? 1 : 16 / sizeof($T1)" />
     <Intrinsic Name="isShortString" Expression="capacity() &lt; bufSize()" />
     <Intrinsic Name="isLongString" Expression="capacity() &gt;= bufSize()" />
+    <Intrinsic Name="c_str" Expression="const_cast&lt;const $T1*&gt;(isShortString() ? _Mypair._Myval2._Bx._Buf : _Mypair._Myval2._Bx._Ptr)" />
     <DisplayString Condition="isShortString()">{_Mypair._Myval2._Bx._Buf,na}</DisplayString>
     <DisplayString Condition="isLongString()">{_Mypair._Myval2._Bx._Ptr,na}</DisplayString>
     <StringView Condition="isShortString()">_Mypair._Myval2._Bx._Buf,na</StringView>


### PR DESCRIPTION
This PR adds a `c_str` intrinsic function to std::basic_string so that it is easier to compare the value of an std::string in a conditional breakpoint. Ideally, we would also include `operator==` and `operator!=` implementations, but CppDebug doesn't have a good way of implementing that currently, but this is still a useful start.

Example of comparing an std::string too a string literal in a conditional breakpoints with this change: `strcmp(myStdStringVariable.c_str(), "some_literal") == 0`