### PR TITLE
Toolset update: MSVC Compiler 19.52.36307.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,12 @@ endif()
 include(CheckCXXSourceCompiles)
 check_cxx_source_compiles([=[
 #include <sdkddkver.h>
-static_assert(WDK_NTDDI_VERSION >= NTDDI_WIN11_GE, "Inspecting WDK_NTDDI_VERSION, the Windows SDK version.");
+static_assert(WDK_NTDDI_VERSION >= NTDDI_WIN11_BR, "Inspecting WDK_NTDDI_VERSION, the Windows SDK version.");
 int main() {}
 ]=] WINDOWS_SDK_VERSION_CHECK)
 
 if(NOT WINDOWS_SDK_VERSION_CHECK)
-    message(FATAL_ERROR "The STL must be built with the Windows 11 SDK (10.0.26100) or later. Follow the README instructions.")
+    message(FATAL_ERROR "The STL must be built with the Windows 11 SDK (10.0.28000) or later. Follow the README instructions.")
 endif()
 
 if(NOT DEFINED VCLIBS_TARGET_ARCHITECTURE)
@@ -88,16 +88,16 @@ set(STL_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/out/bin/${VCLIBS_I386_OR
 # Note that we set _WIN32_WINNT to a high level to make declarations available.
 add_compile_definitions(
     _ALLOW_ITERATOR_DEBUG_LEVEL_MISMATCH WIN32_LEAN_AND_MEAN STRICT _CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS
-    _WIN32_WINNT=0x0A00 NTDDI_VERSION=NTDDI_WIN11_GE)
+    _WIN32_WINNT=0x0A00 NTDDI_VERSION=NTDDI_WIN11_BR)
 
 if(STL_USE_ANALYZE)
-    # TRANSITION, Windows SDK 10.0.26100 emits
+    # TRANSITION, Windows SDK 10.0.28000 emits
     # "warning C6553: The annotation for function 'LCMapStringEx' on _Param_(9) does not apply to a value type."
     # Reported as OS-40109504 "Windows SDK: incorrect SAL annotations on functions the STL uses".
     add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/analyze:autolog-;/wd6553>")
 
     if(VCLIBS_TARGET_ARCHITECTURE STREQUAL "arm64ec")
-        # TRANSITION, Windows SDK 10.0.26100 emits
+        # TRANSITION, Windows SDK 10.0.28000 emits
         # "warning C28301: No annotations for first declaration of 'meow'"
         # for various intrinsics when building for ARM64EC.
         add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/wd28301>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 4.2.3)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 
-if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.51.36223.2")
-    message(FATAL_ERROR "The STL must be built with MSVC Compiler 19.51.36223.2 or later. Follow the README instructions.")
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.52.36307.1")
+    message(FATAL_ERROR "The STL must be built with MSVC Compiler 19.52.36307.1 or later. Follow the README instructions.")
 endif()
 
 include(CheckCXXSourceCompiles)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,10 +91,13 @@ add_compile_definitions(
     _WIN32_WINNT=0x0A00 NTDDI_VERSION=NTDDI_WIN11_BR)
 
 if(STL_USE_ANALYZE)
-    # TRANSITION, Windows SDK 10.0.28000 emits
+    # TRANSITION, Windows SDK 10.0.28000 emits multiple warnings:
     # "warning C6553: The annotation for function 'LCMapStringEx' on _Param_(9) does not apply to a value type."
     # Reported as OS-40109504 "Windows SDK: incorrect SAL annotations on functions the STL uses".
-    add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/analyze:autolog-;/wd6553>")
+    # "warning C28285: For function '_BitScanForward' '_Param_(1)' syntax error in 'SAL_range(0,(sizeof(Mask)*8)-1)' near 'Mask)*8'."
+    # Reported as VSO-2946529 "/analyze emits warning C28285 for _BitScanForward declared by winnt.h".
+    # Fixed by OS-PR-14602802 on 2026-01-22.
+    add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/analyze:autolog-;/wd6553;/wd28285>")
 
     if(VCLIBS_TARGET_ARCHITECTURE STREQUAL "arm64ec")
         # TRANSITION, Windows SDK 10.0.28000 emits

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
     - "MSVC Build Tools for x64/x86 (Preview)"
     - "C++ CMake tools for Windows"
     - "MSVC AddressSanitizer"
-    - "Windows 11 SDK (10.0.26100)" or later
+    - "Windows 11 SDK (10.0.28000)" or later
     - "C++ Clang tools for Windows (20.1.8 - x64/x86)"
     - *Optional, see Note 2 below:* "MSVC Build Tools for ARM64/ARM64EC (Preview)"
 * Install [Python][] 3.14.4 or later.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
     - "Windows 11 SDK (10.0.26100)" or later
     - "C++ Clang tools for Windows (20.1.8 - x64/x86)"
     - *Optional, see Note 2 below:* "MSVC Build Tools for ARM64/ARM64EC (Preview)"
-* Install [Python][] 3.14.3 or later.
+* Install [Python][] 3.14.4 or later.
   + Select "Add python.exe to PATH" if you want to follow the instructions below that invoke `python`.
     Otherwise, you should be familiar with alternative methods.
 

