### PR TITLE
Add `/INFERASANLIBS` to the Clang ARM64 workarounds

### DIFF
--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -4,6 +4,7 @@
 // REQUIRES: x64 || x86 || arm64
 
 #if defined(__clang__) && defined(_M_ARM64) // TRANSITION, LLVM-184902, fixed in Clang 23
+#pragma comment(linker, "/INFERASANLIBS")
 int main() {}
 #else // ^^^ workaround / no workaround vvv
 

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -4,6 +4,7 @@
 // REQUIRES: x64 || x86 || arm64
 
 #if defined(__clang__) && defined(_M_ARM64) // TRANSITION, LLVM-184902, fixed in Clang 23
+#pragma comment(linker, "/INFERASANLIBS")
 int main() {}
 #else // ^^^ workaround / no workaround vvv
 


### PR DESCRIPTION
Followup to #6157's sub-commit "Tests: Enable ASan annotation tests for ARM64, except Clang."

The MSVC-internal test harness lacks this workaround:
https://github.com/microsoft/STL/blob/83a261c44dfbe0b7be33a478aa39802c026517c3/tests/utils/stl/test/tests.py#L349-L351

And to work around https://github.com/llvm/llvm-project/pull/184902 everywhere (GitHub and MSVC), I had to avoid all `#include` directives (which could drag in global initializers that would then crash due to the compiler bug), which also avoided picking up:

https://github.com/microsoft/STL/blob/83a261c44dfbe0b7be33a478aa39802c026517c3/stl/inc/__msvc_sanitizer_annotate_container.hpp#L71-L81

The result is that these tests, newly enabled for ARM64, became successfully empty-ish for GitHub (compiled with `-fsanitize=address` and linked with `/INFERASANLIBS`), but failed to link for the MSVC-internal test harness (compiled with `-fsanitize=address`, but not linked with `/INFERASANLIBS`).

Adding these pragmas to the workaround paths should get the Clang ARM64 configurations passing internally. Reverse-mirrored from MSVC-PR-718376 where I'm verifying that.

(This wasn't noticed until after merging, because the MSVC-internal test harness doesn't run ARM64 by default for PRs, only in CIs. Why yes I am having an excellent Monday, why do you ask.)