### PR TITLE
`<regex>`: Skip initial NFA nodes that do nothing during matching

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1700,7 +1700,7 @@ class _Matcher3 { // provides ways to match a regular expression to a text seque
 public:
     _Matcher3(_It _Pfirst, _It _Plast, const _RxTraits& _Tr, _Root_node* _Re, unsigned int _Nx,
         regex_constants::syntax_option_type _Sf, regex_constants::match_flag_type _Mf)
-        : _Begin(_Pfirst), _End(_Plast), _Rep(_Re), _Sflags(_Sf), _Mflags(_Mf), _Ncap(_Nx),
+        : _Begin(_Pfirst), _End(_Plast), _Sflags(_Sf), _Mflags(_Mf), _Ncap(_Nx),
           _Longest((_Re->_Flags & _Fl_longest) && !(_Mf & regex_constants::match_any)), _Traits(_Tr) {
         _Loop_vals.resize(_Re->_Loops);
         _Adl_verify_range(_Pfirst, _Plast);
@@ -1719,6 +1719,12 @@ public:
         _Iter_diff_t<_It> _Input_length = _STD distance(_Pfirst, _Plast);
         _Frames_limit                   = _Calculate_frames_limit(_Input_length);
         _Complexity_limit               = _Calculate_complexity_limit(_Input_length);
+
+        // TRANSITION, ABI, GH-6025:
+        // The first two nodes are of types _N_begin and _N_capture with capturing group 0.
+        // These nodes do not affect the state of the matcher and thus can be skipped immediately
+        // before engaging the expensive NFA interpreter loop.
+        _Start = _Re->_Next->_Next;
 
 // sanitize multiline mode setting
 #if _REGEX_LEGACY_MULTILINE_MODE
@@ -1763,7 +1769,7 @@ public:
 
         _Matched = false;
 
-        bool _Succeeded = _Match_pat(_Rep) || _Matched;
+        bool _Succeeded = _Match_pat(_Start) || _Matched;
 
         if (!_Succeeded) {
             return false;
@@ -1832,7 +1838,7 @@ private:
 
     _It _Begin;
     _It _End;
-    _Node_base* _Rep;
+    _Node_base* _Start;
     regex_constants::syntax_option_type _Sflags;
     regex_constants::match_flag_type _Mflags;
     bool _Matched = false;
@@ -3997,14 +4003,13 @@ bool _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _N
                 { // record current position
                     auto _Node = static_cast<_Node_capture*>(_Nx);
                     auto _Idx  = _Node->_Idx;
-                    if (_Idx != 0U) {
-                        auto& _Group        = _Tgt_state._Grps[_Idx];
-                        auto _Frame_idx     = _Push_frame(_Rx_unwind_ops::_Capture_restore_begin, _Node);
-                        auto& _Frame        = _Frames[_Frame_idx];
-                        _Frame._Pos         = _Group._Begin;
-                        _Frame._Capture_idx = _Idx;
-                        _Group._Begin       = _Tgt_state._Cur;
-                    }
+                    _STL_INTERNAL_CHECK(_Idx != 0U);
+                    auto& _Group        = _Tgt_state._Grps[_Idx];
+                    auto _Frame_idx     = _Push_frame(_Rx_unwind_ops::_Capture_restore_begin, _Node);
+                    auto& _Frame        = _Frames[_Frame_idx];
+                    _Frame._Pos         = _Group._Begin;
+                    _Frame._Capture_idx = _Idx;
+                    _Group._Begin       = _Tgt_state._Cur;
                     break;
                 }
 
@@ -4469,7 +4474,7 @@ _BidIt _Matcher3<_BidIt, _Elem, _RxTraits, _It, _Alloc>::_Skip(
     static constexpr wchar_t _Line_terminators_wchar_t[] = {static_cast<wchar_t>(_Meta_cr),
         static_cast<wchar_t>(_Meta_nl), static_cast<wchar_t>(_Meta_ls), static_cast<wchar_t>(_Meta_ps)};
     constexpr unsigned int _Max_recursion_depth          = 50U;
-    _Node_base* _Nx                                      = _Node_arg ? _Node_arg : _Rep;
+    _Node_base* _Nx                                      = _Node_arg ? _Node_arg : _Start;
 
     while (_First_arg != _Last && _Nx) { // check current node
         switch (_Nx->_Kind) { // handle current node's type


### PR DESCRIPTION
The NFA generated by the parser always starts with two nodes of type `_N_begin` and `_N_capture` for capturing group 0. However, the matcher does nothing when it encounters these nodes.

While we cannot avoid generating these nodes in the first place (see #6025), this PR skips these nodes during matching to avoid the comparatively expensive (and, in the case of `regex_search()`, potentially repeated) processing of these two nodes by the NFA interpreter.

The improvement vanishes in the noise in the regex_match benchmark on my machine (it probably saves about 5 ns per match and that is just too little), but it is noticeable in the regex_search benchmark (especially in those examples where regex matching is attempted in many different positions in the string).

benchmark | before [ns] | after [ns] | speedup
-- | -- | -- | --
bm_lorem_search/"^bibe"/2 | 69.7545 | 64.5229 | 1.08
bm_lorem_search/"^bibe"/3 | 73.2422 | 64.1741 | 1.14
bm_lorem_search/"^bibe"/4 | 74.986 | 61.3839 | 1.22
bm_lorem_search/"bibe"/2 | 3515.63 | 3222.66 | 1.09
bm_lorem_search/"bibe"/3 | 6835.94 | 5998.88 | 1.14
bm_lorem_search/"bibe"/4 | 12555.8 | 12276.8 | 1.02
bm_lorem_search/"bibe".collate/2 | 3278.46 | 3208.7 | 1.02
bm_lorem_search/"bibe".collate/3 | 6556.92 | 6138.39 | 1.07
bm_lorem_search/"bibe".collate/4 | 13113.8 | 12834.8 | 1.02
bm_lorem_search/"(bibe)"/2 | 7951.97 | 7847.38 | 1.01
bm_lorem_search/"(bibe)"/3 | 15694.8 | 15380.8 | 1.02
bm_lorem_search/"(bibe)"/4 | 30762.2 | 30133.8 | 1.02
bm_lorem_search/"(bibe)+"/2 | 13392.9 | 12555.7 | 1.07
bm_lorem_search/"(bibe)+"/3 | 24309.4 | 25111.6 | 0.97
bm_lorem_search/"(bibe)+"/4 | 50224.3 | 47571.3 | 1.06
bm_lorem_search/"(?:bibe)+"/2 | 7500 | 6975.45 | 1.08
bm_lorem_search/"(?:bibe)+"/3 | 14125.2 | 14195.1 | 1.00
bm_lorem_search/"(?:bibe)+"/4 | 27622.6 | 26994.9 | 1.02
bm_lorem_search/R"(\bbibe)"/2 | 133929 | 88936.9 | 1.51
bm_lorem_search/R"(\bbibe)"/3 | 260911 | 184168 | 1.42
bm_lorem_search/R"(\bbibe)"/4 | 516183 | 368369 | 1.40
bm_lorem_search/R"(\Bibe)"/2 | 324693 | 245857 | 1.32
bm_lorem_search/R"(\Bibe)"/3 | 645229 | 495550 | 1.30
bm_lorem_search/R"(\Bibe)"/4 | 1311380 | 976562 | 1.34
bm_lorem_search/R"((?=....)bibe)"/2 | 5468.75 | 5156.25 | 1.06
bm_lorem_search/R"((?=....)bibe)"/3 | 10498 | 10498 | 1.00
bm_lorem_search/R"((?=....)bibe)"/4 | 21972.7 | 19042.7 | 1.15
bm_lorem_search/R"((?=bibe)....)"/2 | 5156.25 | 5336.23 | 0.97
bm_lorem_search/R"((?=bibe)....)"/3 | 9591.24 | 9416.81 | 1.02
bm_lorem_search/R"((?=bibe)....)"/4 | 19496.1 | 19252.4 | 1.01
bm_lorem_search/R"((?!lorem)bibe)"/2 | 4865.38 | 4708.44 | 1.03
bm_lorem_search/R"((?!lorem)bibe)"/3 | 10044.6 | 9207.55 | 1.09
bm_lorem_search/R"((?!lorem)bibe)"/4 | 18415.3 | 18031.6 | 1.02