### PR TITLE
P4037R1: Supporting signed char and unsigned char in random number generation

### DIFF
--- a/stl/inc/random
+++ b/stl/inc/random
@@ -42,11 +42,10 @@ _STD_BEGIN
         "unsigned short, unsigned int, unsigned long, or unsigned long long");                                        \
     _RNG_PROHIBIT_CHAR(_CheckedType)
 
-#define _RNG_REQUIRE_UINTTYPE(_RandType, _CheckedType)                                                              \
-    static_assert(                                                                                                  \
-        _Is_any_of_v<_CheckedType, unsigned char, unsigned short, unsigned int, unsigned long, unsigned long long>, \
-        "invalid template argument for " #_RandType ": N5054 [rand.req.genl]/1.7 requires one of "                  \
-        "unsigned char, unsigned short, unsigned int, unsigned long, or unsigned long long");                       \
+#define _RNG_REQUIRE_UINTTYPE(_RandType, _CheckedType)                                                         \
+    static_assert(_Is_any_of_v<_CheckedType, unsigned short, unsigned int, unsigned long, unsigned long long>, \
+        "invalid template argument for " #_RandType ": N5054 [rand.req.genl]/1.7 requires one of "             \
+        "unsigned short, unsigned int, unsigned long, or unsigned long long");                                 \
     _RNG_PROHIBIT_CHAR(_CheckedType)
 
 template <class _Seed_seq, class _Self, class _Engine = _Self>

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -32,20 +32,20 @@ _STD_BEGIN
 #define _RNG_REQUIRE_REALTYPE(_RandType, _CheckedType)                    \
     static_assert(_Is_any_of_v<_CheckedType, float, double, long double>, \
         "invalid template argument for " #_RandType                       \
-        ": N4950 [rand.req.genl]/1.4 requires one of float, double, or long double")
+        ": N5054 [rand.req.genl]/1.5 requires one of float, double, or long double")
 
 #define _RNG_REQUIRE_INTTYPE(_RandType, _CheckedType)                                                                 \
     static_assert(_Is_any_of_v<_CheckedType, signed char, short, int, long, long long, unsigned char, unsigned short, \
                       unsigned int, unsigned long, unsigned long long>,                                               \
         "invalid template argument for " #_RandType                                                                   \
-        ": N4950 [rand.req.genl]/1.5 requires one of signed char, short, int, long, long long, unsigned char, "       \
+        ": N5054 [rand.req.genl]/1.6 requires one of signed char, short, int, long, long long, unsigned char, "       \
         "unsigned short, unsigned int, unsigned long, or unsigned long long");                                        \
     _RNG_PROHIBIT_CHAR(_CheckedType)
 
 #define _RNG_REQUIRE_UINTTYPE(_RandType, _CheckedType)                                                              \
     static_assert(                                                                                                  \
         _Is_any_of_v<_CheckedType, unsigned char, unsigned short, unsigned int, unsigned long, unsigned long long>, \
-        "invalid template argument for " #_RandType ": N4950 [rand.req.genl]/1.6 requires one of "                  \
+        "invalid template argument for " #_RandType ": N5054 [rand.req.genl]/1.7 requires one of "                  \
         "unsigned char, unsigned short, unsigned int, unsigned long, or unsigned long long");                       \
     _RNG_PROHIBIT_CHAR(_CheckedType)
 
