### PR TITLE
Toolset update: MSVC Compiler 19.52.36510

### DIFF
--- a/.github/workflows/update-status-chart.yml
+++ b/.github/workflows/update-status-chart.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: ">=25.2.1"
+          node-version: ">=26.4.0"
       - name: Install Packages
         run: |
           npm ci

--- a/.github/workflows/update-status-chart.yml
+++ b/.github/workflows/update-status-chart.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: gh-pages
       - name: Setup Node.js

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,10 +94,7 @@ if(STL_USE_ANALYZE)
     # TRANSITION, Windows SDK 10.0.28000 emits multiple warnings:
     # "warning C6553: The annotation for function 'LCMapStringEx' on _Param_(9) does not apply to a value type."
     # Reported as OS-40109504 "Windows SDK: incorrect SAL annotations on functions the STL uses".
-    # "warning C28285: For function '_BitScanForward' '_Param_(1)' syntax error in 'SAL_range(0,(sizeof(Mask)*8)-1)' near 'Mask)*8'."
-    # Reported as VSO-2946529 "/analyze emits warning C28285 for _BitScanForward declared by winnt.h".
-    # Fixed by OS-PR-14602802 on 2026-01-22.
-    add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/analyze:autolog-;/wd6553;/wd28285>")
+    add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/analyze:autolog-;/wd6553>")
 
     if(VCLIBS_TARGET_ARCHITECTURE STREQUAL "arm64ec")
         # TRANSITION, Windows SDK 10.0.28000 emits

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 4.3.1)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 
-if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.52.36405.1")
-    message(FATAL_ERROR "The STL must be built with MSVC Compiler 19.52.36405.1 or later. Follow the README instructions.")
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.52.36510")
+    message(FATAL_ERROR "The STL must be built with MSVC Compiler 19.52.36510 or later. Follow the README instructions.")
 endif()
 
 include(CheckCXXSourceCompiles)

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
     - "Windows 11 SDK (10.0.28000)" or later
     - "C++ Clang tools for Windows (22.1.3 - x64/x86)"
     - *Optional, see Note 2 below:* "MSVC Build Tools for ARM64/ARM64EC (Preview)"
-* Install [Python][] 3.14.5 or later.
+* Install [Python][] 3.14.6 or later.
   + Select "Add python.exe to PATH" if you want to follow the instructions below that invoke `python`.
     Otherwise, you should be familiar with alternative methods.
 

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,13 +5,13 @@
 
 variables:
 - name: x64SlowPoolName
-  value: 'Stl-2026-05-21T0342-x64-Fasv6-Pool'
+  value: 'Stl-2026-06-25T1103-x64-Fasv6-Pool'
   readonly: true
 - name: x64FastPoolName
-  value: 'Stl-2026-05-21T0342-x64-Fasv7-Pool'
+  value: 'Stl-2026-06-25T1103-x64-Fasv7-Pool'
   readonly: true
 - name: arm64PoolName
-  value: 'Stl-2026-05-21T0342-arm64-Dpsv6-Pool'
+  value: 'Stl-2026-06-25T1103-arm64-Dpsv6-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -49,7 +49,7 @@ if ($VMSku -ieq 'Fasv6') {
   $AvailableLocations = @('eastus2', 'northeurope', 'uksouth')
 }
 
