### PR TITLE
Allow ASan container annotations to activate piecemeal

### DIFF
--- a/stl/inc/__msvc_sanitizer_annotate_container.hpp
+++ b/stl/inc/__msvc_sanitizer_annotate_container.hpp
@@ -129,15 +129,15 @@ _STL_DISABLE_CLANG_WARNINGS
 #endif // ^^^ !defined(_INSERT_OPTIONAL_ANNOTATION) ^^^
 
 #ifdef _ACTIVATE_STRING_ANNOTATION
-#pragma comment(lib, "stl_asan")
+extern "C" __declspec(selectany) const bool _Asan_string_should_annotate = true;
 #pragma detect_mismatch("annotate_string", "1")
 #endif // ^^^ defined(_ACTIVATE_STRING_ANNOTATION) ^^^
 #ifdef _ACTIVATE_VECTOR_ANNOTATION
-#pragma comment(lib, "stl_asan")
+extern "C" __declspec(selectany) const bool _Asan_vector_should_annotate = true;
 #pragma detect_mismatch("annotate_vector", "1")
 #endif // ^^^ defined(_ACTIVATE_VECTOR_ANNOTATION) ^^^
 #ifdef _ACTIVATE_OPTIONAL_ANNOTATION
-#pragma comment(lib, "stl_asan")
+extern "C" __declspec(selectany) const bool _Asan_optional_should_annotate = true;
 #pragma detect_mismatch("annotate_optional", "1")
 #endif // ^^^ defined(_ACTIVATE_OPTIONAL_ANNOTATION) ^^^
 

--- a/stl/inc/__msvc_sanitizer_annotate_container.hpp
+++ b/stl/inc/__msvc_sanitizer_annotate_container.hpp
@@ -128,16 +128,17 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma detect_mismatch("annotate_optional", "0")
 #endif // ^^^ !defined(_INSERT_OPTIONAL_ANNOTATION) ^^^
 
