### PR TITLE
Update Working Draft revision to N5054

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ issue. The [bug tag][] and [enhancement tag][] are being populated.
 
 # Goals
 
-We're implementing the latest C++ Working Draft, currently [N5046][], which will eventually become the next C++
+We're implementing the latest C++ Working Draft, currently [N5054][], which will eventually become the next C++
 International Standard. The terms Working Draft (WD) and Working Paper (WP) are interchangeable; we often
 informally refer to these drafts as "the Standard" while being aware of the difference. (There are other relevant
 Standards; for example, supporting `/std:c++14` and `/std:c++17` involves understanding how the C++14 and C++17
@@ -606,7 +606,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 [LWG issues]: https://cplusplus.github.io/LWG/lwg-toc.html
 [LWG tag]: https://github.com/microsoft/STL/issues?q=is%3Aopen+is%3Aissue+label%3ALWG
 [Microsoft Open Source Code of Conduct]: https://opensource.microsoft.com/codeofconduct/
-[N5046]: https://wg21.link/N5046
+[N5054]: https://wg21.link/N5054
 [NOTICE.txt]: NOTICE.txt
 [STL-CI-badge]: https://dev.azure.com/vclibs/STL/_apis/build/status%2FSTL-CI?branchName=main "STL-CI"
 [STL-CI-link]: https://dev.azure.com/vclibs/STL/_build/latest?definitionId=4&branchName=main


### PR DESCRIPTION
<!-- Before submitting a pull request, please ensure that:

* Any AI-generated code has been clearly disclosed in your PR description.
  We strongly discourage AI-generated changes to product code because the STL
  is a highly unusual codebase with complex correctness and performance
  requirements imposed by the Standard, and highly unusual code patterns that
  don't look like typical codebases. Our intensive code review process
  (to avoid bugs) is intentionally a bottleneck, so we ask that you be
  considerate of the time and effort that we'll need to spend, by starting
  with changes that you fully understand. Test code has weaker requirements,
  so AI-generated changes for tests can be acceptable if properly disclosed.

* Your PR description explains your intent behind the changes.
  We discourage AI-generated PR descriptions because we can read the changes,
  and we have access to the same AI tools that you have, so we can get
  an AI-generated summary if we want.

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->

This PR updates the README’s referenced C++ Working Draft revision from N5046 to N5054, matching the latest draft. Fixes #6368.

Changes:

- Updates the Goals section to reference N5054.
- Updates the corresponding Markdown link definition to [`https://wg21.link/N5054`](https://wg21.link/N5054).