### PR TITLE
Various cleanups

### DIFF
--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -610,7 +610,7 @@ namespace ranges {
             _STL_INTERNAL_STATIC_ASSERT(weakly_incrementable<_Ty>);
             _STL_INTERNAL_STATIC_ASSERT(indirectly_writable<_It, const _Ty&>);
 
-            if constexpr (_Iterator_is_contiguous<_It> && sized_sentinel_for<_Se, _It> && is_integral_v<_Ty>
+            if constexpr (contiguous_iterator<_It> && sized_sentinel_for<_Se, _It> && is_integral_v<_Ty>
                           && sizeof(_Ty) >= 4) {
                 // TRANSITION, DevCom-10593477: help the compiler vectorize
                 const auto _Ptr  = _To_address(_First);

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -871,9 +871,11 @@ public:
     }
 
     void seed(result_type _Xx0 = default_seed) { // set initial values from specified value
-        _Ty _Prev = this->_Ax[0] = _Xx0 & _WMSK;
+        _Ty _Prev    = _Xx0 & _WMSK;
+        this->_Ax[0] = _Prev;
         for (size_t _Ix = 1; _Ix < _Nx; ++_Ix) {
-            _Prev = this->_Ax[_Ix] = (_Ix + _Fx * (_Prev ^ (_Prev >> (_Wx - 2)))) & _WMSK;
+            _Prev          = (_Ix + _Fx * (_Prev ^ (_Prev >> (_Wx - 2)))) & _WMSK;
+            this->_Ax[_Ix] = _Prev;
         }
 
         this->_Idx = _Nx;

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -612,14 +612,14 @@ private:
 #define _ASAN_VECTOR_CREATE_GUARD    _Asan_create_guard _Annotator(*this)
 #define _ASAN_VECTOR_EXTEND_GUARD(n) _Asan_extend_guard _Annotator(this, (n))
 #define _ASAN_VECTOR_RELEASE_GUARD   _Annotator._Release()
-#else // ^^^ _INSERT_VECTOR_ANNOTATION / !_INSERT_VECTOR_ANNOTATION vvv
+#else // ^^^ defined(_INSERT_VECTOR_ANNOTATION) / !defined(_INSERT_VECTOR_ANNOTATION) vvv
 #define _ASAN_VECTOR_MODIFY(n)
 #define _ASAN_VECTOR_REMOVE
 #define _ASAN_VECTOR_CREATE
 #define _ASAN_VECTOR_CREATE_GUARD
 #define _ASAN_VECTOR_EXTEND_GUARD(n)
 #define _ASAN_VECTOR_RELEASE_GUARD
-#endif // ^^^ !_INSERT_VECTOR_ANNOTATION ^^^
+#endif // ^^^ !defined(_INSERT_VECTOR_ANNOTATION) ^^^
 
     using _Scary_val = _Vector_val<conditional_t<_Is_simple_alloc_v<_Alty>, _Simple_types<_Ty>,
         _Vec_iter_types<_Ty, size_type, difference_type, pointer, const_pointer>>>;

--- a/stl/inc/xfilesystem_abi.h
+++ b/stl/inc/xfilesystem_abi.h
@@ -107,8 +107,9 @@ struct __std_fs_find_data { // typedef struct _WIN32_FIND_DATAW {
     unsigned long _File_size_high; //     DWORD nFileSizeHigh;
     unsigned long _File_size_low; //     DWORD nFileSizeLow;
 
-    // MSDN: dwReserved0 specifies the reparse point tag if
-    // MSDN:  (dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0
+    // According to https://learn.microsoft.com/windows/win32/api/minwinbase/ns-minwinbase-win32_find_dataw
+    // dwReserved0 specifies the reparse point tag if
+    // (dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0
 
     __std_fs_reparse_tag _Reparse_point_tag; //     DWORD dwReserved0;
     unsigned long _Reserved1; //     DWORD dwReserved1;

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -805,7 +805,7 @@ struct _Simple_types { // wraps types from allocators with simple addressing for
     using const_pointer   = const value_type*;
 };
 
-// The number of user bytes a single byte of ASAN shadow memory can track.
+// The number of user bytes a single byte of ASan shadow memory can track.
 _INLINE_VAR constexpr size_t _Asan_granularity      = 8;
 _INLINE_VAR constexpr size_t _Asan_granularity_mask = _Asan_granularity - 1;
 

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -747,11 +747,11 @@ private:
 #define _ASAN_STRING_REMOVE(_Str)                       (_Str)._Remove_annotation()
 #define _ASAN_STRING_CREATE(_Str)                       (_Str)._Create_annotation()
 #define _ASAN_STRING_MODIFY(_Str, _Old_size, _New_size) (_Str)._Modify_annotation(_Old_size, _New_size)
-#else // ^^^ _INSERT_STRING_ANNOTATION / !_INSERT_STRING_ANNOTATION vvv
+#else // ^^^ defined(_INSERT_STRING_ANNOTATION) / !defined(_INSERT_STRING_ANNOTATION) vvv
 #define _ASAN_STRING_REMOVE(_Str)
 #define _ASAN_STRING_CREATE(_Str)
 #define _ASAN_STRING_MODIFY(_Str, _Old_size, _New_size)
-#endif // ^^^ !_INSERT_STRING_ANNOTATION ^^^
+#endif // ^^^ !defined(_INSERT_STRING_ANNOTATION) ^^^
 
 public:
     _CONSTEXPR20
@@ -949,9 +949,9 @@ private:
             } else { // _Strat == _Construct_strategy::_From_string
 #ifdef _INSERT_STRING_ANNOTATION
                 _Traits::copy(_My_data._Bx._Buf, _Arg, static_cast<size_t>(_Count + 1));
-#else // ^^^ _INSERT_STRING_ANNOTATION / !_INSERT_STRING_ANNOTATION vvv
+#else // ^^^ defined(_INSERT_STRING_ANNOTATION) / !defined(_INSERT_STRING_ANNOTATION) vvv
                 _Traits::copy(_My_data._Bx._Buf, _Arg, _BUF_SIZE);
-#endif // ^^^ !_INSERT_STRING_ANNOTATION ^^^
+#endif // ^^^ !defined(_INSERT_STRING_ANNOTATION) ^^^
             }
 
             _Proxy._Release();
@@ -1342,7 +1342,7 @@ private:
                 return;
             }
         }
-#endif // !defined(_INSERT_STRING_ANNOTATION)
+#endif // ^^^ !defined(_INSERT_STRING_ANNOTATION) ^^^
 
         if (_Right_data._Large_mode_engaged()) { // steal buffer
             _Swap_proxy_and_iterators(_Right);
@@ -2467,7 +2467,7 @@ public:
                 return;
             }
         }