+extern "C" {
 #ifdef _ACTIVATE_STRING_ANNOTATION
-extern "C" __declspec(selectany) const bool _Asan_string_should_annotate = true;
+__declspec(selectany) const bool _Asan_string_should_annotate = true;
 #pragma detect_mismatch("annotate_string", "1")
 #endif // ^^^ defined(_ACTIVATE_STRING_ANNOTATION) ^^^
 #ifdef _ACTIVATE_VECTOR_ANNOTATION
-extern "C" __declspec(selectany) const bool _Asan_vector_should_annotate = true;
+__declspec(selectany) const bool _Asan_vector_should_annotate = true;
 #pragma detect_mismatch("annotate_vector", "1")
 #endif // ^^^ defined(_ACTIVATE_VECTOR_ANNOTATION) ^^^
 #ifdef _ACTIVATE_OPTIONAL_ANNOTATION
-extern "C" __declspec(selectany) const bool _Asan_optional_should_annotate = true;
+__declspec(selectany) const bool _Asan_optional_should_annotate = true;
 #pragma detect_mismatch("annotate_optional", "1")
 #endif // ^^^ defined(_ACTIVATE_OPTIONAL_ANNOTATION) ^^^
 
@@ -145,7 +146,6 @@ extern "C" __declspec(selectany) const bool _Asan_optional_should_annotate = tru
 #undef _ACTIVATE_VECTOR_ANNOTATION
 #undef _ACTIVATE_OPTIONAL_ANNOTATION
 
-extern "C" {
 #ifdef _INSERT_VECTOR_ANNOTATION
 extern const bool _Asan_vector_should_annotate;
 #endif

--- a/stl/inc/__msvc_sanitizer_annotate_container.hpp
+++ b/stl/inc/__msvc_sanitizer_annotate_container.hpp
@@ -130,15 +130,15 @@ _STL_DISABLE_CLANG_WARNINGS
 
 extern "C" {
 #ifdef _ACTIVATE_STRING_ANNOTATION
-__declspec(selectany) const bool _Asan_string_should_annotate = true;
+__declspec(selectany) extern const bool _Asan_string_should_annotate = true;
 #pragma detect_mismatch("annotate_string", "1")
 #endif // ^^^ defined(_ACTIVATE_STRING_ANNOTATION) ^^^
 #ifdef _ACTIVATE_VECTOR_ANNOTATION
-__declspec(selectany) const bool _Asan_vector_should_annotate = true;
+__declspec(selectany) extern const bool _Asan_vector_should_annotate = true;
 #pragma detect_mismatch("annotate_vector", "1")
 #endif // ^^^ defined(_ACTIVATE_VECTOR_ANNOTATION) ^^^
 #ifdef _ACTIVATE_OPTIONAL_ANNOTATION
-__declspec(selectany) const bool _Asan_optional_should_annotate = true;
+__declspec(selectany) extern const bool _Asan_optional_should_annotate = true;
 #pragma detect_mismatch("annotate_optional", "1")
 #endif // ^^^ defined(_ACTIVATE_OPTIONAL_ANNOTATION) ^^^
 

--- a/stl/src/asan.cpp
+++ b/stl/src/asan.cpp
@@ -1,16 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-namespace std {
-    extern "C" {
-    // TRANSITION, ABI: preserved for compatibility with old headers, which
-    // added stl_asan.lib to the link line. We use __declspec(selectany) to be
-    // compatible with the new headers that define these variables as
-    // __declspec(selectany) in __msvc_sanitizer_annotate_container.hpp.
-    // The new method is preferred because previously enabling just string
-    // would also enable vector and optional. See GH-6186 for details.
-    __declspec(selectany) extern const bool _Asan_string_should_annotate   = true;
-    __declspec(selectany) extern const bool _Asan_vector_should_annotate   = true;
-    __declspec(selectany) extern const bool _Asan_optional_should_annotate = true;
-    } // extern "C"
-} // namespace std
+extern "C" {
+// TRANSITION, ABI: preserved for compatibility with old headers, which
+// added stl_asan.lib to the link line. We use __declspec(selectany) to be
+// compatible with the new headers that define these variables as
+// __declspec(selectany) in __msvc_sanitizer_annotate_container.hpp.
+// The new method is preferred because previously enabling just string
+// would also enable vector and optional. See GH-6186 for details.
+__declspec(selectany) extern const bool _Asan_string_should_annotate   = true;
+__declspec(selectany) extern const bool _Asan_vector_should_annotate   = true;
+__declspec(selectany) extern const bool _Asan_optional_should_annotate = true;
+} // extern "C"

--- a/stl/src/asan.cpp
+++ b/stl/src/asan.cpp
@@ -9,8 +9,8 @@ namespace std {
     // __declspec(selectany) in __msvc_sanitizer_annotate_container.hpp.
     // The new method is preferred because previously enabling just string
     // would also enable vector and optional. See GH-6186 for details.
-    extern __declspec(selectany) const bool _Asan_string_should_annotate   = true;
-    extern __declspec(selectany) const bool _Asan_vector_should_annotate   = true;
-    extern __declspec(selectany) const bool _Asan_optional_should_annotate = true;
+    __declspec(selectany) extern const bool _Asan_string_should_annotate   = true;
+    __declspec(selectany) extern const bool _Asan_vector_should_annotate   = true;
+    __declspec(selectany) extern const bool _Asan_optional_should_annotate = true;
     } // extern "C"
 } // namespace std

--- a/stl/src/asan.cpp
+++ b/stl/src/asan.cpp
@@ -3,11 +3,12 @@
 
 namespace std {
     extern "C" {
-    // Retained for compatibility with old headers that add stl_asan.lib to the link.
-    // Use __declspec(selectany) to be compatible with new version that define these
-    // variables as __declspec(selectany) in __msvc_sanitizer_annotate_container.hpp.
-    // The new method is preferred because previously enabling just string would also
-    // enable vector and optional.
+    // TRANSITION, ABI: preserved for compatibility with old headers, which
+    // added stl_asan.lib to the link line. We use __declspec(selectany) to be
+    // compatible with the new headers that defines these variables as
+    // __declspec(selectany) in __msvc_sanitizer_annotate_container.hpp.
+    // The new method is preferred because previously enabling just string
+    // would also enable vector and optional. See GH-6186 for details.
     extern __declspec(selectany) const bool _Asan_string_should_annotate   = true;
     extern __declspec(selectany) const bool _Asan_vector_should_annotate   = true;
     extern __declspec(selectany) const bool _Asan_optional_should_annotate = true;

--- a/stl/src/asan.cpp
+++ b/stl/src/asan.cpp
@@ -3,6 +3,11 @@
 
 namespace std {
     extern "C" {
+    // Retained for compatibility with old headers that add stl_asan.lib to the link.
+    // Use __declspec(selectany) to be compatible with new version that define these
+    // variables as __declspec(selectany) in __msvc_sanitizer_annotate_container.hpp.
+    // The new method is preferred because previously enabling just string would also
+    // enable vector and optional.
     extern __declspec(selectany) const bool _Asan_string_should_annotate   = true;
     extern __declspec(selectany) const bool _Asan_vector_should_annotate   = true;
     extern __declspec(selectany) const bool _Asan_optional_should_annotate = true;

--- a/stl/src/asan.cpp
+++ b/stl/src/asan.cpp
@@ -5,7 +5,7 @@ namespace std {
     extern "C" {
     // TRANSITION, ABI: preserved for compatibility with old headers, which
     // added stl_asan.lib to the link line. We use __declspec(selectany) to be
-    // compatible with the new headers that defines these variables as
+    // compatible with the new headers that define these variables as
     // __declspec(selectany) in __msvc_sanitizer_annotate_container.hpp.
     // The new method is preferred because previously enabling just string
     // would also enable vector and optional. See GH-6186 for details.

--- a/stl/src/asan.cpp
+++ b/stl/src/asan.cpp
@@ -3,8 +3,8 @@
 
 namespace std {
     extern "C" {
-    extern const bool _Asan_string_should_annotate   = true;
-    extern const bool _Asan_vector_should_annotate   = true;
-    extern const bool _Asan_optional_should_annotate = true;
+    extern __declspec(selectany) const bool _Asan_string_should_annotate   = true;
+    extern __declspec(selectany) const bool _Asan_vector_should_annotate   = true;
+    extern __declspec(selectany) const bool _Asan_optional_should_annotate = true;
     } // extern "C"
 } // namespace std

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -282,6 +282,7 @@ tests\GH_005800_stable_sort_large_alignment
 tests\GH_005816_numeric_limits_traps
 tests\GH_005968_headers_provide_begin_end
 tests\GH_005974_asan_annotate_optional
+tests\GH_006186_asan_annotate_partial
 tests\LWG2381_num_get_floating_point
 tests\LWG2510_tag_classes
 tests\LWG2597_complex_branch_cut

--- a/tests/std/tests/GH_006186_asan_annotate_partial/env.lst
+++ b/tests/std/tests/GH_006186_asan_annotate_partial/env.lst
@@ -1,0 +1,41 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This test matrix is the usual test matrix, with all currently unsupported options removed, crossed with the ASan flags.
+
+# TRANSITION, google/sanitizers#328: clang-cl does not support /MDd or /MTd with ASan
+RUNALL_INCLUDE ..\prefix.lst
+RUNALL_CROSSLIST
+PM_CL="/fsanitize=address /DTEST_ENSURE_VECTOR_ENABLED /DTEST_ENSURE_STRING_ENABLED /DTEST_ENSURE_OPTIONAL_ENABLED"
+PM_CL="/fsanitize=address /D_DISABLE_VECTOR_ANNOTATION /DTEST_ENSURE_STRING_ENABLED /DTEST_ENSURE_OPTIONAL_ENABLED"
+PM_CL="/fsanitize=address /DTEST_ENSURE_VECTOR_ENABLED /D_DISABLE_STRING_ANNOTATION /DTEST_ENSURE_OPTIONAL_ENABLED"
+PM_CL="/fsanitize=address /DTEST_ENSURE_VECTOR_ENABLED /DTEST_ENSURE_STRING_ENABLED /D_DISABLE_OPTIONAL_ANNOTATION"
+PM_CL="/D_ANNOTATE_STL"
+RUNALL_CROSSLIST
+PM_CL="/Zi /wd4611 /w14640 /Zc:threadSafeInit-" PM_LINK="/debug"
+RUNALL_CROSSLIST
+PM_CL="/BE /c /EHsc /MD /std:c++14"
+PM_CL="/BE /c /EHsc /MDd /std:c++17 /permissive-"
+PM_CL="/BE /c /EHsc /MT /std:c++20 /permissive-"
+PM_CL="/BE /c /EHsc /MTd /std:c++latest /permissive-"
+PM_CL="/EHsc /MD /std:c++14"
+PM_CL="/EHsc /MD /std:c++17"
+PM_CL="/EHsc /MD /std:c++20"
+PM_CL="/EHsc /MD /std:c++latest /permissive- /Zc:char8_t- /Zc:preprocessor"
+PM_CL="/EHsc /MD /std:c++latest /permissive- /Zc:noexceptTypes-"
+PM_CL="/EHsc /MDd /std:c++14 /fp:except /Zc:preprocessor"
+PM_CL="/EHsc /MDd /std:c++17 /permissive-"
+PM_CL="/EHsc /MDd /std:c++20 /permissive-"
+PM_CL="/EHsc /MDd /std:c++latest /permissive- /Zc:wchar_t-"
+PM_CL="/EHsc /MDd /std:c++latest /permissive-"
+PM_CL="/EHsc /MT /std:c++latest /permissive- /analyze:only /analyze:autolog-"
+PM_CL="/EHsc /MT /std:c++latest /permissive-"
+PM_CL="/EHsc /MTd /std:c++latest /permissive"
+PM_CL="/EHsc /MTd /std:c++latest /permissive- /analyze:only /analyze:autolog-"
+PM_CL="/EHsc /MTd /std:c++latest /permissive- /fp:strict"
+PM_CL="/EHsc /MTd /std:c++latest /permissive-"
+# TRANSITION, we don't use /ALTERNATENAME for Clang (see GH-5224) so we cannot test /D_ANNOTATE_VECTOR without -fsanitize=address
+PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /EHsc /MD /std:c++14"
+PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /EHsc /MD /std:c++17"
+PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /EHsc /MT /std:c++20 /permissive-"
+PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /EHsc /MT /std:c++latest /permissive- /fp:strict"

--- a/tests/std/tests/GH_006186_asan_annotate_partial/env.lst
+++ b/tests/std/tests/GH_006186_asan_annotate_partial/env.lst
@@ -34,7 +34,6 @@ PM_CL="/EHsc /MTd /std:c++latest /permissive"
 PM_CL="/EHsc /MTd /std:c++latest /permissive- /analyze:only /analyze:autolog-"
 PM_CL="/EHsc /MTd /std:c++latest /permissive- /fp:strict"
 PM_CL="/EHsc /MTd /std:c++latest /permissive-"
-# TRANSITION, we don't use /ALTERNATENAME for Clang (see GH-5224) so we cannot test /D_ANNOTATE_VECTOR without -fsanitize=address
 PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /EHsc /MD /std:c++14"
 PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /EHsc /MD /std:c++17"
 PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /EHsc /MT /std:c++20 /permissive-"

--- a/tests/std/tests/GH_006186_asan_annotate_partial/test.cpp
+++ b/tests/std/tests/GH_006186_asan_annotate_partial/test.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 // REQUIRES: x64 || x86 || arm64
 
 #if defined(__clang__) && defined(_M_ARM64) // TRANSITION, LLVM-184902, fixed in Clang 23

--- a/tests/std/tests/GH_006186_asan_annotate_partial/test.cpp
+++ b/tests/std/tests/GH_006186_asan_annotate_partial/test.cpp
@@ -11,9 +11,11 @@ int main() {}
 #include <cassert>
 #include <vector> // include __msvc_sanitizer_annotate_container.hpp
 
-extern "C" const bool _Asan_vector_should_annotate;
-extern "C" const bool _Asan_string_should_annotate;
-extern "C" const bool _Asan_optional_should_annotate;
+extern "C" {
+extern const bool _Asan_vector_should_annotate;
+extern const bool _Asan_string_should_annotate;
+extern const bool _Asan_optional_should_annotate;
+} // extern "C"
 
 int main() {
 #ifdef TEST_ENSURE_VECTOR_ENABLED

--- a/tests/std/tests/GH_006186_asan_annotate_partial/test.cpp
+++ b/tests/std/tests/GH_006186_asan_annotate_partial/test.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// REQUIRES: x64 || x86 || arm64
+
+#if defined(__clang__) && defined(_M_ARM64) // TRANSITION, LLVM-184902, fixed in Clang 23
+#pragma comment(linker, "/INFERASANLIBS")
+int main() {}
+#else // ^^^ workaround / no workaround vvv
+
+#include <cassert>
+#include <vector> // include __msvc_sanitizer_annotate_container.hpp
+
+extern "C" const bool _Asan_vector_should_annotate;
+extern "C" const bool _Asan_string_should_annotate;
+extern "C" const bool _Asan_optional_should_annotate;
+
+int main() {
+#ifdef TEST_ENSURE_VECTOR_ENABLED
+    assert(_Asan_vector_should_annotate == true);
+#else
+    assert(_Asan_vector_should_annotate == false);
+#endif
+
+#ifdef TEST_ENSURE_STRING_ENABLED
+    assert(_Asan_string_should_annotate == true);
+#else
+    assert(_Asan_string_should_annotate == false);
+#endif
+
+#ifdef TEST_ENSURE_OPTIONAL_ENABLED
+    assert(_Asan_optional_should_annotate == true);
+#else
+    assert(_Asan_optional_should_annotate == false);
+#endif
+}
+
+#endif // ^^^ no workaround ^^^


### PR DESCRIPTION
Fixes #6186.

Previously, ASan annotations for `string`, `vector`, and `optional` were activated by linking with `stl_asan.lib` which set each activation variable to true, leading to ODR violations if some TUs were built with annotations inserted but partially activated.

This change removes the `stl_asan.lib` dependency and allows each option to set the activation variable individually. 

I've retained `stl_asan.lib` and modified the definitions with `__declspec(selectany)` to match those in the headers, and also to ensure compatibility if linking with a static library from a previous version of the toolset.

The test I've included just ensures the annotations can be targeted individually instead of constructing an ASan error. I did this for simplicity (esp as new annotations are added) while still covering every scenario. I limited it to one disabled out of the set instead of exhaustive validation to not devote too much test time to this. 

I've verified the scenario from #6186 locally, as well as ensuring it is backwards compatible with old versions of the headers (meaning, I built the annotated_lib.lib with an old toolset and test.obj with a toolset with this change and manually tried out every combination). Building a static library with the new toolset and linking with an old toolset produces a link error (the old `stl_asan.lib` does not contain `__declspec(selectany)`, so clashes with the definition added in `__msvc_sanitizer_annotate_container.hpp`), but my understanding is that this isn't a supported scenario.