### PR TITLE
`<xloctime>`: Fix `time_put::do_put` to correctly handle %c and %r formatting in "C" locale

### DIFF
--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -888,16 +888,28 @@ protected:
 
     virtual _OutIt __CLR_OR_THIS_CALL do_put(_OutIt _Dest, ios_base& _Iosbase, _Elem, const tm* _Pt, char _Specifier,
         char _Modifier = '\0') const { // put formatted time from _Pt to _Dest for [_Fmtfirst, _Fmtlast)
-        char _Fmt[5] = "!%x\0"; // '!' for nonzero count, null for modifier
+        const char* _Fmt_ptr = nullptr;
+        char _Fmt[5]         = "!%x\0"; // '!' for nonzero count, null for modifier
         size_t _Count;
         size_t _Num;
         string _Str;
 
-        if (_Modifier == '\0') {
-            _Fmt[2] = _Specifier;
-        } else { // add both modifier and specifier
-            _Fmt[2] = _Modifier;
-            _Fmt[3] = _Specifier;
+        if (_Iosbase.getloc() == locale::classic()) {
+            if (_Specifier == 'c') {
+                _Fmt_ptr = "!%a %b %e %T %Y";
+            } else if (_Specifier == 'r') {
+                _Fmt_ptr = "!%I:%M:%S %p";
+            }
+        }
+
+        if (!_Fmt_ptr) {
+            if (_Modifier == '\0') {
+                _Fmt[2] = _Specifier;
+            } else { // add both modifier and specifier
+                _Fmt[2] = _Modifier;
+                _Fmt[3] = _Specifier;
+            }
+            _Fmt_ptr = _Fmt;
         }
 
         int& _Errno_ref      = errno; // Nonzero cost, pay it once
@@ -905,7 +917,7 @@ protected:
 
         for (_Num = 16;; _Num *= 2) { // convert into ever larger string buffer until success
             _Str.append(_Num, '\0');
-            _Count = _Strftime(&_Str[0], _Str.size(), _Fmt, _Pt, _Tnames._Getptr());
+            _Count = _Strftime(&_Str[0], _Str.size(), _Fmt_ptr, _Pt, _Tnames._Getptr());
             if (0 < _Count) {
                 break;
             } else if (_Errno_ref == EINVAL) {
@@ -1034,16 +1046,28 @@ protected:
 
     virtual _OutIt __CLR_OR_THIS_CALL do_put(_OutIt _Dest, ios_base& _Iosbase, _Elem, const tm* _Pt, char _Specifier,
         char _Modifier = '\0') const { // put formatted time from _Pt to _Dest for [_Fmtfirst, _Fmtlast)
-        wchar_t _Fmt[5] = L"!%x\0"; // ! for nonzero count, null for modifier
+        const wchar_t* _Fmt_ptr = nullptr;
+        wchar_t _Fmt[5]         = L"!%x\0"; // ! for nonzero count, null for modifier
         size_t _Count;
         size_t _Num;
         wstring _Str;
 
-        if (_Modifier == '\0') {
-            _Fmt[2] = static_cast<_Elem>(_Specifier); // conversion rule unspecified
-        } else { // add both modifier and specifier
-            _Fmt[2] = static_cast<_Elem>(_Modifier);
-            _Fmt[3] = static_cast<_Elem>(_Specifier);
+        if (_Iosbase.getloc() == locale::classic()) {
+            if (_Specifier == 'c') {
+                _Fmt_ptr = L"!%a %b %e %T %Y";
+            } else if (_Specifier == 'r') {
+                _Fmt_ptr = L"!%I:%M:%S %p";
+            }
+        }
+
+        if (!_Fmt_ptr) {
+            if (_Modifier == '\0') {
+                _Fmt[2] = static_cast<_Elem>(_Specifier);
+            } else {
+                _Fmt[2] = static_cast<_Elem>(_Modifier);
+                _Fmt[3] = static_cast<_Elem>(_Specifier);
+            }
+            _Fmt_ptr = _Fmt;
         }
 
         int& _Errno_ref      = errno; // Nonzero cost, pay it once
@@ -1051,7 +1075,7 @@ protected:
 
         for (_Num = 16;; _Num *= 2) { // convert into ever larger string buffer until success
             _Str.append(_Num, '\0');
-            _Count = _Wcsftime(&_Str[0], _Str.size(), _Fmt, _Pt, _Tnames._Getptr());
+            _Count = _Wcsftime(&_Str[0], _Str.size(), _Fmt_ptr, _Pt, _Tnames._Getptr());
             if (0 < _Count) {
                 break;
             } else if (_Errno_ref == EINVAL) {
@@ -1183,16 +1207,28 @@ protected:
 
     virtual _OutIt __CLR_OR_THIS_CALL do_put(_OutIt _Dest, ios_base& _Iosbase, _Elem, const tm* _Pt, char _Specifier,
         char _Modifier = '\0') const { // put formatted time from _Pt to _Dest for [_Fmtfirst, _Fmtlast)
-        wchar_t _Fmt[5] = L"!%x\0"; // ! for nonzero count, null for modifier
+        const wchar_t* _Fmt_ptr = nullptr;
+        wchar_t _Fmt[5]         = L"!%x\0"; // ! for nonzero count, null for modifier
         size_t _Count;
         size_t _Num;
         wstring _Str;
 
-        if (_Modifier == '\0') {
-            _Fmt[2] = static_cast<_Elem>(_Specifier); // conversion rule unspecified
-        } else { // add both modifier and specifier
-            _Fmt[2] = static_cast<_Elem>(_Modifier);
-            _Fmt[3] = static_cast<_Elem>(_Specifier);
+        if (_Iosbase.getloc() == locale::classic()) {
+            if (_Specifier == 'c') {
+                _Fmt_ptr = L"!%a %b %e %T %Y";
+            } else if (_Specifier == 'r') {
+                _Fmt_ptr = L"!%I:%M:%S %p";
+            }
+        }
+
+        if (!_Fmt_ptr) {
+            if (_Modifier == '\0') {
+                _Fmt[2] = static_cast<_Elem>(_Specifier);
+            } else {
+                _Fmt[2] = static_cast<_Elem>(_Modifier);
+                _Fmt[3] = static_cast<_Elem>(_Specifier);
+            }
+            _Fmt_ptr = _Fmt;
         }
 
         int& _Errno_ref      = errno; // Nonzero cost, pay it once
@@ -1200,7 +1236,7 @@ protected:
 
         for (_Num = 16;; _Num *= 2) { // convert into ever larger string buffer until success
             _Str.append(_Num, '\0');
-            _Count = _Wcsftime(&_Str[0], _Str.size(), _Fmt, _Pt, _Tnames._Getptr());
+            _Count = _Wcsftime(&_Str[0], _Str.size(), _Fmt_ptr, _Pt, _Tnames._Getptr());
             if (0 < _Count) {
                 break;
             } else if (_Errno_ref == EINVAL) {

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -566,9 +566,6 @@ std/localization/locale.categories/category.time/locale.time.get/locale.time.get
 std/localization/locale.categories/category.time/locale.time.get/locale.time.get.members/get_weekday.pass.cpp FAIL
 std/localization/locale.categories/category.time/locale.time.get/locale.time.get.members/get_weekday_wide.pass.cpp FAIL
 
-# GH-6134 <xloctime>: time_put::do_put does not match strftime for the %c and %r specifiers in the "C" locale
-std/localization/locale.categories/category.time/locale.time.put/locale.time.put.members/put2.pass.cpp FAIL
-
 # GH-6135 <xloctime>: time_put_byname doesn't encode the output in UTF-8 even if the locale name contains ".UTF-8"
 std/localization/locale.categories/category.time/locale.time.put.byname/put1.pass.cpp FAIL
 

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -1012,7 +1012,7 @@ void test_local_time_format_formatter() {
     // Implements N4885 [time.zone.zonedtime.nonmembers]/2 for zoned_time.
     empty_braces_helper(ltf, STR("2021-04-19 01:02:03 Meow"));
 
-    assert(format(STR("{:%c, %x, %X}"), ltf) == STR("04/19/21 01:02:03, 04/19/21, 01:02:03"));
+    assert(format(STR("{:%c, %x, %X}"), ltf) == STR("Mon Apr 19 01:02:03 2021, 04/19/21, 01:02:03"));
     assert(format(STR("{:%D %F, %Y %C %y, %b %B %h %m, %d %e, %a %A %u %w}"), ltf)
            == STR("04/19/21 2021-04-19, 2021 20 21, Apr April Apr 04, 19 19, Mon Monday 1 1"));
     assert(format(STR("{:%H %I %M %S, %r, %R %T %p}"), ltf) == STR("01 01 02 03, 01:02:03 AM, 01:02 01:02:03 AM"));
@@ -1027,7 +1027,7 @@ void test_zoned_time_formatter() {
 
     empty_braces_helper(zt, STR("2021-04-19 08:16:17 PDT"), STR("2021-04-19 08:16:17 GMT-7"));
 
-    assert(format(STR("{:%c, %x, %X}"), zt) == STR("04/19/21 08:16:17, 04/19/21, 08:16:17"));
+    assert(format(STR("{:%c, %x, %X}"), zt) == STR("Mon Apr 19 08:16:17 2021, 04/19/21, 08:16:17"));
     assert(format(STR("{:%D %F, %Y %C %y, %b %B %h %m, %d %e, %a %A %u %w}"), zt)
            == STR("04/19/21 2021-04-19, 2021 20 21, Apr April Apr 04, 19 19, Mon Monday 1 1"));
     assert(format(STR("{:%H %I %M %S, %r, %R %T %p}"), zt) == STR("08 08 16 17, 08:16:17 AM, 08:16 08:16:17 AM"));


### PR DESCRIPTION
Fixes #6134.

**Description**
The C standard requires the `%c` and `%r` specifiers to be equivalent to `%a %b %e %T %Y` and `%I:%M:%S %p` respectively in the "C" locale (N3220 § 7.29.3.5/7). While the standard C `strftime` might handle this correctly, the internal UCRT functions `_Strftime` and `_Wcsftime` used by `<xloctime>` do not provide this expected output. This causes a mismatch when using `std::time_put::do_put`.

This PR introduces a workaround in `time_put::do_put`. When `_Iosbase.getloc() == locale::classic()`, it explicitly overrides the format strings for the `%c` and `%r` specifiers with the standard-mandated sequences before passing them to `_Strftime` / `_Wcsftime`. Since this problem only occurs in "C" locale, this workaround resolves the issue without affecting others.

**Testing**
- The workaround allows the failing libcxx test to pass.
- Removed `std/localization/locale.categories/category.time/locale.time.put/locale.time.put.members/put2.pass.cpp` from `tests/libcxx/expected_results.txt`.

<!-- Before submitting a pull request, please ensure that:

* Any AI-generated code has been clearly disclosed in your PR description.
  We strongly discourage AI-generated changes to product code because the STL
  is a highly unusual codebase with complex correctness and performance
  requirements imposed by the Standard, and highly unusual code patterns that
  don't look like typical codebases. Our intensive code review process
  (to avoid bugs) is intentionally a bottleneck, so we ask that you be
  considerate of the time and effort that we'll need to spend, by starting
  with changes that you fully understand. Test code has weaker requirements,
  so AI-generated changes for tests can be acceptable if properly disclosed.

* Your PR description explains your intent behind the changes.
  We discourage AI-generated PR descriptions because we can read the changes,
  and we have access to the same AI tools that you have, so we can get
  an AI-generated summary if we want.

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
