### PR TITLE
Remove LWG-4472 comment from atomic_ref

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2291,7 +2291,7 @@ public:
         }
     }
 
-    explicit atomic_ref(_Ty&&) = delete; // per LWG-4472
+    explicit atomic_ref(_Ty&&) = delete;
 
     atomic_ref(const atomic_ref&) noexcept = default;
 


### PR DESCRIPTION
The fix for LWG-4472 (`atomic_ref<const T>` construction from temporaries) has already been implemented via the = delete on the rvalue-reference constructor. This removes the tracking comment now that the issue has been accepted.

Closes #6222