### PR TITLE
`STL.natvis`: add `layout_stride::mapping` visualizer

### DIFF
--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -2275,27 +2275,27 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         </Loop>
       </CustomListItems>
 
-    <!-- Fully dynamic extents -->
-    <CustomListItems Condition="_Rank == _Rank_dynamic" Optional="true">
-      <Variable Name="idx" InitialValue="0" />
-      <Variable Name="dynptr" InitialValue="($T1*) _Array._Elems" />
-      <Loop>
-        <Break Condition="idx == _Rank_dynamic" />
-        <Item Name="[{idx}] dynamic extent">*dynptr</Item>
-        <Exec>++idx, ++dynptr</Exec>
-      </Loop>
-    </CustomListItems>
+      <!-- Fully dynamic extents -->
+      <CustomListItems Condition="_Rank == _Rank_dynamic" Optional="true">
+        <Variable Name="idx" InitialValue="0" />
+        <Variable Name="dynptr" InitialValue="($T1*) _Array._Elems" />
+        <Loop>
+          <Break Condition="idx == _Rank_dynamic" />
+          <Item Name="[{idx}] dynamic extent">*dynptr</Item>
+          <Exec>++idx, ++dynptr</Exec>
+        </Loop>
+      </CustomListItems>
 
-    <!-- Fully static extents -->
-    <CustomListItems Condition="_Rank_dynamic == 0" Optional="true">
-      <Variable Name="idx" InitialValue="0" />
-      <Variable Name="statptr" InitialValue="(const rank_type*) _Static_extents._Elems" />
-      <Loop>
-        <Break Condition="idx == _Rank" />
-        <Item Name="[{idx}] static extent">($T1) *statptr</Item>
-        <Exec>++idx, ++statptr</Exec>
-      </Loop>
-    </CustomListItems>
+      <!-- Fully static extents -->
+      <CustomListItems Condition="_Rank_dynamic == 0" Optional="true">
+        <Variable Name="idx" InitialValue="0" />
+        <Variable Name="statptr" InitialValue="(const rank_type*) _Static_extents._Elems" />
+        <Loop>
+          <Break Condition="idx == _Rank" />
+          <Item Name="[{idx}] static extent">($T1) *statptr</Item>
+          <Exec>++idx, ++statptr</Exec>
+        </Loop>
+      </CustomListItems>
     </Expand>
   </Type>
 

--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -2299,6 +2299,14 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     </Expand>
   </Type>
 
+  <Type Name="std::layout_stride::mapping&lt;*&gt;">
+    <DisplayString>{{ rank={extents_type::_Rank}, rank_dynamic={extents_type::_Rank_dynamic} }}</DisplayString>
+    <Expand>
+      <Item Name="[extents]" Optional="true">this->_Exts</Item>
+      <Item Name="[strides]" Optional="true">this->_Array</Item>
+    </Expand>
+  </Type>
+
   <Type Name="std::flat_map&lt;*&gt;">
    <AlternativeType Name="std::flat_multimap&lt;*&gt;"/>
     <Intrinsic Name="size" Expression="_Data.keys.size()"/>


### PR DESCRIPTION
Before:
![before](https://github.com/user-attachments/assets/e19e6015-b2b3-4a08-817e-bb6618c4cdfa)

After:
![after](https://github.com/user-attachments/assets/4ff31346-4bbc-47b0-b8cf-8cfa92981395)

<details>
  <summary>before-after code</summary>

  ```c++
  #include <mdspan>
  
  using namespace std;
  
  int main() {
      using E1 = extents<int, 3>;
      layout_stride::mapping<E1> m1({}, array{ 2 });
      (void)m1.stride(0);
  
      using E2 = dextents<short, 2>;
      layout_stride::mapping<E2> m2(E2{ 3, 4 }, to_array<short>({ 5, 1 }));
      (void)m2.stride(1);
  
      using E3 = extents<size_t, 4, dynamic_extent, 6>;
      layout_stride::mapping<E3> m3(E3{ 5 }, to_array<size_t>({ 5, 1, 22 }));
      (void)m3.stride(2);
  }
  ```
</details>

Also fixes indentation in `extents`'s visualizer (added in #6053).