### PR TITLE
Toolset update: Fadsv7, x64/ARM64 phase 2, 48/64-core VMs

### DIFF
--- a/azure-devops/asan-pipeline.yml
+++ b/azure-devops/asan-pipeline.yml
@@ -24,7 +24,7 @@ stages:
       demands: ${{ variables.poolDemands }}
     variables:
     - name: workRoot
-      value: '$(x64PoolWorkRoot)'
+      value: '$(x64SlowPoolWorkRoot)'
       readonly: true
     jobs:
       - template: build-and-test.yml
@@ -43,7 +43,7 @@ stages:
       demands: ${{ variables.poolDemands }}
     variables:
     - name: workRoot
-      value: '$(x64PoolWorkRoot)'
+      value: '$(x64SlowPoolWorkRoot)'
       readonly: true
     jobs:
       - template: build-and-test.yml

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,13 +5,16 @@
 
 variables:
 - name: x64SlowPoolName
-  value: 'Stl-2026-07-15T0800-x64-Fasv6-Pool'
+  value: 'Stl-FIXME-x64-Fasv6-Pool'
+  readonly: true
+- name: x64MediumPoolName
+  value: 'Stl-FIXME-x64-Fasv7-Pool'
   readonly: true
 - name: x64FastPoolName
-  value: 'Stl-2026-07-15T0800-x64-Fasv7-Pool'
+  value: 'Stl-FIXME-x64-Fadsv7-Pool'
   readonly: true
 - name: arm64PoolName
-  value: 'Stl-2026-07-15T0800-arm64-Dpdsv6-Pool'
+  value: 'Stl-FIXME-arm64-Dpdsv6-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'
@@ -19,10 +22,17 @@ variables:
 - name: launchVsDevShell
   value: 'C:\Program Files\Microsoft Visual Studio\18\Insiders\Common7\Tools\Launch-VsDevShell.ps1'
   readonly: true
-# The x64 SKUs Fasv6 and Fasv7 don't have local temporary storage, so they must use 'C:'.
-# When we can use Fadsv7, local temporary storage should be available as 'N:'.
-- name: x64PoolWorkRoot
+# The x64 SKU Fasv6 doesn't have local temporary storage, so it must use 'C:'.
+- name: x64SlowPoolWorkRoot
   value: 'C:'
+  readonly: true
+# The x64 SKU Fasv7 doesn't have local temporary storage, so it must use 'C:'.
+- name: x64MediumPoolWorkRoot
+  value: 'C:'
+  readonly: true
+# The x64 SKU Fadsv7 has local temporary storage, available as 'N:' (for NVMe).
+- name: x64FastPoolWorkRoot
+  value: 'N:'
   readonly: true
 # The arm64 SKU Dpdsv6 has local temporary storage, available as 'E:'.
 - name: arm64PoolWorkRoot

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,16 +5,16 @@
 
 variables:
 - name: x64SlowPoolName
-  value: 'Stl-FIXME-x64-Fasv6-Pool'
+  value: 'Stl-2026-07-18T1628-x64-Fasv6-Pool'
   readonly: true
 - name: x64MediumPoolName
-  value: 'Stl-FIXME-x64-Fasv7-Pool'
+  value: 'Stl-2026-07-18T1628-x64-Fasv7-Pool'
   readonly: true
 - name: x64FastPoolName
-  value: 'Stl-FIXME-x64-Fadsv7-Pool'
+  value: 'Stl-2026-07-18T1628-x64-Fadsv7-Pool'
   readonly: true
 - name: arm64PoolName
-  value: 'Stl-FIXME-arm64-Dpdsv6-Pool'
+  value: 'Stl-2026-07-18T1628-arm64-Dpdsv6-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -47,7 +47,7 @@ if ($VMSku -ieq 'Fasv6') {
   $AvailableLocations = @('australiaeast', 'southcentralus')
 }
 