-$AvailableLocationIdx = 9 # Increment for each new set of pools, to cycle through the available locations.
+$AvailableLocationIdx = 10 # Increment for each new set of pools, to cycle through the available locations.
 $Location = $AvailableLocations[$AvailableLocationIdx % $AvailableLocations.Length]
 
 if ($Arch -ieq 'x64') {

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -66,9 +66,9 @@ $PowerShellArgs = @('/quiet', '/norestart')
 
 # https://www.python.org
 if ($Provisioning_x64) {
-  $PythonUrl = 'https://www.python.org/ftp/python/3.14.5/python-3.14.5-amd64.exe'
+  $PythonUrl = 'https://www.python.org/ftp/python/3.14.6/python-3.14.6-amd64.exe'
 } else {
-  $PythonUrl = 'https://www.python.org/ftp/python/3.14.5/python-3.14.5-arm64.exe'
+  $PythonUrl = 'https://www.python.org/ftp/python/3.14.6/python-3.14.6-arm64.exe'
 }
 $PythonArgs = @('/quiet', 'InstallAllUsers=1', 'PrependPath=1', 'CompileAll=1', 'Include_doc=0')
 

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -58,9 +58,9 @@ foreach ($workload in $VisualStudioWorkloads) {
 
 # https://github.com/PowerShell/PowerShell/releases/latest
 if ($Provisioning_x64) {
-  $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.6.1/PowerShell-7.6.1-win-x64.msi'
+  $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.6.3/PowerShell-7.6.3-win-x64.msi'
 } else {
-  $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.6.1/PowerShell-7.6.1-win-arm64.msi'
+  $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.6.3/PowerShell-7.6.3-win-arm64.msi'
 }
 $PowerShellArgs = @('/quiet', '/norestart')
 

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -74,7 +74,7 @@ $PythonArgs = @('/quiet', 'InstallAllUsers=1', 'PrependPath=1', 'CompileAll=1', 
 
 # https://developer.nvidia.com/cuda-toolkit
 if ($Provisioning_x64) {
-  $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/13.2.1/local_installers/cuda_13.2.1_windows.exe'
+  $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/13.3.0/local_installers/cuda_13.3.0_windows.exe'
 } else {
   $CudaUrl = 'CUDA is not installed for ARM64'
 }

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -3482,11 +3482,9 @@ public:
     template <class _Ptr = pointer, enable_if_t<_Can_dereference<_Ptr>, int> = 0>
     _NODISCARD _CONSTEXPR23 add_lvalue_reference_t<_Ty> operator*() const noexcept(noexcept(*_STD declval<pointer>())) {
 #if _HAS_CXX23
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
         static_assert(
             !reference_converts_from_temporary_v<add_lvalue_reference_t<_Ty>, decltype(*_STD declval<pointer>())>,
             "Can't return a temporary object from unique_ptr::operator*(). (N5014 [unique.ptr.single.observers]/1)");
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
         return *_Mypair._Myval2;
     }

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -4539,33 +4539,25 @@ _NODISCARD auto inout_ptr(_SmartPtr& _Smart_ptr, _ArgsT&&... _Args) {
 #ifdef __cpp_lib_start_lifetime_as // TRANSITION
 _EXPORT_STD template <class _Ty>
 _Ty* start_lifetime_as(void* const _Ptr) noexcept {
-#ifdef __cpp_lib_is_implicit_lifetime // TRANSITION, toolset update
     static_assert(is_implicit_lifetime_v<_Ty>, "T must be an implicit-lifetime type. (N5032 [obj.lifetime]/1)");
-#endif // ^^^ no workaround ^^^
     static_assert(sizeof(_Ty) > 0, "T must be a complete type. (N5032 [obj.lifetime]/1)");
     return __builtin_start_lifetime_as<_Ty>(_Ptr);
 }
 _EXPORT_STD template <class _Ty>
 const _Ty* start_lifetime_as(const void* const _Ptr) noexcept {
-#ifdef __cpp_lib_is_implicit_lifetime // TRANSITION, toolset update
     static_assert(is_implicit_lifetime_v<_Ty>, "T must be an implicit-lifetime type. (N5032 [obj.lifetime]/1)");
-#endif // ^^^ no workaround ^^^
     static_assert(sizeof(_Ty) > 0, "T must be a complete type. (N5032 [obj.lifetime]/1)");
     return __builtin_start_lifetime_as<_Ty>(_Ptr);
 }
 _EXPORT_STD template <class _Ty>
 volatile _Ty* start_lifetime_as(volatile void* const _Ptr) noexcept {
-#ifdef __cpp_lib_is_implicit_lifetime // TRANSITION, toolset update
     static_assert(is_implicit_lifetime_v<_Ty>, "T must be an implicit-lifetime type. (N5032 [obj.lifetime]/1)");
-#endif // ^^^ no workaround ^^^
     static_assert(sizeof(_Ty) > 0, "T must be a complete type. (N5032 [obj.lifetime]/1)");
     return __builtin_start_lifetime_as<_Ty>(_Ptr);
 }
 _EXPORT_STD template <class _Ty>
 const volatile _Ty* start_lifetime_as(const volatile void* const _Ptr) noexcept {
-#ifdef __cpp_lib_is_implicit_lifetime // TRANSITION, toolset update
     static_assert(is_implicit_lifetime_v<_Ty>, "T must be an implicit-lifetime type. (N5032 [obj.lifetime]/1)");
-#endif // ^^^ no workaround ^^^
     static_assert(sizeof(_Ty) > 0, "T must be a complete type. (N5032 [obj.lifetime]/1)");
     return __builtin_start_lifetime_as<_Ty>(_Ptr);
 }

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -4534,7 +4534,7 @@ _NODISCARD auto inout_ptr(_SmartPtr& _Smart_ptr, _ArgsT&&... _Args) {
     }
 }
 
-#ifdef __cpp_lib_start_lifetime_as // TRANSITION
+#ifdef __cpp_lib_start_lifetime_as // TRANSITION, GH-6169
 _EXPORT_STD template <class _Ty>
 _Ty* start_lifetime_as(void* const _Ptr) noexcept {
     static_assert(is_implicit_lifetime_v<_Ty>, "T must be an implicit-lifetime type. (N5032 [obj.lifetime]/1)");

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -204,7 +204,6 @@ using _Three_way_comparison_result_with_tuple_like_t =
 template <class _Ty>
 concept _Tuple_like_non_tuple = !_Is_specialization_v<_Ty, tuple> && _Tuple_like<_Ty>;
 
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
 template <class _Tuple, class... _Args>
 constexpr bool _Tuple_reference_constructs_from_temporary = false;
 template <class... _TupleTypes, class... _Args>
@@ -218,7 +217,6 @@ template <class _Tuple, _Tuple_like _TupleLike, size_t... _Indices>
 constexpr bool
     _Tuple_reference_constructs_from_temporary_for_tuple_like<_Tuple, _TupleLike, index_sequence<_Indices...>> =
         _Tuple_reference_constructs_from_temporary<_Tuple, decltype(_STD get<_Indices>(_STD declval<_TupleLike>()))...>;
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
 template <>
@@ -363,14 +361,12 @@ public:
             noexcept(_Tuple_nothrow_constructible_v<tuple, _This2, _Rest2...>) // strengthened
         : tuple(_Exact_args_t{}, _STD forward<_This2>(_This_arg), _STD forward<_Rest2>(_Rest_arg)...) {}
 #if _HAS_CXX23
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _This2, class... _Rest2,
         enable_if_t<conjunction_v<_STD _Tuple_perfect_val<tuple, _This2, _Rest2...>,
                         _STD _Tuple_constructible_val<tuple, _This2, _Rest2...>>,
             int> = 0>
         requires _Tuple_reference_constructs_from_temporary<tuple, _This2&&, _Rest2&&...>
     explicit(_Tuple_conditional_explicit_v<tuple, _This2, _Rest2...>) tuple(_This2&&, _Rest2&&...) = delete;
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
     tuple(const tuple&) = default;
@@ -383,13 +379,11 @@ public:
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, _Other&...>) tuple(tuple<_Other...>& _Right)
         noexcept(_Tuple_nothrow_constructible_v<tuple, _Other&...>) // strengthened
         : tuple(_Unpack_tuple_t{}, _Right) {}
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class... _Other, enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, _Other&...>,
                                                _STD _Tuple_convert_val<tuple, tuple<_Other...>&, _Other...>>,
                                    int> = 0>
         requires _Tuple_reference_constructs_from_temporary<tuple, _Other&...>
     explicit(_Tuple_conditional_explicit_v<tuple, _Other&...>) tuple(tuple<_Other...>&) = delete;
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
     template <class... _Other, enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, const _Other&...>,
@@ -399,13 +393,11 @@ public:
         noexcept(_Tuple_nothrow_constructible_v<tuple, const _Other&...>) // strengthened
         : tuple(_Unpack_tuple_t{}, _Right) {}
 #if _HAS_CXX23
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class... _Other, enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, const _Other&...>,
                                                _STD _Tuple_convert_val<tuple, const tuple<_Other...>&, _Other...>>,
                                    int> = 0>
         requires _Tuple_reference_constructs_from_temporary<tuple, const _Other&...>
     explicit(_Tuple_conditional_explicit_v<tuple, const _Other&...>) tuple(const tuple<_Other...>&) = delete;
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
     template <class... _Other, enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, _Other...>,
@@ -415,13 +407,11 @@ public:
         noexcept(_Tuple_nothrow_constructible_v<tuple, _Other...>) // strengthened
         : tuple(_Unpack_tuple_t{}, _STD move(_Right)) {}
 #if _HAS_CXX23
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class... _Other, enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, _Other...>,
                                                _STD _Tuple_convert_val<tuple, tuple<_Other...>, _Other...>>,
                                    int> = 0>
         requires _Tuple_reference_constructs_from_temporary<tuple, _Other&&...>
     explicit(_Tuple_conditional_explicit_v<tuple, _Other...>) tuple(tuple<_Other...>&&) = delete;
-#endif // ^^^ no workaround ^^^
 
     template <class... _Other, enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, const _Other...>,
                                                _STD _Tuple_convert_val<tuple, const tuple<_Other...>, _Other...>>,
@@ -429,23 +419,19 @@ public:
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, const _Other...>) tuple(const tuple<_Other...>&& _Right)
         noexcept(_Tuple_nothrow_constructible_v<tuple, const _Other...>) // strengthened
         : tuple(_Unpack_tuple_t{}, _STD move(_Right)) {}
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class... _Other, enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, const _Other...>,
                                                _STD _Tuple_convert_val<tuple, const tuple<_Other...>, _Other...>>,
                                    int> = 0>
         requires _Tuple_reference_constructs_from_temporary<tuple, const _Other&&...>
     explicit(_Tuple_conditional_explicit_v<tuple, const _Other...>) tuple(const tuple<_Other...>&&) = delete;
-#endif // ^^^ no workaround ^^^
 
     template <class _First, class _Second, enable_if_t<_Tuple_constructible_v<tuple, _First&, _Second&>, int> = 0>
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, _First&, _Second&>) tuple(pair<_First, _Second>& _Right)
         noexcept(_Tuple_nothrow_constructible_v<tuple, _First&, _Second&>) // strengthened
         : tuple(_Unpack_tuple_t{}, _Right) {}
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _First, class _Second, enable_if_t<_Tuple_constructible_v<tuple, _First&, _Second&>, int> = 0>
         requires _Tuple_reference_constructs_from_temporary<tuple, _First&, _Second&>
     explicit(_Tuple_conditional_explicit_v<tuple, _First&, _Second&>) tuple(pair<_First, _Second>&) = delete;
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
     template <class _First, class _Second,
@@ -455,13 +441,11 @@ public:
             noexcept(_Tuple_nothrow_constructible_v<tuple, const _First&, const _Second&>) // strengthened
         : tuple(_Unpack_tuple_t{}, _Right) {}
 #if _HAS_CXX23
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _First, class _Second,
         enable_if_t<_Tuple_constructible_v<tuple, const _First&, const _Second&>, int> = 0>
         requires _Tuple_reference_constructs_from_temporary<tuple, const _First&, const _Second&>
     explicit(_Tuple_conditional_explicit_v<tuple, const _First&, const _Second&>)
         tuple(const pair<_First, _Second>&) = delete;
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
     template <class _First, class _Second, enable_if_t<_Tuple_constructible_v<tuple, _First, _Second>, int> = 0>
@@ -469,11 +453,9 @@ public:
         noexcept(_Tuple_nothrow_constructible_v<tuple, _First, _Second>) // strengthened
         : tuple(_Unpack_tuple_t{}, _STD move(_Right)) {}
 #if _HAS_CXX23
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _First, class _Second, enable_if_t<_Tuple_constructible_v<tuple, _First, _Second>, int> = 0>
         requires _Tuple_reference_constructs_from_temporary<tuple, _First&&, _Second&&>
     explicit(_Tuple_conditional_explicit_v<tuple, _First, _Second>) tuple(pair<_First, _Second>&&) = delete;
-#endif // ^^^ no workaround ^^^
 
     template <class _First, class _Second,
         enable_if_t<_Tuple_constructible_v<tuple, const _First, const _Second>, int> = 0>
@@ -481,13 +463,11 @@ public:
         tuple(const pair<_First, _Second>&& _Right)
             noexcept(_Tuple_nothrow_constructible_v<tuple, const _First, const _Second>) // strengthened
         : tuple(_Unpack_tuple_t{}, _STD move(_Right)) {}
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _First, class _Second,
         enable_if_t<_Tuple_constructible_v<tuple, const _First, const _Second>, int> = 0>
         requires _Tuple_reference_constructs_from_temporary<tuple, const _First&&, const _Second&&>
     explicit(_Tuple_conditional_explicit_v<tuple, const _First, const _Second>)
         tuple(const pair<_First, _Second>&&) = delete;
-#endif // ^^^ no workaround ^^^
 
     template <class _Other, class _Indices = index_sequence_for<_Rest...>>
     static constexpr bool _Is_tuple_like_constructor_explicit_v = false;
@@ -508,7 +488,6 @@ public:
     constexpr explicit(_Is_tuple_like_constructor_explicit_v<_Other>) tuple(_Other&& _Right)
         : tuple(_Unpack_tuple_t{}, _STD forward<_Other>(_Right)) {
     }
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <_Different_from<tuple> _Other>
         requires _Tuple_like_non_subrange<_Other> && (1 + sizeof...(_Rest) == tuple_size_v<remove_cvref_t<_Other>>)
                   && _Can_construct_values_from_tuple_like_v<tuple, _Other>
@@ -516,7 +495,6 @@ public:
                       || (!is_convertible_v<_Other, _This> && !is_constructible_v<_This, _Other>) )
                   && _Tuple_reference_constructs_from_temporary_for_tuple_like<tuple, _Other&&>
     explicit(_Is_tuple_like_constructor_explicit_v<_Other>) tuple(_Other&&) = delete;
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
     template <class _Alloc, class _This2 = _This,
