### PR TITLE
Implement LWG-4218 Constraint recursion in `basic_const_iterator`'s relational operators due to ADL + CWG-2369

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2605,30 +2605,30 @@ public:
         return _Current <=> _Right;
     }
 
-    template <_Not_a_const_iterator _Other>
+    template <_Not_a_const_iterator _Other, same_as<_Iter> _Jter>
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
-    _NODISCARD friend constexpr bool operator<(const _Other& _Left, const basic_const_iterator& _Right)
+    _NODISCARD friend constexpr bool operator<(const _Other& _Left, const basic_const_iterator<_Jter>& _Right)
         noexcept(noexcept(_STD _Fake_copy_init<bool>(_Left < _Right._Current))) /* strengthened */ {
         return _Left < _Right._Current;
     }
 
-    template <_Not_a_const_iterator _Other>
+    template <_Not_a_const_iterator _Other, same_as<_Iter> _Jter>
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
-    _NODISCARD friend constexpr bool operator>(const _Other& _Left, const basic_const_iterator& _Right)
+    _NODISCARD friend constexpr bool operator>(const _Other& _Left, const basic_const_iterator<_Jter>& _Right)
         noexcept(noexcept(_STD _Fake_copy_init<bool>(_Left > _Right._Current))) /* strengthened */ {
         return _Left > _Right._Current;
     }
 
-    template <_Not_a_const_iterator _Other>
+    template <_Not_a_const_iterator _Other, same_as<_Iter> _Jter>
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
-    _NODISCARD friend constexpr bool operator<=(const _Other& _Left, const basic_const_iterator& _Right)
+    _NODISCARD friend constexpr bool operator<=(const _Other& _Left, const basic_const_iterator<_Jter>& _Right)
         noexcept(noexcept(_STD _Fake_copy_init<bool>(_Left <= _Right._Current))) /* strengthened */ {
         return _Left <= _Right._Current;
     }
 
-    template <_Not_a_const_iterator _Other>
+    template <_Not_a_const_iterator _Other, same_as<_Iter> _Jter>
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
-    _NODISCARD friend constexpr bool operator>=(const _Other& _Left, const basic_const_iterator& _Right)
+    _NODISCARD friend constexpr bool operator>=(const _Other& _Left, const basic_const_iterator<_Jter>& _Right)
         noexcept(noexcept(_STD _Fake_copy_init<bool>(_Left >= _Right._Current))) /* strengthened */ {
         return _Left >= _Right._Current;
     }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2605,28 +2605,48 @@ public:
         return _Current <=> _Right;
     }
 
-    template <_Not_a_const_iterator _Other, same_as<_Iter> _Jter>
+    template <_Not_a_const_iterator _Other, same_as<_Iter> _Jter
+#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, DevCom-11111696
+        ,
+        _Iter* = nullptr
+#endif // ^^^ workaround ^^^
+        >
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD friend constexpr bool operator<(const _Other& _Left, const basic_const_iterator<_Jter>& _Right)
         noexcept(noexcept(_STD _Fake_copy_init<bool>(_Left < _Right._Current))) /* strengthened */ {
         return _Left < _Right._Current;
     }
 
-    template <_Not_a_const_iterator _Other, same_as<_Iter> _Jter>
+    template <_Not_a_const_iterator _Other, same_as<_Iter> _Jter
+#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, DevCom-11111696
+        ,
+        _Iter* = nullptr
+#endif // ^^^ workaround ^^^
+        >
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD friend constexpr bool operator>(const _Other& _Left, const basic_const_iterator<_Jter>& _Right)
         noexcept(noexcept(_STD _Fake_copy_init<bool>(_Left > _Right._Current))) /* strengthened */ {
         return _Left > _Right._Current;
     }
 
-    template <_Not_a_const_iterator _Other, same_as<_Iter> _Jter>
+    template <_Not_a_const_iterator _Other, same_as<_Iter> _Jter
+#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, DevCom-11111696
+        ,
+        _Iter* = nullptr
+#endif // ^^^ workaround ^^^
+        >
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD friend constexpr bool operator<=(const _Other& _Left, const basic_const_iterator<_Jter>& _Right)
         noexcept(noexcept(_STD _Fake_copy_init<bool>(_Left <= _Right._Current))) /* strengthened */ {
         return _Left <= _Right._Current;
     }
 
-    template <_Not_a_const_iterator _Other, same_as<_Iter> _Jter>
+    template <_Not_a_const_iterator _Other, same_as<_Iter> _Jter
+#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, DevCom-11111696
+        ,
+        _Iter* = nullptr
+#endif // ^^^ workaround ^^^
+        >
         requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD friend constexpr bool operator>=(const _Other& _Left, const basic_const_iterator<_Jter>& _Right)
         noexcept(noexcept(_STD _Fake_copy_init<bool>(_Left >= _Right._Current))) /* strengthened */ {

--- a/tests/std/tests/P2278R4_basic_const_iterator/test.cpp
+++ b/tests/std/tests/P2278R4_basic_const_iterator/test.cpp
@@ -270,7 +270,7 @@ static constexpr int some_ints[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 using Zipped = decltype(views::zip(some_ints) | views::as_const | views::as_rvalue);
 static_assert(same_as<ranges::range_reference_t<Zipped>, tuple<const int&&>>);
 
-// LWG-4218 "Constraint recursion in basic_const_iterator's relational operators due to ADL + CWG 2369"
+// LWG-4218 "Constraint recursion in basic_const_iterator's relational operators due to ADL + CWG-2369"
 namespace lwg_4218 {
     template <class T>
     struct adl_conversion_source {

--- a/tests/std/tests/P2278R4_basic_const_iterator/test.cpp
+++ b/tests/std/tests/P2278R4_basic_const_iterator/test.cpp
@@ -270,6 +270,32 @@ static constexpr int some_ints[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 using Zipped = decltype(views::zip(some_ints) | views::as_const | views::as_rvalue);
 static_assert(same_as<ranges::range_reference_t<Zipped>, tuple<const int&&>>);
 
+// LWG-4218 "Constraint recursion in basic_const_iterator's relational operators due to ADL + CWG 2369"
+namespace lwg_4218 {
+    template <class T>
+    struct adl_conversion_source {
+        operator T() const;
+
+        friend bool operator==(const adl_conversion_source&, const adl_conversion_source&) {
+            return true;
+        }
+        friend bool operator==(const adl_conversion_source&, const T&) {
+            return true;
+        }
+
+        template <same_as<adl_conversion_source> Self>
+        friend partial_ordering operator<=>(const adl_conversion_source&, const Self&) {
+            return partial_ordering::equivalent;
+        }
+    };
+
+    using cvi = basic_const_iterator<vector<int>::iterator>;
+    static_assert(totally_ordered_with<adl_conversion_source<cvi>, cvi>);
+
+    using rcvi = reverse_iterator<cvi>;
+    static_assert(totally_ordered<rcvi>);
+} // namespace lwg_4218
+
 struct instantiator {
     template <input_iterator It>
     static constexpr void call() {


### PR DESCRIPTION
Fixes #6316.

Remarks: Currently, MSVC doesn't give constraint recursion for the original example posted in LWG-4218, perhaps because MSVC hasn't completely implemented CWG-2369. In addition to the original example, this PR adds another example causing constraint recursion for both MSVC and Clang when LWG-4218 is not implemented.

Reported DevCom-11111696 for a bug encountered in CI (with workaround added).