### PR TITLE
Document code-emitting function-like macros

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -376,58 +376,42 @@ struct _NO_SPECIALIZATIONS_OF_TYPE_TRAITS is_compound : bool_constant<!is_fundam
 _EXPORT_STD template <class _Ty>
 _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_compound_v = !is_fundamental_v<_Ty>;
 
-// Code-emitting macros for cv-qualified, ref-qualified, and calling-convention
-// variations.  These macros are used to stamp out repetitive specializations
-// for components that need to handle multiple calling conventions, such as
-// std::function, std::ptr_fun, and various type traits (e.g., is_function).
-// In std::function, the calling convention does not propagate to operator();
-// however, in other contexts the calling convention distinguishes distinct
-// function types and is semantically significant.
-//
-// New code should not use these macros.  They are retained only for existing
-// uses.  (See GH #2279 for rationale.)
-
-// _EMIT_CDECL(FUNC, OPT1, OPT2, OPT3) - Always expands to
-// FUNC(__cdecl, OPT1, OPT2, OPT3). __cdecl is universally supported.
+// _EMIT_CDECL(FUNC, OPT1, OPT2, OPT3) - Always FUNC(__cdecl, ...)
 #define _EMIT_CDECL(FUNC, OPT1, OPT2, OPT3) FUNC(__cdecl, OPT1, OPT2, OPT3)
 
-// _EMIT_CLRCALL(FUNC, OPT1, OPT2, OPT3) - If _M_CEE is defined (managed C++),
-// expands to FUNC(__clrcall, ...); otherwise nothing.
+// _EMIT_CLRCALL(FUNC, OPT1, OPT2, OPT3) - FUNC(__clrcall, ...) if _M_CEE
 #ifdef _M_CEE
 #define _EMIT_CLRCALL(FUNC, OPT1, OPT2, OPT3) FUNC(__clrcall, OPT1, OPT2, OPT3)
-#else // ^^^ __clrcall supported / __clrcall not supported vvv
+#else // ^^^ defined(_M_CEE) / !defined(_M_CEE) vvv
 #define _EMIT_CLRCALL(FUNC, OPT1, OPT2, OPT3)
-#endif // ^^^ __clrcall not supported ^^^
+#endif // ^^^ !defined(_M_CEE) ^^^
 
-// _EMIT_FASTCALL(FUNC, OPT1, OPT2, OPT3) - On x86 without _M_CEE, expands to
-// FUNC(__fastcall, ...); otherwise nothing.
+// _EMIT_FASTCALL(FUNC, OPT1, OPT2, OPT3) - FUNC(__fastcall, ...) on x86, non-CEE
 #if defined(_M_IX86) && !defined(_M_CEE)
 #define _EMIT_FASTCALL(FUNC, OPT1, OPT2, OPT3) FUNC(__fastcall, OPT1, OPT2, OPT3)
-#else // ^^^ __fastcall supported / __fastcall not supported vvv
+#else // ^^^ conditions met / conditions not met vvv
 #define _EMIT_FASTCALL(FUNC, OPT1, OPT2, OPT3)
-#endif // ^^^ __fastcall not supported ^^^
+#endif // ^^^ conditions not met ^^^
 
-// _EMIT_STDCALL / _EMIT_THISCALL - On x86, expand to the corresponding
-// calling convention; otherwise nothing.
+// _EMIT_STDCALL / _EMIT_THISCALL - FUNC(__stdcall, ...) / FUNC(__thiscall, ...) on x86
 #ifdef _M_IX86
 #define _EMIT_STDCALL(FUNC, OPT1, OPT2, OPT3)  FUNC(__stdcall, OPT1, OPT2, OPT3)
 #define _EMIT_THISCALL(FUNC, OPT1, OPT2, OPT3) FUNC(__thiscall, OPT1, OPT2, OPT3)
-#else // ^^^ __stdcall and __thiscall supported / __stdcall and __thiscall not supported vvv
+#else // ^^^ defined(_M_IX86) / !defined(_M_IX86) vvv
 #define _EMIT_STDCALL(FUNC, OPT1, OPT2, OPT3)
 #define _EMIT_THISCALL(FUNC, OPT1, OPT2, OPT3)
-#endif // ^^^ __stdcall and __thiscall not supported ^^^
+#endif // ^^^ !defined(_M_IX86) ^^^
 