-#endif // !defined(_INSERT_STRING_ANNOTATION)
+#endif // ^^^ !defined(_INSERT_STRING_ANNOTATION) ^^^
 
         const bool _My_large    = _My_data._Large_mode_engaged();
         const bool _Right_large = _Right_data._Large_mode_engaged();

--- a/stl/src/pplerror.cpp
+++ b/stl/src/pplerror.cpp
@@ -17,10 +17,13 @@
 
 extern "C" void* __GetPlatformExceptionInfo(int*);
 
+#endif // ^^^ defined(_CRT_APP) || defined(UNDOCKED_WINDOWS_UCRT) ^^^
+
 namespace Concurrency {
     namespace details {
 
         _CRTIMP2 void __thiscall _ExceptionHolder::ReportUnhandledError() {
+#if defined(_CRT_APP) || defined(UNDOCKED_WINDOWS_UCRT)
             if (_M_stdException) {
                 try {
                     std::rethrow_exception(_M_stdException);
@@ -43,19 +46,8 @@ namespace Concurrency {
                     }
                 }
             }
+#endif // ^^^ defined(_CRT_APP) || defined(UNDOCKED_WINDOWS_UCRT) ^^^
         }
 
     } // namespace details
 } // namespace Concurrency
-
-#else // defined(_CRT_APP) || defined(UNDOCKED_WINDOWS_UCRT)
-
-namespace Concurrency {
-    namespace details {
-
-        _CRTIMP2 void __thiscall _ExceptionHolder::ReportUnhandledError() {}
-
-    } // namespace details
-} // namespace Concurrency
-
-#endif // defined(_CRT_APP) || defined(UNDOCKED_WINDOWS_UCRT)

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -11,16 +11,16 @@
 #ifndef UNDOCKED_WINDOWS_UCRT
 #pragma warning(push)
 #pragma warning(disable : 4265) // non-virtual destructor in base class
