### PR TITLE
`<regex>`: Avoid generating empty groups when parsing `?` quantifiers

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -3698,25 +3698,16 @@ void _Builder2<_FwdIt, _Elem, _RxTraits>::_Add_rep(int _Min, int _Max, bool _Gre
         _Node_endif* _End       = new _Node_endif;
         _Node_if* _If_expr      = new _Node_if(_End);
         _Node_if* _If_empty_str = new _Node_if(_End);
-        _Node_base* _Gbegin     = new _Node_base(_N_group);
-        _Node_end_group* _Gend  = new _Node_end_group(_N_end_group, _Fl_none, _Gbegin);
-
-        _If_empty_str->_Next = _Gbegin;
-        _Gbegin->_Prev       = _If_empty_str;
-
-        _Gbegin->_Next = _Gend;
-        _Gend->_Prev   = _Gbegin;
-
-        _Gend->_Next = _End;
-
-        _If_expr->_Child = _If_empty_str;
+        _If_empty_str->_Next    = _End;
+        _If_expr->_Child        = _If_empty_str;
 
         _Link_node(_End);
         _Insert_node(_Pos, _If_expr);
 
         if (!_Greedy) {
-            swap(_If_expr->_Next->_Prev, _If_empty_str->_Next->_Prev); // intentional ADL
-            swap(_If_expr->_Next, _If_empty_str->_Next); // intentional ADL
+            _If_expr->_Next->_Prev = _If_empty_str;
+            _End->_Prev            = _If_expr;
+            _STD swap(_If_expr->_Next, _If_empty_str->_Next);
         }
         return;
     }

--- a/tests/std/tests/VSO_0000000_regex_use/test.cpp
+++ b/tests/std/tests/VSO_0000000_regex_use/test.cpp
@@ -2634,6 +2634,24 @@ void test_gh_6262() {
     }
 }
 
+void test_gh_6267() {
+    // GH-6267: Avoid generating empty groups when parsing `?` quantifiers
+    for (const string re : {"a?", "a??"}) {
+        g_regexTester.should_match("a", re);
+        g_regexTester.should_match("", re);
+    }
+
+    {
+        test_regex re(&g_regexTester, "a?");
+        re.should_search_match("a", "a");
+    }
+
+    {
+        test_regex re(&g_regexTester, "a??");
+        re.should_search_match("a", "");
+    }
+}
+
 int main() {
     test_dev10_449367_case_insensitivity_should_work();
     test_dev11_462743_regex_collate_should_not_disable_regex_icase();
@@ -2703,6 +2721,7 @@ int main() {
     test_gh_6191();
     test_gh_6249();
     test_gh_6262();
+    test_gh_6267();
 
     return g_regexTester.result();
 }


### PR DESCRIPTION
Towards #5962. The parser currently generates empty groups when it represents zero-one quantifiers like `?` by a `_N_if` node with an empty alternative, just as it did for empty alternatives in general before #6249. This removes this empty group from the generated NFA because it's completely unnecessary.

Drive-by change: Replace the first `swap()` call by explicit assignments, and qualify the other `swap()` call because the nodes are STL-internal types, so ADL is not needed here.