### PR TITLE
README: update working draft to N5046

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ issue. The [bug tag][] and [enhancement tag][] are being populated.
 
 # Goals
 
-We're implementing the latest C++ Working Draft, currently [N5032][], which will eventually become the next C++
+We're implementing the latest C++ Working Draft, currently [N5046][], which will eventually become the next C++
 International Standard. The terms Working Draft (WD) and Working Paper (WP) are interchangeable; we often
 informally refer to these drafts as "the Standard" while being aware of the difference. (There are other relevant
 Standards; for example, supporting `/std:c++14` and `/std:c++17` involves understanding how the C++14 and C++17
@@ -606,7 +606,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 [LWG issues]: https://cplusplus.github.io/LWG/lwg-toc.html
 [LWG tag]: https://github.com/microsoft/STL/issues?q=is%3Aopen+is%3Aissue+label%3ALWG
 [Microsoft Open Source Code of Conduct]: https://opensource.microsoft.com/codeofconduct/
-[N5032]: https://wg21.link/N5032
+[N5046]: https://wg21.link/N5046
 [NOTICE.txt]: NOTICE.txt
 [STL-CI-badge]: https://dev.azure.com/vclibs/STL/_apis/build/status%2FSTL-CI?branchName=main "STL-CI"
 [STL-CI-link]: https://dev.azure.com/vclibs/STL/_build/latest?definitionId=4&branchName=main


### PR DESCRIPTION
## Summary
- update the README working draft reference from N5032 to N5046

Fixes #6283.

## Testing
- rg -n "N5032|N5046" README.md

Note: README.md is stored with CRLF line endings in this repository; I preserved that format.