### PR TITLE
`<optional>`: Remove stale LWG-3627 comments

### DIFF
--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -1037,7 +1037,7 @@ _CONSTEXPR20 void swap(optional<_Ty>& _Left, optional<_Ty>& _Right) noexcept(noe
     _Left.swap(_Right);
 }
 
-_EXPORT_STD template <class _Ty, enable_if_t<is_constructible_v<decay_t<_Ty>, _Ty>, int> = 0> // LWG-3627
+_EXPORT_STD template <class _Ty, enable_if_t<is_constructible_v<decay_t<_Ty>, _Ty>, int> = 0>
 _NODISCARD constexpr optional<decay_t<_Ty>> make_optional(_Ty&& _Value)
     noexcept(noexcept(optional<decay_t<_Ty>>{_STD forward<_Ty>(_Value)})) /* strengthened */ {
     return optional<decay_t<_Ty>>{_STD forward<_Ty>(_Value)};

--- a/tests/std/tests/GH_002299_implicit_sfinae_constraints/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002299_implicit_sfinae_constraints/test.compile.pass.cpp
@@ -76,7 +76,7 @@ template <class T, class... Us>
 constexpr bool can_make_optional_usual = can_make_optional_impl<void, T, Us...>;
 
 STATIC_ASSERT(can_make_optional_decay<unique_ptr<int>>);
-STATIC_ASSERT(!can_make_optional_decay<const unique_ptr<int>&>); // LWG-3627
+STATIC_ASSERT(!can_make_optional_decay<const unique_ptr<int>&>);
 STATIC_ASSERT(can_make_optional_usual<int, int>);
 STATIC_ASSERT(!can_make_optional_usual<int, int, int>);
 STATIC_ASSERT(!can_make_optional_usual<int, initializer_list<int>&>);


### PR DESCRIPTION
The resolution for LWG-3627 was already implemented in #2607, so the remaining
comments are no longer needed.

This PR removes the two stale `LWG-3627` comments from `<optional>` and its
test. There are no behavior changes.

No tests were run because this is a comment-only change.

Fixes #5851.

AI assistance: I used Codex to find the comments and help prepare this PR.
I've reviewed and understand the change.
