### PR TITLE
document <xstddef>: add comments for code-emitting macros

### DIFF
--- a/stl/inc/xstddef
+++ b/stl/inc/xstddef
@@ -290,38 +290,61 @@ _NODISCARD constexpr _Ty* _Unfancy(_Ty* _Ptr) noexcept { // do nothing for plain
 }
 _STD_END
 
+// Code-emitting macros for cv-qualified, ref-qualified, and calling-convention
+// variations.  These macros are used to stamp out repetitive specializations
+// for std::function (e.g., std::function<int __stdcall()>) and its internal
+// helpers.  The calling convention does not propagate to operator() and has no
+// semantic effect; it exists only for source compatibility with code that forms
+// function types from explicitly-conventioned function pointers.
+//
+// New code should not use these macros.  They are kept only for existing
+// specializations.  (See GH #2279 for rationale.)
+//
+// _EMIT_CDECL(FUNC, OPT1, OPT2, OPT3) - If __cdecl is supported, expands to
+// FUNC(__cdecl, OPT1, OPT2, OPT3). Otherwise expands to nothing.
 #define _EMIT_CDECL(FUNC, OPT1, OPT2, OPT3) FUNC(__cdecl, OPT1, OPT2, OPT3)
 
+// _EMIT_CLRCALL(FUNC, OPT1, OPT2, OPT3) - If _M_CEE is defined (managed C++),
+// expands to FUNC(__clrcall, OPT1, OPT2, OPT3). Otherwise nothing.
 #ifdef _M_CEE
 #define _EMIT_CLRCALL(FUNC, OPT1, OPT2, OPT3) FUNC(__clrcall, OPT1, OPT2, OPT3)
-
 #else // _M_CEE
 #define _EMIT_CLRCALL(FUNC, OPT1, OPT2, OPT3)
 #endif // _M_CEE
 
+// _EMIT_FASTCALL(FUNC, OPT1, OPT2, OPT3) - On x86 without _M_CEE, expands to
+// FUNC(__fastcall, OPT1, OPT2, OPT3). Otherwise nothing.
 #if defined(_M_IX86) && !defined(_M_CEE)
 #define _EMIT_FASTCALL(FUNC, OPT1, OPT2, OPT3) FUNC(__fastcall, OPT1, OPT2, OPT3)
-
 #else // defined(_M_IX86) && !defined(_M_CEE)
 #define _EMIT_FASTCALL(FUNC, OPT1, OPT2, OPT3)
 #endif // defined(_M_IX86) && !defined(_M_CEE)
 
+// _EMIT_STDCALL(FUNC, OPT1, OPT2, OPT3) - On x86, expands to
+// FUNC(__stdcall, OPT1, OPT2, OPT3). Otherwise nothing.
 #ifdef _M_IX86
 #define _EMIT_STDCALL(FUNC, OPT1, OPT2, OPT3)  FUNC(__stdcall, OPT1, OPT2, OPT3)
+// _EMIT_THISCALL(FUNC, OPT1, OPT2, OPT3) - On x86, expands to
+// FUNC(__thiscall, OPT1, OPT2, OPT3). Otherwise nothing.
 #define _EMIT_THISCALL(FUNC, OPT1, OPT2, OPT3) FUNC(__thiscall, OPT1, OPT2, OPT3)
-
 #else // _M_IX86
 #define _EMIT_STDCALL(FUNC, OPT1, OPT2, OPT3)
 #define _EMIT_THISCALL(FUNC, OPT1, OPT2, OPT3)
 #endif // _M_IX86
 
+// _EMIT_VECTORCALL(FUNC, OPT1, OPT2, OPT3) - On x86 with SSE2 or on x64
+// (excluding _M_CEE), expands to FUNC(__vectorcall, OPT1, OPT2, OPT3).
+// Otherwise nothing.
 #if ((defined(_M_IX86) && _M_IX86_FP >= 2) || defined(_M_X64)) && !defined(_M_CEE)
 #define _EMIT_VECTORCALL(FUNC, OPT1, OPT2, OPT3) FUNC(__vectorcall, OPT1, OPT2, OPT3)
-
 #else // defined(_M_IX86) && _M_IX86_FP >= 2 etc.
 #define _EMIT_VECTORCALL(FUNC, OPT1, OPT2, OPT3)
 #endif // defined(_M_IX86) && _M_IX86_FP >= 2 etc.
 
+// _NON_MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)
+// Emits FUNC for every supported non-member calling convention.
+// Used to generate free-function specializations (e.g., std::function::operator()
+// for different calling conventions).
 #define _NON_MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT) \
     _EMIT_CDECL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)          \
     _EMIT_CLRCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)        \
