### PR TITLE
Toolset update: MSVC Compiler 19.52.36615, and update LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 4.3.1)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 
-if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.52.36530")
-    message(FATAL_ERROR "The STL must be built with MSVC Compiler 19.52.36530 or later. Follow the README instructions.")
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.52.36615")
+    message(FATAL_ERROR "The STL must be built with MSVC Compiler 19.52.36615 or later. Follow the README instructions.")
 endif()
 
 include(CheckCXXSourceCompiles)

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,16 +5,16 @@
 
 variables:
 - name: x64SlowPoolName
-  value: 'Stl-2026-07-27T1320-x64-Fasv6-Pool'
+  value: 'Stl-2026-07-28T0154-x64-Fasv6-Pool'
   readonly: true
 - name: x64MediumPoolName
-  value: 'Stl-2026-07-27T1320-x64-Fasv7-Pool'
+  value: 'Stl-2026-07-28T0154-x64-Fasv7-Pool'
   readonly: true
 - name: x64FastPoolName
-  value: 'Stl-2026-07-27T1320-x64-Fadsv7-Pool'
+  value: 'Stl-2026-07-28T0154-x64-Fadsv7-Pool'
   readonly: true
 - name: arm64PoolName
-  value: 'Stl-2026-07-27T1320-arm64-Dpdsv6-Pool'
+  value: 'Stl-2026-07-28T0154-arm64-Dpdsv6-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,16 +5,16 @@
 
 variables:
 - name: x64SlowPoolName
-  value: 'Stl-2026-07-18T1628-x64-Fasv6-Pool'
+  value: 'Stl-2026-07-27T1320-x64-Fasv6-Pool'
   readonly: true
 - name: x64MediumPoolName
-  value: 'Stl-2026-07-18T1628-x64-Fasv7-Pool'
+  value: 'Stl-2026-07-27T1320-x64-Fasv7-Pool'
   readonly: true
 - name: x64FastPoolName
-  value: 'Stl-2026-07-18T1628-x64-Fadsv7-Pool'
+  value: 'Stl-2026-07-27T1320-x64-Fadsv7-Pool'
   readonly: true
 - name: arm64PoolName
-  value: 'Stl-2026-07-18T1628-arm64-Dpdsv6-Pool'
+  value: 'Stl-2026-07-27T1320-arm64-Dpdsv6-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -65,7 +65,7 @@ if ($VMSku -ieq 'Fasv6') {
   $AvailableLocations = @('australiaeast', 'southcentralus')
 }
 
