### PR TITLE
Overhaul `constexpr <cmath>`

### DIFF
--- a/stl/inc/__msvc_math.hpp
+++ b/stl/inc/__msvc_math.hpp
@@ -350,7 +350,7 @@ _STL_DECLARE_FAMILY1(_CONSTEXPR_CMATH26_NYI_DECL, cosh) // additional workaround
 _STL_DECLARE_FAMILY1(_CONSTEXPR_CMATH26_NYI_DECL, sinh) // additional workarounds for this polyfill are defined below
 _STL_DECLARE_FAMILY1(_CONSTEXPR_CMATH26_NYI_DECL, tanh) // additional workarounds for this polyfill are defined below
 _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, exp)
-_STL_DECLARE_FAMILY1(_CONSTEXPR_CMATH26_NYI_DECL, exp2)
+_STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, exp2)
 _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, expm1)
 _STL_DEF_LASTARG_FAMILY2(_CONSTEXPR_CMATH23, frexp, int*) // _NODISCARD is desirable, despite the out-param
 _STL_DEF_RETURN_FAMILY1(_CONSTEXPR_CMATH23, ilogb, int)

--- a/stl/inc/__msvc_math.hpp
+++ b/stl/inc/__msvc_math.hpp
@@ -192,12 +192,15 @@ extern "C" {
     _NODISCARD specs long double __cdecl name##l(long double) noexcept /* strengthened */;
 
 // Defines a non-overloaded function with signature `float (float)`, then
-// *declares* two non-overloaded functions with signatures `double (double)` and `long double (long double)`.
+// *declares* a non-overloaded function with signature `double (double)`, then
+// defines a non-overloaded function with signature `long double (long double)`.
 // This is used when libc has implemented a function for `float` but has not yet implemented it for `double`.
-#define _STL_DEF_FLOAT_DECLARE_OTHERS1(specs_def_float, specs_decl_others, name)          \
-    _STL_DEF_FUNC1(specs_def_float, name##f, float, float)                                \
-    _NODISCARD specs_decl_others double __cdecl name(double) noexcept /* strengthened */; \
-    _NODISCARD specs_decl_others long double __cdecl name##l(long double) noexcept /* strengthened */;
+#define _STL_DECLARE_DOUBLE_DEF_OTHERS1(specs_def_flt, specs_decl_dbl, specs_def_lng, name)             \
+    _STL_DEF_FUNC1(specs_def_flt, name##f, float, float)                                                \
+    _NODISCARD specs_decl_dbl double __cdecl name(double) noexcept /* strengthened */;                  \
+    _NODISCARD specs_def_lng long double __cdecl name##l(long double _Xx) noexcept /* strengthened */ { \
+        return _CSTD name(static_cast<double>(_Xx));                                                    \
+    }
 
 // Some functions that are needed for C++26 constexpr cmath are not yet implemented by libc.
 // We polyfill the library with the UCRT and mark these functions with this macro.
@@ -270,6 +273,7 @@ _NODISCARD _CONSTEXPR_CMATH23 double __cdecl copysign(double, double) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 float __cdecl cosf(float) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 double __cdecl cos(double) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 float __cdecl coshf(float) noexcept;
+_NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl coshl(long double) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 float __cdecl expf(float) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 double __cdecl exp(double) noexcept;
 _NODISCARD _CONSTEXPR_CMATH23 float __cdecl fabsf(float) noexcept;
@@ -310,11 +314,13 @@ _NODISCARD _CONSTEXPR_CMATH23 long double __cdecl roundl(long double) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 float __cdecl sinf(float) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 double __cdecl sin(double) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 float __cdecl sinhf(float) noexcept;
+_NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl sinhl(long double) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 float __cdecl sqrtf(float) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 double __cdecl sqrt(double) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 float __cdecl tanf(float) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 double __cdecl tan(double) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 float __cdecl tanhf(float) noexcept;
+_NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl tanhl(long double) noexcept;
 _NODISCARD _CONSTEXPR_CMATH23 float __cdecl truncf(float) noexcept;
 _NODISCARD _CONSTEXPR_CMATH23 double __cdecl trunc(double) noexcept;
 _NODISCARD _CONSTEXPR_CMATH23 long double __cdecl truncl(long double) noexcept;
@@ -326,7 +332,7 @@ _NODISCARD _CONSTEXPR_CMATH23 long double __cdecl truncl(long double) noexcept;
 #pragma function(ceilf, ceil)
 #pragma function(copysignf, copysign)
 #pragma function(cosf, cos)
-#pragma function(coshf)
+#pragma function(coshf, coshl)
 #pragma function(expf, exp)
 #pragma function(fabsf, fabs)
 #pragma function(floorf, floor)
@@ -343,10 +349,10 @@ _NODISCARD _CONSTEXPR_CMATH23 long double __cdecl truncl(long double) noexcept;
 #pragma function(rintf, rint, rintl)
 #pragma function(roundf, round, roundl)
 #pragma function(sinf, sin)
-#pragma function(sinhf)
+#pragma function(sinhf, sinhl)
 #pragma function(sqrtf, sqrt)
 #pragma function(tanf, tan)
-#pragma function(tanhf)
+#pragma function(tanhf, tanhl)
 #pragma function(truncf, trunc, truncl)
 
 // The following order matches N5054 [cmath.syn].
@@ -357,12 +363,12 @@ _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, atan)
 _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, cos)
 _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, sin)
 _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, tan)
-_STL_DEF_FLOAT_DECLARE_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, acosh)
-_STL_DEF_FLOAT_DECLARE_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, asinh)
-_STL_DEF_FLOAT_DECLARE_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, atanh)
-_STL_DEF_FLOAT_DECLARE_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, cosh) // additional workarounds below
-_STL_DEF_FLOAT_DECLARE_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, sinh) // additional workarounds below
-_STL_DEF_FLOAT_DECLARE_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, tanh) // additional workarounds below
+_STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, acosh)
+_STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, asinh)
+_STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, atanh)
+_STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, cosh)
+_STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, sinh)
+_STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, tanh)
 _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, exp)
 _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, exp2)
 _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, expm1)
@@ -383,7 +389,7 @@ _STL_DEF_FAMILY1(_CONSTEXPR_CMATH23, fabs)
 _STL_DEF_FAMILY2(_CONSTEXPR_CMATH26, hypot)
 _STL_DEF_FAMILY2(_CONSTEXPR_CMATH26, pow)
 _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, sqrt)
-_STL_DEF_FLOAT_DECLARE_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, erf)
+_STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, erf)
 _STL_DECLARE_FAMILY1(_CONSTEXPR_CMATH26_NYI_DECL, erfc)
 // lgamma() is hand-crafted because it is not yet implemented by libc
 // tgamma() is hand-crafted because it is not yet implemented by libc
@@ -485,19 +491,6 @@ _NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl tgammal(long double _Xx) n
     return __std_smf_tgamma(static_cast<double>(_Xx));
 }
 
-// The UCRT defines the following functions as inline functions that forward to their double siblings,
-// so forward-declaring them without defining them would not result in a successful polyfill.
-#pragma function(coshl, sinhl, tanhl)
-_NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl coshl(long double _Xx) noexcept /* strengthened */ {
-    return _CSTD cosh(static_cast<double>(_Xx));
-}
-_NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl sinhl(long double _Xx) noexcept /* strengthened */ {
-    return _CSTD sinh(static_cast<double>(_Xx));
-}
-_NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl tanhl(long double _Xx) noexcept /* strengthened */ {
-    return _CSTD tanh(static_cast<double>(_Xx));
-}
-
 #undef _STL_DEF_FUNC1
 #undef _STL_DEF_FUNC2
 #undef _STL_DEF_FUNC3
@@ -514,7 +507,7 @@ _NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl tanhl(long double _Xx) noe
 #undef _STL_DEF_OVERLOADED_COMPARISON_FAMILY1
 #undef _STL_DEF_OVERLOADED_COMPARISON_FAMILY2
 #undef _STL_DECLARE_FAMILY1
-#undef _STL_DEF_FLOAT_DECLARE_OTHERS1
+#undef _STL_DECLARE_DOUBLE_DEF_OTHERS1
 #undef _CONSTEXPR_CMATH26_NYI_DECL
 
 } // extern "C"

