### PR TITLE
LWG-3417: Deprecate volatile atomic inc/dec and wait/notify operations

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -1662,23 +1662,23 @@ struct _Atomic_integral_facade : _Atomic_integral<_Ty> {
 
     using _Base::operator++;
     _Ty operator++(int) volatile noexcept {
-        (void) _Deprecate_non_lock_free_volatile<_Ty>;
+        static_assert(_Deprecate_non_lock_free_volatile<_Ty>, "Never fails");
         return const_cast<_Atomic_integral_facade*>(this)->_Base::operator++(0);
     }
 
     _Ty operator++() volatile noexcept {
-        (void) _Deprecate_non_lock_free_volatile<_Ty>;
+        static_assert(_Deprecate_non_lock_free_volatile<_Ty>, "Never fails");
         return const_cast<_Atomic_integral_facade*>(this)->_Base::operator++();
     }
 
     using _Base::operator--;
     _Ty operator--(int) volatile noexcept {
-        (void) _Deprecate_non_lock_free_volatile<_Ty>;
+        static_assert(_Deprecate_non_lock_free_volatile<_Ty>, "Never fails");
         return const_cast<_Atomic_integral_facade*>(this)->_Base::operator--(0);
     }
 
     _Ty operator--() volatile noexcept {
-        (void) _Deprecate_non_lock_free_volatile<_Ty>;
+        static_assert(_Deprecate_non_lock_free_volatile<_Ty>, "Never fails");
         return const_cast<_Atomic_integral_facade*>(this)->_Base::operator--();
     }
 
@@ -1964,7 +1964,7 @@ struct _Atomic_pointer : _Atomic_storage<_Ty> {
     }
 
     _Ty operator++(int) volatile noexcept {
-        (void) _Deprecate_non_lock_free_volatile<_Ty>;
+        static_assert(_Deprecate_non_lock_free_volatile<_Ty>, "Never fails");
         return fetch_add(1);
     }
 
@@ -1973,7 +1973,7 @@ struct _Atomic_pointer : _Atomic_storage<_Ty> {
     }
 
     _Ty operator++() volatile noexcept {
-        (void) _Deprecate_non_lock_free_volatile<_Ty>;
+        static_assert(_Deprecate_non_lock_free_volatile<_Ty>, "Never fails");
         return fetch_add(1) + 1;
     }
 
@@ -1982,7 +1982,7 @@ struct _Atomic_pointer : _Atomic_storage<_Ty> {
     }
 
     _Ty operator--(int) volatile noexcept {
-        (void) _Deprecate_non_lock_free_volatile<_Ty>;
+        static_assert(_Deprecate_non_lock_free_volatile<_Ty>, "Never fails");
         return fetch_add(-1);
     }
 
@@ -1991,7 +1991,7 @@ struct _Atomic_pointer : _Atomic_storage<_Ty> {
     }
 
     _Ty operator--() volatile noexcept {
-        (void) _Deprecate_non_lock_free_volatile<_Ty>;
+        static_assert(_Deprecate_non_lock_free_volatile<_Ty>, "Never fails");
         return fetch_add(-1) - 1;
     }
 
@@ -2250,19 +2250,19 @@ public:
 #if _HAS_CXX20
     using _Base::wait;
     void wait(const _Ty _Expected, const memory_order _Order = memory_order_seq_cst) const volatile noexcept {
-        (void) _Deprecate_non_lock_free_volatile<_Ty>;
+        static_assert(_Deprecate_non_lock_free_volatile<_Ty>, "Never fails");
         const_cast<const atomic*>(this)->_Base::wait(_Expected, _Order);
     }
 
     using _Base::notify_one;
     void notify_one() volatile noexcept {
-        (void) _Deprecate_non_lock_free_volatile<_Ty>;
+        static_assert(_Deprecate_non_lock_free_volatile<_Ty>, "Never fails");
         const_cast<atomic*>(this)->_Base::notify_one();
     }
 
     using _Base::notify_all;
     void notify_all() volatile noexcept {
-        (void) _Deprecate_non_lock_free_volatile<_Ty>;
+        static_assert(_Deprecate_non_lock_free_volatile<_Ty>, "Never fails");
         const_cast<atomic*>(this)->_Base::notify_all();
     }
 #endif // _HAS_CXX20

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -1662,19 +1662,23 @@ struct _Atomic_integral_facade : _Atomic_integral<_Ty> {
 
     using _Base::operator++;
     _Ty operator++(int) volatile noexcept {
+        (void) _Deprecate_non_lock_free_volatile<_Ty>;
         return const_cast<_Atomic_integral_facade*>(this)->_Base::operator++(0);
     }
 
     _Ty operator++() volatile noexcept {
+        (void) _Deprecate_non_lock_free_volatile<_Ty>;
         return const_cast<_Atomic_integral_facade*>(this)->_Base::operator++();
     }
 
     using _Base::operator--;
     _Ty operator--(int) volatile noexcept {
+        (void) _Deprecate_non_lock_free_volatile<_Ty>;
         return const_cast<_Atomic_integral_facade*>(this)->_Base::operator--(0);
     }
 
     _Ty operator--() volatile noexcept {
+        (void) _Deprecate_non_lock_free_volatile<_Ty>;
         return const_cast<_Atomic_integral_facade*>(this)->_Base::operator--();
     }
 
@@ -1960,6 +1964,7 @@ struct _Atomic_pointer : _Atomic_storage<_Ty> {
     }
 
     _Ty operator++(int) volatile noexcept {
+        (void) _Deprecate_non_lock_free_volatile<_Ty>;
         return fetch_add(1);
     }
 
@@ -1968,6 +1973,7 @@ struct _Atomic_pointer : _Atomic_storage<_Ty> {
     }
 
     _Ty operator++() volatile noexcept {
+        (void) _Deprecate_non_lock_free_volatile<_Ty>;
         return fetch_add(1) + 1;
     }
 
@@ -1976,6 +1982,7 @@ struct _Atomic_pointer : _Atomic_storage<_Ty> {
     }
 
     _Ty operator--(int) volatile noexcept {
+        (void) _Deprecate_non_lock_free_volatile<_Ty>;
         return fetch_add(-1);
     }
 
@@ -1984,6 +1991,7 @@ struct _Atomic_pointer : _Atomic_storage<_Ty> {
     }
 
     _Ty operator--() volatile noexcept {
+        (void) _Deprecate_non_lock_free_volatile<_Ty>;
         return fetch_add(-1) - 1;
     }
 
@@ -2242,16 +2250,19 @@ public:
 #if _HAS_CXX20
     using _Base::wait;
     void wait(const _Ty _Expected, const memory_order _Order = memory_order_seq_cst) const volatile noexcept {
+        (void) _Deprecate_non_lock_free_volatile<_Ty>;
         const_cast<const atomic*>(this)->_Base::wait(_Expected, _Order);
     }
 
     using _Base::notify_one;
     void notify_one() volatile noexcept {
+        (void) _Deprecate_non_lock_free_volatile<_Ty>;
         const_cast<atomic*>(this)->_Base::notify_one();
     }
 
     using _Base::notify_all;
     void notify_all() volatile noexcept {
+        (void) _Deprecate_non_lock_free_volatile<_Ty>;
         const_cast<atomic*>(this)->_Base::notify_all();
     }
 #endif // _HAS_CXX20

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -640,6 +640,7 @@ tests\P1645R1_constexpr_numeric
 tests\P1659R3_ranges_alg_ends_with
 tests\P1659R3_ranges_alg_starts_with
 tests\P1682R3_to_underlying
+tests\P1831R1_deprecated_volatile_atomic
 tests\P1899R3_views_stride
 tests\P1899R3_views_stride_death
 tests\P1951R1_default_arguments_pair_forward_ctor

--- a/tests/std/tests/P1831R1_deprecated_volatile_atomic/env.lst
+++ b/tests/std/tests/P1831R1_deprecated_volatile_atomic/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P1831R1_deprecated_volatile_atomic/test.cpp
+++ b/tests/std/tests/P1831R1_deprecated_volatile_atomic/test.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <atomic>
+#include <cassert>
+
+using namespace std;
+
+#pragma warning(push)
+#pragma warning(disable : 4996)
+
+void test_volatile_inc_dec() {
+    volatile atomic<int> ai{10};
+    (void) ai++;
+    (void) ++ai;
+    (void) ai--;
+    (void) --ai;
+
+    int arr[5] = {0};
+    volatile atomic<int*> ap{arr};
+    (void) ap++;
+    (void) ++ap;
+    (void) ap--;
+    (void) --ap;
+}
+
+#if _HAS_CXX20
+void test_volatile_wait_notify() {
+    volatile atomic<int> ai{0};
+    ai.notify_one();
+    ai.notify_all();
+    ai.wait(1);
+
+    int dummy = 0;
+    volatile atomic<int*> ap{&dummy};
+    ap.notify_one();
+    ap.notify_all();
+    int other = 0;
+    ap.wait(&other);
+}
+#endif // _HAS_CXX20
+
+#pragma warning(pop)
+
+int main() {
+    test_volatile_inc_dec();
+#if _HAS_CXX20
+    test_volatile_wait_notify();
+#endif
+}

--- a/tests/std/tests/P1831R1_deprecated_volatile_atomic/test.cpp
+++ b/tests/std/tests/P1831R1_deprecated_volatile_atomic/test.cpp
@@ -1,13 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#define _SILENCE_CXX20_VOLATILE_DEPRECATION_WARNING
+
 #include <atomic>
 #include <cassert>
 
 using namespace std;
-
-#pragma warning(push)
-#pragma warning(disable : 4996)
 
 void test_volatile_inc_dec() {
     volatile atomic<int> ai{10};
@@ -39,8 +38,6 @@ void test_volatile_wait_notify() {
     ap.wait(&other);
 }
 #endif // _HAS_CXX20
-
-#pragma warning(pop)
 
 int main() {
     test_volatile_inc_dec();


### PR DESCRIPTION
Resolves [LWG 3417 (Missing volatile atomic deprecations)](https://cplusplus.github.io/LWG/issue3417) adding deprecation checks to `volatile` atomic increment/decrement operators as well as `wait`/`notify` operations when `is_always_lock_free` is false.

Close #6312