### PR TITLE
`STL.natvis`: add `extents` visualizer

### DIFF
--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -2256,4 +2256,46 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     </Expand>
   </Type>
 
+  <Type Name="std::extents&lt;*&gt;">
+    <DisplayString>{{ rank={_Rank}, rank_dynamic={_Rank_dynamic} }}</DisplayString>
+    <Expand>
+      <!-- Mixed static and dynamic extents -->
+      <CustomListItems Condition="_Rank != _Rank_dynamic" Optional="true">
+        <Variable Name="idx" InitialValue="0" />
+        <Variable Name="statptr" InitialValue="(const rank_type*) _Static_extents._Elems" />
+        <Variable Name="dynptr" InitialValue="($T1*) _Array._Elems" />
+        <Loop>
+          <Break Condition="idx == _Rank" />
+          <If Condition="*statptr == -1">
+            <Item Name="[{idx}] dynamic extent">*dynptr</Item>
+            <Exec>++dynptr</Exec>
+          </If>
+          <Item Condition="*statptr != -1" Name="[{idx}] static extent">($T1) *statptr</Item>
+          <Exec>++idx, ++statptr</Exec>
+        </Loop>
+      </CustomListItems>
+
+    <!-- Fully dynamic extents -->
+    <CustomListItems Condition="_Rank == _Rank_dynamic" Optional="true">
+      <Variable Name="idx" InitialValue="0" />
+      <Variable Name="dynptr" InitialValue="($T1*) _Array._Elems" />
+      <Loop>
+        <Break Condition="idx == _Rank_dynamic" />
+        <Item Name="[{idx}] dynamic extent">*dynptr</Item>
+        <Exec>++idx, ++dynptr</Exec>
+      </Loop>
+    </CustomListItems>
+
+    <!-- Fully static extents -->
+    <CustomListItems Condition="_Rank_dynamic == 0" Optional="true">
+      <Variable Name="idx" InitialValue="0" />
+      <Variable Name="statptr" InitialValue="(const rank_type*) _Static_extents._Elems" />
+      <Loop>
+        <Break Condition="idx == _Rank" />
+        <Item Name="[{idx}] static extent">($T1) *statptr</Item>
+        <Exec>++idx, ++statptr</Exec>
+      </Loop>
+    </CustomListItems>
+    </Expand>
+  </Type>
 </AutoVisualizer>


### PR DESCRIPTION
Before:
![natvis_before](https://github.com/user-attachments/assets/a0b85b9b-1328-4482-a2a4-ab2883b07389)

After:
![natvis_after](https://github.com/user-attachments/assets/88440a66-66f1-422c-ab11-e8cd3b53f002)

<details>
<summary>before-after code</summary>

  ```c++
#include <mdspan>

using namespace std;

int main() {
	extents<signed char> e0;

	extents<unsigned short, 2, 3> e1;
	(void)e1.extent(0);
	(void)e1.static_extent(0);
	
	dextents<int, 2> e2(5, 7);
	(void)e2.extent(0);
	(void)e2.static_extent(0);

	extents<unsigned long, dynamic_extent, dynamic_extent, 17> e3(11, 13);
	(void)e3.extent(0);
	(void)e3.static_extent(0);

	extents<long long, 19, 23, dynamic_extent, 31> e4(29);
	(void)e4.extent(0);
	(void)e4.static_extent(0);
}
  ```
</details>