### PR TITLE
`<regex>`: Avoid generating `_N_nop` nodes when parsing assertions

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1287,7 +1287,7 @@ _BITMASK_OPS(_EMPTY_ARGUMENT, _Node_flags)
 
 enum _Node_type { // type flag for nfa nodes
     _N_none,
-    _N_nop,
+    _N_nop, // TRANSITION, ABI: preserved for binary compatibility, the parser no longer generates _N_nop nodes
     _N_bol,
     _N_eol,
     _N_wbound,
@@ -1613,8 +1613,8 @@ public:
     void _Add_coll(const _Elem*, const _Elem*);
     _Node_base* _Begin_group();
     void _End_group(_Node_base* _Back);
-    _Node_base* _Begin_assert_group(bool);
-    void _End_assert_group(_Node_base*);
+    _Node_assert* _Begin_assert_group2(bool _Neg);
+    void _End_assert_group2(_Node_assert* _Assert_start);
     _Node_base* _Begin_capture_group(unsigned int _Idx);
     void _Add_backreference(unsigned int _Idx);
     _Node_base* _Begin_if(_Node_base* _Start);
@@ -2235,7 +2235,7 @@ private:
     void _AtomEscape();
     void _Do_capture_group();
     void _Do_noncapture_group();
-    void _Do_assert_group(bool);
+    void _Do_assert_group(bool _Neg);
     bool _Wrapped_disjunction();
     void _Quantifier();
     bool _Alternative();
@@ -3620,21 +3620,19 @@ void _Builder2<_FwdIt, _Elem, _RxTraits>::_End_group(_Node_base* _Back) { // add
 }
 
 template <class _FwdIt, class _Elem, class _RxTraits>
-_Node_base* _Builder2<_FwdIt, _Elem, _RxTraits>::_Begin_assert_group(const bool _Neg) { // add assert node
-    auto _Node1_unique   = _STD make_unique<_Node_assert>(_Neg ? _N_neg_assert : _N_assert);
-    _Node_base* _Node2   = new _Node_base(_N_nop);
-    _Node_assert* _Node1 = _Node1_unique.release();
-    _Link_node(_Node1);
-    _Node1->_Child = _Node2;
-    _Node2->_Prev  = _Node1;
-    _Current       = _Node2;
-    return _Node1;
+_Node_assert* _Builder2<_FwdIt, _Elem, _RxTraits>::_Begin_assert_group2(const bool _Neg) { // add assert node
+    const auto _Node = new _Node_assert(_Neg ? _N_neg_assert : _N_assert);
+    _Link_node(_Node);
+    return _Node;
 }
 
 template <class _FwdIt, class _Elem, class _RxTraits>
-void _Builder2<_FwdIt, _Elem, _RxTraits>::_End_assert_group(_Node_base* _Nx) { // add end of assert node
-    _End_group(_Nx);
-    _Current = _Nx;
+void _Builder2<_FwdIt, _Elem, _RxTraits>::_End_assert_group2(_Node_assert* const _Assert_start) {
+    // add end of assert node
+    _End_group(_Assert_start);
+    _Assert_start->_Child = _Assert_start->_Next;
+    _Assert_start->_Next  = nullptr;
+    _Current              = _Assert_start;
 }
 
 template <class _FwdIt, class _Elem, class _RxTraits>
@@ -5539,10 +5537,10 @@ void _Parser2<_FwdIt, _Elem, _RxTraits>::_Do_noncapture_group() { // add non-cap
 }
 
 template <class _FwdIt, class _Elem, class _RxTraits>
-void _Parser2<_FwdIt, _Elem, _RxTraits>::_Do_assert_group(bool _Neg) { // add assert group
-    _Node_base* _Pos1 = _Nfa._Begin_assert_group(_Neg);
+void _Parser2<_FwdIt, _Elem, _RxTraits>::_Do_assert_group(const bool _Neg) { // add assert group
+    const auto _Assert_start = _Nfa._Begin_assert_group2(_Neg);
     _Disjunction();
-    _Nfa._End_assert_group(_Pos1);
+    _Nfa._End_assert_group2(_Assert_start);
 }
 
 template <class _FwdIt, class _Elem, class _RxTraits>


### PR DESCRIPTION
Towards #5962.

This removes the generation of `_N_nop` nodes when parsing assertions. Such a node was generated so that the NFA branch for the body of the assertion could be attached to it. But we can just as well initially generate the branch for the assertion body as the successor of the `_N_assert` node, as though the body wouldn't be part of the assertion but follow it, and then relink the branch into the correct position as the child of the `_N_assert` node.

This appears to have been the last (and maybe always the only) case where the parser generated `_N_nop` nodes. But we must keep around the code  in the matcher that handles this node type until vNext.

## Benchmark
Small but consistent improvement for assertions:

benchmark | before [ns] | after [ns] | speedup
-- | -- | -- | --
bm_lorem_search/"^bibe"/2 | 54.6875 | 50.2232 | 1.09
bm_lorem_search/"^bibe"/3 | 54.6875 | 51.6183 | 1.06
bm_lorem_search/"^bibe"/4 | 53.0134 | 53.0134 | 1.00
bm_lorem_search/"bibe"/2 | 2999.44 | 2849.48 | 1.05
bm_lorem_search/"bibe"/3 | 5580.36 | 5580.36 | 1.00
bm_lorem_search/"bibe"/4 | 11962.9 | 11474.6 | 1.04
bm_lorem_search/"bibe".collate/2 | 2982.01 | 2982.01 | 1.00
bm_lorem_search/"bibe".collate/3 | 5580.36 | 5719.87 | 0.98
bm_lorem_search/"bibe".collate/4 | 11474.6 | 11439.7 | 1.00
bm_lorem_search/"(bibe)"/2 | 3766.73 | 3599.32 | 1.05
bm_lorem_search/"(bibe)"/3 | 7114.96 | 6975.45 | 1.02
bm_lorem_search/"(bibe)"/4 | 14508.9 | 14439.1 | 1.00
bm_lorem_search/"(bibe)+"/2 | 4882.81 | 4813.07 | 1.01
bm_lorem_search/"(bibe)+"/3 | 9416.81 | 8998.29 | 1.05
bm_lorem_search/"(bibe)+"/4 | 18415.3 | 17578.3 | 1.05
bm_lorem_search/"(?:bibe)+"/2 | 3989.95 | 4143.41 | 0.96
bm_lorem_search/"(?:bibe)+"/3 | 8021.76 | 7812.5 | 1.03
bm_lorem_search/"(?:bibe)+"/4 | 15694.8 | 15346 | 1.02
bm_lorem_search/R"(\bbibe)"/2 | 66266.7 | 66964.3 | 0.99
bm_lorem_search/R"(\bbibe)"/3 | 131830 | 125558 | 1.05
bm_lorem_search/R"(\bbibe)"/4 | 254981 | 254981 | 1.00
bm_lorem_search/R"(\Bibe)"/2 | 142997 | 141246 | 1.01
bm_lorem_search/R"(\Bibe)"/3 | 295048 | 278308 | 1.06
bm_lorem_search/R"(\Bibe)"/4 | 599888 | 585938 | 1.02
**bm_lorem_search/R"((?=....)bibe)"/2** | **5000** | **4349.18** | **1.15**
**bm_lorem_search/R"((?=....)bibe)"/3** | **9416.81** | **8579.76** | **1.10**
**bm_lorem_search/R"((?=....)bibe)"/4** | **19252.4** | **17648** | **1.09**
**bm_lorem_search/R"((?=bibe)....)"/2** | **4080.63** | **3850.44** | **1.06**
**bm_lorem_search/R"((?=bibe)....)"/3** | **8021.76** | **7812.5** | **1.03**
**bm_lorem_search/R"((?=bibe)....)"/4** | **16392.3** | **15380.8** | **1.07**
**bm_lorem_search/R"((?!lorem)bibe)"/2** | **3609.79** | **3369.15** | **1.07**
**bm_lorem_search/R"((?!lorem)bibe)"/3** | **6696.43** | **6277.9** | **1.07**
**bm_lorem_search/R"((?!lorem)bibe)"/4** | **13497.4** | **13113.8** | **1.03**
bm_lorem_search/"(bibe\|soda)"/2 | 8998.29 | 8998.29 | 1.00
bm_lorem_search/"(bibe\|soda)"/3 | 18136.2 | 17648 | 1.03
bm_lorem_search/"(bibe\|soda)"/4 | 36062.4 | 34527.8 | 1.04
bm_lorem_search/"(id )?bibe"/2 | 8370.54 | 8370.54 | 1.00
bm_lorem_search/"(id )?bibe"/3 | 16043.5 | 16392.3 | 0.98
bm_lorem_search/"(id )?bibe"/4 | 33691.9 | 32784.6 | 1.03
bm_lorem_search/".bibe"/2 | 3138.95 | 3048.28 | 1.03
bm_lorem_search/".bibe"/3 | 5937.5 | 5719.87 | 1.04
bm_lorem_search/".bibe"/4 | 11160.7 | 11718.8 | 0.95

