### PR TITLE
`<iomanip>`: Add missing Mandates to `get_money`/`put_money`

### DIFF
--- a/stl/inc/iomanip
+++ b/stl/inc/iomanip
@@ -95,11 +95,15 @@ struct _Monobj { // store reference to monetary amount
 
 _EXPORT_STD template <class _Money>
 _NODISCARD _Monobj<_Money> get_money(_Money& _Val_arg, bool _Intl_arg = false) {
+    static_assert(is_same_v<_Money, long double> || _Is_specialization_v<_Money, basic_string>,
+        "_Money must be either long double or a basic_string specialization (N5032 [ext.manip]/2).");
     return _Monobj<_Money>(_Val_arg, _Intl_arg);
 }
 
 _EXPORT_STD template <class _Money>
 _NODISCARD _Monobj<const _Money> put_money(const _Money& _Val_arg, bool _Intl_arg = false) {
+    static_assert(is_same_v<_Money, long double> || _Is_specialization_v<_Money, basic_string>,
+        "_Money must be either long double or a basic_string specialization (N5032 [ext.manip]/5).");
     return _Monobj<const _Money>(_Val_arg, _Intl_arg);
 }
 


### PR DESCRIPTION
MSVC STL currently accepts the following example which violates [[ext.manip]/2](https://eel.is/c++draft/ext.manip#2) and [[ext.manip]/5](https://eel.is/c++draft/ext.manip#5). [Godbolt link](https://godbolt.org/z/aTdoKWMnG).

```C++
#include <functional>
#include <iomanip>
#include <istream>
#include <ostream>
#include <string>

void test(std::istream& is, std::ostream& os) {
    struct xstr : std:: string {};
    xstr x;

    is >> std::get_money(x);
    os << std::put_money(x);

    long double y{};
    auto ref_y = std::ref(y);
    is >> std::get_money(ref_y);
    os << std::put_money(ref_y);
}
```

We need to require that `_Money` is exactly `long double` or `basic_string`, not another convertible/deducible type.