### PR TITLE
Use `extern "C++"` scopes for explicit specializations after P2615R1 Meaningful Exports

### DIFF
--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -803,7 +803,9 @@ _NODISCARD int _Codecvt_do_length(
 
 enum _Codecvt_mode { _Consume_header = 4, _Generate_header = 2 };
 
-extern "C++" template <>
+extern "C++" {
+
+template <>
 class _CRTIMP2_PURE_IMPORT_UNLESS_CODECVT_ID_SATELLITE _CXX20_DEPRECATE_CODECVT_FACETS
     codecvt<char16_t, char, mbstate_t> : public codecvt_base {
     // facet for converting between char16_t and UTF-8 byte sequences
@@ -1101,7 +1103,7 @@ private:
     _Codecvt_mode _Mode; // default: _Consume_header
 };
 
-extern "C++" template <>
+template <>
 class _CRTIMP2_PURE_IMPORT_UNLESS_CODECVT_ID_SATELLITE _CXX20_DEPRECATE_CODECVT_FACETS
     codecvt<char32_t, char, mbstate_t> : public codecvt_base {
     // facet for converting between char32_t and UTF-8 byte sequences
@@ -1355,7 +1357,7 @@ struct _NODISCARD _Codecvt_guard {
     }
 };
 
-extern "C++" template <>
+template <>
 class _CXX20_DEPRECATE_CODECVT_CHAR8_T_FACETS codecvt<char16_t, char8_t, mbstate_t> : public codecvt_base {
     // facet for converting between UTF-16 and UTF-8 sequences
 public:
@@ -1636,7 +1638,7 @@ protected:
     }
 };
 
-extern "C++" template <>
+template <>
 class _CXX20_DEPRECATE_CODECVT_CHAR8_T_FACETS codecvt<char32_t, char8_t, mbstate_t> : public codecvt_base {
     // facet for converting between UTF-32 and UTF-8 sequences
 public:
@@ -1879,7 +1881,7 @@ protected:
 };
 #endif // defined(__cpp_char8_t) && !defined(_M_CEE_PURE)
 
-extern "C++" template <>
+template <>
 class _CRTIMP2_PURE_IMPORT codecvt<wchar_t, char, mbstate_t> : public codecvt_base {
     // facet for converting between wchar_t and char (_Byte) sequences
 public:
@@ -2078,7 +2080,7 @@ private:
 };
 
 #if defined(_NATIVE_WCHAR_T_DEFINED) && !_ENFORCE_FACET_SPECIALIZATIONS
-extern "C++" template <>
+template <>
 class _CRTIMP2_PURE_IMPORT codecvt<unsigned short, char, mbstate_t> : public codecvt_base {
     // facet for converting between unsigned short and char sequences
 public:
@@ -2278,6 +2280,8 @@ private:
     _Locinfo::_Cvtvec _Cvt; // locale info passed to _Mbrtowc, _Wcrtomb
 };
 #endif // defined(_NATIVE_WCHAR_T_DEFINED) && !_ENFORCE_FACET_SPECIALIZATIONS
+
+} // extern "C++"
 
 _EXPORT_STD template <class _Elem, class _Byte, class _Statype>
 class codecvt_byname : public codecvt<_Elem, _Byte, _Statype> {
@@ -2637,7 +2641,9 @@ locale::id ctype<_Elem>::id;
 #pragma clang diagnostic pop
 #endif // defined(__clang__)
 
-extern "C++" template <>
+extern "C++" {
+
+template <>
 class _CRTIMP2_PURE_IMPORT ctype<char> : public ctype_base { // facet for classifying char elements, converting cases
 public:
     using _Elem     = char;
@@ -2827,7 +2833,7 @@ private:
     _Locinfo::_Ctypevec _Ctype; // information
 };
 
-extern "C++" template <>
+template <>
 class _CRTIMP2_PURE_IMPORT
     ctype<wchar_t> : public ctype_base { // facet for classifying wchar_t elements, converting cases
 public:
@@ -3028,7 +3034,7 @@ private:
 };
 
 #if defined(_NATIVE_WCHAR_T_DEFINED) && !_ENFORCE_FACET_SPECIALIZATIONS
-extern "C++" template <>
+template <>
 class _CRTIMP2_PURE_IMPORT
     ctype<unsigned short> : public ctype_base { // facet for classifying unsigned short elements, converting cases
 public:
@@ -3234,6 +3240,8 @@ private:
     _Locinfo::_Cvtvec _Cvt; // conversion information
 };
 #endif // defined(_NATIVE_WCHAR_T_DEFINED) && !_ENFORCE_FACET_SPECIALIZATIONS
+
+} // extern "C++"
 
 _EXPORT_STD template <class _Elem>
 class ctype_byname : public ctype<_Elem> { // ctype for named locale


### PR DESCRIPTION
WG21-P2615R1 Meaningful Exports forbids `extern "C++"` from being directly applied to an explicit specialization. Now, every *declaration* is either a *name-declaration* or a *special-declaration*. An *explicit-specialization* is considered a *special-declaration*. But when directly applying `extern "C++"`, the grammar for *linkage-specialization* requires that the `extern` *string-literal* *name-declaration* syntax cannot accept a *special-declaration*.

Clang 17 [implemented](https://clang.llvm.org/cxx_status.html#cxx20) P2615R1 as a DR in C++20 mode, but as of Clang 20 they don't enforce this rule (yet?). @xiangfan-ms brought this to my attention as he was implementing P2615R1 in MSVC.

The fix is simple: use `extern "C++" { ... }` scopes. 

I am allowing the `_Codecvt_guard` helper to permanently remain in this scope, as it's not harmful, and I didn't think it was worth the effort to pull outside of the scope. (Indeed, right now the entire STL is marked with `extern "C++"` as a workaround.)