### PR TITLE
Implement LWG-4324 `unique_ptr<void>::operator*` is not SFINAE-friendly

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -3372,6 +3372,11 @@ constexpr bool _Can_form_pointer = false;
 template <class _Ty>
 constexpr bool _Can_form_pointer<_Ty, void_t<_Ty*>> = true;
 
+template <class, class = void>
+constexpr bool _Can_dereference = false;
+template <class _Ty>
+constexpr bool _Can_dereference<_Ty, void_t<decltype(*_STD declval<_Ty>())>> = true;
+
 _EXPORT_STD template <class _Ty, class _Dx /* = default_delete<_Ty> */>
 class unique_ptr { // non-copyable pointer to an object
 public:
@@ -3474,6 +3479,7 @@ public:
         return _Mypair._Get_first();
     }
 
+    template <class _Ptr = pointer, enable_if_t<_Can_dereference<_Ptr>, int> = 0>
     _NODISCARD _CONSTEXPR23 add_lvalue_reference_t<_Ty> operator*() const noexcept(noexcept(*_STD declval<pointer>())) {
 #if _HAS_CXX23
 #ifdef __cpp_lib_reference_from_temporary // TRANSITION

--- a/tests/std/tests/Dev11_1140665_unique_ptr_array_conversions/test.cpp
+++ b/tests/std/tests/Dev11_1140665_unique_ptr_array_conversions/test.cpp
@@ -202,6 +202,24 @@ constexpr bool test_lwg3865() {
     return true;
 }
 
+// also test LWG-4324 "unique_ptr<void>::operator* is not SFINAE-friendly"
+
+namespace lwg_4324 {
+    template <class, class = void>
+    constexpr bool can_dereference = false;
+    template <class T>
+    constexpr bool can_dereference<T, void_t<decltype(*declval<T>())>> = true;
+
+    STATIC_ASSERT(can_dereference<unique_ptr<int>>);
+    STATIC_ASSERT(can_dereference<const unique_ptr<int>&>);
+
+    STATIC_ASSERT(!can_dereference<unique_ptr<int[]>>);
+    STATIC_ASSERT(!can_dereference<const unique_ptr<int[]>&>);
+
+    STATIC_ASSERT(!can_dereference<unique_ptr<void>>);
+    STATIC_ASSERT(!can_dereference<const unique_ptr<void>&>);
+} // namespace lwg_4324
+
 int main() {
     {
         assert(g_objects == 0);


### PR DESCRIPTION
Fixes #6210.