### PR TITLE
Added Arm64 feature detections in STL

### DIFF
--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -92,7 +92,7 @@ namespace {
     bool _Use_FEAT_BitPerm() noexcept {
         return IsProcessorFeaturePresent(PF_ARM_SVE_BITPERM_INSTRUCTIONS_AVAILABLE);
     }
-#endif //^^^ defined(_M_ARM64) ^^^
+#endif // ^^^ defined(_M_ARM64) ^^^
 
     size_t _Byte_length(const void* const _First, const void* const _Last) noexcept {
         return static_cast<const unsigned char*>(_Last) - static_cast<const unsigned char*>(_First);


### PR DESCRIPTION
Added Arm64 feature detections in STL

FEAT_DotProd (PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE)
FEAT_I8MM (PF_ARM_V82_I8MM_INSTRUCTIONS_AVAILABLE)
FEAT_SHA3 (PF_ARM_SHA3_INSTRUCTIONS_AVAILABLE)
FEAT_SVE (PF_ARM_SVE_INSTRUCTIONS_AVAILABLE)
FEAT_SVE2 (PF_ARM_SVE2_INSTRUCTIONS_AVAILABLE)
FEAT_SVE2p1 (PF_ARM_SVE2_1_INSTRUCTIONS_AVAILABLE)
FEAT_SVE_SHA3 (PF_ARM_SVE_SHA3_INSTRUCTIONS_AVAILABLE)
FEAT_SVE_AES (PF_ARM_SVE_AES_INSTRUCTIONS_AVAILABLE)
FEAT_SVE_BitPerm (PF_ARM_SVE_BITPERM_INSTRUCTIONS_AVAILABLE)

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
