### PR TITLE
Silence new warning C4877 when overriding deprecated non-pure virtual functions

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -886,9 +886,11 @@
     _Pragma("clang diagnostic push")    \
     _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
 #else // ^^^ defined(__clang__) / !defined(__clang__) vvv
+// warning C4877: overriding non-pure virtual function 'Base::meow': was declared deprecated (/Wall)
+// warning C4996: 'meow': was declared deprecated
 #define _STL_DISABLE_DEPRECATED_WARNING \
     _Pragma("warning(push)")            \
-    _Pragma("warning(disable : 4996)") // was declared deprecated
+    _Pragma("warning(disable : 4877 4996)")
 #endif // ^^^ !defined(__clang__) ^^^
 #endif // _STL_DISABLE_DEPRECATED_WARNING
 // clang-format on

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -790,7 +790,7 @@
 // warning C5285: cannot declare a specialization for 'meow'
 // warning C5291: 'DERIVED': deriving from the base class 'BASE' can cause potential runtime issues
 //                due to an ABI bug. Recommend adding a 4-byte data member to the base class
-//                for the padding at the end of it to work around this bug. (TRANSITION, ABI)
+//                for the padding at the end of it to work around this bug. (/Wall, TRANSITION, ABI)
 // warning C6294: Ill-defined for-loop: initial condition does not satisfy test. Loop body not executed
 
 #ifndef _STL_DISABLED_WARNINGS


### PR DESCRIPTION
* Pre-existing: ABI warning C5291 is off-by-default.
  + Followup to #5645 on 2025-07-15.
* Add new off-by-default warning C4877 to `_STL_DISABLE_DEPRECATED_WARNING`.
  + Implemented by MSVC-PR-734301 on 2026-05-01.
  + I should revert selfbuild fix MSVC-PR-734920 on 2026-05-04.

# Example
```
C:\Temp>type meow.cpp
```
```cpp
#include <__msvc_all_public_headers.hpp>

int main() {}
```

# Before
```
C:\Temp>cl /EHsc /nologo /Wall /std:c++latest /MTd /Od /c meow.cpp
meow.cpp
D:\msvc\binaries\amd64chk\inc\xlocale(2321): warning C4877: overriding non-pure virtual function 'std::codecvt<char16_t,char,mbstate_t>::~codecvt': warning STL4020: std::codecvt<char16_t, char, mbstate_t>, std::codecvt<char32_t, char, mbstate_t>, std::codecvt_byname<char16_t, char, mbstate_t>, and std::codecvt_byname<char32_t, char, mbstate_t> are deprecated in C++20. You can define _SILENCE_CXX20_CODECVT_FACETS_DEPRECATION_WARNING or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to suppress this warning.
D:\msvc\binaries\amd64chk\inc\xlocale(2335): warning C4877: overriding non-pure virtual function 'std::codecvt<char32_t,char,mbstate_t>::~codecvt': warning STL4020: std::codecvt<char16_t, char, mbstate_t>, std::codecvt<char32_t, char, mbstate_t>, std::codecvt_byname<char16_t, char, mbstate_t>, and std::codecvt_byname<char32_t, char, mbstate_t> are deprecated in C++20. You can define _SILENCE_CXX20_CODECVT_FACETS_DEPRECATION_WARNING or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to suppress this warning.
D:\msvc\binaries\amd64chk\inc\xlocale(2350): warning C4877: overriding non-pure virtual function 'std::codecvt<char16_t,char8_t,mbstate_t>::~codecvt': warning STL4047: std::codecvt<char16_t, char8_t, mbstate_t>, std::codecvt<char32_t, char8_t, mbstate_t>, std::codecvt_byname<char16_t, char8_t, mbstate_t>, and std::codecvt_byname<char32_t, char8_t, mbstate_t> are deprecated by LWG-3767. You can define _SILENCE_CXX20_CODECVT_CHAR8_T_FACETS_DEPRECATION_WARNING or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to suppress this warning.
D:\msvc\binaries\amd64chk\inc\xlocale(2364): warning C4877: overriding non-pure virtual function 'std::codecvt<char32_t,char8_t,mbstate_t>::~codecvt': warning STL4047: std::codecvt<char16_t, char8_t, mbstate_t>, std::codecvt<char32_t, char8_t, mbstate_t>, std::codecvt_byname<char16_t, char8_t, mbstate_t>, and std::codecvt_byname<char32_t, char8_t, mbstate_t> are deprecated by LWG-3767. You can define _SILENCE_CXX20_CODECVT_CHAR8_T_FACETS_DEPRECATION_WARNING or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to suppress this warning.
```

For `[[deprecated("reason")]]`, C4877 repeats the reason, otherwise it just says "was declared deprecated".

# After
```
C:\Temp>cl /EHsc /nologo /Wall /std:c++latest /MTd /Od /c meow.cpp /I D:\GitHub\STL\stl\inc
meow.cpp

C:\Temp>
```

As we don't officially attempt to be `/Wall`-clean, we don't have `/Wall` test coverage, but the internal compiler selfbuild will be an effective test (after I remove the workaround in the compiler's sources).