-// _EMIT_VECTORCALL(FUNC, OPT1, OPT2, OPT3) - On x86 with SSE2, or on x64
-// (excluding ARM64EC) without _M_CEE, expands to FUNC(__vectorcall, ...);
-// otherwise nothing.
+// _EMIT_VECTORCALL(FUNC, OPT1, OPT2, OPT3) - FUNC(__vectorcall, ...) if supported
 #if ((defined(_M_IX86) && _M_IX86_FP >= 2) || (defined(_M_X64) && !defined(_M_ARM64EC))) && !defined(_M_CEE)
 #define _EMIT_VECTORCALL(FUNC, OPT1, OPT2, OPT3) FUNC(__vectorcall, OPT1, OPT2, OPT3)
 #else // ^^^ __vectorcall supported / __vectorcall not supported vvv
 #define _EMIT_VECTORCALL(FUNC, OPT1, OPT2, OPT3)
 #endif // ^^^ __vectorcall not supported ^^^
 
-// _NON_MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)
-// Emits FUNC for non-member function types with every supported calling convention.
+// Non-member calling convention family
+// These macros emit FUNC for non-member function types with every supported calling convention.
+
 #define _NON_MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT) \
     _EMIT_CDECL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)          \
     _EMIT_CLRCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)        \
@@ -435,28 +419,21 @@ _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_compound_v = !is_fundamenta
     _EMIT_STDCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)        \
     _EMIT_VECTORCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)
 
-// _NON_MEMBER_CALL_CV(FUNC, REF_OPT, NOEXCEPT_OPT)
-// Like _NON_MEMBER_CALL but iterates over cv-qualifiers:
-// (none), const, volatile, const volatile.
+// Like _NON_MEMBER_CALL but over cv-qualifiers: (none), const, volatile, const volatile
 #define _NON_MEMBER_CALL_CV(FUNC, REF_OPT, NOEXCEPT_OPT)    \
     _NON_MEMBER_CALL(FUNC, , REF_OPT, NOEXCEPT_OPT)         \
     _NON_MEMBER_CALL(FUNC, const, REF_OPT, NOEXCEPT_OPT)    \
     _NON_MEMBER_CALL(FUNC, volatile, REF_OPT, NOEXCEPT_OPT) \
     _NON_MEMBER_CALL(FUNC, const volatile, REF_OPT, NOEXCEPT_OPT)
 
-// _NON_MEMBER_CALL_CV_REF(FUNC, NOEXCEPT_OPT)
-// Like _NON_MEMBER_CALL_CV but additionally iterates over ref-qualifiers:
-// (none), &, &&.
+// Like _NON_MEMBER_CALL_CV but over ref-qualifiers: (none), &, &&
 #define _NON_MEMBER_CALL_CV_REF(FUNC, NOEXCEPT_OPT) \
     _NON_MEMBER_CALL_CV(FUNC, , NOEXCEPT_OPT)       \
     _NON_MEMBER_CALL_CV(FUNC, &, NOEXCEPT_OPT)      \
     _NON_MEMBER_CALL_CV(FUNC, &&, NOEXCEPT_OPT)
 
-// _NON_MEMBER_CALL_CV_REF_NOEXCEPT(FUNC)
-// When __cpp_noexcept_function_type is defined, additionally iterates over
-// noexcept: (none) and noexcept, invoking FUNC for 24 cv-ref-noexcept
-// combinations per enabled calling convention; otherwise 12.
-// Used by _Function_args to recognize every supported function type.
+// _NON_MEMBER_CALL_CV_REF_NOEXCEPT(FUNC) - 12 or 24 cv-ref-noexcept combinations
+// per enabled calling convention. Used by _Function_args.
 #ifdef __cpp_noexcept_function_type
 #define _NON_MEMBER_CALL_CV_REF_NOEXCEPT(FUNC) \
     _NON_MEMBER_CALL_CV_REF(FUNC, )            \
@@ -465,9 +442,9 @@ _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_compound_v = !is_fundamenta
 #define _NON_MEMBER_CALL_CV_REF_NOEXCEPT(FUNC) _NON_MEMBER_CALL_CV_REF(FUNC, )
 #endif // ^^^ !defined(__cpp_noexcept_function_type) ^^^
 
