### PR TITLE
Update libcxx for an upcoming MSVC compiler fix

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1276,3 +1276,7 @@ std/iterators/iterator.container/ssize.LWG3207.compile.pass.cpp:9 SKIPPED
 
 # This test is marked as `REQUIRES: target={{.+}}-apple-{{.+}}`.
 std/input.output/file.streams/fstreams/filebuf.virtuals/overflow.writefail.pass.cpp:9 SKIPPED
+
+# This test has one check guarded in a "not CLANG" block, but upcoming MSVC will implement the
+# same behavior for binding an xvalue conversion function result to a const lvalue reference.
+std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp:9 SKIPPED


### PR DESCRIPTION
This reverse-mirrors @joemmett's MSVC-PR-689579 "Fix VSO-2742607: some `__reference_constructs_from_temporary` issues", which I reported while working on #6095.