### PR TITLE
`<filesystem>`: Fix `weakly_canonical` for drive-relative paths like `"C:bar"`

### DIFF
--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -4137,6 +4137,24 @@ namespace filesystem {
 
         bool _Call_canonical = true;
 
+        // GH-6054: Fix drive-relative paths like "C:bar".
+        // For such paths, root_path() is just the root-name "C:" (no root-directory).
+        // Canonicalize "C:" first (to the current directory on that drive), then append relative elements.
+        if (_Call_canonical && _Normalized.has_root_name() && !_Normalized.has_root_directory()) {
+            _Temp.clear();
+
+            const auto _Err = _Canonical(_Temp, _Result.native());
+
+            if (_Err == __std_win_error::_Success) {
+                _Result = _STD move(_Temp);
+            } else if (__std_is_file_not_found(_Err)) {
+                _Call_canonical = false; // match the loop's behavior
+            } else {
+                _Ec = _Make_ec(_Err);
+                return {};
+            }
+        }
+
         for (const auto& _Elem : _Normalized_relative) {
             _Result /= _Elem;
 


### PR DESCRIPTION
Fixes #6054

## Problem

On Windows, drive-relative paths such as "C:bar" are relative to the
current directory on that drive. However, `std::filesystem::weakly_canonical`
currently returns "C:bar" instead of anchoring the root-name ("C:")
to the drive's current directory (e.g. "C:\Temp\bar").

This happens because the implementation appends path elements before
canonicalizing the drive-relative root-name.

## Fix

When the normalized path has a root-name but no root-directory
(i.e. drive-relative paths like "C:bar"), canonicalize the root-name
("C:") first before appending remaining elements.

This aligns behavior with Windows drive-relative path semantics, where
"C:foo" is relative to the current directory on drive C rather than the
drive root.

Previously, weakly_canonical appended path elements before resolving
the drive-relative root, which produced incorrect results such as
returning "C:bar" instead of an absolute path.

## Test

Added Windows-only regression coverage in
`P0218R1_filesystem::test_weakly_canonical()` verifying:

- "C:" resolves to the drive's current directory
- "C:foo\\bar" resolves relative to that directory
- "C:bar" resolves to `<cwd>\\bar`

The test restores `current_path` to avoid leaking process state.
