### PR TITLE
`<regex>`: Some `_Matcher3::Skip()` cleanups

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -2190,7 +2190,7 @@ public:
         return true;
     }
 
-    _It _Skip(_It, _It, const _Node_base* = nullptr, unsigned int _Recursion_depth = 0U);
+    _It _Skip(_It _First, _It _Last, const _Node_base* _Node_arg = nullptr, unsigned int _Recursion_depth = 0U);
 
 private:
     _Tgt_state_type _Tgt_state;


### PR DESCRIPTION
This PR performs some cleanups to `_Matcher3::_Skip()` that I don't want to mix with the performance work in `_Skip()` to close the big gap with Boost.Regex for disjunctive regexes.

Each cleanup is split into its own commit.

* `_First_arg` => `_First`: I think the local variable was named `_First_arg` to avoid shadowing the member `_First` of `_Matcher3`. But this member was removed a while ago, so we can rename the local variable to the more common name `_First` now.
* add const: The lack of `const` is pervasive in `<regex>`. I have to admit I didn't really cared about this until now because there were more much important problems to solve, but we should change this especially for any pointers to NFA nodes in the matcher. This adds `const` to `_Skip()` and applies the minimally necessary const propagation to `_Do_class()`.
* correct `_Skip` signature: `_Skip()` had the wrong signature: Its callers pass iterators of type `_It` and all functions called internally return `_It` or iterators of the same type they are called with. But even so, the function signature stated that `_Skip()` would take iterators of type `_BidIt` and return an iterator of type `_BidIt`.[^1]
* name all parameters in declaration: I'm not sure whether we should assign names to the parameters in function declarations or not. But assigning parameters to some of them but not all is strange.

[^1]: I think  `_BidIt` is intended to refer to the wrapped and `_It` to the unwrapped iterator type. But this intention hasn't been followed through on. This signature change fixes one inconsistency, but there is at least another one when assigning the capturing group iterators to `match_results` in `_Matcher3::_Match()`. And the apparent consequence of these inconsistencies is that the `regex_match()/search()/replace()` wrappers always set `_BidIt` and `_It` to denote the same type.