### PR TITLE
`<yvals_core.h>`: Update `_MSVC_STL_UPDATE`

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -909,7 +909,7 @@
 
 #define _CPPLIB_VER       650
 #define _MSVC_STL_VERSION 145
-#define _MSVC_STL_UPDATE  202608L
+#define _MSVC_STL_UPDATE  202609L
 
 #ifndef _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
 #if defined(__CUDACC__) && defined(__CUDACC_VER_MAJOR__)


### PR DESCRIPTION
Fixes #6427.