### PR TITLE
`<mdspan>`: Require `mdspan`'s element type to be an object type

### DIFF
--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1257,6 +1257,8 @@ private:
     static_assert(
         sizeof(element_type) > 0, "ElementType must be a complete type (N4950 [mdspan.mdspan.overview]/2.1).");
     static_assert(
+        is_object_v<element_type>, "ElementType must be an object type (N5032 [mdspan.mdspan.overview]/2.1).");
+    static_assert(
         !is_abstract_v<element_type>, "ElementType cannot be an abstract type (N4950 [mdspan.mdspan.overview]/2.1).");
     static_assert(
         !is_array_v<element_type>, "ElementType cannot be an array type (N4950 [mdspan.mdspan.overview]/2.1).");


### PR DESCRIPTION
Fixes #6250.

There's a similar requirement in [[mdspan.accessor.default.overview]/2](https://eel.is/c++draft/mdspan.accessor.default.overview#2), but we don't need to add another `statis_assert`, because for `default_accessor` we're already requiring both `_ElementType&` and `_ElementType*` to be well-formed.

The reference working draft numbers are somehow inconsistent, but I'd like to harmonize all these numbers after the publishment of the C++26 final working draft.