### PR TITLE
`<regex>`: Unwrap iterators in `match_results` overloads

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -2644,7 +2644,7 @@ _OutIt _Format_sed(const match_results<_BidIt, _Alloc>& _Match, _OutIt _Out, _In
 
 template <class _It, class _Elem, class _RxTraits>
 bool _Regex_match2(_It _First, _It _Last, const basic_regex<_Elem, _RxTraits>& _Re,
-    regex_constants::match_flag_type _Flgs) { // try to match regular expression to target text
+    const regex_constants::match_flag_type _Flgs) { // try to match regular expression to target text
     static_assert(_Is_ranges_bidi_iter_v<_It>,
         "regex_match requires bidirectional iterators or stronger. See N5014 [re.alg.match]/1.");
 
@@ -2662,7 +2662,7 @@ bool _Regex_match2(_It _First, _It _Last, const basic_regex<_Elem, _RxTraits>& _
 
 template <class _BidIt, class _Alloc, class _Elem, class _RxTraits>
 bool _Regex_match2(_BidIt _First, _BidIt _Last, match_results<_BidIt, _Alloc>& _Matches,
-    const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs) {
+    const basic_regex<_Elem, _RxTraits>& _Re, const regex_constants::match_flag_type _Flgs) {
     // try to match regular expression to target text
     static_assert(_Is_ranges_bidi_iter_v<_BidIt>,
         "regex_match requires bidirectional iterators or stronger. See N5014 [re.alg.match]/1.");

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -2122,15 +2122,6 @@ public:
         _Mflags |= _Mf;
     }
 
-    void _Clearf(regex_constants::match_flag_type _Mf) { // clear specified flags
-        _Mflags &= ~_Mf;
-    }
-
-    bool _Match2(_It _Pfirst) { // try to match
-        _Begin = _Pfirst;
-        return _Match2();
-    }
-
     bool _Match2() { // try to match
         _Tgt_state._Cur = _Begin;
         _Frames_count   = 0;
@@ -2139,10 +2130,9 @@ public:
         return _Match_pat(_Start) || _Matched;
     }
 
+    bool _Search();
     template <class _BidIt, class _Alsubmatch>
-    void _Copy_captures(match_results<_BidIt, _Alsubmatch>& _Matches);
-
-    _It _Skip(_It _First, _It _Last, const _Node_base* _Node_arg = nullptr, unsigned int _Recursion_depth = 0U);
+    void _Copy_captures2(match_results<_BidIt, _Alsubmatch>& _Matches, _BidIt _Orig_last);
 
 private:
     long long _Complexity_limit;
@@ -2180,6 +2170,7 @@ private:
     bool _Better_match();
     bool _Is_wbound() const;
     typename _RxTraits::char_class_type _Lookup_char_class(_Elem) const;
+    _It _Skip2(_It _First, _It _Last, const _Node_base* _Nx, unsigned int _Recursion_depth);
 
 public:
     _Matcher3(const _Matcher3&)            = delete;
@@ -2651,17 +2642,11 @@ _OutIt _Format_sed(const match_results<_BidIt, _Alloc>& _Match, _OutIt _Out, _In
     return _Out;
 }
 
-template <class _BidIt, class _Alloc, class _Elem, class _RxTraits, class _It>
-bool _Regex_match2(const _It _First, const _It _Last, match_results<_BidIt, _Alloc>* const _Matches,
-    const basic_regex<_Elem, _RxTraits>& _Re, const regex_constants::match_flag_type _Flgs) {
-    // try to match regular expression to target text
+template <class _It, class _Elem, class _RxTraits>
+bool _Regex_match2(_It _First, _It _Last, const basic_regex<_Elem, _RxTraits>& _Re,
+    regex_constants::match_flag_type _Flgs) { // try to match regular expression to target text
     static_assert(_Is_ranges_bidi_iter_v<_It>,
         "regex_match requires bidirectional iterators or stronger. See N5014 [re.alg.match]/1.");
-
-    if (_Matches) { // clear _Matches before doing work
-        _Matches->_Ready = true;
-        _Matches->_Resize(0);
-    }
 
     if (_Re._Empty()) {
         return false;
@@ -2672,16 +2657,37 @@ bool _Regex_match2(const _It _First, const _It _Last, match_results<_BidIt, _All
     _Matcher3<_Elem, _RxTraits, _It, void> _Mx(
         _First, _Last, _Re._Get_traits(), _Re._Get(), _Re.mark_count() + 1, _Re.flags(), _Flgs, _Stackbuf, true);
 
+    return _Mx._Match2();
+}
+
+template <class _BidIt, class _Alloc, class _Elem, class _RxTraits>
+bool _Regex_match2(_BidIt _First, _BidIt _Last, match_results<_BidIt, _Alloc>& _Matches,
+    const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs) {
+    // try to match regular expression to target text
+    static_assert(_Is_ranges_bidi_iter_v<_BidIt>,
+        "regex_match requires bidirectional iterators or stronger. See N5014 [re.alg.match]/1.");
+    using _It = _Remove_cvref_t<decltype(_STD _Get_unwrapped(_First))>;
+
+    // clear _Matches before doing work
+    _Matches._Ready = true;
+    _Matches._Resize(0);
+
+    if (_Re._Empty()) {
+        return false;
+    }
+
+    alignas(_Loop_vals_v3_t<_Iter_diff_t<_It>>) alignas(_Rx_capture_range_t<_It>) //
+        alignas(_Rx_state_frame_t<_It>) unsigned char _Stackbuf[4096];
+    _Matcher3<_Elem, _RxTraits, _It, void> _Mx(_STD _Get_unwrapped(_First), _STD _Get_unwrapped(_Last),
+        _Re._Get_traits(), _Re._Get(), _Re.mark_count() + 1, _Re.flags(), _Flgs, _Stackbuf, true);
+
     if (!_Mx._Match2()) {
         return false;
     }
 
-    if (_Matches) {
-        _Mx._Copy_captures(*_Matches);
-        _Matches->_Org           = _First;
-        _Matches->_Pfx().first   = _First;
-        _Matches->_Pfx().matched = _Matches->_Pfx().first != _Matches->_Pfx().second;
-    }
+    _Matches._Org         = _First;
+    _Matches._Pfx().first = _STD move(_First);
+    _Mx._Copy_captures2(_Matches, _STD move(_Last));
 
     return true;
 }
@@ -2691,7 +2697,7 @@ bool regex_match(_BidIt _First, _BidIt _Last, match_results<_BidIt, _Alloc>& _Ma
     const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // try to match regular expression to target text
     _STD _Adl_verify_range(_First, _Last);
-    return _STD _Regex_match2(_First, _Last, _STD addressof(_Matches), _Re, _Flgs);
+    return _STD _Regex_match2(_First, _Last, _Matches, _Re, _Flgs);
 }
 
 _EXPORT_STD template <class _BidIt, class _Elem, class _RxTraits>
@@ -2699,25 +2705,24 @@ _NODISCARD bool regex_match(_BidIt _First, _BidIt _Last, const basic_regex<_Elem
     regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // try to match regular expression to target text
     _STD _Adl_verify_range(_First, _Last);
-    return _STD _Regex_match2(_Get_unwrapped(_First), _Get_unwrapped(_Last),
-        static_cast<match_results<_Unwrapped_t<const _BidIt&>>*>(nullptr), _Re, _Flgs | regex_constants::match_any);
+    return _STD _Regex_match2(
+        _STD _Get_unwrapped(_First), _STD _Get_unwrapped(_Last), _Re, _Flgs | regex_constants::match_any);
 }
 
 _EXPORT_STD template <class _Elem, class _RxTraits>
 _NODISCARD bool regex_match(_In_z_ const _Elem* _Str, const basic_regex<_Elem, _RxTraits>& _Re,
     regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // try to match regular expression to target text
-    const _Elem* _Last = _Str + char_traits<_Elem>::length(_Str);
-    return _STD _Regex_match2(
-        _Str, _Last, static_cast<match_results<const _Elem*>*>(nullptr), _Re, _Flgs | regex_constants::match_any);
+    const auto _Last = _Str + char_traits<_Elem>::length(_Str);
+    return _STD _Regex_match2(_Str, _Last, _Re, _Flgs | regex_constants::match_any);
 }
 
 _EXPORT_STD template <class _Elem, class _Alloc, class _RxTraits>
 bool regex_match(_In_z_ const _Elem* _Str, match_results<const _Elem*, _Alloc>& _Matches,
     const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // try to match regular expression to target text
-    const _Elem* _Last = _Str + char_traits<_Elem>::length(_Str);
-    return _STD _Regex_match2(_Str, _Last, _STD addressof(_Matches), _Re, _Flgs);
+    const auto _Last = _Str + char_traits<_Elem>::length(_Str);
+    return _STD _Regex_match2(_Str, _Last, _Matches, _Re, _Flgs);
 }
 
 _EXPORT_STD template <class _StTraits, class _StAlloc, class _Alloc, class _Elem, class _RxTraits>
@@ -2725,7 +2730,7 @@ bool regex_match(const basic_string<_Elem, _StTraits, _StAlloc>& _Str,
     match_results<typename basic_string<_Elem, _StTraits, _StAlloc>::const_iterator, _Alloc>& _Matches,
     const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // try to match regular expression to target text
-    return _STD _Regex_match2(_Str.begin(), _Str.end(), _STD addressof(_Matches), _Re, _Flgs);
+    return _STD _Regex_match2(_Str.begin(), _Str.end(), _Matches, _Re, _Flgs);
 }
 
 _EXPORT_STD template <class _StTraits, class _StAlloc, class _Alloc, class _Elem, class _RxTraits>
@@ -2737,57 +2742,60 @@ _EXPORT_STD template <class _StTraits, class _StAlloc, class _Elem, class _RxTra
 _NODISCARD bool regex_match(const basic_string<_Elem, _StTraits, _StAlloc>& _Str,
     const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // try to match regular expression to target text
-    return _STD _Regex_match2(_Str.data(), _Str.data() + _Str.size(),
-        static_cast<match_results<const _Elem*>*>(nullptr), _Re, _Flgs | regex_constants::match_any);
+    auto _First = _Str.data();
+    return _STD _Regex_match2(_First, _First + _Str.size(), _Re, _Flgs | regex_constants::match_any);
 }
 
-template <class _BidIt, class _Alloc, class _Elem, class _RxTraits, class _It>
-bool _Regex_search3(_It _First, _It _Last, match_results<_BidIt, _Alloc>* _Matches,
-    const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs) {
+template <class _It, class _Elem, class _RxTraits>
+bool _Regex_search3(const _It _First, const _It _Last, const basic_regex<_Elem, _RxTraits>& _Re,
+    const regex_constants::match_flag_type _Flgs) {
     // search for regular expression match in target text
     static_assert(_Is_ranges_bidi_iter_v<_It>,
         "regex_search requires bidirectional iterators or stronger. See N5014 [re.alg.search]/1.");
 
-    if (_Matches) { // clear _Matches before doing work
-        _Matches->_Ready = true;
-        _Matches->_Resize(0);
-    }
-
     if (_Re._Empty()) {
         return false;
     }
-
-    bool _Found      = false;
-    const _It _Begin = _First;
 
     alignas(_Loop_vals_v3_t<_Iter_diff_t<_It>>) alignas(_Rx_capture_range_t<_It>) //
         alignas(_Rx_state_frame_t<_It>) unsigned char _Stackbuf[4096];
     _Matcher3<_Elem, _RxTraits, _It, void> _Mx(
         _First, _Last, _Re._Get_traits(), _Re._Get(), _Re.mark_count() + 1, _Re.flags(), _Flgs, _Stackbuf, false);
 
-    if (_Mx._Match2()) {
-        _Found = true;
-    } else if (_First != _Last && !(_Flgs & regex_constants::match_continuous)) { // try more on suffixes
-        _Mx._Setf(regex_constants::match_prev_avail);
-        _Mx._Clearf(regex_constants::_Match_not_null);
-        while ((_First = _Mx._Skip(++_First, _Last)) != _Last) {
-            if (_Mx._Match2(_First)) { // found match starting at _First
-                _Found = true;
-                break;
-            }
-        }
+    return _Mx._Search();
+}
 
-        if (!_Found && _Mx._Match2(_Last)) {
-            _Found = true;
-        }
+
+template <class _BidIt, class _Alloc, class _Elem, class _RxTraits>
+bool _Regex_search3(_BidIt _First, _BidIt _Last, match_results<_BidIt, _Alloc>& _Matches,
+    const basic_regex<_Elem, _RxTraits>& _Re, const regex_constants::match_flag_type _Flgs) {
+    // search for regular expression match in target text
+    static_assert(_Is_ranges_bidi_iter_v<_BidIt>,
+        "regex_search requires bidirectional iterators or stronger. See N5014 [re.alg.search]/1.");
+
+    using _It = _Remove_cvref_t<decltype(_STD _Get_unwrapped(_First))>;
+
+    // clear _Matches before doing work
+    _Matches._Ready = true;
+    _Matches._Resize(0);
+
+    if (_Re._Empty()) {
+        return false;
     }
 
-    if (_Found && _Matches) { // update _Matches
-        _Mx._Copy_captures(*_Matches);
-        _Matches->_Pfx().first   = _Begin;
-        _Matches->_Pfx().matched = _Matches->_Pfx().first != _Matches->_Pfx().second;
+    alignas(_Loop_vals_v3_t<_Iter_diff_t<_It>>) alignas(_Rx_capture_range_t<_It>) //
+        alignas(_Rx_state_frame_t<_It>) unsigned char _Stackbuf[4096];
+    _Matcher3<_Elem, _RxTraits, _It, void> _Mx(_STD _Get_unwrapped(_First), _STD _Get_unwrapped(_Last),
+        _Re._Get_traits(), _Re._Get(), _Re.mark_count() + 1, _Re.flags(), _Flgs, _Stackbuf, false);
+
+    if (!_Mx._Search()) {
+        return false;
     }
-    return _Found;
+
+    // update _Matches
+    _Matches._Pfx().first = _STD move(_First);
+    _Mx._Copy_captures2(_Matches, _STD move(_Last));
+    return true;
 }
 
 _EXPORT_STD template <class _BidIt, class _Alloc, class _Elem, class _RxTraits>
@@ -2796,7 +2804,7 @@ bool regex_search(_BidIt _First, _BidIt _Last, match_results<_BidIt, _Alloc>& _M
     // search for regular expression match in target text
     _STD _Adl_verify_range(_First, _Last);
     _Matches._Org = _First;
-    return _STD _Regex_search3(_First, _Last, _STD addressof(_Matches), _Re, _Flgs);
+    return _STD _Regex_search3(_First, _Last, _Matches, _Re, _Flgs);
 }
 
 _EXPORT_STD template <class _BidIt, class _Elem, class _RxTraits>
@@ -2804,16 +2812,15 @@ _NODISCARD bool regex_search(_BidIt _First, _BidIt _Last, const basic_regex<_Ele
     regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // search for regular expression match in target text
     _STD _Adl_verify_range(_First, _Last);
-    return _STD _Regex_search3(_Get_unwrapped(_First), _Get_unwrapped(_Last),
-        static_cast<match_results<_Unwrapped_t<const _BidIt&>>*>(nullptr), _Re, _Flgs | regex_constants::match_any);
+    return _STD _Regex_search3(
+        _STD _Get_unwrapped(_First), _STD _Get_unwrapped(_Last), _Re, _Flgs | regex_constants::match_any);
 }
 
 _EXPORT_STD template <class _Elem, class _RxTraits>
 _NODISCARD bool regex_search(_In_z_ const _Elem* _Str, const basic_regex<_Elem, _RxTraits>& _Re,
     regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // search for regular expression match in target text
-    return _STD _Regex_search3(_Str, _Str + char_traits<_Elem>::length(_Str),
-        static_cast<match_results<const _Elem*>*>(nullptr), _Re, _Flgs | regex_constants::match_any);
+    return _STD _Regex_search3(_Str, _Str + char_traits<_Elem>::length(_Str), _Re, _Flgs | regex_constants::match_any);
 }
 
 _EXPORT_STD template <class _Elem, class _Alloc, class _RxTraits>
@@ -2821,7 +2828,7 @@ bool regex_search(_In_z_ const _Elem* _Str, match_results<const _Elem*, _Alloc>&
     const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // search for regular expression match in target text
     _Matches._Org = _Str;
-    return _STD _Regex_search3(_Str, _Str + char_traits<_Elem>::length(_Str), _STD addressof(_Matches), _Re, _Flgs);
+    return _STD _Regex_search3(_Str, _Str + char_traits<_Elem>::length(_Str), _Matches, _Re, _Flgs);
 }
 
 _EXPORT_STD template <class _StTraits, class _StAlloc, class _Alloc, class _Elem, class _RxTraits>
@@ -2831,7 +2838,7 @@ bool regex_search(const basic_string<_Elem, _StTraits, _StAlloc>& _Str,
     // search for regular expression match in target text
     auto _First   = _Str.begin();
     _Matches._Org = _First;
-    return _STD _Regex_search3(_First, _Str.end(), _STD addressof(_Matches), _Re, _Flgs);
+    return _STD _Regex_search3(_First, _Str.end(), _Matches, _Re, _Flgs);
 }
 
 _EXPORT_STD template <class _StTraits, class _StAlloc, class _Alloc, class _Elem, class _RxTraits>
@@ -2843,12 +2850,8 @@ _EXPORT_STD template <class _StTraits, class _StAlloc, class _Elem, class _RxTra
 _NODISCARD bool regex_search(const basic_string<_Elem, _StTraits, _StAlloc>& _Str,
     const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // search for regular expression match in target text
-    using _Iter = typename basic_string<_Elem, _StTraits, _StAlloc>::const_pointer;
-
-    _Iter _First = _Str.c_str();
-    _Iter _Last  = _First + _Str.size();
-    return _STD _Regex_search3(
-        _First, _Last, static_cast<match_results<_Iter>*>(nullptr), _Re, _Flgs | regex_constants::match_any);
+    const auto _First = _Str.data();
+    return _STD _Regex_search3(_First, _First + _Str.size(), _Re, _Flgs | regex_constants::match_any);
 }
 
 template <class _OutIt, class _BidIt, class _RxTraits, class _Elem, class _Traits, class _Alloc>
@@ -2863,9 +2866,7 @@ _OutIt _Regex_replace1(_OutIt _Result, _BidIt _First, _BidIt _Last, const basic_
     regex_constants::match_flag_type _Not_null{};
 
     _Matches._Org = _Pos;
-    while (_STD _Regex_search3(_Pos, _Last, _STD addressof(_Matches), _Re, _Flags | _Not_null)) {
-
-        // replace at each match
+    while (_STD _Regex_search3(_Pos, _Last, _Matches, _Re, _Flags | _Not_null)) { // replace at each match
         if (!(_Flgs & regex_constants::format_no_copy)) {
             _Result = _STD copy(_Matches.prefix().first, _Matches.prefix().second, _Result);
         }
@@ -2969,7 +2970,7 @@ public:
         : _Begin(_First), _End(_Last), _MyRe(_STD addressof(_Re)), _Flags(_Fl) {
         _STD _Adl_verify_range(_Begin, _End);
         _MyVal._Org = _Begin;
-        if (!_STD _Regex_search3(_Begin, _End, _STD addressof(_MyVal), *_MyRe, _Flags)) {
+        if (!_STD _Regex_search3(_Begin, _End, _MyVal, *_MyRe, _Flags)) {
             _MyRe = nullptr;
         } else {
             this->_Adopt(_MyRe);
@@ -3029,7 +3030,7 @@ public:
 
             // _Adl_verify_range(_Start, _End) checked in constructor
             if (_Start == _End
-                || !_STD _Regex_search3(_Start, _End, _STD addressof(_MyVal), *_MyRe,
+                || !_STD _Regex_search3(_Start, _End, _MyVal, *_MyRe,
                     _Flags | regex_constants::_Match_not_null)) { // store end-of-sequence iterator
                 _MyRe = nullptr;
 
@@ -3050,7 +3051,7 @@ public:
         _Flags |= regex_constants::match_prev_avail;
 
         // _Adl_verify_range(_Start, _End) checked in constructor
-        if (!_STD _Regex_search3(_Start, _End, _STD addressof(_MyVal), *_MyRe, _Flags)) {
+        if (!_STD _Regex_search3(_Start, _End, _MyVal, *_MyRe, _Flags)) {
             // mark at end of sequence
             _MyRe = nullptr;
 
@@ -4845,37 +4846,55 @@ bool _Matcher3<_Elem, _RxTraits, _It, _Alloc>::_Match_pat(_Node_base* _Nx) { // 
     return !_Failed;
 }
 
+template <class _Iter, class _UIter>
+constexpr void _Assign_wrapped(_Iter& _It, _UIter&& _UIt, const _Iter& _It_in_range) {
+    if constexpr (_Wrapped_seekable_v<_Iter, _UIter>) {
+        _It = _It_in_range;
+        _It._Seek_to(_STD forward<_UIter>(_UIt));
+    } else {
+        _It = _STD forward<_UIter>(_UIt);
+    }
+}
+
 template <class _Elem, class _RxTraits, class _It, class _Alloc>
 template <class _BidIt, class _Alsubmatch>
-void _Matcher3<_Elem, _RxTraits, _It, _Alloc>::_Copy_captures(match_results<_BidIt, _Alsubmatch>& _Matches) {
-    // copy captures into match_results
+void _Matcher3<_Elem, _RxTraits, _It, _Alloc>::_Copy_captures2(
+    match_results<_BidIt, _Alsubmatch>& _Matches, const _BidIt _Orig_last) { // copy captures into match_results
     _Matches._Resize(_Ncap);
     const auto& _Result = _Longest ? _Res : _Tgt_state;
 
     auto& _Submatch0   = _Matches._At(0U);
     _Submatch0.matched = true;
-    _Submatch0.first   = _Begin;
-    _Submatch0.second  = _Result._Cur;
+    _STD _Assign_wrapped(_Submatch0.first, _Begin, _Orig_last);
+    _STD _Assign_wrapped(_Submatch0.second, _Result._Cur, _Orig_last);
+
 
     for (unsigned int _Idx = 1U; _Idx < _Ncap; ++_Idx) { // copy submatch _Idx
-        if (_Result._Grp_valid._Get(_Idx - 1U)) { // copy successful match
-            _Matches._At(_Idx).matched = true;
-            _Matches._At(_Idx).first   = _Result._Grps[_Idx - 1U]._Begin;
-            _Matches._At(_Idx).second  = _Result._Grps[_Idx - 1U]._End;
+        auto& _Submatch   = _Matches._At(_Idx);
+        const bool _Valid = _Result._Grp_valid._Get(_Idx - 1U);
+        _Submatch.matched = _Valid;
+        if (_Valid) { // copy successful match
+            auto& _Capture = _Result._Grps[_Idx - 1U];
+            _STD _Assign_wrapped(_Submatch.first, _Capture._Begin, _Orig_last);
+            _STD _Assign_wrapped(_Submatch.second, _Capture._End, _Orig_last);
         } else { // copy failed match
-            _Matches._At(_Idx).matched = false;
-            _Matches._At(_Idx).first   = _End;
-            _Matches._At(_Idx).second  = _End;
+            _Submatch.first  = _Orig_last;
+            _Submatch.second = _Orig_last;
         }
     }
-    _Matches._Pfx().second = _Matches._At(0).first;
 
-    _Matches._Sfx().first   = _Matches._At(0).second;
-    _Matches._Sfx().second  = _End;
-    _Matches._Sfx().matched = _Matches._Sfx().first != _Matches._Sfx().second;
+    auto& _Prefix   = _Matches._Pfx();
+    _Prefix.second  = _Submatch0.first;
+    _Prefix.matched = _Prefix.first != _Prefix.second;
 
-    _Matches._Null().first  = _End;
-    _Matches._Null().second = _End;
+    auto& _Suffix   = _Matches._Sfx();
+    _Suffix.first   = _Submatch0.second;
+    _Suffix.second  = _Orig_last;
+    _Suffix.matched = _Suffix.first != _Suffix.second;
+
+    auto& _Null  = _Matches._Null();
+    _Null.first  = _Orig_last;
+    _Null.second = _STD move(_Orig_last);
 }
 
 template <class _FwdIt, class _Int>
@@ -4896,8 +4915,8 @@ void _Advance_at_most(_FwdIt& _Pos, const _FwdIt& _Last, _Int _Amount) {
 }
 
 template <class _Elem, class _RxTraits, class _It, class _Alloc>
-_It _Matcher3<_Elem, _RxTraits, _It, _Alloc>::_Skip(
-    _It _First, const _It _Last, const _Node_base* const _Node_arg, const unsigned int _Recursion_depth) {
+_It _Matcher3<_Elem, _RxTraits, _It, _Alloc>::_Skip2(
+    _It _First, const _It _Last, const _Node_base* _Nx, const unsigned int _Recursion_depth) {
     // skip until possible match
     // assumes --_First is valid
     static constexpr char _Line_terminators_char[]       = {static_cast<char>(_Meta_cr), static_cast<char>(_Meta_nl)};
@@ -4905,7 +4924,6 @@ _It _Matcher3<_Elem, _RxTraits, _It, _Alloc>::_Skip(
         static_cast<wchar_t>(_Meta_nl), static_cast<wchar_t>(_Meta_ls), static_cast<wchar_t>(_Meta_ps)};
     constexpr unsigned int _Max_recursion_depth          = 50U;
     constexpr short _Max_lookahead                       = 512;
-    const _Node_base* _Nx                                = _Node_arg ? _Node_arg : _Start;
 
     while (_First != _Last && _Nx) { // check current node
         switch (_Nx->_Kind) { // handle current node's type
@@ -5026,7 +5044,7 @@ _It _Matcher3<_Elem, _RxTraits, _It, _Alloc>::_Skip(
 
                     for (const _Node_if* _Alternative = _Node; _Alternative && _First != _Alt_last;
                         _Alternative                  = _Alternative->_Child) {
-                        _Alt_last = _Skip(_First, _Alt_last, _Alternative->_Next, _Recursion_depth + 1U);
+                        _Alt_last = _Skip2(_First, _Alt_last, _Alternative->_Next, _Recursion_depth + 1U);
                     }
 
                     _First = _Alt_last;
@@ -5059,8 +5077,8 @@ _It _Matcher3<_Elem, _RxTraits, _It, _Alloc>::_Skip(
                 for (;;) {
                     _It _Lookahead_last = _First;
                     _STD _Advance_at_most(_Lookahead_last, _Last, _Max_lookahead);
-                    const _It _Intermediate = _Skip(_First, _Lookahead_last, _Node->_Next, _Recursion_depth + 1U);
-                    _First = _Skip(_First, _Intermediate, _Node->_End_rep->_Next, _Recursion_depth + 1U);
+                    const _It _Intermediate = _Skip2(_First, _Lookahead_last, _Node->_Next, _Recursion_depth + 1U);
+                    _First = _Skip2(_First, _Intermediate, _Node->_End_rep->_Next, _Recursion_depth + 1U);
 
                     if (_First != _Lookahead_last || _First == _Last) {
                         break;
@@ -5077,15 +5095,15 @@ _It _Matcher3<_Elem, _RxTraits, _It, _Alloc>::_Skip(
                 }
 
                 const auto _Node = static_cast<const _Node_assert*>(_Nx);
-                _First           = _Skip(_First, _Last, _Node->_Child, _Recursion_depth + 1U);
+                _First           = _Skip2(_First, _Last, _Node->_Child, _Recursion_depth + 1U);
                 _It _Next;
                 for (;;) {
-                    _Next = _Skip(_First, _Last, _Node->_Next, _Recursion_depth + 1U);
+                    _Next = _Skip2(_First, _Last, _Node->_Next, _Recursion_depth + 1U);
                     if (_Next == _First) {
                         return _First;
                     }
 
-                    _First = _Skip(_Next, _Last, _Node->_Child, _Recursion_depth + 1U);
+                    _First = _Skip2(_Next, _Last, _Node->_Child, _Recursion_depth + 1U);
                     if (_Next == _First) {
                         return _First;
                     }
@@ -5116,7 +5134,7 @@ _It _Matcher3<_Elem, _RxTraits, _It, _Alloc>::_Skip(
                     return _First;
                 }
 
-                _First = _Skip(++_First, _Last, _Nx->_Next, _Recursion_depth + 1U);
+                _First = _Skip2(++_First, _Last, _Nx->_Next, _Recursion_depth + 1U);
                 return --_First;
             }
 
@@ -5136,6 +5154,33 @@ _It _Matcher3<_Elem, _RxTraits, _It, _Alloc>::_Skip(
         }
     }
     return _First;
+}
+
+
+template <class _Elem, class _RxTraits, class _It, class _Alloc>
+bool _Matcher3<_Elem, _RxTraits, _It, _Alloc>::_Search() {
+    auto _First = _Begin;
+    auto _Last  = _End;
+
+    if (_Match2()) {
+        return true;
+    }
+
+    if (_First == _Last || (_Mflags & regex_constants::match_continuous) != 0) {
+        return false;
+    }
+
+    // try more on suffixes
+    _Mflags = (_Mflags | regex_constants::match_prev_avail) & ~regex_constants::_Match_not_null;
+    while ((_First = _Skip2(++_First, _Last, _Start, 0U)) != _Last) {
+        _Begin = _First;
+        if (_Match2()) { // found match starting at _First
+            return true;
+        }
+    }
+
+    _Begin = _Last;
+    return _Match2();
 }
 
 template <class _FwdIt, class _Elem, class _RxTraits>

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -2643,7 +2643,7 @@ _OutIt _Format_sed(const match_results<_BidIt, _Alloc>& _Match, _OutIt _Out, _In
 }
 
 template <class _It, class _Elem, class _RxTraits>
-bool _Regex_match2(_It _First, _It _Last, const basic_regex<_Elem, _RxTraits>& _Re,
+bool _Regex_match4(_It _First, _It _Last, const basic_regex<_Elem, _RxTraits>& _Re,
     const regex_constants::match_flag_type _Flgs) { // try to match regular expression to target text
     static_assert(_Is_ranges_bidi_iter_v<_It>,
         "regex_match requires bidirectional iterators or stronger. See N5014 [re.alg.match]/1.");
@@ -2661,7 +2661,7 @@ bool _Regex_match2(_It _First, _It _Last, const basic_regex<_Elem, _RxTraits>& _
 }
 
 template <class _BidIt, class _Alloc, class _Elem, class _RxTraits>
-bool _Regex_match2(_BidIt _First, _BidIt _Last, match_results<_BidIt, _Alloc>& _Matches,
+bool _Regex_match4(_BidIt _First, _BidIt _Last, match_results<_BidIt, _Alloc>& _Matches,
     const basic_regex<_Elem, _RxTraits>& _Re, const regex_constants::match_flag_type _Flgs) {
     // try to match regular expression to target text
     static_assert(_Is_ranges_bidi_iter_v<_BidIt>,
@@ -2697,7 +2697,7 @@ bool regex_match(_BidIt _First, _BidIt _Last, match_results<_BidIt, _Alloc>& _Ma
     const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // try to match regular expression to target text
     _STD _Adl_verify_range(_First, _Last);
-    return _STD _Regex_match2(_First, _Last, _Matches, _Re, _Flgs);
+    return _STD _Regex_match4(_First, _Last, _Matches, _Re, _Flgs);
 }
 
 _EXPORT_STD template <class _BidIt, class _Elem, class _RxTraits>
@@ -2705,7 +2705,7 @@ _NODISCARD bool regex_match(_BidIt _First, _BidIt _Last, const basic_regex<_Elem
     regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // try to match regular expression to target text
     _STD _Adl_verify_range(_First, _Last);
-    return _STD _Regex_match2(
+    return _STD _Regex_match4(
         _STD _Get_unwrapped(_First), _STD _Get_unwrapped(_Last), _Re, _Flgs | regex_constants::match_any);
 }
 
@@ -2714,7 +2714,7 @@ _NODISCARD bool regex_match(_In_z_ const _Elem* _Str, const basic_regex<_Elem, _
     regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // try to match regular expression to target text
     const auto _Last = _Str + char_traits<_Elem>::length(_Str);
-    return _STD _Regex_match2(_Str, _Last, _Re, _Flgs | regex_constants::match_any);
+    return _STD _Regex_match4(_Str, _Last, _Re, _Flgs | regex_constants::match_any);
 }
 
 _EXPORT_STD template <class _Elem, class _Alloc, class _RxTraits>
@@ -2722,7 +2722,7 @@ bool regex_match(_In_z_ const _Elem* _Str, match_results<const _Elem*, _Alloc>& 
     const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // try to match regular expression to target text
     const auto _Last = _Str + char_traits<_Elem>::length(_Str);
-    return _STD _Regex_match2(_Str, _Last, _Matches, _Re, _Flgs);
+    return _STD _Regex_match4(_Str, _Last, _Matches, _Re, _Flgs);
 }
 
 _EXPORT_STD template <class _StTraits, class _StAlloc, class _Alloc, class _Elem, class _RxTraits>
@@ -2730,7 +2730,7 @@ bool regex_match(const basic_string<_Elem, _StTraits, _StAlloc>& _Str,
     match_results<typename basic_string<_Elem, _StTraits, _StAlloc>::const_iterator, _Alloc>& _Matches,
     const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // try to match regular expression to target text
-    return _STD _Regex_match2(_Str.begin(), _Str.end(), _Matches, _Re, _Flgs);
+    return _STD _Regex_match4(_Str.begin(), _Str.end(), _Matches, _Re, _Flgs);
 }
 
 _EXPORT_STD template <class _StTraits, class _StAlloc, class _Alloc, class _Elem, class _RxTraits>
@@ -2743,7 +2743,7 @@ _NODISCARD bool regex_match(const basic_string<_Elem, _StTraits, _StAlloc>& _Str
     const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // try to match regular expression to target text
     auto _First = _Str.data();
-    return _STD _Regex_match2(_First, _First + _Str.size(), _Re, _Flgs | regex_constants::match_any);
+    return _STD _Regex_match4(_First, _First + _Str.size(), _Re, _Flgs | regex_constants::match_any);
 }
 
 template <class _It, class _Elem, class _RxTraits>

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -2666,7 +2666,6 @@ bool _Regex_match2(_BidIt _First, _BidIt _Last, match_results<_BidIt, _Alloc>& _
     // try to match regular expression to target text
     static_assert(_Is_ranges_bidi_iter_v<_BidIt>,
         "regex_match requires bidirectional iterators or stronger. See N5014 [re.alg.match]/1.");
-    using _It = _Remove_cvref_t<decltype(_STD _Get_unwrapped(_First))>;
 
     // clear _Matches before doing work
     _Matches._Ready = true;
@@ -2676,6 +2675,7 @@ bool _Regex_match2(_BidIt _First, _BidIt _Last, match_results<_BidIt, _Alloc>& _
         return false;
     }
 
+    using _It = _Remove_cvref_t<decltype(_STD _Get_unwrapped(_First))>;
     alignas(_Loop_vals_v3_t<_Iter_diff_t<_It>>) alignas(_Rx_capture_range_t<_It>) //
         alignas(_Rx_state_frame_t<_It>) unsigned char _Stackbuf[4096];
     _Matcher3<_Elem, _RxTraits, _It, void> _Mx(_STD _Get_unwrapped(_First), _STD _Get_unwrapped(_Last),
@@ -2773,8 +2773,6 @@ bool _Regex_search3(_BidIt _First, _BidIt _Last, match_results<_BidIt, _Alloc>& 
     static_assert(_Is_ranges_bidi_iter_v<_BidIt>,
         "regex_search requires bidirectional iterators or stronger. See N5014 [re.alg.search]/1.");
 
-    using _It = _Remove_cvref_t<decltype(_STD _Get_unwrapped(_First))>;
-
     // clear _Matches before doing work
     _Matches._Ready = true;
     _Matches._Resize(0);
@@ -2783,6 +2781,7 @@ bool _Regex_search3(_BidIt _First, _BidIt _Last, match_results<_BidIt, _Alloc>& 
         return false;
     }
 
+    using _It = _Remove_cvref_t<decltype(_STD _Get_unwrapped(_First))>;
     alignas(_Loop_vals_v3_t<_Iter_diff_t<_It>>) alignas(_Rx_capture_range_t<_It>) //
         alignas(_Rx_state_frame_t<_It>) unsigned char _Stackbuf[4096];
     _Matcher3<_Elem, _RxTraits, _It, void> _Mx(_STD _Get_unwrapped(_First), _STD _Get_unwrapped(_Last),

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -2747,7 +2747,7 @@ _NODISCARD bool regex_match(const basic_string<_Elem, _StTraits, _StAlloc>& _Str
 }
 
 template <class _It, class _Elem, class _RxTraits>
-bool _Regex_search3(const _It _First, const _It _Last, const basic_regex<_Elem, _RxTraits>& _Re,
+bool _Regex_search4(const _It _First, const _It _Last, const basic_regex<_Elem, _RxTraits>& _Re,
     const regex_constants::match_flag_type _Flgs) {
     // search for regular expression match in target text
     static_assert(_Is_ranges_bidi_iter_v<_It>,
@@ -2767,7 +2767,7 @@ bool _Regex_search3(const _It _First, const _It _Last, const basic_regex<_Elem, 
 
 
 template <class _BidIt, class _Alloc, class _Elem, class _RxTraits>
-bool _Regex_search3(_BidIt _First, _BidIt _Last, match_results<_BidIt, _Alloc>& _Matches,
+bool _Regex_search4(_BidIt _First, _BidIt _Last, match_results<_BidIt, _Alloc>& _Matches,
     const basic_regex<_Elem, _RxTraits>& _Re, const regex_constants::match_flag_type _Flgs) {
     // search for regular expression match in target text
     static_assert(_Is_ranges_bidi_iter_v<_BidIt>,
@@ -2803,7 +2803,7 @@ bool regex_search(_BidIt _First, _BidIt _Last, match_results<_BidIt, _Alloc>& _M
     // search for regular expression match in target text
     _STD _Adl_verify_range(_First, _Last);
     _Matches._Org = _First;
-    return _STD _Regex_search3(_First, _Last, _Matches, _Re, _Flgs);
+    return _STD _Regex_search4(_First, _Last, _Matches, _Re, _Flgs);
 }
 
 _EXPORT_STD template <class _BidIt, class _Elem, class _RxTraits>
@@ -2811,7 +2811,7 @@ _NODISCARD bool regex_search(_BidIt _First, _BidIt _Last, const basic_regex<_Ele
     regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // search for regular expression match in target text
     _STD _Adl_verify_range(_First, _Last);
-    return _STD _Regex_search3(
+    return _STD _Regex_search4(
         _STD _Get_unwrapped(_First), _STD _Get_unwrapped(_Last), _Re, _Flgs | regex_constants::match_any);
 }
 
@@ -2819,7 +2819,7 @@ _EXPORT_STD template <class _Elem, class _RxTraits>
 _NODISCARD bool regex_search(_In_z_ const _Elem* _Str, const basic_regex<_Elem, _RxTraits>& _Re,
     regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // search for regular expression match in target text
-    return _STD _Regex_search3(_Str, _Str + char_traits<_Elem>::length(_Str), _Re, _Flgs | regex_constants::match_any);
+    return _STD _Regex_search4(_Str, _Str + char_traits<_Elem>::length(_Str), _Re, _Flgs | regex_constants::match_any);
 }
 
 _EXPORT_STD template <class _Elem, class _Alloc, class _RxTraits>
@@ -2827,7 +2827,7 @@ bool regex_search(_In_z_ const _Elem* _Str, match_results<const _Elem*, _Alloc>&
     const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // search for regular expression match in target text
     _Matches._Org = _Str;
-    return _STD _Regex_search3(_Str, _Str + char_traits<_Elem>::length(_Str), _Matches, _Re, _Flgs);
+    return _STD _Regex_search4(_Str, _Str + char_traits<_Elem>::length(_Str), _Matches, _Re, _Flgs);
 }
 
 _EXPORT_STD template <class _StTraits, class _StAlloc, class _Alloc, class _Elem, class _RxTraits>
@@ -2837,7 +2837,7 @@ bool regex_search(const basic_string<_Elem, _StTraits, _StAlloc>& _Str,
     // search for regular expression match in target text
     auto _First   = _Str.begin();
     _Matches._Org = _First;
-    return _STD _Regex_search3(_First, _Str.end(), _Matches, _Re, _Flgs);
+    return _STD _Regex_search4(_First, _Str.end(), _Matches, _Re, _Flgs);
 }
 
 _EXPORT_STD template <class _StTraits, class _StAlloc, class _Alloc, class _Elem, class _RxTraits>
@@ -2850,7 +2850,7 @@ _NODISCARD bool regex_search(const basic_string<_Elem, _StTraits, _StAlloc>& _St
     const basic_regex<_Elem, _RxTraits>& _Re, regex_constants::match_flag_type _Flgs = regex_constants::match_default) {
     // search for regular expression match in target text
     const auto _First = _Str.data();
-    return _STD _Regex_search3(_First, _First + _Str.size(), _Re, _Flgs | regex_constants::match_any);
+    return _STD _Regex_search4(_First, _First + _Str.size(), _Re, _Flgs | regex_constants::match_any);
 }
 
 template <class _OutIt, class _BidIt, class _RxTraits, class _Elem, class _Traits, class _Alloc>
@@ -2865,7 +2865,7 @@ _OutIt _Regex_replace1(_OutIt _Result, _BidIt _First, _BidIt _Last, const basic_
     regex_constants::match_flag_type _Not_null{};
 
     _Matches._Org = _Pos;
-    while (_STD _Regex_search3(_Pos, _Last, _Matches, _Re, _Flags | _Not_null)) { // replace at each match
+    while (_STD _Regex_search4(_Pos, _Last, _Matches, _Re, _Flags | _Not_null)) { // replace at each match
         if (!(_Flgs & regex_constants::format_no_copy)) {
             _Result = _STD copy(_Matches.prefix().first, _Matches.prefix().second, _Result);
         }
@@ -2969,7 +2969,7 @@ public:
         : _Begin(_First), _End(_Last), _MyRe(_STD addressof(_Re)), _Flags(_Fl) {
         _STD _Adl_verify_range(_Begin, _End);
         _MyVal._Org = _Begin;
-        if (!_STD _Regex_search3(_Begin, _End, _MyVal, *_MyRe, _Flags)) {
+        if (!_STD _Regex_search4(_Begin, _End, _MyVal, *_MyRe, _Flags)) {
             _MyRe = nullptr;
         } else {
             this->_Adopt(_MyRe);
@@ -3029,7 +3029,7 @@ public:
 
             // _Adl_verify_range(_Start, _End) checked in constructor
             if (_Start == _End
-                || !_STD _Regex_search3(_Start, _End, _MyVal, *_MyRe,
+                || !_STD _Regex_search4(_Start, _End, _MyVal, *_MyRe,
                     _Flags | regex_constants::_Match_not_null)) { // store end-of-sequence iterator
                 _MyRe = nullptr;
 
@@ -3050,7 +3050,7 @@ public:
         _Flags |= regex_constants::match_prev_avail;
 
         // _Adl_verify_range(_Start, _End) checked in constructor
-        if (!_STD _Regex_search3(_Start, _End, _MyVal, *_MyRe, _Flags)) {
+        if (!_STD _Regex_search4(_Start, _End, _MyVal, *_MyRe, _Flags)) {
             // mark at end of sequence
             _MyRe = nullptr;
 

--- a/tests/std/tests/VSO_0000000_regex_use/test.cpp
+++ b/tests/std/tests/VSO_0000000_regex_use/test.cpp
@@ -2732,8 +2732,8 @@ void test_gh_6423() {
     const regex re("a((bc)*d)e");
     {
         cmatch cm;
-        const char* input = "abcbcde";
-        const char* last  = input + char_traits<char>::length(input);
+        const char* const input = "abcbcde";
+        const char* const last  = input + char_traits<char>::length(input);
         assert(regex_match(input, re));
         assert(regex_match(input, cm, re));
         assert(cm.ready());
@@ -2814,8 +2814,8 @@ void test_gh_6423() {
 
     {
         cmatch cm;
-        const char* input = "xyzabcbcdezyx";
-        const char* last  = input + char_traits<char>::length(input);
+        const char* const input = "xyzabcbcdezyx";
+        const char* const last  = input + char_traits<char>::length(input);
         assert(regex_search(input, re));
         assert(regex_search(input, cm, re));
         assert(cm.ready());

--- a/tests/std/tests/VSO_0000000_regex_use/test.cpp
+++ b/tests/std/tests/VSO_0000000_regex_use/test.cpp
@@ -2726,6 +2726,174 @@ void test_gh_6359() {
     g_regexTester.should_capture("a", "(?:(?=(a)))?a", "");
 }
 
+void test_gh_6423() {
+    // GH-6423: Unwrap iterators in `match_results` overloads
+    // Test that all regex_match and regex_search overloads still compile and work in principle
+    const regex re("a((bc)*d)e");
+    {
+        cmatch cm;
+        const char* input = "abcbcde";
+        const char* last  = input + char_traits<char>::length(input);
+        assert(regex_match(input, re));
+        assert(regex_match(input, cm, re));
+        assert(cm.ready());
+        assert(cm.size() == 3);
+        assert(cm[0].matched);
+        assert(cm[0].first == input);
+        assert(cm[0].second == last);
+        assert(cm.position(0) == 0);
+        assert(cm[1].matched);
+        assert(cm[1].first == input + 1);
+        assert(cm[1].second == input + 6);
+        assert(cm.position(1) == 1);
+        assert(cm[2].matched);
+        assert(cm[2].first == input + 3);
+        assert(cm[2].second == input + 5);
+        assert(cm.position(2) == 3);
+        assert(!cm.prefix().matched);
+        assert(cm.prefix().first == input);
+        assert(cm.prefix().second == input);
+        assert(!cm.suffix().matched);
+        assert(cm.suffix().first == last);
+        assert(cm.suffix().second == last);
+    }
+
+    {
+        smatch sm;
+        const string input = "abcbcde";
+        assert(regex_match(input, re));
+        assert(regex_match(input, sm, re));
+        assert(sm.ready());
+        assert(sm.size() == 3);
+        assert(sm[0].matched);
+        assert(sm[0].first == input.begin());
+        assert(sm[0].second == input.end());
+        assert(sm.position(0) == 0);
+        assert(sm[1].matched);
+        assert(sm[1].first == input.begin() + 1);
+        assert(sm[1].second == input.begin() + 6);
+        assert(sm.position(1) == 1);
+        assert(sm[2].matched);
+        assert(sm[2].first == input.begin() + 3);
+        assert(sm[2].second == input.begin() + 5);
+        assert(sm.position(2) == 3);
+        assert(!sm.prefix().matched);
+        assert(sm.prefix().first == input.begin());
+        assert(sm.prefix().second == input.begin());
+        assert(!sm.suffix().matched);
+        assert(sm.suffix().first == input.end());
+        assert(sm.suffix().second == input.end());
+    }
+
+    {
+        match_results<vector<char>::const_iterator> vm;
+        const vector<char> input = {'a', 'b', 'c', 'b', 'c', 'd', 'e'};
+        assert(regex_match(input.begin(), input.end(), re));
+        assert(regex_match(input.begin(), input.end(), vm, re));
+        assert(vm.ready());
+        assert(vm.size() == 3);
+        assert(vm[0].matched);
+        assert(vm[0].first == input.begin());
+        assert(vm[0].second == input.end());
+        assert(vm.position(0) == 0);
+        assert(vm[1].matched);
+        assert(vm[1].first == input.begin() + 1);
+        assert(vm[1].second == input.begin() + 6);
+        assert(vm.position(1) == 1);
+        assert(vm[2].matched);
+        assert(vm[2].first == input.begin() + 3);
+        assert(vm[2].second == input.begin() + 5);
+        assert(vm.position(2) == 3);
+        assert(!vm.prefix().matched);
+        assert(vm.prefix().first == input.begin());
+        assert(vm.prefix().second == input.begin());
+        assert(!vm.suffix().matched);
+        assert(vm.suffix().first == input.end());
+        assert(vm.suffix().second == input.end());
+    }
+
+    {
+        cmatch cm;
+        const char* input = "xyzabcbcdezyx";
+        const char* last  = input + char_traits<char>::length(input);
+        assert(regex_search(input, re));
+        assert(regex_search(input, cm, re));
+        assert(cm.ready());
+        assert(cm.size() == 3);
+        assert(cm[0].matched);
+        assert(cm[0].first == input + 3);
+        assert(cm[0].second == last - 3);
+        assert(cm.position(0) == 3);
+        assert(cm[1].matched);
+        assert(cm[1].first == input + 4);
+        assert(cm[1].second == input + 9);
+        assert(cm.position(1) == 4);
+        assert(cm[2].matched);
+        assert(cm[2].first == input + 6);
+        assert(cm[2].second == input + 8);
+        assert(cm.prefix().matched);
+        assert(cm.prefix().first == input);
+        assert(cm.prefix().second == input + 3);
+        assert(cm.suffix().matched);
+        assert(cm.suffix().first == last - 3);
+        assert(cm.suffix().second == last);
+    }
+
+    {
+        smatch sm;
+        const string input = "xyzabcbcdezyx";
+        assert(regex_search(input, re));
+        assert(regex_search(input, sm, re));
+        assert(sm.ready());
+        assert(sm.size() == 3);
+        assert(sm[0].matched);
+        assert(sm[0].first == input.begin() + 3);
+        assert(sm[0].second == input.end() - 3);
+        assert(sm.position(0) == 3);
+        assert(sm[1].matched);
+        assert(sm[1].first == input.begin() + 4);
+        assert(sm[1].second == input.begin() + 9);
+        assert(sm.position(1) == 4);
+        assert(sm[2].matched);
+        assert(sm[2].first == input.begin() + 6);
+        assert(sm[2].second == input.begin() + 8);
+        assert(sm.position(2) == 6);
+        assert(sm.prefix().matched);
+        assert(sm.prefix().first == input.begin());
+        assert(sm.prefix().second == input.begin() + 3);
+        assert(sm.suffix().matched);
+        assert(sm.suffix().first == input.end() - 3);
+        assert(sm.suffix().second == input.end());
+    }
+
+    {
+        match_results<vector<char>::const_iterator> vm;
+        const vector<char> input = {'x', 'y', 'z', 'a', 'b', 'c', 'b', 'c', 'd', 'e', 'z', 'y', 'x'};
+        assert(regex_search(input.begin(), input.end(), re));
+        assert(regex_search(input.begin(), input.end(), vm, re));
+        assert(vm.ready());
+        assert(vm.size() == 3);
+        assert(vm[0].matched);
+        assert(vm[0].first == input.begin() + 3);
+        assert(vm[0].second == input.end() - 3);
+        assert(vm.position(0) == 3);
+        assert(vm[1].matched);
+        assert(vm[1].first == input.begin() + 4);
+        assert(vm[1].second == input.begin() + 9);
+        assert(vm.position(1) == 4);
+        assert(vm[2].matched);
+        assert(vm[2].first == input.begin() + 6);
+        assert(vm[2].second == input.begin() + 8);
+        assert(vm.position(2) == 6);
+        assert(vm.prefix().matched);
+        assert(vm.prefix().first == input.begin());
+        assert(vm.prefix().second == input.begin() + 3);
+        assert(vm.suffix().matched);
+        assert(vm.suffix().first == input.end() - 3);
+        assert(vm.suffix().second == input.end());
+    }
+}
+
 int main() {
     test_dev10_449367_case_insensitivity_should_work();
     test_dev11_462743_regex_collate_should_not_disable_regex_icase();
@@ -2798,6 +2966,7 @@ int main() {
     test_gh_6267();
     test_gh_6289();
     test_gh_6359();
+    test_gh_6423();
 
     return g_regexTester.result();
 }


### PR DESCRIPTION
When `match_results` are requested by users, the matcher in `<regex>` doesn't actually perform any unwrapping or rewrapping of iterators. Instead, matching is performed using wrapped iterators, unnecessarily degrading performance.

On the other hand, iterators are properly unwrapped if no `match_results` are requested, but at the cost of unnecessarily instantiating `match_results` with the internal unwrapped iterator type.

There had been an attempt to represent wrapped and unwrapped iterators using distinct `_BidIt` and `_It` template parameters of the `_Matcher` class template, but this attempt was dysfunctional and was removed in the recent months. Instead, all of the internal machinery dependent on the unwrapped and wrapped iterator type has been centralized in the `_Copy_captures` member function so that only this member function is now potentially dependent on wrapped and unwrapped iterator type simultaneously.

This PR splits the internal `_Regex_match2` and `_Regex_search3` functions each into two overloads, one returning `match_results` and one that does not. The ones that do not return `match_results` take unwrapped iterators, construct the matcher and then perform a match or search. This avoids an unnecessary instantiation of `match_results`. Those returning `match_results` take wrapped iterators, unwrap them to construct the matcher, perform a match or search and then copy the captures to the `match_results` using the matcher's `_Copy_captures2` member function. Thus, the matcher's iterator template parameter is always an unwrapped iterator type now.

The `_Copy_captures2` member takes a reference to the `match_results` object and a wrapped iterator to the end of the input range. Since the iterators in the `match_results` initially do not point into the input range, we first have to assign them a wrapped iterator pointing to the input range before they can be seeked to the position of the unwrapped iterator. For this purpose, `_Copy_captures2` calls the new `_Assign_wrapped` function that handles this assignment of unwrapped iterators to out-of-range wrapped iterators. (If preferred, we can move this function from `<regex>` next to `_Seek_wrapped` in `<xutility>`.)

The common search logic to the `_Regex_search2` overloads has been moved to a new `_Search` member function of the `_Matcher3` class template. Because this new member function can access and mutate the matcher's internal state, the member functions `_Clearf` and `_Match2` with an iterator argument become unnecessary and the `_Skip` member function can be made private and no longer has to handle a null `_Node` argument (at the cost of renaming it for ABI compatibility).

The added test is a small smoke test checking all overloads of `regex_match` and `regex_search`. It seems we didn't have anything testing that these overloads even compile in a single place. For most overloads, we appear to have relied on some individual tests that really intended to test something else but happened to exert these overloads by chance.