### PR TITLE
Properly cite EDG bug affecting C++20 Down With Typename

### DIFF
--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -1014,7 +1014,7 @@ protected:
     }
 
 private:
-    // FIXME, typename is an EDG workaround
+    // typename is a workaround for VSO-2680018 (EDG)
     template <class _KTy, class _MTy, class _Comp, class _KeyCont, class _MappedCont, class _Pred>
     friend typename flat_map<_KTy, _MTy, _Comp, _KeyCont, _MappedCont>::size_type erase_if(
         flat_map<_KTy, _MTy, _Comp, _KeyCont, _MappedCont>&, _Pred);

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -653,7 +653,7 @@ private:
         }
     }
 
-    // FIXME, typename is an EDG workaround
+    // typename is a workaround for VSO-2680018 (EDG)
     template <class _Kty2, class _Keylt2, class _Container2, class _Pred2>
     friend typename _Container2::size_type erase_if(flat_set<_Kty2, _Keylt2, _Container2>&, _Pred2);
     template <class _Kty2, class _Keylt2, class _Container2, class _Pred2>


### PR DESCRIPTION
I finally got around to reporting VSO-2680018 "EDG doesn't implement C++20 Down With Typename for return types of friend functions":

```
C:\Temp>type meow.cpp
```
```cpp
template <typename T>
struct Iterator {
    using Diff = int;
};

struct Sentinel {
    template <typename T>
    friend Iterator<T>::Diff operator-(Sentinel, Iterator<T>) {
        return 0;
    }
};

int main() {
    Sentinel s;
    Iterator<double> i;
    s - i;
}
```
```
C:\Temp>cl /EHsc /nologo /W4 /std:c++20 /c meow.cpp
meow.cpp

C:\Temp>clang-cl /EHsc /nologo /W4 /std:c++20 /c meow.cpp

C:\Temp>cl /EHsc /nologo /W4 /std:c++20 /c /BE meow.cpp
meow.cpp
"meow.cpp", line 8: error: use the 'typename' keyword to treat nontype
          "Iterator<T>::Diff [with T=T]" as a type in a dependent context
      friend Iterator<T>::Diff operator-(Sentinel, Iterator<T>) {
             ^
```