-#endif
+#endif // ^^^ !defined(UNDOCKED_WINDOWS_UCRT) ^^^
 #include <wrl.h>
 #ifndef UNDOCKED_WINDOWS_UCRT
 #pragma warning(pop)
-#endif
+#endif // ^^^ !defined(UNDOCKED_WINDOWS_UCRT) ^^^
 #include <ctxtcall.h>
 #include <functional>
 #include <stdexcept>
 #include <windows.foundation.diagnostics.h>
-#endif
+#endif // ^^^ defined(_CRT_APP) || defined(UNDOCKED_WINDOWS_UCRT) ^^^
 
 namespace Concurrency {
 

--- a/tests/std/tests/Dev11_0000000_tuple_cat/test.cpp
+++ b/tests/std/tests/Dev11_0000000_tuple_cat/test.cpp
@@ -154,7 +154,10 @@ constexpr bool test() {
     }
 
     {
-        int w = 11, x = 22, y = 33, z = 44;
+        int w = 11;
+        int x = 22;
+        int y = 33;
+        int z = 44;
 
         tuple<int&, const int&, int&&, const int&&> t0(w, x, move(y), move(z));
 

--- a/tests/std/tests/Dev11_0019127_singular_iterators/test.cpp
+++ b/tests/std/tests/Dev11_0019127_singular_iterators/test.cpp
@@ -36,8 +36,16 @@ void test_sequence() {
     c.push_back(22);
     c.push_back(33);
 
-    typename C::iterator i1 = c.begin(), i2 = c.begin(), i3 = c.begin(), i4 = c.begin();
-    typename C::iterator x1, x2, x3, x4, x5, x6;
+    typename C::iterator i1 = c.begin();
+    typename C::iterator i2 = c.begin();
+    typename C::iterator i3 = c.begin();
+    typename C::iterator i4 = c.begin();
+    typename C::iterator x1;
+    typename C::iterator x2;
+    typename C::iterator x3;
+    typename C::iterator x4;
+    typename C::iterator x5;
+    typename C::iterator x6;
 
     x1 = i1;
     assert(*x1 == 11);
@@ -63,8 +71,16 @@ void test_map() {
     m.insert(make_pair(22, 456));
     m.insert(make_pair(33, 789));
 
-    typename M::iterator i1 = m.find(22), i2 = m.find(22), i3 = m.find(22), i4 = m.find(22);
-    typename M::iterator x1, x2, x3, x4, x5, x6;
+    typename M::iterator i1 = m.find(22);
+    typename M::iterator i2 = m.find(22);
+    typename M::iterator i3 = m.find(22);
+    typename M::iterator i4 = m.find(22);
+    typename M::iterator x1;
+    typename M::iterator x2;
+    typename M::iterator x3;
+    typename M::iterator x4;
+    typename M::iterator x5;
+    typename M::iterator x6;
 
     x1 = i1;
     assert(x1->second == 456);
@@ -90,8 +106,16 @@ void test_set() {
     s.insert(22);
     s.insert(33);
 
-    typename S::iterator i1 = s.find(22), i2 = s.find(22), i3 = s.find(22), i4 = s.find(22);
-    typename S::iterator x1, x2, x3, x4, x5, x6;
+    typename S::iterator i1 = s.find(22);
+    typename S::iterator i2 = s.find(22);
+    typename S::iterator i3 = s.find(22);
+    typename S::iterator i4 = s.find(22);
+    typename S::iterator x1;
+    typename S::iterator x2;
+    typename S::iterator x3;
+    typename S::iterator x4;
+    typename S::iterator x5;
+    typename S::iterator x6;
 
     x1 = i1;
     assert(*x1 == 22);
@@ -131,8 +155,16 @@ int main() {
         f.push_front(22);
         f.push_front(11);
 
-        forward_list<int>::iterator i1 = f.begin(), i2 = f.begin(), i3 = f.begin(), i4 = f.begin();
-        forward_list<int>::iterator x1, x2, x3, x4, x5, x6;
+        forward_list<int>::iterator i1 = f.begin();
+        forward_list<int>::iterator i2 = f.begin();
+        forward_list<int>::iterator i3 = f.begin();
+        forward_list<int>::iterator i4 = f.begin();
+        forward_list<int>::iterator x1;
+        forward_list<int>::iterator x2;
+        forward_list<int>::iterator x3;
+        forward_list<int>::iterator x4;
+        forward_list<int>::iterator x5;
+        forward_list<int>::iterator x6;
 
         x1 = i1;
         assert(*x1 == 11);
@@ -154,8 +186,16 @@ int main() {
     {
         array<int, 3> a = {{11, 22, 33}};
 
-        array<int, 3>::iterator i1 = a.begin(), i2 = a.begin(), i3 = a.begin(), i4 = a.begin();
-        array<int, 3>::iterator x1, x2, x3, x4, x5, x6;
+        array<int, 3>::iterator i1 = a.begin();
+        array<int, 3>::iterator i2 = a.begin();
+        array<int, 3>::iterator i3 = a.begin();
+        array<int, 3>::iterator i4 = a.begin();
+        array<int, 3>::iterator x1;
+        array<int, 3>::iterator x2;
+        array<int, 3>::iterator x3;
+        array<int, 3>::iterator x4;
+        array<int, 3>::iterator x5;
+        array<int, 3>::iterator x6;
 
         x1 = i1;
         assert(*x1 == 11);
@@ -177,8 +217,16 @@ int main() {
     {
         string s("meow");
 
-        string::iterator i1 = s.begin(), i2 = s.begin(), i3 = s.begin(), i4 = s.begin();
-        string::iterator x1, x2, x3, x4, x5, x6;
+        string::iterator i1 = s.begin();
+        string::iterator i2 = s.begin();
+        string::iterator i3 = s.begin();
+        string::iterator i4 = s.begin();
+        string::iterator x1;
+        string::iterator x2;
+        string::iterator x3;
+        string::iterator x4;
+        string::iterator x5;
+        string::iterator x6;
 
         x1 = i1;
         assert(*x1 == 'm');
@@ -202,8 +250,15 @@ int main() {
         const regex r("\\w+");
 
         sregex_iterator i1(s.begin(), s.end(), r);
-        sregex_iterator i2(i1), i3(i1), i4(i1);
-        sregex_iterator x1, x2, x3, x4, x5, x6;
+        sregex_iterator i2(i1);
+        sregex_iterator i3(i1);
+        sregex_iterator i4(i1);
+        sregex_iterator x1;
+        sregex_iterator x2;
+        sregex_iterator x3;
+        sregex_iterator x4;
+        sregex_iterator x5;
+        sregex_iterator x6;
 
         x1 = i1;
         assert((*x1)[0] == "cute");
@@ -227,8 +282,15 @@ int main() {
         const regex r("\\w+");
 
         sregex_token_iterator i1(s.begin(), s.end(), r);
-        sregex_token_iterator i2(i1), i3(i1), i4(i1);
-        sregex_token_iterator x1, x2, x3, x4, x5, x6;
+        sregex_token_iterator i2(i1);
+        sregex_token_iterator i3(i1);
+        sregex_token_iterator i4(i1);
+        sregex_token_iterator x1;
+        sregex_token_iterator x2;
+        sregex_token_iterator x3;
+        sregex_token_iterator x4;
+        sregex_token_iterator x5;
+        sregex_token_iterator x6;
 
         x1 = i1;
         assert(*x1 == "cute");
@@ -253,8 +315,16 @@ int main() {
         v.push_back(22);
         v.push_back(33);
 
-        vector<int>::reverse_iterator i1 = v.rbegin(), i2 = v.rbegin(), i3 = v.rbegin(), i4 = v.rbegin();
-        vector<int>::reverse_iterator x1, x2, x3, x4, x5, x6;
+        vector<int>::reverse_iterator i1 = v.rbegin();
+        vector<int>::reverse_iterator i2 = v.rbegin();
+        vector<int>::reverse_iterator i3 = v.rbegin();
+        vector<int>::reverse_iterator i4 = v.rbegin();
+        vector<int>::reverse_iterator x1;
+        vector<int>::reverse_iterator x2;
+        vector<int>::reverse_iterator x3;
+        vector<int>::reverse_iterator x4;
+        vector<int>::reverse_iterator x5;
+        vector<int>::reverse_iterator x6;
 
         x1 = i1;
         assert(*x1 == 33);

--- a/tests/std/tests/Dev11_0748972_function_crash_out_of_memory/test.cpp
+++ b/tests/std/tests/Dev11_0748972_function_crash_out_of_memory/test.cpp
@@ -78,7 +78,11 @@ void test(const int num) {
         memset(pv, 0xCC, sizeof(bits));
 
         vector<int> v(10, 1729);
-        long long a = 0, b = 0, c = 0, d = 0, e = 0;
+        long long a     = 0;
+        long long b     = 0;
+        long long c     = 0;
+        long long d     = 0;
+        long long e     = 0;
         auto big_lambda = [v, a, b, c, d, e] {
             (void) v;
             (void) a;

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -1928,7 +1928,7 @@ void run_allocator_matrix() {
 }
 
 void test_DevCom_10116361() {
-    // We failed to null-terminate copies of SSO strings with ASAN annotations active.
+    // We failed to null-terminate copies of SSO strings with ASan annotations active.
 #ifdef _WIN64
     constexpr const char* text = "testtest";
     constexpr size_t n         = 8;
@@ -1950,7 +1950,7 @@ void test_DevCom_10116361() {
 }
 
 void test_DevCom_10109507() {
-    // replace failed to correctly munge asan annotations while working
+    // replace failed to correctly munge ASan annotations while working
     string s("abcd");
     s.replace(0, 1, "ef", 2);
     s.replace(0, 0, "xy", 2);
@@ -1965,7 +1965,7 @@ void test_gh_3883() {
 }
 
 void test_gh_3955() {
-    // GH-3955 <xstring>: ASAN report container-overflow in a legal case
+    // GH-3955 <xstring>: ASan report container-overflow in a legal case
     string s(19, '0');
     s = &s[3];
     assert(s == string(16, '0'));

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -206,7 +206,7 @@ bool verify_vector(vector<T, Alloc>& vec) {
 #else // ^^^ ASan instrumentation enabled / ASan instrumentation disabled vvv
     (void) vec;
     return true;
-#endif // Asan instrumentation disabled
+#endif // ^^^ ASan instrumentation disabled ^^^
 }
 
 // Note: This class does not satisfy all the allocator requirements but is sufficient for this test.

--- a/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
+++ b/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
@@ -479,7 +479,8 @@ namespace {
         namespace is_equal {
             void test() {
                 {
-                    compare_resource<false> r1, r2;
+                    compare_resource<false> r1;
+                    compare_resource<false> r2;
                     // resources with the same address are equal regardless of what do_is_equal returns.
                     CHECK(r1 == r1);
                     CHECK(!(r1 != r1));
@@ -487,7 +488,8 @@ namespace {
                     CHECK(r2 != r1);
                 }
                 {
-                    compare_resource<true> r1, r2;
+                    compare_resource<true> r1;
+                    compare_resource<true> r2;
                     CHECK(r1 == r1);
                     CHECK(!(r1 != r1));
                     CHECK(r1 == r2);
@@ -496,7 +498,8 @@ namespace {
                     CHECK(!(r2 != r1));
                 }
                 {
-                    checked_resource r1, r2;
+                    checked_resource r1;
+                    checked_resource r2;
                     CHECK(r1 == r1);
                     CHECK(!(r1 != r1));
                     r1.ptr_ = &r2;
@@ -1451,7 +1454,8 @@ namespace {
         namespace is_equal {
             template <class PoolResource>
             void test_is_equal() {
-                PoolResource pr1, pr2;
+                PoolResource pr1;
+                PoolResource pr2;
                 CHECK(pr1 == pr1);
                 CHECK(!(pr1 != pr1));
                 CHECK(pr1.is_equal(pr1));

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -1204,7 +1204,8 @@ namespace iterator_cust_swap_test {
         // This test notably executes both at runtime and at compiletime.
         static_assert(bullet2<int*>);
 
-        int i0 = 42, i1 = 13;
+        int i0 = 42;
+        int i1 = 13;
         static_assert(same_as<decltype(ranges::iter_swap(&i0, &i1)), void>);
         ranges::iter_swap(&i0, &i1);
         assert(i0 == 13);

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -1800,7 +1800,8 @@ namespace test_ranges_swap {
         using ranges::swap;
 
         {
-            DoNotUseFallback x, y;
+            DoNotUseFallback x;
+            DoNotUseFallback y;
             swap(x, y);
         }
         {
@@ -2121,7 +2122,8 @@ namespace test_swappable_with {
         } // namespace N
 
         void test() {
-            int i = 1, j = 2;
+            int i = 1;
+            int j = 2;
             lv_swap(i, j);
             assert(i == 2 && j == 1);
 

--- a/tests/std/tests/P2093R14_formatted_output/test.cpp
+++ b/tests/std/tests/P2093R14_formatted_output/test.cpp
@@ -121,9 +121,11 @@ namespace test {
     private:
         void delete_console() {
             if (is_console_valid()) {
-                // According to the MSDN, we don't call CloseHandle() on handles passed to _open_osfhandle(),
-                // and we don't call _close() on file descriptors passed to _fdopen(). So, our only clean-up
-                // task is to call fclose().
+                // According to the documentation, our only clean-up task is to call fclose().
+                // * https://learn.microsoft.com/cpp/c-runtime-library/reference/open-osfhandle
+                //   + "Don't call the Win32 function CloseHandle on the original handle."
+                // * https://learn.microsoft.com/cpp/c-runtime-library/reference/fdopen-wfdopen
+                //   + "If _fdopen is successful, don't call _close on the file descriptor."
                 fclose(file_stream_ptr);
 
                 console_handle  = nullptr;

--- a/tests/std/tests/VSO_0000000_instantiate_iterators_misc/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0000000_instantiate_iterators_misc/test.compile.pass.cpp
@@ -1547,7 +1547,8 @@ void tuple_test() {
     (void) get<volatile int>(tuple<volatile int>{});
     (void) get<const volatile int>(tuple<const volatile int>{});
 
-    int a = 1, b = 2;
+    int a     = 1;
+    int b     = 2;
     tie(a, b) = make_tuple(a, b);
     (void) forward_as_tuple(string{}, string{});
 

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -346,7 +346,7 @@ class STLTest(Test):
             self._addCustomFeature('MT')
             self._addCustomFeature('static_CRT')
 
-        # clang doesn't know how to link in the VS version of the asan runtime automatically
+        # Clang doesn't know how to link in the VS version of the ASan runtime automatically
         if 'asan' in self.config.available_features and 'clang' in self.config.available_features:
             self.linkFlags.append("/INFERASANLIBS")
 


### PR DESCRIPTION
* Improve comments citing MSDN.
* Comments: Consistently capitalize ASan (and other minor cleanups).
* ppltasks.cpp: Add preprocessor comments.
* pplerror.cpp: Adjust preprocessor logic, no functional change.
* Avoid multi-assigns in `mersenne_twister_engine::seed()`, no functional change.
  + This reverses the order in which we initialize/assign the local variable `_Prev` but that has no effect.
* `ranges::iota` can use `contiguous_iterator`.
* Improve preprocessor comments for ASan annotations.
* Avoid multi-definitions.
