### PR TITLE
[NFCI] Report ASan build telemetry via BinSkim

### DIFF
--- a/azure-devops/build-and-test.yml
+++ b/azure-devops/build-and-test.yml
@@ -67,6 +67,20 @@ jobs:
       configureTesting: ${{ parameters.configureTesting }}
       buildStl: ${{ parameters.buildStl }}
       testsBuildOnly: ${{ parameters.testsBuildOnly }}
+  # Emit per-binary ASan usage telemetry (BinSkim BA2032) for ASan-instrumented
+  # builds. See: https://aka.ms/useasan
+  - ${{ if and(parameters.asanBuild, parameters.buildStl) }}:
+    - task: BinSkim@4
+      displayName: 'Emit ASan usage telemetry (BinSkim BA2032)'
+      inputs:
+        TargetPattern: guardianGlob
+        AnalyzeTargetGlob: +:f|$(buildOutputLocation)\**\*.dll;+:f|$(buildOutputLocation)\**\*.exe
+        toolVersion: '4.4.9'
+      env:
+        GDN_BINSKIM_RUNONLYRULES: BA2032
+        GDN_BINSKIM_KIND: Fail;Pass;Informational
+    - task: PostAnalysis@2
+      displayName: 'Publish BinSkim BA2032 telemetry to Guardian'
   - template: build-benchmarks.yml
     parameters:
       hostArch: ${{ parameters.hostArch }}


### PR DESCRIPTION
**Disclosure:** AI-was used to draft this PR, but it was reviewed by me (as always).

**Context:** the MSVC ASan team is interested in collecting per-binary ASan usage telemetry across the company. It is fairly clear how to do this for closed-source / ADO repos as the 1ES framework already provides us with all the hooks we need to insert an auto-injected telemetry task.

However, for OSS repos like this one, our strategy is less clear. That said, I'm under the impression that just adding a **BinSkim** step, configured to emit ASan telemetry, should suffice to emit telemetry for the STL.

**This PR** adds a BinSkim ADO task, configured to emit ASan telemetry, to the `asanBuild` mode of `build-and-test.yml`. My hope is to trigger the pipeline and confirm in the backend (kusto) that the telemetry is emitted and correctly associated with the GitHub STL repo. If it is, I'd be interested in merging this.

_Thanks!_
