### PR TITLE
Implement LWG-4510 Ambiguity of `std::ranges::advance` and `std::ranges::next` when the difference type is also a sentinel type

### DIFF
--- a/stl/inc/__msvc_iter_core.hpp
+++ b/stl/inc/__msvc_iter_core.hpp
@@ -406,7 +406,8 @@ concept input_or_output_iterator = requires(_It __i) {
 } && weakly_incrementable<_It>;
 
 _EXPORT_STD template <class _Se, class _It>
-concept sentinel_for = semiregular<_Se> && input_or_output_iterator<_It> && _Weakly_equality_comparable_with<_Se, _It>;
+concept sentinel_for = semiregular<_Se> && !_Integer_like<_Se> && input_or_output_iterator<_It>
+                    && _Weakly_equality_comparable_with<_Se, _It>;
 
 _EXPORT_STD template <class _Se, class _It> // specializations allowed by N5014 [iterator.concept.sizedsentinel]/3
 constexpr bool disable_sized_sentinel_for = false;

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -3686,7 +3686,7 @@ namespace lwg4510 {
         using difference_type = int;
 
         IterType& operator++();
-        IterType& operator++(int);
+        IterType operator++(int);
         IterType& operator*() const;
     };
 

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <__msvc_int128.hpp>
 #include <cassert>
 #include <compare>
 #include <concepts>
@@ -1544,6 +1545,27 @@ namespace iterator_concept_sentinel_test {
         return (unpack_iterator<Is>(std::make_index_sequence<iterator_archetype_max + 1>{}) && ...);
     }
     static_assert(unpack_sentinel(std::make_index_sequence<sentinel_archetype_max + 1>{}));
