### PR TITLE
[WIP] Capture memory dumps on STL-ASan-CI test failures

### DIFF
--- a/azure-devops/run-tests.yml
+++ b/azure-devops/run-tests.yml
@@ -20,7 +20,11 @@ steps:
   timeoutInMinutes: 30
   condition: and(succeeded(), ${{ parameters.runTesting }})
   workingDirectory: $(buildOutputLocation)
-  env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
+  env:
+    TMP: $(tmpDir)
+    TEMP: $(tmpDir)
+    ${{ if eq(parameters.testTargets, 'STL-ASan-CI') }}:
+      ASAN_OPTIONS: windows_capture_dump_on_deadly_signal=true
 - task: PublishTestResults@2
   displayName: 'Publish Tests'
   timeoutInMinutes: 5


### PR DESCRIPTION
⚠️ _This is a work in progress_ ⚠️

**Related to:** https://github.com/microsoft/STL/issues/4324

**Context:** 
The STL-ASan-CI pipeline has been flaky in x86 for a long time now. We've made some progress, such as identifying that the issue may be related to a `nullptr` de-reference, and that it seemingly occurs during program shutdown, but we have yet to root cause it.

**This PR** aims to make a dent in root causing the problem by opting in to capturing memory dumps when a program fast-fails.

**The next step** is to kick off the pipeline a few times internally, and confirm this is working / producing dumps (a log should be emitted). Then we'll want to move those dumps to the pipeline attachments area, so they can be further analyzed.