### PR TITLE
Use TBL instead of REV, EXT in Neon implementation of `reverse`

### DIFF
--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -592,7 +592,6 @@ namespace {
                 return vrev64_u8(_Val);
             }
 
-
             static uint8x16_t _Rev(const uint8x16_t _Val) noexcept {
                 static constexpr uint8_t _Idx_arr[16] = {15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
                 const auto _Idx                       = vld1q_u8(_Idx_arr);

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -592,9 +592,11 @@ namespace {
                 return vrev64_u8(_Val);
             }
 
+
             static uint8x16_t _Rev(const uint8x16_t _Val) noexcept {
-                const uint8x16_t _Rev_val = vrev64q_u8(_Val);
-                return vextq_u8(_Rev_val, _Rev_val, 8);
+                static constexpr uint8_t _Idx_arr[16] = {15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
+                const auto _Idx                       = vld1q_u8(_Idx_arr);
+                return vqtbl1q_u8(_Val, _Idx);
             }
         };
 
@@ -604,8 +606,9 @@ namespace {
             }
 
             static uint8x16_t _Rev(const uint8x16_t _Val) noexcept {
-                const uint8x16_t _Rev_val = vreinterpretq_u8_u16(vrev64q_u16(vreinterpretq_u16_u8(_Val)));
-                return vextq_u8(_Rev_val, _Rev_val, 8);
+                static constexpr uint8_t _Idx_arr[16] = {14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1};
+                const auto _Idx                       = vld1q_u8(_Idx_arr);
+                return vqtbl1q_u8(_Val, _Idx);
             }
         };
 
@@ -615,8 +618,9 @@ namespace {
             }
 
             static uint8x16_t _Rev(const uint8x16_t _Val) noexcept {
-                const uint8x16_t _Rev_val = vreinterpretq_u8_u32(vrev64q_u32(vreinterpretq_u32_u8(_Val)));
-                return vextq_u8(_Rev_val, _Rev_val, 8);
+                static constexpr uint8_t _Idx_arr[16] = {12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3};
+                const auto _Idx                       = vld1q_u8(_Idx_arr);
+                return vqtbl1q_u8(_Val, _Idx);
             }
         };
 


### PR DESCRIPTION
On modern Neoverse cores this is the faster sequence, as TBL has full throughput.

# Benchmark results: 

## Neoverse N2
benchmark | speedup
--- | ---
`r<std::uint8_t>/3449` | 1.03
`r<std::uint8_t>/63` | 1.044
`r<std::uint8_t>/31` | 0.993
`r<std::uint8_t>/15` | 1.005
`r<std::uint8_t>/7` | 1.025
`r<std::uint16_t>/3449` | 1.1
`r<std::uint16_t>/63` | 0.995
`r<std::uint16_t>/31` | 1.02
`r<std::uint16_t>/15` | 0.965
`r<std::uint16_t>/7` | 1.069
`r<std::uint32_t>/3449` | 1.163
`r<std::uint32_t>/63` | 1.055
`r<std::uint32_t>/31` | 1.068
`r<std::uint32_t>/15` | 1.029
`r<std::uint32_t>/7` | 0.992
`r<std::uint64_t>/3449` | 0.995
`r<std::uint64_t>/63` | 0.999
`r<std::uint64_t>/31` | 0.99
`r<std::uint64_t>/15` | 1.018
`r<std::uint64_t>/7` | 0.992
`rc<std::uint8_t>/3449` | 1.197
`rc<std::uint8_t>/63` | 1.022
`rc<std::uint8_t>/31` | 1.023
`rc<std::uint8_t>/15` | 1.035
`rc<std::uint8_t>/7` | 1.008
`rc<std::uint16_t>/3449` | 1.296
`rc<std::uint16_t>/63` | 1.129
`rc<std::uint16_t>/31` | 1.047
`rc<std::uint16_t>/15` | 1.015
`rc<std::uint16_t>/7` | 1.037
`rc<std::uint32_t>/3449` | 1.134
`rc<std::uint32_t>/63` | 1.196
`rc<std::uint32_t>/31` | 1.168
`rc<std::uint32_t>/15` | 1.088
`rc<std::uint32_t>/7` | 1.085
`rc<std::uint64_t>/3449` | 1
`rc<std::uint64_t>/63` | 1.004
`rc<std::uint64_t>/31` | 0.952
`rc<std::uint64_t>/15` | 1.002
`rc<std::uint64_t>/7` | 1.019


## Neoverse V3 2x128
benchmark | speedup
--- | ---
`r<std::uint8_t>/3449` | 1.282
`r<std::uint8_t>/63` | 1.098
`r<std::uint8_t>/31` | 0.988
`r<std::uint8_t>/15` | 0.99
`r<std::uint8_t>/7` | 0.89
`r<std::uint16_t>/3449` | 1.342
`r<std::uint16_t>/63` | 1.088
`r<std::uint16_t>/31` | 1.016
`r<std::uint16_t>/15` | 1.062
`r<std::uint16_t>/7` | 1.009
`r<std::uint32_t>/3449` | 1.333
`r<std::uint32_t>/63` | 1.002
`r<std::uint32_t>/31` | 1.032
`r<std::uint32_t>/15` | 1.081
`r<std::uint32_t>/7` | 0.956
`rc<std::uint8_t>/3449` | 1.552
`rc<std::uint8_t>/63` | 1.007
`rc<std::uint8_t>/31` | 1.022
`rc<std::uint8_t>/15` | 0.99
`rc<std::uint8_t>/7` | 0.987
`rc<std::uint16_t>/3449` | 1.666
`rc<std::uint16_t>/63` | 0.954
`rc<std::uint16_t>/31` | 0.979
`rc<std::uint16_t>/15` | 0.987
`rc<std::uint16_t>/7` | 0.992
`rc<std::uint32_t>/3449` | 1.628
`rc<std::uint32_t>/63` | 1.409
`rc<std::uint32_t>/31` | 1.058
`rc<std::uint32_t>/15` | 1.152
`rc<std::uint32_t>/7` | 1.006