-// _MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)
-// Same as _NON_MEMBER_CALL but also emits __thiscall (x86 only).
-// Used for member function types in type traits and internal helpers.
+// Member calling convention family
+// Same as _NON_MEMBER_CALL but also emits __thiscall on x86.
+
 #define _MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT) \
     _EMIT_CDECL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)      \
     _EMIT_CLRCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)    \
@@ -476,10 +453,6 @@ _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_compound_v = !is_fundamenta
     _EMIT_THISCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)   \
     _EMIT_VECTORCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)
 
-// _MEMBER_CALL_CV, _MEMBER_CALL_CV_REF, _MEMBER_CALL_CV_REF_NOEXCEPT
-// Member-function counterparts of the _NON_MEMBER_CALL family.
-// Used for type traits and internal helpers that need member-function
-// calling-convention specializations.
 #define _MEMBER_CALL_CV(FUNC, REF_OPT, NOEXCEPT_OPT)    \
     _MEMBER_CALL(FUNC, , REF_OPT, NOEXCEPT_OPT)         \
     _MEMBER_CALL(FUNC, const, REF_OPT, NOEXCEPT_OPT)    \
@@ -499,14 +472,9 @@ _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_compound_v = !is_fundamenta
 #define _MEMBER_CALL_CV_REF_NOEXCEPT(FUNC) _MEMBER_CALL_CV_REF(FUNC, )
 #endif // ^^^ !defined(__cpp_noexcept_function_type) ^^^
 
-// _CLASS_DEFINE_CV_REF_NOEXCEPT(CLASS)
-// Generates a flat list of CLASS expansions for every cv-ref-noexcept
-// combination (12 or 24, depending on __cpp_noexcept_function_type).
-// Used by type traits to generate cv-ref-noexcept specializations for ellipsis
-// function types, which do not have calling-convention variants.
-//
-// This macro exists only for legacy specializations.  New components should
-// generate these specializations without using this macro.
+// _CLASS_DEFINE_CV_REF_NOEXCEPT(CLASS) - Flat list of 12 or 24 cv-ref-noexcept
+// combinations. Used for ellipsis function type traits. Retained for legacy
+// specializations; new components should avoid this macro.
 #ifdef __cpp_noexcept_function_type
 #define _CLASS_DEFINE_CV_REF_NOEXCEPT(CLASS) \
     CLASS(_EMPTY_ARGUMENT)                   \

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -384,8 +384,8 @@ _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_compound_v = !is_fundamenta
 // however, in other contexts the calling convention distinguishes distinct
 // function types and is semantically significant.
 //
-// New code should not use these macros.  They are kept only for existing
-// specializations.  (See GH #2279 for rationale.)
+// New code should not use these macros.  They are retained only for existing
+// uses.  (See GH #2279 for rationale.)
 
 // _EMIT_CDECL(FUNC, OPT1, OPT2, OPT3) - Always expands to
 // FUNC(__cdecl, OPT1, OPT2, OPT3). __cdecl is universally supported.
@@ -427,8 +427,7 @@ _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_compound_v = !is_fundamenta
 #endif // ^^^ __vectorcall not supported ^^^
 
 // _NON_MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)
-// Emits FUNC for every supported non-member calling convention.
-// Used to generate free-function specializations (e.g., std::function::operator()).
+// Emits FUNC for non-member function types with every supported calling convention.
 #define _NON_MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT) \
     _EMIT_CDECL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)          \
     _EMIT_CLRCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)        \
@@ -455,9 +454,9 @@ _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_compound_v = !is_fundamenta
 
 // _NON_MEMBER_CALL_CV_REF_NOEXCEPT(FUNC)
 // When __cpp_noexcept_function_type is defined, additionally iterates over
-// noexcept: (none) and noexcept, yielding 24 specializations; otherwise 12.
-// Used by std::function, ptr_fun, and type traits to generate overloads
-// that vary by calling convention.
+// noexcept: (none) and noexcept, invoking FUNC for 24 cv-ref-noexcept
+// combinations per enabled calling convention; otherwise 12.
+// Used by _Function_args to recognize every supported function type.
 #ifdef __cpp_noexcept_function_type
 #define _NON_MEMBER_CALL_CV_REF_NOEXCEPT(FUNC) \
     _NON_MEMBER_CALL_CV_REF(FUNC, )            \
@@ -468,6 +467,7 @@ _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_compound_v = !is_fundamenta
 
 // _MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)
 // Same as _NON_MEMBER_CALL but also emits __thiscall (x86 only).
