### PR TITLE
Avoid runtime sign dispatch in vectorized `minmax_element`

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -71,8 +71,8 @@ _Min_max_element_t __stdcall __std_minmax_element_4u(const void* _First, const v
 _Min_max_element_t __stdcall __std_minmax_element_8i(const void* _First, const void* _Last) noexcept;
 _Min_max_element_t __stdcall __std_minmax_element_8u(const void* _First, const void* _Last) noexcept;
 #endif // ^^^ _VECTORIZED_MINMAX_ELEMENT_64BIT_INT ^^^
-_Min_max_element_t __stdcall __std_minmax_element_f_no_unused(const void* _First, const void* _Last) noexcept;
-_Min_max_element_t __stdcall __std_minmax_element_d_no_unused(const void* _First, const void* _Last) noexcept;
+_Min_max_element_t __stdcall __std_minmax_element_f_(const void* _First, const void* _Last) noexcept;
+_Min_max_element_t __stdcall __std_minmax_element_d_(const void* _First, const void* _Last) noexcept;
 #endif // ^^^ _VECTORIZED_MINMAX_ELEMENT ^^^
 
 #if _VECTORIZED_MINMAX
@@ -219,9 +219,9 @@ pair<_Ty*, _Ty*> _Minmax_element_vectorized(_Ty* const _First, _Ty* const _Last)
     _Min_max_element_t _Res;
 
     if constexpr (is_same_v<remove_const_t<_Ty>, float>) {
-        _Res = ::__std_minmax_element_f_no_unused(_First, _Last);
+        _Res = ::__std_minmax_element_f_(_First, _Last);
     } else if constexpr (_Is_any_of_v<remove_const_t<_Ty>, double, long double>) {
-        _Res = ::__std_minmax_element_d_no_unused(_First, _Last);
+        _Res = ::__std_minmax_element_d_(_First, _Last);
     } else if constexpr (sizeof(_Ty) == 1) {
         if constexpr (_Signed) {
             _Res = ::__std_minmax_element_1i(_First, _Last);

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -206,8 +206,8 @@ const void* __stdcall __std_min_element_4u(const void* _First, const void* _Last
 const void* __stdcall __std_min_element_8i(const void* _First, const void* _Last) noexcept;
 const void* __stdcall __std_min_element_8u(const void* _First, const void* _Last) noexcept;
 #endif // ^^^ _VECTORIZED_MINMAX_ELEMENT_64BIT_INT ^^^
-const void* __stdcall __std_min_element_f_no_unused(const void* _First, const void* _Last) noexcept;
-const void* __stdcall __std_min_element_d_no_unused(const void* _First, const void* _Last) noexcept;
+const void* __stdcall __std_min_element_f_(const void* _First, const void* _Last) noexcept;
+const void* __stdcall __std_min_element_d_(const void* _First, const void* _Last) noexcept;
 
 const void* __stdcall __std_max_element_1i(const void* _First, const void* _Last) noexcept;
 const void* __stdcall __std_max_element_1u(const void* _First, const void* _Last) noexcept;
@@ -219,8 +219,8 @@ const void* __stdcall __std_max_element_4u(const void* _First, const void* _Last
 const void* __stdcall __std_max_element_8i(const void* _First, const void* _Last) noexcept;
 const void* __stdcall __std_max_element_8u(const void* _First, const void* _Last) noexcept;
 #endif // ^^^ _VECTORIZED_MINMAX_ELEMENT_64BIT_INT ^^^
-const void* __stdcall __std_max_element_f_no_unused(const void* _First, const void* _Last) noexcept;
-const void* __stdcall __std_max_element_d_no_unused(const void* _First, const void* _Last) noexcept;
+const void* __stdcall __std_max_element_f_(const void* _First, const void* _Last) noexcept;
+const void* __stdcall __std_max_element_d_(const void* _First, const void* _Last) noexcept;
 #endif // ^^^ _VECTORIZED_MINMAX_ELEMENT ^^^
 
 #if _VECTORIZED_MINMAX
@@ -410,9 +410,9 @@ _Ty* _Min_element_vectorized(_Ty* const _First, _Ty* const _Last) noexcept {
     constexpr bool _Signed = is_signed_v<_Ty>;
 
     if constexpr (is_same_v<remove_const_t<_Ty>, float>) {
-        return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_min_element_f_no_unused(_First, _Last)));
+        return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_min_element_f_(_First, _Last)));
     } else if constexpr (_Is_any_of_v<remove_const_t<_Ty>, double, long double>) {
-        return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_min_element_d_no_unused(_First, _Last)));
+        return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_min_element_d_(_First, _Last)));
     } else if constexpr (sizeof(_Ty) == 1) {
         if constexpr (_Signed) {
             return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_min_element_1i(_First, _Last)));
