### PR TITLE
Add Neon bitmap implementation of `find_first_of`

### DIFF
--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -5818,7 +5818,9 @@ namespace {
             template <class _Ty>
             __forceinline bool _Make_bitmap_large_neon(
                 const void* const _Needle, const size_t _Needle_length, uint8x16x2_t& _Bitmap) noexcept {
-                static constexpr uint8_t _Mask_arr[16] = {
+                // TRANSITION, not yet reported: Unlike for x64, where `static constexpr` arrays improve codegen,
+                // `static constexpr` would degrade codegen here.
+                constexpr uint8_t _Mask_arr[16] = {
                     0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80};
                 const auto _Mask = vld1q_u8(_Mask_arr);
 


### PR DESCRIPTION
This PR adds a Neon bitmap implementation of `find_first_of`.

Benchmark results:
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/harlim01/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/harlim01/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">

</head>

<body link="#467886" vlink="#96607D">


  | MSVC | Clang
-- | -- | --
bm<AlgType::str_member_first,   char>/2/3 | 0.955 | 1.012
bm<AlgType::str_member_first,   char>/6/81 | 1.023 | 0.993
bm<AlgType::str_member_first,   char>/7/4 | 0.96 | 0.889
bm<AlgType::str_member_first,   char>/9/3 | 0.782 | 0.803
bm<AlgType::str_member_first,   char>/22/5 | 0.837 | 0.814
bm<AlgType::str_member_first,   char>/58/2 | 0.721 | 0.756
bm<AlgType::str_member_first,   char>/75/85 | 1.41 | 1.327
bm<AlgType::str_member_first,   char>/102/4 | 0.836 | 0.818
bm<AlgType::str_member_first,   char>/200/46 | 2.4 | 2.185
bm<AlgType::str_member_first,   char>/325/1 | 1.053 | 1.052
bm<AlgType::str_member_first,   char>/400/50 | 3.225 | 2.875
bm<AlgType::str_member_first,   char>/1011/11 | 3.422 | 3.407
bm<AlgType::str_member_first,   char>/1280/46 | 5.238 | 3.924
bm<AlgType::str_member_first,   char>/1502/23 | 5.106 | 4.261
bm<AlgType::str_member_first,   char>/2203/54 | 4.778 | 4.259
bm<AlgType::str_member_first,   char>/3056/7 | 2.337 | 2.337
bm<AlgType::str_member_first,   wchar_t>/2/3 | 1.025 | 1
bm<AlgType::str_member_first,   wchar_t>/6/81 | 0.978 | 0.998
bm<AlgType::str_member_first,   wchar_t>/7/4 | 0.906 | 0.986
bm<AlgType::str_member_first,   wchar_t>/9/3 | 1.004 | 1
bm<AlgType::str_member_first,   wchar_t>/22/5 | 0.933 | 0.931
bm<AlgType::str_member_first,   wchar_t>/58/2 | 0.921 | 0.862
bm<AlgType::str_member_first,   wchar_t>/75/85 | 1.346 | 1.385
bm<AlgType::str_member_first,   wchar_t>/102/4 | 1.039 | 1.007
bm<AlgType::str_member_first,   wchar_t>/200/46 | 1.997 | 2.034
bm<AlgType::str_member_first,   wchar_t>/325/1 | 1.045 | 1.051
bm<AlgType::str_member_first,   wchar_t>/400/50 | 2.556 | 2.556
bm<AlgType::str_member_first,   wchar_t>/1011/11 | 3.143 | 3.295
bm<AlgType::str_member_first,   wchar_t>/1280/46 | 3.333 | 3.259
bm<AlgType::str_member_first,   wchar_t>/1502/23 | 3.401 | 3.487
bm<AlgType::str_member_first,   wchar_t>/2203/54 | 3.364 | 3.419
bm<AlgType::str_member_first,   wchar_t>/3056/7 | 2.8 | 2.864
bm<AlgType::str_member_first,   char32_t>/2/3 | 1.022 | 0.995
bm<AlgType::str_member_first,   char32_t>/6/81 | 1 | 0.978
bm<AlgType::str_member_first,   char32_t>/7/4 | 0.95 | 0.99
bm<AlgType::str_member_first,   char32_t>/9/3 | 0.936 | 0.94
bm<AlgType::str_member_first,   char32_t>/22/5 | 1.017 | 0.98
bm<AlgType::str_member_first,   char32_t>/58/2 | 0.81 | 0.989
bm<AlgType::str_member_first,   char32_t>/75/85 | 1.217 | 1.208
bm<AlgType::str_member_first,   char32_t>/102/4 | 1.609 | 1.68
bm<AlgType::str_member_first,   char32_t>/200/46 | 1.789 | 1.712
bm<AlgType::str_member_first,   char32_t>/325/1 | 1.146 | 0.889
bm<AlgType::str_member_first,   char32_t>/400/50 | 2.034 | 1.993
bm<AlgType::str_member_first,   char32_t>/1011/11 | 2.256 | 2.332
bm<AlgType::str_member_first,   char32_t>/1280/46 | 2.391 | 2.353
bm<AlgType::str_member_first,   char32_t>/1502/23 | 2.546 | 2.415
bm<AlgType::str_member_first,   char32_t>/2203/54 | 2.477 | 2.406
bm<AlgType::str_member_first,   char32_t>/3056/7 | 2.419 | 2.475
bm<AlgType::str_member_first_not,   char>/2/3 | 0.964 | 1.023
bm<AlgType::str_member_first_not,   char>/6/81 | 0.978 | 0.952
bm<AlgType::str_member_first_not,   char>/7/4 | 0.896 | 0.873
bm<AlgType::str_member_first_not,   char>/9/3 | 0.772 | 0.793
bm<AlgType::str_member_first_not,   char>/22/5 | 0.857 | 0.797
bm<AlgType::str_member_first_not,   char>/58/2 | 0.762 | 0.788
bm<AlgType::str_member_first_not,   char>/75/85 | 1.201 | 1.327
bm<AlgType::str_member_first_not,   char>/102/4 | 0.874 | 0.874
bm<AlgType::str_member_first_not,   char>/200/46 | 1.839 | 2.185
bm<AlgType::str_member_first_not,   char>/325/1 | 0.853 | 0.944
bm<AlgType::str_member_first_not,   char>/400/50 | 2.634 | 2.819
bm<AlgType::str_member_first_not,   char>/1011/11 | 3.5 | 3.481
bm<AlgType::str_member_first_not,   char>/1280/46 | 3.477 | 3.886
bm<AlgType::str_member_first_not,   char>/1502/23 | 3.628 | 4.249
bm<AlgType::str_member_first_not,   char>/2203/54 | 3.663 | 4.13
bm<AlgType::str_member_first_not,   char>/3056/7 | 2.326 | 2.381
bm<AlgType::str_member_first_not,   wchar_t>/2/3 | 1.032 | 1.016
bm<AlgType::str_member_first_not,   wchar_t>/6/81 | 0.978 | 1.023
bm<AlgType::str_member_first_not,   wchar_t>/7/4 | 0.926 | 0.993
bm<AlgType::str_member_first_not,   wchar_t>/9/3 | 1 | 0.976
bm<AlgType::str_member_first_not,   wchar_t>/22/5 | 0.936 | 0.959
bm<AlgType::str_member_first_not,   wchar_t>/58/2 | 0.955 | 1.023
bm<AlgType::str_member_first_not,   wchar_t>/75/85 | 1.385 | 1.442
bm<AlgType::str_member_first_not,   wchar_t>/102/4 | 1.022 | 1.023
bm<AlgType::str_member_first_not,   wchar_t>/200/46 | 2.054 | 2.098
bm<AlgType::str_member_first_not,   wchar_t>/325/1 | 1.071 | 1.045
bm<AlgType::str_member_first_not,   wchar_t>/400/50 | 2.621 | 2.621
bm<AlgType::str_member_first_not,   wchar_t>/1011/11 | 3.261 | 3.402
bm<AlgType::str_member_first_not,   wchar_t>/1280/46 | 3.333 | 3.333
bm<AlgType::str_member_first_not,   wchar_t>/1502/23 | 3.566 | 3.487
bm<AlgType::str_member_first_not,   wchar_t>/2203/54 | 3.439 | 3.444
bm<AlgType::str_member_first_not,   wchar_t>/3056/7 | 2.995 | 2.927



</body>

</html>
