### PR TITLE
`<regex>`: Implement small buffer optimization to store loop state

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1649,7 +1649,7 @@ private:
     using _Al_pointer   = _Alloc_ptr_t<_Alloc>;
     using _Al_size_type = _Alloc_size_t<_Alloc>;
 
-    struct _Val {
+    struct _Buffer_range {
         _Al_pointer _First{};
         _Al_pointer _Last{};
         bool _Allocated{false};
@@ -1745,7 +1745,7 @@ private:
         _Guard._Ptr      = nullptr;
     }
 
-    _Compressed_pair<_Alloc, _Val> _Mypair;
+    _Compressed_pair<_Alloc, _Buffer_range> _Mypair;
 };
 
 template <class _BidIt>


### PR DESCRIPTION
Disclaimer: Low-level memory management is not my forte, because I mostly write Java code in my day-to-day job.

Towards #5969.

This implements a minimal fixed-size buffer to support some small buffer optimizations during regex matching. In the first step, this fixed-size buffer is only used for the loop state storage (because this requires minimal changes in the matcher), but I plan to use it to store the state of capturing groups as well in follow-up PRs. For frames, we rather need a vector-like data structure that can grow but uses stack storage when the number of frames is few.

The fixed-size buffer takes an allocator in preparation for #174.

Since I want to use some common storage space on the stack for all of these buffers, the stack storage is not an internal member of the buffers but supplied as a pointer to them from the outside. The fixed-size buffer reports back to what extent it has made use of the stack storage. (We don't need this in this PR yet, because the stack storage is only by a single fixed-size buffer. But this will change when more buffers make use of the stack storage.)

The stack storage is also not a member of `_Matcher3` so that we can adjust its size in the future without having to rename the class.

I wasn't sure what exception to throw if too much memory is requested from the fixed-size buffer, but then went with `regex_error(error_stack)` because I would like to avoid exceptions not of type `regex_error` and the description of `error_stack` is "There was insufficient memory to determine whether the regular expression could match the specified character sequence." (The other candidate is `error_space`. But it is described as "There was insufficient memory to convert the expression into a finite state machine.", so it appears to be intended for parsing and not matching.)

I do wonder whether we should call `std::launder()` when repurposing the stack storage (here, specifically, in `_Rx_fixed_size_buffer::_Use_external_buf()`). But it seems this isn't done elsewhere in the STL, including `_Optimistic_temporary_buffer`.

## Benchmarks

I highlighted the relevant lines in `regex_search` where the matcher uses some loop state. (The `regex_match` benchmark is inconclusive, the difference vanishes in the noise on my machine.)

benchmark | before [ns] | after [ns] | speedup
-- | -- | -- | --
bm_lorem_search/"^bibe"/2 | 57.20 | 59.99 | 0.95
bm_lorem_search/"^bibe"/3 | 58.59 | 59.38 | 0.99
bm_lorem_search/"^bibe"/4 | 61.38 | 58.59 | 1.05
bm_lorem_search/"bibe"/2 | 3048.28 | 2849.48 | 1.07
bm_lorem_search/"bibe"/3 | 6093.75 | 5719.87 | 1.07
bm_lorem_search/"bibe"/4 | 11439.70 | 11474.60 | 1.00
bm_lorem_search/"bibe".collate/2 | 3076.18 | 3138.95 | 0.98
bm_lorem_search/"bibe".collate/3 | 5937.50 | 5781.25 | 1.03
bm_lorem_search/"bibe".collate/4 | 11718.80 | 11160.70 | 1.05
bm_lorem_search/"(bibe)"/2 | 6975.45 | 7324.22 | 0.95
bm_lorem_search/"(bibe)"/3 | 14299.70 | 14229.90 | 1.00
bm_lorem_search/"(bibe)"/4 | 28250.40 | 28250.40 | 1.00
**bm_lorem_search/"(bibe)+"/2** | **12207.00** | **11090.90** | **1.10**
**bm_lorem_search/"(bibe)+"/3** | **23541.90** | **22216.50** | **1.06**
**bm_lorem_search/"(bibe)+"/4** | **43946.30** | **43526.20** | **1.01**
**bm_lorem_search/"(?:bibe)+"/2** | **6975.45** | **5937.50** | **1.17**
**bm_lorem_search/"(?:bibe)+"/3** | **13497.40** | **11230.50** | **1.20**
**bm_lorem_search/"(?:bibe)+"/4** | **26681.00** | **22949.20** | **1.16**
bm_lorem_search/R"(\bbibe)"/2 | 83705.40 | 81961.50 | 1.02
bm_lorem_search/R"(\bbibe)"/3 | 168795.00 | 167411.00 | 1.01
bm_lorem_search/R"(\bbibe)"/4 | 336967.00 | 314991.00 | 1.07
bm_lorem_search/R"(\Bibe)"/2 | 184168.00 | 187976.00 | 0.98
bm_lorem_search/R"(\Bibe)"/3 | 360695.00 | 385010.00 | 0.94
bm_lorem_search/R"(\Bibe)"/4 | 749860.00 | 739397.00 | 1.01
bm_lorem_search/R"((?=....)bibe)"/2 | 4865.38 | 4865.38 | 1.00
bm_lorem_search/R"((?=....)bibe)"/3 | 10044.60 | 9626.07 | 1.04
bm_lorem_search/R"((?=....)bibe)"/4 | 19252.40 | 19043.00 | 1.01
bm_lorem_search/R"((?=bibe)....)"/2 | 4854.90 | 4603.80 | 1.05
bm_lorem_search/R"((?=bibe)....)"/3 | 9207.55 | 9207.55 | 1.00
bm_lorem_search/R"((?=bibe)....)"/4 | 17996.80 | 17578.30 | 1.02
bm_lorem_search/R"((?!lorem)bibe)"/2 | 4589.84 | 4589.84 | 1.00
bm_lorem_search/R"((?!lorem)bibe)"/3 | 8719.31 | 8893.69 | 0.98
bm_lorem_search/R"((?!lorem)bibe)"/4 | 17089.80 | 17089.80 | 1.00