### PR TITLE
MSBuild changes for Arm64X

### DIFF
--- a/stl/msbuild/stl_base/msvcp.settings.targets
+++ b/stl/msbuild/stl_base/msvcp.settings.targets
@@ -42,7 +42,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
         <LinkGenerateDebugInformation>true</LinkGenerateDebugInformation>
         <LinkProgramDataBaseFileName>$(OutputPath)\$(OutputName)$(_PDB_VER_NAME_)$(DllPdbFlavorSuffix)</LinkProgramDataBaseFileName>
-        <LinkProgramDataBaseFileName Condition="'$(BuildArchitecture)' =='arm64ec' and '$(Platform)' != '$(BuildArchitecture)'">$(OutputPath)\$(OutputName).arm64$(DllPdbFlavorSuffix)</LinkProgramDataBaseFileName>
+        <LinkProgramDataBaseFileName Condition="'$(BuildingArm64XEC)' == 'true'">$(OutputPath)\$(OutputName).arm64$(DllPdbFlavorSuffix)</LinkProgramDataBaseFileName>
 
         <LinkAdditionalOptions>-debugtype:cv,fixup $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions Condition="$(DebugBuild) != 'true'">-opt:ref,icf=3 $(LinkAdditionalOptions)</LinkAdditionalOptions>


### PR DESCRIPTION
This reverse-mirrors Daniel Winsor's MSVC-PR-772917 "Use Platform & Configuration for Arm64X and spectre".

It's specific to the MSVC-internal MSBuild system and has no impact on our GitHub CMake/Ninja build system.