@@ -541,7 +519,6 @@ public:
         tuple(allocator_arg_t, const _Alloc& _Al, _This2&& _This_arg, _Rest2&&... _Rest_arg)
         : tuple(_Alloc_exact_args_t{}, _Al, _STD forward<_This2>(_This_arg), _STD forward<_Rest2>(_Rest_arg)...) {}
 #if _HAS_CXX23
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _Alloc, class _This2, class... _Rest2,
         enable_if_t<conjunction_v<_STD _Tuple_perfect_val<tuple, _This2, _Rest2...>,
                         _STD _Tuple_constructible_val<tuple, _This2, _Rest2...>>,
@@ -549,7 +526,6 @@ public:
         requires _Tuple_reference_constructs_from_temporary<tuple, _This2&&, _Rest2&&...>
     explicit(_Tuple_conditional_explicit_v<tuple, _This2, _Rest2...>)
         tuple(allocator_arg_t, const _Alloc&, _This2&&, _Rest2&&...) = delete;
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
     template <class _Alloc, class _This2 = _This,
@@ -569,7 +545,6 @@ public:
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, _Other&...>)
         tuple(allocator_arg_t, const _Alloc& _Al, tuple<_Other...>& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _Right) {}
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _Alloc, class... _Other,
         enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, _Other&...>,
                         _STD _Tuple_convert_val<tuple, tuple<_Other...>&, _Other...>>,
