### PR TITLE
`<regex>`: Add test coverage for capture group reset between match attempts in `regex_search()`

### DIFF
--- a/tests/std/tests/VSO_0000000_regex_use/test.cpp
+++ b/tests/std/tests/VSO_0000000_regex_use/test.cpp
@@ -2441,6 +2441,20 @@ void test_gh_6022() {
     g_regexTester.should_match("abaaacaabaaaadab", R"((?:(a*)b(\1*)a*c)+aabaaaad\2b)");
 }
 
+void test_gh_6118() {
+    // GH-6118: regex_search() sometimes incorrectly matches capturing groups
+    // regex_search() failed to reset capture groups between match attempts.
+    {
+        test_regex re_matching_inbetween(&g_regexTester, "a|(b)c");
+        re_matching_inbetween.should_search_match_capture_groups("ba", "a", match_default, {{-1, -1}});
+    }
+
+    {
+        test_regex re_matching_at_end(&g_regexTester, "$|(b)c");
+        re_matching_at_end.should_search_match_capture_groups("b", "", match_default, {{-1, -1}});
+    }
+}
+
 int main() {
     test_dev10_449367_case_insensitivity_should_work();
     test_dev11_462743_regex_collate_should_not_disable_regex_icase();
@@ -2503,6 +2517,7 @@ int main() {
     test_gh_5939();
     test_gh_5944();
     test_gh_6022();
+    test_gh_6118();
 
     return g_regexTester.result();
 }


### PR DESCRIPTION
We failed to notice that we regressed #6118 and that we later fixed it again. The regression and the fix were subtle side effects of changes that were intended to fix other issues in the capture group handling in the regex matcher (#5456, #5865 and #5918). But we didn't realize the impact on the capture group reset between match attempts in `regex_search()` for any of them.

This PR adds some minimal test coverage for the capture group reset in `regex_search()` so that we will not accidentally regress this again. Each test case covers one of the two `_Matcher3::_Match()` calls in `regex_search` after the initial match attempt.

I confirmed that MSVC Build Tools 19.50 fails both test cases.