@@ -1501,8 +1501,7 @@ public:
     template <class _Elem, class _Traits>
     friend basic_istream<_Elem, _Traits>& operator>>(
         basic_istream<_Elem, _Traits>& _Istr, uniform_int_distribution& _Dist) {
-        using _Read_ty = conditional_t<sizeof(result_type) == 1,
-            conditional_t<is_signed_v<result_type>, int, unsigned int>, result_type>;
+        using _Read_ty = decltype(+result_type{});
 
         _Read_ty _Min0;
         _Read_ty _Max0;

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -25,27 +25,28 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 
 _STD_BEGIN
-#define _RNG_PROHIBIT_CHAR(_CheckedType)               \
-    static_assert(!_Is_character<_CheckedType>::value, \
-        "note: char, signed char, unsigned char, char8_t, int8_t, and uint8_t are not allowed")
+#define _RNG_PROHIBIT_CHAR(_CheckedType)                                                                         \
+    static_assert(!_Is_character<_CheckedType>::value || _Is_any_of_v<_CheckedType, signed char, unsigned char>, \
+        "note: char, wchar_t, char8_t, char16_t, and char32_t are not allowed")
 
 #define _RNG_REQUIRE_REALTYPE(_RandType, _CheckedType)                    \
     static_assert(_Is_any_of_v<_CheckedType, float, double, long double>, \
         "invalid template argument for " #_RandType                       \
         ": N4950 [rand.req.genl]/1.4 requires one of float, double, or long double")
 
-#define _RNG_REQUIRE_INTTYPE(_RandType, _CheckedType)                                                                  \
-    static_assert(_Is_any_of_v<_CheckedType, short, int, long, long long, unsigned short, unsigned int, unsigned long, \
-                      unsigned long long>,                                                                             \
-        "invalid template argument for " #_RandType                                                                    \
-        ": N4950 [rand.req.genl]/1.5 requires one of short, int, long, long long, unsigned short, unsigned int, "      \
-        "unsigned long, or unsigned long long");                                                                       \
+#define _RNG_REQUIRE_INTTYPE(_RandType, _CheckedType)                                                                 \
+    static_assert(_Is_any_of_v<_CheckedType, signed char, short, int, long, long long, unsigned char, unsigned short, \
+                      unsigned int, unsigned long, unsigned long long>,                                               \
+        "invalid template argument for " #_RandType                                                                   \
+        ": N4950 [rand.req.genl]/1.5 requires one of signed char, short, int, long, long long, unsigned char, "       \
+        "unsigned short, unsigned int, unsigned long, or unsigned long long");                                        \
     _RNG_PROHIBIT_CHAR(_CheckedType)
 
-#define _RNG_REQUIRE_UINTTYPE(_RandType, _CheckedType)                                                             \
-    static_assert(_Is_any_of_v<_CheckedType, unsigned short, unsigned int, unsigned long, unsigned long long>,     \
-        "invalid template argument for " #_RandType ": N4950 [rand.req.genl]/1.6 requires one of unsigned short, " \
-        "unsigned int, unsigned long, or unsigned long long");                                                     \
+#define _RNG_REQUIRE_UINTTYPE(_RandType, _CheckedType)                                                              \
+    static_assert(                                                                                                  \
+        _Is_any_of_v<_CheckedType, unsigned char, unsigned short, unsigned int, unsigned long, unsigned long long>, \
+        "invalid template argument for " #_RandType ": N4950 [rand.req.genl]/1.6 requires one of "                  \
+        "unsigned char, unsigned short, unsigned int, unsigned long, or unsigned long long");                       \
     _RNG_PROHIBIT_CHAR(_CheckedType)
 
 template <class _Seed_seq, class _Self, class _Engine = _Self>
@@ -1500,17 +1501,21 @@ public:
     template <class _Elem, class _Traits>
     friend basic_istream<_Elem, _Traits>& operator>>(
         basic_istream<_Elem, _Traits>& _Istr, uniform_int_distribution& _Dist) {
-        uniform_int_distribution::result_type _Min0;
-        uniform_int_distribution::result_type _Max0;
+        using _Read_ty = conditional_t<sizeof(result_type) == 1,
+            conditional_t<is_signed_v<result_type>, int, unsigned int>, result_type>;
+
+        _Read_ty _Min0;
+        _Read_ty _Max0;
+
         _Istr >> _Min0 >> _Max0;
-        _Dist._Par._Init(_Min0, _Max0);
+        _Dist._Par._Init(static_cast<result_type>(_Min0), static_cast<result_type>(_Max0));
         return _Istr;
     }
 
     template <class _Elem, class _Traits>
     friend basic_ostream<_Elem, _Traits>& operator<<(
         basic_ostream<_Elem, _Traits>& _Ostr, const uniform_int_distribution& _Dist) {
-        return _Ostr << _Dist._Par._Min << ' ' << _Dist._Par._Max;
+        return _Ostr << +_Dist._Par._Min << ' ' << +_Dist._Par._Max;
     }
 
     _NODISCARD friend bool operator==(

--- a/tests/std/tests/GH_000178_uniform_int/test.cpp
+++ b/tests/std/tests/GH_000178_uniform_int/test.cpp
@@ -4,7 +4,9 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <limits>
 #include <random>
+#include <sstream>
 
 using namespace std;
 
@@ -63,6 +65,39 @@ bool test_modulus_bias() {
     return chi_squared <= threshold;
 }
 
+template <class IntType>
+bool test_8bit_distribution() {
+    mt19937 gen(1337);
+
+    constexpr IntType min_val = (numeric_limits<IntType>::min)();
+    constexpr IntType max_val = (numeric_limits<IntType>::max)();
+
+    uniform_int_distribution<IntType> dist_full(min_val, max_val);
+    assert(dist_full.a() == min_val);
+    assert(dist_full.b() == max_val);
+
+    for (int i = 0; i < 100; ++i) {
+        const IntType val = dist_full(gen);
+        assert(val >= min_val && val <= max_val);
+    }
+
+    stringstream ss;
+    ss << dist_full;
+
+    uniform_int_distribution<IntType> dist_io(0, 0);
+    ss >> dist_io;
+    assert(dist_full == dist_io);
+
+    return true;
+}
+
+bool test_p4037r1_char_types() {
+    assert(test_8bit_distribution<signed char>());
+    assert(test_8bit_distribution<unsigned char>());
+
+    return true;
+}
+
 int main() {
     // Four cases tested below:
     // (1) URBG provides enough bits to completely fill the underlying type
@@ -75,6 +110,8 @@ int main() {
     assert((basic_test<independent_bits_engine<mt19937, 25, uint32_t>>()));
 
     assert(test_modulus_bias());
+
+    assert(test_p4037r1_char_types());
 
     return 0;
 }

--- a/tests/std/tests/P0024R2_parallel_algorithms_replace/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_replace/test.cpp
@@ -14,8 +14,8 @@ using namespace std::execution;
 
 void test_case_replace_parallel(const size_t testSize, mt19937& gen) {
     vector<char> actual(testSize);
-    uniform_int_distribution<int> dist('a', 'z');
-    generate(actual.begin(), actual.end(), [&]() { return static_cast<char>(dist(gen)); });
+    uniform_int_distribution<signed char> dist('a', 'z');
+    generate(actual.begin(), actual.end(), [&]() { return dist(gen); });
 
     vector<char> expected(actual);
     replace(expected.begin(), expected.end(), 'a', 'b');
@@ -25,8 +25,8 @@ void test_case_replace_parallel(const size_t testSize, mt19937& gen) {
 
 void test_case_replace_if_parallel(const size_t testSize, mt19937& gen) {
     vector<char> actual(testSize);
-    uniform_int_distribution<int> dist('a', 'z');
-    generate(actual.begin(), actual.end(), [&]() { return static_cast<char>(dist(gen)); });
+    uniform_int_distribution<signed char> dist('a', 'z');
+    generate(actual.begin(), actual.end(), [&]() { return dist(gen); });
 
     auto pred = [](char c) { return c == 'a'; };
 

--- a/tests/std/tests/P0220R1_searchers/test.cpp
+++ b/tests/std/tests/P0220R1_searchers/test.cpp
@@ -395,13 +395,13 @@ void test_case_randomized_cases() {
     string haystack(MaxHaystackLength, '?');
     const auto haystack_first = haystack.c_str();
 
-    for (int max_char = 'b'; max_char <= 'f'; ++max_char) {
-        uniform_int_distribution<int> characters('a', max_char);
+    for (char max_char = 'b'; max_char <= 'f'; ++max_char) {
+        uniform_int_distribution<signed char> characters('a', max_char);
 
         for (int n = 0; n < Needles; ++n) {
             needle.resize(needle_length(mt));
             for (auto& ch : needle) {
-                ch = static_cast<char>(characters(mt));
+                ch = characters(mt);
             }
             const auto needle_last = needle_first + needle.size();
 
@@ -412,7 +412,7 @@ void test_case_randomized_cases() {
             for (int h = 0; h < Haystacks; ++h) {
                 haystack.resize(haystack_length(mt));
                 for (auto& ch : haystack) {
-                    ch = static_cast<char>(characters(mt));
+                    ch = characters(mt);
                 }
                 const auto haystack_last = haystack_first + haystack.size();
 


### PR DESCRIPTION
Updated internal type constraints to allow signed char and unsigned char in `std::uniform_int_distribution` and the `operator<<` and `operator>>` stream overloads to handle 8-bit integer types properly.

Removed unnecessary historical workarounds.

Close #6240 