### PR TITLE
`<__msvc_threads_core.hpp>`: Revert `alignas` changes that broke `mutex` and `condition_variable` for `/clr`

### DIFF
--- a/stl/inc/__msvc_threads_core.hpp
+++ b/stl/inc/__msvc_threads_core.hpp
@@ -43,6 +43,7 @@ struct _Mtx_internal_imp_t {
     int _Type{};
     union {
         _Stl_critical_section _Critical_section{};
+        // TRANSITION, VSO-1659383 and VSO-2616030, use _Aligned_storage_t instead of alignas until /clr is fixed
         _STD _Aligned_storage_t<_Critical_section_size, alignof(void*)> _Cs_storage;
     };
     long _Thread_id{};
@@ -68,6 +69,7 @@ struct _Cnd_internal_imp_t {
 
     union {
         _Stl_condition_variable _Stl_cv{};
+        // TRANSITION, VSO-1659383 and VSO-2616030, use _Aligned_storage_t instead of alignas until /clr is fixed
         _STD _Aligned_storage_t<_Cnd_internal_imp_size, alignof(void*)> _Cv_storage;
     };
 };


### PR DESCRIPTION
We merged #5811 which is about to ship in MSVC Build Tools 14.51, but it's causing major user heartburn: DevCom-11059932 VSO-2841023 "C++ toolset 14.51.36014 Preview alignment changes breaks C++/CLI code".

This cleanup would have been nice to have, but we need to revert it until the `/clr` `alignas` bugs VSO-1659383 and VSO-2616030 are fixed.

* Revert product code changes from #5811.
* Comment workarounds.
