### PR TITLE
Update llvm-project

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1161,7 +1161,7 @@ std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp:9 SKIPPED
 std/algorithms/alg.nonmodifying/alg.find.last/ranges.find_last.pass.cpp:9 SKIPPED
 std/algorithms/alg.nonmodifying/alg.find/find.pass.cpp:9 SKIPPED
 std/algorithms/alg.nonmodifying/alg.find/ranges.find.pass.cpp:9 SKIPPED
-std/algorithms/alg.nonmodifying/alg.fold/left_folds.pass.cpp:9 SKIPPED
+std/algorithms/alg.nonmodifying/alg.fold/ranges.fold_left.pass.cpp:9 SKIPPED
 std/atomics/atomics.ref/compare_exchange_strong.pass.cpp:9 SKIPPED
 std/atomics/atomics.ref/compare_exchange_weak.pass.cpp:9 SKIPPED
 std/atomics/atomics.ref/wait.pass.cpp:9 SKIPPED

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -263,16 +263,17 @@ std/language.support/support.limits/support.limits.general/cstdlib.version.compi
 
 # P0543R3 Saturation Arithmetic
 # Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.
-std/numerics/numeric.ops/numeric.ops.sat/add_sat.compile.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/add_sat.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/div_sat.compile.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/div_sat.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/mul_sat.compile.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/mul_sat.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/saturate_cast.compile.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/saturate_cast.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/sub_sat.compile.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/sub_sat.pass.cpp FAIL
+std/numerics/numeric.ops/numeric.ops.sat/saturating_add.compile.pass.cpp FAIL
+std/numerics/numeric.ops/numeric.ops.sat/saturating_add.pass.cpp FAIL
+std/numerics/numeric.ops/numeric.ops.sat/saturating_cast.compile.pass.cpp FAIL
+std/numerics/numeric.ops/numeric.ops.sat/saturating_cast.pass.cpp FAIL
+std/numerics/numeric.ops/numeric.ops.sat/saturating_div.assert.pass.cpp FAIL
+std/numerics/numeric.ops/numeric.ops.sat/saturating_div.compile.pass.cpp FAIL
+std/numerics/numeric.ops/numeric.ops.sat/saturating_div.pass.cpp FAIL
+std/numerics/numeric.ops/numeric.ops.sat/saturating_mul.compile.pass.cpp FAIL
+std/numerics/numeric.ops/numeric.ops.sat/saturating_mul.pass.cpp FAIL
+std/numerics/numeric.ops/numeric.ops.sat/saturating_sub.compile.pass.cpp FAIL
+std/numerics/numeric.ops/numeric.ops.sat/saturating_sub.pass.cpp FAIL
 
 # P1789R3 Library Support For Expansion Statements
 # Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -267,7 +267,6 @@ std/numerics/numeric.ops/numeric.ops.sat/saturating_add.compile.pass.cpp FAIL
 std/numerics/numeric.ops/numeric.ops.sat/saturating_add.pass.cpp FAIL
 std/numerics/numeric.ops/numeric.ops.sat/saturating_cast.compile.pass.cpp FAIL
 std/numerics/numeric.ops/numeric.ops.sat/saturating_cast.pass.cpp FAIL
-std/numerics/numeric.ops/numeric.ops.sat/saturating_div.assert.pass.cpp FAIL
 std/numerics/numeric.ops/numeric.ops.sat/saturating_div.compile.pass.cpp FAIL
 std/numerics/numeric.ops/numeric.ops.sat/saturating_div.pass.cpp FAIL
 std/numerics/numeric.ops/numeric.ops.sat/saturating_mul.compile.pass.cpp FAIL
@@ -283,6 +282,30 @@ std/utilities/intseq/intseq.binding/tuple_interface.compile.pass.cpp FAIL
 # P2592R3 Hashing Support For chrono Value Classes
 # Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.
 std/time/time.hash/time.hash_enabled.pass.cpp FAIL
+
+# P2714R1 bind_front(), bind_back(), not_fn() For NTTP Callables
+# Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.
+std/utilities/function.objects/func.bind.partial/bind_front.nttp.pass.cpp FAIL
+
+# P2781R9 constant_wrapper
+# Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.
+std/utilities/const.wrap.class/adl.compile.pass.cpp FAIL
+std/utilities/const.wrap.class/assign.pass.cpp FAIL
+std/utilities/const.wrap.class/binary_ops.pass.cpp FAIL
+std/utilities/const.wrap.class/call.pass.cpp FAIL
+std/utilities/const.wrap.class/comma.pass.cpp FAIL
+std/utilities/const.wrap.class/comp.pass.cpp FAIL
+std/utilities/const.wrap.class/convert.pass.cpp FAIL
+std/utilities/const.wrap.class/ctad.compile.pass.cpp FAIL
+std/utilities/const.wrap.class/cw.pass.cpp FAIL
+std/utilities/const.wrap.class/cw_fixed.array.ctor.pass.cpp FAIL
+std/utilities/const.wrap.class/cw_fixed.ctor.pass.cpp FAIL
+std/utilities/const.wrap.class/general.pass.cpp FAIL
+std/utilities/const.wrap.class/mem_ptr.pass.cpp FAIL
+std/utilities/const.wrap.class/pseudo_mutators.pass.cpp FAIL
+std/utilities/const.wrap.class/subscript.pass.cpp FAIL
+std/utilities/const.wrap.class/types.compile.pass.cpp FAIL
+std/utilities/const.wrap.class/unary_ops.pass.cpp FAIL
 
 # P2835R7 atomic_ref::address()
 # Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -740,6 +740,10 @@ std/localization/locale.categories/category.time/locale.time.get.byname/get_date
 std/localization/locale.categories/category.time/locale.time.get.byname/get_one.pass.cpp FAIL
 std/localization/locale.categories/category.time/locale.time.get.byname/get_one_wide.pass.cpp FAIL
 
+# Bogus test rejects our validly strengthened noexcept:
+# static_assert(!noexcept((std::move(stride_iter).base())));
+std/ranges/range.adaptors/range.stride.view/iterator/base.pass.cpp FAIL
+
 
 # *** LIKELY STL BUGS ***
 # Not analyzed, likely STL bugs. Various assertions.
@@ -1151,6 +1155,10 @@ std/utilities/meta/meta.unary/meta.unary.prop/reference_constructs_from_temporar
 std/strings/basic.string/string.modifiers/string_replace/size_size_string_size_size.pass.cpp:0 SKIPPED
 std/strings/basic.string/string.modifiers/string_replace/size_size_string_size_size.pass.cpp:1 SKIPPED
 
+# Not analyzed.
+# MSVC error C2036: '_Sent': unknown size
+# Clang error: arithmetic on a pointer to void
+std/ranges/range.adaptors/range.stride.view/end.pass.cpp FAIL
 
 
 # *** MSVC-INTERNAL TEST HARNESS ISSUES (note: configuration :9 restricts these skips to be MSVC-internal) ***


### PR DESCRIPTION
* Update llvm-project.
  + llvm/llvm-project#188613
  + llvm/llvm-project#194707
* `left_folds.pass.cpp` was renamed to `ranges.fold_left.pass.cpp`.
  + llvm/llvm-project#180214
* `numeric.ops.sat` tests were renamed.
  + llvm/llvm-project#189574
* Categorize `range.stride.view` failures.