+// Used for member function types in type traits and internal helpers.
 #define _MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT) \
     _EMIT_CDECL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)      \
     _EMIT_CLRCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)    \
@@ -502,11 +502,11 @@ _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_compound_v = !is_fundamenta
 // _CLASS_DEFINE_CV_REF_NOEXCEPT(CLASS)
 // Generates a flat list of CLASS expansions for every cv-ref-noexcept
 // combination (12 or 24, depending on __cpp_noexcept_function_type).
-// Used to define internal wrapper classes (e.g., in std::function)
-// that vary by qualifier.
+// Used by type traits to generate cv-ref-noexcept specializations for ellipsis
+// function types, which do not have calling-convention variants.
 //
-// This macro exists only for legacy specializations.  New components
-// (e.g., move_only_function) intentionally do not provide such coverage.
+// This macro exists only for legacy specializations.  New components should
+// generate these specializations without using this macro.
 #ifdef __cpp_noexcept_function_type
 #define _CLASS_DEFINE_CV_REF_NOEXCEPT(CLASS) \
     CLASS(_EMPTY_ARGUMENT)                   \

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -376,20 +376,39 @@ struct _NO_SPECIALIZATIONS_OF_TYPE_TRAITS is_compound : bool_constant<!is_fundam
 _EXPORT_STD template <class _Ty>
 _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_compound_v = !is_fundamental_v<_Ty>;
 
+// Code-emitting macros for cv-qualified, ref-qualified, and calling-convention
+// variations.  These macros are used to stamp out repetitive specializations
+// for components that need to handle multiple calling conventions, such as
+// std::function, std::ptr_fun, and various type traits (e.g., is_function).
+// In std::function, the calling convention does not propagate to operator();
+// however, in other contexts the calling convention distinguishes distinct
+// function types and is semantically significant.
+//
+// New code should not use these macros.  They are kept only for existing
+// specializations.  (See GH #2279 for rationale.)
+
+// _EMIT_CDECL(FUNC, OPT1, OPT2, OPT3) - Always expands to
+// FUNC(__cdecl, OPT1, OPT2, OPT3). __cdecl is universally supported.
 #define _EMIT_CDECL(FUNC, OPT1, OPT2, OPT3) FUNC(__cdecl, OPT1, OPT2, OPT3)
 
+// _EMIT_CLRCALL(FUNC, OPT1, OPT2, OPT3) - If _M_CEE is defined (managed C++),
+// expands to FUNC(__clrcall, ...); otherwise nothing.
 #ifdef _M_CEE
 #define _EMIT_CLRCALL(FUNC, OPT1, OPT2, OPT3) FUNC(__clrcall, OPT1, OPT2, OPT3)
 #else // ^^^ __clrcall supported / __clrcall not supported vvv
 #define _EMIT_CLRCALL(FUNC, OPT1, OPT2, OPT3)
 #endif // ^^^ __clrcall not supported ^^^
 
+// _EMIT_FASTCALL(FUNC, OPT1, OPT2, OPT3) - On x86 without _M_CEE, expands to
+// FUNC(__fastcall, ...); otherwise nothing.
 #if defined(_M_IX86) && !defined(_M_CEE)
 #define _EMIT_FASTCALL(FUNC, OPT1, OPT2, OPT3) FUNC(__fastcall, OPT1, OPT2, OPT3)
 #else // ^^^ __fastcall supported / __fastcall not supported vvv
 #define _EMIT_FASTCALL(FUNC, OPT1, OPT2, OPT3)
 #endif // ^^^ __fastcall not supported ^^^
 
+// _EMIT_STDCALL / _EMIT_THISCALL - On x86, expand to the corresponding
+// calling convention; otherwise nothing.
 #ifdef _M_IX86
 #define _EMIT_STDCALL(FUNC, OPT1, OPT2, OPT3)  FUNC(__stdcall, OPT1, OPT2, OPT3)
 #define _EMIT_THISCALL(FUNC, OPT1, OPT2, OPT3) FUNC(__thiscall, OPT1, OPT2, OPT3)
@@ -398,12 +417,18 @@ _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_compound_v = !is_fundamenta
 #define _EMIT_THISCALL(FUNC, OPT1, OPT2, OPT3)
 #endif // ^^^ __stdcall and __thiscall not supported ^^^
 
