### PR TITLE
Implement LWG-3599 The `const` overload of `lazy_split_view::begin` should be constrained by `const Pattern`

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3984,7 +3984,7 @@ namespace ranges {
         }
 
         _NODISCARD constexpr auto begin() const
-            requires forward_range<_Vw> && forward_range<const _Vw>
+            requires forward_range<_Vw> && forward_range<const _Vw> && forward_range<const _Pat>
         {
             return _Outer_iter<true>{*this, _RANGES begin(_Range)};
         }
@@ -3997,7 +3997,8 @@ namespace ranges {
         }
 
         _NODISCARD constexpr auto end() const {
-            if constexpr (forward_range<_Vw> && forward_range<const _Vw> && common_range<const _Vw>) {
+            if constexpr (forward_range<_Vw> && forward_range<const _Vw> && common_range<const _Vw>
+                          && forward_range<const _Pat>) {
                 return _Outer_iter<true>{*this, _RANGES end(_Range)};
             } else {
                 return default_sentinel;

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -189,6 +189,9 @@ std/re/re.regex/re.regex.construct/bad_escape.pass.cpp FAIL
 # libc++ doesn't implement LWG-3187
 std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_piecewise_pair_evil.pass.cpp FAIL
 
+# libc++ doesn't implement LWG-3599 "The `const` overload of `lazy_split_view::begin` should be constrained by `const Pattern`"
+std/ranges/range.adaptors/range.lazy.split/begin.pass.cpp FAIL
+
 # libc++ doesn't implement LWG-3670
 std/ranges/range.factories/range.iota.view/iterator/member_typedefs.compile.pass.cpp FAIL
 

--- a/tests/std/tests/P0896R4_views_lazy_split/test.cpp
+++ b/tests/std/tests/P0896R4_views_lazy_split/test.cpp
@@ -351,6 +351,22 @@ constexpr bool instantiation_test() {
     return true;
 }
 
+constexpr bool test_lwg_3599() {
+    auto p = views::iota(0) | views::take(1) | views::reverse;
+    auto r = views::single(42) | views::lazy_split(p);
+    auto f = r.front();
+
+    static_assert(ranges::forward_range<remove_cvref_t<decltype(r)>>);
+    static_assert(!ranges::forward_range<const remove_cvref_t<decltype(r)>>);
+    static_assert(ranges::forward_range<remove_cvref_t<decltype(f)>>);
+
+    assert(ranges::distance(r) == 1);
+    assert(f.front() == 42);
+    assert(ranges::distance(f) == 1);
+
+    return true;
+}
+
 constexpr bool test_lwg_3904() {
     auto r = views::single(0) | views::lazy_split(0);
     auto i = r.begin();
@@ -370,6 +386,9 @@ void test_lwg_4027() { // COMPILE-ONLY
 int main() {
     static_assert(instantiation_test());
     instantiation_test();
+
+    static_assert(test_lwg_3599());
+    assert(test_lwg_3599());
 
     static_assert(test_lwg_3904());
     assert(test_lwg_3904());


### PR DESCRIPTION
Fixes #6202.

Blocked libcxx test(s):
- `std/ranges/range.adaptors/range.lazy.split/begin.pass.cpp`