@@ -329,17 +352,30 @@ _STD_END
     _EMIT_STDCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)        \
     _EMIT_VECTORCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)
 
+// _NON_MEMBER_CALL_CV(FUNC, REF_OPT, NOEXCEPT_OPT)
+// Like _NON_MEMBER_CALL but iterates over cv-qualifiers:
+// (none), const, volatile, const volatile.
 #define _NON_MEMBER_CALL_CV(FUNC, REF_OPT, NOEXCEPT_OPT)    \
     _NON_MEMBER_CALL(FUNC, , REF_OPT, NOEXCEPT_OPT)         \
     _NON_MEMBER_CALL(FUNC, const, REF_OPT, NOEXCEPT_OPT)    \
     _NON_MEMBER_CALL(FUNC, volatile, REF_OPT, NOEXCEPT_OPT) \
     _NON_MEMBER_CALL(FUNC, const volatile, REF_OPT, NOEXCEPT_OPT)
 
+// _NON_MEMBER_CALL_CV_REF(FUNC, NOEXCEPT_OPT)
+// Like _NON_MEMBER_CALL_CV but additionally iterates over ref-qualifiers:
+// (none), &, &&.
 #define _NON_MEMBER_CALL_CV_REF(FUNC, NOEXCEPT_OPT) \
     _NON_MEMBER_CALL_CV(FUNC, , NOEXCEPT_OPT)       \
     _NON_MEMBER_CALL_CV(FUNC, &, NOEXCEPT_OPT)      \
     _NON_MEMBER_CALL_CV(FUNC, &&, NOEXCEPT_OPT)
 
+// _NON_MEMBER_CALL_CV_REF_NOEXCEPT(FUNC)
+// When __cpp_noexcept_function_type is defined, additionally iterates over
+// noexcept: (none) and noexcept, yielding 4*3*2 = 24 specializations.
+// Otherwise falls back to _NON_MEMBER_CALL_CV_REF(FUNC, ) (12 specializations).
+//
+// This is the primary macro used by std::function to generate all required
+// operator() overloads with all calling conventions.
 #ifdef __cpp_noexcept_function_type
 #define _NON_MEMBER_CALL_CV_REF_NOEXCEPT(FUNC) \
     _NON_MEMBER_CALL_CV_REF(FUNC, )            \
@@ -348,6 +384,9 @@ _STD_END
 #define _NON_MEMBER_CALL_CV_REF_NOEXCEPT(FUNC) _NON_MEMBER_CALL_CV_REF(FUNC, )
 #endif // __cpp_noexcept_function_type
 
+// _MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)
+// Same as _NON_MEMBER_CALL but also emits __thiscall (x86 only).
+// Used to generate member-function specializations.
 #define _MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT) \
     _EMIT_CDECL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)      \
     _EMIT_CLRCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)    \
@@ -356,17 +395,23 @@ _STD_END
     _EMIT_THISCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)   \
     _EMIT_VECTORCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)
 
+// _MEMBER_CALL_CV(FUNC, REF_OPT, NOEXCEPT_OPT)
+// Like _MEMBER_CALL but iterates over cv-qualifiers.
 #define _MEMBER_CALL_CV(FUNC, REF_OPT, NOEXCEPT_OPT)    \
     _MEMBER_CALL(FUNC, , REF_OPT, NOEXCEPT_OPT)         \
     _MEMBER_CALL(FUNC, const, REF_OPT, NOEXCEPT_OPT)    \
     _MEMBER_CALL(FUNC, volatile, REF_OPT, NOEXCEPT_OPT) \
     _MEMBER_CALL(FUNC, const volatile, REF_OPT, NOEXCEPT_OPT)
 
+// _MEMBER_CALL_CV_REF(FUNC, NOEXCEPT_OPT)
+// Like _MEMBER_CALL_CV but iterates over ref-qualifiers.
 #define _MEMBER_CALL_CV_REF(FUNC, NOEXCEPT_OPT) \
     _MEMBER_CALL_CV(FUNC, , NOEXCEPT_OPT)       \
     _MEMBER_CALL_CV(FUNC, &, NOEXCEPT_OPT)      \
     _MEMBER_CALL_CV(FUNC, &&, NOEXCEPT_OPT)
 
