### PR TITLE
Update comments to reflect standardized predicate move guarantee;

### DIFF
--- a/tests/std/tests/P0896R4_views_drop_while/test.cpp
+++ b/tests/std/tests/P0896R4_views_drop_while/test.cpp
@@ -425,7 +425,7 @@ int main() {
     static_assert((instantiation_test(), true));
     instantiation_test();
 
-    { // Validate **non-standard guarantee** that predicates are moved into the range adaptor closure, and into the view
+    { // Validate guarantee that predicates are moved into the range adaptor closure, and into the view
         // object from an rvalue closure
         struct Fn {
             Fn()     = default;

--- a/tests/std/tests/P0896R4_views_filter/test.cpp
+++ b/tests/std/tests/P0896R4_views_filter/test.cpp
@@ -427,8 +427,8 @@ int main() {
     static_assert((instantiation_test(), true));
     instantiation_test();
 
-    { // Validate **non-standard guarantee** that predicates are moved into the range adaptor closure, and into the view
-      // object from an rvalue closure
+    { // Validate guarantee that predicates are moved into the range adaptor closure, and into
+      // the view object from an rvalue closure
         struct Fn {
             Fn()     = default;
             Fn(Fn&&) = default;

--- a/tests/std/tests/P0896R4_views_take_while/test.cpp
+++ b/tests/std/tests/P0896R4_views_take_while/test.cpp
@@ -523,7 +523,7 @@ int main() {
     static_assert((instantiation_test(), true));
     instantiation_test();
 
-    { // Validate **non-standard guarantee** that predicates are moved into the range adaptor closure, and into the view
+    { // Validate guarantee that predicates are moved into the range adaptor closure, and into the view
         // object from an rvalue closure
         struct Fn {
             Fn()     = default;

--- a/tests/std/tests/P0896R4_views_transform/test.cpp
+++ b/tests/std/tests/P0896R4_views_transform/test.cpp
@@ -917,7 +917,7 @@ int main() {
     static_assert((iterator_instantiation_test(), true));
     iterator_instantiation_test();
 
-    { // Validate **non-standard guarantee** that predicates are moved into the range adaptor closure, and into the view
+    { // Validate guarantee that predicates are moved into the range adaptor closure, and into the view
       // object from an rvalue closure
         struct Fn {
             Fn()     = default;


### PR DESCRIPTION
P2281R1 standardized moving predicates into range adaptor closures and views from
rvalue closures, so this behavior is no longer non-standard. Updated comments to
match the current standard.

Closes #6077 