### PR TITLE
Overhaul `constexpr` `<cstdlib>` and `<cinttypes>`

### DIFF
--- a/stl/inc/__msvc_inttypes.hpp
+++ b/stl/inc/__msvc_inttypes.hpp
@@ -51,15 +51,19 @@ typedef _Lldiv_t imaxdiv_t;
 #define _CONSTEXPR_CINTTYPES23 inline
 #endif // ^^^ inline when /Zc:cmath- opts out of constexpr, and in C++20 and earlier ^^^
 
-[[nodiscard]] _Check_return_ _CONSTEXPR_CINTTYPES23 intmax_t __cdecl imaxabs(_In_ intmax_t _Number) noexcept
-/* strengthened */ {
-    return _Number >= 0 ? _Number : -_Number;
-}
+extern "C++" {
+inline namespace _Msvc_inttypes {
+    [[nodiscard]] _Check_return_ _CONSTEXPR_CINTTYPES23 intmax_t __cdecl imaxabs(_In_ intmax_t _Number) noexcept
+    /* strengthened */ {
+        return _Number >= 0 ? _Number : -_Number;
+    }
 
-[[nodiscard]] _Check_return_ _CONSTEXPR_CINTTYPES23 imaxdiv_t __cdecl imaxdiv(
-    _In_ intmax_t _Numerator, _In_ intmax_t _Denominator) noexcept /* strengthened */ {
-    return {_Numerator / _Denominator, _Numerator % _Denominator};
-}
+    [[nodiscard]] _Check_return_ _CONSTEXPR_CINTTYPES23 imaxdiv_t __cdecl imaxdiv(
+        _In_ intmax_t _Numerator, _In_ intmax_t _Denominator) noexcept /* strengthened */ {
+        return {_Numerator / _Denominator, _Numerator % _Denominator};
+    }
+} // namespace _Msvc_inttypes
+} // extern "C++"
 
 #undef _CONSTEXPR_CINTTYPES23
 