+// _MEMBER_CALL_CV_REF_NOEXCEPT(FUNC)
+// Same logic as _NON_MEMBER_CALL_CV_REF_NOEXCEPT but for member functions.
 #ifdef __cpp_noexcept_function_type
 #define _MEMBER_CALL_CV_REF_NOEXCEPT(FUNC) \
     _MEMBER_CALL_CV_REF(FUNC, )            \
@@ -375,10 +420,19 @@ _STD_END
 #define _MEMBER_CALL_CV_REF_NOEXCEPT(FUNC) _MEMBER_CALL_CV_REF(FUNC, )
 #endif // __cpp_noexcept_function_type
 
+// _CLASS_DEFINE_CONST(CLASS) - Expands CLASS with no qualifiers and with const.
 #define _CLASS_DEFINE_CONST(CLASS) \
     CLASS(_EMPTY_ARGUMENT)         \
     CLASS(const)
 
+// _CLASS_DEFINE_CV_REF_NOEXCEPT(CLASS)
+// Generates a flat list of CLASS expansions for every cv-ref-noexcept
+// combination (12 or 24, depending on __cpp_noexcept_function_type).
+// Used to define internal wrapper classes (e.g., in std::function)
+// that vary by qualifier.
+//
+// This macro exists only for legacy specializations.  New components
+// (e.g., move_only_function) intentionally do not provide such coverage.
 #ifdef __cpp_noexcept_function_type
 #define _CLASS_DEFINE_CV_REF_NOEXCEPT(CLASS) \
     CLASS(_EMPTY_ARGUMENT)                   \

--- a/stl/inc/xstddef
+++ b/stl/inc/xstddef
@@ -300,6 +300,9 @@ _STD_END
 //
 // New code should not use these macros.  They are kept only for existing
 // specializations.  (See GH #2279 for rationale.)
+
+// _EMIT_CDECL(FUNC, OPT1, OPT2, OPT3) - If __cdecl is supported, expands to
+// FUNC(__cdecl, OPT1, OPT2, OPT3). Otherwise expands to nothing.
 #define _EMIT_CDECL(FUNC, OPT1, OPT2, OPT3) FUNC(__cdecl, OPT1, OPT2, OPT3)
 
 // _EMIT_CLRCALL(FUNC, OPT1, OPT2, OPT3) - If _M_CEE is defined (managed C++),
@@ -320,10 +323,10 @@ _STD_END
 
 // _EMIT_STDCALL(FUNC, OPT1, OPT2, OPT3) - On x86, expands to
 // FUNC(__stdcall, OPT1, OPT2, OPT3). Otherwise nothing.
-#ifdef _M_IX86
-#define _EMIT_STDCALL(FUNC, OPT1, OPT2, OPT3)  FUNC(__stdcall, OPT1, OPT2, OPT3)
 // _EMIT_THISCALL(FUNC, OPT1, OPT2, OPT3) - On x86, expands to
 // FUNC(__thiscall, OPT1, OPT2, OPT3). Otherwise nothing.
+#ifdef _M_IX86
+#define _EMIT_STDCALL(FUNC, OPT1, OPT2, OPT3)  FUNC(__stdcall, OPT1, OPT2, OPT3)
 #define _EMIT_THISCALL(FUNC, OPT1, OPT2, OPT3) FUNC(__thiscall, OPT1, OPT2, OPT3)
 #else // _M_IX86
 #define _EMIT_STDCALL(FUNC, OPT1, OPT2, OPT3)
@@ -339,13 +342,10 @@ _STD_END
 #define _EMIT_VECTORCALL(FUNC, OPT1, OPT2, OPT3)
 #endif // defined(_M_IX86) && _M_IX86_FP >= 2 etc.
 
-// _NON_MEMBER_CALL_CV_REF_NOEXCEPT(FUNC)
-// When __cpp_noexcept_function_type is defined, additionally iterates over
-// noexcept: (none) and noexcept, yielding 4*3*2 = 24 specializations.
-// Otherwise falls back to _NON_MEMBER_CALL_CV_REF(FUNC, ) (12 specializations).
-//
-// Used by std::function, ptr_fun, and type traits to generate overloads or
-// specializations that vary by calling convention.
+// _NON_MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)
+// Emits FUNC for every supported non-member calling convention.
+// Used to generate free-function specializations (e.g., std::function::operator()
+// for different calling conventions).
 #define _NON_MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT) \
     _EMIT_CDECL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)          \
     _EMIT_CLRCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)        \
@@ -375,8 +375,8 @@ _STD_END
 // noexcept: (none) and noexcept, yielding 4*3*2 = 24 specializations.
 // Otherwise falls back to _NON_MEMBER_CALL_CV_REF(FUNC, ) (12 specializations).
 //