+// _EMIT_VECTORCALL(FUNC, OPT1, OPT2, OPT3) - On x86 with SSE2, or on x64
+// (excluding ARM64EC) without _M_CEE, expands to FUNC(__vectorcall, ...);
+// otherwise nothing.
 #if ((defined(_M_IX86) && _M_IX86_FP >= 2) || (defined(_M_X64) && !defined(_M_ARM64EC))) && !defined(_M_CEE)
 #define _EMIT_VECTORCALL(FUNC, OPT1, OPT2, OPT3) FUNC(__vectorcall, OPT1, OPT2, OPT3)
 #else // ^^^ __vectorcall supported / __vectorcall not supported vvv
 #define _EMIT_VECTORCALL(FUNC, OPT1, OPT2, OPT3)
 #endif // ^^^ __vectorcall not supported ^^^
 
+// _NON_MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)
+// Emits FUNC for every supported non-member calling convention.
+// Used to generate free-function specializations (e.g., std::function::operator()).
 #define _NON_MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT) \
     _EMIT_CDECL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)          \
     _EMIT_CLRCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)        \
@@ -411,17 +436,28 @@ _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_compound_v = !is_fundamenta
     _EMIT_STDCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)        \
     _EMIT_VECTORCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)
 
+// _NON_MEMBER_CALL_CV(FUNC, REF_OPT, NOEXCEPT_OPT)
+// Like _NON_MEMBER_CALL but iterates over cv-qualifiers:
+// (none), const, volatile, const volatile.
 #define _NON_MEMBER_CALL_CV(FUNC, REF_OPT, NOEXCEPT_OPT)    \
     _NON_MEMBER_CALL(FUNC, , REF_OPT, NOEXCEPT_OPT)         \
     _NON_MEMBER_CALL(FUNC, const, REF_OPT, NOEXCEPT_OPT)    \
     _NON_MEMBER_CALL(FUNC, volatile, REF_OPT, NOEXCEPT_OPT) \
     _NON_MEMBER_CALL(FUNC, const volatile, REF_OPT, NOEXCEPT_OPT)
 
+// _NON_MEMBER_CALL_CV_REF(FUNC, NOEXCEPT_OPT)
+// Like _NON_MEMBER_CALL_CV but additionally iterates over ref-qualifiers:
+// (none), &, &&.
 #define _NON_MEMBER_CALL_CV_REF(FUNC, NOEXCEPT_OPT) \
     _NON_MEMBER_CALL_CV(FUNC, , NOEXCEPT_OPT)       \
     _NON_MEMBER_CALL_CV(FUNC, &, NOEXCEPT_OPT)      \
     _NON_MEMBER_CALL_CV(FUNC, &&, NOEXCEPT_OPT)
 
+// _NON_MEMBER_CALL_CV_REF_NOEXCEPT(FUNC)
+// When __cpp_noexcept_function_type is defined, additionally iterates over
+// noexcept: (none) and noexcept, yielding 24 specializations; otherwise 12.
+// Used by std::function, ptr_fun, and type traits to generate overloads
+// that vary by calling convention.
 #ifdef __cpp_noexcept_function_type
 #define _NON_MEMBER_CALL_CV_REF_NOEXCEPT(FUNC) \
     _NON_MEMBER_CALL_CV_REF(FUNC, )            \
@@ -430,6 +466,8 @@ _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_compound_v = !is_fundamenta
 #define _NON_MEMBER_CALL_CV_REF_NOEXCEPT(FUNC) _NON_MEMBER_CALL_CV_REF(FUNC, )
 #endif // ^^^ !defined(__cpp_noexcept_function_type) ^^^
 
+// _MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)
+// Same as _NON_MEMBER_CALL but also emits __thiscall (x86 only).
 #define _MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT) \
     _EMIT_CDECL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)      \
     _EMIT_CLRCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)    \
@@ -438,6 +476,10 @@ _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_compound_v = !is_fundamenta
     _EMIT_THISCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)   \
     _EMIT_VECTORCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)
 
+// _MEMBER_CALL_CV, _MEMBER_CALL_CV_REF, _MEMBER_CALL_CV_REF_NOEXCEPT
+// Member-function counterparts of the _NON_MEMBER_CALL family.
+// Used for type traits and internal helpers that need member-function
+// calling-convention specializations.
 #define _MEMBER_CALL_CV(FUNC, REF_OPT, NOEXCEPT_OPT)    \
     _MEMBER_CALL(FUNC, , REF_OPT, NOEXCEPT_OPT)         \
     _MEMBER_CALL(FUNC, const, REF_OPT, NOEXCEPT_OPT)    \
