### PR TITLE
Toolset update: MSVC Compiler 19.52.36530, Dpdsv6

### DIFF
--- a/.github/workflows/update-status-chart.yml
+++ b/.github/workflows/update-status-chart.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           ref: gh-pages
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ">=26.4.0"
       - name: Install Packages

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 4.3.1)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 
-if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.52.36510")
-    message(FATAL_ERROR "The STL must be built with MSVC Compiler 19.52.36510 or later. Follow the README instructions.")
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.52.36530")
+    message(FATAL_ERROR "The STL must be built with MSVC Compiler 19.52.36530 or later. Follow the README instructions.")
 endif()
 
 include(CheckCXXSourceCompiles)

--- a/azure-devops/asan-pipeline.yml
+++ b/azure-devops/asan-pipeline.yml
@@ -22,6 +22,10 @@ stages:
     pool:
       name: ${{ variables.x64SlowPoolName }}
       demands: ${{ variables.poolDemands }}
+    variables:
+    - name: workRoot
+      value: '$(x64PoolWorkRoot)'
+      readonly: true
     jobs:
       - template: build-and-test.yml
         parameters:
@@ -37,6 +41,10 @@ stages:
     pool:
       name: ${{ variables.x64SlowPoolName }}
       demands: ${{ variables.poolDemands }}
+    variables:
+    - name: workRoot
+      value: '$(x64PoolWorkRoot)'
+      readonly: true
     jobs:
       - template: build-and-test.yml
         parameters:
@@ -52,6 +60,10 @@ stages:
     pool:
       name: ${{ variables.arm64PoolName }}
       demands: ${{ variables.poolDemands }}
+    variables:
+    - name: workRoot
+      value: '$(arm64PoolWorkRoot)'
+      readonly: true
     jobs:
       - template: build-and-test.yml
         parameters:

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,13 +5,13 @@
 
 variables:
 - name: x64SlowPoolName
-  value: 'Stl-2026-06-25T1103-x64-Fasv6-Pool'
+  value: 'Stl-2026-07-15T0800-x64-Fasv6-Pool'
   readonly: true
 - name: x64FastPoolName
-  value: 'Stl-2026-06-25T1103-x64-Fasv7-Pool'
+  value: 'Stl-2026-07-15T0800-x64-Fasv7-Pool'
   readonly: true
 - name: arm64PoolName
-  value: 'Stl-2026-06-25T1103-arm64-Dpsv6-Pool'
+  value: 'Stl-2026-07-15T0800-arm64-Dpdsv6-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -19,17 +19,26 @@ variables:
 - name: launchVsDevShell
   value: 'C:\Program Files\Microsoft Visual Studio\18\Insiders\Common7\Tools\Launch-VsDevShell.ps1'
   readonly: true
+# The x64 SKUs Fasv6 and Fasv7 don't have local temporary storage, so they must use 'C:'.
+# When we can use Fadsv7, local temporary storage should be available as 'N:'.
+- name: x64PoolWorkRoot
+  value: 'C:'
+  readonly: true
+# The arm64 SKU Dpdsv6 has local temporary storage, available as 'E:'.
+- name: arm64PoolWorkRoot
+  value: 'E:'
+  readonly: true
 - name: tmpDir
-  value: 'C:\stlTemp'
+  value: '$(workRoot)\stlTemp'
   readonly: true
 - name: buildOutputLocation
-  value: 'C:\stlBuild'
+  value: '$(workRoot)\stlBuild'
   readonly: true
 - name: benchmarkBuildOutputLocation
-  value: 'C:\stlBenchmark'
+  value: '$(workRoot)\stlBenchmark'
   readonly: true
 - name: validationBuildOutputLocation
-  value: 'C:\stlValidation'
+  value: '$(workRoot)\stlValidation'
   readonly: true
 - name: Codeql.SkipTaskAutoInjection
   value: true

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -9,11 +9,11 @@ Creates a 1ES Hosted Pool, set up for the STL's CI.
 See https://github.com/microsoft/STL/wiki/Checklist-for-Toolset-Updates for more information.
 
 .PARAMETER VMSku
