### PR TITLE
Declare `__isa_available` and `__isa_enabled` properly

### DIFF
--- a/stl/inc/__msvc_bit_utils.hpp
+++ b/stl/inc/__msvc_bit_utils.hpp
@@ -20,10 +20,13 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-_STD_BEGIN
+#ifndef _M_ARM64
 extern "C" {
 extern int __isa_available;
 }
+#endif // ^^^ !defined(_M_ARM64) ^^^
+
+_STD_BEGIN
 
 _INLINE_VAR constexpr int _Stl_isa_available_sse42 = 2; // equal to __ISA_AVAILABLE_SSE42
 _INLINE_VAR constexpr int _Stl_isa_available_avx2  = 5; // equal to __ISA_AVAILABLE_AVX2

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -19,7 +19,9 @@
 #include <intrin.h>
 #include <isa_availability.h>
 
-extern "C" long __isa_enabled;
+extern "C" {
+extern int __isa_enabled; // TRANSITION, <isa_availability.h> will declare this soon after 2026-06-09
+}
 #endif // ^^^ !defined(_M_ARM64) && !defined(_M_ARM64EC) ^^^
 
 namespace {

--- a/tests/std/include/test_vector_algorithms_support.hpp
+++ b/tests/std/include/test_vector_algorithms_support.hpp
@@ -41,7 +41,9 @@ inline void initialize_randomness(std::mt19937_64& gen) {
 }
 
 #if (defined(_M_IX86) || defined(_M_X64)) && !defined(_M_CEE_PURE)
-extern "C" long __isa_enabled;
+extern "C" {
+extern int __isa_enabled; // TRANSITION, <isa_availability.h> will declare this soon after 2026-06-09
+}
 
 inline void disable_instructions(ISA_AVAILABILITY isa) {
     const unsigned long as_ulong = static_cast<unsigned long>(isa);


### PR DESCRIPTION
In conjunction with my upcoming changes to VCRuntime/VCStartup for low-overhead `IsProcessorFeaturePresent()` results, I'm cleaning up `<isa_availability.h>` and noticed several issues in the STL.

First, these variables are of type `int`. Second, they live in the global namespace. Third, they don't exist for actual ARM64.

These STL changes will work with both the old and new VCRuntime/VCStartup.