### PR TITLE
Vector algorithms: Add compile time checks for ISA features

### DIFF
--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -29,7 +29,7 @@ extern "C" long __isa_enabled;
 namespace {
 #if !defined(_M_ARM64) && !defined(_M_ARM64EC)
     bool _Use_avx2() noexcept {
-        return __check_arch_support(__IA_SUPPORT_VECTOR256, 0) || __isa_enabled & (1 << __ISA_AVAILABLE_AVX2);
+        return __check_arch_support(__IA_SUPPORT_VECTOR256, 0) || (__isa_enabled & (1 << __ISA_AVAILABLE_AVX2));
     }
 
     bool _Use_sse42() noexcept {


### PR DESCRIPTION
When the STL is compiled with /arch:SSE4.2 or /arch:AVX2, the runtime checks for the respective ISA features (SSE42, AVX2) are unnecessary. This change adds a compile time check using __check_arch_support to avoid the runtime cost.