-The VM SKU can be Fasv6, Fasv7, or Dpsv6.
+The VM SKU can be Fasv6, Fasv7, or Dpdsv6.
 #>
 [CmdletBinding(PositionalBinding=$false)]
 Param(
-  [Parameter(Mandatory)][ValidateSet('Fasv6', 'Fasv7', 'Dpsv6')][String]$VMSku
+  [Parameter(Mandatory)][ValidateSet('Fasv6', 'Fasv7', 'Dpdsv6')][String]$VMSku
 )
 
 $ErrorActionPreference = 'Stop'
@@ -21,16 +21,14 @@ $ErrorActionPreference = 'Stop'
 $CurrentDate = Get-Date
 $Timestamp = $CurrentDate.ToString('yyyy-MM-ddTHHmm')
 
-# | SKU   | Location      | Cores | Notes              |
-# |-------|---------------|------:|--------------------|
-# | Fasv6 | eastus2       |  4096 |                    |
-# | Fasv7 | australiaeast |   740 |                    |
-# | Fasv7 | northeurope   |   640 |                    |
-# | Fasv7 | southeastasia |   640 |                    |
-# | Dpsv6 | eastus2       |  1024 |                    |
-# | Dpsv6 | northeurope   |  1024 |                    |
-# | Dpsv6 | uksouth       |  1024 |                    |
-# | Dpsv6 | westcentralus |   672 | Not currently used |
+# | SKU    | Location       | Cores | Notes              |
+# |--------|----------------|------:|--------------------|
+# | Fasv6  | eastus2        |  4096 |                    |
+# | Fasv7  | australiaeast  |   740 |                    |
+# | Fasv7  | northeurope    |   640 |                    |
+# | Fasv7  | southeastasia  |   640 |                    |
+# | Dpdsv6 | australiaeast  |  2048 |                    |
+# | Dpdsv6 | southcentralus |  2048 |                    |
 
 if ($VMSku -ieq 'Fasv6') {
   $Arch = 'x64'
@@ -42,11 +40,11 @@ if ($VMSku -ieq 'Fasv6') {
   $VMSize = 'Standard_F32as_v7'
   $PoolSize = 20 # Locations where we have quota for at least 640 cores (20 VMs):
   $AvailableLocations = @('australiaeast', 'northeurope', 'southeastasia')
-} elseif ($VMSku -ieq 'Dpsv6') {
+} elseif ($VMSku -ieq 'Dpdsv6') {
   $Arch = 'arm64'
-  $VMSize = 'Standard_D32ps_v6'
-  $PoolSize = 32 # Locations where we have quota for at least 1024 cores (32 VMs):
-  $AvailableLocations = @('eastus2', 'northeurope', 'uksouth')
+  $VMSize = 'Standard_D32pds_v6'
+  $PoolSize = 64 # Locations where we have quota for at least 2048 cores (64 VMs):
+  $AvailableLocations = @('australiaeast', 'southcentralus')
 }
 
 $AvailableLocationIdx = 11 # Increment for each new set of pools, to cycle through the available locations.

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -49,7 +49,7 @@ if ($VMSku -ieq 'Fasv6') {
   $AvailableLocations = @('eastus2', 'northeurope', 'uksouth')
 }
 
-$AvailableLocationIdx = 10 # Increment for each new set of pools, to cycle through the available locations.
+$AvailableLocationIdx = 11 # Increment for each new set of pools, to cycle through the available locations.
 $Location = $AvailableLocations[$AvailableLocationIdx % $AvailableLocations.Length]
 
 if ($Arch -ieq 'x64') {

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -74,7 +74,7 @@ $PythonArgs = @('/quiet', 'InstallAllUsers=1', 'PrependPath=1', 'CompileAll=1', 
 
 # https://developer.nvidia.com/cuda-toolkit
 if ($Provisioning_x64) {
-  $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/13.3.0/local_installers/cuda_13.3.0_windows.exe'
+  $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/13.3.1/local_installers/cuda_13.3.1_windows.exe'
 } else {
   $CudaUrl = 'CUDA is not installed for ARM64'
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,10 @@ stages:
     pool:
       name: ${{ variables.x64SlowPoolName }}
       demands: ${{ variables.poolDemands }}
+    variables:
+    - name: workRoot
+      value: '$(x64PoolWorkRoot)'
+      readonly: true
     jobs:
       - template: azure-devops/format-validation.yml
 
@@ -25,6 +29,10 @@ stages:
     pool:
       name: ${{ variables.x64SlowPoolName }}
       demands: ${{ variables.poolDemands }}
+    variables:
+    - name: workRoot
+      value: '$(x64PoolWorkRoot)'
+      readonly: true
     jobs:
       - template: azure-devops/build-and-test.yml
         parameters:
@@ -43,6 +51,10 @@ stages:
     pool:
       name: ${{ variables.x64SlowPoolName }}
       demands: ${{ variables.poolDemands }}
+    variables:
+    - name: workRoot
+      value: '$(x64PoolWorkRoot)'
+      readonly: true
     jobs:
       - template: azure-devops/build-and-test.yml
         parameters:
@@ -61,6 +73,10 @@ stages:
     pool:
       name: ${{ variables.x64SlowPoolName }}
       demands: ${{ variables.poolDemands }}
+    variables:
+    - name: workRoot
+      value: '$(x64PoolWorkRoot)'
+      readonly: true
     jobs:
       - template: azure-devops/build-and-test.yml
         parameters:
@@ -79,6 +95,10 @@ stages:
     pool:
       name: ${{ variables.x64SlowPoolName }}
       demands: ${{ variables.poolDemands }}
+    variables:
+    - name: workRoot
+      value: '$(x64PoolWorkRoot)'
+      readonly: true
     jobs:
       - template: azure-devops/build-and-test.yml
         parameters:
@@ -99,6 +119,10 @@ stages:
     pool:
       name: ${{ variables.arm64PoolName }}
       demands: ${{ variables.poolDemands }}
+    variables:
+    - name: workRoot
+      value: '$(arm64PoolWorkRoot)'
+      readonly: true
     jobs:
       - template: azure-devops/build-and-test.yml
         parameters:
@@ -117,6 +141,10 @@ stages:
     pool:
       name: ${{ variables.x64SlowPoolName }}
       demands: ${{ variables.poolDemands }}
+    variables:
+    - name: workRoot
+      value: '$(x64PoolWorkRoot)'
+      readonly: true
     jobs:
       - template: azure-devops/build-and-test.yml
         parameters:
@@ -139,6 +167,10 @@ stages:
     pool:
       name: ${{ variables.x64FastPoolName }}
       demands: ${{ variables.poolDemands }}
+    variables:
+    - name: workRoot
+      value: '$(x64PoolWorkRoot)'
+      readonly: true
     jobs:
       - template: azure-devops/build-and-test.yml
         parameters:
@@ -152,6 +184,10 @@ stages:
     pool:
       name: ${{ variables.x64SlowPoolName }}
       demands: ${{ variables.poolDemands }}
+    variables:
+    - name: workRoot
+      value: '$(x64PoolWorkRoot)'
+      readonly: true
     jobs:
       - template: azure-devops/build-and-test.yml
         parameters:
@@ -167,6 +203,10 @@ stages:
     pool:
       name: ${{ variables.arm64PoolName }}
       demands: ${{ variables.poolDemands }}
+    variables:
+    - name: workRoot
+      value: '$(arm64PoolWorkRoot)'
+      readonly: true
     jobs:
       - template: azure-devops/build-and-test.yml
         parameters:
@@ -182,6 +222,10 @@ stages:
     pool:
       name: ${{ variables.arm64PoolName }}
       demands: ${{ variables.poolDemands }}
+    variables:
+    - name: workRoot
+      value: '$(arm64PoolWorkRoot)'
+      readonly: true
     jobs:
       - template: azure-devops/build-and-test.yml
         parameters:


### PR DESCRIPTION
* Cycle locations.
* Got 2048 cores of Dpdsv6 in australiaeast and southcentralus.
* workRoot: Use C: for x64, versus E: for arm64.
* actions/setup-node v7.
* CUDA 13.3.1.
* MSVC Compiler 19.52.36530 (now required).
* New pools.

[STL-ASan-CI passed.](https://dev.azure.com/vclibs/STL/_build/results?buildId=20833&view=results)