### PR TITLE
Implement LWG-4314: Missing move in mdspan layout mapping::operator()

### DIFF
--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -728,7 +728,8 @@ public:
               && conjunction_v<is_convertible<_IndexTypes, index_type>...,
                   is_nothrow_constructible<index_type, _IndexTypes>...>
     _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
-        return _Index_impl(make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...);
+        return _Index_impl(
+            make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_STD move(_Indices))...);
     }
 
     _NODISCARD static constexpr bool is_always_unique() noexcept {

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -572,7 +572,8 @@ public:
               && conjunction_v<is_convertible<_IndexTypes, index_type>...,
                   is_nothrow_constructible<index_type, _IndexTypes>...>
     _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
-        return _Index_impl(make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...);
+        return _Index_impl(
+            make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_STD move(_Indices))...);
     }
 
     _NODISCARD static constexpr bool is_always_unique() noexcept {

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -977,7 +977,8 @@ public:
               && conjunction_v<is_convertible<_IndexTypes, index_type>...,
                   is_nothrow_constructible<index_type, _IndexTypes>...>
     _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
-        return _Index_impl(make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...);
+        return _Index_impl(
+            make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_STD move(_Indices))...);
     }
 
     _NODISCARD static constexpr bool is_always_unique() noexcept {

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -340,6 +340,23 @@ constexpr void check_call_operator() {
         assert(m3(1, 2) == 11);
         assert(m3(4, 5) == 29);
     }
+
+    { // LWG-4314: Missing move in mdspan layout mapping::operator()
+        struct LwgIndex {
+            constexpr operator int() & noexcept {
+                return 0;
+            }
+
+            constexpr operator int() && noexcept {
+                return 1;
+            }
+        };
+
+        layout_left::mapping<extents<int, 2>> m;
+        LwgIndex idx;
+        assert(m(idx) == 1);
+        assert(m(LwgIndex{}) == 1);
+    }
 }
 
 constexpr void check_stride_function() {

--- a/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
@@ -341,6 +341,23 @@ constexpr void check_call_operator() {
         assert(m3(2, 2) == 12);
         assert(m3(3, 4) == 19);
     }
+
+    { // LWG-4314: Missing move in mdspan layout mapping::operator()
+        struct LwgIndex {
+            constexpr operator int() & noexcept {
+                return 1;
+            }
+
+            constexpr operator int() && noexcept {
+                return 0;
+            }
+        };
+
+        layout_right::mapping<extents<int, 2>> m;
+        LwgIndex idx;
+        assert(m(idx) == 0);
+        assert(m(LwgIndex{}) == 0);
+    }
 }
 
 constexpr void check_stride_function() {

--- a/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
@@ -548,6 +548,23 @@ constexpr void check_call_operator() {
         assert(m4(1, 1, 1) == 19);
         assert(m4(1, 2, 4) == 29);
     }
+
+    { // LWG-4314: Missing move in mdspan layout mapping::operator()
+        struct LwgIndex {
+            constexpr operator int() & noexcept {
+                return 0;
+            }
+
+            constexpr operator int() && noexcept {
+                return 1;
+            }
+        };
+
+        layout_stride::mapping<extents<int, 3>> m({}, array{2});
+        LwgIndex idx;
+        assert(m(idx) == 2);
+        assert(m(LwgIndex{}) == 2);
+    }
 }
 
 constexpr void check_stride_function() {


### PR DESCRIPTION
This PR implements changes to [[mdspan.layout.left.obs]](https://wg21.link/mdspan.layout.left.obs), [[mdspan.layout.right.obs]](https://wg21.link/mdspan.layout.right.obs), and [[mdspan.layout.stride.obs]](https://wg21.link/mdspan.layout.stride.obs). Other changes cannot be addressed here, because:
* We don't implement padded layouts,
* We already have call to `std::forward` in `_Mdspan_checked_index_cast`:
  https://github.com/microsoft/STL/blob/da06be8fa38418772506328177b703b28ca75699/stl/inc/mdspan#L1225-L1237
* Effect of `std::forward` in other occurrences of *`index-cast`* should not be observable by users.

I think we should close #6209 and mention LWG-4314 in #3807.