### PR TITLE
Toolset update: MSVC Compiler 19.52.36629

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,9 @@ cmake_minimum_required(VERSION 4.3.1)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 
-if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.52.36615")
-    message(FATAL_ERROR "The STL must be built with MSVC Compiler 19.52.36615 or later. Follow the README instructions.")
+set(expected_msvc_compiler_version "19.52.36629")
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS expected_msvc_compiler_version)
+    message(FATAL_ERROR "The STL must be built with MSVC Compiler ${expected_msvc_compiler_version} or later. Follow the README instructions.")
 endif()
 
 include(CheckCXXSourceCompiles)

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
   + **You must install the Insiders IDE and the Preview build tools for STL development.** *See Note 1 below.*
   + Select the "Desktop development with C++" workload.
   + Select the following components at a minimum:
+    - "MSVC Build Tools for x64/x86 (Latest)" <!-- TRANSITION, DevCom-11142709 -->
     - "MSVC Build Tools for x64/x86 (Preview)"
     - "C++ CMake tools for Windows"
     - "MSVC AddressSanitizer"

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
     - "Windows 11 SDK (10.0.28000)" or later
     - "C++ Clang tools for Windows (22.1.3 - x64/x86)"
     - *Optional, see Note 2 below:* "MSVC Build Tools for ARM64/ARM64EC (Preview)"
-* Install [Python][] 3.14.6 or later.
+* Install [Python][] 3.14.7 or later.
   + Select "Add python.exe to PATH" if you want to follow the instructions below that invoke `python`.
     Otherwise, you should be familiar with alternative methods.
 

--- a/azure-devops/config.yml
+++ b/azure-devops/config.yml
@@ -5,16 +5,16 @@
 
 variables:
 - name: x64SlowPoolName
-  value: 'Stl-2026-07-28T0154-x64-Fasv6-Pool'
+  value: 'Stl-2026-08-25T2113-x64-Fasv6-Pool'
   readonly: true
 - name: x64MediumPoolName
-  value: 'Stl-2026-07-28T0154-x64-Fasv7-Pool'
+  value: 'Stl-2026-08-25T2113-x64-Fasv7-Pool'
   readonly: true
 - name: x64FastPoolName
-  value: 'Stl-2026-07-28T0154-x64-Fadsv7-Pool'
+  value: 'Stl-2026-08-25T2113-x64-Fadsv7-Pool'
   readonly: true
 - name: arm64PoolName
-  value: 'Stl-2026-07-28T0154-arm64-Dpdsv6-Pool'
+  value: 'Stl-2026-08-25T2113-arm64-Dpdsv6-Pool'
   readonly: true
 - name: poolDemands
   value: 'EnableSpotVM -equals false'

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -65,7 +65,7 @@ if ($VMSku -ieq 'Fasv6') {
   $AvailableLocations = @('australiaeast', 'southcentralus')
 }
 