-$AvailableLocationIdx = 12 # Increment for each new set of pools, to cycle through the available locations.
+$AvailableLocationIdx = 13 # Increment for each new set of pools, to cycle through the available locations.
 $Location = $AvailableLocations[$AvailableLocationIdx % $AvailableLocations.Length]
 
 if ($Arch -ieq 'x64') {

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -32,7 +32,7 @@ $Timestamp = $CurrentDate.ToString('yyyy-MM-ddTHHmm')
 # | SKU    | Location       | Cores | Notes
 # |--------|----------------|------:|-------
 # | Fasv6  | eastus2        |  4096 |
-# | Fasv7  | australiaeast  |   740 |
+# | Fasv7  | australiaeast  |   740 | Currently unused to stay within our regional (all-SKU) quota of 4736 cores
 # | Fasv7  | northeurope    |   640 |
 # | Fasv7  | southeastasia  |   640 |
 # | Fadsv7 | australiaeast  |  2048 |
@@ -50,7 +50,7 @@ if ($VMSku -ieq 'Fasv6') {
   $ProtoVMSize = 'Standard_F16as_v7'
   $PoolSkuName = 'Standard_F48as_v7'
   $PoolSize = 13 # Locations where we have quota for at least 640 cores (13 VMs):
-  $AvailableLocations = @('australiaeast', 'northeurope', 'southeastasia')
+  $AvailableLocations = @('northeurope', 'southeastasia')
 } elseif ($VMSku -ieq 'Fadsv7') {
   $Arch = 'x64'
   $ProtoVMSize = 'Standard_F16ads_v7'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -58,9 +58,9 @@ foreach ($workload in $VisualStudioWorkloads) {
 
 # https://github.com/PowerShell/PowerShell/releases/latest
 if ($Provisioning_x64) {
-  $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.6.3/PowerShell-7.6.3-win-x64.msi'
+  $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.6.4/PowerShell-7.6.4-win-x64.msi'
 } else {
-  $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.6.3/PowerShell-7.6.3-win-arm64.msi'
+  $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.6.4/PowerShell-7.6.4-win-arm64.msi'
 }
 $PowerShellArgs = @('/quiet', '/norestart')
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -241,6 +241,18 @@ std/strings/c.strings/cuchar.compile.pass.cpp FAIL
 std/language.support/support.limits/support.limits.general/cmath.version.compile.pass.cpp FAIL
 std/language.support/support.limits/support.limits.general/cstdlib.version.compile.pass.cpp FAIL
 std/numerics/c.math/fpclassify.pass.cpp FAIL
+std/numerics/c.math/isgreater.pass.cpp:0 FAIL
+std/numerics/c.math/isgreater.pass.cpp:1 FAIL
+std/numerics/c.math/isgreaterequal.pass.cpp:0 FAIL
+std/numerics/c.math/isgreaterequal.pass.cpp:1 FAIL
+std/numerics/c.math/isless.pass.cpp:0 FAIL
+std/numerics/c.math/isless.pass.cpp:1 FAIL
+std/numerics/c.math/islessequal.pass.cpp:0 FAIL
+std/numerics/c.math/islessequal.pass.cpp:1 FAIL
+std/numerics/c.math/islessgreater.pass.cpp:0 FAIL
+std/numerics/c.math/islessgreater.pass.cpp:1 FAIL
+std/numerics/c.math/isunordered.pass.cpp:0 FAIL
+std/numerics/c.math/isunordered.pass.cpp:1 FAIL
 
 # P0543R3 Saturation Arithmetic
 # Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -291,10 +291,7 @@ std/utilities/const.wrap.class/call.pass.cpp FAIL
 std/utilities/const.wrap.class/comma.pass.cpp FAIL
 std/utilities/const.wrap.class/comp.pass.cpp FAIL
 std/utilities/const.wrap.class/convert.pass.cpp FAIL
-std/utilities/const.wrap.class/ctad.compile.pass.cpp FAIL
 std/utilities/const.wrap.class/cw.pass.cpp FAIL
-std/utilities/const.wrap.class/cw_fixed.array.ctor.pass.cpp FAIL
-std/utilities/const.wrap.class/cw_fixed.ctor.pass.cpp FAIL
 std/utilities/const.wrap.class/general.pass.cpp FAIL
 std/utilities/const.wrap.class/mem_ptr.pass.cpp FAIL
 std/utilities/const.wrap.class/pseudo_mutators.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -42,12 +42,6 @@ std/numerics/rand/rand.dist/rand.dist.uni/rand.dist.uni.real/param_ctor.pass.cpp
 # LLVM-122638: [libc++][test] re.regex.construct/bad_backref.pass.cpp assumes non-standard extension to extended regular expressions
 std/re/re.regex/re.regex.construct/bad_backref.pass.cpp FAIL
 
-# LLVM-138375: [libc++][test] Make narrowing in nasty_char_traits::to_char_type more explicit
-std/strings/basic.string/string.modifiers/string_append/initializer_list.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_append/initializer_list.pass.cpp:1 FAIL
-std/strings/basic.string/string.modifiers/string_assign/string.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_assign/string.pass.cpp:1 FAIL
-
 # LLVM-158302: Clang 20 i686-pc-windows-msvc regression, silent bad codegen for std::current_exception()
 # SKIPPED because this is x86-specific.
 std/language.support/support.exception/except.nested/assign.pass.cpp:2 SKIPPED

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -66,9 +66,6 @@ std/language.support/support.exception/except.nested/ctor_default.pass.cpp:2 SKI
 std/concepts/concepts.compare/concept.equalitycomparable/equality_comparable_with.compile.pass.cpp:2 FAIL
 std/language.support/cmp/cmp.concept/three_way_comparable_with.compile.pass.cpp:2 FAIL
 
-# LLVM-182390: [libc++][test] facet.num.get.members/get_long.pass.cpp uses std::to_string() without including <string>
-std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_long.pass.cpp FAIL
-
 # LLVM-182392: [libc++][test] vector/trivial_relocation.pass.cpp uses implementation-specific attribute [[clang::trivial_abi]]
 std/containers/sequences/vector/trivial_relocation.pass.cpp:0 FAIL
 std/containers/sequences/vector/trivial_relocation.pass.cpp:1 FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -36,12 +36,6 @@ std/time/time.syn/formatter.zoned_time.pass.cpp:1 FAIL
 # LLVM-74838: [libc++] std::regex match_prev_avail implementation is regressed
 std/re/re.const/re.matchflag/match_prev_avail.pass.cpp FAIL
 
-# LLVM-90196: [libc++][format] Formatting range with m range-type is incorrect
-std/utilities/format/format.range/format.range.formatter/format.functions.format.pass.cpp FAIL
-std/utilities/format/format.range/format.range.formatter/format.functions.vformat.pass.cpp FAIL
-std/utilities/format/format.range/format.range.fmtset/format.functions.format.pass.cpp FAIL
-std/utilities/format/format.range/format.range.fmtset/format.functions.vformat.pass.cpp FAIL
-
 # LLVM-100506: [libc++][test] Precondition violation in rand.dist.uni.real/param_ctor.pass.cpp
 std/numerics/rand/rand.dist/rand.dist.uni/rand.dist.uni.real/param_ctor.pass.cpp FAIL
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1212,17 +1212,6 @@ std/utilities/memory/util.smartptr/util.smartptr.shared/pointer_destruction.pass
 # Clang error: incomplete type 'complete_type_allocator<std::_Ref_count_resource_alloc<int *, std::default_delete<int>, complete_type_allocator<int>>>' used in type trait expression
 std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/pointer_deleter_allocator.pass.cpp FAIL
 
-# Not analyzed.
-# MSVC warning C4804: '<<': unsafe use of type 'bool' in operation
-std/language.support/support.types/byteops/lshift.assign.pass.cpp:0 FAIL
-std/language.support/support.types/byteops/lshift.assign.pass.cpp:1 FAIL
-std/language.support/support.types/byteops/lshift.pass.cpp:0 FAIL
-std/language.support/support.types/byteops/lshift.pass.cpp:1 FAIL
-std/language.support/support.types/byteops/rshift.assign.pass.cpp:0 FAIL
-std/language.support/support.types/byteops/rshift.assign.pass.cpp:1 FAIL
-std/language.support/support.types/byteops/rshift.pass.cpp:0 FAIL
-std/language.support/support.types/byteops/rshift.pass.cpp:1 FAIL
-
 # Not analyzed. MSVC's STL doesn't support _BitInt, but the tests ask Clang, which reports that support is available.
 std/containers/views/mdspan/extents/bitint.pass.cpp:2 FAIL
 std/language.support/support.limits/limits/numeric.limits.members/digits.pass.cpp:2 FAIL
@@ -1271,6 +1260,10 @@ std/depr/depr.c.headers/setjmp_h.compile.pass.cpp:9 SKIPPED
 std/input.output/file.streams/fstreams/ifstream.members/buffered_reads.pass.cpp:9 SKIPPED
 std/input.output/file.streams/fstreams/ofstream.members/buffered_writes.pass.cpp:9 SKIPPED
 std/language.support/support.runtime/csetjmp.pass.cpp:9 SKIPPED
+std/language.support/support.types/byteops/lshift.assign.pass.cpp:9 SKIPPED
+std/language.support/support.types/byteops/lshift.pass.cpp:9 SKIPPED
+std/language.support/support.types/byteops/rshift.assign.pass.cpp:9 SKIPPED
+std/language.support/support.types/byteops/rshift.pass.cpp:9 SKIPPED
 std/numerics/numeric.ops/numeric.ops.midpoint/midpoint.pointer.pass.cpp:9 SKIPPED
 std/ranges/range.adaptors/range.lazy.split/constraints.compile.pass.cpp:9 SKIPPED
 std/ranges/range.utility/range.utility.conv/to.pass.cpp:9 SKIPPED

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1212,27 +1212,6 @@ std/utilities/memory/util.smartptr/util.smartptr.shared/pointer_destruction.pass
 # Clang error: incomplete type 'complete_type_allocator<std::_Ref_count_resource_alloc<int *, std::default_delete<int>, complete_type_allocator<int>>>' used in type trait expression
 std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/pointer_deleter_allocator.pass.cpp FAIL
 
-# Not analyzed. MSVC's STL doesn't support _BitInt, but the tests ask Clang, which reports that support is available.
-std/containers/views/mdspan/extents/bitint.pass.cpp:2 FAIL
-std/language.support/support.limits/limits/numeric.limits.members/digits.pass.cpp:2 FAIL
-std/language.support/support.limits/limits/numeric.limits.members/digits10.pass.cpp:2 FAIL
-std/language.support/support.limits/limits/numeric.limits.members/max.pass.cpp:2 FAIL
-std/language.support/support.limits/limits/numeric.limits.members/min.pass.cpp:2 FAIL
-std/numerics/bit/bit.pow.two/bit_ceil.pass.cpp:2 FAIL
-std/numerics/bit/bit.pow.two/bit_floor.pass.cpp:2 FAIL
-std/numerics/bit/bit.pow.two/bit_width.pass.cpp:2 FAIL
-std/numerics/bit/bit.pow.two/has_single_bit.pass.cpp:2 FAIL
-std/numerics/bit/bitops.count/countl_one.pass.cpp:2 FAIL
-std/numerics/bit/bitops.count/countl_zero.pass.cpp:2 FAIL
-std/numerics/bit/bitops.count/countr_one.pass.cpp:2 FAIL
-std/numerics/bit/bitops.count/countr_zero.pass.cpp:2 FAIL
-std/numerics/bit/bitops.count/popcount.pass.cpp:2 FAIL
-std/numerics/bit/bitops.rot/rotl.pass.cpp:2 FAIL
-std/numerics/bit/bitops.rot/rotr.pass.cpp:2 FAIL
-std/numerics/bit/byteswap.pass.cpp:2 FAIL
-std/numerics/c.math/abs.pass.cpp:2 FAIL
-std/utilities/utility/utility.intcmp/intcmp.bitint.pass.cpp:2 FAIL
-
 
 # *** MSVC-INTERNAL TEST HARNESS ISSUES (note: configuration :9 restricts these skips to be MSVC-internal) ***
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -240,6 +240,7 @@ std/strings/c.strings/cuchar.compile.pass.cpp FAIL
 # P0533R9 constexpr For <cmath> And <cstdlib>
 std/language.support/support.limits/support.limits.general/cmath.version.compile.pass.cpp FAIL
 std/language.support/support.limits/support.limits.general/cstdlib.version.compile.pass.cpp FAIL
+std/numerics/c.math/fpclassify.pass.cpp FAIL
 
 # P0543R3 Saturation Arithmetic
 # Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.
@@ -258,6 +259,10 @@ std/numerics/numeric.ops/numeric.ops.sat/saturating_sub.pass.cpp FAIL
 # Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.
 std/utilities/intseq/intseq.binding/structured_binding.pass.cpp FAIL
 std/utilities/intseq/intseq.binding/tuple_interface.compile.pass.cpp FAIL
+
+# P1885R12 <text_encoding>: Naming Text Encodings To Demystify Them
+# Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.
+std/language.support/support.limits/support.limits.general/text_encoding.version.compile.pass.cpp FAIL
 
 # P2592R3 Hashing Support For chrono Value Classes
 # Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.
@@ -297,6 +302,12 @@ std/utilities/function.objects/refwrap/refwrap.comparisons/compare.three_way.ref
 # P2988R12 optional<T&>
 # Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.
 std/utilities/optional/optional.object/optional.object.ctor/ref_t.pass.cpp FAIL
+
+# P3029R1 Improving mdspan And span CTAD
+# Will be implemented by GH-5692.
+std/containers/views/mdspan/extents/ctad.pass.cpp FAIL
+std/containers/views/mdspan/mdspan/deduction.pass.cpp FAIL
+std/containers/views/views.span/span.cons/deduct.pass.cpp FAIL
 
 # P3044R2 basic_string::subview()
 # Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.
@@ -747,6 +758,13 @@ std/localization/locale.categories/category.time/locale.time.get.byname/get_one_
 # static_assert(!noexcept((std::move(stride_iter).base())));
 std/ranges/range.adaptors/range.stride.view/iterator/base.pass.cpp FAIL
 
+# Bogus cpp03_allocator is not rebindable
+std/containers/sequences/vector/vector.cons/construct_iter_iter.pass.cpp FAIL
+std/containers/sequences/vector/vector.cons/construct_iter_iter_alloc.pass.cpp FAIL
+
+# Bogus ASSERT_NOT_NOEXCEPT rejects our strengthening
+std/input.output/syncstream/syncbuf/syncstream.syncbuf.assign/swap.pass.cpp FAIL
+
 
 # *** LIKELY STL BUGS ***
 # Not analyzed, likely STL bugs. Various assertions.
@@ -1172,6 +1190,62 @@ std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_const_move.pass.cpp:1 FAIL
 
 # Not analyzed, MSVC truncation warnings, Clang static_assert.
 std/algorithms/alg.nonmodifying/alg.fold/ranges.fold_right_last.pass.cpp FAIL
+
+# Not analyzed, test aborts.
+std/containers/unord/unord.map/unord.map.cnstr/exceptions.pass.cpp FAIL
+
+# Not analyzed.
+# MSVC error C2440: 'initializing': cannot convert from 'const std::shared_ptr<int>::{ctor}::_Fancy_t' to 'const std::shared_ptr<int>::{ctor}::_Raw_t'
+# Clang error: no viable conversion from 'const _Fancy_t' (aka 'const Pointer<int>') to 'const _Raw_t' (aka 'int *const')
+std/utilities/memory/util.smartptr/util.smartptr.shared/pointer_destruction.pass.cpp FAIL
+
+# Not analyzed.
+# MSVC error C2139: 'complete_type_allocator<_Newfirst>': an undefined class is not allowed as an argument to compiler intrinsic type trait '__is_empty'
+# Clang error: incomplete type 'complete_type_allocator<std::_Ref_count_resource_alloc<int *, std::default_delete<int>, complete_type_allocator<int>>>' used in type trait expression
+std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/pointer_deleter_allocator.pass.cpp FAIL
+
+# Not analyzed.
+# MSVC warning C4804: '<<': unsafe use of type 'bool' in operation
+std/language.support/support.types/byteops/lshift.assign.pass.cpp:0 FAIL
+std/language.support/support.types/byteops/lshift.assign.pass.cpp:1 FAIL
+std/language.support/support.types/byteops/lshift.pass.cpp:0 FAIL
+std/language.support/support.types/byteops/lshift.pass.cpp:1 FAIL
+std/language.support/support.types/byteops/rshift.assign.pass.cpp:0 FAIL
+std/language.support/support.types/byteops/rshift.assign.pass.cpp:1 FAIL
+std/language.support/support.types/byteops/rshift.pass.cpp:0 FAIL
+std/language.support/support.types/byteops/rshift.pass.cpp:1 FAIL
+
+# Not analyzed.
+# MSVC warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
+std/algorithms/alg.nonmodifying/alg.find.first.of/pstl.find_first_of_pred.pass.cpp:0 FAIL
+std/algorithms/alg.nonmodifying/alg.find.first.of/pstl.find_first_of_pred.pass.cpp:1 FAIL
+std/algorithms/alg.nonmodifying/alg.find.first.of/pstl.find_first_of.pass.cpp:0 FAIL
+std/algorithms/alg.nonmodifying/alg.find.first.of/pstl.find_first_of.pass.cpp:1 FAIL
+std/algorithms/alg.nonmodifying/mismatch/pstl.mismatch_pred.pass.cpp:0 FAIL
+std/algorithms/alg.nonmodifying/mismatch/pstl.mismatch_pred.pass.cpp:1 FAIL
+std/algorithms/alg.nonmodifying/mismatch/pstl.mismatch.pass.cpp:0 FAIL
+std/algorithms/alg.nonmodifying/mismatch/pstl.mismatch.pass.cpp:1 FAIL
+
+# Not analyzed. MSVC's STL doesn't support _BitInt, but the tests ask Clang, which reports that support is available.
+std/containers/views/mdspan/extents/bitint.pass.cpp:2 FAIL
+std/language.support/support.limits/limits/numeric.limits.members/digits.pass.cpp:2 FAIL
+std/language.support/support.limits/limits/numeric.limits.members/digits10.pass.cpp:2 FAIL
+std/language.support/support.limits/limits/numeric.limits.members/max.pass.cpp:2 FAIL
+std/language.support/support.limits/limits/numeric.limits.members/min.pass.cpp:2 FAIL
+std/numerics/bit/bit.pow.two/bit_ceil.pass.cpp:2 FAIL
+std/numerics/bit/bit.pow.two/bit_floor.pass.cpp:2 FAIL
+std/numerics/bit/bit.pow.two/bit_width.pass.cpp:2 FAIL
+std/numerics/bit/bit.pow.two/has_single_bit.pass.cpp:2 FAIL
+std/numerics/bit/bitops.count/countl_one.pass.cpp:2 FAIL
+std/numerics/bit/bitops.count/countl_zero.pass.cpp:2 FAIL
+std/numerics/bit/bitops.count/countr_one.pass.cpp:2 FAIL
+std/numerics/bit/bitops.count/countr_zero.pass.cpp:2 FAIL
+std/numerics/bit/bitops.count/popcount.pass.cpp:2 FAIL
+std/numerics/bit/bitops.rot/rotl.pass.cpp:2 FAIL
+std/numerics/bit/bitops.rot/rotr.pass.cpp:2 FAIL
+std/numerics/bit/byteswap.pass.cpp:2 FAIL
+std/numerics/c.math/abs.pass.cpp:2 FAIL
+std/utilities/utility/utility.intcmp/intcmp.bitint.pass.cpp:2 FAIL
 
 
 # *** MSVC-INTERNAL TEST HARNESS ISSUES (note: configuration :9 restricts these skips to be MSVC-internal) ***

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -237,6 +237,15 @@ std/language.support/support.dynamic/new.delete/new.delete.single/new.size_nothr
 std/depr/depr.c.headers/uchar_h.compile.pass.cpp FAIL
 std/strings/c.strings/cuchar.compile.pass.cpp FAIL
 
+# P0493R5 Atomic Minimum/Maximum
+# Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.
+std/atomics/atomics.ref/fetch_max.pass.cpp FAIL
+std/atomics/atomics.ref/fetch_min.pass.cpp FAIL
+std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_max_explicit.pass.cpp FAIL
+std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_max.pass.cpp FAIL
+std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_min_explicit.pass.cpp FAIL
+std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_min.pass.cpp FAIL
+
 # P0533R9 constexpr For <cmath> And <cstdlib>
 std/language.support/support.limits/support.limits.general/cmath.version.compile.pass.cpp FAIL
 std/language.support/support.limits/support.limits.general/cstdlib.version.compile.pass.cpp FAIL
@@ -267,6 +276,22 @@ std/numerics/numeric.ops/numeric.ops.sat/saturating_mul.pass.cpp FAIL
 std/numerics/numeric.ops/numeric.ops.sat/saturating_sub.compile.pass.cpp FAIL
 std/numerics/numeric.ops/numeric.ops.sat/saturating_sub.pass.cpp FAIL
 
+# P0792R14 function_ref: A Type-Erased Callable Reference
+# Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.
+std/utilities/function.objects/func.wrap/func.wrap.ref/ctad.pass.cpp FAIL
+std/utilities/function.objects/func.wrap/func.wrap.ref/func.wrap.ref.ctor/assign.delete.pass.cpp FAIL
+std/utilities/function.objects/func.wrap/func.wrap.ref/func.wrap.ref.ctor/constant_wrapper.pass.cpp FAIL
+std/utilities/function.objects/func.wrap/func.wrap.ref/func.wrap.ref.ctor/constant_wrapper_ptr.pass.cpp FAIL
+std/utilities/function.objects/func.wrap/func.wrap.ref/func.wrap.ref.ctor/constant_wrapper_ref.pass.cpp FAIL
+std/utilities/function.objects/func.wrap/func.wrap.ref/func.wrap.ref.ctor/copy.pass.cpp FAIL
+std/utilities/function.objects/func.wrap/func.wrap.ref/func.wrap.ref.ctor/copy_assign.pass.cpp FAIL
+std/utilities/function.objects/func.wrap/func.wrap.ref/func.wrap.ref.ctor/function_ptr.pass.cpp FAIL
+std/utilities/function.objects/func.wrap/func.wrap.ref/func.wrap.ref.ctor/move.pass.cpp FAIL
+std/utilities/function.objects/func.wrap/func.wrap.ref/func.wrap.ref.ctor/move_assign.pass.cpp FAIL
+std/utilities/function.objects/func.wrap/func.wrap.ref/func.wrap.ref.ctor/ref.pass.cpp FAIL
+std/utilities/function.objects/func.wrap/func.wrap.ref/func.wrap.ref.inv/invoke.pass.cpp FAIL
+std/utilities/function.objects/func.wrap/func.wrap.ref/trivially_copyable.compile.pass.cpp FAIL
+
 # P1789R3 Library Support For Expansion Statements
 # Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.
 std/utilities/intseq/intseq.binding/structured_binding.pass.cpp FAIL
@@ -275,6 +300,60 @@ std/utilities/intseq/intseq.binding/tuple_interface.compile.pass.cpp FAIL
 # P1885R12 <text_encoding>: Naming Text Encodings To Demystify Them
 # Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.
 std/language.support/support.limits/support.limits.general/text_encoding.version.compile.pass.cpp FAIL
+std/localization/locales/locale/locale.members/encoding.pass.cpp FAIL
+std/text/text_encoding/text_encoding.ctor/default.pass.cpp FAIL
+std/text/text_encoding/text_encoding.ctor/id.pass.cpp FAIL
+std/text/text_encoding/text_encoding.ctor/string_view.pass.cpp FAIL
+std/text/text_encoding/text_encoding.eq/equal.id.pass.cpp FAIL
+std/text/text_encoding/text_encoding.eq/equal.pass.cpp FAIL
+std/text/text_encoding/text_encoding.hash/enabled_hash.pass.cpp FAIL
+std/text/text_encoding/text_encoding.hash/hash.pass.cpp FAIL
+std/text/text_encoding/text_encoding.members/aliases_view.compile.pass.cpp FAIL
+std/text/text_encoding/text_encoding.members/aliases.pass.cpp FAIL
+std/text/text_encoding/text_encoding.members/environment.pass.cpp FAIL
+std/text/text_encoding/text_encoding.members/id.compile.pass.cpp FAIL
+std/text/text_encoding/text_encoding.members/literal.pass.cpp FAIL
+std/text/text_encoding/text_encoding.members/text_encoding.aliases_view/begin.pass.cpp FAIL
+std/text/text_encoding/text_encoding.members/text_encoding.aliases_view/empty.pass.cpp FAIL
+std/text/text_encoding/text_encoding.members/text_encoding.aliases_view/end.pass.cpp FAIL
+std/text/text_encoding/text_encoding.members/text_encoding.aliases_view/front.pass.cpp FAIL
+std/text/text_encoding/text_encoding.members/text_encoding.aliases_view/index.pass.cpp FAIL
+std/text/text_encoding/text_encoding.members/text_encoding.aliases_view/iterator.pass.cpp FAIL
+std/text/text_encoding/text_encoding.members/text_encoding.aliases_view/operator-bool.pass.cpp FAIL
+std/text/text_encoding/trivially_copyable.compile.pass.cpp FAIL
+
+# P1901R2 Enabling The Use Of weak_ptr As Keys In Unordered Associative Containers
+# Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.
+std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.obs/owner_equal_shared_ptr.pass.cpp FAIL
+std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.obs/owner_equal_weak_ptr.pass.cpp FAIL
+std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.obs/owner_hash.pass.cpp FAIL
+std/utilities/memory/util.smartptr/util.smartptr.weak/util.smartptr.ownerequal/owner_equal.pass.cpp FAIL
+std/utilities/memory/util.smartptr/util.smartptr.weak/util.smartptr.ownerhash/owner_hash.pass.cpp FAIL
+std/utilities/memory/util.smartptr/util.smartptr.weak/util.smartptr.weak.obs/owner_equal_shared_ptr.pass.cpp FAIL
+std/utilities/memory/util.smartptr/util.smartptr.weak/util.smartptr.weak.obs/owner_equal_weak_ptr.pass.cpp FAIL
+std/utilities/memory/util.smartptr/util.smartptr.weak/util.smartptr.weak.obs/owner_hash.pass.cpp FAIL
+std/utilities/memory/util.smartptr/util.smartptr.weak/util.smartptr.weak.obs/owner_hash.pass.cpp FAIL
+
+# P2542R8 views::concat
+# Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.
+std/ranges/range.adaptors/range.concat/adaptor.pass.cpp FAIL
+std/ranges/range.adaptors/range.concat/begin.pass.cpp FAIL
+std/ranges/range.adaptors/range.concat/constraints.pass.cpp FAIL
+std/ranges/range.adaptors/range.concat/ctad.pass.cpp FAIL
+std/ranges/range.adaptors/range.concat/ctor.default.pass.cpp FAIL
+std/ranges/range.adaptors/range.concat/ctor.views.pass.cpp FAIL
+std/ranges/range.adaptors/range.concat/end.pass.cpp FAIL
+std/ranges/range.adaptors/range.concat/iterator/arithmetic.pass.cpp FAIL
+std/ranges/range.adaptors/range.concat/iterator/compare.pass.cpp FAIL
+std/ranges/range.adaptors/range.concat/iterator/ctor.other.pass.cpp FAIL
+std/ranges/range.adaptors/range.concat/iterator/decrement.pass.cpp FAIL
+std/ranges/range.adaptors/range.concat/iterator/deref.pass.cpp FAIL
+std/ranges/range.adaptors/range.concat/iterator/increment.pass.cpp FAIL
+std/ranges/range.adaptors/range.concat/iterator/iter_move.pass.cpp FAIL
+std/ranges/range.adaptors/range.concat/iterator/iter_swap.pass.cpp FAIL
+std/ranges/range.adaptors/range.concat/iterator/member_types.compile.pass.cpp FAIL
+std/ranges/range.adaptors/range.concat/iterator/subscript.pass.cpp FAIL
+std/ranges/range.adaptors/range.concat/size.pass.cpp FAIL
 
 # P2592R3 Hashing Support For chrono Value Classes
 # Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.
@@ -300,6 +379,10 @@ std/utilities/const.wrap.class/pseudo_mutators.pass.cpp FAIL
 std/utilities/const.wrap.class/subscript.pass.cpp FAIL
 std/utilities/const.wrap.class/types.compile.pass.cpp FAIL
 std/utilities/const.wrap.class/unary_ops.pass.cpp FAIL
+
+# P2821R5 span::at()
+# Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.
+std/containers/views/views.span/span.elem/at.pass.cpp FAIL
 
 # P2835R7 atomic_ref::address()
 # Add 'std-at-least-c++26' to tests/utils/stl/test/tests.py when beginning work on C++26.
@@ -1257,6 +1340,9 @@ std/language.support/support.types/byteops/rshift.assign.pass.cpp:9 SKIPPED
 std/language.support/support.types/byteops/rshift.pass.cpp:9 SKIPPED
 std/numerics/numeric.ops/numeric.ops.midpoint/midpoint.pointer.pass.cpp:9 SKIPPED
 std/ranges/range.adaptors/range.lazy.split/constraints.compile.pass.cpp:9 SKIPPED
+std/ranges/range.factories/range.iota.view/ctor.value.bound.pass.cpp:9 SKIPPED
+std/ranges/range.factories/range.iota.view/end.pass.cpp:9 SKIPPED
+std/ranges/range.factories/range.iota.view/iterator/star.pass.cpp:9 SKIPPED
 std/ranges/range.utility/range.utility.conv/to.pass.cpp:9 SKIPPED
 std/thread/thread.jthread/assign.move.pass.cpp:9 SKIPPED
 std/utilities/meta/meta.unary/dependent_return_type.pass.cpp:9 SKIPPED
@@ -1302,6 +1388,9 @@ std/time/time.syn/formatter.weekday_last.pass.cpp:9 SKIPPED
 std/time/time.syn/formatter.weekday.pass.cpp:9 SKIPPED
 std/time/time.syn/formatter.year_month_day.pass.cpp:9 SKIPPED
 std/utilities/function.objects/func.wrap/func.wrap.func/noncopyable_return_type.pass.cpp:9 SKIPPED
+
+# This test is marked as `XFAIL: !has-128-bit-atomics`, but the MSVC-internal test harness doesn't yet parse XFAIL.
+std/atomics/atomics.types.generic/padding.pass.cpp:9 SKIPPED
 
 # This test is marked as `REQUIRES: large_tests`. The GitHub test harness doesn't define that feature, so it doesn't
 # run this test. However, the MSVC-internal test harness doesn't yet parse REQUIRES, and simply runs everything.

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -906,6 +906,14 @@ std/algorithms/alg.modifying.operations/alg.fill/fill_n.pass.cpp:0 SKIPPED
 std/algorithms/alg.modifying.operations/alg.fill/fill_n.pass.cpp:1 SKIPPED
 std/algorithms/alg.modifying.operations/alg.random.shuffle/ranges_shuffle.pass.cpp:0 SKIPPED
 std/algorithms/alg.modifying.operations/alg.random.shuffle/ranges_shuffle.pass.cpp:1 SKIPPED
+std/algorithms/alg.nonmodifying/alg.find.first.of/pstl.find_first_of_pred.pass.cpp:0 SKIPPED
+std/algorithms/alg.nonmodifying/alg.find.first.of/pstl.find_first_of_pred.pass.cpp:1 SKIPPED
+std/algorithms/alg.nonmodifying/alg.find.first.of/pstl.find_first_of.pass.cpp:0 SKIPPED
+std/algorithms/alg.nonmodifying/alg.find.first.of/pstl.find_first_of.pass.cpp:1 SKIPPED
+std/algorithms/alg.nonmodifying/mismatch/pstl.mismatch_pred.pass.cpp:0 SKIPPED
+std/algorithms/alg.nonmodifying/mismatch/pstl.mismatch_pred.pass.cpp:1 SKIPPED
+std/algorithms/alg.nonmodifying/mismatch/pstl.mismatch.pass.cpp:0 SKIPPED
+std/algorithms/alg.nonmodifying/mismatch/pstl.mismatch.pass.cpp:1 SKIPPED
 std/containers/associative/map/map.access/iterator.pass.cpp:0 SKIPPED
 std/containers/associative/map/map.access/iterator.pass.cpp:1 SKIPPED
 std/iterators/predef.iterators/move.iterators/move.iter.ops/move.iter.op.-/sentinel.pass.cpp:0 SKIPPED
@@ -1214,17 +1222,6 @@ std/language.support/support.types/byteops/rshift.assign.pass.cpp:0 FAIL
 std/language.support/support.types/byteops/rshift.assign.pass.cpp:1 FAIL
 std/language.support/support.types/byteops/rshift.pass.cpp:0 FAIL
 std/language.support/support.types/byteops/rshift.pass.cpp:1 FAIL
-
-# Not analyzed.
-# MSVC warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
-std/algorithms/alg.nonmodifying/alg.find.first.of/pstl.find_first_of_pred.pass.cpp:0 FAIL
-std/algorithms/alg.nonmodifying/alg.find.first.of/pstl.find_first_of_pred.pass.cpp:1 FAIL
-std/algorithms/alg.nonmodifying/alg.find.first.of/pstl.find_first_of.pass.cpp:0 FAIL
-std/algorithms/alg.nonmodifying/alg.find.first.of/pstl.find_first_of.pass.cpp:1 FAIL
-std/algorithms/alg.nonmodifying/mismatch/pstl.mismatch_pred.pass.cpp:0 FAIL
-std/algorithms/alg.nonmodifying/mismatch/pstl.mismatch_pred.pass.cpp:1 FAIL
-std/algorithms/alg.nonmodifying/mismatch/pstl.mismatch.pass.cpp:0 FAIL
-std/algorithms/alg.nonmodifying/mismatch/pstl.mismatch.pass.cpp:1 FAIL
 
 # Not analyzed. MSVC's STL doesn't support _BitInt, but the tests ask Clang, which reports that support is available.
 std/containers/views/mdspan/extents/bitint.pass.cpp:2 FAIL


### PR DESCRIPTION
* Cycle locations.
* PowerShell 7.6.4.
* MSVC Compiler 19.52.36615 (now required).
  + Picks up MSVC-PR-757497 "feat(cmath, 36 of N): loosen cli flag incompatibilities".
* New pools.
* Update llvm-project.
* Remove tests deleted by llvm/llvm-project#203338.
* llvm/llvm-project#182390 was fixed.
* llvm/llvm-project#90196 was fixed.
* llvm/llvm-project#138375 was fixed.
* Categorize failing tests.
* Avoid putting too much pressure on Australia East.
* New pools, again.
* Group x64 truncation warnings, mark them as SKIPPED.
* Update llvm-project again.
* llvm/llvm-project#212433 added `ADDITIONAL_COMPILE_FLAGS(cl-style-warnings)`.
* llvm/llvm-project#212435 fixed the `_BitInt` failures.
* llvm/llvm-project#210075 implemented more constexpr for cmath (that works for Clang).
* Update libcxx/expected_results.txt for the MSVC-internal test harness.