+
+    // Test LWG-4510
+    // "Ambiguity of std::ranges::advance and std::ranges::next when the difference type is also a sentinel type"
+    template <class T>
+    struct iterator {
+        using difference_type = int;
+
+        iterator& operator++();
+        iterator& operator++(int);
+        iterator& operator*() const;
+    };
+
+    struct any {
+        any(const auto&);
+
+        friend bool operator==(const any&, const any&);
+    };
+
+    static_assert(std::input_or_output_iterator<iterator<any>>);
+    static_assert(!std::sentinel_for<int, iterator<any>>);
+    static_assert(!std::sentinel_for<std::_Unsigned128, iterator<any>>);
 } // namespace iterator_concept_sentinel_test
 
 namespace iterator_concept_sizedsentinel_test {

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -3688,6 +3688,8 @@ namespace lwg4510 {
         IterType& operator++();
         IterType operator++(int);
         IterType& operator*() const;
+
+        friend bool operator==(const IterType&, const IterType&);
     };
 
     struct AnyType {
@@ -3698,6 +3700,7 @@ namespace lwg4510 {
     };
 
     static_assert(std::input_or_output_iterator<IterType<AnyType>>);
+    static_assert(std::sentinel_for<IterType<AnyType>, IterType<AnyType>>);
     static_assert(!std::sentinel_for<int, IterType<AnyType>>);
     static_assert(!std::sentinel_for<std::_Unsigned128, IterType<AnyType>>);
 } // namespace lwg4510

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -3691,7 +3691,8 @@ namespace lwg4510 {
     };
 
     struct AnyType {
-        AnyType(const auto&);
+        template <class T>
+        AnyType(const T&);
 
         friend bool operator==(const AnyType&, const AnyType&);
     };

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -3682,23 +3682,23 @@ namespace lwg4510 {
     // Test LWG-4510
     // "Ambiguity of std::ranges::advance and std::ranges::next when the difference type is also a sentinel type"
     template <class T>
-    struct iterator {
+    struct IterType {
         using difference_type = int;
 
-        iterator& operator++();
-        iterator& operator++(int);
-        iterator& operator*() const;
+        IterType& operator++();
+        IterType& operator++(int);
+        IterType& operator*() const;
     };
 
-    struct any {
-        any(const auto&);
+    struct AnyType {
+        AnyType(const auto&);
 
-        friend bool operator==(const any&, const any&);
+        friend bool operator==(const AnyType&, const AnyType&);
     };
 
-    static_assert(std::input_or_output_iterator<iterator<any>>);
-    static_assert(!std::sentinel_for<int, iterator<any>>);
-    static_assert(!std::sentinel_for<std::_Unsigned128, iterator<any>>);
+    static_assert(std::input_or_output_iterator<IterType<AnyType>>);
+    static_assert(!std::sentinel_for<int, IterType<AnyType>>);
+    static_assert(!std::sentinel_for<std::_Unsigned128, IterType<AnyType>>);
 } // namespace lwg4510
 
 namespace vso1121031 {

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -1545,27 +1545,6 @@ namespace iterator_concept_sentinel_test {
         return (unpack_iterator<Is>(std::make_index_sequence<iterator_archetype_max + 1>{}) && ...);
     }
     static_assert(unpack_sentinel(std::make_index_sequence<sentinel_archetype_max + 1>{}));
-
-    // Test LWG-4510
-    // "Ambiguity of std::ranges::advance and std::ranges::next when the difference type is also a sentinel type"
-    template <class T>
-    struct iterator {
-        using difference_type = int;
-
-        iterator& operator++();
-        iterator& operator++(int);
-        iterator& operator*() const;
-    };
-
-    struct any {
-        any(const auto&);
-
-        friend bool operator==(const any&, const any&);
-    };
-
-    static_assert(std::input_or_output_iterator<iterator<any>>);
-    static_assert(!std::sentinel_for<int, iterator<any>>);
-    static_assert(!std::sentinel_for<std::_Unsigned128, iterator<any>>);
 } // namespace iterator_concept_sentinel_test
 
 namespace iterator_concept_sizedsentinel_test {
@@ -3698,6 +3677,29 @@ namespace lwg3420 {
     static_assert(!has_member_difference_type<std::iterator_traits<X>>);
     static_assert(!has_member_value_type<std::iterator_traits<X>>);
 } // namespace lwg3420
+
+namespace lwg4510 {
+    // Test LWG-4510
+    // "Ambiguity of std::ranges::advance and std::ranges::next when the difference type is also a sentinel type"
+    template <class T>
+    struct iterator {
+        using difference_type = int;
+
+        iterator& operator++();
+        iterator& operator++(int);
+        iterator& operator*() const;
+    };
+
+    struct any {
+        any(const auto&);
+
+        friend bool operator==(const any&, const any&);
+    };
+
+    static_assert(std::input_or_output_iterator<iterator<any>>);
+    static_assert(!std::sentinel_for<int, iterator<any>>);
+    static_assert(!std::sentinel_for<std::_Unsigned128, iterator<any>>);
+} // namespace lwg4510
 
 namespace vso1121031 {
     // Validate that indirectly_readable_traits accepts type arguments with both value_type and element_type nested


### PR DESCRIPTION
Fixes #6218.

<!-- Before submitting a pull request, please ensure that:

* Any AI-generated code has been clearly disclosed in your PR description.
  We strongly discourage AI-generated changes to product code because the STL
  is a highly unusual codebase with complex correctness and performance
  requirements imposed by the Standard, and highly unusual code patterns that
  don't look like typical codebases. Our intensive code review process
  (to avoid bugs) is intentionally a bottleneck, so we ask that you be
  considerate of the time and effort that we'll need to spend, by starting
  with changes that you fully understand. Test code has weaker requirements,
  so AI-generated changes for tests can be acceptable if properly disclosed.

* Your PR description explains your intent behind the changes.
  We discourage AI-generated PR descriptions because we can read the changes,
  and we have access to the same AI tools that you have, so we can get
  an AI-generated summary if we want.

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
