### PR TITLE
Implement LWG-3797 `elements_view` insufficiently constrained

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -4706,7 +4706,9 @@ namespace ranges {
     template <class _Tuple, size_t _Index>
     concept _Has_tuple_element =
 #if _HAS_CXX23
-        _Tuple_like<_Tuple> && _Index < tuple_size_v<_Tuple>;
+        _Tuple_like<_Tuple> && _Index < tuple_size_v<_Tuple> && requires(_Tuple __t) {
+            { _STD get<_Index>(__t) } -> convertible_to<const tuple_element_t<_Index, _Tuple>&>;
+        };
 #else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
         requires(_Tuple __t) {
             typename tuple_size<_Tuple>::type;

--- a/tests/std/tests/P0896R4_views_elements/test.cpp
+++ b/tests/std/tests/P0896R4_views_elements/test.cpp
@@ -414,6 +414,32 @@ void test_gh_3014() { // COMPILE-ONLY
     [[maybe_unused]] decltype(as_const(r).begin()) i = r.begin(); // Check 'iterator(iterator<!Const> i)'
 }
 
+// LWG-3797 "elements_view insufficiently constrained"
+namespace lwg_3797 {
+    struct Constifier {
+        template <class T>
+        constexpr const T& operator()(const T& t) const noexcept {
+            return t;
+        }
+    };
+
+    struct Mover {
+        template <class T>
+        constexpr remove_reference_t<T>&& operator()(T&& t) const noexcept {
+            return static_cast<remove_reference_t<T>&&>(t);
+        }
+    };
+
+    using MoveOnlySubrange = ranges::subrange<test::iterator<test::input, int>, test::sentinel<int>>;
+    static_assert(!CanViewElements<vector<MoveOnlySubrange>>);
+    static_assert(!CanViewElements<decltype(vector<MoveOnlySubrange>{} | views::transform(Constifier{}))>);
+    static_assert(!CanViewElements<decltype(vector<MoveOnlySubrange>{} | views::transform(Mover{}))>);
+#if _HAS_CXX23
+    static_assert(!CanViewElements<decltype(vector<MoveOnlySubrange>{} | views::as_const)>);
+    static_assert(!CanViewElements<decltype(vector<MoveOnlySubrange>{} | views::as_rvalue)>);
+#endif // _HAS_CXX23
+} // namespace lwg_3797
+
 int main() {
     { // Validate copyable views
         constexpr span<const P> s{some_pairs};


### PR DESCRIPTION
Fixes #6204.

----

However, it seems that `elements_view` becomes overconstrained with this fix, although it was already overconstrained in C++20. Currently (after LWG-3797) the following code is rejected, while it seems to me that it can be made to work. 
```C++
using MoveOnlySubrange = std::ranges::subrange<MoveOnlyIter, Sentinel>;
std::vector<MoveOnlySubrange> v;
for (auto&& elem : v | std::views::as_rvalue | std::views::elements<0>) {
    // ...
}
```

Seems like that the constraints of `elements_view` are somehow imprecise. Especially, `_Has_tuple_element` doesn't seem to handle rvalues well. IMO, ideally, they should only match validness of iterator's `operator*` while additionally requiring tuple-like-ness.