### PR TITLE
`<flat_meow>`: Implement natvis visualizers for `flat_multimeow`, simplify visualizer for `flat_map`

### DIFF
--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -2325,7 +2325,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
   <!-- fallback when the primary visualization (above) fails to parse, e.g. some custom containers -->
   <Type Name="std::flat_map&lt;*&gt;" Priority="MediumLow">
-    <DisplayString>{_Data}</DisplayString>
+    <AlternativeType Name="std::flat_multimap&lt;*&gt;"/>
+    <Intrinsic Name="size" Expression="_Data.keys.size()"/>
+    <DisplayString>{{ size={size()} }}</DisplayString>
     <Expand>
       <Item Name="[comparator]" ExcludeView="simple">_Key_compare</Item>
       <Item Name="[keys]">_Data.keys</Item>


### PR DESCRIPTION
Revisit natvis definitions for `flat_meow`: remove unnecessary special cases for `flat_map` without changing the visualization.

- Use the same visualizer for `flat_(multi)set`
- Remove all special cases for `flat_map` and merge them into a single definition.
- Use the same visualizer for `flat_(multi)map`

Towards #5950 