### PR TITLE
Add `es-metadata.yml`

### DIFF
--- a/es-metadata.yml
+++ b/es-metadata.yml
@@ -1,0 +1,9 @@
+schemaVersion: 1.0.0
+providers:
+- provider: InventoryAsCode
+  version: 1.0.0
+  metadata:
+    routing:
+      defaultAreaPath:
+        org: devdiv
+        path: DevDiv\Cpp Language and Toolset\Libraries\Core Libraries\STL


### PR DESCRIPTION
This reverse-mirrors Jennifer Yao's MSVC-PR-764338 "Add `es-metadata.yml` files". These are MSVC-internal files used for automatically routing bugs, and the STL's directory needs one.

Because these were automatically generated and are MSVC-internal, I didn't want to alter this file with a comment/license banner. We probably could, since YAML supports comments, but I didn't think it was necessary or worth the headache (we skip license banners only on files that don't support them or that must/should remain unaltered, and I think this qualifies).