--- a/stl/inc/__msvc_math.hpp
+++ b/stl/inc/__msvc_math.hpp
@@ -23,8 +23,6 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-#pragma warning(disable : 4163) // 'meow' not available as an intrinsic function
-
 extern "C++" {
 namespace _Msvc { // duplicate type traits not provided by <yvals_core.h>
     template <class _Ty>
@@ -90,9 +88,8 @@ namespace _Msvc { // duplicate type traits not provided by <yvals_core.h>
     template <bool _Test, class _Ty = void>
     using _Enable_if_t = typename _Enable_if<_Test, _Ty>::type;
 } // namespace _Msvc
-} // extern "C++"
 
-extern "C" {
+inline namespace _Msvc_math {
 
 #define _STL_DEF_FUNC1(specs, name, ret, arg0)                                \
     _NODISCARD specs ret __cdecl name(arg0 _Xx) noexcept /* strengthened */ { \
@@ -186,10 +183,12 @@ extern "C" {
 
 // *Declares* three non-overloaded functions with signature `fp-type (fp-type)`.
 // These declarations are intended to match UCRT function definitions because libc does not yet implement them fully.
-#define _STL_DECLARE_FAMILY1(specs, name)                                      \
-    _NODISCARD specs float __cdecl name##f(float) noexcept /* strengthened */; \
-    _NODISCARD specs double __cdecl name(double) noexcept /* strengthened */;  \
-    _NODISCARD specs long double __cdecl name##l(long double) noexcept /* strengthened */;
+#define _STL_DECLARE_FAMILY1(specs, name)                                                  \
+    extern "C" {                                                                           \
+    _NODISCARD specs float __cdecl name##f(float) noexcept /* strengthened */;             \
+    _NODISCARD specs double __cdecl name(double) noexcept /* strengthened */;              \
+    _NODISCARD specs long double __cdecl name##l(long double) noexcept /* strengthened */; \
+    } /* extern "C" */
 
 // Defines a non-overloaded function with signature `float (float)`, then
 // *declares* a non-overloaded function with signature `double (double)`, then
@@ -197,7 +196,9 @@ extern "C" {
 // This is used when libc has implemented a function for `float` but has not yet implemented it for `double`.
 #define _STL_DECLARE_DOUBLE_DEF_OTHERS1(specs_def_flt, specs_decl_dbl, specs_def_lng, name)             \
     _STL_DEF_FUNC1(specs_def_flt, name##f, float, float)                                                \
+    extern "C" {                                                                                        \
     _NODISCARD specs_decl_dbl double __cdecl name(double) noexcept /* strengthened */;                  \
+    } /* extern "C" */                                                                                  \
     _NODISCARD specs_def_lng long double __cdecl name##l(long double _Xx) noexcept /* strengthened */ { \
         return _CSTD name(static_cast<double>(_Xx));                                                    \
     }
@@ -211,11 +212,11 @@ extern "C" {
 // using the x87 instruction set and FLT_EVAL_METHOD is 2. (When /fp:fast is used,
 // floating-point operations may be consistent, so we use the default types.)
 #if defined(_M_IX86) && _M_IX86_FP < 2 && !defined(_M_FP_FAST)
-using float_t  = long double;
-using double_t = long double;
+    using float_t  = long double;
+    using double_t = long double;
 #else
-using float_t  = float;
-using double_t = double;
+    using float_t  = float;
+    using double_t = double;
 #endif
 
 #define MATH_ERRNO     1
@@ -249,247 +250,149 @@ using double_t = double;
 #define HUGE_VALL (__builtin_infl())
 #define NAN       (__builtin_nanf(""))
 
-// The nan family of functions is not routed to builtins because the builtins
-// require a string literal argument and so cannot uphold the interface of these functions.
-_NODISCARD float __cdecl nanf(const char*) noexcept /* strengthened */;
-_NODISCARD double __cdecl nan(const char*) noexcept /* strengthened */;
-_NODISCARD long double __cdecl nanl(const char*) noexcept /* strengthened */;
+    // The nan family of functions is not routed to builtins because the builtins
+    // require a string literal argument and so cannot uphold the interface of these functions.
+    extern "C" {
+    _NODISCARD float __cdecl nanf(const char*) noexcept /* strengthened */;
+    _NODISCARD double __cdecl nan(const char*) noexcept /* strengthened */;
+    _NODISCARD long double __cdecl nanl(const char*) noexcept /* strengthened */;
+    } // extern "C"
 
-// Under /Oi (implied by /O2), MSVC treats the following functions as intrinsics that cannot be redefined.
-// We use `#pragma function` to instruct MSVC to treat them as regular functions that can be defined,
-// but we first need to declare them.
-_NODISCARD _CONSTEXPR_CMATH26 float __cdecl acosf(float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 double __cdecl acos(double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 float __cdecl asinf(float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 double __cdecl asin(double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 float __cdecl atan2f(float, float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 double __cdecl atan2(double, double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 float __cdecl atanf(float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 double __cdecl atan(double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 float __cdecl ceilf(float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 double __cdecl ceil(double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 float __cdecl copysignf(float, float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 double __cdecl copysign(double, double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 float __cdecl cosf(float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 double __cdecl cos(double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 float __cdecl coshf(float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl coshl(long double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 float __cdecl expf(float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 double __cdecl exp(double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 float __cdecl fabsf(float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 double __cdecl fabs(double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 float __cdecl floorf(float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 double __cdecl floor(double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 float __cdecl fmaf(float, float, float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 double __cdecl fma(double, double, double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 long double __cdecl fmal(long double, long double, long double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 float __cdecl fmaxf(float, float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 double __cdecl fmax(double, double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 long double __cdecl fmaxl(long double, long double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 float __cdecl fminf(float, float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 double __cdecl fmin(double, double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 long double __cdecl fminl(long double, long double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 float __cdecl fmodf(float, float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 double __cdecl fmod(double, double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 float __cdecl log10f(float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 double __cdecl log10(double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 float __cdecl log2f(float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 double __cdecl log2(double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 float __cdecl logf(float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 double __cdecl log(double) noexcept;
-_NODISCARD inline long __cdecl lrintf(float) noexcept;
-_NODISCARD inline long __cdecl lrint(double) noexcept;
-_NODISCARD inline long __cdecl lrintl(long double) noexcept;
-_NODISCARD inline float __cdecl nearbyintf(float) noexcept;
-_NODISCARD inline double __cdecl nearbyint(double) noexcept;
-_NODISCARD inline long double __cdecl nearbyintl(long double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 float __cdecl powf(float, float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 double __cdecl pow(double, double) noexcept;
-_NODISCARD inline float __cdecl rintf(float) noexcept;
-_NODISCARD inline double __cdecl rint(double) noexcept;
-_NODISCARD inline long double __cdecl rintl(long double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 float __cdecl roundf(float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 double __cdecl round(double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 long double __cdecl roundl(long double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 float __cdecl sinf(float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 double __cdecl sin(double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 float __cdecl sinhf(float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl sinhl(long double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 float __cdecl sqrtf(float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 double __cdecl sqrt(double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 float __cdecl tanf(float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 double __cdecl tan(double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26 float __cdecl tanhf(float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl tanhl(long double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 float __cdecl truncf(float) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 double __cdecl trunc(double) noexcept;
-_NODISCARD _CONSTEXPR_CMATH23 long double __cdecl truncl(long double) noexcept;
+    // The following order matches N5054 [cmath.syn].
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, acos)
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, asin)
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, atan)
+    // atan2() is hand-crafted because of the workaround for LLVM-214934
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, cos)
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, sin)
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, tan)
+    _STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, acosh)
+    _STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, asinh)
+    _STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, atanh)
+    _STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, cosh)
+    _STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, sinh)
+    _STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, tanh)
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, exp)
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, exp2)
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, expm1)
+    _STL_DEF_LASTARG_FAMILY2(_CONSTEXPR_CMATH23, frexp, int*) // _NODISCARD is desirable, despite the out-param
+    _STL_DEF_RETURN_FAMILY1(_CONSTEXPR_CMATH23, ilogb, int)
+    _STL_DEF_LASTARG_FAMILY2(_CONSTEXPR_CMATH23, ldexp, int)
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, log)
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, log10)
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, log1p)
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, log2)
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH23, logb)
+    // modf() is hand-crafted because it has a unique signature
+    _STL_DEF_LASTARG_FAMILY2(_CONSTEXPR_CMATH23, scalbn, int)
+    _STL_DEF_LASTARG_FAMILY2(_CONSTEXPR_CMATH23, scalbln, long)
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, cbrt)
+    // abs() is in <__msvc_stdlib.hpp>
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH23, fabs)
+    _STL_DEF_FAMILY2(_CONSTEXPR_CMATH26, hypot)
+    _STL_DEF_FAMILY2(_CONSTEXPR_CMATH26, pow)
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, sqrt)
+    _STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, erf)
+    _STL_DECLARE_FAMILY1(_CONSTEXPR_CMATH26_NYI_DECL, erfc)
+    // lgamma() is hand-crafted because it is not yet implemented by libc
+    // tgamma() is hand-crafted because it is not yet implemented by libc
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH23, ceil)
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH23, floor)
+    _STL_DEF_FAMILY1(inline, nearbyint)
+    _STL_DEF_FAMILY1(inline, rint)
+    _STL_DEF_RETURN_FAMILY1(inline, lrint, long)
+    _STL_DEF_RETURN_FAMILY1(inline, llrint, long long)
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH23, round)
+    _STL_DEF_RETURN_FAMILY1(_CONSTEXPR_CMATH23, lround, long)
+    _STL_DEF_RETURN_FAMILY1(_CONSTEXPR_CMATH23, llround, long long)
+    _STL_DEF_FAMILY1(_CONSTEXPR_CMATH23, trunc)
+    _STL_DEF_FAMILY2(_CONSTEXPR_CMATH23, fmod)
+    _STL_DEF_FAMILY2(_CONSTEXPR_CMATH23, remainder)
+    _STL_DEF_LASTARG_FAMILY3(_CONSTEXPR_CMATH23, remquo, int*) // _NODISCARD is desirable, despite the out-param
+    _STL_DEF_FAMILY2(_CONSTEXPR_CMATH23, copysign)
+    // nan() is declared above
+    _STL_DEF_FAMILY2(_CONSTEXPR_CMATH23, nextafter)
+    _STL_DEF_LASTARG_FAMILY2(_CONSTEXPR_CMATH23, nexttoward, long double)
+    _STL_DEF_FAMILY2(_CONSTEXPR_CMATH23, fdim)
+    _STL_DEF_FAMILY2(_CONSTEXPR_CMATH23, fmax)
+    _STL_DEF_FAMILY2(_CONSTEXPR_CMATH23, fmin)
+    _STL_DEF_FAMILY3(_CONSTEXPR_CMATH23, fma)
 
-#pragma function(acosf, acos)
-#pragma function(asinf, asin)
-#pragma function(atan2f, atan2)
-#pragma function(atanf, atan)
-#pragma function(ceilf, ceil)
-#pragma function(copysignf, copysign)
-#pragma function(cosf, cos)
-#pragma function(coshf, coshl)
-#pragma function(expf, exp)
-#pragma function(fabsf, fabs)
-#pragma function(floorf, floor)
-#pragma function(fmaf, fma, fmal)
-#pragma function(fmaxf, fmax, fmaxl)
-#pragma function(fminf, fmin, fminl)
-#pragma function(fmodf, fmod)
-#pragma function(log10f, log10)
-#pragma function(log2f, log2)
-#pragma function(logf, log)
-#pragma function(lrintf, lrint, lrintl)
-#pragma function(nearbyintf, nearbyint, nearbyintl)
-#pragma function(powf, pow)
-#pragma function(rintf, rint, rintl)
-#pragma function(roundf, round, roundl)
-#pragma function(sinf, sin)
-#pragma function(sinhf, sinhl)
-#pragma function(sqrtf, sqrt)
-#pragma function(tanf, tan)
-#pragma function(tanhf, tanhl)
-#pragma function(truncf, trunc, truncl)
+    _STL_DEF_OVERLOADED_CLASSIFICATION_FAMILY1(_CONSTEXPR_CMATH23, int, fpclassify, /*unchanged*/)
+    _STL_DEF_OVERLOADED_CLASSIFICATION_FAMILY1(_CONSTEXPR_CMATH23, bool, isfinite, <= 0)
+    _STL_DEF_OVERLOADED_CLASSIFICATION_FAMILY1(_CONSTEXPR_CMATH23, bool, isinf, == FP_INFINITE)
+    _STL_DEF_OVERLOADED_CLASSIFICATION_FAMILY1(_CONSTEXPR_CMATH23, bool, isnan, == FP_NAN)
+    _STL_DEF_OVERLOADED_CLASSIFICATION_FAMILY1(_CONSTEXPR_CMATH23, bool, isnormal, == FP_NORMAL)
 
-// The following order matches N5054 [cmath.syn].
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, acos)
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, asin)
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, atan)
-// atan2() is hand-crafted because of the workaround for LLVM-214934
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, cos)
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, sin)
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, tan)
-_STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, acosh)
-_STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, asinh)
-_STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, atanh)
-_STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, cosh)
-_STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, sinh)
-_STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, tanh)
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, exp)
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, exp2)
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, expm1)
-_STL_DEF_LASTARG_FAMILY2(_CONSTEXPR_CMATH23, frexp, int*) // _NODISCARD is desirable, despite the out-param
-_STL_DEF_RETURN_FAMILY1(_CONSTEXPR_CMATH23, ilogb, int)
-_STL_DEF_LASTARG_FAMILY2(_CONSTEXPR_CMATH23, ldexp, int)
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, log)
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, log10)
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, log1p)
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, log2)
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH23, logb)
-// modf() is hand-crafted because it has a unique signature
-_STL_DEF_LASTARG_FAMILY2(_CONSTEXPR_CMATH23, scalbn, int)
-_STL_DEF_LASTARG_FAMILY2(_CONSTEXPR_CMATH23, scalbln, long)
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, cbrt)
-// abs() is in <__msvc_stdlib.hpp>
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH23, fabs)
-_STL_DEF_FAMILY2(_CONSTEXPR_CMATH26, hypot)
-_STL_DEF_FAMILY2(_CONSTEXPR_CMATH26, pow)
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, sqrt)
-_STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, erf)
-_STL_DECLARE_FAMILY1(_CONSTEXPR_CMATH26_NYI_DECL, erfc)
-// lgamma() is hand-crafted because it is not yet implemented by libc
-// tgamma() is hand-crafted because it is not yet implemented by libc
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH23, ceil)
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH23, floor)
-_STL_DEF_FAMILY1(inline, nearbyint)
-_STL_DEF_FAMILY1(inline, rint)
-_STL_DEF_RETURN_FAMILY1(inline, lrint, long)
-_STL_DEF_RETURN_FAMILY1(inline, llrint, long long)
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH23, round)
-_STL_DEF_RETURN_FAMILY1(_CONSTEXPR_CMATH23, lround, long)
-_STL_DEF_RETURN_FAMILY1(_CONSTEXPR_CMATH23, llround, long long)
-_STL_DEF_FAMILY1(_CONSTEXPR_CMATH23, trunc)
-_STL_DEF_FAMILY2(_CONSTEXPR_CMATH23, fmod)
-_STL_DEF_FAMILY2(_CONSTEXPR_CMATH23, remainder)
-_STL_DEF_LASTARG_FAMILY3(_CONSTEXPR_CMATH23, remquo, int*) // _NODISCARD is desirable, despite the out-param
-_STL_DEF_FAMILY2(_CONSTEXPR_CMATH23, copysign)
-// nan() is declared above
-_STL_DEF_FAMILY2(_CONSTEXPR_CMATH23, nextafter)
-_STL_DEF_LASTARG_FAMILY2(_CONSTEXPR_CMATH23, nexttoward, long double)
-_STL_DEF_FAMILY2(_CONSTEXPR_CMATH23, fdim)
-_STL_DEF_FAMILY2(_CONSTEXPR_CMATH23, fmax)
-_STL_DEF_FAMILY2(_CONSTEXPR_CMATH23, fmin)
-_STL_DEF_FAMILY3(_CONSTEXPR_CMATH23, fma)
+    _STL_DEF_OVERLOADED_COMPARISON_FAMILY1(_CONSTEXPR_CMATH23, signbit)
+    _STL_DEF_OVERLOADED_COMPARISON_FAMILY2(_CONSTEXPR_CMATH23, isgreater)
+    _STL_DEF_OVERLOADED_COMPARISON_FAMILY2(_CONSTEXPR_CMATH23, isgreaterequal)
+    _STL_DEF_OVERLOADED_COMPARISON_FAMILY2(_CONSTEXPR_CMATH23, isless)
+    _STL_DEF_OVERLOADED_COMPARISON_FAMILY2(_CONSTEXPR_CMATH23, islessequal)
+    _STL_DEF_OVERLOADED_COMPARISON_FAMILY2(_CONSTEXPR_CMATH23, islessgreater)
+    _STL_DEF_OVERLOADED_COMPARISON_FAMILY2(_CONSTEXPR_CMATH23, isunordered)
 
-extern "C++" {
-_STL_DEF_OVERLOADED_CLASSIFICATION_FAMILY1(_CONSTEXPR_CMATH23, int, fpclassify, /*unchanged*/)
-_STL_DEF_OVERLOADED_CLASSIFICATION_FAMILY1(_CONSTEXPR_CMATH23, bool, isfinite, <= 0)
-_STL_DEF_OVERLOADED_CLASSIFICATION_FAMILY1(_CONSTEXPR_CMATH23, bool, isinf, == FP_INFINITE)
-_STL_DEF_OVERLOADED_CLASSIFICATION_FAMILY1(_CONSTEXPR_CMATH23, bool, isnan, == FP_NAN)
-_STL_DEF_OVERLOADED_CLASSIFICATION_FAMILY1(_CONSTEXPR_CMATH23, bool, isnormal, == FP_NORMAL)
-
-_STL_DEF_OVERLOADED_COMPARISON_FAMILY1(_CONSTEXPR_CMATH23, signbit)
-_STL_DEF_OVERLOADED_COMPARISON_FAMILY2(_CONSTEXPR_CMATH23, isgreater)
-_STL_DEF_OVERLOADED_COMPARISON_FAMILY2(_CONSTEXPR_CMATH23, isgreaterequal)
-_STL_DEF_OVERLOADED_COMPARISON_FAMILY2(_CONSTEXPR_CMATH23, isless)
-_STL_DEF_OVERLOADED_COMPARISON_FAMILY2(_CONSTEXPR_CMATH23, islessequal)
-_STL_DEF_OVERLOADED_COMPARISON_FAMILY2(_CONSTEXPR_CMATH23, islessgreater)
-_STL_DEF_OVERLOADED_COMPARISON_FAMILY2(_CONSTEXPR_CMATH23, isunordered)
-} // extern "C++"
-
-_NODISCARD _CONSTEXPR_CMATH26 float __cdecl atan2f(float _Xx0, float _Xx1) noexcept /* strengthened */ {
-    return __builtin_atan2f(_Xx0, _Xx1);
-}
-_NODISCARD _CONSTEXPR_CMATH26 double __cdecl atan2(double _Xx0, double _Xx1) noexcept /* strengthened */ {
-    const double _Result = __builtin_atan2(_Xx0, _Xx1);
-    if (_Result == 0.0 && _Xx0 != 0.0) { // TRANSITION, LLVM-214934: Preserve the sign of zero when atan2 underflows.
-        return __builtin_copysign(0.0, _Xx0); // __builtin_atan2 can return +0 for tiny negative results.
+    _NODISCARD _CONSTEXPR_CMATH26 float __cdecl atan2f(float _Xx0, float _Xx1) noexcept /* strengthened */ {
+        return __builtin_atan2f(_Xx0, _Xx1);
     }
-    return _Result;
-}
-_NODISCARD _CONSTEXPR_CMATH26 long double __cdecl atan2l(long double _Xx0, long double _Xx1) noexcept
-/* strengthened */ {
-    return _CSTD atan2(static_cast<double>(_Xx0), static_cast<double>(_Xx1));
-}
+    _NODISCARD _CONSTEXPR_CMATH26 double __cdecl atan2(double _Xx0, double _Xx1) noexcept /* strengthened */ {
+        const double _Result = __builtin_atan2(_Xx0, _Xx1);
+        if (_Result == 0.0 && _Xx0 != 0.0) { // TRANSITION, LLVM-214934: Preserve the sign of zero during underflow.
+            return __builtin_copysign(0.0, _Xx0); // __builtin_atan2 can return +0 for tiny negative results.
+        }
+        return _Result;
+    }
+    _NODISCARD _CONSTEXPR_CMATH26 long double __cdecl atan2l(long double _Xx0, long double _Xx1) noexcept
+    /* strengthened */ {
+        return _CSTD atan2(static_cast<double>(_Xx0), static_cast<double>(_Xx1));
+    }
 
-// _NODISCARD is desirable, despite the out-param
-_NODISCARD _CONSTEXPR_CMATH23 float __cdecl modff(float _Xx0, float* _Xx1) noexcept /* strengthened */ {
-    return __builtin_modff(_Xx0, _Xx1);
-}
-_NODISCARD _CONSTEXPR_CMATH23 double __cdecl modf(double _Xx0, double* _Xx1) noexcept /* strengthened */ {
-    return __builtin_modf(_Xx0, _Xx1);
-}
-_NODISCARD _CONSTEXPR_CMATH23 long double __cdecl modfl(long double _Xx0, long double* _Xx1) noexcept
-/* strengthened */ {
-    return __builtin_modfl(_Xx0, _Xx1);
-}
+    // _NODISCARD is desirable, despite the out-param
+    _NODISCARD _CONSTEXPR_CMATH23 float __cdecl modff(float _Xx0, float* _Xx1) noexcept /* strengthened */ {
+        return __builtin_modff(_Xx0, _Xx1);
+    }
+    _NODISCARD _CONSTEXPR_CMATH23 double __cdecl modf(double _Xx0, double* _Xx1) noexcept /* strengthened */ {
+        return __builtin_modf(_Xx0, _Xx1);
+    }
+    _NODISCARD _CONSTEXPR_CMATH23 long double __cdecl modfl(long double _Xx0, long double* _Xx1) noexcept
+    /* strengthened */ {
+        return __builtin_modfl(_Xx0, _Xx1);
+    }
 
-// libc does not yet implement lgamma or tgamma. Polyfilling with the UCRT's implementation
-// pulls in the UCRT's fma, which results in linker errors due to our conflicting definition.
-// Instead, we prearranged for implementations of lgamma and tgamma to be ready in the satellite lib.
-//
-// _CRT_SATELLITE_2 is commented out because it is undefined at the point of this header's inclusion.
-// We'd normally address that by including yvals.h, but that makes this header non-core.
-// Otherwise, this header can be a core header. The macro definition is empty in usage,
-// so the comment has the same physical effect (though maybe a different mental effect).
-_NODISCARD /*_CRT_SATELLITE_2*/ float __stdcall __std_smf_lgammaf(float) noexcept;
-_NODISCARD /*_CRT_SATELLITE_2*/ double __stdcall __std_smf_lgamma(double) noexcept;
-_NODISCARD /*_CRT_SATELLITE_2*/ float __stdcall __std_smf_tgammaf(float) noexcept;
-_NODISCARD /*_CRT_SATELLITE_2*/ double __stdcall __std_smf_tgamma(double) noexcept;
+    // libc does not yet implement lgamma or tgamma. Polyfilling with the UCRT's implementation
+    // pulls in the UCRT's fma, which results in linker errors due to our conflicting definition.
+    // Instead, we prearranged for implementations of lgamma and tgamma to be ready in the satellite lib.
+    //
+    // _CRT_SATELLITE_2 is commented out because it is undefined at the point of this header's inclusion.
+    // We'd normally address that by including yvals.h, but that makes this header non-core.
+    // Otherwise, this header can be a core header. The macro definition is empty in usage,
+    // so the comment has the same physical effect (though maybe a different mental effect).
+    extern "C" {
+    _NODISCARD /*_CRT_SATELLITE_2*/ float __stdcall __std_smf_lgammaf(float) noexcept;
+    _NODISCARD /*_CRT_SATELLITE_2*/ double __stdcall __std_smf_lgamma(double) noexcept;
+    _NODISCARD /*_CRT_SATELLITE_2*/ float __stdcall __std_smf_tgammaf(float) noexcept;
+    _NODISCARD /*_CRT_SATELLITE_2*/ double __stdcall __std_smf_tgamma(double) noexcept;
+    } // extern "C"
 
-_NODISCARD _CONSTEXPR_CMATH26_NYI float __cdecl lgammaf(float _Xx) noexcept /* strengthened */ {
-    return __std_smf_lgammaf(_Xx);
-}
-_NODISCARD _CONSTEXPR_CMATH26_NYI double __cdecl lgamma(double _Xx) noexcept /* strengthened */ {
-    return __std_smf_lgamma(_Xx);
-}
-_NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl lgammal(long double _Xx) noexcept /* strengthened */ {
-    return __std_smf_lgamma(static_cast<double>(_Xx));
-}
+    _NODISCARD _CONSTEXPR_CMATH26_NYI float __cdecl lgammaf(float _Xx) noexcept /* strengthened */ {
+        return __std_smf_lgammaf(_Xx);
+    }
+    _NODISCARD _CONSTEXPR_CMATH26_NYI double __cdecl lgamma(double _Xx) noexcept /* strengthened */ {
+        return __std_smf_lgamma(_Xx);
+    }
+    _NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl lgammal(long double _Xx) noexcept /* strengthened */ {
+        return __std_smf_lgamma(static_cast<double>(_Xx));
+    }
 
-_NODISCARD _CONSTEXPR_CMATH26_NYI float __cdecl tgammaf(float _Xx) noexcept /* strengthened */ {
-    return __std_smf_tgammaf(_Xx);
-}
-_NODISCARD _CONSTEXPR_CMATH26_NYI double __cdecl tgamma(double _Xx) noexcept /* strengthened */ {
-    return __std_smf_tgamma(_Xx);
-}
-_NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl tgammal(long double _Xx) noexcept /* strengthened */ {
-    return __std_smf_tgamma(static_cast<double>(_Xx));
-}
+    _NODISCARD _CONSTEXPR_CMATH26_NYI float __cdecl tgammaf(float _Xx) noexcept /* strengthened */ {
+        return __std_smf_tgammaf(_Xx);
+    }
+    _NODISCARD _CONSTEXPR_CMATH26_NYI double __cdecl tgamma(double _Xx) noexcept /* strengthened */ {
+        return __std_smf_tgamma(_Xx);
+    }
+    _NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl tgammal(long double _Xx) noexcept /* strengthened */ {
+        return __std_smf_tgamma(static_cast<double>(_Xx));
+    }
 
 #undef _STL_DEF_FUNC1
 #undef _STL_DEF_FUNC2
@@ -510,7 +413,8 @@ _NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl tgammal(long double _Xx) n
 #undef _STL_DECLARE_DOUBLE_DEF_OTHERS1
 #undef _CONSTEXPR_CMATH26_NYI_DECL
 
-} // extern "C"
+} // namespace _Msvc_math
+} // extern "C++"
 
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/stl/inc/__msvc_math.hpp
+++ b/stl/inc/__msvc_math.hpp
@@ -294,8 +294,8 @@ inline namespace _Msvc_math {
     _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, sqrt)
     _STL_DECLARE_DOUBLE_DEF_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, _CONSTEXPR_CMATH26_NYI, erf)
     _STL_DECLARE_FAMILY1(_CONSTEXPR_CMATH26_NYI_DECL, erfc)
-    // lgamma() is hand-crafted because it is not yet implemented by libc
-    // tgamma() is hand-crafted because it is not yet implemented by libc
+    _STL_DECLARE_FAMILY1(_CONSTEXPR_CMATH26_NYI_DECL, lgamma)
+    _STL_DECLARE_FAMILY1(_CONSTEXPR_CMATH26_NYI_DECL, tgamma)
     _STL_DEF_FAMILY1(_CONSTEXPR_CMATH23, ceil)
     _STL_DEF_FAMILY1(_CONSTEXPR_CMATH23, floor)
     _STL_DEF_FAMILY1(inline, nearbyint)
@@ -357,41 +357,6 @@ inline namespace _Msvc_math {
     _NODISCARD _CONSTEXPR_CMATH23 long double __cdecl modfl(long double _Xx0, long double* _Xx1) noexcept
     /* strengthened */ {
         return __builtin_modfl(_Xx0, _Xx1);
-    }
-
-    // libc does not yet implement lgamma or tgamma. Polyfilling with the UCRT's implementation
-    // pulls in the UCRT's fma, which results in linker errors due to our conflicting definition.
-    // Instead, we prearranged for implementations of lgamma and tgamma to be ready in the satellite lib.
-    //
-    // _CRT_SATELLITE_2 is commented out because it is undefined at the point of this header's inclusion.
-    // We'd normally address that by including yvals.h, but that makes this header non-core.
-    // Otherwise, this header can be a core header. The macro definition is empty in usage,
-    // so the comment has the same physical effect (though maybe a different mental effect).
-    extern "C" {
-    _NODISCARD /*_CRT_SATELLITE_2*/ float __stdcall __std_smf_lgammaf(float) noexcept;
-    _NODISCARD /*_CRT_SATELLITE_2*/ double __stdcall __std_smf_lgamma(double) noexcept;
-    _NODISCARD /*_CRT_SATELLITE_2*/ float __stdcall __std_smf_tgammaf(float) noexcept;
-    _NODISCARD /*_CRT_SATELLITE_2*/ double __stdcall __std_smf_tgamma(double) noexcept;
-    } // extern "C"
-
-    _NODISCARD _CONSTEXPR_CMATH26_NYI float __cdecl lgammaf(float _Xx) noexcept /* strengthened */ {
-        return __std_smf_lgammaf(_Xx);
-    }
-    _NODISCARD _CONSTEXPR_CMATH26_NYI double __cdecl lgamma(double _Xx) noexcept /* strengthened */ {
-        return __std_smf_lgamma(_Xx);
-    }
-    _NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl lgammal(long double _Xx) noexcept /* strengthened */ {
-        return __std_smf_lgamma(static_cast<double>(_Xx));
-    }
-
-    _NODISCARD _CONSTEXPR_CMATH26_NYI float __cdecl tgammaf(float _Xx) noexcept /* strengthened */ {
-        return __std_smf_tgammaf(_Xx);
-    }
-    _NODISCARD _CONSTEXPR_CMATH26_NYI double __cdecl tgamma(double _Xx) noexcept /* strengthened */ {
-        return __std_smf_tgamma(_Xx);
-    }
-    _NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl tgammal(long double _Xx) noexcept /* strengthened */ {
-        return __std_smf_tgamma(static_cast<double>(_Xx));
     }
 
 #undef _STL_DEF_FUNC1

--- a/stl/inc/__msvc_math.hpp
+++ b/stl/inc/__msvc_math.hpp
@@ -191,6 +191,14 @@ extern "C" {
     _NODISCARD specs double __cdecl name(double) noexcept /* strengthened */;  \
     _NODISCARD specs long double __cdecl name##l(long double) noexcept /* strengthened */;
 
+// Defines a non-overloaded function with signature `float (float)`, then
+// *declares* two non-overloaded functions with signatures `double (double)` and `long double (long double)`.
+// This is used when libc has implemented a function for `float` but has not yet implemented it for `double`.
+#define _STL_DEF_FLOAT_DECLARE_OTHERS1(specs_def_float, specs_decl_others, name)          \
+    _STL_DEF_FUNC1(specs_def_float, name##f, float, float)                                \
+    _NODISCARD specs_decl_others double __cdecl name(double) noexcept /* strengthened */; \
+    _NODISCARD specs_decl_others long double __cdecl name##l(long double) noexcept /* strengthened */;
+
 // Some functions that are needed for C++26 constexpr cmath are not yet implemented by libc.
 // We polyfill the library with the UCRT and mark these functions with this macro.
 // The resulting declarations are not able to be used during constant evaluation yet.
@@ -261,6 +269,7 @@ _NODISCARD _CONSTEXPR_CMATH23 float __cdecl copysignf(float, float) noexcept;
 _NODISCARD _CONSTEXPR_CMATH23 double __cdecl copysign(double, double) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 float __cdecl cosf(float) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 double __cdecl cos(double) noexcept;
+_NODISCARD _CONSTEXPR_CMATH26 float __cdecl coshf(float) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 float __cdecl expf(float) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 double __cdecl exp(double) noexcept;
 _NODISCARD _CONSTEXPR_CMATH23 float __cdecl fabsf(float) noexcept;
@@ -300,10 +309,12 @@ _NODISCARD _CONSTEXPR_CMATH23 double __cdecl round(double) noexcept;
 _NODISCARD _CONSTEXPR_CMATH23 long double __cdecl roundl(long double) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 float __cdecl sinf(float) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 double __cdecl sin(double) noexcept;
+_NODISCARD _CONSTEXPR_CMATH26 float __cdecl sinhf(float) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 float __cdecl sqrtf(float) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 double __cdecl sqrt(double) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 float __cdecl tanf(float) noexcept;
 _NODISCARD _CONSTEXPR_CMATH26 double __cdecl tan(double) noexcept;
+_NODISCARD _CONSTEXPR_CMATH26 float __cdecl tanhf(float) noexcept;
 _NODISCARD _CONSTEXPR_CMATH23 float __cdecl truncf(float) noexcept;
 _NODISCARD _CONSTEXPR_CMATH23 double __cdecl trunc(double) noexcept;
 _NODISCARD _CONSTEXPR_CMATH23 long double __cdecl truncl(long double) noexcept;
@@ -315,6 +326,7 @@ _NODISCARD _CONSTEXPR_CMATH23 long double __cdecl truncl(long double) noexcept;
 #pragma function(ceilf, ceil)
 #pragma function(copysignf, copysign)
 #pragma function(cosf, cos)
+#pragma function(coshf)
 #pragma function(expf, exp)
 #pragma function(fabsf, fabs)
 #pragma function(floorf, floor)
@@ -331,8 +343,10 @@ _NODISCARD _CONSTEXPR_CMATH23 long double __cdecl truncl(long double) noexcept;
 #pragma function(rintf, rint, rintl)
 #pragma function(roundf, round, roundl)
 #pragma function(sinf, sin)
+#pragma function(sinhf)
 #pragma function(sqrtf, sqrt)
 #pragma function(tanf, tan)
+#pragma function(tanhf)
 #pragma function(truncf, trunc, truncl)
 
 // The following order matches N5054 [cmath.syn].
@@ -343,12 +357,12 @@ _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, atan)
 _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, cos)
 _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, sin)
 _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, tan)
-_STL_DECLARE_FAMILY1(_CONSTEXPR_CMATH26_NYI_DECL, acosh)
-_STL_DECLARE_FAMILY1(_CONSTEXPR_CMATH26_NYI_DECL, asinh)
-_STL_DECLARE_FAMILY1(_CONSTEXPR_CMATH26_NYI_DECL, atanh)
-_STL_DECLARE_FAMILY1(_CONSTEXPR_CMATH26_NYI_DECL, cosh) // additional workarounds for this polyfill are defined below
-_STL_DECLARE_FAMILY1(_CONSTEXPR_CMATH26_NYI_DECL, sinh) // additional workarounds for this polyfill are defined below
-_STL_DECLARE_FAMILY1(_CONSTEXPR_CMATH26_NYI_DECL, tanh) // additional workarounds for this polyfill are defined below
+_STL_DEF_FLOAT_DECLARE_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, acosh)
+_STL_DEF_FLOAT_DECLARE_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, asinh)
+_STL_DEF_FLOAT_DECLARE_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, atanh)
+_STL_DEF_FLOAT_DECLARE_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, cosh) // additional workarounds below
+_STL_DEF_FLOAT_DECLARE_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, sinh) // additional workarounds below
+_STL_DEF_FLOAT_DECLARE_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, tanh) // additional workarounds below
 _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, exp)
 _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, exp2)
 _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, expm1)