@@ -577,7 +552,6 @@ public:
         requires _Tuple_reference_constructs_from_temporary<tuple, _Other&...>
     explicit(_Tuple_conditional_explicit_v<tuple, _Other&...>)
         tuple(allocator_arg_t, const _Alloc&, tuple<_Other...>&) = delete;
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
     template <class _Alloc, class... _Other,
@@ -588,7 +562,6 @@ public:
         tuple(allocator_arg_t, const _Alloc& _Al, const tuple<_Other...>& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _Right) {}
 #if _HAS_CXX23
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _Alloc, class... _Other,
         enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, const _Other&...>,
                         _STD _Tuple_convert_val<tuple, const tuple<_Other...>&, _Other...>>,
@@ -596,7 +569,6 @@ public:
         requires _Tuple_reference_constructs_from_temporary<tuple, const _Other&...>
     explicit(_Tuple_conditional_explicit_v<tuple, const _Other&...>)
         tuple(allocator_arg_t, const _Alloc&, const tuple<_Other...>&) = delete;
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
     template <class _Alloc, class... _Other,
@@ -607,7 +579,6 @@ public:
         tuple(allocator_arg_t, const _Alloc& _Al, tuple<_Other...>&& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
 #if _HAS_CXX23
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _Alloc, class... _Other,
         enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, _Other...>,
                         _STD _Tuple_convert_val<tuple, tuple<_Other...>, _Other...>>,
@@ -615,7 +586,6 @@ public:
         requires _Tuple_reference_constructs_from_temporary<tuple, _Other&&...>
     explicit(_Tuple_conditional_explicit_v<tuple, _Other...>)
         tuple(allocator_arg_t, const _Alloc&, tuple<_Other...>&&) = delete;
-#endif // ^^^ no workaround ^^^
 
     template <class _Alloc, class... _Other,
         enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, const _Other...>,
@@ -624,7 +594,6 @@ public:
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, const _Other...>)
         tuple(allocator_arg_t, const _Alloc& _Al, const tuple<_Other...>&& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _Alloc, class... _Other,
         enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, const _Other...>,
                         _STD _Tuple_convert_val<tuple, const tuple<_Other...>, _Other...>>,
@@ -632,20 +601,17 @@ public:
         requires _Tuple_reference_constructs_from_temporary<tuple, const _Other&&...>
     explicit(_Tuple_conditional_explicit_v<tuple, const _Other...>)
         tuple(allocator_arg_t, const _Alloc&, const tuple<_Other...>&&) = delete;
-#endif // ^^^ no workaround ^^^
 
     template <class _Alloc, class _First, class _Second,
         enable_if_t<_Tuple_constructible_v<tuple, _First&, _Second&>, int> = 0>
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, _First&, _Second&>)
         tuple(allocator_arg_t, const _Alloc& _Al, pair<_First, _Second>& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _Right) {}
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _Alloc, class _First, class _Second,
         enable_if_t<_Tuple_constructible_v<tuple, _First&, _Second&>, int> = 0>
         requires _Tuple_reference_constructs_from_temporary<tuple, _First&, _Second&>
     explicit(_Tuple_conditional_explicit_v<tuple, _First&, _Second&>)
         tuple(allocator_arg_t, const _Alloc&, pair<_First, _Second>&) = delete;
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
     template <class _Alloc, class _First, class _Second,
