### PR TITLE
`<regex>`: Fix reentrant loops containing backreferences

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1269,18 +1269,18 @@ _INLINE_VAR constexpr unsigned int _Bmp_size  = (_Bmp_max + _Bmp_chrs - 1U) / _B
 _INLINE_VAR constexpr unsigned int _ARRAY_THRESHOLD = 4U;
 
 enum _Node_flags : int { // flags for nfa nodes with special properties
-    _Fl_none              = 0x000,
-    _Fl_negate            = 0x001,
-    _Fl_greedy            = 0x002,
-    _Fl_longest           = 0x008, // TRANSITION, ABI: 0x004 is unused; the parser previously marked some nodes with it
-    _Fl_class_negated_w   = 0x100,
-    _Fl_class_negated_s   = 0x200,
-    _Fl_class_negated_d   = 0x400,
-    _Fl_class_cl_all_bits = 0x800, // TRANSITION, ABI: GH-5242
-    _Fl_begin_needs_w     = 0x100,
-    _Fl_begin_needs_s     = 0x200,
-    _Fl_begin_needs_d     = 0x400,
-    _Fl_rep_branchless    = 0x800,
+    _Fl_none              = 0x0000,
+    _Fl_negate            = 0x0001,
+    _Fl_greedy            = 0x0002,
+    _Fl_longest           = 0x0008, // TRANSITION, ABI: 0x004 is unused; the parser previously marked some nodes with it
+    _Fl_class_negated_w   = 0x0100,
+    _Fl_class_negated_s   = 0x0200,
+    _Fl_class_negated_d   = 0x0400,
+    _Fl_class_cl_all_bits = 0x0800, // TRANSITION, ABI: GH-5242
+    _Fl_begin_needs_w     = 0x0100,
+    _Fl_begin_needs_s     = 0x0200,
+    _Fl_begin_needs_d     = 0x0400,
+    _Fl_rep_branchless    = 0x1000,
 };
 
 _BITMASK_OPS(_EMPTY_ARGUMENT, _Node_flags)
@@ -5511,6 +5511,14 @@ void _Parser2<_FwdIt, _Elem, _RxTraits>::_Calculate_loop_simplicity(
             }
             break;
 
+        case _N_back:
+            if (_Outer_rep && !_Nonreentrant) {
+                // The content and thus length of a back-reference may change
+                // when a loop is reentered
+                _Outer_rep->_Flags &= ~_Fl_rep_branchless;
+            }
+            break;
+
         case _N_group:
         case _N_capture:
         case _N_none:
@@ -5523,7 +5531,6 @@ void _Parser2<_FwdIt, _Elem, _RxTraits>::_Calculate_loop_simplicity(
         case _N_end_group:
         case _N_end_assert:
         case _N_end_capture:
-        case _N_back:
         case _N_endif:
         case _N_begin:
         case _N_end:

--- a/tests/std/tests/VSO_0000000_regex_use/test.cpp
+++ b/tests/std/tests/VSO_0000000_regex_use/test.cpp
@@ -2437,6 +2437,8 @@ void test_gh_6022() {
     g_regexTester.should_not_match(
         "bacabcdacdabbaddabbcdcdba", R"((?:(?:([abc])([abc]))*d)*cabcdacdabbaddabbcdcd\1\2)");
     g_regexTester.should_match("bacabcdacdabbaddabbcdcd", R"((?:(?:([abc])([abc]))*d)*bacabcdacdabbaddabbcdcd\1\2)");
+
+    g_regexTester.should_match("abaaacaabaaaadab", R"((?:(a*)b(\1*)a*c)+aabaaaad\2b)");
 }
 
 int main() {


### PR DESCRIPTION
I introduced a subtle bug in #6022: I missed that there are loops that get marked as branchless but can match strings of different lengths, so the value of `_Loop_length` in the loop state can change. This applies to loops with backreferences, since the length of the captured string might have changed when the loop is reentered.

The problem is that `_Loop_length` is used during unwinding of branchless/simple loops, but its value is not restored during backtracking.

I see two ways to fix this:

* The matcher restores `_Loop_length`  like `_Loop_frame_idx` and `_Loop_idx` during backtracking. But there is no unused memory to store this value on the stack, so we would have to add a new frame to the stack or increase the size of each frame. 
* The parser does not mark loops containing backreferences as branchless if they are reentrant (even though they are branchless, strictly speaking).

Given that this is about relatively rare regexes that contain subpatterns like `(prefix(\1)*suffix)*`, the first option seems like a waste of memory pessimizing more common regexes. For this reason, I went for the latter option.

`_N_rep`, `_N_if`, `_N_assert` and `_N_class` (if collating elements are contained) are other node types that can cause a loop to match strings or capturing groups of different lengths. but they are already handled. The remaining node types always match strings of the same length.

While debugging this, I was a bit annoyed that the debugger showed the `_Fl_rep_branchless` flag under the name `_Fl_class_cl_all_bits`, so I moved the flag to another free bit for the `_N_rep` node type in this PR. (We could also reuse mask `0x0004`, since the old parser never set this bit on nodes of type `_N_rep`, but this is probably unnecessarily subtle while we still have plenty of bits available.)