@@ -451,9 +451,9 @@ _Ty* _Max_element_vectorized(_Ty* const _First, _Ty* const _Last) noexcept {
     constexpr bool _Signed = is_signed_v<_Ty>;
 
     if constexpr (is_same_v<remove_const_t<_Ty>, float>) {
-        return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_max_element_f_no_unused(_First, _Last)));
+        return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_max_element_f_(_First, _Last)));
     } else if constexpr (_Is_any_of_v<remove_const_t<_Ty>, double, long double>) {
-        return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_max_element_d_no_unused(_First, _Last)));
+        return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_max_element_d_(_First, _Last)));
     } else if constexpr (sizeof(_Ty) == 1) {
         if constexpr (_Signed) {
             return const_cast<_Ty*>(static_cast<const _Ty*>(::__std_max_element_1i(_First, _Last)));

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -3770,11 +3770,11 @@ const void* __stdcall __std_min_element_8u(const void* const _First, const void*
 }
 #endif // ^^^ !defined(_M_ARM64) ^^^
 
-const void* __stdcall __std_min_element_f_no_unused(const void* const _First, const void* const _Last) noexcept {
+const void* __stdcall __std_min_element_f_(const void* const _First, const void* const _Last) noexcept {
     return _Sorting::_Minmax_element_disp<_Sorting::_Mode_min, _Sorting::_Traits_f, false>(_First, _Last);
 }
 
-const void* __stdcall __std_min_element_d_no_unused(const void* const _First, const void* const _Last) noexcept {
+const void* __stdcall __std_min_element_d_(const void* const _First, const void* const _Last) noexcept {
     return _Sorting::_Minmax_element_disp<_Sorting::_Mode_min, _Sorting::_Traits_d, false>(_First, _Last);
 }
 
@@ -3821,12 +3821,12 @@ const void* __stdcall __std_min_element_8(
 
 // TRANSITION, ABI: __std_min_element_f() is preserved for binary compatibility (x64/x86/ARM64EC)
 const void* __stdcall __std_min_element_f(const void* const _First, const void* const _Last, bool) noexcept {
-    return __std_min_element_f_no_unused(_First, _Last);
+    return __std_min_element_f_(_First, _Last);
 }
 
 // TRANSITION, ABI: __std_min_element_d() is preserved for binary compatibility (x64/x86/ARM64EC)
 const void* __stdcall __std_min_element_d(const void* const _First, const void* const _Last, bool) noexcept {
-    return __std_min_element_d_no_unused(_First, _Last);
+    return __std_min_element_d_(_First, _Last);
 }
 #endif // ^^^ !defined(_M_ARM64) ^^^
 
@@ -3864,11 +3864,11 @@ const void* __stdcall __std_max_element_8u(const void* const _First, const void*
 }
 #endif // ^^^ !defined(_M_ARM64) ^^^
 
-const void* __stdcall __std_max_element_f_no_unused(const void* const _First, const void* const _Last) noexcept {
+const void* __stdcall __std_max_element_f_(const void* const _First, const void* const _Last) noexcept {
     return _Sorting::_Minmax_element_disp<_Sorting::_Mode_max, _Sorting::_Traits_f, false>(_First, _Last);
 }
 
-const void* __stdcall __std_max_element_d_no_unused(const void* const _First, const void* const _Last) noexcept {
+const void* __stdcall __std_max_element_d_(const void* const _First, const void* const _Last) noexcept {
     return _Sorting::_Minmax_element_disp<_Sorting::_Mode_max, _Sorting::_Traits_d, false>(_First, _Last);
 }
 
@@ -3915,12 +3915,12 @@ const void* __stdcall __std_max_element_8(
 
 // TRANSITION, ABI: __std_max_element_f() is preserved for binary compatibility (x64/x86/ARM64EC)
 const void* __stdcall __std_max_element_f(const void* const _First, const void* const _Last, bool) noexcept {
-    return __std_max_element_f_no_unused(_First, _Last);
+    return __std_max_element_f_(_First, _Last);
 }
 
 // TRANSITION, ABI: __std_max_element_d() is preserved for binary compatibility (x64/x86/ARM64EC)
 const void* __stdcall __std_max_element_d(const void* const _First, const void* const _Last, bool) noexcept {
-    return __std_max_element_d_no_unused(_First, _Last);
+    return __std_max_element_d_(_First, _Last);
 }
 #endif // ^^^ !defined(_M_ARM64) ^^^
 
@@ -3958,13 +3958,11 @@ _Min_max_element_t __stdcall __std_minmax_element_8u(const void* const _First, c
 }
 #endif // ^^^ !defined(_M_ARM64) ^^^
 
-_Min_max_element_t __stdcall __std_minmax_element_f_no_unused(
-    const void* const _First, const void* const _Last) noexcept {
+_Min_max_element_t __stdcall __std_minmax_element_f_(const void* const _First, const void* const _Last) noexcept {
     return _Sorting::_Minmax_element_disp<_Sorting::_Mode_both, _Sorting::_Traits_f, false>(_First, _Last);
 }
 
-_Min_max_element_t __stdcall __std_minmax_element_d_no_unused(
-    const void* const _First, const void* const _Last) noexcept {
+_Min_max_element_t __stdcall __std_minmax_element_d_(const void* const _First, const void* const _Last) noexcept {
     return _Sorting::_Minmax_element_disp<_Sorting::_Mode_both, _Sorting::_Traits_d, false>(_First, _Last);
 }
 
@@ -4011,12 +4009,12 @@ _Min_max_element_t __stdcall __std_minmax_element_8(
 
 // TRANSITION, ABI: __std_minmax_element_f() is preserved for binary compatibility (x64/x86/ARM64EC)
 _Min_max_element_t __stdcall __std_minmax_element_f(const void* const _First, const void* const _Last, bool) noexcept {
-    return __std_minmax_element_f_no_unused(_First, _Last);
+    return __std_minmax_element_f_(_First, _Last);
 }
 
 // TRANSITION, ABI: __std_minmax_element_d() is preserved for binary compatibility (x64/x86/ARM64EC)
 _Min_max_element_t __stdcall __std_minmax_element_d(const void* const _First, const void* const _Last, bool) noexcept {
-    return __std_minmax_element_d_no_unused(_First, _Last);
+    return __std_minmax_element_d_(_First, _Last);
 }
 #endif // ^^^ !defined(_M_ARM64) ^^^
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/STL/issues/6176

I'm not sure about the naming of `__std_{min,max,minmax}_element_{f,d}_no_unused` - if anyone has any better suggestions!