@@ -654,13 +620,11 @@ public:
         tuple(allocator_arg_t, const _Alloc& _Al, const pair<_First, _Second>& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _Right) {}
 #if _HAS_CXX23
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _Alloc, class _First, class _Second,
         enable_if_t<_Tuple_constructible_v<tuple, const _First&, const _Second&>, int> = 0>
         requires _Tuple_reference_constructs_from_temporary<tuple, const _First&, const _Second&>
     explicit(_Tuple_conditional_explicit_v<tuple, const _First&, const _Second&>)
         tuple(allocator_arg_t, const _Alloc&, const pair<_First, _Second>&) = delete;
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
     template <class _Alloc, class _First, class _Second,
@@ -669,26 +633,22 @@ public:
         tuple(allocator_arg_t, const _Alloc& _Al, pair<_First, _Second>&& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
 #if _HAS_CXX23
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _Alloc, class _First, class _Second,
         enable_if_t<_Tuple_constructible_v<tuple, _First, _Second>, int> = 0>
         requires _Tuple_reference_constructs_from_temporary<tuple, _First&&, _Second&&>
     explicit(_Tuple_conditional_explicit_v<tuple, _First, _Second>)
         tuple(allocator_arg_t, const _Alloc&, pair<_First, _Second>&&) = delete;
-#endif // ^^^ no workaround ^^^
 
     template <class _Alloc, class _First, class _Second,
         enable_if_t<_Tuple_constructible_v<tuple, const _First, const _Second>, int> = 0>
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, const _First, const _Second>)
         tuple(allocator_arg_t, const _Alloc& _Al, const pair<_First, _Second>&& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _Alloc, class _First, class _Second,
         enable_if_t<_Tuple_constructible_v<tuple, const _First, const _Second>, int> = 0>
         requires _Tuple_reference_constructs_from_temporary<tuple, const _First&&, const _Second&&>
     explicit(_Tuple_conditional_explicit_v<tuple, const _First, const _Second>)
         tuple(allocator_arg_t, const _Alloc&, const pair<_First, _Second>&&) = delete;
-#endif // ^^^ no workaround ^^^
 
 #ifdef __EDG__ // TRANSITION, VSO-1900279
     template <class _Alloc, class _Other, enable_if_t<_Can_construct_from_tuple_like<_Other, tuple>, int> = 0>
@@ -702,7 +662,6 @@ public:
         tuple(allocator_arg_t, const _Alloc& _Al, _Other&& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD forward<_Other>(_Right)) {
     }
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _Alloc, _Different_from<tuple> _Other>
         requires _Tuple_like_non_subrange<_Other> && (1 + sizeof...(_Rest) == tuple_size_v<remove_cvref_t<_Other>>)
                   && _Can_construct_values_from_tuple_like_v<tuple, _Other>
@@ -710,7 +669,6 @@ public:
                       || (!is_convertible_v<_Other, _This> && !is_constructible_v<_This, _Other>) )
                   && _Tuple_reference_constructs_from_temporary_for_tuple_like<tuple, _Other&&>
     explicit(_Is_tuple_like_constructor_explicit_v<_Other>) tuple(allocator_arg_t, const _Alloc&, _Other&&) = delete;
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
     tuple& operator=(const volatile tuple&) = delete;
