### PR TITLE
<yvals_core.h>: Update _MSVC_STL_UPDATE to September 2026

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -909,7 +909,7 @@
 
 #define _CPPLIB_VER       650
 #define _MSVC_STL_VERSION 145
-#define _MSVC_STL_UPDATE  202608L
+#define _MSVC_STL_UPDATE  202609L
 
 #ifndef _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
 #if defined(__CUDACC__) && defined(__CUDACC_VER_MAJOR__)


### PR DESCRIPTION
Updates `_MSVC_STL_UPDATE` to `202609L` for the September 2026 release marker.

This changes no behavior, identifiers, or ABI. The one-line diff was checked with `git diff --check`; no build was run because only the date marker changes.

AI disclosure: I used an AI coding assistant to inspect the contribution rules, make this requested one-token update, and run the checks. I reviewed and fully understand the resulting change. No external project or implementation was used as source material.

Fixes #6427
