### PR TITLE
Test: Remove broken `TEST_EVERYTHING` branch from `P0896R4_views_elements`

### DIFF
--- a/tests/std/tests/P0896R4_views_elements/test.cpp
+++ b/tests/std/tests/P0896R4_views_elements/test.cpp
@@ -365,9 +365,6 @@ using test_range =
         test::ProxyRef::no>;
 
 constexpr void instantiation_test() {
-#ifdef TEST_EVERYTHING
-    test_in<instantiator, const P>();
-#else // ^^^ test all input range permutations / test only "interesting" permutations vvv
     // The view is sensitive to category, commonality, size, and differencing, but cannot handle proxies.
     using test::Common, test::Sized;
 
@@ -391,7 +388,6 @@ constexpr void instantiation_test() {
     instantiator::call<test_range<contiguous_iterator_tag, Sized::no, Common::yes>>();
     instantiator::call<test_range<contiguous_iterator_tag, Sized::yes, Common::no>>();
     instantiator::call<test_range<contiguous_iterator_tag, Sized::yes, Common::yes>>();
-#endif // TEST_EVERYTHING
 }
 
 // GH-3014 "<ranges>: list-initialization is misused"


### PR DESCRIPTION
Fixes #6237.

This removes the `TEST_EVERYTHING` branch from `P0896R4_views_elements`.

That branch tries to instantiate proxy-reference ranges, but those references aren't tuple-like and can't satisfy `elements_view`'s constraints. The existing explicit matrix already covers the relevant non-proxy combinations, so it now runs regardless of whether `TEST_EVERYTHING` is defined.

Validation:
- Built and ran `P0896R4_views_elements` normally with `/W4 /WX`.
- Built and ran it again with `/DTEST_EVERYTHING /W4 /WX`.
- Both configurations passed.

AI disclosure: OpenAI Codex with GPT-5.6 Sol was used to inspect the issue and apply this four-line test-only deletion. I reviewed the final diff and test results before submission.