@@ -1271,12 +1229,10 @@ template <class _Ty, class _Tuple, enable_if_t<_Can_make_from_tuple<_Ty, _Tuple>
 _NODISCARD constexpr _Ty make_from_tuple(_Tuple&& _Tpl) noexcept(noexcept(_STD _Make_from_tuple_impl<_Ty>(
     _STD forward<_Tuple>(_Tpl), make_index_sequence<tuple_size_v<remove_reference_t<_Tuple>>>{}))) /* strengthened */ {
 #if _HAS_CXX23
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     if constexpr (tuple_size_v<remove_reference_t<_Tuple>> == 1) {
         static_assert(!reference_constructs_from_temporary_v<_Ty, decltype(_STD get<0>(_STD forward<_Tuple>(_Tpl)))>,
             "Cannot bind a temporary to the returned reference which will always be dangling (N5014 [tuple.apply]/2).");
     }
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
     // construct _Ty from the elements of _Tpl
     return _STD _Make_from_tuple_impl<_Ty>(

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -192,11 +192,7 @@ template <class _TTuple, class _UTuple, class _Indices = make_index_sequence<tup
 struct _Three_way_comparison_result_with_tuple_like {};
 
 template <class... _TTypes, class _UTuple, size_t... _Indices>
-    requires
-#if !defined(__clang__) && !defined(__EDG__) && _MSC_VER < 1951 // TRANSITION, toolset update
-    (sizeof...(_TTypes) == sizeof...(_Indices)) &&
-#endif // ^^^ workaround ^^^
-    (requires { typename _Synth_three_way_result<_TTypes, tuple_element_t<_Indices, _UTuple>>; } && ...)
+    requires (requires { typename _Synth_three_way_result<_TTypes, tuple_element_t<_Indices, _UTuple>>; } && ...)
 struct _Three_way_comparison_result_with_tuple_like<tuple<_TTypes...>, _UTuple, index_sequence<_Indices...>> {
     using type = common_comparison_category_t<_Synth_three_way_result<_TTypes, tuple_element_t<_Indices, _UTuple>>...>;
 };

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -727,13 +727,11 @@ _EXPORT_STD template <class _Ty>
 _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_trivially_copyable_v = __is_trivially_copyable(_Ty);
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_is_implicit_lifetime // TRANSITION, toolset update
 _EXPORT_STD template <class _Ty>
 struct _NO_SPECIALIZATIONS_OF_TYPE_TRAITS is_implicit_lifetime : bool_constant<__builtin_is_implicit_lifetime(_Ty)> {};
 
 _EXPORT_STD template <class _Ty>
 _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_implicit_lifetime_v = __builtin_is_implicit_lifetime(_Ty);
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
 _EXPORT_STD template <class _Ty>

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -755,7 +755,6 @@ _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool has_unique_object_representati
 #endif // _HAS_CXX17
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
 _EXPORT_STD template <class _Ty, class _Uty>
 struct _NO_SPECIALIZATIONS_OF_TYPE_TRAITS reference_constructs_from_temporary
     : bool_constant<__reference_constructs_from_temporary(_Ty, _Uty)> {};
@@ -771,7 +770,6 @@ struct _NO_SPECIALIZATIONS_OF_TYPE_TRAITS reference_converts_from_temporary
 _EXPORT_STD template <class _Ty, class _Uty>
 _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool reference_converts_from_temporary_v =
     __reference_converts_from_temporary(_Ty, _Uty);
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
 #if _HAS_CXX17
@@ -1858,13 +1856,8 @@ template <class _From, class _To, class = void>
 struct _Invoke_convertible : false_type {};
 
 #if _HAS_CXX23
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
 template <class _To, class _From>
 using _Not_reference_converts_from_temporary = bool_constant<!reference_converts_from_temporary_v<_To, _From>>;
-#else // ^^^ no workaround / workaround vvv
-template <class _To, class _From>
-using _Not_reference_converts_from_temporary = true_type;
-#endif // ^^^ workaround ^^^
 #else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
 template <class _To, class _From>
 using _Not_reference_converts_from_temporary = true_type;

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -277,14 +277,12 @@ struct pair { // store a pair of values
         : first(_STD forward<_Other1>(_Val1)), second(_STD forward<_Other2>(_Val2)) {
     }
 #if _HAS_CXX23
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _Other1 = _Ty1, class _Other2 = _Ty2,
         enable_if_t<conjunction_v<is_constructible<_Ty1, _Other1>, is_constructible<_Ty2, _Other2>>, int> = 0>
         requires reference_constructs_from_temporary_v<_Ty1, _Other1&&>
                   || reference_constructs_from_temporary_v<_Ty2, _Other2&&>
     explicit(!conjunction_v<is_convertible<_Other1, _Ty1>, is_convertible<_Other2, _Ty2>>)
         pair(_Other1&&, _Other2&&) = delete;
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
     pair(const pair&) = default;
@@ -297,14 +295,12 @@ struct pair { // store a pair of values
         pair(pair<_Other1, _Other2>& _Right) noexcept(
             is_nothrow_constructible_v<_Ty1, _Other1&> && is_nothrow_constructible_v<_Ty2, _Other2&>) // strengthened
         : first(_Right.first), second(_Right.second) {}
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _Other1, class _Other2>
         requires is_constructible_v<_Ty1, _Other1&> && is_constructible_v<_Ty2, _Other2&>
                   && (reference_constructs_from_temporary_v<_Ty1, _Other1&>
                       || reference_constructs_from_temporary_v<_Ty2, _Other2&>)
     explicit(!conjunction_v<is_convertible<_Other1&, _Ty1>, is_convertible<_Other2&, _Ty2>>)
         pair(pair<_Other1, _Other2>&) = delete;
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
     template <class _Other1, class _Other2,
@@ -316,7 +312,6 @@ struct pair { // store a pair of values
                      && is_nothrow_constructible_v<_Ty2, const _Other2&>) // strengthened
         : first(_Right.first), second(_Right.second) {}
 #if _HAS_CXX23
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _Other1, class _Other2,
         enable_if_t<conjunction_v<is_constructible<_Ty1, const _Other1&>, is_constructible<_Ty2, const _Other2&>>,
             int> = 0>
@@ -324,7 +319,6 @@ struct pair { // store a pair of values
                   || reference_constructs_from_temporary_v<_Ty2, const _Other2&>
     explicit(!conjunction_v<is_convertible<const _Other1&, _Ty1>, is_convertible<const _Other2&, _Ty2>>)
         pair(const pair<_Other1, _Other2>&) = delete;
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
     template <class _Other1, class _Other2,
@@ -334,14 +328,12 @@ struct pair { // store a pair of values
             is_nothrow_constructible_v<_Ty1, _Other1> && is_nothrow_constructible_v<_Ty2, _Other2>) // strengthened
         : first(_STD forward<_Other1>(_Right.first)), second(_STD forward<_Other2>(_Right.second)) {}
 #if _HAS_CXX23
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _Other1, class _Other2,
         enable_if_t<conjunction_v<is_constructible<_Ty1, _Other1>, is_constructible<_Ty2, _Other2>>, int> = 0>
         requires reference_constructs_from_temporary_v<_Ty1, _Other1&&>
                   || reference_constructs_from_temporary_v<_Ty2, _Other2&&>
     explicit(!conjunction_v<is_convertible<_Other1, _Ty1>, is_convertible<_Other2, _Ty2>>)
         pair(pair<_Other1, _Other2>&&) = delete;
-#endif // ^^^ no workaround ^^^
 
     template <class _Other1, class _Other2>
         requires is_constructible_v<_Ty1, const _Other1> && is_constructible_v<_Ty2, const _Other2>
@@ -350,14 +342,12 @@ struct pair { // store a pair of values
             noexcept(is_nothrow_constructible_v<_Ty1, const _Other1>
                      && is_nothrow_constructible_v<_Ty2, const _Other2>) // strengthened
         : first(_STD forward<const _Other1>(_Right.first)), second(_STD forward<const _Other2>(_Right.second)) {}
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <class _Other1, class _Other2>
         requires is_constructible_v<_Ty1, const _Other1> && is_constructible_v<_Ty2, const _Other2>
                   && (reference_constructs_from_temporary_v<_Ty1, const _Other1 &&>
                       || reference_constructs_from_temporary_v<_Ty2, const _Other2 &&>)
     explicit(!conjunction_v<is_convertible<const _Other1, _Ty1>, is_convertible<const _Other2, _Ty2>>)
         pair(const pair<_Other1, _Other2>&&) = delete;
-#endif // ^^^ no workaround ^^^
 
 #ifdef __EDG__ // TRANSITION, VSO-1900279
     template <class _Other, enable_if_t<_Can_construct_from_pair_like<_Other, _Ty1, _Ty2>, int> = 0>
@@ -372,7 +362,6 @@ struct pair { // store a pair of values
                  && is_nothrow_constructible_v<_Ty2, decltype(_STD get<1>(_STD declval<_Other>()))>) // strengthened
         : first(_STD get<0>(_STD forward<_Other>(_Right))), second(_STD get<1>(_STD forward<_Other>(_Right))) {
     }
-#ifdef __cpp_lib_reference_from_temporary // TRANSITION
     template <_Pair_like_non_subrange _Other>
         requires conjunction_v<is_constructible<_Ty1, decltype(_STD get<0>(_STD declval<_Other>()))>,
                      is_constructible<_Ty2, decltype(_STD get<1>(_STD declval<_Other>()))>>
@@ -380,7 +369,6 @@ struct pair { // store a pair of values
                       || reference_constructs_from_temporary_v<_Ty2, decltype(_STD get<1>(_STD declval<_Other>()))>)
     explicit(!conjunction_v<is_convertible<decltype(_STD get<0>(_STD declval<_Other>())), _Ty1>,
         is_convertible<decltype(_STD get<1>(_STD declval<_Other>())), _Ty2>>) pair(_Other&&) = delete;
-#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX23
 
     template <class... _Types1, class... _Types2>

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1760,33 +1760,29 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_generator                         202207L
 #define __cpp_lib_invoke_r                          202106L
 #define __cpp_lib_ios_noreplace                     202207L
-
-#if defined(__clang__) || defined(__EDG__) || _MSC_VER >= 1951 // TRANSITION, toolset update
-#define __cpp_lib_is_implicit_lifetime 202302L
-#endif // ^^^ no workaround ^^^
-
-#define __cpp_lib_is_scoped_enum           202011L
-#define __cpp_lib_mdspan                   202207L
-#define __cpp_lib_move_only_function       202110L
-#define __cpp_lib_out_ptr                  202311L
-#define __cpp_lib_print                    202406L
-#define __cpp_lib_ranges_as_const          202311L
-#define __cpp_lib_ranges_as_rvalue         202207L
-#define __cpp_lib_ranges_cartesian_product 202207L
-#define __cpp_lib_ranges_chunk             202202L
-#define __cpp_lib_ranges_chunk_by          202202L
-#define __cpp_lib_ranges_contains          202207L
-#define __cpp_lib_ranges_enumerate         202302L
-#define __cpp_lib_ranges_find_last         202207L
-#define __cpp_lib_ranges_fold              202207L
-#define __cpp_lib_ranges_iota              202202L
-#define __cpp_lib_ranges_join_with         202202L
-#define __cpp_lib_ranges_repeat            202207L
-#define __cpp_lib_ranges_slide             202202L
-#define __cpp_lib_ranges_starts_ends_with  202106L
-#define __cpp_lib_ranges_stride            202207L
-#define __cpp_lib_ranges_to_container      202202L
-#define __cpp_lib_ranges_zip               202110L
+#define __cpp_lib_is_implicit_lifetime              202302L
+#define __cpp_lib_is_scoped_enum                    202011L
+#define __cpp_lib_mdspan                            202207L
+#define __cpp_lib_move_only_function                202110L
+#define __cpp_lib_out_ptr                           202311L
+#define __cpp_lib_print                             202406L
+#define __cpp_lib_ranges_as_const                   202311L
+#define __cpp_lib_ranges_as_rvalue                  202207L
+#define __cpp_lib_ranges_cartesian_product          202207L
+#define __cpp_lib_ranges_chunk                      202202L
+#define __cpp_lib_ranges_chunk_by                   202202L
+#define __cpp_lib_ranges_contains                   202207L
+#define __cpp_lib_ranges_enumerate                  202302L
+#define __cpp_lib_ranges_find_last                  202207L
+#define __cpp_lib_ranges_fold                       202207L
+#define __cpp_lib_ranges_iota                       202202L
+#define __cpp_lib_ranges_join_with                  202202L
+#define __cpp_lib_ranges_repeat                     202207L
+#define __cpp_lib_ranges_slide                      202202L
+#define __cpp_lib_ranges_starts_ends_with           202106L
+#define __cpp_lib_ranges_stride                     202207L
+#define __cpp_lib_ranges_to_container               202202L
+#define __cpp_lib_ranges_zip                        202110L
 
 #if defined(__clang__) || defined(__EDG__) || _MSC_VER >= 1951 // TRANSITION, GH-5755, toolset update
 #define __cpp_lib_reference_from_temporary 202202L

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1787,7 +1787,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_spanstream                        202106L
 #define __cpp_lib_stacktrace                        202011L
 
-#if !defined(__clang__) && !defined(__EDG__) && _MSC_VER >= 1951 // TRANSITION, GH-6169, toolset update
+#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, GH-6169 tracking LLVM-105234 and VSO-2846756
 #define __cpp_lib_start_lifetime_as 202207L
 #endif // ^^^ no workaround ^^^
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1783,13 +1783,9 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_ranges_stride                     202207L
 #define __cpp_lib_ranges_to_container               202202L
 #define __cpp_lib_ranges_zip                        202110L
-
-#if defined(__clang__) || defined(__EDG__) || _MSC_VER >= 1951 // TRANSITION, GH-5755, toolset update
-#define __cpp_lib_reference_from_temporary 202202L
-#endif // ^^^ no workaround ^^^
-
-#define __cpp_lib_spanstream 202106L
-#define __cpp_lib_stacktrace 202011L
+#define __cpp_lib_reference_from_temporary          202202L
+#define __cpp_lib_spanstream                        202106L
+#define __cpp_lib_stacktrace                        202011L
 
 #if !defined(__clang__) && !defined(__EDG__) && _MSC_VER >= 1951 // TRANSITION, GH-6169, toolset update
 #define __cpp_lib_start_lifetime_as 202207L

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -919,8 +919,8 @@ _EMIT_STL_ERROR(STL1002, "Unexpected compiler version, expected CUDA 13.3 or new
 _EMIT_STL_ERROR(STL1000, "Unexpected compiler version, expected Clang 22 or newer.");
 #endif // ^^^ old Clang ^^^
 #elif defined(_MSC_VER)
-#if _MSC_VER < 1950 // Coarse-grained, not inspecting _MSC_FULL_VER
-_EMIT_STL_ERROR(STL1001, "Unexpected compiler version, expected MSVC Compiler 19.50 or newer.");
+#if _MSC_VER < 1951 // Coarse-grained, not inspecting _MSC_FULL_VER
+_EMIT_STL_ERROR(STL1001, "Unexpected compiler version, expected MSVC Compiler 19.51 or newer.");
 #endif // ^^^ old MSVC ^^^
 #else // vvv other compilers vvv
 // not attempting to detect other compilers

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -909,8 +909,8 @@
 
 #ifndef _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
 #if defined(__CUDACC__) && defined(__CUDACC_VER_MAJOR__)
-#if __CUDACC_VER_MAJOR__ < 13 || (__CUDACC_VER_MAJOR__ == 13 && __CUDACC_VER_MINOR__ < 2)
-_EMIT_STL_ERROR(STL1002, "Unexpected compiler version, expected CUDA 13.2 or newer.");
+#if __CUDACC_VER_MAJOR__ < 13 || (__CUDACC_VER_MAJOR__ == 13 && __CUDACC_VER_MINOR__ < 3)
+_EMIT_STL_ERROR(STL1002, "Unexpected compiler version, expected CUDA 13.3 or newer.");
 #endif // ^^^ old CUDA ^^^
 #elif defined(__EDG__)
 // not attempting to detect __EDG_VERSION__ being less than expected

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-find_package(Python "3.14.5" REQUIRED COMPONENTS Interpreter)
+find_package(Python "3.14.6" REQUIRED COMPONENTS Interpreter)
 
 set(STL_BUILD_ROOT "${PROJECT_BINARY_DIR}/out")
 set(STL_SOURCE_DIR "${PROJECT_SOURCE_DIR}")

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -360,8 +360,6 @@ std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.
 # DevCom-1436243 VSO-1335743 constexpr new initialized array
 std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset_self.pass.cpp:0 FAIL
 std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset_self.pass.cpp:1 FAIL
-std/utilities/smartptr/unique.ptr/unique.ptr.create/make_unique.array.pass.cpp:0 FAIL
-std/utilities/smartptr/unique.ptr/unique.ptr.create/make_unique.array.pass.cpp:1 FAIL
 
 # DevCom-1626139 VSO-1456427 "compile-time NaN comparison"
 std/iterators/predef.iterators/reverse.iterators/reverse.iter.cmp/three-way.pass.cpp:0 FAIL

--- a/tests/std/tests/P2321R2_views_adjacent/test.cpp
+++ b/tests/std/tests/P2321R2_views_adjacent/test.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#if defined(_PREFAST_) && defined(_M_IX86) // TRANSITION, VSO-1639191
+int main() {}
+#else // ^^^ workaround / no workaround vvv
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -1026,3 +1029,4 @@ int main() {
 #endif
     instantiation_input_only_test();
 }
+#endif // ^^^ no workaround ^^^

--- a/tests/std/tests/P2590R2_explicit_lifetime_management/test.cpp
+++ b/tests/std/tests/P2590R2_explicit_lifetime_management/test.cpp
@@ -6,7 +6,7 @@
 #include <memory>
 using namespace std;
 
-#ifdef __cpp_lib_start_lifetime_as // TRANSITION
+#ifdef __cpp_lib_start_lifetime_as // TRANSITION, GH-6169
 struct Point {
     int x;
     int y;


### PR DESCRIPTION
* Cycle locations.
* PowerShell 7.6.3.
* Python 3.14.6 (now required).
* CUDA 13.3.0 (now required).
* MSVC Compiler 19.52.36510 (now required).
* `yvals_core.h`: Require MSVC Compiler 19.51.
* Boost.Math 1.91.0.
  + Fixes #6152 / DevCom-10383094 / VSO-1830422.
* actions/checkout v7.
* Node.js 26.4.0.
* New pools.
* Internal toolset update: Remove `tuple` workaround for VSO-2826400.
* Internal toolset update: `__cpp_lib_is_implicit_lifetime` is always available in C++23 mode.
* Internal toolset update: `__cpp_lib_reference_from_temporary` is always available in C++23 mode.
  + Fixes #5755.
* Internal toolset update: `__cpp_lib_start_lifetime_as` is always defined for real MSVC.
* WinSDK 10.0.28000.2114 fixed VSO-2946529 "`/analyze` emits warning C28285 for `_BitScanForward` declared by `winnt.h`".
  + WinSDK 10.0.28000.1890 was reportedly the first release with this fix.
* libcxx `make_unique.array.pass.cpp` is now passing for MSVC.
* `P2321R2_views_adjacent`: Work around x86 `/analyze` OOM.