### PR TITLE
Implement LWG-2746 Inconsistency between requirements for `emplace` between `optional` and `variant`

### DIFF
--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -382,7 +382,7 @@ public:
         return *this;
     }
 
-    template <class... _Types>
+    template <class... _Types, enable_if_t<is_constructible_v<_Ty, _Types...>, int> = 0>
     _CONSTEXPR20 _Ty& emplace(_Types&&... _Args)
         noexcept(is_nothrow_constructible_v<_Ty, _Types...>) /* strengthened */ {
         reset();

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -8365,6 +8365,7 @@ int run_test()
 
 #include <cassert>
 #include <optional>
+#include <string>
 #include <type_traits>
 #include <utility>
 
@@ -8402,6 +8403,29 @@ namespace msvc {
         static_assert(check_size<not_empty>);
         static_assert(check_size<many_bases>);
     } // namespace size
+
+    namespace lwg2746 {
+        template <class V, class T, class... Args>
+        constexpr bool can_emplace_impl = false;
+        template <class T, class... Args>
+        constexpr bool
+            can_emplace_impl<std::void_t<decltype(std::declval<T&>().emplace(std::declval<Args>()...))>, T, Args...> =
+                true;
+
+        template <class T, class... Args>
+        constexpr bool can_emplace = can_emplace_impl<void, T, Args...>;
+
+        static_assert(can_emplace<std::optional<int>>);
+        static_assert(can_emplace<std::optional<int>, int>);
+        static_assert(!can_emplace<std::optional<int>, std::string>);
+        static_assert(!can_emplace<std::optional<int>, int, int>);
+
+        static_assert(can_emplace<std::optional<std::string>, const std::string&>);
+        static_assert(can_emplace<std::optional<std::string>, const char*, unsigned int>);
+        static_assert(!can_emplace<std::optional<std::string>, const wchar_t*, unsigned int>);
+        static_assert(can_emplace<std::optional<std::string>, std::initializer_list<char>>);
+        static_assert(!can_emplace<std::optional<std::string>, std::initializer_list<int>>);
+    } // namespace lwg2746
 
     namespace lwg2842 {
         struct ConvertibleFromInPlace {


### PR DESCRIPTION
Fixes #6200.

It should be sufficient to just test that `optional::emplace` correctly behaves in SFINAE.