-// This is the primary macro used by std::function to generate all required
-// operator() overloads with all calling conventions.
+// Used by std::function, ptr_fun, and type traits to generate overloads or
+// specializations that vary by calling convention.
 #ifdef __cpp_noexcept_function_type
 #define _NON_MEMBER_CALL_CV_REF_NOEXCEPT(FUNC) \
     _NON_MEMBER_CALL_CV_REF(FUNC, )            \

--- a/stl/inc/xstddef
+++ b/stl/inc/xstddef
@@ -292,16 +292,14 @@ _STD_END
 
 // Code-emitting macros for cv-qualified, ref-qualified, and calling-convention
 // variations.  These macros are used to stamp out repetitive specializations
-// for std::function (e.g., std::function<int __stdcall()>) and its internal
-// helpers.  The calling convention does not propagate to operator() and has no
-// semantic effect; it exists only for source compatibility with code that forms
-// function types from explicitly-conventioned function pointers.
+// for components that need to handle multiple calling conventions, such as
+// std::function, std::ptr_fun, and various type traits (e.g., is_function).
+// In std::function, the calling convention does not propagate to operator();
+// however, in other contexts the calling convention distinguishes distinct
+// function types and is semantically significant.
 //
 // New code should not use these macros.  They are kept only for existing
 // specializations.  (See GH #2279 for rationale.)
-//
-// _EMIT_CDECL(FUNC, OPT1, OPT2, OPT3) - If __cdecl is supported, expands to
-// FUNC(__cdecl, OPT1, OPT2, OPT3). Otherwise expands to nothing.
 #define _EMIT_CDECL(FUNC, OPT1, OPT2, OPT3) FUNC(__cdecl, OPT1, OPT2, OPT3)
 
 // _EMIT_CLRCALL(FUNC, OPT1, OPT2, OPT3) - If _M_CEE is defined (managed C++),
@@ -341,10 +339,13 @@ _STD_END
 #define _EMIT_VECTORCALL(FUNC, OPT1, OPT2, OPT3)
 #endif // defined(_M_IX86) && _M_IX86_FP >= 2 etc.
 
-// _NON_MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)
-// Emits FUNC for every supported non-member calling convention.
-// Used to generate free-function specializations (e.g., std::function::operator()
-// for different calling conventions).
+// _NON_MEMBER_CALL_CV_REF_NOEXCEPT(FUNC)
+// When __cpp_noexcept_function_type is defined, additionally iterates over
+// noexcept: (none) and noexcept, yielding 4*3*2 = 24 specializations.
+// Otherwise falls back to _NON_MEMBER_CALL_CV_REF(FUNC, ) (12 specializations).
+//
+// Used by std::function, ptr_fun, and type traits to generate overloads or
+// specializations that vary by calling convention.
 #define _NON_MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT) \
     _EMIT_CDECL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)          \
     _EMIT_CLRCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)        \
@@ -412,6 +413,8 @@ _STD_END
 
 // _MEMBER_CALL_CV_REF_NOEXCEPT(FUNC)
 // Same logic as _NON_MEMBER_CALL_CV_REF_NOEXCEPT but for member functions.
+// Used for type traits and other internal helpers that need member-function
+// calling-convention specializations.
 #ifdef __cpp_noexcept_function_type
 #define _MEMBER_CALL_CV_REF_NOEXCEPT(FUNC) \
     _MEMBER_CALL_CV_REF(FUNC, )            \


### PR DESCRIPTION
<!-- Before submitting a pull request, please ensure that:

* Any AI-generated code has been clearly disclosed in your PR description.
  We strongly discourage AI-generated changes to product code because the STL
  is a highly unusual codebase with complex correctness and performance
  requirements imposed by the Standard, and highly unusual code patterns that
  don't look like typical codebases. Our intensive code review process
  (to avoid bugs) is intentionally a bottleneck, so we ask that you be
  considerate of the time and effort that we'll need to spend, by starting
  with changes that you fully understand. Test code has weaker requirements,
  so AI-generated changes for tests can be acceptable if properly disclosed.

* Your PR description explains your intent behind the changes.
  We discourage AI-generated PR descriptions because we can read the changes,
  and we have access to the same AI tools that you have, so we can get
  an AI-generated summary if we want.

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
Adds documentation comments for the code-emitting macros at the end of <xstddef>.
Explains the purpose of each macro, their parameters, platform conditions,
and their historical role in generating std::function specializations.
These macros exist only for legacy support (see GH #2279 for rationale).

Addresses #348