@@ -457,6 +499,14 @@ _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_compound_v = !is_fundamenta
 #define _MEMBER_CALL_CV_REF_NOEXCEPT(FUNC) _MEMBER_CALL_CV_REF(FUNC, )
 #endif // ^^^ !defined(__cpp_noexcept_function_type) ^^^
 
+// _CLASS_DEFINE_CV_REF_NOEXCEPT(CLASS)
+// Generates a flat list of CLASS expansions for every cv-ref-noexcept
+// combination (12 or 24, depending on __cpp_noexcept_function_type).
+// Used to define internal wrapper classes (e.g., in std::function)
+// that vary by qualifier.
+//
+// This macro exists only for legacy specializations.  New components
+// (e.g., move_only_function) intentionally do not provide such coverage.
 #ifdef __cpp_noexcept_function_type
 #define _CLASS_DEFINE_CV_REF_NOEXCEPT(CLASS) \
     CLASS(_EMPTY_ARGUMENT)                   \

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -389,9 +389,9 @@ _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_compound_v = !is_fundamenta
 // _EMIT_FASTCALL(FUNC, OPT1, OPT2, OPT3) - FUNC(__fastcall, ...) on x86, non-CEE
 #if defined(_M_IX86) && !defined(_M_CEE)
 #define _EMIT_FASTCALL(FUNC, OPT1, OPT2, OPT3) FUNC(__fastcall, OPT1, OPT2, OPT3)
-#else // ^^^ conditions met / conditions not met vvv
+#else // ^^^ defined(_M_IX86) && !defined(_M_CEE) / !(defined(_M_IX86) && !defined(_M_CEE)) vvv
 #define _EMIT_FASTCALL(FUNC, OPT1, OPT2, OPT3)
-#endif // ^^^ conditions not met ^^^
+#endif // ^^^ !(defined(_M_IX86) && !defined(_M_CEE)) ^^^
 
 // _EMIT_STDCALL / _EMIT_THISCALL - FUNC(__stdcall, ...) / FUNC(__thiscall, ...) on x86
 #ifdef _M_IX86
@@ -411,7 +411,6 @@ _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_compound_v = !is_fundamenta
 
 // Non-member calling convention family
 // These macros emit FUNC for non-member function types with every supported calling convention.
-
 #define _NON_MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT) \
     _EMIT_CDECL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)          \
     _EMIT_CLRCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)        \
@@ -444,7 +443,6 @@ _NO_SPECIALIZATIONS_OF_TYPE_TRAITS constexpr bool is_compound_v = !is_fundamenta
 
 // Member calling convention family
 // Same as _NON_MEMBER_CALL but also emits __thiscall on x86.
-
 #define _MEMBER_CALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT) \
     _EMIT_CDECL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)      \
     _EMIT_CLRCALL(FUNC, CV_OPT, REF_OPT, NOEXCEPT_OPT)    \


### PR DESCRIPTION
<!-- Before submitting a pull request, please ensure that:

* Any AI-generated code has been clearly disclosed in your PR description.
  We strongly discourage AI-generated changes to product code because the STL
  is a highly unusual codebase with complex correctness and performance
  requirements imposed by the Standard, and highly unusual code patterns that
  don't look like typical codebases. Our intensive code review process
  (to avoid bugs) is intentionally a bottleneck, so we ask that you be
  considerate of the time and effort that we'll need to spend, by starting
  with changes that you fully understand. Test code has weaker requirements,
  so AI-generated changes for tests can be acceptable if properly disclosed.

* Your PR description explains your intent behind the changes.
  We discourage AI-generated PR descriptions because we can read the changes,
  and we have access to the same AI tools that you have, so we can get
  an AI-generated summary if we want.

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
<type_traits>: Document code-emitting function-like macros

This PR adds comments to document the code-emitting macros that used to live in
<xstddef> and now live in <type_traits>. These macros are used to stamp out
specializations for all the different calling conventions, cv/ref qualifiers,
and noexcept variations that we support.

These macros are kept around only for existing uses (see GH #2279 for why).
New code shouldn't rely on them.

Closes #348.