### PR TITLE
Implement LWG-4125 `move_iterator`'s default constructor should be constrained

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4393,11 +4393,7 @@ struct _Move_iterator_category {
 _EXPORT_STD template <class _Iter>
 class move_iterator : public _Move_iterator_category<_Iter> {
 private:
-#if _HAS_CXX17
     _Iter _Current = _Iter();
-#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
-    _Iter _Current;
-#endif // ^^^ !_HAS_CXX17 ^^^
 
 public:
     using iterator_type   = _Iter;
@@ -4428,16 +4424,11 @@ public:
         conditional_t<is_reference_v<_Iter_ref_t<_Iter>>, remove_reference_t<_Iter_ref_t<_Iter>>&&, _Iter_ref_t<_Iter>>;
 #endif // ^^^ !_HAS_CXX20 ^^^
 
-#if _HAS_CXX17
-    constexpr move_iterator()
+    _CONSTEXPR17 move_iterator()
 #if _HAS_CXX20
         requires default_initializable<_Iter>
 #endif // _HAS_CXX20
     = default;
-#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
-    move_iterator() noexcept(is_nothrow_default_constructible_v<_Iter>) // strengthened
-        : _Current() {}
-#endif // ^^^ !_HAS_CXX17 ^^^
 
     _CONSTEXPR17 explicit move_iterator(_Iter _Right) noexcept(is_nothrow_move_constructible_v<_Iter>) // strengthened
         : _Current(_STD move(_Right)) {}

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4393,7 +4393,11 @@ struct _Move_iterator_category {
 _EXPORT_STD template <class _Iter>
 class move_iterator : public _Move_iterator_category<_Iter> {
 private:
-    _Iter _Current{};
+#if _HAS_CXX17
+    _Iter _Current = _Iter();
+#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
+    _Iter _Current;
+#endif // ^^^ !_HAS_CXX17 ^^^
 
 public:
     using iterator_type   = _Iter;
@@ -4424,7 +4428,16 @@ public:
         conditional_t<is_reference_v<_Iter_ref_t<_Iter>>, remove_reference_t<_Iter_ref_t<_Iter>>&&, _Iter_ref_t<_Iter>>;
 #endif // ^^^ !_HAS_CXX20 ^^^
 
-    _CONSTEXPR17 move_iterator() = default;
+#if _HAS_CXX17
+    constexpr move_iterator()
+#if _HAS_CXX20
+        requires default_initializable<_Iter>
+#endif // _HAS_CXX20
+    = default;
+#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
+    move_iterator() noexcept(is_nothrow_default_constructible_v<_Iter>) // strengthened
+        : _Current() {}
+#endif // ^^^ !_HAS_CXX17 ^^^
 
     _CONSTEXPR17 explicit move_iterator(_Iter _Right) noexcept(is_nothrow_move_constructible_v<_Iter>) // strengthened
         : _Current(_STD move(_Right)) {}

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -861,9 +861,6 @@ std/utilities/variant/variant.variant/variant.ctor/T.pass.cpp:2 FAIL
 std/input.output/filesystems/class.path/path.member/path.charconv.pass.cpp:0 FAIL
 std/input.output/filesystems/class.path/path.member/path.charconv.pass.cpp:1 FAIL
 
-# Not analyzed. Clang is attempting to default construct cpp17_input_iterator<int *>.
-std/iterators/predef.iterators/move.iterators/move.iterator/iterator_concept_conformance.compile.pass.cpp:2 FAIL
-
 # Not analyzed. Asserting about alloc_count.
 std/thread/futures/futures.promise/alloc_ctor.pass.cpp FAIL
 std/thread/futures/futures.promise/move_assign.pass.cpp FAIL

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -115,6 +115,20 @@ struct simple_input_iter {
     bool operator==(simple_input_iter const&) const = default;
 };
 
+struct empty_list_input_iter {
+    using value_type      = double;
+    using difference_type = long;
+
+    // not default constructible, although initializable with {}
+    explicit empty_list_input_iter(std::initializer_list<int>);
+
+    value_type operator*() const;
+    empty_list_input_iter& operator++();
+    empty_list_input_iter operator++(int);
+
+    bool operator==(const empty_list_input_iter&) const = default;
+};
+
 template <class Base = empty_type>
 struct simple_forward_iter : Base {
     using value_type      = double;
@@ -943,6 +957,7 @@ namespace iterator_traits_test {
     // * 3.2.2: "... Otherwise, reference names iter_reference_t<I>."
     // * 3.2.3.4 "... Otherwise, iterator_category names... input_iterator_tag."
     static_assert(check<simple_input_iter, no_such_type, input_iterator_tag, double, long, void, double>());
+    static_assert(check<empty_list_input_iter, no_such_type, input_iterator_tag, double, long, void, double>());
 
     // N4928 [iterator.traits]:
     // * 3.2.1: "... Otherwise, pointer names void."
@@ -3330,7 +3345,7 @@ namespace reverse_iterator_test {
 namespace move_iterator_test {
     using std::bidirectional_iterator_tag, std::default_sentinel_t, std::forward_iterator_tag, std::input_iterator_tag,
         std::move_iterator, std::move_sentinel, std::random_access_iterator_tag, std::same_as, std::string,
-        std::three_way_comparable, std::three_way_comparable_with;
+        std::three_way_comparable, std::three_way_comparable_with, std::default_initializable;
 
     template <bool CanCopy>
     struct input_iter {
@@ -3419,6 +3434,8 @@ namespace move_iterator_test {
     static_assert(same_as<move_iterator<simple_forward_iter<>>::iterator_category, forward_iterator_tag>);
     static_assert(same_as<move_iterator<simple_input_iter>::iterator_concept, input_iterator_tag>);
     static_assert(same_as<move_iterator<simple_input_iter>::iterator_category, input_iterator_tag>);
+    static_assert(same_as<move_iterator<empty_list_input_iter>::iterator_concept, input_iterator_tag>);
+    static_assert(same_as<move_iterator<empty_list_input_iter>::iterator_category, input_iterator_tag>);
     static_assert(same_as<move_iterator<input_iter<true>>::iterator_concept, input_iterator_tag>);
     static_assert(same_as<move_iterator<xvalue_random_iter>::iterator_concept, random_access_iterator_tag>);
     static_assert(same_as<move_iterator<xvalue_random_iter>::iterator_category, random_access_iterator_tag>);
@@ -3523,6 +3540,14 @@ namespace move_iterator_test {
         !has_greater_eq<move_iterator<simple_random_iter<sentinel_base>>, move_sentinel<std::default_sentinel_t>>);
     static_assert(!three_way_comparable<move_iterator<simple_random_iter<sentinel_base>>,
         move_sentinel<std::default_sentinel_t>>);
+
+    // LWG-4125 "move_iterator's default constructor should be constrained"
+    // Validate default-constructibility
+    static_assert(!default_initializable<move_iterator<simple_input_iter>>);
+    static_assert(!default_initializable<move_iterator<empty_list_input_iter>>);
+    static_assert(default_initializable<move_iterator<input_iter<true>>>);
+    static_assert(default_initializable<move_iterator<input_iter<false>>>);
+    static_assert(default_initializable<move_iterator<int*>>);
 
     // GH-3014 "<ranges>: list-initialization is misused"
     void test_gh_3014() { // COMPILE-ONLY

--- a/tests/std/tests/P2441R2_views_join_with/test.cpp
+++ b/tests/std/tests/P2441R2_views_join_with/test.cpp
@@ -375,9 +375,6 @@ struct instantiator {
             Outer empty{span<Inner, 0>{}};
             test_one(empty, "*#"sv, views::empty<char>);
         }
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, LLVM-60293 and VSO-1900294
-        if constexpr (ranges::forward_range<Outer> || ranges::common_range<Outer>)
-#endif // ^^^ workaround ^^^
         { // Range-of-rvalue delimiter
             Inner inner_ranges[] = {Inner{span{input[0]}}, Inner{span{input[1]}}, Inner{span{input[2]}},
                 Inner{span{input[3]}}, Inner{span{input[4]}}, Inner{span{input[5]}}, Inner{span{input[6]}},


### PR DESCRIPTION
Fixes #6314. Fixes #3377 (by making LLVM-60293 and VSO-1900294 no longer relevant).

Unblocked libcxx test(s):
- `std/iterators/predef.iterators/move.iterators/move.iterator/iterator_concept_conformance.compile.pass.cpp`

Remarks:
- The associated constraint is added since C++20, which is consistent with WG21-P2325R3 that is clearly a DR against C++20.
- This PR also uses the default member initializer `= _Iter();` in C++14 mode. Due to lack of guaranteed copy elision in C++14, such default member initializer would cause one more move construction when RVO is not performed. The move construction is required to be well-formed, and in most (but not all) situations it won't cause side effects.
- Pre-existing default member initializer `{}` accepts invalid cases. E.g. `empty_list_input_iter` added to the test file can be direct-list-initialized from `{}`, but can't be value initialized. So the default constructor of `empty_list_input_iter` should be ill-formed in old modes.