### PR TITLE
`<__msvc_math.hpp>`: Restore and test `_USE_MATH_DEFINES` support

### DIFF
--- a/stl/inc/__msvc_math.hpp
+++ b/stl/inc/__msvc_math.hpp
@@ -23,6 +23,13 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+// https://learn.microsoft.com/cpp/c-runtime-library/math-constants
+// These non-Standard macros (`M_PI` etc.) are widely used, but at least they're opt-in.
+// The <numbers> header is a Standard alternative.
+#ifdef _USE_MATH_DEFINES
+#include <corecrt_math_defines.h>
+#endif
+
 extern "C++" {
 namespace _Msvc { // duplicate type traits not provided by <yvals_core.h>
     template <class _Ty>

--- a/tests/std/tests/P0533R9_constexpr_for_cmath_and_cstdlib/env.lst
+++ b/tests/std/tests/P0533R9_constexpr_for_cmath_and_cstdlib/env.lst
@@ -24,6 +24,8 @@ PM_CL="/EHsc /Zc:cmath /std:c++latest /MD"
 PM_CL="/EHsc /Zc:cmath /std:c++latest /MDd"
 PM_CL="/EHsc /Zc:cmath /std:c++latest /MT"
 PM_CL="/EHsc /Zc:cmath /std:c++latest /MTd"
+# And test the non-Standard macros:
+PM_CL="/EHsc /Zc:cmath /std:c++latest /MTd /D_USE_MATH_DEFINES"
 
 # Explicitly disable libc-based math:
 PM_CL="/EHsc /Zc:cmath- /std:c++14 /MD"
@@ -46,3 +48,5 @@ PM_CL="/EHsc /Zc:cmath- /std:c++latest /MD"
 PM_CL="/EHsc /Zc:cmath- /std:c++latest /MDd"
 PM_CL="/EHsc /Zc:cmath- /std:c++latest /MT"
 PM_CL="/EHsc /Zc:cmath- /std:c++latest /MTd"
+# And test the non-Standard macros:
+PM_CL="/EHsc /Zc:cmath- /std:c++latest /MTd /D_USE_MATH_DEFINES"

--- a/tests/std/tests/P0533R9_constexpr_for_cmath_and_cstdlib/test.cpp
+++ b/tests/std/tests/P0533R9_constexpr_for_cmath_and_cstdlib/test.cpp
@@ -690,3 +690,9 @@ int main() {
 #endif // ^^^ _HAS_CXX26 && defined(_MSVC_LIBC_MATH) ^^^
 #endif // ^^^ defined(__cpp_lib_constexpr_cmath) ^^^
 }
+
+#ifdef _USE_MATH_DEFINES
+static_assert(static_cast<int>(M_PI * 100.0) == 314, "Unexpected value for M_PI, reboot universe and try again.");
+#elif defined(M_PI)
+static_assert(false, "When _USE_MATH_DEFINES is not defined, M_PI should not be defined.");
+#endif // ^^^ defined(M_PI) ^^^


### PR DESCRIPTION
Followup to #6413.

While validating `/Zc:cmath` (which enables LLVM libc generally, and C++23/26 `constexpr <cmath>` specifically) against our Real World Code test suite of popular open-source projects, @Codiferous found that usage of our non-Standard math macros is extremely widespread, and this is a major blocking issue for `/Zc:cmath` adoption.

As a general rule we still want to avoid providing non-Standard legacy math machinery in our new replacement header, but in this case we need to compromise for the sake of practicality. The good news is that this stuff is opt-in via an `_Ugly` macro, so users won't get it if they don't specifically ask for it.