### PR TITLE
`<flat_map>`, `<flat_set>`: Use inverse key_compare instead of synthesized equivalence

### DIFF
--- a/stl/inc/flat_map
+++ b/stl/inc/flat_map
@@ -1123,8 +1123,9 @@ private:
             return [](const_reference _Left, const_reference _Right)
                        _STATIC_CALL_OPERATOR { return _Left.first == _Right.first; };
         } else {
-            return
-                [this](const_reference _Left, const_reference _Right) { return _Key_equal(_Left.first, _Right.first); };
+            return [this](const_reference _Left, const_reference _Right) {
+                return !_Key_compare(_Left.first, _Right.first);
+            };
         }
     }
 

--- a/stl/inc/flat_set
+++ b/stl/inc/flat_set
@@ -713,8 +713,7 @@ private:
         if constexpr (_Equivalence_is_equality<_Keylt, _Kty>) {
             return equal_to<>{};
         } else {
-            return
-                [this](const _Kty& _Lhs, const _Kty& _Rhs) { return !_Compare(_Lhs, _Rhs) && !_Compare(_Rhs, _Lhs); };
+            return [this](const _Kty& _Lhs, const _Kty& _Rhs) { return !_Compare(_Lhs, _Rhs); };
         }
     }
 


### PR DESCRIPTION
Fixes #6027

As @StephanTLavavej observed, `unique` passes predicate arguments in the guaranteed order, so we don't need a specialized algorithm.