### PR TITLE
Fix CodeQL warnings in Python

### DIFF
--- a/tests/utils/stl/test/format.py
+++ b/tests/utils/stl/test/format.py
@@ -130,7 +130,9 @@ class STLTestFormat:
 
         env = _mergeEnvironments(os.environ, testStep.env)
 
-        return testStep.cmd, *stl.util.executeCommand(testStep.cmd, cwd=testStep.workDir, env=env)
+        out, err, exitCode = stl.util.executeCommand(testStep.cmd, cwd=testStep.workDir, env=env)
+
+        return testStep.cmd, out, err, exitCode
 
     def getStages(self, test, litConfig):
         @dataclass

--- a/tests/utils/stl/test/format.py
+++ b/tests/utils/stl/test/format.py
@@ -112,19 +112,15 @@ class STLTestFormat:
 
             # cpfecl translates /Fo into --import_dir, but that is not
             # used in the same way by upstream EDG.
-            try:
+            if '--import_dir' in cmd:
                 index = cmd.index('--import_dir')
                 cmd.pop(index)
                 cmd.pop(index)
-            except ValueError:
-                pass
 
             # --print_diagnostics is not recognized by upstream EDG.
-            try:
+            if '--print_diagnostics' in cmd:
                 index = cmd.index('--print_diagnostics')
                 cmd.pop(index)
-            except ValueError:
-                pass
 
             yield TestStep(cmd, shared.execDir, shared.env, False)
 

--- a/tests/utils/stl/test/params.py
+++ b/tests/utils/stl/test/params.py
@@ -73,7 +73,7 @@ def getDefaultParameters(config, litConfig):
       Parameter(name="priority", choices=["idle", "low", "normal"], default="idle", type=str,
                 help='Process priority to run tests with: "idle" (the default), "low", or "normal". ' +
                   'Module "psutil" must be installed for this to have any effect.',
-                actions=lambda prio: beNice(prio)),
+                actions=beNice),
     ]
 
     return DEFAULT_PARAMETERS

--- a/tests/utils/stl/util.py
+++ b/tests/utils/stl/util.py
@@ -132,7 +132,9 @@ def killProcessAndChildren(pid):
             try:
                 child.kill()
             except psutil.NoSuchProcess:
+                # CodeQL: Intentionally ignore this exception; if the process has already terminated, that's fine.
                 pass
         psutilProc.kill()
     except psutil.NoSuchProcess:
+        # CodeQL: Intentionally ignore this exception; if the process has already terminated, that's fine.
         pass


### PR DESCRIPTION
* Fix CodeQL "Unnecessary lambda".
* Fix CodeQL "Empty except".
  + Instead of calling index() and ignoring ValueError, we can guard the logic with `if VALUE in LIST`.
* Suppress CodeQL "Empty except".
  + The warnings say "Except doesn't do anything and has no comment", so we should be able to add comments to suppress the warnings. Unlike C++ CodeQL suppressions, we don't have an opaque ID with a specific suppression syntax to follow, but prefixing the comment with "CodeQL:" will be a good reminder that these comments serve a purpose.
* Attempt to fix CodeQL "Mismatch in multiple assignment".
  + For the line `cmd, out, err, rc = self.runStep(step, litConfig)` this is complaining: "Assigning multiple variables without ensuring that you define a value for each variable causes an exception at runtime." I speculate that this is happening because CodeQL doesn't understand what we're doing with the 3-tuple returned by executeCommand(). I'm hoping that explicitly unpacking it into 3 variables, before composing runStep()'s 4-tuple result, will make it happy.