@@ -369,7 +383,7 @@ _STL_DEF_FAMILY1(_CONSTEXPR_CMATH23, fabs)
 _STL_DEF_FAMILY2(_CONSTEXPR_CMATH26, hypot)
 _STL_DEF_FAMILY2(_CONSTEXPR_CMATH26, pow)
 _STL_DEF_FAMILY1(_CONSTEXPR_CMATH26, sqrt)
-_STL_DECLARE_FAMILY1(_CONSTEXPR_CMATH26_NYI_DECL, erf)
+_STL_DEF_FLOAT_DECLARE_OTHERS1(_CONSTEXPR_CMATH26, _CONSTEXPR_CMATH26_NYI_DECL, erf)
 _STL_DECLARE_FAMILY1(_CONSTEXPR_CMATH26_NYI_DECL, erfc)
 // lgamma() is hand-crafted because it is not yet implemented by libc
 // tgamma() is hand-crafted because it is not yet implemented by libc
@@ -473,19 +487,6 @@ _NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl tgammal(long double _Xx) n
 
 // The UCRT defines the following functions as inline functions that forward to their double siblings,
 // so forward-declaring them without defining them would not result in a successful polyfill.
-#if defined(_M_IX86) && !defined(_M_HYBRID_X86_ARM64)
-#pragma function(coshf, sinhf, tanhf)
-_NODISCARD _CONSTEXPR_CMATH26_NYI float __cdecl coshf(float _Xx) noexcept /* strengthened */ {
-    return __builtin_coshf(_Xx);
-}
-_NODISCARD _CONSTEXPR_CMATH26_NYI float __cdecl sinhf(float _Xx) noexcept /* strengthened */ {
-    return __builtin_sinhf(_Xx);
-}
-_NODISCARD _CONSTEXPR_CMATH26_NYI float __cdecl tanhf(float _Xx) noexcept /* strengthened */ {
-    return __builtin_tanhf(_Xx);
-}
-#endif // ^^^ defined(_M_IX86) && !defined(_M_HYBRID_X86_ARM64) ^^^
-
 #pragma function(coshl, sinhl, tanhl)
 _NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl coshl(long double _Xx) noexcept /* strengthened */ {
     return _CSTD cosh(static_cast<double>(_Xx));
@@ -513,6 +514,7 @@ _NODISCARD _CONSTEXPR_CMATH26_NYI long double __cdecl tanhl(long double _Xx) noe
 #undef _STL_DEF_OVERLOADED_COMPARISON_FAMILY1
 #undef _STL_DEF_OVERLOADED_COMPARISON_FAMILY2
 #undef _STL_DECLARE_FAMILY1
+#undef _STL_DEF_FLOAT_DECLARE_OTHERS1
 #undef _CONSTEXPR_CMATH26_NYI_DECL
 
 } // extern "C"

