### PR TITLE
Determine `TESTS_BUILD_ONLY`'s default by probing.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -65,9 +65,6 @@
           "arm64",
           ""
         ]
-      },
-      "cacheVariables": {
-        "TESTS_BUILD_ONLY": true
       }
     },
     {
@@ -87,7 +84,6 @@
         ]
       },
       "cacheVariables": {
-        "TESTS_BUILD_ONLY": true,
         "VCLIBS_TARGET_ARCHITECTURE": "ARM64EC"
       }
     }

--- a/README.md
+++ b/README.md
@@ -184,10 +184,10 @@ For example, `<atomic>` has conditionally compiled code for the `_M_ARM64` and `
 The following instructions assume that you're starting in the previously cloned `STL` directory.
 If you installed VS to a non-default location, change the `vcvarsall.bat` paths below accordingly.
 
-To build the x64 target (recommended):
+To build the x64 target (recommended on x64 hosts):
 
 1. `pushd "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\VC\Auxiliary\Build"`
-1. `vcvarsall.bat x64 -vcvars_ver=preview`
+1. `vcvarsall.bat x64 -vcvars_ver=preview` (x64 hosts) or `vcvarsall.bat arm64_x64 -vcvars_ver=preview` (ARM64 hosts)
 1. `popd`
 1. `cmake --preset x64`
 1. `cmake --build --preset x64`
@@ -195,15 +195,15 @@ To build the x64 target (recommended):
 To build the x86 target:
 
 1. `pushd "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\VC\Auxiliary\Build"`
-1. `vcvarsall.bat x86 -vcvars_ver=preview`
+1. `vcvarsall.bat x86 -vcvars_ver=preview` (x64 hosts) or `vcvarsall.bat arm64_x86 -vcvars_ver=preview` (ARM64 hosts)
 1. `popd`
 1. `cmake --preset x86`
 1. `cmake --build --preset x86`
 
-To build the ARM64 target:
+To build the ARM64 target (recommended on ARM64 hosts):
 
 1. `pushd "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\VC\Auxiliary\Build"`
-1. `vcvarsall.bat x64_arm64 -vcvars_ver=preview`
+1. `vcvarsall.bat x64_arm64 -vcvars_ver=preview` (x64 hosts) or `vcvarsall.bat arm64 -vcvars_ver=preview` (ARM64 hosts)
 1. `popd`
 1. `cmake --preset ARM64`
 1. `cmake --build --preset ARM64`
@@ -211,23 +211,10 @@ To build the ARM64 target:
 To build the ARM64EC target:
 
 1. `pushd "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\VC\Auxiliary\Build"`
-1. `vcvarsall.bat x64_arm64 -vcvars_ver=preview`
+1. `vcvarsall.bat x64_arm64 -vcvars_ver=preview` (x64 hosts) or `vcvarsall.bat arm64 -vcvars_ver=preview` (ARM64 hosts)
 1. `popd`
 1. `cmake --preset ARM64EC`
 1. `cmake --build --preset ARM64EC`
-
-## Building ARM64 Natively
-
-By default, the x64 and x86 presets are configured to both build and run the tests.
-The ARM64 and ARM64EC presets assume that you're cross-compiling, so they enable an option `TESTS_BUILD_ONLY`
-to build test executables without running them. If you have an ARM64 machine, you'll want to use
-the native compiler, and you'll want to disable `TESTS_BUILD_ONLY`:
-
-1. `pushd "%ProgramFiles%\Microsoft Visual Studio\18\Insiders\VC\Auxiliary\Build"`
-1. `vcvarsall.bat arm64 -vcvars_ver=preview`
-1. `popd`
-1. `cmake --preset ARM64 -DTESTS_BUILD_ONLY=OFF`
-1. `cmake --build --preset ARM64`
 
 # How To Consume
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,35 @@ set(LLVM_PROJECT_SOURCE_DIR "${STL_SOURCE_DIR}/llvm-project" CACHE PATH
 set(LIBCXX_SOURCE_DIR "${LLVM_PROJECT_SOURCE_DIR}/libcxx" CACHE PATH
     "Location of the libcxx source tree")
 
-option(TESTS_BUILD_ONLY "Only run the build steps of tests" OFF)
+if(NOT DEFINED TESTS_CAN_RUN)
+    set(TESTS_RUN_PROBE "${CMAKE_CURRENT_BINARY_DIR}/tests-run-probe${CMAKE_EXECUTABLE_SUFFIX}")
+    set(TESTS_SAVED_TRY_COMPILE_TARGET_TYPE "${CMAKE_TRY_COMPILE_TARGET_TYPE}")
+    set(CMAKE_TRY_COMPILE_TARGET_TYPE EXECUTABLE)
+    try_compile(TESTS_COMPILED
+        SOURCE_FROM_CONTENT test.cpp "int main() {}"
+        COPY_FILE "${TESTS_RUN_PROBE}"
+        NO_CACHE)
+    set(CMAKE_TRY_COMPILE_TARGET_TYPE "${TESTS_SAVED_TRY_COMPILE_TARGET_TYPE}")
+    unset(TESTS_SAVED_TRY_COMPILE_TARGET_TYPE)
+
+    set(TESTS_CAN_RUN OFF)
+    if(TESTS_COMPILED)
+        execute_process(COMMAND "${TESTS_RUN_PROBE}" RESULT_VARIABLE TESTS_RUN_RESULT)
+        if("${TESTS_RUN_RESULT}" STREQUAL "0")
+            set(TESTS_CAN_RUN ON)
+        endif()
+    endif()
+    file(REMOVE "${TESTS_RUN_PROBE}")
+    set(TESTS_CAN_RUN "${TESTS_CAN_RUN}" CACHE INTERNAL "Whether test executables can run on the build host")
+endif()
+
+if(TESTS_CAN_RUN)
+    set(TESTS_BUILD_ONLY_DEFAULT OFF)
+else()
+    set(TESTS_BUILD_ONLY_DEFAULT ON)
+endif()
+
+option(TESTS_BUILD_ONLY "Only run the build steps of tests" "${TESTS_BUILD_ONLY_DEFAULT}")
 
 add_subdirectory(libcxx)
 add_subdirectory(std)


### PR DESCRIPTION
... rather than hard coding ARM64==off

This should make the docs change in https://github.com/microsoft/STL/pull/6383/ unnecessary by making the build system do the correct thing by default.

GPT 5.6-Sol was used in preparing these changes.