### PR TITLE
Vector algorithms: trim runtime coverage for ARM64EC non-vectorized fallbacks

### DIFF
--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -1441,18 +1441,6 @@ void test_vector_algorithms(mt19937_64& gen) {
     test_swap_arrays<uint64_t, 512>(gen);
 }
 
-void test_vector_algorithms_fallbacks(mt19937_64& gen) {
-    test_min_max_element<long long>(gen);
-    test_min_max_element<unsigned long long>(gen);
-
-    test_min_max_element_pointers(gen);
-
-    test_replace<int>(gen);
-    test_replace<unsigned int>(gen);
-    test_replace<long long>(gen);
-    test_replace<unsigned long long>(gen);
-}
-
 template <typename Container1, typename Container2>
 void test_two_containers() {
     Container1 one                  = {10, 20, 30, 40, 50};
@@ -1967,14 +1955,24 @@ int main() {
     assert(test_constexpr());
 #endif // _HAS_CXX20
     run_randomized_tests_with_different_isa_levels([](mt19937_64& gen) {
-#ifndef _CALL_ALL_X64_VECTOR_ALGORITHMS_ON_ARM64EC
+#ifdef _CALL_ALL_X64_VECTOR_ALGORITHMS_ON_ARM64EC
+        // Test the algorithms that *aren't* vectorized for ARM64EC:
+        test_min_max_element<long long>(gen);
+        test_min_max_element<unsigned long long>(gen);
+
+        test_min_max_element_pointers(gen);
+
+        test_replace<int>(gen);
+        test_replace<unsigned int>(gen);
+        test_replace<long long>(gen);
+        test_replace<unsigned long long>(gen);
+
+        test_bitset(gen);
+#else // ^^^ defined(_CALL_ALL_X64_VECTOR_ALGORITHMS_ON_ARM64EC) / normal test coverage vvv
         test_vector_algorithms(gen);
         test_various_containers();
         test_bitset(gen);
         test_string(gen);
-#else // ^ !defined(_CALL_ALL_X64_VECTOR_ALGORITHMS_ON_ARM64EC) / defined(_CALL_ALL_X64_VECTOR_ALGORITHMS_ON_ARM64EC) v
-        test_vector_algorithms_fallbacks(gen);
-        test_bitset(gen);
-#endif // ^^^ !defined(_CALL_ALL_X64_VECTOR_ALGORITHMS_ON_ARM64EC) ^^^
+#endif // ^^^ normal test coverage ^^^
     });
 }


### PR DESCRIPTION
Follow up on #6107.

We can't have complexity in test matrices, especially for internal test runs, so let's trim the excess coverage otherwise.

I know it still adds some complexity in another place, so it is still controversial.

Trim random coverage, which is time-consuming, for the algorithms that are vectorized everywhere and don't have fallbacks.
After #6141, #6139, and #6143 this excludes all string algorithms. The following are left: `bitset`, `replace`, and `minmax_element` for 64-bit integers and pointers.

Deliberately avoided checking for `_VECTORIZED_*` macros. We still need `_USE_STD_VECTOR_ALGORITHMS=0` coverage intact, and we need the machinery to be tested independently.