--- a/azure-devops/build-benchmarks.yml
+++ b/azure-devops/build-benchmarks.yml
@@ -24,7 +24,7 @@ steps:
       if (Test-Path -LiteralPath "$(benchmarkBuildOutputLocation)\${{ parameters.compiler }}") {
           Remove-Item -LiteralPath "$(benchmarkBuildOutputLocation)\${{ parameters.compiler }}" -Recurse -Force
       }
-      & "$(launchVsDevShell)" -HostArch ${{ parameters.hostArch }} -Arch ${{ parameters.targetArch }}
+      & "$(launchVsDevShell)" -Preview -NoLogo -HostArch ${{ parameters.hostArch }} -Arch ${{ parameters.targetArch }}
       cmake -G Ninja `
       -DCMAKE_CXX_COMPILER=${{ parameters.compiler }} `
       -DCMAKE_BUILD_TYPE=Release `
@@ -45,7 +45,7 @@ steps:
     targetType: inline
     script: |
       $PSNativeCommandUseErrorActionPreference = $true
-      & "$(launchVsDevShell)" -HostArch ${{ parameters.hostArch }} -Arch ${{ parameters.targetArch }}
+      & "$(launchVsDevShell)" -Preview -NoLogo -HostArch ${{ parameters.hostArch }} -Arch ${{ parameters.targetArch }}
       cmake --build "$(benchmarkBuildOutputLocation)\${{ parameters.compiler }}"
   timeoutInMinutes: 2
   env: { TMP: $(tmpDir), TEMP: $(tmpDir) }

--- a/azure-devops/cmake-configure-build.yml
+++ b/azure-devops/cmake-configure-build.yml
@@ -37,7 +37,7 @@ steps:
       if (Test-Path -LiteralPath "$(buildOutputLocation)") {
           Remove-Item -LiteralPath "$(buildOutputLocation)" -Recurse -Force
       }
-      & "$(launchVsDevShell)" -HostArch ${{ parameters.hostArch }} -Arch ${{ parameters.targetArch }}
+      & "$(launchVsDevShell)" -Preview -NoLogo -HostArch ${{ parameters.hostArch }} -Arch ${{ parameters.targetArch }}
       cmake -G Ninja `
       -DCMAKE_CXX_COMPILER=cl `
       -DCMAKE_BUILD_TYPE=Release `
@@ -57,7 +57,7 @@ steps:
     targetType: inline
     script: |
       $PSNativeCommandUseErrorActionPreference = $true
-      & "$(launchVsDevShell)" -HostArch ${{ parameters.hostArch }} -Arch ${{ parameters.targetArch }}
+      & "$(launchVsDevShell)" -Preview -NoLogo -HostArch ${{ parameters.hostArch }} -Arch ${{ parameters.targetArch }}
       cmake --build "$(buildOutputLocation)"
   timeoutInMinutes: 5
   condition: and(succeeded(), ${{ parameters.buildStl }})

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,13 +5,13 @@
 
 variables:
 - name: x64SlowPoolName
-  value: 'Stl-2026-04-01T0703-x64-Fasv6-Pool'
+  value: 'Stl-2026-04-17T0531-x64-Fasv6-Pool'
   readonly: true
 - name: x64FastPoolName
-  value: 'Stl-2026-04-01T0703-x64-Fasv7-Pool'
+  value: 'Stl-2026-04-17T0531-x64-Fasv7-Pool'
   readonly: true
 - name: arm64PoolName
-  value: 'Stl-2026-04-01T0703-arm64-Dpsv6-Pool'
+  value: 'Stl-2026-04-17T0531-arm64-Dpsv6-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -49,7 +49,7 @@ if ($VMSku -ieq 'Fasv6') {
   $AvailableLocations = @('eastus2', 'northeurope', 'uksouth')
 }
 
