### PR TITLE
These tests appear to be passing under ASan

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -263,12 +263,6 @@ std/language.support/support.dynamic/new.delete/new.delete.array/new.size_nothro
 std/language.support/support.dynamic/new.delete/new.delete.single/new.size_align_nothrow.pass.cpp:1 FAIL
 std/language.support/support.dynamic/new.delete/new.delete.single/new.size_nothrow.pass.cpp:1 FAIL
 
-# Not analyzed. SKIPPED because this is x86-specific.
-# ERROR: AddressSanitizer: allocator is out of memory trying to allocate NNNN bytes
-std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_strong.pass.cpp:1 SKIPPED
-std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_weak.pass.cpp:1 SKIPPED
-std/input.output/syncstream/osyncstream/thread/several_threads.pass.cpp:1 SKIPPED
-
 
 # *** MISSING STL FEATURES ***
 # Missing mbrtoc8 and c8rtomb


### PR DESCRIPTION
<details>
<summary>Manually verified with ASan</summary>

```

C:\Project\STL>cmake --preset x86 -DSTL_ASAN_BUILD=ON
-- The CXX compiler identification is MSVC 19.50.35724.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/18/Insiders/VC/Tools/MSVC/14.50.35717/bin/Hostx64/x86/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- The ASM_MASM compiler identification is MSVC
-- Found assembler: C:/Program Files/Microsoft Visual Studio/18/Insiders/VC/Tools/MSVC/14.50.35717/bin/Hostx64/x86/ml.exe
-- Found clang-format: C:/Program Files/Microsoft Visual Studio/18/Insiders/VC/Tools/Llvm/x64/bin/clang-format.exe (found expected version "20.1.8")
-- Building with ASan enabled
-- Boost.Math: standalone mode ON
-- Configuring done (5.5s)
-- Generating done (1.9s)
-- Build files have been written to: C:/Project/STL/out/x86

C:\Project\STL>cmake --build --preset x86
[762/762] Linking CXX static library out\lib\i386\libcpmtd0.lib

C:\Project\STL>cd \Project\STL\out\x86

C:\Project\STL\out\x86>python tests\utils\stl-lit\stl-lit.py -Dtags=ASAN ..\..\llvm-project\libcxx\test\std\atomics/atomics.types.generic/atomics.types.float
NOTE: Module "psutil" is not installed, so the priority setting "idle" has no effect.
-- Testing: 54 tests, 12 workers --
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/types.compile.pass.cpp:0 (1 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/notify_one.pass.cpp:0 (2 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/exchange.pass.cpp:0 (3 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/exchange.pass.cpp:2 (4 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/store.pass.cpp:0 (5 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/types.compile.pass.cpp:2 (6 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/store.pass.cpp:2 (7 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/assign.pass.cpp:0 (8 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/operator.plus_equals.pass.cpp:2 (9 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/assign.pass.cpp:2 (10 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/operator.plus_equals.pass.cpp:0 (11 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/lockfree.pass.cpp:0 (12 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/lockfree.pass.cpp:2 (13 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/notify_one.pass.cpp:2 (14 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/fetch_sub.pass.cpp:0 (15 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/fetch_sub.pass.cpp:2 (16 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/operator.float.pass.cpp:0 (17 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/operator.float.pass.cpp:2 (18 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/notify_all.pass.cpp:0 (19 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/notify_all.pass.cpp:2 (20 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/fetch_add.pass.cpp:0 (21 of 54)
PASS: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/types.compile.pass.cpp:1 (22 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/fetch_add.pass.cpp:2 (23 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/operator.minus_equals.pass.cpp:0 (24 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/operator.minus_equals.pass.cpp:2 (25 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/ctor.pass.cpp:0 (26 of 54)
PASS: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/lockfree.pass.cpp:1 (27 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/ctor.pass.cpp:2 (28 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/wait.pass.cpp:0 (29 of 54)
PASS: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/ctor.pass.cpp:1 (30 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/wait.pass.cpp:2 (31 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/load.pass.cpp:0 (32 of 54)
PASS: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/operator.float.pass.cpp:1 (33 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/load.pass.cpp:2 (34 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_weak.pass.cpp:0 (35 of 54)
PASS: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/assign.pass.cpp:1 (36 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_weak.pass.cpp:2 (37 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/copy.compile.pass.cpp:0 (38 of 54)
PASS: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/operator.plus_equals.pass.cpp:1 (39 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/copy.compile.pass.cpp:2 (40 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_strong.pass.cpp:0 (41 of 54)
PASS: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/copy.compile.pass.cpp:1 (42 of 54)
SKIPPED: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_strong.pass.cpp:2 (43 of 54)
PASS: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/operator.minus_equals.pass.cpp:1 (44 of 54)
PASS: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/exchange.pass.cpp:1 (45 of 54)
PASS: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/fetch_sub.pass.cpp:1 (46 of 54)
PASS: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/fetch_add.pass.cpp:1 (47 of 54)
PASS: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/store.pass.cpp:1 (48 of 54)
PASS: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/load.pass.cpp:1 (49 of 54)
PASS: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/notify_one.pass.cpp:1 (50 of 54)
PASS: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/notify_all.pass.cpp:1 (51 of 54)
PASS: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/wait.pass.cpp:1 (52 of 54)
PASS: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_weak.pass.cpp:1 (53 of 54)
PASS: libc++ :: std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_strong.pass.cpp:1 (54 of 54)

Testing Time: 14.27s

Total Discovered Tests: 54
  Skipped: 36 (66.67%)
  Passed : 18 (33.33%)

C:\Project\STL\out\x86>python tests\utils\stl-lit\stl-lit.py -Dtags=ASAN ..\..\llvm-project\libcxx\test\std\input.output/syncstream/osyncstream/thread -v
NOTE: Module "psutil" is not installed, so the priority setting "idle" has no effect.
-- Testing: 6 tests, 6 workers --
SKIPPED: libc++ :: std/input.output/syncstream/osyncstream/thread/basic.pass.cpp:2 (1 of 6)
SKIPPED: libc++ :: std/input.output/syncstream/osyncstream/thread/basic.pass.cpp:0 (2 of 6)
SKIPPED: libc++ :: std/input.output/syncstream/osyncstream/thread/several_threads.pass.cpp:0 (3 of 6)
SKIPPED: libc++ :: std/input.output/syncstream/osyncstream/thread/several_threads.pass.cpp:2 (4 of 6)
PASS: libc++ :: std/input.output/syncstream/osyncstream/thread/basic.pass.cpp:1 (5 of 6)
PASS: libc++ :: std/input.output/syncstream/osyncstream/thread/several_threads.pass.cpp:1 (6 of 6)

Testing Time: 10.68s

Total Discovered Tests: 6
  Skipped: 4 (66.67%)
  Passed : 2 (33.33%)

```
</details>