### PR TITLE
`<xmemory>`: Document the iterator debugging invariants

### DIFF
--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1208,6 +1208,22 @@ struct _Iterator_base0 {
     static constexpr bool _Unwrap_when_unverified = true;
 };
 
+// The iterator debugging library (IDL) below lets a container invalidate ("orphan") its iterators without either
+// side needing to know about the other directly, by routing everything through a shared proxy object. Invariants:
+//
+// * Every container owns a dynamically allocated _Container_proxy at all times, including in its
+//   default-constructed and moved-from states.
+// * A container and its proxy always point to each other (_Container_base12::_Myproxy and
+//   _Container_proxy::_Mycont, respectively), regardless of whether IDL is enabled; if a proxy exists, this holds.
+// * Every valid iterator holds a non-owning pointer to its parent container's proxy (_Iterator_base12::_Myproxy).
+//   An orphaned iterator has a null _Myproxy.
+// * The proxy's _Myfirstiter, together with each iterator's _Mynextiter, forms an intrusive singly linked list of
+//   iterators rooted at the proxy. Every valid iterator belonging to a container is reachable through this list;
+//   there are no valid "free-floating" iterators.
+// * Whenever the proxies and the intrusive list are manipulated, the debug lock (_Lockit(_LOCK_DEBUG)) is held.
+//   The only things we do outside of that lock are things like iterator compatibility checks that compare proxy
+//   pointers: those pointers don't change even if the containers are being swapped concurrently (only the
+//   proxies' data members change, not their addresses).
 struct _Container_base12;
 struct _Container_proxy { // store head of iterator chain and back pointer
     _CONSTEXPR20 _Container_proxy() noexcept = default;

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1208,11 +1208,15 @@ struct _Iterator_base0 {
     static constexpr bool _Unwrap_when_unverified = true;
 };
 
-// The iterator debugging library (IDL) below lets a container invalidate ("orphan") its iterators without either
-// side needing to know about the other directly, by routing everything through a shared proxy object. Invariants:
+// The machinery below implements iterator debugging (informally "IDL", after the _ITERATOR_DEBUG_LEVEL macro,
+// where "L" stands for "level"). It lets a container invalidate ("orphan") its iterators without either side
+// needing to know about the other directly, by routing everything through a shared proxy object. Invariants:
 //
 // * Every container owns a dynamically allocated _Container_proxy at all times, including in its
-//   default-constructed and moved-from states.
+//   default-constructed and moved-from states. This is TRANSITION, ABI: allocating the proxy separately (instead
+//   of, say, storing it inline) is the major reason many containers' allocator-extended move constructors and
+//   move assignment operators aren't unconditionally noexcept -- reloading the proxy when allocators compare
+//   unequal can throw. We intend to revisit this strategy in vNext (see #169).
 // * A container and its proxy always point to each other (_Container_base12::_Myproxy and
 //   _Container_proxy::_Mycont, respectively), regardless of whether IDL is enabled; if a proxy exists, this holds.
 // * Every valid iterator holds a non-owning pointer to its parent container's proxy (_Iterator_base12::_Myproxy).
@@ -1220,10 +1224,12 @@ struct _Iterator_base0 {
 // * The proxy's _Myfirstiter, together with each iterator's _Mynextiter, forms an intrusive singly linked list of
 //   iterators rooted at the proxy. Every valid iterator belonging to a container is reachable through this list;
 //   there are no valid "free-floating" iterators.
-// * Whenever the proxies and the intrusive list are manipulated, the debug lock (_Lockit(_LOCK_DEBUG)) is held.
-//   The only things we do outside of that lock are things like iterator compatibility checks that compare proxy
-//   pointers: those pointers don't change even if the containers are being swapped concurrently (only the
-//   proxies' data members change, not their addresses).
+// * Whenever the proxies and the intrusive list are manipulated at runtime, the debug lock (_Lockit(_LOCK_DEBUG))
+//   is held. During constant evaluation, we skip the lock entirely and go straight to the unlocked paths (see the
+//   is_constant_evaluated() checks below), since constant evaluation is inherently single-threaded and _Lockit
+//   isn't usable there. The only other things we do outside of the lock at runtime are things like iterator
+//   compatibility checks that compare proxy pointers: those pointers don't change even if the containers are
+//   being swapped concurrently (only the proxies' data members change, not their addresses).
 struct _Container_base12;
 struct _Container_proxy { // store head of iterator chain and back pointer
     _CONSTEXPR20 _Container_proxy() noexcept = default;

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1229,10 +1229,10 @@ struct _Iterator_base0 {
 // * A container and its proxy always point to each other, via _Container_base12::_Myproxy and
 //   _Container_proxy::_Mycont respectively. (_Container_proxy_ptr12 can briefly hold a freshly allocated proxy
 //   that isn't bound to a container yet; see _Leave_proxy_unbound and _Bind.)
-// * Every iterator associated with a parent container holds a non-owning pointer to that container's proxy
-//   (_Iterator_base12::_Myproxy). Container-driven orphaning nulls that pointer, but _Orphan_all only does so at
-//   level 2. Below level 2, an iterator invalidated by its container retains its _Myproxy, which dangles only once
-//   the proxy itself is destroyed.
+// * Every iterator associated with a parent container holds a non-owning pointer to that container's proxy
+//   (_Iterator_base12::_Myproxy). Container-driven orphaning nulls that pointer, but _Orphan_all only does so at
+//   level 2. Below level 2, an iterator invalidated by its container retains its _Myproxy, which dangles only once
+//   the proxy itself is destroyed.
 //
 // Additional invariants at _ITERATOR_DEBUG_LEVEL == 2 only, where we also track iterators individually:
 //

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1210,11 +1210,15 @@ struct _Iterator_base0 {
 
 // The machinery below implements iterator debugging (informally "IDL", after the _ITERATOR_DEBUG_LEVEL macro,
 // where "L" stands for "level"). It lets a container invalidate ("orphan") its iterators without either side
-// needing to know about the other directly, by routing everything through a shared proxy object. Only containers
-// with _ITERATOR_DEBUG_LEVEL != 0 use it; at level 0 they derive from _Container_base0 and use
-// _Fake_proxy_ptr_impl instead, and no proxy is allocated at all.
+// needing to know about the other directly, by routing everything through a shared proxy object.
 //
-// Invariants at both levels 1 and 2:
+// Most containers use it only when _ITERATOR_DEBUG_LEVEL != 0; at level 0 they derive from _Container_base0 and
+// use _Fake_proxy_ptr_impl, so no proxy is allocated. deque is the exception: _Deque_val derives from
+// _Container_base12 and _Deque_const_iterator from _Iterator_base12 at every level, because deque's offset-based
+// iterators reach the container through the proxy (see _Getcont() and _Unwrapped()) even when iterator debugging
+// is off. A deque therefore allocates a real proxy at level 0 too.
+//
+// Invariants for any container that uses _Container_base12:
 //
 // * Such a container owns a dynamically allocated _Container_proxy at all times, including in its
 //   default-constructed and moved-from states. This is TRANSITION, ABI: allocating the proxy separately (instead
@@ -1222,22 +1226,23 @@ struct _Iterator_base0 {
 //   move assignment operators aren't unconditionally noexcept -- reloading the proxy when allocators compare
 //   unequal can throw. We intend to revisit this strategy in vNext (see GH-169).
 // * A container and its proxy always point to each other, via _Container_base12::_Myproxy and
-//   _Container_proxy::_Mycont respectively.
+//   _Container_proxy::_Mycont respectively. (_Container_proxy_ptr12 can briefly hold a freshly allocated proxy
+//   that isn't bound to a container yet; see _Leave_proxy_unbound and _Bind.)
 // * Every valid iterator holds a non-owning pointer to its parent container's proxy (_Iterator_base12::_Myproxy);
 //   an orphaned iterator has a null _Myproxy.
 //
-// Additional invariants at level 2 only, where we also track the container's iterators individually:
+// Additional invariants at _ITERATOR_DEBUG_LEVEL == 2 only, where we also track iterators individually:
 //
 // * The proxy's _Myfirstiter, together with each iterator's _Mynextiter, forms an intrusive singly linked list of
 //   iterators rooted at the proxy. Every valid iterator belonging to a container is reachable through this list;
-//   there are no valid "free-floating" iterators. At level 1 this list is unused: _Adopt merely copies _Myproxy,
-//   _Orphan_all does nothing, and _Myfirstiter remains null.
+//   there are no valid "free-floating" iterators. Below level 2 the list is unused: _Adopt merely copies
+//   _Myproxy, _Orphan_all does nothing, and _Myfirstiter remains null.
 // * Whenever that list is manipulated at runtime, the debug lock (_Lockit(_LOCK_DEBUG)) is held. During constant
 //   evaluation we skip the lock and take the unlocked paths instead (see the is_constant_evaluated() checks
 //   below), as constant evaluation is single-threaded and _Lockit isn't usable there.
 //
 // The lock guards that list, not the proxy pointers themselves: _Alloc_proxy and _Reload_proxy install a new
-// proxy without taking it at either level, and at level 1 _Swap_proxy_and_iterators calls the unlocked helper
+// proxy without taking it at any level, and below level 2 _Swap_proxy_and_iterators calls the unlocked helper
 // directly. The other things we do outside the lock are things like iterator compatibility checks that compare
 // proxy pointers: those pointers don't change when containers are swapped (only the proxies' data members
 // change, not their addresses).

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1230,8 +1230,9 @@ struct _Iterator_base0 {
 //   _Container_proxy::_Mycont respectively. (_Container_proxy_ptr12 can briefly hold a freshly allocated proxy
 //   that isn't bound to a container yet; see _Leave_proxy_unbound and _Bind.)
 // * Every valid iterator holds a non-owning pointer to its parent container's proxy (_Iterator_base12::_Myproxy).
-//   Orphaning an iterator nulls that pointer, but only level 2 actually orphans anything: _Orphan_all is a no-op
-//   below it, so an invalidated iterator there keeps its now-dangling _Myproxy.
+//   Orphaning an iterator nulls that pointer, but only level 2 tracks invalidation and can null iterators through
+//   _Orphan_all. Below it, _Orphan_all is a no-op, so an invalidated iterator retains its _Myproxy; that pointer
+//   becomes dangling only when the proxy itself is destroyed.
 //
 // Additional invariants at _ITERATOR_DEBUG_LEVEL == 2 only, where we also track iterators individually:
 //

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1210,26 +1210,37 @@ struct _Iterator_base0 {
 
 // The machinery below implements iterator debugging (informally "IDL", after the _ITERATOR_DEBUG_LEVEL macro,
 // where "L" stands for "level"). It lets a container invalidate ("orphan") its iterators without either side
-// needing to know about the other directly, by routing everything through a shared proxy object. Invariants:
+// needing to know about the other directly, by routing everything through a shared proxy object. Only containers
+// with _ITERATOR_DEBUG_LEVEL != 0 use it; at level 0 they derive from _Container_base0 and use
+// _Fake_proxy_ptr_impl instead, and no proxy is allocated at all.
 //
-// * Every container owns a dynamically allocated _Container_proxy at all times, including in its
+// Invariants at both levels 1 and 2:
+//
+// * Such a container owns a dynamically allocated _Container_proxy at all times, including in its
 //   default-constructed and moved-from states. This is TRANSITION, ABI: allocating the proxy separately (instead
 //   of, say, storing it inline) is the major reason many containers' allocator-extended move constructors and
 //   move assignment operators aren't unconditionally noexcept -- reloading the proxy when allocators compare
-//   unequal can throw. We intend to revisit this strategy in vNext (see #169).
-// * A container and its proxy always point to each other (_Container_base12::_Myproxy and
-//   _Container_proxy::_Mycont, respectively), regardless of whether IDL is enabled; if a proxy exists, this holds.
-// * Every valid iterator holds a non-owning pointer to its parent container's proxy (_Iterator_base12::_Myproxy).
-//   An orphaned iterator has a null _Myproxy.
+//   unequal can throw. We intend to revisit this strategy in vNext (see GH-169).
+// * A container and its proxy always point to each other, via _Container_base12::_Myproxy and
+//   _Container_proxy::_Mycont respectively.
+// * Every valid iterator holds a non-owning pointer to its parent container's proxy (_Iterator_base12::_Myproxy);
+//   an orphaned iterator has a null _Myproxy.
+//
+// Additional invariants at level 2 only, where we also track the container's iterators individually:
+//
 // * The proxy's _Myfirstiter, together with each iterator's _Mynextiter, forms an intrusive singly linked list of
 //   iterators rooted at the proxy. Every valid iterator belonging to a container is reachable through this list;
-//   there are no valid "free-floating" iterators.
-// * Whenever the proxies and the intrusive list are manipulated at runtime, the debug lock (_Lockit(_LOCK_DEBUG))
-//   is held. During constant evaluation, we skip the lock entirely and go straight to the unlocked paths (see the
-//   is_constant_evaluated() checks below), since constant evaluation is inherently single-threaded and _Lockit
-//   isn't usable there. The only other things we do outside of the lock at runtime are things like iterator
-//   compatibility checks that compare proxy pointers: those pointers don't change even if the containers are
-//   being swapped concurrently (only the proxies' data members change, not their addresses).
+//   there are no valid "free-floating" iterators. At level 1 this list is unused: _Adopt merely copies _Myproxy,
+//   _Orphan_all does nothing, and _Myfirstiter remains null.
+// * Whenever that list is manipulated at runtime, the debug lock (_Lockit(_LOCK_DEBUG)) is held. During constant
+//   evaluation we skip the lock and take the unlocked paths instead (see the is_constant_evaluated() checks
+//   below), as constant evaluation is single-threaded and _Lockit isn't usable there.
+//
+// The lock guards that list, not the proxy pointers themselves: _Alloc_proxy and _Reload_proxy install a new
+// proxy without taking it at either level, and at level 1 _Swap_proxy_and_iterators calls the unlocked helper
+// directly. The other things we do outside the lock are things like iterator compatibility checks that compare
+// proxy pointers: those pointers don't change when containers are swapped (only the proxies' data members
+// change, not their addresses).
 struct _Container_base12;
 struct _Container_proxy { // store head of iterator chain and back pointer
     _CONSTEXPR20 _Container_proxy() noexcept = default;

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1229,9 +1229,10 @@ struct _Iterator_base0 {
 // * A container and its proxy always point to each other, via _Container_base12::_Myproxy and
 //   _Container_proxy::_Mycont respectively. (_Container_proxy_ptr12 can briefly hold a freshly allocated proxy
 //   that isn't bound to a container yet; see _Leave_proxy_unbound and _Bind.)
-// * Every valid iterator holds a non-owning pointer to its parent container's proxy (_Iterator_base12::_Myproxy).
-//   Orphaning an iterator nulls that pointer, but only level 2 orphans anything: _Orphan_all is a no-op below
-//   it, so an invalidated iterator retains its _Myproxy, which dangles only once the proxy itself is destroyed.
+// * Every iterator associated with a parent container holds a non-owning pointer to that container's proxy
+//   (_Iterator_base12::_Myproxy). Container-driven orphaning nulls that pointer, but _Orphan_all only does so at
+//   level 2. Below level 2, an iterator invalidated by its container retains its _Myproxy, which dangles only once
+//   the proxy itself is destroyed.
 //
 // Additional invariants at _ITERATOR_DEBUG_LEVEL == 2 only, where we also track iterators individually:
 //

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1232,7 +1232,7 @@ struct _Iterator_base0 {
 // * Every valid iterator holds a non-owning pointer to its parent container's proxy (_Iterator_base12::_Myproxy).
 //   Orphaning an iterator nulls that pointer, but only level 2 tracks invalidation and can null iterators through
 //   _Orphan_all. Below it, _Orphan_all is a no-op, so an invalidated iterator retains its _Myproxy; that pointer
-//   becomes dangling only when the proxy itself is destroyed.
+//   becomes dangling only when the proxy itself is destroyed.
 
 //   becomes dangling only when the proxy itself is destroyed.
 

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1230,12 +1230,8 @@ struct _Iterator_base0 {
 //   _Container_proxy::_Mycont respectively. (_Container_proxy_ptr12 can briefly hold a freshly allocated proxy
 //   that isn't bound to a container yet; see _Leave_proxy_unbound and _Bind.)
 // * Every valid iterator holds a non-owning pointer to its parent container's proxy (_Iterator_base12::_Myproxy).
-//   Orphaning an iterator nulls that pointer, but only level 2 tracks invalidation and can null iterators through
-//   _Orphan_all. Below it, _Orphan_all is a no-op, so an invalidated iterator retains its _Myproxy; that pointer
-//   becomes dangling only when the proxy itself is destroyed.
-
-//   becomes dangling only when the proxy itself is destroyed.
-
+//   Orphaning an iterator nulls that pointer, but only level 2 orphans anything: _Orphan_all is a no-op below
+//   it, so an invalidated iterator retains its _Myproxy, which dangles only once the proxy itself is destroyed.
 //
 // Additional invariants at _ITERATOR_DEBUG_LEVEL == 2 only, where we also track iterators individually:
 //

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1221,15 +1221,17 @@ struct _Iterator_base0 {
 // Invariants for any container that uses _Container_base12:
 //
 // * Such a container owns a dynamically allocated _Container_proxy at all times, including in its
-//   default-constructed and moved-from states. This is TRANSITION, ABI: allocating the proxy separately (instead
-//   of, say, storing it inline) is the major reason many containers' allocator-extended move constructors and
-//   move assignment operators aren't unconditionally noexcept -- reloading the proxy when allocators compare
-//   unequal can throw. We intend to revisit this strategy in vNext (see GH-169).
+//   default-constructed and moved-from states. This is TRANSITION, ABI: because the proxy is allocated separately
+//   instead of being stored inline, any operation that has to attach a fresh proxy has to allocate. Where such an
+//   operation is still declared noexcept, it deliberately terminates on OOM rather than weaken its specification
+//   -- see the _Reload_proxy call in vector's move assignment operator, tagged TRANSITION, VSO-466800. We intend
+//   to revisit this strategy in vNext (see GH-169).
 // * A container and its proxy always point to each other, via _Container_base12::_Myproxy and
 //   _Container_proxy::_Mycont respectively. (_Container_proxy_ptr12 can briefly hold a freshly allocated proxy
 //   that isn't bound to a container yet; see _Leave_proxy_unbound and _Bind.)
-// * Every valid iterator holds a non-owning pointer to its parent container's proxy (_Iterator_base12::_Myproxy);
-//   an orphaned iterator has a null _Myproxy.
+// * Every valid iterator holds a non-owning pointer to its parent container's proxy (_Iterator_base12::_Myproxy).
+//   Orphaning an iterator nulls that pointer, but only level 2 actually orphans anything: _Orphan_all is a no-op
+//   below it, so an invalidated iterator there keeps its now-dangling _Myproxy.
 //
 // Additional invariants at _ITERATOR_DEBUG_LEVEL == 2 only, where we also track iterators individually:
 //
@@ -1243,9 +1245,10 @@ struct _Iterator_base0 {
 //
 // The lock guards that list, not the proxy pointers themselves: _Alloc_proxy and _Reload_proxy install a new
 // proxy without taking it at any level, and below level 2 _Swap_proxy_and_iterators calls the unlocked helper
-// directly. The other things we do outside the lock are things like iterator compatibility checks that compare
-// proxy pointers: those pointers don't change when containers are swapped (only the proxies' data members
-// change, not their addresses).
+// directly. Iterator compatibility checks also run outside the lock; they compare the container addresses that
+// _Getcont() reads back out of the proxies (see deque's _Compat). Note what swapping actually changes: the two
+// containers exchange their _Myproxy values and each proxy's _Mycont is rewritten to its new container, while
+// existing iterators go on pointing at the same proxy object -- which is how they follow the contents across.
 struct _Container_base12;
 struct _Container_proxy { // store head of iterator chain and back pointer
     _CONSTEXPR20 _Container_proxy() noexcept = default;

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1237,9 +1237,11 @@ struct _Iterator_base0 {
 // Additional invariants at _ITERATOR_DEBUG_LEVEL == 2 only, where we also track iterators individually:
 //
 // * The proxy's _Myfirstiter, together with each iterator's _Mynextiter, forms an intrusive singly linked list of
-//   iterators rooted at the proxy. Every valid iterator belonging to a container is reachable through this list;
-//   there are no valid "free-floating" iterators. Below level 2 the list is unused: _Adopt merely copies
-//   _Myproxy, _Orphan_all does nothing, and _Myfirstiter remains null.
+//   iterators rooted at the proxy. Every valid iterator currently associated with a container is reachable
+//   through this list. A null _Myproxy means no such association: the iterator was orphaned, was never adopted,
+//   or disowned itself -- an end-of-sequence regex_iterator is a valid iterator in that state (see the
+//   _Adopt(nullptr) calls in <regex>). Below level 2 the list is unused: _Adopt merely copies _Myproxy,
+//   _Orphan_all does nothing, and _Myfirstiter remains null.
 // * Whenever that list is manipulated at runtime, the debug lock (_Lockit(_LOCK_DEBUG)) is held. During constant
 //   evaluation we skip the lock and take the unlocked paths instead (see the is_constant_evaluated() checks
 //   below), as constant evaluation is single-threaded and _Lockit isn't usable there.

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1233,6 +1233,9 @@ struct _Iterator_base0 {
 //   Orphaning an iterator nulls that pointer, but only level 2 tracks invalidation and can null iterators through
 //   _Orphan_all. Below it, _Orphan_all is a no-op, so an invalidated iterator retains its _Myproxy; that pointer
 //   becomes dangling only when the proxy itself is destroyed.
+
+//   becomes dangling only when the proxy itself is destroyed.
+
 //
 // Additional invariants at _ITERATOR_DEBUG_LEVEL == 2 only, where we also track iterators individually:
 //


### PR DESCRIPTION
Closes #2084.

The iterator debugging (IDL) proxy/iterator machinery in `<xmemory>`
(`_Container_proxy`, `_Container_base12`, `_Iterator_base12`) wasn't
commented at all, even though its invariants are non-obvious (intrusive
linked list of iterators, mutual container/proxy pointers, locking rules).
@StephanTLavavej explained these invariants in the issue thread (originally
via a linked Discord screenshot from 2021), so this PR just captures that
explanation as a comment next to the code it describes, so it doesn't only
live in a screenshot linked from a 4-year-old issue comment.

I verified the described invariants (mutual _Myproxy/_Mycont pointers, the
_Myfirstiter/_Mynextiter intrusive list, the _Lockit(_LOCK_DEBUG) locking
rule) still match the current code exactly before writing this up.

No behavior change -- comment-only.