--- a/stl/inc/__msvc_stdlib.hpp
+++ b/stl/inc/__msvc_stdlib.hpp
@@ -222,46 +222,37 @@ typedef struct _lldiv_t {
 #define _CONSTEXPR_CSTDLIB23 inline
 #endif // ^^^ inline when /Zc:cmath- opts out of constexpr, and in C++20 and earlier ^^^
 
-_Check_return_ _CONSTEXPR_CSTDLIB23 int __cdecl abs(_In_ int) noexcept;
-_Check_return_ _CONSTEXPR_CSTDLIB23 long __cdecl labs(_In_ long) noexcept;
-_Check_return_ _CONSTEXPR_CSTDLIB23 long long __cdecl llabs(_In_ long long) noexcept;
-_Check_return_ _CONSTEXPR_CSTDLIB23 div_t __cdecl div(_In_ int, _In_ int) noexcept;
-_Check_return_ _CONSTEXPR_CSTDLIB23 ldiv_t __cdecl ldiv(_In_ long, _In_ long) noexcept;
-_Check_return_ _CONSTEXPR_CSTDLIB23 lldiv_t __cdecl lldiv(_In_ long long, _In_ long long) noexcept;
+extern "C++" {
+inline namespace _Msvc_stdlib {
+    [[nodiscard]] _Check_return_ _CONSTEXPR_CSTDLIB23 int __cdecl abs(_In_ int _Xx) noexcept /* strengthened */ {
+        return _Xx >= 0 ? _Xx : -_Xx;
+    }
 
-#pragma warning(push)
-#pragma warning(disable : 4163) // 'meow' not available as an intrinsic function
-#pragma function(abs, labs, llabs)
-#pragma function(div, ldiv, lldiv)
-#pragma warning(pop)
+    [[nodiscard]] _Check_return_ _CONSTEXPR_CSTDLIB23 long __cdecl labs(_In_ long _Xx) noexcept /* strengthened */ {
+        return _Xx >= 0 ? _Xx : -_Xx;
+    }
 
-[[nodiscard]] _Check_return_ _CONSTEXPR_CSTDLIB23 int __cdecl abs(_In_ int _Xx) noexcept /* strengthened */ {
-    return _Xx >= 0 ? _Xx : -_Xx;
-}
+    [[nodiscard]] _Check_return_ _CONSTEXPR_CSTDLIB23 long long __cdecl llabs(_In_ long long _Xx) noexcept
+    /* strengthened */ {
+        return _Xx >= 0 ? _Xx : -_Xx;
+    }
 
-[[nodiscard]] _Check_return_ _CONSTEXPR_CSTDLIB23 long __cdecl labs(_In_ long _Xx) noexcept /* strengthened */ {
-    return _Xx >= 0 ? _Xx : -_Xx;
-}
+    [[nodiscard]] _Check_return_ _CONSTEXPR_CSTDLIB23 div_t __cdecl div(
+        _In_ int _Numerator, _In_ int _Denominator) noexcept /* strengthened */ {
+        return {_Numerator / _Denominator, _Numerator % _Denominator};
+    }
 
-[[nodiscard]] _Check_return_ _CONSTEXPR_CSTDLIB23 long long __cdecl llabs(_In_ long long _Xx) noexcept
-/* strengthened */ {
-    return _Xx >= 0 ? _Xx : -_Xx;
-}
+    [[nodiscard]] _Check_return_ _CONSTEXPR_CSTDLIB23 ldiv_t __cdecl ldiv(
+        _In_ long _Numerator, _In_ long _Denominator) noexcept /* strengthened */ {
+        return {_Numerator / _Denominator, _Numerator % _Denominator};
+    }
 
-[[nodiscard]] _Check_return_ _CONSTEXPR_CSTDLIB23 div_t __cdecl div(_In_ int _Numerator, _In_ int _Denominator) noexcept
-/* strengthened */ {
-    return {_Numerator / _Denominator, _Numerator % _Denominator};
-}
-
-[[nodiscard]] _Check_return_ _CONSTEXPR_CSTDLIB23 ldiv_t __cdecl ldiv(
-    _In_ long _Numerator, _In_ long _Denominator) noexcept /* strengthened */ {
-    return {_Numerator / _Denominator, _Numerator % _Denominator};
-}
-
-[[nodiscard]] _Check_return_ _CONSTEXPR_CSTDLIB23 lldiv_t __cdecl lldiv(
-    _In_ long long _Numerator, _In_ long long _Denominator) noexcept /* strengthened */ {
-    return {_Numerator / _Denominator, _Numerator % _Denominator};
-}
+    [[nodiscard]] _Check_return_ _CONSTEXPR_CSTDLIB23 lldiv_t __cdecl lldiv(
+        _In_ long long _Numerator, _In_ long long _Denominator) noexcept /* strengthened */ {
+        return {_Numerator / _Denominator, _Numerator % _Denominator};
+    }
+} // namespace _Msvc_stdlib
+} // extern "C++"
 
 _Check_return_ __int64 __cdecl _abs64(_In_ __int64 _Number);
 
@@ -302,23 +293,25 @@ _ACRTIMP errno_t __cdecl rand_s(_Out_ unsigned int* _RandomValue);
 
 
 extern "C++" {
-[[nodiscard]] _CONSTEXPR_CSTDLIB23 long abs(long const _Xx) noexcept /* strengthened */ {
-    return labs(_Xx);
-}
+inline namespace _Msvc_stdlib {
+    [[nodiscard]] _CONSTEXPR_CSTDLIB23 long abs(long const _Xx) noexcept /* strengthened */ {
+        return labs(_Xx);
+    }
 
-[[nodiscard]] _CONSTEXPR_CSTDLIB23 long long abs(long long const _Xx) noexcept /* strengthened */ {
-    return llabs(_Xx);
-}
+    [[nodiscard]] _CONSTEXPR_CSTDLIB23 long long abs(long long const _Xx) noexcept /* strengthened */ {
+        return llabs(_Xx);
+    }
 
-[[nodiscard]] _CONSTEXPR_CSTDLIB23 ldiv_t div(long const _Numerator, long const _Denominator) noexcept
-/* strengthened */ {
-    return ldiv(_Numerator, _Denominator);
-}
+    [[nodiscard]] _CONSTEXPR_CSTDLIB23 ldiv_t div(long const _Numerator, long const _Denominator) noexcept
+    /* strengthened */ {
+        return ldiv(_Numerator, _Denominator);
+    }
 
-[[nodiscard]] _CONSTEXPR_CSTDLIB23 lldiv_t div(long long const _Numerator, long long const _Denominator) noexcept
-/* strengthened */ {
-    return lldiv(_Numerator, _Denominator);
-}
+    [[nodiscard]] _CONSTEXPR_CSTDLIB23 lldiv_t div(long long const _Numerator, long long const _Denominator) noexcept
+    /* strengthened */ {
+        return lldiv(_Numerator, _Denominator);
+    }
+} // namespace _Msvc_stdlib
 } // extern "C++"
 
 #undef _CONSTEXPR_CSTDLIB23

--- a/stl/inc/__msvc_stdlib.hpp
+++ b/stl/inc/__msvc_stdlib.hpp
@@ -295,21 +295,21 @@ _ACRTIMP errno_t __cdecl rand_s(_Out_ unsigned int* _RandomValue);
 extern "C++" {
 inline namespace _Msvc_stdlib {
     [[nodiscard]] _CONSTEXPR_CSTDLIB23 long abs(long const _Xx) noexcept /* strengthened */ {
-        return labs(_Xx);
+        return _Xx >= 0 ? _Xx : -_Xx;
     }
 
     [[nodiscard]] _CONSTEXPR_CSTDLIB23 long long abs(long long const _Xx) noexcept /* strengthened */ {
-        return llabs(_Xx);
+        return _Xx >= 0 ? _Xx : -_Xx;
     }
 
     [[nodiscard]] _CONSTEXPR_CSTDLIB23 ldiv_t div(long const _Numerator, long const _Denominator) noexcept
     /* strengthened */ {
-        return ldiv(_Numerator, _Denominator);
+        return {_Numerator / _Denominator, _Numerator % _Denominator};
     }
 
     [[nodiscard]] _CONSTEXPR_CSTDLIB23 lldiv_t div(long long const _Numerator, long long const _Denominator) noexcept
     /* strengthened */ {
-        return lldiv(_Numerator, _Denominator);
+        return {_Numerator / _Denominator, _Numerator % _Denominator};
     }
 } // namespace _Msvc_stdlib
 } // extern "C++"


### PR DESCRIPTION
Followup to #6434.

* Apply the `extern "C++"` `inline namespace` technique to `__msvc_inttypes.hpp` and `__msvc_stdlib.hpp`.
  + Reported by @Codiferous. I forgot about these headers. The same technique is needed to avoid linker errors with UCRT `div()`.
  + This also allows us to avoid the annoying "declare then `#pragma function`" dance.
* Avoid unnecessary function calls in `abs()` and `div()` overloads.
  + This is a pure cleanup to improve non-optimized debug mode codegen.