-$AvailableLocationIdx = 11 # Increment for each new set of pools, to cycle through the available locations.
+$AvailableLocationIdx = 12 # Increment for each new set of pools, to cycle through the available locations.
 $Location = $AvailableLocations[$AvailableLocationIdx % $AvailableLocations.Length]
 
 if ($Arch -ieq 'x64') {

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -9,11 +9,11 @@ Creates a 1ES Hosted Pool, set up for the STL's CI.
 See https://github.com/microsoft/STL/wiki/Checklist-for-Toolset-Updates for more information.
 
 .PARAMETER VMSku
-The VM SKU can be Fasv6, Fasv7, or Dpdsv6.
+The VM SKU can be Fasv6, Fasv7, Fadsv7, or Dpdsv6.
 #>
 [CmdletBinding(PositionalBinding=$false)]
 Param(
-  [Parameter(Mandatory)][ValidateSet('Fasv6', 'Fasv7', 'Dpdsv6')][String]$VMSku
+  [Parameter(Mandatory)][ValidateSet('Fasv6', 'Fasv7', 'Fadsv7', 'Dpdsv6')][String]$VMSku
 )
 
 $ErrorActionPreference = 'Stop'
@@ -27,6 +27,7 @@ $Timestamp = $CurrentDate.ToString('yyyy-MM-ddTHHmm')
 # | Fasv7  | australiaeast  |   740 |                    |
 # | Fasv7  | northeurope    |   640 |                    |
 # | Fasv7  | southeastasia  |   640 |                    |
+# | Fadsv7 | australiaeast  |  2048 |                    |
 # | Dpdsv6 | australiaeast  |  2048 |                    |
 # | Dpdsv6 | southcentralus |  2048 |                    |
 
@@ -40,6 +41,11 @@ if ($VMSku -ieq 'Fasv6') {
   $VMSize = 'Standard_F32as_v7'
   $PoolSize = 20 # Locations where we have quota for at least 640 cores (20 VMs):
   $AvailableLocations = @('australiaeast', 'northeurope', 'southeastasia')
+} elseif ($VMSku -ieq 'Fadsv7') {
+  $Arch = 'x64'
+  $VMSize = 'Standard_F32ads_v7'
+  $PoolSize = 32 # We have quota for 2048 cores (64 VMs), so we can have old and new pools of 32 VMs each.
+  $AvailableLocations = @('australiaeast')
 } elseif ($VMSku -ieq 'Dpdsv6') {
   $Arch = 'arm64'
   $VMSize = 'Standard_D32pds_v6'

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -21,15 +21,23 @@ $ErrorActionPreference = 'Stop'
 $CurrentDate = Get-Date
 $Timestamp = $CurrentDate.ToString('yyyy-MM-ddTHHmm')
 
-# | SKU    | Location       | Cores | Notes              |
-# |--------|----------------|------:|--------------------|
-# | Fasv6  | eastus2        |  4096 |                    |
-# | Fasv7  | australiaeast  |   740 |                    |
-# | Fasv7  | northeurope    |   640 |                    |
-# | Fasv7  | southeastasia  |   640 |                    |
-# | Fadsv7 | australiaeast  |  2048 |                    |
-# | Dpdsv6 | australiaeast  |  2048 |                    |
-# | Dpdsv6 | southcentralus |  2048 |                    |
+# We use 16 cores for the prototype VM ($ProtoVMSize) because we don't need a ton of cores to run provision-image.ps1,
+# and this allows us to stay below our total regional vCPU quota when running create-1es-hosted-pool.ps1 for several
+# SKUs simultaneously. (Our regional vCPU quota is 100, "enforced across all VM series in a given region" as
+# https://learn.microsoft.com/azure/quotas/regional-quota-requests explains. We're creating individual prototype VMs,
+# outside of the 1ES Hosted Pools we prepare later, so the prototypes are subject to the limit of 100.)
+# As long as everything else matches, we can use the image captured from the prototype VM
+# to create a 1ES Hosted Pool with larger VMs ($PoolSkuName) without any issues.
+
+# | SKU    | Location       | Cores | Notes
+# |--------|----------------|------:|-------
+# | Fasv6  | eastus2        |  4096 |
+# | Fasv7  | australiaeast  |   740 |
+# | Fasv7  | northeurope    |   640 |
+# | Fasv7  | southeastasia  |   640 |
+# | Fadsv7 | australiaeast  |  2048 |
+# | Dpdsv6 | australiaeast  |  2048 |
+# | Dpdsv6 | southcentralus |  2048 |
 
 if ($VMSku -ieq 'Fasv6') {
   $Arch = 'x64'

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -33,22 +33,26 @@ $Timestamp = $CurrentDate.ToString('yyyy-MM-ddTHHmm')
 
 if ($VMSku -ieq 'Fasv6') {
   $Arch = 'x64'
-  $VMSize = 'Standard_F64as_v6'
+  $ProtoVMSize = 'Standard_F16as_v6'
+  $PoolSkuName = 'Standard_F64as_v6'
   $PoolSize = 32 # We have quota for 4096 cores (64 VMs), so we can have old and new pools of 32 VMs each.
   $AvailableLocations = @('eastus2')
 } elseif ($VMSku -ieq 'Fasv7') {
   $Arch = 'x64'
-  $VMSize = 'Standard_F48as_v7'
+  $ProtoVMSize = 'Standard_F16as_v7'
+  $PoolSkuName = 'Standard_F48as_v7'
   $PoolSize = 13 # Locations where we have quota for at least 640 cores (13 VMs):
   $AvailableLocations = @('australiaeast', 'northeurope', 'southeastasia')
 } elseif ($VMSku -ieq 'Fadsv7') {
   $Arch = 'x64'
-  $VMSize = 'Standard_F48ads_v7'
+  $ProtoVMSize = 'Standard_F16ads_v7'
+  $PoolSkuName = 'Standard_F48ads_v7'
   $PoolSize = 21 # We have quota for 2048 cores (42 VMs), so we can have old and new pools of 21 VMs each.
   $AvailableLocations = @('australiaeast')
 } elseif ($VMSku -ieq 'Dpdsv6') {
   $Arch = 'arm64'
-  $VMSize = 'Standard_D64pds_v6'
+  $ProtoVMSize = 'Standard_D16pds_v6'
+  $PoolSkuName = 'Standard_D64pds_v6'
   $PoolSize = 32 # Locations where we have quota for at least 2048 cores (32 VMs):
   $AvailableLocations = @('australiaeast', 'southcentralus')
 }
@@ -219,13 +223,13 @@ Display-ProgressBar -Status 'Creating prototype VM config'
 if ($Arch -ieq 'x64') {
   $VM = New-AzVMConfig `
     -VMName $ProtoVMName `
-    -VMSize $VMSize `
+    -VMSize $ProtoVMSize `
     -DiskControllerType 'NVMe' `
     -Priority 'Regular'
 } else {
   $VM = New-AzVMConfig `
     -VMName $ProtoVMName `
-    -VMSize $VMSize `
+    -VMSize $ProtoVMSize `
     -DiskControllerType 'SCSI' `
     -Priority 'Regular' `
     -SecurityType 'TrustedLaunch' `
@@ -432,7 +436,7 @@ $PoolName = "$ResourceGroupName-Pool"
 $PoolProperties = @{
   'organization' = 'https://dev.azure.com/vclibs'
   'projects' = @('STL')
-  'sku' = @{ 'name' = $VMSize; 'tier' = 'StandardSSD'; 'enableSpot' = $false; }
+  'sku' = @{ 'name' = $PoolSkuName; 'tier' = 'StandardSSD'; 'enableSpot' = $false; }
   'images' = @(@{ 'imageName' = $ImageName; 'poolBufferPercentage' = '100'; })
   'maxPoolSize' = $PoolSize
   'agentProfile' = @{ 'type' = 'Stateless'; }

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -33,23 +33,23 @@ $Timestamp = $CurrentDate.ToString('yyyy-MM-ddTHHmm')
 
 if ($VMSku -ieq 'Fasv6') {
   $Arch = 'x64'
-  $VMSize = 'Standard_F32as_v6'
-  $PoolSize = 64 # We have quota for 4096 cores (128 VMs), so we can have old and new pools of 64 VMs each.
+  $VMSize = 'Standard_F64as_v6'
+  $PoolSize = 32 # We have quota for 4096 cores (64 VMs), so we can have old and new pools of 32 VMs each.
   $AvailableLocations = @('eastus2')
 } elseif ($VMSku -ieq 'Fasv7') {
   $Arch = 'x64'
-  $VMSize = 'Standard_F32as_v7'
-  $PoolSize = 20 # Locations where we have quota for at least 640 cores (20 VMs):
+  $VMSize = 'Standard_F48as_v7'
+  $PoolSize = 13 # Locations where we have quota for at least 640 cores (13 VMs):
   $AvailableLocations = @('australiaeast', 'northeurope', 'southeastasia')
 } elseif ($VMSku -ieq 'Fadsv7') {
   $Arch = 'x64'
-  $VMSize = 'Standard_F32ads_v7'
-  $PoolSize = 32 # We have quota for 2048 cores (64 VMs), so we can have old and new pools of 32 VMs each.
+  $VMSize = 'Standard_F48ads_v7'
+  $PoolSize = 21 # We have quota for 2048 cores (42 VMs), so we can have old and new pools of 21 VMs each.
   $AvailableLocations = @('australiaeast')
 } elseif ($VMSku -ieq 'Dpdsv6') {
   $Arch = 'arm64'
-  $VMSize = 'Standard_D32pds_v6'
-  $PoolSize = 64 # Locations where we have quota for at least 2048 cores (64 VMs):
+  $VMSize = 'Standard_D64pds_v6'
+  $PoolSize = 32 # Locations where we have quota for at least 2048 cores (32 VMs):
   $AvailableLocations = @('australiaeast', 'southcentralus')
 }
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,28 +68,6 @@ stages:
           configureTesting: false
           runTesting: false
 
-  - stage: Build_ARM64_Cross
-    dependsOn: []
-    displayName: 'Build ARM64 (Cross)'
-    pool:
-      name: ${{ variables.x64MediumPoolName }}
-      demands: ${{ variables.poolDemands }}
-    variables:
-    - name: workRoot
-      value: '$(x64MediumPoolWorkRoot)'
-      readonly: true
-    jobs:
-      - template: azure-devops/build-and-test.yml
-        parameters:
-          hostArch: x64
-          targetArch: arm64
-          targetPlatform: arm64
-          analyzeBuild: true
-          buildBenchmarks: true
-          numShards: 1
-          configureTesting: false
-          runTesting: false
-
   # This ARM64-native build will detect problems with the ARM64 pool as early as possible.
   # The stage dependencies are structured to optimize the critical path.
   - stage: Build_ARM64_Native

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -138,8 +138,8 @@ stages:
       - Code_Format
       - Build_x64
       - Build_x86
-      - Build_ARM64_Cross
-      - Build_ARM64EC_Cross
+      - Build_ARM64
+      - Build_ARM64EC
       - Configure_Tests
     displayName: 'Test x64'
     pool:
@@ -158,8 +158,12 @@ stages:
 
   - stage: Test_ARM64
     dependsOn:
-      - Build_ARM64_Native
-      - Test_x64
+      - Code_Format
+      - Build_x64
+      - Build_x86
+      - Build_ARM64
+      - Build_ARM64EC
+      - Configure_Tests
     displayName: 'Test ARM64'
     pool:
       name: ${{ variables.arm64PoolName }}
@@ -177,7 +181,9 @@ stages:
 
 ##### Phase 3: Secondary Test Architectures #####
   - stage: Test_x86
-    dependsOn: Test_x64
+    dependsOn:
+      - Test_x64
+      - Test_ARM64
     displayName: 'Test x86'
     pool:
       name: ${{ variables.x64SlowPoolName }}
@@ -195,8 +201,8 @@ stages:
 
   - stage: Test_ARM64EC
     dependsOn:
-      - Build_ARM64_Native
       - Test_x64
+      - Test_ARM64
     displayName: 'Test ARM64EC'
     pool:
       name: ${{ variables.arm64PoolName }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,11 +68,9 @@ stages:
           configureTesting: false
           runTesting: false
 
-  # This ARM64-native build will detect problems with the ARM64 pool as early as possible.
-  # The stage dependencies are structured to optimize the critical path.
-  - stage: Build_ARM64_Native
+  - stage: Build_ARM64
     dependsOn: []
-    displayName: 'Build ARM64 (Native)'
+    displayName: 'Build ARM64'
     pool:
       name: ${{ variables.arm64PoolName }}
       demands: ${{ variables.poolDemands }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,20 +90,20 @@ stages:
           configureTesting: false
           runTesting: false
 
-  - stage: Build_ARM64EC_Cross
+  - stage: Build_ARM64EC
     dependsOn: []
-    displayName: 'Build ARM64EC (Cross)'
+    displayName: 'Build ARM64EC'
     pool:
-      name: ${{ variables.x64MediumPoolName }}
+      name: ${{ variables.arm64PoolName }}
       demands: ${{ variables.poolDemands }}
     variables:
     - name: workRoot
-      value: '$(x64MediumPoolWorkRoot)'
+      value: '$(arm64PoolWorkRoot)'
       readonly: true
     jobs:
       - template: azure-devops/build-and-test.yml
         parameters:
-          hostArch: x64
+          hostArch: arm64
           targetArch: arm64
           targetPlatform: arm64ec
           analyzeBuild: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,28 +89,6 @@ stages:
           configureTesting: false
           runTesting: false
 
-  - stage: Build_ARM64EC_Cross
-    dependsOn: []
-    displayName: 'Build ARM64EC (Cross)'
-    pool:
-      name: ${{ variables.x64MediumPoolName }}
-      demands: ${{ variables.poolDemands }}
-    variables:
-    - name: workRoot
-      value: '$(x64MediumPoolWorkRoot)'
-      readonly: true
-    jobs:
-      - template: azure-devops/build-and-test.yml
-        parameters:
-          hostArch: x64
-          targetArch: arm64
-          targetPlatform: arm64ec
-          analyzeBuild: true
-          buildBenchmarks: true
-          numShards: 1
-          configureTesting: false
-          runTesting: false
-
   # This ARM64-native build will detect problems with the ARM64 pool as early as possible.
   # The stage dependencies are structured to optimize the critical path.
   - stage: Build_ARM64_Native
@@ -129,6 +107,28 @@ stages:
           hostArch: arm64
           targetArch: arm64
           targetPlatform: arm64
+          analyzeBuild: true
+          buildBenchmarks: true
+          numShards: 1
+          configureTesting: false
+          runTesting: false
+
+  - stage: Build_ARM64EC_Cross
+    dependsOn: []
+    displayName: 'Build ARM64EC (Cross)'
+    pool:
+      name: ${{ variables.x64MediumPoolName }}
+      demands: ${{ variables.poolDemands }}
+    variables:
+    - name: workRoot
+      value: '$(x64MediumPoolWorkRoot)'
+      readonly: true
+    jobs:
+      - template: azure-devops/build-and-test.yml
+        parameters:
+          hostArch: x64
+          targetArch: arm64
+          targetPlatform: arm64ec
           analyzeBuild: true
           buildBenchmarks: true
           numShards: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,7 @@ pr:
   drafts: false
 
 stages:
+##### Phase 1: Initial Builds #####
   - stage: Code_Format
     dependsOn: []
     displayName: 'Code Format'
@@ -155,6 +156,7 @@ stages:
           buildStl: false
           runTesting: false
 
+##### Phase 2: Primary Test Architectures #####
   - stage: Test_x64
     dependsOn:
       - Code_Format
@@ -197,6 +199,7 @@ stages:
           targetArch: arm64
           targetPlatform: arm64
 
+##### Phase 3: Secondary Test Architectures #####
   - stage: Test_x86
     dependsOn: Test_x64
     displayName: 'Test x86'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -178,23 +178,6 @@ stages:
           targetArch: x64
           targetPlatform: x64
 
-  - stage: Test_x86
-    dependsOn: Test_x64
-    displayName: 'Test x86'
-    pool:
-      name: ${{ variables.x64SlowPoolName }}
-      demands: ${{ variables.poolDemands }}
-    variables:
-    - name: workRoot
-      value: '$(x64SlowPoolWorkRoot)'
-      readonly: true
-    jobs:
-      - template: azure-devops/build-and-test.yml
-        parameters:
-          hostArch: x86
-          targetArch: x86
-          targetPlatform: x86
-
   - stage: Test_ARM64
     dependsOn:
       - Build_ARM64_Native
@@ -213,6 +196,23 @@ stages:
           hostArch: arm64
           targetArch: arm64
           targetPlatform: arm64
+
+  - stage: Test_x86
+    dependsOn: Test_x64
+    displayName: 'Test x86'
+    pool:
+      name: ${{ variables.x64SlowPoolName }}
+      demands: ${{ variables.poolDemands }}
+    variables:
+    - name: workRoot
+      value: '$(x64SlowPoolWorkRoot)'
+      readonly: true
+    jobs:
+      - template: azure-devops/build-and-test.yml
+        parameters:
+          hostArch: x86
+          targetArch: x86
+          targetPlatform: x86
 
   - stage: Test_ARM64EC
     dependsOn:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ stages:
     dependsOn: []
     displayName: 'Code Format'
     pool:
-      name: ${{ variables.x64SlowPoolName }}
+      name: ${{ variables.x64MediumPoolName }}
       demands: ${{ variables.poolDemands }}
     variables:
     - name: workRoot
@@ -27,7 +27,7 @@ stages:
     dependsOn: []
     displayName: 'Build x64'
     pool:
-      name: ${{ variables.x64SlowPoolName }}
+      name: ${{ variables.x64MediumPoolName }}
       demands: ${{ variables.poolDemands }}
     variables:
     - name: workRoot
@@ -49,7 +49,7 @@ stages:
     dependsOn: []
     displayName: 'Build x86'
     pool:
-      name: ${{ variables.x64SlowPoolName }}
+      name: ${{ variables.x64MediumPoolName }}
       demands: ${{ variables.poolDemands }}
     variables:
     - name: workRoot
@@ -71,7 +71,7 @@ stages:
     dependsOn: []
     displayName: 'Build ARM64 (Cross)'
     pool:
-      name: ${{ variables.x64SlowPoolName }}
+      name: ${{ variables.x64MediumPoolName }}
       demands: ${{ variables.poolDemands }}
     variables:
     - name: workRoot
@@ -93,7 +93,7 @@ stages:
     dependsOn: []
     displayName: 'Build ARM64EC (Cross)'
     pool:
-      name: ${{ variables.x64SlowPoolName }}
+      name: ${{ variables.x64MediumPoolName }}
       demands: ${{ variables.poolDemands }}
     variables:
     - name: workRoot
@@ -139,7 +139,7 @@ stages:
     dependsOn: []
     displayName: 'Configure Tests'
     pool:
-      name: ${{ variables.x64SlowPoolName }}
+      name: ${{ variables.x64MediumPoolName }}
       demands: ${{ variables.poolDemands }}
     variables:
     - name: workRoot

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ stages:
       demands: ${{ variables.poolDemands }}
     variables:
     - name: workRoot
-      value: '$(x64PoolWorkRoot)'
+      value: '$(x64MediumPoolWorkRoot)'
       readonly: true
     jobs:
       - template: azure-devops/format-validation.yml
@@ -31,7 +31,7 @@ stages:
       demands: ${{ variables.poolDemands }}
     variables:
     - name: workRoot
-      value: '$(x64PoolWorkRoot)'
+      value: '$(x64MediumPoolWorkRoot)'
       readonly: true
     jobs:
       - template: azure-devops/build-and-test.yml
@@ -53,7 +53,7 @@ stages:
       demands: ${{ variables.poolDemands }}
     variables:
     - name: workRoot
-      value: '$(x64PoolWorkRoot)'
+      value: '$(x64MediumPoolWorkRoot)'
       readonly: true
     jobs:
       - template: azure-devops/build-and-test.yml
@@ -75,7 +75,7 @@ stages:
       demands: ${{ variables.poolDemands }}
     variables:
     - name: workRoot
-      value: '$(x64PoolWorkRoot)'
+      value: '$(x64MediumPoolWorkRoot)'
       readonly: true
     jobs:
       - template: azure-devops/build-and-test.yml
@@ -97,7 +97,7 @@ stages:
       demands: ${{ variables.poolDemands }}
     variables:
     - name: workRoot
-      value: '$(x64PoolWorkRoot)'
+      value: '$(x64MediumPoolWorkRoot)'
       readonly: true
     jobs:
       - template: azure-devops/build-and-test.yml
@@ -143,7 +143,7 @@ stages:
       demands: ${{ variables.poolDemands }}
     variables:
     - name: workRoot
-      value: '$(x64PoolWorkRoot)'
+      value: '$(x64MediumPoolWorkRoot)'
       readonly: true
     jobs:
       - template: azure-devops/build-and-test.yml
@@ -169,7 +169,7 @@ stages:
       demands: ${{ variables.poolDemands }}
     variables:
     - name: workRoot
-      value: '$(x64PoolWorkRoot)'
+      value: '$(x64FastPoolWorkRoot)'
       readonly: true
     jobs:
       - template: azure-devops/build-and-test.yml
@@ -186,7 +186,7 @@ stages:
       demands: ${{ variables.poolDemands }}
     variables:
     - name: workRoot
-      value: '$(x64PoolWorkRoot)'
+      value: '$(x64SlowPoolWorkRoot)'
       readonly: true
     jobs:
       - template: azure-devops/build-and-test.yml


### PR DESCRIPTION
Overview
===
This adds an [Fadsv7](https://learn.microsoft.com/azure/virtual-machines/sizes/compute-optimized/fadsv7-series) pool, which is the fastest available x64 SKU: non-SMT Zen 5, with NVMe temp storage.

And now that we have more and larger pools, this restructures the dependencies between stages. I'm replacing a complicated dependency graph with simpler phases, where each phase needs to succeed before the next phase begins. 

We start with a Phase 1 of initial builds, which verify that the PR conforms to our formatting and validation requirements, that the STL builds for all architectures (with `/analyze`), and that the tests successfully configure. We now rely on ARM64 and ARM64EC native builds, and we don't bother with cross builds.

Then we have a Phase 2 of primary test architectures, where x64 and ARM64 run simultaneously. Finally, we have a Phase 3 of secondary test architectures: x86 and ARM64EC. (Previously, we gated x64 to run first, followed by x86, ARM64, and ARM64EC simultaneously.)

By spreading out the test architectures like this, we reduce each PR's maximum pressure on the pools (particularly the ARM64 pool). For the first time, I'm also giving the initial stages a dedicated pool, so even if the PR/CI system is under heavy load, initial checks won't be held up behind larger test runs.

For PRs with failing tests in x64, this will waste an ARM64 test run compared to the previous structure, but we still save the secondary test runs (which is better than other PR systems which I shall not discuss here). On the plus side, ARM64-only failures will now avoid wasting x86/ARM64EC test runs, and will deliver feedback faster.

I'm also changing our VMs to be larger: 48-core when we're limited by quota, 64-core when we're less constrained. The SKUs with temp storage (Fadsv7 and Dpdsv6) especially benefit from higher core counts. We'll unlock further gains when we improve long-running tests, which waste a lot of time at the end of each test pass with low parallelism.

I also had to change `create-1es-hosted-pool.ps1` to prepare prototype VMs with only 16 cores, before imaging them to create the pools with larger VMs. I'm adding a comment explaining why we're doing this and why it works.

Pool structure
===
* Medium pool (Fasv7)
  + Used for the Phase 1 initial builds only.
  + 13 VMs, each 48-core. We use 4 VMs per PR, so this gives us throughput for 3 PRs. (Phase 1 is very fast, so this is unlikely to be a bottleneck.)
* Fast pool (Fadsv7)
  + Used for the Phase 2 x64 tests only.
  + 21 VMs, each 48-core. We use 10 VMs per PR, so this gives us throughput for 2 PRs. (As the name implies, this one is fast, and each PR uses it for only one phase, so it shouldn't be a bottleneck.)
* Slow pool (Fasv6)
  + Used for the Phase 3 x86 tests (plus ASan CI).
  + 32 VMs, each 64-core. We use 10 VMs per PR, so this gives us throughput for 3 PRs.
  + Note: 64-core Fasv6 really is substantially slower than 48-core Fadsv7.
* ARM64 pool (Dpdsv6)
  + 32 VMs, each 64-core. We use at most 10 VMs simultaneously (2 in Phase 1, 10 in Phase 2, 10 in Phase 3), so this gives us throughput for 3 PRs.

If and when I can obtain more quota, we may simplify this pool structure in the future.

Commits
===
* Cycle locations.
* Got quota for 2048 cores of Fadsv7 in australiaeast.
* Change initial stages to use a Medium pool.
* Split work root usage into Slow/Medium/Fast.
* Split pools and work roots into Slow/Medium/Fast.
* Move Test_x86 down, no other changes.
* Move Build_ARM64EC_Cross down, no other changes.
* Add Phase 1/2/3 comments.
* Drop Build_ARM64_Cross.
* Rename Build_ARM64_Native => Build_ARM64, drop outdated comments.
* Change Build_ARM64EC_Cross to be native, now named Build_ARM64EC.
* Change dependencies to actually implement the phase structure.
* Adjust VM/pool sizes.
* Split `$VMSize` into `$ProtoVMSize` (16-core) and `$PoolSkuName` (48-core or 64-core).
* Final pools.
* Add a comment about 16-core embiggening to 48/64-core, and make Notes open-ended.