-$AvailableLocationIdx = 7 # Increment for each new set of pools, to cycle through the available locations.
+$AvailableLocationIdx = 8 # Increment for each new set of pools, to cycle through the available locations.
 $Location = $AvailableLocations[$AvailableLocationIdx % $AvailableLocations.Length]
 
 if ($Arch -ieq 'x64') {

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -180,11 +180,6 @@ $NetworkSecurityGroup = New-AzNetworkSecurityGroup `
 ####################################################################################################
 Display-ProgressBar -Status 'Creating virtual network subnet config'
 
-# TRANSITION, 2026-03-31: "After March 31, 2026, new virtual networks will default to using private subnets,
-# meaning that an explicit outbound method must be enabled in order to reach public endpoints on the Internet
-# and within Microsoft."
-# https://learn.microsoft.com/azure/virtual-network/ip-services/default-outbound-access
-# We're using `-DefaultOutboundAccess $false` to opt-in early.
 $SubnetName = "$ResourceGroupName-Subnet"
 $Subnet = New-AzVirtualNetworkSubnetConfig `
   -Name $SubnetName `

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -29,23 +29,24 @@ $Timestamp = $CurrentDate.ToString('yyyy-MM-ddTHHmm')
 # | Fasv7 | southeastasia |   640 |                    |
 # | Dpsv6 | eastus2       |  1024 |                    |
 # | Dpsv6 | northeurope   |  1024 |                    |
+# | Dpsv6 | uksouth       |  1024 |                    |
 # | Dpsv6 | westcentralus |   672 | Not currently used |
 
 if ($VMSku -ieq 'Fasv6') {
   $Arch = 'x64'
   $VMSize = 'Standard_F32as_v6'
-  $PoolSize = 64
+  $PoolSize = 64 # We have quota for 4096 cores (128 VMs), so we can have old and new pools of 64 VMs each.
   $AvailableLocations = @('eastus2')
 } elseif ($VMSku -ieq 'Fasv7') {
   $Arch = 'x64'
   $VMSize = 'Standard_F32as_v7'
-  $PoolSize = 20
+  $PoolSize = 20 # Locations where we have quota for at least 640 cores (20 VMs):
   $AvailableLocations = @('australiaeast', 'northeurope', 'southeastasia')
 } elseif ($VMSku -ieq 'Dpsv6') {
   $Arch = 'arm64'
   $VMSize = 'Standard_D32ps_v6'
-  $PoolSize = 32
-  $AvailableLocations = @('eastus2', 'northeurope') # Locations where CPP_STL_GitHub has quota for 1024 cores (32 VMs).
+  $PoolSize = 32 # Locations where we have quota for at least 1024 cores (32 VMs):
+  $AvailableLocations = @('eastus2', 'northeurope', 'uksouth')
 }
 
 $AvailableLocationIdx = 7 # Increment for each new set of pools, to cycle through the available locations.

--- a/azure-devops/format-validation.yml
+++ b/azure-devops/format-validation.yml
@@ -19,7 +19,7 @@ jobs:
           if (Test-Path -LiteralPath "$(validationBuildOutputLocation)") {
               Remove-Item -LiteralPath "$(validationBuildOutputLocation)" -Recurse -Force
           }
-          & "$(launchVsDevShell)" -HostArch x64 -Arch x64
+          & "$(launchVsDevShell)" -Preview -NoLogo -HostArch x64 -Arch x64
           cmake -G Ninja -S $(Build.SourcesDirectory)/tools -B "$(validationBuildOutputLocation)"
           cmake --build "$(validationBuildOutputLocation)"
       timeoutInMinutes: 5
@@ -31,7 +31,7 @@ jobs:
         targetType: inline
         script: |
           $PSNativeCommandUseErrorActionPreference = $true
-          & "$(launchVsDevShell)" -HostArch x64 -Arch x64
+          & "$(launchVsDevShell)" -Preview -NoLogo -HostArch x64 -Arch x64
           cmake --build "$(validationBuildOutputLocation)" --target run-format
       timeoutInMinutes: 5
       env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
@@ -42,7 +42,7 @@ jobs:
         targetType: inline
         script: |
           $PSNativeCommandUseErrorActionPreference = $true
-          & "$(launchVsDevShell)" -HostArch x64 -Arch x64
+          & "$(launchVsDevShell)" -Preview -NoLogo -HostArch x64 -Arch x64
           cmake --build "$(validationBuildOutputLocation)" --target run-validate
       timeoutInMinutes: 2
       env: { TMP: $(tmpDir), TEMP: $(tmpDir) }

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -66,9 +66,9 @@ $PowerShellArgs = @('/quiet', '/norestart')
 
 # https://www.python.org
 if ($Provisioning_x64) {
-  $PythonUrl = 'https://www.python.org/ftp/python/3.14.3/python-3.14.3-amd64.exe'
+  $PythonUrl = 'https://www.python.org/ftp/python/3.14.4/python-3.14.4-amd64.exe'
 } else {
-  $PythonUrl = 'https://www.python.org/ftp/python/3.14.3/python-3.14.3-arm64.exe'
+  $PythonUrl = 'https://www.python.org/ftp/python/3.14.4/python-3.14.4-arm64.exe'
 }
 $PythonArgs = @('/quiet', 'InstallAllUsers=1', 'PrependPath=1', 'CompileAll=1', 'Include_doc=0')
 

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -42,7 +42,7 @@ $VisualStudioWorkloads = @(
   'Microsoft.VisualStudio.Component.VC.Preview.ARM64',
   'Microsoft.VisualStudio.Component.VC.Preview.CLI.Support',
   'Microsoft.VisualStudio.Component.VC.Preview.Tools.x86.x64',
-  'Microsoft.VisualStudio.Component.Windows11SDK.26100'
+  'Microsoft.VisualStudio.Component.Windows11SDK.28000'
 )
 
 # https://learn.microsoft.com/visualstudio/install/visual-studio-on-arm-devices

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -74,7 +74,7 @@ $PythonArgs = @('/quiet', 'InstallAllUsers=1', 'PrependPath=1', 'CompileAll=1', 
 
 # https://developer.nvidia.com/cuda-toolkit
 if ($Provisioning_x64) {
-  $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/13.2.0/local_installers/cuda_13.2.0_windows.exe'
+  $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/13.2.1/local_installers/cuda_13.2.1_windows.exe'
 } else {
   $CudaUrl = 'CUDA is not installed for ARM64'
 }

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -185,13 +185,6 @@ if ($Provisioning_x64) {
   EnableNativeNVMe
 }
 
-# TRANSITION, patch Launch-VsDevShell.ps1 to pass `-vcvars_ver=preview` before a proper parameter is available.
-Write-Host 'Patching Launch-VsDevShell.ps1...'
-$launchVsDevShell = 'C:\Program Files\Microsoft Visual Studio\18\Insiders\Common7\Tools\Launch-VsDevShell.ps1'
-$paramRegex = 'VsInstanceId = \$instanceId'
-$paramSubst = '$&; DevCmdArguments = "-vcvars_ver=preview";'
-(Get-Content -Raw $launchVsDevShell) -creplace $paramRegex, $paramSubst | Set-Content -NoNewLine $launchVsDevShell
-
 # Tell create-1es-hosted-pool.ps1 that we succeeded.
 Write-Host 'PROVISION_IMAGE_SUCCEEDED'
 

--- a/azure-devops/run-tests.yml
+++ b/azure-devops/run-tests.yml
@@ -21,7 +21,7 @@ steps:
     targetType: inline
     script: |
       $PSNativeCommandUseErrorActionPreference = $true
-      & "$(launchVsDevShell)" -HostArch ${{ parameters.hostArch }} -Arch ${{ parameters.targetArch }}
+      & "$(launchVsDevShell)" -Preview -NoLogo -HostArch ${{ parameters.hostArch }} -Arch ${{ parameters.targetArch }}
       ninja --verbose -k 0 ${{ parameters.testTargets }}
   timeoutInMinutes: 30
   condition: and(succeeded(), ${{ parameters.runTesting }})

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -4539,7 +4539,7 @@ _NODISCARD auto inout_ptr(_SmartPtr& _Smart_ptr, _ArgsT&&... _Args) {
 #ifdef __cpp_lib_start_lifetime_as // TRANSITION
 _EXPORT_STD template <class _Ty>
 _Ty* start_lifetime_as(void* const _Ptr) noexcept {
-#ifdef __cpp_lib_is_implicit_lifetime // TRANSITION
+#ifdef __cpp_lib_is_implicit_lifetime // TRANSITION, toolset update
     static_assert(is_implicit_lifetime_v<_Ty>, "T must be an implicit-lifetime type. (N5032 [obj.lifetime]/1)");
 #endif // ^^^ no workaround ^^^
     static_assert(sizeof(_Ty) > 0, "T must be a complete type. (N5032 [obj.lifetime]/1)");
@@ -4547,7 +4547,7 @@ _Ty* start_lifetime_as(void* const _Ptr) noexcept {
 }
 _EXPORT_STD template <class _Ty>
 const _Ty* start_lifetime_as(const void* const _Ptr) noexcept {
-#ifdef __cpp_lib_is_implicit_lifetime // TRANSITION
+#ifdef __cpp_lib_is_implicit_lifetime // TRANSITION, toolset update
     static_assert(is_implicit_lifetime_v<_Ty>, "T must be an implicit-lifetime type. (N5032 [obj.lifetime]/1)");
 #endif // ^^^ no workaround ^^^
     static_assert(sizeof(_Ty) > 0, "T must be a complete type. (N5032 [obj.lifetime]/1)");
@@ -4555,7 +4555,7 @@ const _Ty* start_lifetime_as(const void* const _Ptr) noexcept {
 }
 _EXPORT_STD template <class _Ty>
 volatile _Ty* start_lifetime_as(volatile void* const _Ptr) noexcept {
-#ifdef __cpp_lib_is_implicit_lifetime // TRANSITION
+#ifdef __cpp_lib_is_implicit_lifetime // TRANSITION, toolset update
     static_assert(is_implicit_lifetime_v<_Ty>, "T must be an implicit-lifetime type. (N5032 [obj.lifetime]/1)");
 #endif // ^^^ no workaround ^^^
     static_assert(sizeof(_Ty) > 0, "T must be a complete type. (N5032 [obj.lifetime]/1)");
@@ -4563,7 +4563,7 @@ volatile _Ty* start_lifetime_as(volatile void* const _Ptr) noexcept {
 }
 _EXPORT_STD template <class _Ty>
 const volatile _Ty* start_lifetime_as(const volatile void* const _Ptr) noexcept {
-#ifdef __cpp_lib_is_implicit_lifetime // TRANSITION
+#ifdef __cpp_lib_is_implicit_lifetime // TRANSITION, toolset update
     static_assert(is_implicit_lifetime_v<_Ty>, "T must be an implicit-lifetime type. (N5032 [obj.lifetime]/1)");
 #endif // ^^^ no workaround ^^^
     static_assert(sizeof(_Ty) > 0, "T must be a complete type. (N5032 [obj.lifetime]/1)");

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -718,7 +718,7 @@ _EXPORT_STD template <class _Ty>
 _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_trivially_copyable_v = __is_trivially_copyable(_Ty);
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_is_implicit_lifetime // TRANSITION
+#ifdef __cpp_lib_is_implicit_lifetime // TRANSITION, toolset update
 _EXPORT_STD template <class _Ty>
 struct _NO_SPECIALIZATIONS_OF_TYPE_TRAITS is_implicit_lifetime : bool_constant<__builtin_is_implicit_lifetime(_Ty)> {};
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1759,7 +1759,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_invoke_r                          202106L
 #define __cpp_lib_ios_noreplace                     202207L
 
-#if !defined(__EDG__) && (defined(__clang__) || _MSC_VER >= 1951) // TRANSITION, GH-5738, VSO-2581623, toolset update
+#if defined(__clang__) || defined(__EDG__) || _MSC_VER >= 1951 // TRANSITION, toolset update
 #define __cpp_lib_is_implicit_lifetime 202302L
 #endif // ^^^ no workaround ^^^
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-find_package(Python "3.14.3" REQUIRED COMPONENTS Interpreter)
+find_package(Python "3.14.4" REQUIRED COMPONENTS Interpreter)
 
 set(STL_BUILD_ROOT "${PROJECT_BINARY_DIR}/out")
 set(STL_SOURCE_DIR "${PROJECT_SOURCE_DIR}")

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -399,14 +399,10 @@ std/strings/strings.erasure/erase.pass.cpp:1 FAIL
 # VSO-2338880 constexpr error in vector::iterator's _Compat() check when using views::transform
 std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.pass.cpp:0 FAIL
 std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.pass.cpp:1 FAIL
-std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.segmented.pass.cpp:0 FAIL
-std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.segmented.pass.cpp:1 FAIL
 std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_n.segmented.pass.cpp:0 FAIL
 std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_n.segmented.pass.cpp:1 FAIL
 std/algorithms/alg.modifying.operations/alg.copy/ranges.copy.segmented.pass.cpp:0 FAIL
 std/algorithms/alg.modifying.operations/alg.copy/ranges.copy.segmented.pass.cpp:1 FAIL
-std/algorithms/alg.modifying.operations/alg.move/ranges.move_backward.segmented.pass.cpp:0 FAIL
-std/algorithms/alg.modifying.operations/alg.move/ranges.move_backward.segmented.pass.cpp:1 FAIL
 std/algorithms/alg.modifying.operations/alg.move/ranges.move.segmented.pass.cpp:0 FAIL
 std/algorithms/alg.modifying.operations/alg.move/ranges.move.segmented.pass.cpp:1 FAIL
 
@@ -423,14 +419,6 @@ std/containers/views/mdspan/mdspan/index_operator.pass.cpp:1 FAIL
 # VSO-2574469 constexpr error in unique_ptr with a reference-to-function deleter: failure was caused by a read of an uninitialized symbol
 std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/pointer_deleter.pass.cpp:0 FAIL
 std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/pointer_deleter.pass.cpp:1 FAIL
-
-# VSO-2574473 constexpr error in ranges::join_with_view: failure was caused by unevaluable pointer value
-std/ranges/range.adaptors/range.adjacent.transform/general.pass.cpp:0 FAIL
-std/ranges/range.adaptors/range.adjacent.transform/general.pass.cpp:1 FAIL
-std/ranges/range.adaptors/range.adjacent/general.pass.cpp:0 FAIL
-std/ranges/range.adaptors/range.adjacent/general.pass.cpp:1 FAIL
-std/ranges/range.adaptors/range.join.with/range.join.with.iterator/ctor.not_const.pass.cpp:0 FAIL
-std/ranges/range.adaptors/range.join.with/range.join.with.iterator/ctor.not_const.pass.cpp:1 FAIL
 
 # VSO-2574489 constexpr ICE-on-valid with vector<bool>
 std/algorithms/alg.modifying.operations/alg.copy/copy_n.pass.cpp:0 FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1247,7 +1247,3 @@ std/iterators/iterator.container/ssize.LWG3207.compile.pass.cpp:9 SKIPPED
 
 # This test is marked as `REQUIRES: target={{.+}}-apple-{{.+}}`.
 std/input.output/file.streams/fstreams/filebuf.virtuals/overflow.writefail.pass.cpp:9 SKIPPED
-
-# This test has one check guarded in a "not CLANG" block, but upcoming MSVC will implement the
-# same behavior for binding an xvalue conversion function result to a const lvalue reference.
-std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp:9 SKIPPED

--- a/tests/std/tests/P0009R18_mdspan_extents/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_extents/test.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#if defined(_PREFAST_) && defined(_M_IX86) // TRANSITION, VSO-1639191
+int main() {}
+#else // ^^^ workaround / no workaround vvv
 #include <array>
 #include <cassert>
 #include <concepts>
@@ -549,3 +552,4 @@ int main() {
     static_assert(test());
     test();
 }
+#endif // ^^^ no workaround ^^^

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#if defined(_PREFAST_) && defined(_M_IX86) // TRANSITION, VSO-1639191
+int main() {}
+#else // ^^^ workaround / no workaround vvv
 #include <array>
 #include <cassert>
 #include <concepts>
@@ -493,3 +496,4 @@ int main() {
     static_assert(test());
     test();
 }
+#endif // ^^^ no workaround ^^^

--- a/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#if defined(_PREFAST_) && defined(_M_IX86) // TRANSITION, VSO-1639191
+int main() {}
+#else // ^^^ workaround / no workaround vvv
 #include <array>
 #include <cassert>
 #include <concepts>
@@ -509,3 +512,4 @@ int main() {
     static_assert(test());
     test();
 }
+#endif // ^^^ no workaround ^^^

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -2438,10 +2438,6 @@ void test_lwg_3886_volatile() {
 // Test LWG-3891: "LWG 3870 breaks std::expected<cv T, E>"
 
 struct FakeCvAssignable {
-#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, DevCom-11070772
-    char c_{};
-#endif // ^^^ workaround ^^^
-
     FakeCvAssignable()                                   = default;
     FakeCvAssignable(const FakeCvAssignable&)            = default;
     FakeCvAssignable(FakeCvAssignable&&)                 = default;

--- a/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
+++ b/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
@@ -675,14 +675,8 @@ constexpr bool test_construct_at_array() {
 
     test_std_construct_at_array<string, 1>();
     test_ranges_construct_at_array<string, 1>();
-
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, DevCom-11012299
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
-    {
-        test_std_construct_at_array<string, 42>();
-        test_ranges_construct_at_array<string, 42>();
-    }
+    test_std_construct_at_array<string, 42>();
+    test_ranges_construct_at_array<string, 42>();
 
     return true;
 }

--- a/tests/std/tests/P0896R4_ranges_alg_replace_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_replace_copy/test.cpp
@@ -10,6 +10,7 @@ int main() {}
 #include <ranges>
 #include <utility>
 
+#include <is_permissive.hpp>
 #include <range_algorithm_support.hpp>
 using namespace std;
 using P = pair<int, int>;
@@ -29,27 +30,32 @@ struct instantiator {
 
     template <ranges::input_range Read, indirectly_writable<ranges::range_reference_t<Read>> Write>
     static constexpr void call() {
-        using ranges::replace_copy, ranges::replace_copy_result, ranges::equal, ranges::iterator_t;
-        { // Validate iterator + sentinel overload
-            P output[5] = {{-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}};
-            Read wrapped_input{input};
+#ifdef _M_IX86 // TRANSITION, GH-3567
+        if constexpr (!is_permissive_v<Read>)
+#endif // ^^^ workaround ^^^
+        {
+            using ranges::replace_copy, ranges::replace_copy_result, ranges::equal, ranges::iterator_t;
+            { // Validate iterator + sentinel overload
+                P output[5] = {{-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}};
+                Read wrapped_input{input};
 
-            auto result =
-                replace_copy(wrapped_input.begin(), wrapped_input.end(), Write{output}, 47, P{47, 1}, get_second);
-            static_assert(same_as<decltype(result), replace_copy_result<iterator_t<Read>, Write>>);
-            assert(result.in == wrapped_input.end());
-            assert(result.out.peek() == output + 5);
-            assert(equal(output, expected));
-        }
-        { // Validate range overload
-            P output[5] = {{-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}};
-            Read wrapped_input{input};
+                auto result =
+                    replace_copy(wrapped_input.begin(), wrapped_input.end(), Write{output}, 47, P{47, 1}, get_second);
+                static_assert(same_as<decltype(result), replace_copy_result<iterator_t<Read>, Write>>);
+                assert(result.in == wrapped_input.end());
+                assert(result.out.peek() == output + 5);
+                assert(equal(output, expected));
+            }
+            { // Validate range overload
+                P output[5] = {{-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}};
+                Read wrapped_input{input};
 
-            auto result = replace_copy(wrapped_input, Write{output}, 47, P{47, 1}, get_second);
-            static_assert(same_as<decltype(result), replace_copy_result<iterator_t<Read>, Write>>);
-            assert(result.in == wrapped_input.end());
-            assert(result.out.peek() == output + 5);
-            assert(equal(output, expected));
+                auto result = replace_copy(wrapped_input, Write{output}, 47, P{47, 1}, get_second);
+                static_assert(same_as<decltype(result), replace_copy_result<iterator_t<Read>, Write>>);
+                assert(result.in == wrapped_input.end());
+                assert(result.out.peek() == output + 5);
+                assert(equal(output, expected));
+            }
         }
     }
 };

--- a/tests/std/tests/P0896R4_ranges_alg_replace_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_replace_copy/test.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#if defined(_PREFAST_) && defined(_M_IX86) // TRANSITION, VSO-1639191
+int main() {}
+#else // ^^^ workaround / no workaround vvv
 #include <algorithm>
 #include <cassert>
 #include <concepts>
@@ -57,3 +60,4 @@ int main() {
 #endif // TRANSITION, GH-1030
     input_range_output_iterator_permutations<instantiator, P const, P>();
 }
+#endif // ^^^ no workaround ^^^

--- a/tests/std/tests/P0896R4_ranges_alg_replace_copy_if/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_replace_copy_if/test.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#if defined(_PREFAST_) && defined(_M_IX86) // TRANSITION, VSO-1639191
+int main() {}
+#else // ^^^ workaround / no workaround vvv
 #include <algorithm>
 #include <cassert>
 #include <concepts>
@@ -59,3 +62,4 @@ int main() {
 #endif // TRANSITION, GH-1030
     input_range_output_iterator_permutations<instantiator, P const, P>();
 }
+#endif // ^^^ no workaround ^^^

--- a/tests/std/tests/P0896R4_ranges_alg_replace_copy_if/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_replace_copy_if/test.cpp
@@ -10,6 +10,7 @@ int main() {}
 #include <ranges>
 #include <utility>
 
+#include <is_permissive.hpp>
 #include <range_algorithm_support.hpp>
 using namespace std;
 using P = pair<int, int>;
@@ -31,27 +32,32 @@ struct instantiator {
 
     template <ranges::input_range Read, indirectly_writable<ranges::range_reference_t<Read>> Write>
     static constexpr void call() {
-        using ranges::replace_copy_if, ranges::replace_copy_if_result, ranges::equal, ranges::iterator_t;
-        { // Validate iterator + sentinel overload
-            P output[5] = {{-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}};
-            Read wrapped_input{input};
+#ifdef _M_IX86 // TRANSITION, GH-3567
+        if constexpr (!is_permissive_v<Read>)
+#endif // ^^^ workaround ^^^
+        {
+            using ranges::replace_copy_if, ranges::replace_copy_if_result, ranges::equal, ranges::iterator_t;
+            { // Validate iterator + sentinel overload
+                P output[5] = {{-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}};
+                Read wrapped_input{input};
 
-            auto result = replace_copy_if(
-                wrapped_input.begin(), wrapped_input.end(), Write{output}, matches, P{47, 1}, get_second);
-            static_assert(same_as<decltype(result), replace_copy_if_result<iterator_t<Read>, Write>>);
-            assert(result.in == wrapped_input.end());
-            assert(result.out.peek() == output + 5);
-            assert(equal(output, expected));
-        }
-        { // Validate range overload
-            P output[5] = {{-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}};
-            Read wrapped_input{input};
+                auto result = replace_copy_if(
+                    wrapped_input.begin(), wrapped_input.end(), Write{output}, matches, P{47, 1}, get_second);
+                static_assert(same_as<decltype(result), replace_copy_if_result<iterator_t<Read>, Write>>);
+                assert(result.in == wrapped_input.end());
+                assert(result.out.peek() == output + 5);
+                assert(equal(output, expected));
+            }
+            { // Validate range overload
+                P output[5] = {{-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}};
+                Read wrapped_input{input};
 
-            auto result = replace_copy_if(wrapped_input, Write{output}, matches, P{47, 1}, get_second);
-            static_assert(same_as<decltype(result), replace_copy_if_result<iterator_t<Read>, Write>>);
-            assert(result.in == wrapped_input.end());
-            assert(result.out.peek() == output + 5);
-            assert(equal(output, expected));
+                auto result = replace_copy_if(wrapped_input, Write{output}, matches, P{47, 1}, get_second);
+                static_assert(same_as<decltype(result), replace_copy_if_result<iterator_t<Read>, Write>>);
+                assert(result.in == wrapped_input.end());
+                assert(result.out.peek() == output + 5);
+                assert(equal(output, expected));
+            }
         }
     }
 };

--- a/tests/std/tests/P2374R4_views_cartesian_product/test.cpp
+++ b/tests/std/tests/P2374R4_views_cartesian_product/test.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#if defined(_PREFAST_) && defined(_M_IX86) // TRANSITION, VSO-1639191
+int main() {}
+#else // ^^^ workaround / no workaround vvv
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -1013,3 +1016,4 @@ int main() {
     static_assert((test_gh_4425(), true));
     test_gh_4425();
 }
+#endif // ^^^ no workaround ^^^

--- a/tests/std/tests/P2374R4_views_cartesian_product_recommended_practices/test.compile.pass.cpp
+++ b/tests/std/tests/P2374R4_views_cartesian_product_recommended_practices/test.compile.pass.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#if !(defined(_PREFAST_) && defined(_M_IX86)) // TRANSITION, VSO-1639191
 // Check MSVC-STL internal machinery
 
 #include <array>
@@ -493,3 +494,4 @@ constexpr bool test() {
 }
 
 static_assert(test());
+#endif // ^^^ no workaround ^^^

--- a/tests/std/tests/P2674R1_is_implicit_lifetime/test.compile.pass.cpp
+++ b/tests/std/tests/P2674R1_is_implicit_lifetime/test.compile.pass.cpp
@@ -154,7 +154,7 @@ static_assert(test_implicit_lifetime_cv<false, UserProvidedDestructorClass>);
 static_assert(test_implicit_lifetime_cv<true, StringAggregateWithImplicitlyDeclaredDestructor>);
 static_assert(test_implicit_lifetime_cv<false, StringAggregateWithUserProvidedDestructor>);
 static_assert(test_implicit_lifetime_cv<true, NonAggregateWithTrivialCtorAndTrivialDtor>);
-#ifndef __clang__ // TRANSITION, LLVM-160610
+#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, LLVM-160610, VSO-2941370 (EDG)
 static_assert(test_implicit_lifetime_cv<false, NonAggregateWithNonTrivialCtor>);
 static_assert(test_implicit_lifetime_cv<false, NonAggregateWithUserProvidedCtor>);
 #endif // ^^^ no workaround ^^^

--- a/tests/std/tests/P2674R1_is_implicit_lifetime/test.compile.pass.cpp
+++ b/tests/std/tests/P2674R1_is_implicit_lifetime/test.compile.pass.cpp
@@ -124,7 +124,6 @@ private:
     int num;
 };
 
-#ifdef __cpp_lib_is_implicit_lifetime
 template <bool Val, typename T>
 constexpr bool test_implicit_lifetime = is_implicit_lifetime_v<T> == Val && is_implicit_lifetime<T>::value == Val;
 template <bool Val, typename T>
@@ -177,4 +176,3 @@ static_assert(test_implicit_lifetime<false, long&>);
 static_assert(test_implicit_lifetime<false, long&&>);
 static_assert(test_implicit_lifetime<false, const long&>);
 static_assert(test_implicit_lifetime<false, const long&&>);
-#endif // ^^^ defined(__cpp_lib_is_implicit_lifetime) ^^^

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -555,7 +555,7 @@ STATIC_ASSERT(__cpp_lib_is_constant_evaluated == 201811L);
 
 STATIC_ASSERT(__cpp_lib_is_final == 201402L);
 
-#if _HAS_CXX23 && !defined(__EDG__) // TRANSITION, GH-5738 tracking VSO-2581623 (EDG)
+#if _HAS_CXX23
 STATIC_ASSERT(__cpp_lib_is_implicit_lifetime == 202302L);
 #elif defined(__cpp_lib_is_implicit_lifetime)
 #error __cpp_lib_is_implicit_lifetime is defined

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -261,7 +261,7 @@ class STLTest(Test):
                 self.compileFlags.append('/arm64EC')
                 self.linkFlags.append('/machine:arm64ec')
 
-                # TRANSITION, Windows SDK 10.0.26100 emits
+                # TRANSITION, Windows SDK 10.0.28000 emits
                 # "warning C28301: No annotations for first declaration of 'meow'"
                 # for various intrinsics when building for ARM64EC.
                 self.compileFlags.append('/wd28301')


### PR DESCRIPTION
* Got 1024 cores of Dpsv6 in uksouth, add comments.
* VS-PR-713550 on 2026-03-03 added `-Preview -NoLogo` to `Launch-VsDevShell.ps1`.
* Cycle locations.
* Remove TRANSITION comment about DefaultOutboundAccess.
  + To be safe, I'm going to keep passing `-DefaultOutboundAccess $false`.
* Python 3.14.4 (now required).
* CUDA 13.2.1.
  + Intentionally not increasing the requirement for patch versions.
* MSVC Compiler 19.52.36307.1 (now required).
  + Still can't update yvals_core.h due to the internal toolset.
* Windows 11 SDK 10.0.28000 (now required for STL development, but not usage).
  + Verified that warnings still repro.
* VS-PR-713693 on 2026-03-03 fixed DevCom-11012299 "EDG crashes when handling placement-new".
* VS-PR-713693 on 2026-03-03 fixed VSO-2581623 "EDG should implement `__builtin_is_implicit_lifetime`".
* libcxx/expected_results.txt: Cleanup an unnecessary MSVC-internal skip.
  + Followup to #6197. Any mention of a test as FAIL or SKIPPED for any configuration causes the MSVC-internal harness to skip it for all configurations.
* Some constexpr FAILs are now passing.
* Extend Clang workaround to EDG.
  + Reported VSO-2941370 "EDG `__builtin_is_implicit_lifetime` isn't checking for trivial constructors".
* New pools.
* MSVC-PR-720628 on 2026-03-26 fixed DevCom-11070772 "MSVC fails to activate a union member of certain empty class type during constant evaluation".
  + This workaround was very recently added by #6233.
* Work around VSO-2946529 "`/analyze` emits warning C28285 for `_BitScanForward` declared by winnt.h".
  + This has already been fixed by [OS-PR-14602802](https://microsoft.visualstudio.com/DefaultCollection/OS/_git/os.2020/pullrequest/14602802) on 2026-01-22, but I'm not sure when it'll ship (i.e. in a patch release of 10.0.28000.x, or in a whole new version which would take much longer).
* Work around VSO-1639191 "Excessive memory consumption with `/analyze` targeting x86".
  + Fine-grained workarounds don't appear to be viable, so I'm disabling the entire tests. Because this is specific to x86 `/analyze`, we still have reasonable coverage of x86 vanilla and non-x86 `/analyze`.
* Work around #3567.
  + The tests for `ranges::replace_copy` and `ranges::replace_copy_if` are now OOMing for x86 `/permissive` configurations. Add a targeted workaround for this. Note that we still have reasonable coverage of x86 strict and non-x86 `/permissive`.
