### PR TITLE
`<regex>`: Tolerate iterators with `explicit` default ctors

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1841,8 +1841,8 @@ private:
 
 template <class _BidIt>
 struct _Rx_capture_range_t { // stores a pair of iterators
-    _BidIt _Begin;
-    _BidIt _End;
+    _BidIt _Begin{};
+    _BidIt _End{};
 };
 
 template <class _BidIt, class _Alloc>


### PR DESCRIPTION
Fixes internal VSO-2800682.

#6092 followed by #6127 implemented a small buffer optimization storing (potentially user-defined) iterators in an aggregate `_Rx_capture_range_t<_BidIt>`, then constructing that aggregate with `_Ty{}`:

https://github.com/microsoft/STL/blob/8f6bbd3ecb2447f49a28a8924b2cd1162b1f5fad/stl/inc/regex#L1842-L1846
https://github.com/microsoft/STL/blob/8f6bbd3ecb2447f49a28a8924b2cd1162b1f5fad/stl/inc/regex#L1748

This is sensitive to `explicit` default ctors, through Standardese that I was previously unfamiliar with. WG21-N5032 \[dcl.init.aggr\]/5:

> For a non-union aggregate, each element that is not an explicitly initialized element is initialized as follows:
> - If the element has a default member initializer (\[class.mem\]), the element is initialized from that initializer.
> - Otherwise, if the element is not a reference, the element is copy-initialized from an empty initializer list (\[dcl.init.list\]).
> - Otherwise, the program is ill-formed.

The phrase "copy-initialized from an empty initializer list" is what rejects `explicit` default ctors.

Interestingly, the Standard requires forward-or-stronger iterators to be default-constructible, but only explicitly.
\[forward.iterators\]/1.2 "A class or pointer type `X` meets the *Cpp17ForwardIterator* requirements if \[...\] `X` meets the *Cpp17DefaultConstructible* requirements", then \[tab:cpp17.defaultconstructible\] requires only `T t;`, `T u{};`, `T()`, `T{}`.

We can fix our code by adding DMIs to activate [dcl.init.aggr\]/5.1, which is a good idea in any event (helps avoid garbage-init).

Related: https://github.com/notepad-plus-plus/notepad-plus-plus/pull/17816