--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -41,7 +41,7 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float acos(_In_ float _Xx) noexcept
     return _CSTD acosf(_Xx);
 }
 
-_NODISCARD _Check_return_ inline float acosh(_In_ float _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI float acosh(_In_ float _Xx) noexcept /* strengthened */ {
     return _CSTD acoshf(_Xx);
 }
 
@@ -49,7 +49,7 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float asin(_In_ float _Xx) noexcept
     return _CSTD asinf(_Xx);
 }
 
-_NODISCARD _Check_return_ inline float asinh(_In_ float _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI float asinh(_In_ float _Xx) noexcept /* strengthened */ {
     return _CSTD asinhf(_Xx);
 }
 
@@ -57,7 +57,7 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float atan(_In_ float _Xx) noexcept
     return _CSTD atanf(_Xx);
 }
 
-_NODISCARD _Check_return_ inline float atanh(_In_ float _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI float atanh(_In_ float _Xx) noexcept /* strengthened */ {
     return _CSTD atanhf(_Xx);
 }
 
@@ -94,15 +94,15 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float cos(_In_ float _Xx) noexcept 
     return _CSTD cosf(_Xx);
 }
 
-_NODISCARD _Check_return_ inline float cosh(_In_ float _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI float cosh(_In_ float _Xx) noexcept /* strengthened */ {
     return _CSTD coshf(_Xx);
 }
 
-_NODISCARD _Check_return_ inline float erf(_In_ float _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI float erf(_In_ float _Xx) noexcept /* strengthened */ {
     return _CSTD erff(_Xx);
 }
 
-_NODISCARD _Check_return_ inline float erfc(_In_ float _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI float erfc(_In_ float _Xx) noexcept /* strengthened */ {
     return _CSTD erfcf(_Xx);
 }
 
@@ -169,7 +169,7 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH23 float ldexp(_In_ float _Xx, _In_ in
     return _CSTD ldexpf(_Xx, _Yx);
 }
 
-_NODISCARD _Check_return_ inline float lgamma(_In_ float _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI float lgamma(_In_ float _Xx) noexcept /* strengthened */ {
     return _CSTD lgammaf(_Xx);
 }
 
@@ -267,7 +267,7 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float sin(_In_ float _Xx) noexcept 
     return _CSTD sinf(_Xx);
 }
 
-_NODISCARD _Check_return_ inline float sinh(_In_ float _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI float sinh(_In_ float _Xx) noexcept /* strengthened */ {
     return _CSTD sinhf(_Xx);
 }
 
@@ -279,11 +279,11 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float tan(_In_ float _Xx) noexcept 
     return _CSTD tanf(_Xx);
 }
 
-_NODISCARD _Check_return_ inline float tanh(_In_ float _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI float tanh(_In_ float _Xx) noexcept /* strengthened */ {
     return _CSTD tanhf(_Xx);
 }
 
-_NODISCARD _Check_return_ inline float tgamma(_In_ float _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI float tgamma(_In_ float _Xx) noexcept /* strengthened */ {
     return _CSTD tgammaf(_Xx);
 }
 
@@ -301,7 +301,7 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 long double acos(_In_ long double _
     return _CSTD acosl(_Xx);
 }
 
-_NODISCARD _Check_return_ inline long double acosh(_In_ long double _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI long double acosh(_In_ long double _Xx) noexcept /* strengthened */ {
     return _CSTD acoshl(_Xx);
 }
 
@@ -309,7 +309,7 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 long double asin(_In_ long double _
     return _CSTD asinl(_Xx);
 }
 
-_NODISCARD _Check_return_ inline long double asinh(_In_ long double _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI long double asinh(_In_ long double _Xx) noexcept /* strengthened */ {
     return _CSTD asinhl(_Xx);
 }
 
@@ -317,7 +317,7 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 long double atan(_In_ long double _
     return _CSTD atanl(_Xx);
 }
 
-_NODISCARD _Check_return_ inline long double atanh(_In_ long double _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI long double atanh(_In_ long double _Xx) noexcept /* strengthened */ {
     return _CSTD atanhl(_Xx);
 }
 
@@ -356,15 +356,15 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 long double cos(_In_ long double _X
     return _CSTD cosl(_Xx);
 }
 
-_NODISCARD _Check_return_ inline long double cosh(_In_ long double _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI long double cosh(_In_ long double _Xx) noexcept /* strengthened */ {
     return _CSTD coshl(_Xx);
 }
 
-_NODISCARD _Check_return_ inline long double erf(_In_ long double _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI long double erf(_In_ long double _Xx) noexcept /* strengthened */ {
     return _CSTD erfl(_Xx);
 }
 
-_NODISCARD _Check_return_ inline long double erfc(_In_ long double _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI long double erfc(_In_ long double _Xx) noexcept /* strengthened */ {
     return _CSTD erfcl(_Xx);
 }
 
@@ -438,7 +438,7 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH23 long double ldexp(_In_ long double 
     return _CSTD ldexpl(_Xx, _Yx);
 }
 
-_NODISCARD _Check_return_ inline long double lgamma(_In_ long double _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI long double lgamma(_In_ long double _Xx) noexcept /* strengthened */ {
     return _CSTD lgammal(_Xx);
 }
 
@@ -541,7 +541,7 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 long double sin(_In_ long double _X
     return _CSTD sinl(_Xx);
 }
 
-_NODISCARD _Check_return_ inline long double sinh(_In_ long double _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI long double sinh(_In_ long double _Xx) noexcept /* strengthened */ {
     return _CSTD sinhl(_Xx);
 }
 
@@ -553,11 +553,11 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 long double tan(_In_ long double _X
     return _CSTD tanl(_Xx);
 }
 
-_NODISCARD _Check_return_ inline long double tanh(_In_ long double _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI long double tanh(_In_ long double _Xx) noexcept /* strengthened */ {
     return _CSTD tanhl(_Xx);
 }
 
-_NODISCARD _Check_return_ inline long double tgamma(_In_ long double _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI long double tgamma(_In_ long double _Xx) noexcept /* strengthened */ {
     return _CSTD tgammal(_Xx);
 }
 

--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -1698,16 +1698,15 @@ _NODISCARD _CONSTEXPR_CMATH26_NYI auto hypot(const _Ty1 _Dx, const _Ty2 _Dy, con
 }
 
 #if _HAS_CXX20
-_EXPORT_STD _NODISCARD constexpr inline float lerp(const float _ArgA, const float _ArgB, const float _ArgT) noexcept {
+_EXPORT_STD _NODISCARD constexpr float lerp(const float _ArgA, const float _ArgB, const float _ArgT) noexcept {
     return _Common_lerp(_ArgA, _ArgB, _ArgT);
 }
 
-_EXPORT_STD _NODISCARD constexpr inline double lerp(
-    const double _ArgA, const double _ArgB, const double _ArgT) noexcept {
+_EXPORT_STD _NODISCARD constexpr double lerp(const double _ArgA, const double _ArgB, const double _ArgT) noexcept {
     return _Common_lerp(_ArgA, _ArgB, _ArgT);
 }
 
-_EXPORT_STD _NODISCARD constexpr inline long double lerp(
+_EXPORT_STD _NODISCARD constexpr long double lerp(
     const long double _ArgA, const long double _ArgB, const long double _ArgT) noexcept {
     return _Common_lerp(static_cast<double>(_ArgA), static_cast<double>(_ArgB), static_cast<double>(_ArgT));
 }

--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -110,7 +110,7 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float exp(_In_ float _Xx) noexcept 
     return _CSTD expf(_Xx);
 }
 
-_NODISCARD _Check_return_ inline float exp2(_In_ float _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float exp2(_In_ float _Xx) noexcept /* strengthened */ {
     return _CSTD exp2f(_Xx);
 }
 
@@ -372,7 +372,7 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 long double exp(_In_ long double _X
     return _CSTD expl(_Xx);
 }
 
-_NODISCARD _Check_return_ inline long double exp2(_In_ long double _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26 long double exp2(_In_ long double _Xx) noexcept /* strengthened */ {
     return _CSTD exp2l(_Xx);
 }
 
@@ -874,7 +874,7 @@ _GENERIC_MATH1(_CONSTEXPR_CMATH26_NYI, cosh)
 _GENERIC_MATH1(_CONSTEXPR_CMATH26_NYI, sinh)
 _GENERIC_MATH1(_CONSTEXPR_CMATH26_NYI, tanh)
 _GENERIC_MATH1(_CONSTEXPR_CMATH26, exp)
-_GENERIC_MATH1(_CONSTEXPR_CMATH26_NYI, exp2)
+_GENERIC_MATH1(_CONSTEXPR_CMATH26, exp2)
 _GENERIC_MATH1(_CONSTEXPR_CMATH26, expm1)
 // frexp() is hand-crafted
 _GENERIC_MATH1R(_CONSTEXPR_CMATH23, ilogb, int)

--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -41,7 +41,7 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float acos(_In_ float _Xx) noexcept
     return _CSTD acosf(_Xx);
 }
 
-_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI float acosh(_In_ float _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float acosh(_In_ float _Xx) noexcept /* strengthened */ {
     return _CSTD acoshf(_Xx);
 }
 
@@ -49,7 +49,7 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float asin(_In_ float _Xx) noexcept
     return _CSTD asinf(_Xx);
 }
 
-_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI float asinh(_In_ float _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float asinh(_In_ float _Xx) noexcept /* strengthened */ {
     return _CSTD asinhf(_Xx);
 }
 
@@ -57,7 +57,7 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float atan(_In_ float _Xx) noexcept
     return _CSTD atanf(_Xx);
 }
 
-_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI float atanh(_In_ float _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float atanh(_In_ float _Xx) noexcept /* strengthened */ {
     return _CSTD atanhf(_Xx);
 }
 
@@ -94,11 +94,11 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float cos(_In_ float _Xx) noexcept 
     return _CSTD cosf(_Xx);
 }
 
-_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI float cosh(_In_ float _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float cosh(_In_ float _Xx) noexcept /* strengthened */ {
     return _CSTD coshf(_Xx);
 }
 
-_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI float erf(_In_ float _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float erf(_In_ float _Xx) noexcept /* strengthened */ {
     return _CSTD erff(_Xx);
 }
 
@@ -267,7 +267,7 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float sin(_In_ float _Xx) noexcept 
     return _CSTD sinf(_Xx);
 }
 
-_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI float sinh(_In_ float _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float sinh(_In_ float _Xx) noexcept /* strengthened */ {
     return _CSTD sinhf(_Xx);
 }
 
@@ -279,7 +279,7 @@ _NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float tan(_In_ float _Xx) noexcept 
     return _CSTD tanf(_Xx);
 }
 
-_NODISCARD _Check_return_ _CONSTEXPR_CMATH26_NYI float tanh(_In_ float _Xx) noexcept /* strengthened */ {
+_NODISCARD _Check_return_ _CONSTEXPR_CMATH26 float tanh(_In_ float _Xx) noexcept /* strengthened */ {
     return _CSTD tanhf(_Xx);
 }
 

--- a/stl/msbuild/stl_2/amd64.exports
+++ b/stl/msbuild/stl_2/amd64.exports
@@ -34,8 +34,6 @@ __std_smf_laguerre
 __std_smf_laguerref
 __std_smf_legendre
 __std_smf_legendref
-__std_smf_lgamma
-__std_smf_lgammaf
 __std_smf_riemann_zeta
 __std_smf_riemann_zetaf
 __std_smf_sph_bessel
@@ -44,5 +42,3 @@ __std_smf_sph_legendre
 __std_smf_sph_legendref
 __std_smf_sph_neumann
 __std_smf_sph_neumannf
-__std_smf_tgamma
-__std_smf_tgammaf

--- a/stl/msbuild/stl_2/arm64.exports
+++ b/stl/msbuild/stl_2/arm64.exports
@@ -34,8 +34,6 @@ __std_smf_laguerre
 __std_smf_laguerref
 __std_smf_legendre
 __std_smf_legendref
-__std_smf_lgamma
-__std_smf_lgammaf
 __std_smf_riemann_zeta
 __std_smf_riemann_zetaf
 __std_smf_sph_bessel
@@ -44,5 +42,3 @@ __std_smf_sph_legendre
 __std_smf_sph_legendref
 __std_smf_sph_neumann
 __std_smf_sph_neumannf
-__std_smf_tgamma
-__std_smf_tgammaf

--- a/stl/msbuild/stl_2/i386.exports
+++ b/stl/msbuild/stl_2/i386.exports
@@ -34,8 +34,6 @@ ___std_smf_laguerre@12
 ___std_smf_laguerref@8
 ___std_smf_legendre@12
 ___std_smf_legendref@8
-___std_smf_lgamma@8
-___std_smf_lgammaf@4
 ___std_smf_riemann_zeta@8
 ___std_smf_riemann_zetaf@4
 ___std_smf_sph_bessel@12
@@ -44,5 +42,3 @@ ___std_smf_sph_legendre@16
 ___std_smf_sph_legendref@12
 ___std_smf_sph_neumann@12
 ___std_smf_sph_neumannf@8
-___std_smf_tgamma@8
-___std_smf_tgammaf@4

--- a/stl/src/special_math.cpp
+++ b/stl/src/special_math.cpp
@@ -30,7 +30,6 @@
 #include <boost/math/special_functions/ellint_2.hpp>
 #include <boost/math/special_functions/ellint_3.hpp>
 #include <boost/math/special_functions/expint.hpp>
-#include <boost/math/special_functions/gamma.hpp>
 #include <boost/math/special_functions/hermite.hpp>
 #include <boost/math/special_functions/laguerre.hpp>
 #include <boost/math/special_functions/legendre.hpp>
@@ -409,24 +408,6 @@ extern "C" {
     return _Boost_call([=] { return ::boost::math::legendre_p(_Pl, _Px); });
 }
 
-[[nodiscard]] _CRT_SATELLITE_2 double __stdcall __std_smf_lgamma(const double _Px) noexcept {
-    if (_STD isnan(_Px)) {
-        return _Px;
-    }
-
-    // TRANSITION, investigate handling C23 7.12.1 "Treatment of error conditions" and 7.12.8.3 "The lgamma functions".
-    return _Boost_call([=] { return ::boost::math::lgamma(_Px); });
-}
-
-[[nodiscard]] _CRT_SATELLITE_2 float __stdcall __std_smf_lgammaf(const float _Px) noexcept {
-    if (_STD isnan(_Px)) {
-        return _Px;
-    }
-
-    // TRANSITION, investigate handling C23 7.12.1 "Treatment of error conditions" and 7.12.8.3 "The lgamma functions".
-    return _Boost_call([=] { return ::boost::math::lgamma(_Px); });
-}
-
 [[nodiscard]] _CRT_SATELLITE_2 double __stdcall __std_smf_riemann_zeta(const double _Px) noexcept {
     if (_STD isnan(_Px)) {
         return _Px;
@@ -494,24 +475,6 @@ extern "C" {
     }
 
     return _Boost_call([=] { return ::boost::math::sph_neumann(_Pn, _Px); });
-}
-
-[[nodiscard]] _CRT_SATELLITE_2 double __stdcall __std_smf_tgamma(const double _Px) noexcept {
-    if (_STD isnan(_Px)) {
-        return _Px;
-    }
-
-    // TRANSITION, investigate handling C23 7.12.1 "Treatment of error conditions" and 7.12.8.4 "The tgamma functions".
-    return _Boost_call([=] { return ::boost::math::tgamma(_Px); });
-}
-
-[[nodiscard]] _CRT_SATELLITE_2 float __stdcall __std_smf_tgammaf(const float _Px) noexcept {
-    if (_STD isnan(_Px)) {
-        return _Px;
-    }
-
-    // TRANSITION, investigate handling C23 7.12.1 "Treatment of error conditions" and 7.12.8.4 "The tgamma functions".
-    return _Boost_call([=] { return ::boost::math::tgamma(_Px); });
 }
 } // extern "C"
 

--- a/tests/std/tests/P0533R9_constexpr_for_cmath_and_cstdlib/test.cpp
+++ b/tests/std/tests/P0533R9_constexpr_for_cmath_and_cstdlib/test.cpp
@@ -469,46 +469,68 @@ CONSTEXPR_CMATH26 bool test_cmath_cxx26() {
     assert(round(tanl(0.6l) * 1000.0l) == 684.0l);
     assert(round(tan(1729) * 1000.0) == 2087.0);
 
+    assert(round(acosh(3.3f) * 1000.0f) == 1863.0f);
     if (!_Is_constant_evaluated()) { // TRANSITION, GH-3789
-        assert(round(acosh(3.3f) * 1000.0f) == 1863.0f);
         assert(round(acosh(3.3) * 1000.0) == 1863.0);
         assert(round(acosh(3.3l) * 1000.0l) == 1863.0l);
-        assert(round(acoshf(3.3f) * 1000.0f) == 1863.0f);
+    }
+    assert(round(acoshf(3.3f) * 1000.0f) == 1863.0f);
+    if (!_Is_constant_evaluated()) { // TRANSITION, GH-3789
         assert(round(acoshl(3.3l) * 1000.0l) == 1863.0l);
         assert(round(acosh(7) * 1000.0) == 2634.0);
+    }
 
-        assert(round(asinh(3.3f) * 1000.0f) == 1909.0f);
+    assert(round(asinh(3.3f) * 1000.0f) == 1909.0f);
+    if (!_Is_constant_evaluated()) { // TRANSITION, GH-3789
         assert(round(asinh(3.3) * 1000.0) == 1909.0);
         assert(round(asinh(3.3l) * 1000.0l) == 1909.0l);
-        assert(round(asinhf(3.3f) * 1000.0f) == 1909.0f);
+    }
+    assert(round(asinhf(3.3f) * 1000.0f) == 1909.0f);
+    if (!_Is_constant_evaluated()) { // TRANSITION, GH-3789
         assert(round(asinhl(3.3l) * 1000.0l) == 1909.0l);
         assert(round(asinh(7) * 1000.0) == 2644.0);
+    }
 
-        assert(round(atanh(0.6f) * 1000.0f) == 693.0f);
+    assert(round(atanh(0.6f) * 1000.0f) == 693.0f);
+    if (!_Is_constant_evaluated()) { // TRANSITION, GH-3789
         assert(round(atanh(0.6) * 1000.0) == 693.0);
         assert(round(atanh(0.6l) * 1000.0l) == 693.0l);
-        assert(round(atanhf(0.6f) * 1000.0f) == 693.0f);
+    }
+    assert(round(atanhf(0.6f) * 1000.0f) == 693.0f);
+    if (!_Is_constant_evaluated()) { // TRANSITION, GH-3789
         assert(round(atanhl(0.6l) * 1000.0l) == 693.0l);
         assert(round(atanh(0) * 1000.0) == 0.0);
+    }
 
-        assert(round(cosh(0.6f) * 1000.0f) == 1185.0f);
+    assert(round(cosh(0.6f) * 1000.0f) == 1185.0f);
+    if (!_Is_constant_evaluated()) { // TRANSITION, GH-3789
         assert(round(cosh(0.6) * 1000.0) == 1185.0);
         assert(round(cosh(0.6l) * 1000.0l) == 1185.0l);
-        assert(round(coshf(0.6f) * 1000.0f) == 1185.0f);
+    }
+    assert(round(coshf(0.6f) * 1000.0f) == 1185.0f);
+    if (!_Is_constant_evaluated()) { // TRANSITION, GH-3789
         assert(round(coshl(0.6l) * 1000.0l) == 1185.0l);
         assert(round(cosh(2) * 1000.0) == 3762.0);
+    }
 
-        assert(round(sinh(0.6f) * 1000.0f) == 637.0f);
+    assert(round(sinh(0.6f) * 1000.0f) == 637.0f);
+    if (!_Is_constant_evaluated()) { // TRANSITION, GH-3789
         assert(round(sinh(0.6) * 1000.0) == 637.0);
         assert(round(sinh(0.6l) * 1000.0l) == 637.0l);
-        assert(round(sinhf(0.6f) * 1000.0f) == 637.0f);
+    }
+    assert(round(sinhf(0.6f) * 1000.0f) == 637.0f);
+    if (!_Is_constant_evaluated()) { // TRANSITION, GH-3789
         assert(round(sinhl(0.6l) * 1000.0l) == 637.0l);
         assert(round(sinh(2) * 1000.0) == 3627.0);
+    }
 
-        assert(round(tanh(0.6f) * 1000.0f) == 537.0f);
+    assert(round(tanh(0.6f) * 1000.0f) == 537.0f);
+    if (!_Is_constant_evaluated()) { // TRANSITION, GH-3789
         assert(round(tanh(0.6) * 1000.0) == 537.0);
         assert(round(tanh(0.6l) * 1000.0l) == 537.0l);
-        assert(round(tanhf(0.6f) * 1000.0f) == 537.0f);
+    }
+    assert(round(tanhf(0.6f) * 1000.0f) == 537.0f);
+    if (!_Is_constant_evaluated()) { // TRANSITION, GH-3789
         assert(round(tanhl(0.6l) * 1000.0l) == 537.0l);
         assert(round(tanh(2) * 1000.0) == 964.0);
     }
@@ -600,11 +622,13 @@ CONSTEXPR_CMATH26 bool test_cmath_cxx26() {
     assert(round(sqrtl(0.6l) * 1000.0l) == 775.0l);
     assert(round(sqrt(7) * 1000.0) == 2646.0);
 
+    assert(round(erf(0.6f) * 1000.0f) == 604.0f);
     if (!_Is_constant_evaluated()) { // TRANSITION, GH-3789
-        assert(round(erf(0.6f) * 1000.0f) == 604.0f);
         assert(round(erf(0.6) * 1000.0) == 604.0);
         assert(round(erf(0.6l) * 1000.0l) == 604.0l);
-        assert(round(erff(0.6f) * 1000.0f) == 604.0f);
+    }
+    assert(round(erff(0.6f) * 1000.0f) == 604.0f);
+    if (!_Is_constant_evaluated()) { // TRANSITION, GH-3789
         assert(round(erfl(0.6l) * 1000.0l) == 604.0l);
         assert(round(erf(1) * 1000.0) == 843.0);
 

--- a/tests/std/tests/P0533R9_constexpr_for_cmath_and_cstdlib/test.cpp
+++ b/tests/std/tests/P0533R9_constexpr_for_cmath_and_cstdlib/test.cpp
@@ -520,14 +520,12 @@ CONSTEXPR_CMATH26 bool test_cmath_cxx26() {
     assert(round(expl(0.6l) * 1000.0l) == 1822.0l);
     assert(round(exp(2) * 1000.0) == 7389.0);
 
-    if (!_Is_constant_evaluated()) { // TRANSITION, GH-3789
-        assert(round(exp2(0.6f) * 1000.0f) == 1516.0f);
-        assert(round(exp2(0.6) * 1000.0) == 1516.0);
-        assert(round(exp2(0.6l) * 1000.0l) == 1516.0l);
-        assert(round(exp2f(0.6f) * 1000.0f) == 1516.0f);
-        assert(round(exp2l(0.6l) * 1000.0l) == 1516.0l);
-        assert(round(exp2(-3) * 1000.0) == 125.0);
-    }
+    assert(round(exp2(0.6f) * 1000.0f) == 1516.0f);
+    assert(round(exp2(0.6) * 1000.0) == 1516.0);
+    assert(round(exp2(0.6l) * 1000.0l) == 1516.0l);
+    assert(round(exp2f(0.6f) * 1000.0f) == 1516.0f);
+    assert(round(exp2l(0.6l) * 1000.0l) == 1516.0l);
+    assert(round(exp2(-3) * 1000.0) == 125.0);
 
     assert(round(expm1(0.6f) * 1000.0f) == 822.0f);
     assert(round(expm1(0.6) * 1000.0) == 822.0);


### PR DESCRIPTION
This PR avoids the need for a whole bunch of workarounds in `constexpr <cmath>` and should make it possible for `/Zc:cmath` TUs to coexist with `/Zc:cmath-` TUs.

* `exp2` is completely ready to be `_CONSTEXPR_CMATH26`.
  + See LLVM libc's status at https://libc.llvm.org/headers/math/index.html .
* cmath: Mark `float`/`long double` overloads as `_CONSTEXPR_CMATH26_NYI`; the generic macros already are.
  + This will make it easier to remember to update these overloads in the future.
* cmath: `constexpr inline` => `constexpr` for `lerp`.
  + This is an unrelated cleanup while we're in the neighborhood, for an issue that was introduced on 2020-07-29 by #1048.
* Implement the `float` versions of `acosh, asinh, atanh, cosh, sinh, tanh, erf` with LLVM libc, making them C++26 constexpr.
  + These are also ready (and we were using some builtins, just not making them constexpr).
* Instead of declaring MEOWl, define it as wrapping MEOW.
* Use `extern "C"` for decls, but `extern "C++"` with an `inline namespace` for defns.
  + This should avoid conflicts with the UCRT, while remaining invisible to users. This also avoids intrinsic headaches.
* Declare UCRT lgamma/tgamma instead of implementing with Boost.Math.
  + This avoids messing with the satellite DLL's export surface before we ship 14.52.
  + Resolves #6417 by making it moot.
