### PR TITLE
Implement LWG-4511 Inconsistency between the deduction guide of `std::mdspan` taking `(data_handle_type, mapping_type, accessor_type)` and the corresponding constructor

### DIFF
--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1550,7 +1550,7 @@ mdspan(_ElementType*, const _MappingType&)
     -> mdspan<_ElementType, typename _MappingType::extents_type, typename _MappingType::layout_type>;
 
 template <class _MappingType, class _AccessorType>
-mdspan(const typename _AccessorType::data_handle_type&, const _MappingType&, const _AccessorType&)
+mdspan(typename _AccessorType::data_handle_type, const _MappingType&, const _AccessorType&)
     -> mdspan<typename _AccessorType::element_type, typename _MappingType::extents_type,
         typename _MappingType::layout_type, _AccessorType>;
 

--- a/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
@@ -1339,7 +1339,7 @@ constexpr void check_deduction_guides() {
         // (with volatile data_handle_type, per LWG-4511)
         int a[1]{};
         int* volatile p = a;
-        mdspan mds{p, layout_right::mapping<std::extents<std::size_t, 1>>{}, default_accessor<int>{}};
+        mdspan mds{p, layout_right::mapping<extents<size_t, 1>>{}, default_accessor<int>{}};
         static_assert(same_as<decltype(mds), mdspan<int, extents<size_t, 1>>>);
     }
 }

--- a/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_mdspan/test.cpp
@@ -1329,10 +1329,18 @@ constexpr void check_deduction_guides() {
         static_assert(same_as<decltype(mds2), mdspan<const long, dextents<int, 3>, layout_stride>>);
     }
 
-    { // const typename AccessorType::data_handle_type&, const MappingType&, const AccessorType&
+    { // typename AccessorType::data_handle_type, const MappingType&, const AccessorType&
         vector<bool> bools = {true, false, true, false};
         mdspan mds{bools.begin(), TrackingLayout<>::mapping<extents<int, 2, 2>>(1), VectorBoolAccessor{}};
         static_assert(same_as<decltype(mds), mdspan<bool, extents<int, 2, 2>, TrackingLayout<>, VectorBoolAccessor>>);
+    }
+
+    if !consteval { // typename AccessorType::data_handle_type, const MappingType&, const AccessorType&
+        // (with volatile data_handle_type, per LWG-4511)
+        int a[1]{};
+        int* volatile p = a;
+        mdspan mds{p, layout_right::mapping<std::extents<std::size_t, 1>>{}, default_accessor<int>{}};
+        static_assert(same_as<decltype(mds), mdspan<int, extents<size_t, 1>>>);
     }
 }
 


### PR DESCRIPTION
Fixes #6219.