### PR TITLE
`README.md`: Improve the Block Diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,25 +559,25 @@ subgraph VisualStudioSubgraph[Visual Studio]
   STLNode("<b>STL</b>")
   subgraph VCRuntimeSubgraph[VCRuntime]
     direction TB
-    VCStartupNode("<b>VCStartup</b>")
     VCRuntimeNode("<b>VCRuntime</b>")
+    VCStartupNode("<b>VCStartup</b>")
   end
 end
 subgraph WindowsSDKSubgraph[Windows SDK]
   UniversalCRTNode("<b>Universal CRT</b>")
 end
 STLNode ==> VCRuntimeSubgraph & UniversalCRTNode
-VCStartupNode ==> VCRuntimeNode ==> UniversalCRTNode
+VCRuntimeNode ==> VCStartupNode ==> UniversalCRTNode
 ```
 
 * **STL**: This repo; provides C++ Standard Library headers, separately compiled implementations
   of most of the iostreams functionality, and a few runtime support components like `std::exception_ptr`.
-* **VCStartup**: Provides compiler support mechanisms that live in each binary; such as machinery
-  to call constructors and destructors for global variables, the entry point, and the `/GS` cookie.
-  Merged into static and import libraries of VCRuntime.
 * **VCRuntime**: Provides compiler support mechanisms that can be shared between binaries;
   code that the compiler calls on your behalf, such as the C++ exception handling runtime,
   `string.h` intrinsics, math intrinsics, and declarations for CPU-vendor-specific intrinsics.
+* **VCStartup**: Provides compiler support mechanisms that live in each binary; such as machinery
+  to call constructors and destructors for global variables, the entry point, and the `/GS` cookie.
+  Merged into static and import libraries of VCRuntime.
 * **Universal CRT**: Windows component that provides C library support, such as `printf`,
   C locales, and some POSIX-like shims for the Windows API, like `_stat`.
 

--- a/README.md
+++ b/README.md
@@ -553,37 +553,33 @@ vehicles.
 ```mermaid
 flowchart TB
 %%{ init: {"flowchart": {"htmlLabels": true}} }%%
-    classDef default text-align:left
-    subgraph VisualStudioSubgraph[Visual Studio]
-        direction TB
-        STLNode("<b>STL</b>
-        This repo; provides C++ Standard Library headers, separately
-        compiled implementations of most of the iostreams functionality,
-        and a few runtime support components like std::exception_ptr.")
-        subgraph VCRuntimeSubgraph[VCRuntime]
-            direction TB
-            VCStartupNode("<b>VCStartup</b>
-            Provides compiler support mechanisms that
-            live in each binary; such as machinery to
-            call constructors and destructors for global
-            variables, the entry point, and the /GS cookie.<br>
-            Merged into static and import libraries of VCRuntime.")
-            VCRuntimeNode("<b>VCRuntime</b>
-            Provides compiler support mechanisms that can be
-            shared between binaries; code that the compiler calls
-            on your behalf, such as the C++ exception handling
-            runtime, string.h intrinsics, math intrinsics, and
-            declarations for CPU-vendor-specific intrinsics.")
-        end
-    end
-    subgraph WindowsSDKSubgraph[Windows SDK]
-        UniversalCRTNode("<b>Universal CRT</b>
-        Windows component that provides C library support, such as printf,
-        C locales, and some POSIX-like shims for the Windows API, like _stat.")
-    end
-    STLNode ==> VCRuntimeSubgraph & UniversalCRTNode
-    VCStartupNode ==> VCRuntimeNode ==> UniversalCRTNode
+classDef default text-align:left
+subgraph VisualStudioSubgraph[Visual Studio]
+  direction TB
+  STLNode("<b>STL</b>")
+  subgraph VCRuntimeSubgraph[VCRuntime]
+    direction TB
+    VCStartupNode("<b>VCStartup</b>")
+    VCRuntimeNode("<b>VCRuntime</b>")
+  end
+end
+subgraph WindowsSDKSubgraph[Windows SDK]
+  UniversalCRTNode("<b>Universal CRT</b>")
+end
+STLNode ==> VCRuntimeSubgraph & UniversalCRTNode
+VCStartupNode ==> VCRuntimeNode ==> UniversalCRTNode
 ```
+
+* **STL**: This repo; provides C++ Standard Library headers, separately compiled implementations
+  of most of the iostreams functionality, and a few runtime support components like `std::exception_ptr`.
+* **VCStartup**: Provides compiler support mechanisms that live in each binary; such as machinery
+  to call constructors and destructors for global variables, the entry point, and the `/GS` cookie.
+  Merged into static and import libraries of VCRuntime.
+* **VCRuntime**: Provides compiler support mechanisms that can be shared between binaries;
+  code that the compiler calls on your behalf, such as the C++ exception handling runtime,
+  `string.h` intrinsics, math intrinsics, and declarations for CPU-vendor-specific intrinsics.
+* **Universal CRT**: Windows component that provides C library support, such as `printf`,
+  C locales, and some POSIX-like shims for the Windows API, like `_stat`.
 
 # Contributing
 


### PR DESCRIPTION
This makes the Block Diagram, which is written in [Mermaid](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams), way more readable by moving the text descriptions out of the diagram. Their embedded line breaks were creating a mess.

This additionally changes the Block Diagram to depict VCRuntime depending on VCStartup. This area is surprisingly complicated, but @amyw-msft agreed that this is the best way to present things for STL maintainers and contributors.

<details><summary>Click to expand Before screenshot:</summary>
<img width="1273" height="2685" alt="before" src="https://github.com/user-attachments/assets/0e18ba5c-e7b8-461e-a79d-869a8f92719a" />
</details>

<details><summary>Click to expand After screenshot:</summary>
<img width="668" height="800" alt="after" src="https://github.com/user-attachments/assets/7258bd2c-81c5-442e-83df-3d008c33bcbb" />
</details>