-$AvailableLocationIdx = 13 # Increment for each new set of pools, to cycle through the available locations.
+$AvailableLocationIdx = 14 # Increment for each new set of pools, to cycle through the available locations.
 $Location = $AvailableLocations[$AvailableLocationIdx % $AvailableLocations.Length]
 
 if ($Arch -ieq 'x64') {

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -58,9 +58,9 @@ foreach ($workload in $VisualStudioWorkloads) {
 
 # https://github.com/PowerShell/PowerShell/releases/latest
 if ($Provisioning_x64) {
-  $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.6.4/PowerShell-7.6.4-win-x64.msi'
+  $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.6.5/PowerShell-7.6.5-win-x64.msi'
 } else {
-  $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.6.4/PowerShell-7.6.4-win-arm64.msi'
+  $PowerShellUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.6.5/PowerShell-7.6.5-win-arm64.msi'
 }
 $PowerShellArgs = @('/quiet', '/norestart')
 

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -66,9 +66,9 @@ $PowerShellArgs = @('/quiet', '/norestart')
 
 # https://www.python.org
 if ($Provisioning_x64) {
-  $PythonUrl = 'https://www.python.org/ftp/python/3.14.6/python-3.14.6-amd64.exe'
+  $PythonUrl = 'https://www.python.org/ftp/python/3.14.7/python-3.14.7-amd64.exe'
 } else {
-  $PythonUrl = 'https://www.python.org/ftp/python/3.14.6/python-3.14.6-arm64.exe'
+  $PythonUrl = 'https://www.python.org/ftp/python/3.14.7/python-3.14.7-arm64.exe'
 }
 $PythonArgs = @('/quiet', 'InstallAllUsers=1', 'PrependPath=1', 'CompileAll=1', 'Include_doc=0')
 

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -42,6 +42,7 @@ $VisualStudioWorkloads = @(
   'Microsoft.VisualStudio.Component.VC.Preview.ARM64',
   'Microsoft.VisualStudio.Component.VC.Preview.CLI.Support',
   'Microsoft.VisualStudio.Component.VC.Preview.Tools.x86.x64',
+  'Microsoft.VisualStudio.Component.VC.Tools.x86.x64', # TRANSITION, DevCom-11142709
   'Microsoft.VisualStudio.Component.Windows11SDK.28000'
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-find_package(Python "3.14.6" REQUIRED COMPONENTS Interpreter)
+find_package(Python "3.14.7" REQUIRED COMPONENTS Interpreter)
 
 set(STL_BUILD_ROOT "${PROJECT_BINARY_DIR}/out")
 set(STL_SOURCE_DIR "${PROJECT_SOURCE_DIR}")

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -496,32 +496,6 @@ std/algorithms/robust_against_adl.compile.pass.cpp:1 FAIL
 std/language.support/support.rtti/type.info/type_info.equal.pass.cpp:0 FAIL
 std/language.support/support.rtti/type.info/type_info.equal.pass.cpp:1 FAIL
 
-# VSO-2338829 constexpr error "subtracting pointers to elements of different arrays" in _String_const_iterator::_Verify_offset()
-std/strings/basic.string/string.modifiers/string_erase/iter.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_erase/iter.pass.cpp:1 FAIL
-std/strings/basic.string/string.modifiers/string_erase/iter_iter.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_erase/iter_iter.pass.cpp:1 FAIL
-std/strings/basic.string/string.modifiers/string_insert/iter_iter_iter.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_insert/iter_iter_iter.pass.cpp:1 FAIL
-std/strings/basic.string/string.modifiers/string_insert/iter_size_char.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_insert/iter_size_char.pass.cpp:1 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_iter_iter.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_iter_iter.pass.cpp:1 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_pointer.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_pointer.pass.cpp:1 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_pointer_size.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_pointer_size.pass.cpp:1 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_size_char.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_size_char.pass.cpp:1 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_string.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_string.pass.cpp:1 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_string_view.pass.cpp:0 FAIL
-std/strings/basic.string/string.modifiers/string_replace/iter_iter_string_view.pass.cpp:1 FAIL
-std/strings/strings.erasure/erase_if.pass.cpp:0 FAIL
-std/strings/strings.erasure/erase_if.pass.cpp:1 FAIL
-std/strings/strings.erasure/erase.pass.cpp:0 FAIL
-std/strings/strings.erasure/erase.pass.cpp:1 FAIL
-
 # VSO-2338880 constexpr error in vector::iterator's _Compat() check when using views::transform
 std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.pass.cpp:0 FAIL
 std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.pass.cpp:1 FAIL

--- a/tests/libcxx/usual_matrix.lst
+++ b/tests/libcxx/usual_matrix.lst
@@ -6,5 +6,5 @@ RUNALL_CROSSLIST
 *	PM_CL="/EHsc /MTd /std:c++latest /permissive- /utf-8 /FImsvc_stdlib_force_include.h /wd4643"
 RUNALL_CROSSLIST
 PM_CL="/Zc:preprocessor"
-ASAN	PM_CL="-fsanitize=address /Zi" PM_LINK="/debug"
+ASAN	PM_CL="/Zc:preprocessor -fsanitize=address /Zi" PM_LINK="/debug"
 PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call"


### PR DESCRIPTION
* libcxx/usual_matrix.lst: Add `/Zc:preprocessor` to ASan, missed in #4052.
* libcxx/expected_results.txt: Enable passing tests.
  + VSO-2338829 "constexpr error 'subtracting pointers to elements of different arrays' in `_String_const_iterator::_Verify_offset()`" was fixed by MSVC-PR-760585 on 2026-07-24 and a regression test was added by MSVC-PR-773972 on 2026-08-25.
* Cycle locations.
* Python 3.14.7.
* PowerShell 7.6.5.
* MSVC Compiler 19.52.36629, centralize version.
  + As requested by @davidmrdavid in https://github.com/microsoft/STL/pull/6385#discussion_r3677862513.
* Work around DevCom-11142709 "MSVC Build Tools Preview omits vcvars batch files unless Latest is installed".
* New pools.

[STL-ASan-CI passed.](https://dev.azure.com/vclibs/STL/_build/results?buildId=20992&view=results)